### PR TITLE
docs(rust): fix broken rustdoc links in the ockam crate

### DIFF
--- a/implementations/rust/ockam/ockam/src/protocols/parser.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/parser.rs
@@ -115,7 +115,7 @@ impl<W: Worker> ProtocolParserImpl<W> {
 
     /// Parse a message based on its protocol
     ///
-    /// You may want to call [`prepare()`](Self::prepare) before
+    /// You may want to call [`prepare()`](ProtocolParser::prepare) before
     /// calling this function.
     pub fn parse(self: Arc<Self>, w: &mut W, ctx: &mut Context, msg: &Routed<Any>) -> Result<bool> {
         // Parse message as a ProtocolPayload to grab the ProtocolId

--- a/implementations/rust/ockam/ockam/src/stream/cmd.rs
+++ b/implementations/rust/ockam/ockam/src/stream/cmd.rs
@@ -27,7 +27,7 @@ impl StreamWorkerCmd {
     ///
     /// When sending `Pull { num: 0 }` all available messages are
     /// pulled.  It is recommended to configure your stream consumer
-    /// into ["forwarding mode"](crate::stream::Stream::recipient).
+    /// into ["forwarding mode"](crate::stream::Stream::with_recipient).
     pub fn pull(num: usize) -> ProtocolPayload {
         ProtocolPayload::new(ProtocolId::from("internal.stream.pull"), Self::Pull { num })
     }


### PR DESCRIPTION
Rebase of https://github.com/ockam-network/ockam/pull/2049