### PR TITLE
chore(rust): fix warnings in `ockam_node` under no_std+alloc

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -3,7 +3,6 @@
 use crate::{relay::RelayMessage, router::Router, NodeMessage};
 use ockam_core::{Address, Result};
 
-use crate::error::Error;
 use crate::tokio::{runtime::Runtime, sync::mpsc::Sender};
 use core::future::Future;
 use ockam_core::compat::sync::Arc;
@@ -63,7 +62,7 @@ impl Executor {
         crate::block_future(&rt, async move { self.router.run().await })?;
 
         let res = crate::block_future(&rt, async move { join_body.await })
-            .map_err(|_| Error::ExecutorBodyJoinError)?;
+            .map_err(|_| crate::error::Error::ExecutorBodyJoinError)?;
 
         Ok(res)
     }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -17,7 +17,7 @@ extern crate core;
 #[macro_use]
 extern crate alloc;
 
-#[macro_use]
+#[cfg_attr(feature = "std", macro_use)]
 extern crate tracing;
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Since nobody seems to have gotten to it yet. Fixes #2063