### PR TITLE
feat(rust): add examples dirs to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     # like `members = ["**/Cargo.toml/.."]`.
     "implementations/rust/ockam/*/src/..",
     "examples/rust/*/src/..",
+    "examples/rust/*/examples/..",
 
     "tools/ockam-hub-cli",
     "tools/docs/example_runner",


### PR DESCRIPTION
We have a lot of code in `examples` subdirectories. Running examples complains about not being in a workspace. This PR adds these directories.
