### PR TITLE
fix commit_lint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,5 @@
 name: Lint Commit Messages
-on: [push, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   commitlint:


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
commit_lint workflow only check for push thereby only linting HEAD commit.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Run workflow on pull_request
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
