### PR TITLE
build(elixir): move default config to mix.exs file

### DIFF
--- a/examples/elixir/get_started/setup.exs
+++ b/examples/elixir/get_started/setup.exs
@@ -8,4 +8,4 @@ Mix.install([
   {:ranch, "~> 1.8"}
 ])
 
-Application.put_env(:ockam, Ockam.Wire, default: Ockam.Wire.Binary.V2)
+Application.load(:ockam)

--- a/implementations/elixir/ockam/ockam/config/config.exs
+++ b/implementations/elixir/ockam/ockam/config/config.exs
@@ -1,8 +1,6 @@
+## Application configuration used in release as sys.config or mix run
+## THIS CONFIGURATION IS NOT LOADED IF THE APP IS LOADED AS A DEPENDENCY
+
 import Config
-
-config :ockam, Ockam.Wire, default: Ockam.Wire.Binary.V2
-
-config :logger, :console, metadata: [:module, :line, :pid], level: :info
-# config :logger, handle_sasl_reports: true
 
 import_config "#{Mix.env()}.exs"

--- a/implementations/elixir/ockam/ockam/mix.exs
+++ b/implementations/elixir/ockam/ockam/mix.exs
@@ -43,7 +43,8 @@ defmodule Ockam.MixProject do
   def application do
     [
       mod: {Ockam, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      env: [{Ockam.Wire, [default: Ockam.Wire.Binary.V2]}]
     ]
   end
 

--- a/implementations/elixir/ockam/ockam_hub/config/config.exs
+++ b/implementations/elixir/ockam/ockam_hub/config/config.exs
@@ -1,8 +1,9 @@
+## Application configuration used in release as sys.config or mix run
+## THIS CONFIGURATION IS NOT LOADED IF THE APP IS LOADED AS A DEPENDENCY
+
 import Config
 
 config :logger, level: :info
-
-config :ockam, Ockam.Wire, default: Ockam.Wire.Binary.V2
 
 config :logger, :console, metadata: [:module, :line, :pid]
 

--- a/implementations/elixir/ockam/ockam_kafka/config/config.exs
+++ b/implementations/elixir/ockam/ockam_kafka/config/config.exs
@@ -1,3 +1,6 @@
+## Application configuration used in release as sys.config or mix run
+## THIS CONFIGURATION IS NOT LOADED IF THE APP IS LOADED AS A DEPENDENCY
+
 import Config
 
 config :ockam_kafka,


### PR DESCRIPTION
Config values from `config/config.exs` are only loaded when building
from the app directory.
If the app is built as a dependency, configuration should be specified
in the mix.exs file.