### PR TITLE
ci: remove `cargo audit` for `cargo deny`

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -33,7 +33,6 @@ commands {
       'cargo check',
       'cargo fmt --all -- --check',
       'cargo clippy --all --all-targets -- --cap-lints=warn',
-      'cargo audit',
       'cargo deny check licenses advisories',
     ],
     veryClean: [


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->
Remove `cargo audit` as `cargo deny advisories` implements same functionality
## Current Behaviour

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
