### PR TITLE
Replace `Into<String>` with `AsRef<str>` in `ockam_transport_websocket`

### DIFF
--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -91,8 +91,8 @@ pub struct WebSocketTransport {
 /// WebSocket address type constant
 pub const WS: u8 = 2;
 
-fn parse_socket_addr<S: Into<String>>(s: S) -> Result<SocketAddr> {
-    Ok(s.into()
+fn parse_socket_addr<S: AsRef<str>>(s: S) -> Result<SocketAddr> {
+    Ok(s.as_ref()
         .parse()
         .map_err(|_| TransportError::InvalidAddress)?)
 }
@@ -115,14 +115,14 @@ impl WebSocketTransport {
     }
 
     /// Establish an outgoing WebSocket connection on an existing transport
-    pub async fn connect<S: Into<String>>(&self, peer: S) -> Result<()> {
-        let peer = WebSocketAddr::from_str(&peer.into())?;
+    pub async fn connect<S: AsRef<str>>(&self, peer: S) -> Result<()> {
+        let peer = WebSocketAddr::from_str(peer.as_ref())?;
         init::start_connection(&self.ctx, &self.router, peer).await?;
         Ok(())
     }
 
     /// Start listening to incoming connections on an existing transport
-    pub async fn listen<S: Into<String>>(&self, bind_addr: S) -> Result<()> {
+    pub async fn listen<S: AsRef<str>>(&self, bind_addr: S) -> Result<()> {
         let bind_addr = parse_socket_addr(bind_addr)?;
         self.router.bind(bind_addr).await?;
         Ok(())


### PR DESCRIPTION
<!--
Thank you for sending a pull request :heart:
-->
### Proposed Changes
<!--
Please describe the changes in your pull request.

If this pull request resolves an already recorded bug or a feature request, be sure to link to that issue.
-->

This PR replaces `Into<String>` bounds `AsRef<str>` for functions that just need a &str.

closes #1970

