### PR TITLE
chore(rust): remove `None` errors from error enums

### DIFF
--- a/implementations/rust/ockam/ockam/src/error.rs
+++ b/implementations/rust/ockam/ockam/src/error.rs
@@ -2,8 +2,7 @@
 #![allow(missing_docs)] // Contents are self describing for now.
 #[derive(Clone, Copy, Debug)]
 pub enum OckamError {
-    None,
-    BareError,
+    BareError = 1,
     VerifyFailed,
     InvalidInternalState,
     InvalidProof,

--- a/implementations/rust/ockam/ockam_channel/src/error.rs
+++ b/implementations/rust/ockam/ockam_channel/src/error.rs
@@ -2,10 +2,8 @@ use ockam_core::Error;
 
 /// Types of errors that may occur constructing a secure channel.
 pub enum SecureChannelError {
-    /// No error.
-    None,
     /// The key exchange process failed.
-    KeyExchange,
+    KeyExchange = 1,
     /// Internal state is invalid.
     InvalidInternalState,
     /// Expected nonce was invalid.

--- a/implementations/rust/ockam/ockam_entity/src/credential/error.rs
+++ b/implementations/rust/ockam/ockam_entity/src/credential/error.rs
@@ -4,10 +4,8 @@ use ockam_core::Error;
 /// a credential.
 #[derive(Clone, Copy, Debug)]
 pub enum CredentialError {
-    /// No error
-    None,
     /// Mismatched number of attributes in schema and provided claims to be signed
-    MismatchedAttributesAndClaims,
+    MismatchedAttributesAndClaims = 1,
     /// Mismatched attribute type and provided claim
     MismatchedAttributeClaimType,
     /// Data that cannot be converted to a claim
@@ -38,7 +36,6 @@ impl CredentialError {
 
     pub(crate) const fn as_u32(self) -> u32 {
         match self {
-            CredentialError::None => 0,
             CredentialError::MismatchedAttributesAndClaims => 100,
             CredentialError::MismatchedAttributeClaimType => 200,
             CredentialError::InvalidCredentialAttribute => 300,

--- a/implementations/rust/ockam/ockam_entity/src/error.rs
+++ b/implementations/rust/ockam/ockam_entity/src/error.rs
@@ -1,7 +1,6 @@
 #[derive(Clone, Copy, Debug)]
 pub enum EntityError {
-    None,
-    BareError,
+    BareError = 1,
     VerifyFailed,
     InvalidInternalState,
     InvalidProof,

--- a/implementations/rust/ockam/ockam_ffi/src/error.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/error.rs
@@ -45,11 +45,8 @@ impl From<Error> for FfiOckamError {
 /// Represents the failures that can occur in an Ockam FFI Vault.
 #[derive(Clone, Copy, Debug)]
 pub enum FfiError {
-    /// No error.
-    None,
-
     /// Persistence is not supported for this Vault implementation.
-    VaultDoesntSupportPersistence,
+    VaultDoesntSupportPersistence = 1,
 
     /// An underlying filesystem error prevented Vault creation.
     ErrorCreatingFilesystemVault,

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/error.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/error.rs
@@ -4,9 +4,7 @@ use ockam_core::Error;
 /// an Ockam X3DH kex
 #[derive(Clone, Copy, Debug)]
 pub enum X3DHError {
-    /// None
-    None,
-    InvalidState,
+    InvalidState = 1,
     MessageLenMismatch,
     SignatureLenMismatch,
     InvalidHash,

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/error.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/error.rs
@@ -4,10 +4,8 @@ use ockam_core::Error;
 /// an Ockam XX Key Agreement
 #[derive(Clone, Copy, Debug)]
 pub enum XXError {
-    /// No error.
-    None,
     /// The key exchange protocol is in an invalid state.
-    InvalidState,
+    InvalidState = 1,
     /// An internal Vault error has occurred.
     InternalVaultError,
     /// A message had an unexpected length.

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -4,10 +4,8 @@ use core::fmt::Debug;
 /// Error declarations.
 #[derive(Clone, Copy, Debug)]
 pub enum Error {
-    /// No error
-    None,
     /// Unable to gracefully stop the Node.
-    FailedStopNode,
+    FailedStopNode = 1,
     /// Unable to start a worker
     FailedStartWorker,
     /// Unable to start a processor

--- a/implementations/rust/ockam/ockam_vault/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault/src/error.rs
@@ -4,10 +4,8 @@ use ockam_core::Error;
 /// an Ockam vault
 #[derive(Clone, Copy, Debug)]
 pub enum VaultError {
-    /// No error
-    None,
     /// Secret does not belong to this vault
-    SecretFromAnotherVault,
+    SecretFromAnotherVault = 1,
     /// Public key is invalid
     InvalidPublicKey,
     /// Unknown ECDH key type

--- a/implementations/rust/ockam/ockam_vault_sync_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault_sync_core/src/error.rs
@@ -4,10 +4,8 @@ use ockam_core::Error;
 /// an Ockam vault sync core
 #[derive(Clone, Copy, Debug)]
 pub enum VaultSyncCoreError {
-    /// No error.
-    None,
     /// Invalid response type.
-    InvalidResponseType,
+    InvalidResponseType = 1,
 }
 
 impl VaultSyncCoreError {


### PR DESCRIPTION
Rebase of https://github.com/ockam-network/ockam/pull/2059