### PR TITLE
Introduce replacement error type.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1394,6 +1395,7 @@ name = "ockam_core"
 version = "0.46.0"
 dependencies = [
  "async-trait",
+ "backtrace",
  "cfg-if",
  "core2",
  "futures-util",
@@ -1401,11 +1403,14 @@ dependencies = [
  "heapless",
  "hex",
  "ockam_macros",
+ "once_cell",
  "rand 0.8.4",
  "rand_pcg",
  "serde 1.0.136",
  "serde_bare",
  "spin",
+ "tracing",
+ "tracing-error",
  "zeroize",
 ]
 
@@ -2530,7 +2535,19 @@ checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2540,6 +2557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -22,7 +22,7 @@ publish = true
 rust-version = "1.56.0"
 
 [features]
-default = ["std"]
+default = ["std", "error-traces"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
@@ -33,6 +33,7 @@ std = [
     "rand/std_rng",
     "serde_bare/std",
     "ockam_macros/std",
+    "once_cell/std",
 ]
 
 # Feature: "no_std" enables functionality required for platforms
@@ -48,6 +49,10 @@ alloc = [
     "serde_bare/alloc",
 ]
 bls = []
+
+# Error traces cover whether not our errors capture backtraces and/or spantraces
+# by default.
+error-traces = ["backtrace", "tracing-error", "once_cell"]
 
 [dependencies]
 ockam_macros = { path = "../ockam_macros", version = "^0.7.0", default_features = false }
@@ -75,3 +80,7 @@ futures-util = { version = "0.3.17", default-features = false, features = [
 ] }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 cfg-if = "1.0"
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+tracing-error = { version = "0.2", default-features = false, optional = true }
+backtrace = { version = "0.3", default-features = false, features = ["std", "serialize-serde"], optional = true }
+once_cell = { version = "1", optional = true, default-features = false }

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -36,7 +36,7 @@ pub mod collections {
 pub mod error {
     #[cfg(not(feature = "std"))]
     pub trait Error: core::fmt::Debug + core::fmt::Display {
-        fn source(&self) -> Option<&(dyn Error + 'static)> {
+        fn cause(&self) -> Option<&(dyn Error + 'static)> {
             None
         }
     }
@@ -232,6 +232,13 @@ pub mod task {
 
 /// std::vec
 pub mod vec {
+    #[cfg(feature = "alloc")]
+    pub use alloc::vec::*;
+    #[cfg(not(feature = "alloc"))]
+    pub type Vec<T> = heapless::Vec<T, 64>;
+}
+pub mod fmt {
+    pub use alloc::fmt::*;
     #[cfg(feature = "alloc")]
     pub use alloc::vec::*;
     #[cfg(not(feature = "alloc"))]

--- a/implementations/rust/ockam/ockam_core/src/error/code.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/code.rs
@@ -1,0 +1,416 @@
+//! Ockam error code enumerations.
+//!
+//! These are deliberately abstract, and do not cover all possible errors in
+//! detail. Some of the motivation behind this includes:
+//!
+//! 1. Allow code which wishes to categorize, filter, or otherwise handle errors
+//!    to do so generically without forcing them to hard-code numeric values.
+//! 2. To avoid each component needing to choose globally unique error numbers.
+use serde::{Deserialize, Serialize};
+
+/// A set of abstract error codes describing an error. See the [module-level
+/// documentation](crate::error::codes) for details.
+///
+/// The fields of this struct are `pub` for matching, but you need to go through
+/// one of the [constructor functions](ErrorCode::new) to create one of these
+/// (and not a literal), as it is a `#[non_exhaustive]` type (which may change in
+/// the future, since it's unclear if this provides value).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ErrorCode {
+    // Maintenance note: Don't reorder these fields or cfg them out, it's
+    // somewhat important for serialization (at least via BARE) that these are
+    // the same in all configurations -- therefore, all items in this struct
+    // should be reasonable to include on embedded as well (going any higher
+    // than 64 bits seems likely to be too far in that context -- even this much
+    // is perhaps pushing it).
+    /// The [`Origin`] of this error.
+    pub origin: Origin,
+    /// The [`Kind`] of this error.
+    pub kind: Kind,
+    /// An additional identifying numeric payload, or 0 if none is relevant.
+    ///
+    /// For example, it would be reasonable for this field to hold:
+    /// - HTTP status code
+    /// - OS `errno`/`GetLastError` code
+    /// - The exit status returned by a subprocess
+    /// - A numeric error code from some other system
+    /// - Et cetera.
+    ///
+    /// But should generally not be used to hold non-identifying metadata, such
+    /// as the date, device IDs, as that information should be stored on the
+    /// payload itself.
+    ///
+    /// Concretely: two `ErrorCode` with different `extra` values should
+    /// identify types of errors.
+    // TODO: is 32 bits okay on embedded? This puts us to 64 bits for the
+    // structure in practice, but means that we'll alwasy be able to hold OS
+    // errors, as well as `old_error::Error::code`.
+    pub extra: i32,
+}
+
+impl ErrorCode {
+    /// Construct the `ErrorCode` for an error.
+    #[cold]
+    pub fn new(origin: Origin, kind: Kind) -> Self {
+        Self {
+            origin,
+            kind,
+            extra: 0,
+        }
+    }
+    /// Construct the `ErrorCode` for an error which contains an additional
+    /// numeric payload.
+    #[cold]
+    pub fn new_with_extra(origin: Origin, kind: Kind, extra: i32) -> Self {
+        Self {
+            origin,
+            kind,
+            extra,
+        }
+    }
+
+    /// Construct an error code with very little useful information
+    #[cold]
+    pub fn unknown() -> Self {
+        Self {
+            origin: Origin::Unknown,
+            kind: Kind::Unknown,
+            extra: 0,
+        }
+    }
+
+    /// Attach an origin and/or kind to the error, without risk of overwriting more
+    /// precise information value.
+    #[must_use]
+    pub fn update_unknown(
+        mut self,
+        o: impl Into<Option<Origin>>,
+        k: impl Into<Option<Kind>>,
+    ) -> Self {
+        if let (Origin::Unknown, Some(o)) = (self.origin, o.into()) {
+            self.origin = o;
+        }
+        if let (Kind::Unknown, Some(k)) = (self.kind, k.into()) {
+            self.kind = k;
+        }
+        self
+    }
+}
+
+/// Origin indicates the abstract source of an error.
+///
+/// Note that [`Error`](super::Error) should already contain precise origin
+/// information (file, line) where the error originated from.
+///
+// Internal note: Once we stablize the API, we should not remove these, just stop emitting them.
+#[repr(u8)]
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Serialize, Deserialize)]
+pub enum Origin {
+    /// An error for which there is no way to determine a more specific origin.
+    ///
+    /// Eventually this should also be used for errors which, during
+    /// deserialization, have an unknown `Origin` (for now this is too
+    /// error-prone for various reasons).
+    Unknown = 0,
+    /// Reserved for errors emitted by applications using ockam.
+    Application = 1,
+    /// An error originating from the vault.
+    Vault = 2,
+    /// Errors emitted by the transport layer.
+    Transport = 3,
+    /// Errors from some part of the node implementation — the router or relay,
+    /// for example.
+    Node = 4,
+    /// Errors from the surface API — for example: the FFI layer.
+    Api = 5,
+    /// Errors from within the identity-management code.
+    Identity = 6,
+    /// Errors from the secure channel implementation.
+    Channel = 7,
+    /// Errors occurring from the one of the key exchange implementations.
+    KeyExchange = 8,
+    /// An error which occurs in the executor (e.g. `ockam_executor`, since
+    /// `tokio` errors will likely come from elsewhere).
+    Executor = 9,
+    /// Other errors from within `ockam` or `ockam_core`.
+    Core = 10,
+    /// Errors from other sources, such as libraries extending `ockam`.
+    ///
+    /// Note: The actual source (file, line, ...) will (hopefully) be available
+    /// on the error itself, as one of the members of the payload.
+    Other = 11,
+    // This is a `#[non_exhaustive]` enum — we're free to add more variants
+    // here. Do not add any which contain payloads (it should stay a "C style
+    // enum"). Payload information should be added to the error itself.
+}
+
+/// Catgory indicates "what went wrong", in abstract terms.
+///
+/// # Choosing a `Kind`
+///
+/// - [`Kind::Io`], [`Kind::Protocol`], and [`Kind::Other`] should only be used
+///   if there's no more specific option.
+///
+///     For example, a network timeout is a type of IO error, however it should
+///     use [`Kind::Timeout`] rather than [`Kind::Io`].
+///
+/// - [`Kind::Invalid`] should be used when the input will never be valid (at
+///   least in this version of the software), rather than input which is invalid
+///   because of the current system state.
+///
+///     For example, an unknown identifier should use [`Kind::NotFound`] (for
+///     example `ockam_vault_core`'s `Secret`) rather than [`Kind::Invalid`],
+///
+/// - [`Kind::Cancelled`], [`Kind::Timeout`], and [`Kind::Shutdown`] all sound
+///   similar, but:
+///
+///     - [`Kind::Timeout`] should be used to map operations which timeout
+///       externally, such as network requests. These may succeed if retried.
+///
+///     - [`Kind::Shutdown`] should be used to indicate the operation failed due
+///       to the node shutting down.
+///
+///     - [`Kind::Cancelled`] is used when a request to cancel the operation
+///       comes in while the operation is in progress.
+#[repr(u8)]
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Kind {
+    /// Indicates that there is no way to determine a more specific kind.
+    // Internal note: We should not emit this from within the
+    // `ockam-network/ockam` crates.
+    Unknown = 0,
+
+    /// Used for serious internal errors, including panics.
+    ///
+    /// This generally should not be used unless we'd accept a bug report for
+    /// the error.
+    Internal = 1,
+
+    /// The input was fundamentally invalid.
+    ///
+    /// For example, this is appropriate to use when:
+    ///
+    /// - A null pointer being passed as input in the FFI.
+    /// - A string is used as input which is not UTF-8.
+    /// - Parse failures of various kinds, but be sure to include more specific
+    ///   information in the [`Error`](crate::Error) payload.
+    ///
+    /// Note that it is not appropriate for input which is invalid only due to
+    /// the current system state.
+    // Internal note: Check if there's a more specific `Kind` before using this
+    // — it should mostly be `Origin
+    Invalid = 2,
+
+    /// The requested operation is not supported/implemented by that component.
+    ///
+    /// For example, this is appropriate for a component (for example, a custom
+    /// Vault) which do not implement the entire API surface.
+    Unsupported = 3,
+
+    /// Some referenced entity was not found.
+    ///
+    /// For example, this may be appropriate for:
+    ///
+    /// - A vault which does not recognize a `Secret` which it recieves.
+    /// - FFI that recieves an integer `handle` that does not belong to any
+    ///   known entity.
+    /// - Local [`Address`](crate::Address) which don't correspond to any known
+    ///   `Worker` or `Processor`.
+    /// - [`Address`](crate::Address) with a transport of an unknown or
+    ///   unsupported type.
+    ///
+    /// Information about what exactly it is that could not be located should be
+    /// available on the [`Error`](crate::Error) itself.
+    NotFound = 4,
+
+    /// The operation failed because
+    ///
+    /// For example, this may be appropriate for:
+    ///
+    /// - A vault which does not recognize a `Secret` which it recieves.
+    /// - FFI that recieves an integer `handle` that does not belong to any
+    ///   known entity.
+    /// - Local [`Address`](crate::Address) which don't correspond to any known
+    ///   `Worker` or `Processor`.
+    /// - [`Address`](crate::Address) with a transport of an unknown or
+    ///   unsupported type.
+    ///
+    /// Information about what exactly it is that could not be located should be
+    /// available on the [`Error`](crate::Error) itself.
+    AlreadyExists = 5,
+
+    /// Indicates that some resource has been exhausted, or would be exhausted
+    /// if the request were to be fulfilled.
+    ///
+    /// The resource in question could be memory, open file descriptors,
+    /// storage, quota, simultaneous in-flight messages or tasks...
+    ///
+    /// Information about which resource it was that was exhausted should be
+    /// available on the [`Error`](crate::Error) itself.
+    ResourceExhausted = 6,
+
+    /// An API was misused in some unspecific fashion.
+    ///
+    /// This is mostly intended for FFI and other non-Rust bindings — for
+    /// example, it would be appropriate to map [`core::cell::BorrowError`] to
+    /// this.
+    // Internal note: Check if there's a more specific `Kind` before using this.
+    Misuse = 7,
+
+    /// Indicates the operation failed due to a cancellation request.
+    ///
+    /// See the type documentation on the difference between this,
+    /// [`Kind::Shutdown`] and [`Kind::Timeout`].
+    Cancelled = 8,
+
+    /// Indicates that the operation failed due to the node shutting down.
+    ///
+    /// See the type documentation on the difference between this,
+    /// [`Kind::Cancelled`] and [`Kind::Timeout`].
+    Shutdown = 9,
+
+    /// Indicates that the operation failed due to an external operation timing
+    /// out, such as a network request, which may succeed if retried.
+    ///
+    /// See the type documentation on the difference between this,
+    /// [`Kind::Shutdown`] and [`Kind::Cancelled`].
+    Timeout = 10,
+
+    /// Indicates an operation failed due to simultaneous attempts to modify a
+    /// resource.
+    Conflict = 11,
+
+    /// Indicates an a failure to deserialize a message (or in rare cases,
+    /// failure to serialize).
+    Serialization = 12,
+
+    /// Indicates some other I/O error.
+    ///
+    /// Specifics should be available on error payload.
+    // Internal note: Check if there's a more specific `Kind` before using this.
+    Io = 13,
+
+    /// Indicates some other I/O error.
+    ///
+    /// Specifics should be available on error payload.
+    // Internal note: Check if there's a more specific `Kind` before using this.
+    Protocol = 14,
+
+    /// Indicates an error that
+    ///
+    /// Specifics should be available on error payload.
+    // Internal note: Check if there's a more specific `Kind` before using this.
+    Other = 15,
+    // This is a `#[non_exhaustive]` enum — we're free to add more variants
+    // here. Do not add any which contain payloads (it should stay a "C style
+    // enum"). Payload information should be added to the error itself.
+    //
+    // That said, until we finish migrating over to this, it's expected that
+    // we'll need to add several new variants to all of these.
+}
+
+// Helper macro for converting a number into an enum variant with that value.
+// Variants do not need to be contiguous. Requires listing the error variants
+// again, but forces a compile-time error if the list is missing a variant.
+macro_rules! from_prim {
+    ($prim:expr => $Enum:ident { $($Variant:ident),* $(,)? }) => {{
+        // Force a compile error if the list gets out of date.
+        const _: fn(e: $Enum) = |e: $Enum| match e {
+            $($Enum::$Variant => ()),*
+        };
+        match $prim {
+            $(v if v == ($Enum::$Variant as _) => Some($Enum::$Variant),)*
+            _ => None,
+        }
+    }}
+}
+
+impl Origin {
+    /// Attempt to convert a numeric value into an `Origin`.
+    ///
+    /// `From<u8>` is also implemented, replacing unknown inputs with
+    /// `Self::Unknown`.
+    #[track_caller]
+    pub fn from_u8(n: u8) -> Option<Self> {
+        from_prim!(n => Origin {
+            Unknown,
+            Application,
+            Vault,
+            Transport,
+            Node,
+            Api,
+            Identity,
+            Channel,
+            KeyExchange,
+            Executor,
+            Core,
+            Other,
+        })
+    }
+}
+
+impl From<u8> for Origin {
+    #[track_caller]
+    fn from(src: u8) -> Self {
+        match Self::from_u8(src) {
+            Some(n) => n,
+            None => {
+                warn!("Unknown error origin: {}", src);
+                Self::Unknown
+            }
+        }
+    }
+}
+
+impl Kind {
+    /// Attempt to construct a `Kind` from the numeric value.
+    pub fn from_u8(n: u8) -> Option<Self> {
+        from_prim!(n => Kind {
+            Unknown,
+            Internal,
+            Invalid,
+            Unsupported,
+            NotFound,
+            AlreadyExists,
+            ResourceExhausted,
+            Misuse,
+            Cancelled,
+            Shutdown,
+            Timeout,
+            Conflict,
+            Io,
+            Protocol,
+            Serialization,
+            Other
+        })
+    }
+}
+
+impl From<u8> for Kind {
+    #[track_caller]
+    fn from(src: u8) -> Self {
+        match Self::from_u8(src) {
+            Some(n) => n,
+            None => {
+                warn!("Unknown error origin: {}", src);
+                Self::Unknown
+            }
+        }
+    }
+}
+
+impl core::fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Kind of halfway between debug and display, TBH, but it's only used in
+        // the Error debug output.
+        write!(f, "[Origin::{:?}; Kind::{:?}", self.origin, self.kind,)?;
+        if self.extra != 0 {
+            write!(f, "; code = {}]", self.extra)
+        } else {
+            write!(f, "]")
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/error/inner.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/inner.rs
@@ -1,0 +1,135 @@
+use super::code::ErrorCode;
+use crate::compat::{boxed::Box, error::Error as ErrorTrait, string::String};
+use serde::{Deserialize, Serialize};
+
+mod formatting;
+#[cfg(all(feature = "std", feature = "error-traces"))]
+mod trace_config;
+
+type BoxDynErr = Box<dyn ErrorTrait + Send + Sync + 'static>;
+
+/// The internal error type, which [`super::NewError`] wraps.
+///
+/// When an allocator is available, this is `Box`ed for performance reasons,
+/// (although some of the fields here are a little goofy in low level contexts).
+#[derive(Serialize, Deserialize)]
+pub(super) struct ErrorData {
+    pub(super) code: ErrorCode,
+    // TODO: these should not be disabled for no_std, but: not as simple as
+    // `#[cfg()]`ing the fields out, as this changes the serialization format.
+    payload: Vec<PayloadEntry>,
+    source_loc: Location,
+    #[serde(skip, default)]
+    cause: Option<BoxDynErr>,
+    #[serde(skip, default)]
+    local: Option<Vec<LocalPayloadEntry>>,
+}
+
+impl ErrorData {
+    #[cold]
+    #[track_caller]
+    pub(super) fn new<E>(code: ErrorCode, cause: E) -> Self
+    where
+        E: Into<Box<dyn ErrorTrait + Send + Sync>>,
+    {
+        Self::new_inner(code, cause.into(), core::any::type_name::<E>())
+    }
+
+    #[cold]
+    #[track_caller]
+    pub(super) fn new_inner(
+        code: ErrorCode,
+        cause: Box<dyn ErrorTrait + Send + Sync>,
+        type_name: &'static str,
+    ) -> Self {
+        let location = core::panic::Location::caller();
+        let debug = crate::compat::format!("{:?}", cause);
+        let display = crate::compat::format!("{}", cause);
+        #[allow(unused_mut)]
+        let mut local: Vec<LocalPayloadEntry> = vec![];
+
+        #[cfg(all(feature = "std", feature = "error-traces"))]
+        if trace_config::BACKTRACE_ENABLED.get() {
+            local.push(LocalPayloadEntry::Backtrace(backtrace::Backtrace::new()));
+        }
+        #[cfg(all(feature = "std", feature = "error-traces"))]
+        if trace_config::SPANTRACE_ENABLED.get() {
+            local.push(LocalPayloadEntry::Spantrace(
+                tracing_error::SpanTrace::capture(),
+            ));
+        }
+        Self {
+            code,
+            cause: Some(cause),
+            source_loc: location.into(),
+            local: Some(local),
+            payload: vec![PayloadEntry::Cause {
+                display,
+                debug,
+                type_name: type_name.to_owned(),
+            }],
+        }
+    }
+    #[cold]
+    pub fn add_context(&mut self, key: &str, val: &dyn core::fmt::Display) {
+        self.payload.push(PayloadEntry::Info(
+            key.into(),
+            crate::compat::format!("{}", val),
+        ));
+    }
+
+    pub fn cause(&self) -> Option<&(dyn ErrorTrait + Send + Sync + 'static)> {
+        self.cause.as_deref()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum PayloadEntry {
+    // `Display` for the error cause (note that this may instead be used for the
+    // `message`).
+    Cause {
+        display: String,
+        debug: String,
+        type_name: String,
+    },
+    // Miscellaneous info — type name of the worker that caused the error for
+    // example, or a human description of the cause.
+    Info(String, String),
+}
+
+// Information that is only relevant on this machine. May be logged, so should
+// not contain sensitive data, but is discarded when serializing.
+#[derive(Debug)]
+enum LocalPayloadEntry {
+    #[cfg(all(feature = "std", feature = "backtrace"))]
+    Backtrace(backtrace::Backtrace),
+    #[cfg(all(feature = "std", feature = "tracing-error"))]
+    Spantrace(tracing_error::SpanTrace),
+}
+
+/// Serializable version of `core::panic::Location`, as returned by
+/// `core::panic::Location::caller()`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Location {
+    file: String,
+    line: u32,
+    column: u32,
+}
+
+impl From<&core::panic::Location<'_>> for Location {
+    fn from(p: &core::panic::Location<'_>) -> Self {
+        Self {
+            file: p.file().into(),
+            line: p.line().into(),
+            column: p.column().into(),
+        }
+    }
+}
+
+impl core::fmt::Display for Location {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // This format is compatible with most editors, and is used by rust (and
+        // many others) for source location output.
+        write!(f, "{}:{}:{}", self.file, self.line, self.column)
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/error/inner/formatting.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/inner/formatting.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+impl core::fmt::Display for ErrorData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(c) = &self.cause {
+            c.fmt(f)
+        } else {
+            let c = self
+                .payload
+                .iter()
+                .find(|p| matches!(p, PayloadEntry::Cause { .. }));
+            if let Some(PayloadEntry::Cause { display, .. }) = c {
+                f.pad(display)
+            } else {
+                // Best we can do, I suppose.
+                write!(f, "Ockam error [{}] at {}", self.code, self.source_loc)
+            }
+        }
+    }
+}
+
+impl core::fmt::Debug for ErrorData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "Ockam Error [{}] at {}", self.code, self.source_loc,)?;
+        writeln!(f, "--- Details ---")?;
+        if let Some(c) = &self.cause {
+            // TODO: iterate the cause chain, print the whole thing outp
+            writeln!(f, "- Caused by: {}", c)?;
+        }
+        for e in self.payload.iter() {
+            match e {
+                PayloadEntry::Info(k, v) => {
+                    writeln!(f, "- info {:?}: {}", k, v)?;
+                }
+                PayloadEntry::Cause {
+                    display,
+                    debug,
+                    type_name,
+                } => {
+                    writeln!(f, "- possible root cause `{}`: {}", type_name, display)?;
+                    writeln!(f, "  debug output: ")?;
+                    for line in debug.lines() {
+                        writeln!(f, "    {}", line)?;
+                    }
+                }
+            }
+        }
+
+        if let Some(local) = self.local.as_ref() {
+            for e in local {
+                match e {
+                    LocalPayloadEntry::Spantrace(t) => {
+                        writeln!(f, "--- Captured Spantrace ---")?;
+                        writeln!(f, "{}", t)?;
+                    }
+                    LocalPayloadEntry::Backtrace(t) => {
+                        writeln!(f, "--- Captured Backtrace ---")?;
+                        // TODO: Finish up filtering out pointless frames -- see
+                        // https://gist.github.com/thomcc/0e9f1cc4dd9f6f12943a158eeb848f7e
+                        writeln!(f, "{:?}", t)?;
+                    }
+                }
+            }
+        }
+        writeln!(f, "--------------------------")?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/error/inner/trace_config.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/inner/trace_config.rs
@@ -1,0 +1,179 @@
+//! Note: This module is private, and only enabled if both `std` and
+//! `error-traces` are on.
+use core::sync::atomic::{AtomicU8, Ordering};
+
+#[cfg(feature = "std")]
+pub(super) static BACKTRACE_ENABLED: TraceConfig = TraceConfig::new(
+    &["OCKAM_BACKTRACE", "RUST_LIB_BACKTRACE", "RUST_BACKTRACE"],
+    false,
+);
+
+#[cfg(feature = "std")]
+pub(super) static SPANTRACE_ENABLED: TraceConfig = TraceConfig::new(
+    &[
+        "OCKAM_SPANTRACE",
+        "OCKAM_BACKTRACE",
+        "RUST_LIB_BACKTRACE",
+        "RUST_BACKTRACE",
+    ],
+    true,
+);
+
+pub(super) struct TraceConfig {
+    state: AtomicU8,
+    vars: &'static [&'static str],
+    default: bool,
+}
+
+impl TraceConfig {
+    pub const fn new(vars: &'static [&'static str], default: bool) -> Self {
+        Self {
+            state: AtomicU8::new(encode_opt_bool(None)),
+            vars,
+            default,
+        }
+    }
+    pub(super) fn get(&self) -> bool {
+        are_traces_enabled(&self.state, || {
+            check_env_vars(self.vars).unwrap_or(self.default)
+        })
+    }
+}
+
+fn check_env_vars(vars: &[&str]) -> Option<bool> {
+    vars.iter()
+        .copied()
+        .find_map(|name| std::env::var_os(name))
+        .map(|val| val != "0")
+}
+
+// This is generic for testing — call `are_backtraces_enabled()` instead.
+fn are_traces_enabled(state: &AtomicU8, read_env: impl FnOnce() -> bool) -> bool {
+    // Relaxed is fine here, since we are only interested in the effects on a
+    // single memory location.
+    match decode_opt_bool(state.load(Ordering::Relaxed)) {
+        Some(b) => b,
+        None => {
+            let enabled = read_env();
+            state.store(encode_opt_bool(Some(enabled)), Ordering::Relaxed);
+            enabled
+        }
+    }
+}
+
+// Conceptually stores an `Option<bool>`, which stores the cached result of
+// `env_backtrace_enabled()`. It uses 0 for None, and 1 plus the bool value
+// for anything else (false is 1, true is 2).
+fn decode_opt_bool(n: u8) -> Option<bool> {
+    match n {
+        0 => None,
+        n => Some((n - 1) != 0),
+    }
+}
+const fn encode_opt_bool(u: Option<bool>) -> u8 {
+    match u {
+        None => 0,
+        Some(b) => b as u8 + 1,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::ffi::{OsStr, OsString};
+    #[test]
+    fn test_bool_enc() {
+        assert_eq!(decode_opt_bool(encode_opt_bool(None)), None);
+        assert_eq!(decode_opt_bool(encode_opt_bool(Some(false))), Some(false));
+        assert_eq!(decode_opt_bool(encode_opt_bool(Some(true))), Some(true));
+        assert_eq!(encode_opt_bool(decode_opt_bool(0)), 0);
+        assert_eq!(encode_opt_bool(decode_opt_bool(1)), 1);
+        assert_eq!(encode_opt_bool(decode_opt_bool(2)), 2);
+    }
+
+    // RAII type with a `Drop` which restores an env var to the value it had
+    // previously.
+    //
+    // (To fix this, we could probably take advantage of the fact that
+    // `check_env_vars` and such accepts a list of arbitrary varnames, and use a
+    // set of random, or otherwise externally meaningless, vars. I don't *think*
+    // that would cause any problems...)
+    struct AutoVar {
+        name: String,
+        val: Option<OsString>,
+    }
+    impl AutoVar {
+        fn new(name: impl Into<String>) -> Self {
+            let name = name.into();
+            let val = std::env::var_os(&name);
+            Self { name, val }
+        }
+    }
+    impl Drop for AutoVar {
+        fn drop(&mut self) {
+            force_var(&self.name, self.val.as_ref().map(|v| &**v));
+        }
+    }
+    // like env::set_var, but takes an option and unsets the var on `None`
+    fn force_var<V: AsRef<OsStr>>(name: &str, value: Option<V>) {
+        match value {
+            None => std::env::remove_var(name),
+            Some(v) => std::env::set_var(name, v),
+        }
+    }
+
+    #[test]
+    fn test_env() {
+        #[track_caller]
+        fn testcase(
+            ockam_bt: Option<&'static str>,
+            rust_lib_bt: Option<&'static str>,
+            rust_bt: Option<&'static str>,
+            want: bool,
+        ) {
+            // We avoid the real var names here, and use
+            // `__FAKE_VAR_FOR_TESTS`-suffixed equivalents, to avoid a situation
+            // where an unrelated test running concurrently to this one fails
+            // and doesn't have any backtrace info because it happened during a
+            // period of time where we disabled `RUST_BACKTRACE` or
+            // `RUST_LIB_BACKTRACE` or whatever. This would only be relevant for
+            // unit tests inside `ockam_core`, but would be annoying
+            // nonetheless.
+            //
+            // This also saves us from having to explicitly `drop(guards)`
+            // before the assert at the end of this function -- otherwise we'd
+            // hit this problem here.
+            let _guards = [
+                AutoVar::new("OCKAM_BACKTRACE__FAKE_VAR_FOR_TESTS"),
+                AutoVar::new("RUST_LIB_BACKTRACE__FAKE_VAR_FOR_TESTS"),
+                AutoVar::new("RUST_BACKTRACE__FAKE_VAR_FOR_TESTS"),
+            ];
+            force_var("OCKAM_BACKTRACE__FAKE_VAR_FOR_TESTS", ockam_bt);
+            force_var("RUST_LIB_BACKTRACE__FAKE_VAR_FOR_TESTS", rust_lib_bt);
+            force_var("RUST_BACKTRACE__FAKE_VAR_FOR_TESTS", rust_bt);
+            let got = check_env_vars(&[
+                "OCKAM_BACKTRACE__FAKE_VAR_FOR_TESTS",
+                "RUST_LIB_BACKTRACE__FAKE_VAR_FOR_TESTS",
+                "RUST_BACKTRACE__FAKE_VAR_FOR_TESTS",
+            ]);
+            assert_eq!(
+                got.unwrap_or(false),
+                want,
+                "ockam: {:?}, rust_lib: {:?}, rust: {:?}, interpreted as {:?}",
+                ockam_bt,
+                rust_lib_bt,
+                rust_bt,
+                got,
+            );
+        }
+        testcase(None, None, None, false);
+        for filler in [None, Some(""), Some("1"), Some("0")] {
+            testcase(Some(""), filler, filler, true);
+            testcase(None, Some(""), filler, true);
+            testcase(None, None, Some(""), true);
+            testcase(Some("0"), filler, filler, false);
+            testcase(None, Some("0"), filler, false);
+            testcase(None, None, Some("0"), false);
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/error/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/mod.rs
@@ -1,0 +1,113 @@
+//! Error and Result types
+#![allow(missing_docs, dead_code)] // FIXME DONOTLAND
+use crate::compat::{boxed::Box, error::Error as ErrorTrait};
+use serde::{Deserialize, Serialize};
+
+pub mod code;
+mod inner;
+
+// We box the internal error type if an allocator is available — this is (often
+// significantly) more efficient in the success path.
+#[cfg(feature = "alloc")]
+type ErrorData = Box<inner::ErrorData>;
+// When an allocator is not available, we represent the internal error inline.
+// It should be smaller in this configuration, which avoids much of the cost.
+#[cfg(not(feature = "alloc"))]
+type ErrorData = Inner;
+
+/// The type of errors returned by Ockam functions.
+///
+/// Errors store:
+///
+/// - A set of [error codes](`codes::Code`), which abstractly describe the
+///   problem and allow easily matching against specific categories of error.
+/// - An open-ended payload, to which arbitrary data can be attached.
+/// - The "cause", of this error, if it has not been lost to serialization.
+/// - Various debugging information, such as a backtrace and spantrace (which is
+///   lost over serialization).
+#[derive(Serialize, Deserialize)]
+pub struct Error2(ErrorData);
+impl Error2 {
+    /// Construct a new error given ErrorCodes and a cause.
+    #[cold]
+    #[track_caller]
+    pub fn new<E>(code: code::ErrorCode, cause: E) -> Self
+    where
+        E: Into<Box<dyn crate::compat::error::Error + Send + Sync>>,
+    {
+        Self(inner::ErrorData::new(code, cause).into())
+    }
+
+    /// Construct a new error with "unknown" error codes.
+    ///
+    /// This ideally should not be used inside Ockam.
+    #[cold]
+    pub fn new_unknown<E>(cause: E) -> Self
+    where
+        E: Into<Box<dyn crate::compat::error::Error + Send + Sync>>,
+    {
+        Self::new(code::ErrorCode::unknown(), cause)
+    }
+
+    /// Return the [codes](`codes::ErrorCodes`) that identify this error.
+    pub fn code(&self) -> code::ErrorCode {
+        self.0.code
+    }
+
+    /// Attach additional unstructured informaton to the error.
+    #[must_use]
+    pub fn context(mut self, key: &str, val: impl core::fmt::Display) -> Self {
+        self.0.add_context(key, &val);
+        self
+    }
+}
+
+impl From<crate::old_error::Error> for Error2 {
+    #[cold]
+    #[track_caller]
+    fn from(src: crate::old_error::Error) -> Self {
+        let origin = match src.domain() {
+            o if o.starts_with("OCKAM_NODE") => code::Origin::Node,
+            o if o.starts_with("OCKAM_EXECUTOR") => code::Origin::Executor,
+            o if o.starts_with("OCKAM_TRANSPORT") => code::Origin::Transport,
+            o if o.starts_with("OCKAM_KEX") => code::Origin::KeyExchange,
+            o if o.starts_with("OCKAM_ENTITY")
+                || o.starts_with("OCKAM_IDENTITY")
+                || o.starts_with("OCKAM_CREDENTIAL") =>
+            {
+                code::Origin::Identity
+            }
+            o if o.starts_with("OCKAM_VAULT") => code::Origin::Vault,
+            o if o.starts_with("OCKAM_FFI") => code::Origin::Api,
+            o if o.starts_with("OCKAM") => code::Origin::Other,
+            _ => code::Origin::Unknown,
+        };
+        let kind = code::Kind::Unknown;
+        let ec = code::ErrorCode::new_with_extra(origin, kind, src.code() as i32);
+        let orig_domain = src.domain().clone();
+        Error2::new(ec, src).context("domain", orig_domain)
+    }
+}
+
+impl core::fmt::Debug for Error2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl core::fmt::Display for Error2 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl ErrorTrait for Error2 {
+    fn source(&self) -> Option<&(dyn ErrorTrait + 'static)> {
+        if let Some(e) = self.0.cause() {
+            let force_coersion: &(dyn ErrorTrait + 'static) = e;
+            Some(force_coersion)
+        } else {
+            None
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -25,6 +25,10 @@ extern crate core;
 #[macro_use]
 extern crate alloc;
 
+// Allow use of logging macros directly.
+#[macro_use]
+extern crate tracing;
+
 pub use async_trait::async_trait;
 
 pub extern crate hashbrown;
@@ -45,13 +49,15 @@ extern crate futures_util;
 
 mod access_control;
 pub mod compat;
-mod error;
+pub mod error;
 mod message;
 mod processor;
 mod routing;
 mod uint;
 pub mod vault;
 mod worker;
+
+mod old_error;
 
 pub use access_control::*;
 pub use error::*;
@@ -61,6 +67,8 @@ pub use routing::*;
 pub use traits::*;
 pub use uint::*;
 pub use worker::*;
+
+pub use old_error::*;
 
 #[cfg(feature = "std")]
 pub use std::println;
@@ -79,7 +87,7 @@ pub mod println_no_std {
 /// Module for custom implementation of standard traits.
 pub mod traits {
     use crate::compat::boxed::Box;
-    use crate::error::Result;
+    use crate::Result;
 
     /// Clone trait for async structs.
     #[async_trait]

--- a/implementations/rust/ockam/ockam_core/src/old_error.rs
+++ b/implementations/rust/ockam/ockam_core/src/old_error.rs
@@ -1,4 +1,6 @@
-//! Error and Result types
+//! Legacy Error and Result types.
+//!
+//! Over time we will be migrating away from this.
 
 use crate::compat::string::String;
 use core::fmt::{self, Display, Formatter};


### PR DESCRIPTION
This introduces the new error handling type, which has been mercilessly ripped out from the other branch I was working on, but is a lot less of a "rewrite the world" kind of change, and something we can migrate to. For example, this doesn't migrate us to it at all. That's something we'll do as we clean up some of the code.

There are a couple pieces that aren't *quite* finished, such as backtrace/spantrace handling (for one, do we want/need both of these?), and I suspect the things I'm doing here are... suboptimal on embedded. I'll write down a concrete list after the demo meeting, but I don't think anything is a deal-breaker quite yet (unless no_std is broken, which should be an easy fix).

Anyway, there's quite a bit of documentation in the comments, so see that for more details!