### PR TITLE
Remove outdated documentation about UserParser

### DIFF
--- a/implementations/rust/ockam/ockam/src/protocols/parser.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/parser.rs
@@ -12,9 +12,6 @@ use ockam_core::Decodable;
 
 /// A parser for a protocol fragment
 ///
-/// **If you are not a protocol author, you may want to use
-/// [`UserParser`](UserParser) instead!**
-///
 /// Protocols are implemented as separate structures, wrapped in a
 /// carrier type.  Because Rust can't have a function return different
 /// types from a function, each protocol message (here called


### PR DESCRIPTION
This resolves one of the errors mentioned in #1969. Currently when I run `cargo doc` for the rust implementation there is this error:
```shell
error: unresolved link to `UserParser`
  --> src/protocols/parser.rs:16:20
   |
16 | /// [`UserParser`](UserParser) instead!**
   |                    ^^^^^^^^^^ no item named `UserParser` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
```

The reason for this error is that the type `UserParser` has been removed in 552d079e2b9bb672f5415769ce59331228355940. I believe there is no equivalent type in the code base, therefore it makes no sense to mention it in the documentation. 

