### PR TITLE
fix(rust): remove explicit vers from dev-dependencies in node_test_attr

### DIFF
--- a/implementations/rust/ockam/ockam_node_test_attribute/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node_test_attribute/Cargo.toml
@@ -34,6 +34,6 @@ quote = "1.0"
 syn = {version = "1.0", features = ["full", "extra-traits"]}
 
 [dev-dependencies]
-ockam = { path = "../ockam", version = "0.35.0", default-features = false, features = ["std"] }
-ockam_node = { path = "../ockam_node", version = "0.34.0", default-features = false, features = ["std"] }
+ockam = { path = "../ockam",  default-features = false, features = ["std"] }
+ockam_node = { path = "../ockam_node", default-features = false, features = ["std"] }
 trybuild = "1.0"


### PR DESCRIPTION
Accidentally created a circular dependency
