### PR TITLE
chore(elixir): fix build breaking on elixir 1.12 because of defguard

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/address.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/address.ex
@@ -24,8 +24,10 @@ defprotocol Ockam.Address do
   Allowed in guard tests. Inlined by the compiler.
   """
   @doc guard: true
-  defguard is_address_type(term)
-           when is_atom(term) or (is_integer(term) and term >= 0 and term <= 255)
+  Kernel.defguard(
+    is_address_type(term)
+    when is_atom(term) or (is_integer(term) and term >= 0 and term <= 255)
+  )
 end
 
 defimpl Ockam.Address, for: Any do


### PR DESCRIPTION
Rebase of https://github.com/ockam-network/ockam/pull/1717