### PR TITLE
Refactored `impl Into<String>` to generic `S: AsRef<str>`

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -47,8 +47,8 @@ use ockam_transport_core::TransportError;
 /// TCP address type constant
 pub const TCP: u8 = 1;
 
-fn parse_socket_addr(s: impl Into<String>) -> Result<SocketAddr> {
-    Ok(s.into()
+fn parse_socket_addr<S: AsRef<str>>(s: S) -> Result<SocketAddr> {
+    Ok(s.as_ref()
         .parse()
         .map_err(|_| TransportError::InvalidAddress)?)
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -117,8 +117,8 @@ impl TcpRouterHandle {
     }
 
     /// Establish an outgoing TCP connection on an existing transport
-    pub async fn connect(&self, peer: impl Into<String>) -> Result<()> {
-        let (peer_addr, hostnames) = Self::resolve_peer(peer)?;
+    pub async fn connect<S: AsRef<str>>(&self, peer: S) -> Result<()> {
+        let (peer_addr, hostnames) = Self::resolve_peer(peer.as_ref())?;
 
         let pair = WorkerPair::start(&self.ctx, peer_addr, hostnames).await?;
         self.register(&pair).await?;
@@ -127,8 +127,8 @@ impl TcpRouterHandle {
     }
 
     /// Establish an outgoing TCP connection for Portal Outlet
-    pub async fn connect_outlet(&self, peer: impl Into<String>) -> Result<Address> {
-        let (peer_addr, _) = Self::resolve_peer(peer)?;
+    pub async fn connect_outlet<S: AsRef<str>>(&self, peer: S) -> Result<Address> {
+        let (peer_addr, _) = Self::resolve_peer(peer.as_ref())?;
 
         let address = PortalWorkerPair::new_outlet(&self.ctx, peer_addr).await?;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -54,13 +54,13 @@ impl TcpTransport {
     }
 
     /// Establish an outgoing TCP connection on an existing transport
-    pub async fn connect(&self, peer: impl Into<String>) -> Result<()> {
-        self.router_handle.connect(peer).await
+    pub async fn connect<S: AsRef<str>>(&self, peer: S) -> Result<()> {
+        self.router_handle.connect(peer.as_ref()).await
     }
 
     /// Start listening to incoming connections on an existing transport
-    pub async fn listen(&self, bind_addr: impl Into<String>) -> Result<()> {
-        let bind_addr = parse_socket_addr(bind_addr)?;
+    pub async fn listen<S: AsRef<str>>(&self, bind_addr: S) -> Result<()> {
+        let bind_addr = parse_socket_addr(bind_addr.as_ref())?;
         self.router_handle.bind(bind_addr).await?;
         Ok(())
     }
@@ -71,12 +71,12 @@ impl TcpTransport {
     /// Messages and forward them to Outlet using onward_route. Inlet is bidirectional: Ockam
     /// Messages sent to Inlet from Outlet (using return route) will be streamed to Tcp connection.
     /// Pair of corresponding Inlet and Outlet is called Portal.
-    pub async fn create_inlet(
+    pub async fn create_inlet<S: AsRef<str>>(
         &self,
-        bind_addr: impl Into<String>,
+        bind_addr: S,
         onward_route: impl Into<Route>,
     ) -> Result<Address> {
-        let bind_addr = parse_socket_addr(bind_addr)?;
+        let bind_addr = parse_socket_addr(bind_addr.as_ref())?;
         let addr = self
             .router_handle
             .bind_inlet(onward_route, bind_addr)


### PR DESCRIPTION
Issue: #1945 

Two instances of `impl Into<String>` remain in `ockam_transport_tcp/`:
- handle.rs:92, return value includes type `Vec<String>` so it requires owned strings.
- transport.rs:103, `TcpOutletListenWorker::start` method requires type `String` for the parameter.


