### PR TITLE
ci: ignore rustsec-2020-0159

### DIFF
--- a/implementations/rust/deny.toml
+++ b/implementations/rust/deny.toml
@@ -21,5 +21,6 @@ unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2020-0071"
+    "RUSTSEC-2020-0071",
+    "RUSTSEC-2020-0159"
 ]


### PR DESCRIPTION
Temporarily ignores RUSTSEC-2020-0159, a potential segfault in chrono. See [this issue](https://github.com/ockam-network/ockam/issues/2025)