### PR TITLE
remove cargo deny installation in `CI`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,5 @@ unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2020-0159",
-    "RUSTSEC-2022-0008"
+    "RUSTSEC-2020-0159"
 ]

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -42,7 +42,6 @@ task lint_cargo_clippy {
 
 task lint_cargo_deny {
   doLast {
-    exec { commandLine cargo('install', '--locked', '--version', '0.11.0', 'cargo-deny') }
     exec { commandLine cargo('deny', '--all-features', '--manifest-path=../../Cargo.toml', 'check', 'licenses', 'advisories') }
   }
 }


### PR DESCRIPTION
Remove cargo deny installation from CI
Remove RUSTSEC-2022-0008 ignore from deny config closes https://github.com/ockam-network/ockam/issues/2540