### PR TITLE
feat(rust): add tokio-console tracing to ockam_node

### DIFF
--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -88,6 +88,8 @@ alloc = [
     "serde/alloc",
 ]
 
+console = ["ockam_node/console"]
+
 [[test]]
 name = "tests"
 path = "tests/main.rs"

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -42,6 +42,10 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc"]
 # workers at startup via the trace! macro.
 dump_internals = []
 
+# Feature: "console" enables the tokio-console tracing Layer.
+console = ["std"]
+
+
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.45.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.6.0"}
@@ -59,3 +63,5 @@ tracing-subscriber = { version = "0.3", features = [
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
 ockam_executor = { path = "../ockam_executor", version = "^0.14.0", default-features = false, optional = true }
+console-subscriber = "0.1.1"
+


### PR DESCRIPTION
#2378 

This commit:
1. adds the tokio/console-subscriber's tracing Layer to ockam_node's
`setup_tracing()` function.
2. adds the `ockam_node/console` feature for conditional compilation.