### PR TITLE
ci: temporarily ignore rustsec-2020-0071

### DIFF
--- a/implementations/rust/deny.toml
+++ b/implementations/rust/deny.toml
@@ -20,3 +20,6 @@ allow = [
 unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
+ignore = [
+    "RUSTSEC-2020-0071"
+]


### PR DESCRIPTION
This is a temporary workaround for [https://github.com/ockam-network/ockam/issues/2025](https://github.com/ockam-network/ockam/issues/2025)

Updates deny.toml to ignore this advisory