### PR TITLE
chore(rust): remove infallible conversions from string to address

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end-to-end protected channels over multi-hop, multi-protocol transport routes:
 // examples/hello.rs
 use ockam::{
     identity::{Identity, TrustEveryonePolicy},
-    route,
+    try_route,
     vault::Vault,
     Context, Result,
 };
@@ -108,7 +108,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     //
     // This message will automatically get encrypted when it enters the channel
     // and decrypted just before it exits the channel.
-    ctx.send(route![channel, "app"], "Hello Ockam!".to_string()).await?;
+    ctx.send(try_route![channel, "app"]?, "Hello Ockam!".to_string())
+        .await?;
 
     // Wait to receive a message for the "app" worker and print it.
     let message = ctx.receive::<String>().await?;

--- a/documentation/guides/rust/get-started/04-transport/README.md
+++ b/documentation/guides/rust/get-started/04-transport/README.md
@@ -62,7 +62,7 @@ Add the following code to this file:
 // examples/04-routing-over-transport-initiator.rs
 // This node routes a message, to a worker on a different node, over the tcp transport.
 
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -70,7 +70,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over a tcp transport.
-    let r = route![(TCP, "localhost:4000"), "echoer"];
+    let r = try_route![(TCP, "localhost:4000"), "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.
@@ -185,7 +185,7 @@ Add the following code to this file:
 // examples/04-routing-over-transport-two-hops-initiator.rs
 // This node routes a message, to a worker on a different node, over two tcp transport hops.
 
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -193,7 +193,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over two tcp hops.
-    let r = route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"];
+    let r = try_route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/documentation/guides/rust/get-started/05-secure-channel/README.md
+++ b/documentation/guides/rust/get-started/05-secure-channel/README.md
@@ -117,7 +117,7 @@ Add the following code to this file:
 // It then routes a message, to a worker on a different node, through this encrypted channel.
 
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -131,11 +131,12 @@ async fn main(mut ctx: Context) -> Result<()> {
     let alice = Identity::create(&ctx, &vault).await?;
 
     // Connect to a secure channel listener and perform a handshake.
-    let r = route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "bob_listener"];
+    let r = try_route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "bob_listener"]?;
     let channel = alice.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // Send a message to the echoer worker via the channel.
-    ctx.send(route![channel, "echoer"], "Hello Ockam!".to_string()).await?;
+    ctx.send(try_route![channel, "echoer"]?, "Hello Ockam!".to_string())
+        .await?;
 
     // Wait to receive a reply and print it.
     let reply = ctx.receive::<String>().await?;

--- a/documentation/guides/rust/get-started/09-streams/README.md
+++ b/documentation/guides/rust/get-started/09-streams/README.md
@@ -77,10 +77,10 @@ For example:
 ```rust
 // Send a message
 ctx.send(
-    route![
+    try_route![
         sender.clone(), // via the "initiator-to-responder" stream
         "echoer"        // to the "echoer" worker
-    ],
+    ]?,
     "Hello World!".to_string()
 )
 .await?;
@@ -166,7 +166,7 @@ Add the following code to this file:
 
 ```rust
 // examples/09-streams-initiator.rs
-use ockam::{route, stream::Stream, Context, Result, TcpTransport, TCP};
+use ockam::{route, stream::Stream, try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -190,10 +190,10 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Send a message
     ctx.send(
-        route![
+        try_route![
             sender.clone(), // via the "initiator-to-responder" stream
             "echoer"        // to the "echoer" worker
-        ],
+        ]?,
         "Hello World!".to_string(),
     )
     .await?;

--- a/documentation/guides/rust/get-started/10-secure-channel-via-streams/README.md
+++ b/documentation/guides/rust/get-started/10-secure-channel-via-streams/README.md
@@ -92,7 +92,9 @@ Add the following code to this file:
 
 ```rust
 // examples/10-secure-channel-via-streams-initiator.rs
-use ockam::{channel::SecureChannel, route, stream::Stream, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{
+    channel::SecureChannel, route, stream::Stream, try_route, vault::Vault, Context, Result, TcpTransport, TCP,
+};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -120,20 +122,20 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create a secure channel
     let secure_channel = SecureChannel::create(
         &ctx,
-        route![
+        try_route![
             sender.clone(),            // via the "sc-initiator-to-responder" stream
             "secure_channel_listener"  // to the "secure_channel_listener" listener
-        ],
+        ]?,
         &vault,
     )
     .await?;
 
     // Send a message
     ctx.send(
-        route![
+        try_route![
             secure_channel.address(), // via the secure channel
             "echoer"                  // to the "echoer" worker
-        ],
+        ]?,
         "Hello World!".to_string(),
     )
     .await?;

--- a/documentation/use-cases/end-to-end-encryption-with-rust/README.md
+++ b/documentation/use-cases/end-to-end-encryption-with-rust/README.md
@@ -182,7 +182,7 @@ Create a file at `examples/alice.rs` and copy the below code snippet to it.
 ```rust
 // examples/alice.rs
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, TcpTransport, TCP};
 use std::io;
 
 #[ockam::node]
@@ -207,7 +207,7 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Combine the tcp address of the node and the forwarding_address to get a route
     // to Bob's secure channel listener.
-    let route_to_bob_listener = route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"];
+    let route_to_bob_listener = try_route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"]?;
 
     // As Alice, connect to Bob's secure channel listener, and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.
@@ -225,7 +225,8 @@ async fn main(mut ctx: Context) -> Result<()> {
         let message = message.trim();
 
         // Send the provided message, through the channel, to Bob's echoer.
-        ctx.send(route![channel.clone(), "echoer"], message.to_string()).await?;
+        ctx.send(try_route![channel.clone(), "echoer"]?, message.to_string())
+            .await?;
 
         // Wait to receive an echo and print it.
         let reply = ctx.receive::<String>().await?;

--- a/documentation/use-cases/secure-remote-access-tunnels/README.md
+++ b/documentation/use-cases/secure-remote-access-tunnels/README.md
@@ -88,7 +88,7 @@ Create a file at `examples/01-inlet-outlet.rs` and copy the below code snippet t
 
 ```rust
 // examples/01-inlet-outlet.rs
-use ockam::{route, Context, Result, TcpTransport};
+use ockam::{try_route, Context, Result, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -129,7 +129,7 @@ async fn main(ctx: Context) -> Result<()> {
     //    and send it as raw TCP data to a connected TCP client.
 
     let inlet_address = std::env::args().nth(1).expect("no inlet address given");
-    tcp.create_inlet(inlet_address, route!["outlet"]).await?;
+    tcp.create_inlet(inlet_address, try_route!["outlet"]?).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.
@@ -218,7 +218,7 @@ Create a file at `examples/02-inlet.rs` and copy the below code snippet to it.
 
 ```rust
 // examples/02-inlet.rs
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -228,7 +228,7 @@ async fn main(ctx: Context) -> Result<()> {
     // We know the network address of the node with an Outlet, we also know that the Outlet is
     // running at Ockam Worker address "outlet" on that node.
 
-    let route_to_outlet = route![(TCP, "127.0.0.1:4000"), "outlet"];
+    let route_to_outlet = try_route![(TCP, "127.0.0.1:4000"), "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001
@@ -356,7 +356,7 @@ Create a file at `examples/03-inlet.rs` and copy the below code snippet to it.
 ```rust
 // examples/03-inlet.rs
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -373,13 +373,13 @@ async fn main(ctx: Context) -> Result<()> {
 
     let vault = Vault::create();
     let e = Identity::create(&ctx, &vault).await?;
-    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"];
+    let r = try_route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"]?;
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
     // we also now that Outlet lives at "outlet" address at that node.
 
-    let route_to_outlet = route![channel, "outlet"];
+    let route_to_outlet = try_route![channel, "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001
@@ -510,7 +510,7 @@ async fn main(ctx: Context) -> Result<()> {
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address in Hub is:");
-    println!("{}", forwarder.remote_address());
+    println!("{:?}", forwarder.remote_address());
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.
@@ -524,7 +524,7 @@ Create a file at `examples/04-inlet.rs` and copy the below code snippet to it.
 ```rust
 // examples/04-inlet.rs
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, Route, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, Route, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -543,16 +543,16 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Expect second command line argument to be the Outlet node forwarder address
     let forwarding_address = std::env::args().nth(2).expect("no outlet forwarding address given");
-    let r = route![
+    let r = try_route![
         (TCP, "1.node.ockam.network:4000"),
         forwarding_address,
         "secure_channel_listener"
-    ];
+    ]?;
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
     // we also now that Outlet lives at "outlet" address at that node.
-    let route_to_outlet: Route = route![channel, "outlet"];
+    let route_to_outlet: Route = try_route![channel, "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/file_transfer/examples/receiver.rs
+++ b/examples/rust/file_transfer/examples/receiver.rs
@@ -118,7 +118,7 @@ async fn main(ctx: Context) -> Result<()> {
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Receiver is:");
-    println!("{}", forwarder.remote_address());
+    println!("{:?}", forwarder.remote_address());
 
     // Start a worker, of type FileReception, at address "receiver".
     ctx.start_worker("receiver", FileReception::default()).await?;

--- a/examples/rust/file_transfer/examples/sender.rs
+++ b/examples/rust/file_transfer/examples/sender.rs
@@ -3,7 +3,7 @@
 use file_transfer::{FileData, FileDescription};
 use ockam::{
     identity::{Identity, TrustEveryonePolicy},
-    route,
+    try_route,
     vault::Vault,
     Context,
 };
@@ -53,7 +53,7 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Combine the tcp address of the node and the forwarding_address to get a route
     // to Receiver's secure channel listener.
-    let route_to_receiver_listener = route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"];
+    let route_to_receiver_listener = try_route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"]?;
 
     // As Sender, connect to the Receiver's secure channel listener, and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Receiver.
@@ -79,7 +79,7 @@ async fn main(ctx: Context) -> Result<()> {
         size: metadata.len() as usize,
     });
 
-    ctx.send(route![channel.clone(), "receiver"], descr).await?;
+    ctx.send(try_route![channel.clone(), "receiver"]?, descr).await?;
 
     let mut buffer = vec![0u8; opt.chunk_size];
     loop {
@@ -88,7 +88,7 @@ async fn main(ctx: Context) -> Result<()> {
                 break;
             }
             let data = FileData::Data(buffer[..count].to_vec());
-            ctx.send(route![channel.clone(), "receiver"], data).await?;
+            ctx.send(try_route![channel.clone(), "receiver"]?, data).await?;
         }
     }
 

--- a/examples/rust/get_started/examples/03-routing-many-hops.rs
+++ b/examples/rust/get_started/examples/03-routing-many-hops.rs
@@ -1,7 +1,7 @@
 // This node routes a message through many hops.
 
 use hello_ockam::{Echoer, Hop};
-use ockam::{route, Context, Result};
+use ockam::{try_route, Context, Result};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -14,7 +14,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     ctx.start_worker("h3", Hop).await?;
 
     // Send a message to the echoer worker via the "h1", "h2", and "h3" workers
-    let r = route!["h1", "h2", "h3", "echoer"];
+    let r = try_route!["h1", "h2", "h3", "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/examples/rust/get_started/examples/03-routing.rs
+++ b/examples/rust/get_started/examples/03-routing.rs
@@ -1,7 +1,7 @@
 // This node routes a message.
 
 use hello_ockam::{Echoer, Hop};
-use ockam::{route, Context, Result};
+use ockam::{try_route, Context, Result};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -13,7 +13,8 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Send a message to the worker at address "echoer",
     // via the worker at address "h1"
-    ctx.send(route!["h1", "echoer"], "Hello Ockam!".to_string()).await?;
+    ctx.send(try_route!["h1", "echoer"]?, "Hello Ockam!".to_string())
+        .await?;
 
     // Wait to receive a reply and print it.
     let reply = ctx.receive::<String>().await?;

--- a/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
@@ -1,6 +1,6 @@
 // This node routes a message, to a worker on a different node, over the tcp transport.
 
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -8,7 +8,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over a tcp transport.
-    let r = route![(TCP, "localhost:4000"), "echoer"];
+    let r = try_route![(TCP, "localhost:4000"), "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
@@ -1,6 +1,6 @@
 // This node routes a message, to a worker on a different node, over two tcp transport hops.
 
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -8,7 +8,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over two tcp hops.
-    let r = route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"];
+    let r = try_route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/examples/rust/get_started/examples/09-streams-initiator.rs
+++ b/examples/rust/get_started/examples/09-streams-initiator.rs
@@ -1,4 +1,4 @@
-use ockam::{route, stream::Stream, Context, Result, TcpTransport, TCP};
+use ockam::{route, stream::Stream, try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -22,10 +22,10 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Send a message
     ctx.send(
-        route![
+        try_route![
             sender.clone(), // via the "initiator-to-responder" stream
             "echoer"        // to the "echoer" worker
-        ],
+        ]?,
         "Hello World!".to_string(),
     )
     .await?;

--- a/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
+++ b/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
@@ -1,4 +1,6 @@
-use ockam::{channel::SecureChannel, route, stream::Stream, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{
+    channel::SecureChannel, route, stream::Stream, try_route, vault::Vault, Context, Result, TcpTransport, TCP,
+};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -26,20 +28,20 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create a secure channel
     let secure_channel = SecureChannel::create(
         &ctx,
-        route![
+        try_route![
             sender.clone(),            // via the "sc-initiator-to-responder" stream
             "secure_channel_listener"  // to the "secure_channel_listener" listener
-        ],
+        ]?,
         &vault,
     )
     .await?;
 
     // Send a message
     ctx.send(
-        route![
+        try_route![
             secure_channel.address(), // via the secure channel
             "echoer"                  // to the "echoer" worker
-        ],
+        ]?,
         "Hello World!".to_string(),
     )
     .await?;

--- a/examples/rust/get_started/examples/alice.rs
+++ b/examples/rust/get_started/examples/alice.rs
@@ -1,5 +1,5 @@
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, TcpTransport, TCP};
 use std::io;
 
 #[ockam::node]
@@ -24,7 +24,7 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Combine the tcp address of the node and the forwarding_address to get a route
     // to Bob's secure channel listener.
-    let route_to_bob_listener = route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"];
+    let route_to_bob_listener = try_route![(TCP, "1.node.ockam.network:4000"), forwarding_address, "listener"]?;
 
     // As Alice, connect to Bob's secure channel listener, and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.
@@ -42,7 +42,8 @@ async fn main(mut ctx: Context) -> Result<()> {
         let message = message.trim();
 
         // Send the provided message, through the channel, to Bob's echoer.
-        ctx.send(route![channel.clone(), "echoer"], message.to_string()).await?;
+        ctx.send(try_route![channel.clone(), "echoer"]?, message.to_string())
+            .await?;
 
         // Wait to receive an echo and print it.
         let reply = ctx.receive::<String>().await?;

--- a/examples/rust/get_started/examples/bob.rs
+++ b/examples/rust/get_started/examples/bob.rs
@@ -12,7 +12,7 @@ impl Worker for Echoer {
     type Message = String;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        println!("\n[✓] Address: {}, Received: {}", ctx.address(), msg);
+        println!("\n[✓] Address: {:?}, Received: {}", ctx.address(), msg);
 
         // Echo the message body back on its return_route.
         ctx.send(msg.return_route(), msg.body()).await
@@ -48,7 +48,7 @@ async fn main(ctx: Context) -> Result<()> {
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Bob is:");
-    println!("{}", forwarder.remote_address());
+    println!("{:?}", forwarder.remote_address());
 
     // Start a worker, of type Echoer, at address "echoer".
     // This worker will echo back every message it receives, along its return route.

--- a/examples/rust/get_started/examples/hello.rs
+++ b/examples/rust/get_started/examples/hello.rs
@@ -1,6 +1,6 @@
 use ockam::{
     identity::{Identity, TrustEveryonePolicy},
-    route,
+    try_route,
     vault::Vault,
     Context, Result,
 };
@@ -29,7 +29,8 @@ async fn main(mut ctx: Context) -> Result<()> {
     //
     // This message will automatically get encrypted when it enters the channel
     // and decrypted just before it exits the channel.
-    ctx.send(route![channel, "app"], "Hello Ockam!".to_string()).await?;
+    ctx.send(try_route![channel, "app"]?, "Hello Ockam!".to_string())
+        .await?;
 
     // Wait to receive a message for the "app" worker and print it.
     let message = ctx.receive::<String>().await?;

--- a/examples/rust/get_started/src/echoer.rs
+++ b/examples/rust/get_started/src/echoer.rs
@@ -8,7 +8,7 @@ impl Worker for Echoer {
     type Message = String;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        println!("Address: {}, Received: {}", ctx.address(), msg);
+        println!("Address: {:?}, Received: {}", ctx.address(), msg);
 
         // Echo the message body back on its return_route.
         ctx.send(msg.return_route(), msg.body()).await

--- a/examples/rust/get_started/src/hop.rs
+++ b/examples/rust/get_started/src/hop.rs
@@ -10,7 +10,7 @@ impl Worker for Hop {
     /// This handle function takes any incoming message and forwards
     /// it to the next hop in it's onward route
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
-        println!("Address: {}, Received: {}", ctx.address(), msg);
+        println!("Address: {:?}, Received: {}", ctx.address(), msg);
 
         // Some type conversion
         let mut message = msg.into_local_message();

--- a/examples/rust/get_started/src/logger.rs
+++ b/examples/rust/get_started/src/logger.rs
@@ -19,9 +19,13 @@ impl Worker for Logger {
         let payload = transport_msg.payload.clone();
 
         if let Ok(str) = String::from_utf8(payload.clone()) {
-            println!("Address: {}, Received string: {}", ctx.address(), str);
+            println!("Address: {:?}, Received string: {}", ctx.address(), str);
         } else {
-            println!("Address: {}, Received binary: {}", ctx.address(), hex::encode(&payload));
+            println!(
+                "Address: {:?}, Received binary: {}",
+                ctx.address(),
+                hex::encode(&payload)
+            );
         }
 
         ctx.forward(local_msg).await

--- a/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
+++ b/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
@@ -15,7 +15,7 @@ impl Worker for Echoer {
     type Message = String;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        println!("\n[✓] Address: {}, Received: {}", ctx.address(), msg);
+        println!("\n[✓] Address: {:?}, Received: {}", ctx.address(), msg);
 
         // Echo the message body back on its return_route.
         ctx.send(msg.return_route(), msg.body()).await

--- a/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
@@ -1,4 +1,4 @@
-use ockam::{route, Context, Result, TcpTransport};
+use ockam::{try_route, Context, Result, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -39,7 +39,7 @@ async fn main(ctx: Context) -> Result<()> {
     //    and send it as raw TCP data to a connected TCP client.
 
     let inlet_address = std::env::args().nth(1).expect("no inlet address given");
-    tcp.create_inlet(inlet_address, route!["outlet"]).await?;
+    tcp.create_inlet(inlet_address, try_route!["outlet"]?).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
@@ -1,4 +1,4 @@
-use ockam::{route, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -8,7 +8,7 @@ async fn main(ctx: Context) -> Result<()> {
     // We know the network address of the node with an Outlet, we also know that the Outlet is
     // running at Ockam Worker address "outlet" on that node.
 
-    let route_to_outlet = route![(TCP, "127.0.0.1:4000"), "outlet"];
+    let route_to_outlet = try_route![(TCP, "127.0.0.1:4000"), "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
@@ -1,5 +1,5 @@
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -16,13 +16,13 @@ async fn main(ctx: Context) -> Result<()> {
 
     let vault = Vault::create();
     let e = Identity::create(&ctx, &vault).await?;
-    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"];
+    let r = try_route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"]?;
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
     // we also now that Outlet lives at "outlet" address at that node.
 
-    let route_to_outlet = route![channel, "outlet"];
+    let route_to_outlet = try_route![channel, "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
@@ -1,5 +1,5 @@
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, Route, TcpTransport, TCP};
+use ockam::{try_route, vault::Vault, Context, Result, Route, TcpTransport, TCP};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -18,16 +18,16 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Expect second command line argument to be the Outlet node forwarder address
     let forwarding_address = std::env::args().nth(2).expect("no outlet forwarding address given");
-    let r = route![
+    let r = try_route![
         (TCP, "1.node.ockam.network:4000"),
         forwarding_address,
         "secure_channel_listener"
-    ];
+    ]?;
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
     // we also now that Outlet lives at "outlet" address at that node.
-    let route_to_outlet: Route = route![channel, "outlet"];
+    let route_to_outlet: Route = try_route![channel, "outlet"]?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -44,7 +44,7 @@ async fn main(ctx: Context) -> Result<()> {
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address in Hub is:");
-    println!("{}", forwarder.remote_address());
+    println!("{:?}", forwarder.remote_address());
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/implementations/rust/ockam/ockam/src/channel/tests.rs
+++ b/implementations/rust/ockam/ockam/src/channel/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     pipe::{ReceiverConfirm, ReceiverOrdering, SenderConfirm},
     Context,
 };
-use ockam_core::Result;
+use ockam_core::{try_route, Result};
 
 #[crate::test]
 async fn simple_channel(ctx: &mut Context) -> Result<()> {
@@ -17,11 +17,11 @@ async fn simple_channel(ctx: &mut Context) -> Result<()> {
 
     // Create a channel via the listener.  We re-use the
     // ChannelBuilder here but could also use a new one
-    let ch = builder.connect(vec!["my-channel-listener"]).await?;
+    let ch = builder.connect(try_route!["my-channel-listener"]?).await?;
 
     // Send a message through the channel
     let msg = "Hello through the channel!".to_string();
-    ctx.send(ch.tx().append("app"), msg.clone()).await?;
+    ctx.send(ch.tx().try_append("app")?, msg.clone()).await?;
 
     // Then wait for the message through the channel
     let recv = ctx.receive().await?;
@@ -46,11 +46,11 @@ async fn reliable_channel(ctx: &mut Context) -> Result<()> {
 
     // Create a channel via the listener.  We re-use the
     // ChannelBuilder here but could also use a new one
-    let ch = builder.connect(vec!["my-channel-listener"]).await?;
+    let ch = builder.connect(try_route!["my-channel-listener"]?).await?;
 
     // Send a message through the channel
     let msg = "Hello through the channel!".to_string();
-    ctx.send(ch.tx().append("app"), msg.clone()).await?;
+    ctx.send(ch.tx().try_append("app")?, msg.clone()).await?;
 
     // Then wait for the message through the channel
     let recv = ctx.receive().await?;

--- a/implementations/rust/ockam/ockam/src/channel/worker.rs
+++ b/implementations/rust/ockam/ockam/src/channel/worker.rs
@@ -109,7 +109,7 @@ impl Worker for ChannelWorker {
         ctx.set_cluster(CLUSTER_NAME).await?;
 
         debug!(
-            "Initialise ChannelWorker (pub: {}, int: {})",
+            "Initialise ChannelWorker (pub: {:?}, int: {:?})",
             self.self_addrs.0, self.self_addrs.1
         );
 
@@ -124,7 +124,10 @@ impl Worker for ChannelWorker {
     }
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
-        trace!("Channel receiving message to address '{}'", msg.msg_addr());
+        trace!(
+            "Channel receiving message to address '{:?}'",
+            msg.msg_addr()
+        );
         self.handle_external(ctx, msg).await
     }
 }
@@ -142,7 +145,7 @@ impl ChannelWorker {
     /// buffer.
     async fn init_stage1(&mut self, ctx: &mut Context) -> Result<()> {
         debug!(
-            "Stage 1 channel init: Sender '{}' and Receiver '{}' pipes",
+            "Stage 1 channel init: Sender '{:?}' and Receiver '{:?}' pipes",
             self.tx_addr, self.rx_addr
         );
 
@@ -169,7 +172,7 @@ impl ChannelWorker {
         // which the peer channel worker will associate with this
         // worker.  That way we can distinguish between messages sent
         // to us by users, and messages sent to us by the PipeReceiver
-        debug!("{}: Initiating channel creation handshake", ctx.address());
+        debug!("{:?}: Initiating channel creation handshake", ctx.address());
         ctx.send_from_address(
             self.listener.clone().unwrap(),
             ChannelCreationHandshake {
@@ -196,7 +199,7 @@ impl ChannelWorker {
     /// No further initialisation is needed past this point
     async fn init_stage2(&mut self, ctx: &mut Context) -> Result<()> {
         debug!(
-            "Stage 2 channel init: Sender '{}' and Receiver '{}' pipes",
+            "Stage 2 channel init: Sender '{:?}' and Receiver '{:?}' pipes",
             self.tx_addr, self.rx_addr
         );
 
@@ -262,7 +265,7 @@ impl ChannelWorker {
                     .modify()
                     .prepend(self.self_addrs.0.clone());
             }
-            addr => warn!("Received invalid message to address {}", addr),
+            addr => warn!("Received invalid message to address {:?}", addr),
         }
 
         // Forward message

--- a/implementations/rust/ockam/ockam/src/delay.rs
+++ b/implementations/rust/ockam/ockam/src/delay.rs
@@ -15,7 +15,7 @@ impl<M: Message> DelayedEvent<M> {
         let child_ctx = ctx.new_context(Address::random_local()).await?;
 
         debug!(
-            "Creating a delayed event with address '{}'",
+            "Creating a delayed event with address '{:?}'",
             child_ctx.address()
         );
 

--- a/implementations/rust/ockam/ockam/src/forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/forwarder.rs
@@ -52,7 +52,7 @@ impl Forwarder {
         forward_route: Route,
         registration_payload: Vec<u8>,
     ) -> Result<()> {
-        info!("Created new alias for {}", forward_route);
+        info!("Created new alias for {:?}", forward_route);
         let address = Address::random_local();
         let forwarder = Self {
             forward_route,
@@ -87,7 +87,7 @@ impl Worker for Forwarder {
         msg: Routed<Self::Message>,
     ) -> Result<()> {
         info!(
-            "Alias forward from {} to {}",
+            "Alias forward from {:?} to {:?}",
             msg.sender(),
             self.forward_route.next().unwrap(),
         );

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -58,8 +58,8 @@ pub mod workers;
 pub use ockam_identity as identity;
 
 pub use ockam_core::{
-    errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage, Message, ProtocolId,
-    Result, Route, Routed, TransportMessage, Worker,
+    errcode, route, try_route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage, Message,
+    ProtocolId, Result, Route, Routed, TransportMessage, Worker,
 };
 
 /// Mark an Ockam Worker implementation.

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/resend.rs
@@ -60,7 +60,7 @@ impl BehaviorHook for SenderConfirm {
             InternalCmd::Resend(Resend { idx }) => match self.on_route.remove(idx) {
                 Some(msg) => {
                     debug!(
-                        "Received message index '{}' timeout: resending to peer {}",
+                        "Received message index '{}' timeout: resending to peer {:?}",
                         idx, peer
                     );
 

--- a/implementations/rust/ockam/ockam/src/pipe/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/tests.rs
@@ -3,19 +3,25 @@ use crate::{
     protocols::pipe::{internal::InternalCmd, PipeMessage},
     Context,
 };
-use ockam_core::{async_trait, Address, Result, Route};
+use ockam_core::{async_trait, try_route, Address, Result, Route};
 
 use super::behavior::ReceiverOrdering;
+
+fn app() -> Address {
+    Address::local("app")
+}
 
 #[crate::test]
 async fn static_simple_pipe(ctx: &mut Context) -> Result<()> {
     receiver(ctx, "pipe-receiver").await?;
-    let tx = connect_static(ctx, vec!["pipe-receiver"]).await?;
+    let tx = connect_static(ctx, try_route!["pipe-receiver"]?).await?;
 
     let sent_msg = String::from("Hello Ockam!");
-    info!("Sending message '{}' through pipe sender {}", sent_msg, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg.clone()).await?;
 
     let msg = ctx.receive().await?;
     info!("App reiceved msg: '{}'", msg);
@@ -29,15 +35,17 @@ async fn static_confirm_pipe(ctx: &mut Context) -> Result<()> {
     receiver_with_behavior(ctx, "pipe-receiver", PipeBehavior::with(ReceiverConfirm)).await?;
     let tx = connect_static_with_behavior(
         ctx,
-        vec!["pipe-receiver"],
+        try_route!["pipe-receiver"]?,
         PipeBehavior::with(SenderConfirm::new()),
     )
     .await?;
 
     let sent_msg = String::from("Hello Ockam!");
-    info!("Sending message '{}' through pipe sender {}", sent_msg, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg.clone()).await?;
 
     let msg = ctx.receive().await?;
     info!("App reiceved msg: '{}'", msg);
@@ -111,15 +119,17 @@ async fn fails_static_confirm_pipe(ctx: &mut Context) -> Result<()> {
     receiver_with_behavior(ctx, "pipe-receiver", DropDelivery).await?;
     let tx = connect_static_with_behavior(
         ctx,
-        vec!["pipe-receiver"],
+        try_route!["pipe-receiver"]?,
         PipeBehavior::with(SenderConfirm::new()).attach(ConfirmTimeout),
     )
     .await?;
 
     let sent_msg = String::from("Hello Ockam!");
-    info!("Sending message '{}' through pipe sender {}", sent_msg, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg.clone()).await?;
 
     let invalid = ctx.receive::<String>().await?;
     warn!("App reiceved msg: '{}'", invalid);
@@ -135,14 +145,18 @@ async fn static_ordering_pipe(ctx: &mut Context) -> Result<()> {
     let tx = connect_static(ctx, "pipe-receiver").await?;
 
     let sent_msg1 = String::from("Message number one");
-    info!("Sending message '{}' through pipe sender {}", sent_msg1, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg1.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg1, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg1.clone()).await?;
 
     let sent_msg2 = String::from("Message number two");
-    info!("Sending message '{}' through pipe sender {}", sent_msg2, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg2.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg2, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg2.clone()).await?;
 
     let msg1 = ctx.receive().await?;
     info!("App reiceved msg: '{}'", msg1);
@@ -173,14 +187,18 @@ async fn static_confirm_ordering_pipe(ctx: &mut Context) -> Result<()> {
     .await?;
 
     let sent_msg1 = String::from("Message number one");
-    info!("Sending message '{}' through pipe sender {}", sent_msg1, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg1.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg1, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg1.clone()).await?;
 
     let sent_msg2 = String::from("Message number two");
-    info!("Sending message '{}' through pipe sender {}", sent_msg2, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg2.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg2, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg2.clone()).await?;
 
     let msg1 = ctx.receive().await?;
     info!("App reiceved msg: '{}'", msg1);
@@ -212,14 +230,18 @@ async fn static_confirm_ordering_pipe_reversed(ctx: &mut Context) -> Result<()> 
     .await?;
 
     let sent_msg1 = String::from("Message number one");
-    info!("Sending message '{}' through pipe sender {}", sent_msg1, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg1.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg1, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg1.clone()).await?;
 
     let sent_msg2 = String::from("Message number two");
-    info!("Sending message '{}' through pipe sender {}", sent_msg2, tx);
-    ctx.send(vec![tx.clone(), "app".into()], sent_msg2.clone())
-        .await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        sent_msg2, tx
+    );
+    ctx.send(vec![tx.clone(), app()], sent_msg2.clone()).await?;
 
     let msg1 = ctx.receive().await?;
     info!("App reiceved msg: '{}'", msg1);
@@ -239,8 +261,11 @@ async fn simple_pipe_handshake(ctx: &mut Context) -> Result<()> {
     let tx = connect_dynamic(ctx, listener.into()).await.unwrap();
 
     let msg_sent = String::from("Message for my best friend");
-    info!("Sending message '{}' through pipe sender {}", msg_sent, tx);
-    ctx.send(vec![tx, "app".into()], msg_sent.clone()).await?;
+    info!(
+        "Sending message '{}' through pipe sender {:?}",
+        msg_sent, tx
+    );
+    ctx.send(vec![tx, app()], msg_sent.clone()).await?;
 
     let msg = ctx.receive().await?;
     info!("App received msg: '{}'", msg);
@@ -266,12 +291,11 @@ async fn layered_pipe(ctx: &mut Context) -> Result<()> {
 
     // Then create the confirm pipe pair
     receiver_with_behavior(ctx, "confirm-receiver", ReceiverOrdering::new()).await?;
-    let confirm_tx = connect_static(ctx, vec![ord_tx.clone(), "confirm-receiver".into()]).await?;
+    let confirm_tx = connect_static(ctx, try_route![ord_tx.clone(), "confirm-receiver"]?).await?;
 
     // Then we can send a message through this concoction
     let msg = "Hello through nested pipes!".to_string();
-    ctx.send(vec![confirm_tx, "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![confirm_tx, app()], msg.clone()).await?;
 
     // Wait for the message to arrive
     let msg_recv = ctx.receive().await?;

--- a/implementations/rust/ockam/ockam/src/pipe2/listener.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/listener.rs
@@ -22,7 +22,7 @@ impl Worker for PipeListener {
         // handshake request.  We probably want to check the metadata
         // in that OckamMessage to make sure.
         debug!(
-            "Receiving pipe creation handshake from {}",
+            "Receiving pipe creation handshake from {:?}",
             msg.return_route()
         );
 

--- a/implementations/rust/ockam/ockam/src/pipe2/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/mod.rs
@@ -65,7 +65,7 @@ enum Mode {
 ///     .await?;
 ///
 /// ctx.send(
-///     vec![result.addr(), "app".into()], // Send a message through the pipe to "app"
+///     vec![result.addr(), "app".try_into()?], // Send a message through the pipe to "app"
 ///     String::from("Hello you on the other end of this pipe!"),
 /// )
 /// .await?;

--- a/implementations/rust/ockam/ockam/src/pipe2/receiver.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/receiver.rs
@@ -20,7 +20,7 @@ impl Worker for PipeReceiver {
         ctx.set_cluster(crate::pipe2::CLUSTER_NAME).await?;
         if self.init_addr.is_some() {
             debug!(
-                "PipeReceiver '{}' waiting for initialisation message",
+                "PipeReceiver '{:?}' waiting for initialisation message",
                 ctx.address()
             );
         }
@@ -29,7 +29,7 @@ impl Worker for PipeReceiver {
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<OckamMessage>) -> Result<()> {
         debug!(
-            "PipeReceiver: received message to address: {}",
+            "PipeReceiver: received message to address: {:?}",
             msg.msg_addr()
         );
 
@@ -68,7 +68,7 @@ impl Worker for PipeReceiver {
                     }
                     Ok(())
                 } else {
-                    trace!("Forwarding message to worker system: {}", addr);
+                    trace!("Forwarding message to worker system: {:?}", addr);
                     self.system.handle_message(ctx, msg).await
                 }
             }

--- a/implementations/rust/ockam/ockam/src/pipe2/sender.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/sender.rs
@@ -30,7 +30,7 @@ impl Worker for PipeSender {
         // If the worker was initialised with a "Listener" peer we
         // subsequently start the handshake to create a pipe receiver
         if let Some(PeerRoute::Listener(ref route, ref addr)) = self.peer {
-            debug!("Sending pipe2 handshake request to listener: {}", route);
+            debug!("Sending pipe2 handshake request to listener: {:?}", route);
             ctx.send_from_address(route.clone(), OckamMessage::new(Any)?, addr.clone())
                 .await?;
         }
@@ -40,7 +40,7 @@ impl Worker for PipeSender {
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
         debug!(
-            "PipeSender '{}': handling incoming message to {}",
+            "PipeSender '{:?}': handling incoming message to {:?}",
             ctx.address(),
             msg.onward_route()
         );
@@ -87,7 +87,7 @@ impl PipeSender {
     /// type and then dispatch it into the worker system.
     async fn handle_api_msg(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
         trace!(
-            "PipeSender '{}' handling initial user message stage...",
+            "PipeSender '{:?}' handling initial user message stage...",
             ctx.address()
         );
 
@@ -119,7 +119,7 @@ impl PipeSender {
     /// and encodings has now been set-up.
     async fn handle_fin_msg(&mut self, ctx: &mut Context, msg: OckamMessage) -> Result<()> {
         trace!(
-            "PipeSender '{}' handling final user message stage...",
+            "PipeSender '{:?}' handling final user message stage...",
             ctx.address()
         );
 

--- a/implementations/rust/ockam/ockam/src/pipe2/tests.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/tests.rs
@@ -1,6 +1,10 @@
 use crate::{pipe2::PipeBuilder, Context};
 use ockam_core::{compat::string::String, Address, Result};
 
+fn app() -> Address {
+    Address::local("app")
+}
+
 #[crate::test]
 async fn very_simple_pipe2(ctx: &mut Context) -> Result<()> {
     info!("Starting the test...");
@@ -11,18 +15,17 @@ async fn very_simple_pipe2(ctx: &mut Context) -> Result<()> {
         .receive(rx_addr.clone())
         .build(ctx)
         .await?;
-    info!("Created receiver pipe: {}", rx.addr());
+    info!("Created receiver pipe: {:?}", rx.addr());
 
     // Connect to a static receiver
     let sender = PipeBuilder::fixed()
         .connect(vec![rx_addr])
         .build(ctx)
         .await?;
-    info!("Created sender pipe: {}", sender.addr());
+    info!("Created sender pipe: {:?}", sender.addr());
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -32,7 +35,7 @@ async fn very_simple_pipe2(ctx: &mut Context) -> Result<()> {
 #[crate::test]
 async fn handshake_pipe(ctx: &mut Context) -> Result<()> {
     let listener = PipeBuilder::dynamic()
-        .receive("my-pipe-listener")
+        .receive(Address::local("my-pipe-listener"))
         .build(ctx)
         .await?;
 
@@ -43,8 +46,7 @@ async fn handshake_pipe(ctx: &mut Context) -> Result<()> {
         .await?;
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -62,7 +64,7 @@ async fn fixed_delivery_pipe(ctx: &mut Context) -> Result<()> {
         .delivery_ack()
         .build(ctx)
         .await?;
-    info!("Created receiver pipe: {}", rx.addr());
+    info!("Created receiver pipe: {:?}", rx.addr());
 
     // Connect to a static receiver
     let sender = PipeBuilder::fixed()
@@ -71,11 +73,10 @@ async fn fixed_delivery_pipe(ctx: &mut Context) -> Result<()> {
         .build(ctx)
         .await?;
 
-    info!("Created sender pipe: {}", sender.addr());
+    info!("Created sender pipe: {:?}", sender.addr());
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -85,7 +86,7 @@ async fn fixed_delivery_pipe(ctx: &mut Context) -> Result<()> {
 #[crate::test]
 async fn dynamic_delivery_pipe(ctx: &mut Context) -> Result<()> {
     let listener = PipeBuilder::dynamic()
-        .receive("my-pipe-listener")
+        .receive(Address::local("my-pipe-listener"))
         .delivery_ack()
         .build(ctx)
         .await?;
@@ -98,8 +99,7 @@ async fn dynamic_delivery_pipe(ctx: &mut Context) -> Result<()> {
         .await?;
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -117,7 +117,7 @@ async fn fixed_ordering_pipe(ctx: &mut Context) -> Result<()> {
         .enforce_ordering()
         .build(ctx)
         .await?;
-    info!("Created receiver pipe: {}", rx.addr());
+    info!("Created receiver pipe: {:?}", rx.addr());
 
     // Connect to a static receiver
     let sender = PipeBuilder::fixed()
@@ -126,11 +126,10 @@ async fn fixed_ordering_pipe(ctx: &mut Context) -> Result<()> {
         .build(ctx)
         .await?;
 
-    info!("Created sender pipe: {}", sender.addr());
+    info!("Created sender pipe: {:?}", sender.addr());
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -148,7 +147,7 @@ async fn fixed_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
         .enforce_ordering()
         .build(ctx)
         .await?;
-    info!("Created receiver pipe: {}", rx.addr());
+    info!("Created receiver pipe: {:?}", rx.addr());
 
     // Connect to a static receiver
     let sender = PipeBuilder::fixed()
@@ -158,11 +157,10 @@ async fn fixed_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
         .build(ctx)
         .await?;
 
-    info!("Created sender pipe: {}", sender.addr());
+    info!("Created sender pipe: {:?}", sender.addr());
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);
@@ -172,7 +170,7 @@ async fn fixed_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
 #[crate::test]
 async fn dynamic_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
     let listener = PipeBuilder::dynamic()
-        .receive("my-pipe-listener")
+        .receive(Address::local("my-pipe-listener"))
         .delivery_ack()
         .enforce_ordering()
         .build(ctx)
@@ -187,8 +185,7 @@ async fn dynamic_delivery_and_ordering_pipe(ctx: &mut Context) -> Result<()> {
         .await?;
 
     let msg = String::from("Hello through the pipe");
-    ctx.send(vec![sender.addr(), "app".into()], msg.clone())
-        .await?;
+    ctx.send(vec![sender.addr(), app()], msg.clone()).await?;
 
     let msg2 = ctx.receive::<String>().await?;
     assert_eq!(msg, *msg2);

--- a/implementations/rust/ockam/ockam/src/stream/consumer.rs
+++ b/implementations/rust/ockam/ockam/src/stream/consumer.rs
@@ -45,7 +45,7 @@ async fn handle_response(
     match response {
         Response::Init(InitResponse { stream_name }) => {
             info!(
-                "Initialised consumer for stream '{}' and route: {}",
+                "Initialised consumer for stream '{}' and route: {:?}",
                 stream_name, return_route
             );
 
@@ -101,7 +101,7 @@ async fn handle_response(
                 // Either forward to the next hop, or to the consumer address
                 let res = match trans.onward_route.next() {
                     Ok(addr) => {
-                        info!("Forwarding {} message to addr: {}", w.receiver_name, addr);
+                        info!("Forwarding {} message to addr: {:?}", w.receiver_name, addr);
                         let local_msg = LocalMessage::new(trans, Vec::new());
                         ctx.forward(local_msg).await
                     }
@@ -191,7 +191,7 @@ impl Worker for StreamConsumer {
     /// This involves sending a CreateStreamRequest to the peer and
     /// waiting for a reply.
     async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
-        info!("Initialising stream consumer {}", ctx.address());
+        info!("Initialising stream consumer {:?}", ctx.address());
 
         // Send a create_stream_request with the registered name
         ctx.send(
@@ -215,7 +215,7 @@ impl Worker for StreamConsumer {
             handle_cmd(self, ctx, msg, cmd).await?;
         } else {
             warn!(
-                "Unhandled message for consumer {}: {:?}", // TODO: attempt to get protocol ID
+                "Unhandled message for consumer {:?}: {:?}", // TODO: attempt to get protocol ID
                 ctx.address(),
                 msg.body()
             );
@@ -235,8 +235,8 @@ impl StreamConsumer {
         interval: Duration,
         _forwarding_address: Option<Address>, // TODO implement forwarding
         receiver_rx: Address,
-        stream_service: String,
-        index_service: String,
+        stream_service: Address,
+        index_service: Address,
     ) -> Self {
         Self {
             client_id,

--- a/implementations/rust/ockam/ockam/src/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/stream/mod.rs
@@ -199,8 +199,8 @@ impl Stream {
                     self.interval,
                     self.forwarding_address.clone(),
                     receiver_rx.clone(),
-                    self.stream_service.clone(),
-                    self.index_service.clone(),
+                    self.stream_service.clone().try_into()?,
+                    self.index_service.clone().try_into()?,
                 ),
             )
             .await?;

--- a/implementations/rust/ockam/ockam/src/stream/producer.rs
+++ b/implementations/rust/ockam/ockam/src/stream/producer.rs
@@ -38,7 +38,7 @@ async fn handle_response(
             w.init = true;
 
             info!(
-                "Initialised producer for stream '{}' and route: {}",
+                "Initialised producer for stream '{}' and route: {:?}",
                 stream_name, w.route
             );
 
@@ -46,7 +46,7 @@ async fn handle_response(
             let outbox = core::mem::take(&mut w.outbox);
             for trans in outbox.into_iter() {
                 let route = w.route.clone();
-                debug!("Sending queued message to {}", route);
+                debug!("Sending queued message to {:?}", route);
                 ctx.send(route, trans).await?;
             }
 
@@ -84,7 +84,7 @@ impl Worker for StreamProducer {
             self.route
                 .clone()
                 .modify()
-                .append(self.stream_service.clone()),
+                .try_append(self.stream_service.clone())?,
             CreateStreamRequest::new(Some(self.sender_name.clone())),
         )
         .await

--- a/implementations/rust/ockam/ockam/src/system/hooks/delivery.rs
+++ b/implementations/rust/ockam/ockam/src/system/hooks/delivery.rs
@@ -49,7 +49,7 @@ impl SystemHandler<Context, OckamMessage> for SenderConfirm {
         ctx: &mut Context,
         msg: Routed<OckamMessage>,
     ) -> Result<()> {
-        trace!("SenderDelivery '{}' handling incoming message", self_addr);
+        trace!("SenderDelivery '{:?}' handling incoming message", self_addr);
 
         match msg
             .generic
@@ -93,7 +93,7 @@ impl SystemHandler<Context, OckamMessage> for SenderConfirm {
                     .get(0)
                     .and_then(|id| Address::decode(id).ok())
                     .unwrap();
-                info!("Received ACK for message: {}", ack_id);
+                info!("Received ACK for message: {:?}", ack_id);
                 self.journal.remove(&ack_id);
             }
 
@@ -155,7 +155,10 @@ impl SystemHandler<Context, OckamMessage> for ReceiverConfirm {
         ctx: &mut Context,
         msg: Routed<OckamMessage>,
     ) -> Result<()> {
-        trace!("ReceiverDelivery '{}' handling incoming message", self_addr);
+        trace!(
+            "ReceiverDelivery '{:?}' handling incoming message",
+            self_addr
+        );
 
         // First grab the return route so we may edit it later
         let mut return_route = msg.return_route();

--- a/implementations/rust/ockam/ockam/src/system/mod.rs
+++ b/implementations/rust/ockam/ockam/src/system/mod.rs
@@ -67,21 +67,20 @@ impl<C: Send + 'static, M: Message> WorkerSystem<C, M> {
     }
 
     /// Attach a system handler to this system
-    pub fn attach<A, H>(&mut self, addr: A, handler: H)
+    pub fn attach<H>(&mut self, addr: Address, handler: H)
     where
-        A: Into<Address>,
         H: SystemHandler<C, M> + Send + 'static,
     {
-        self.map.insert(addr.into(), Box::new(handler));
+        self.map.insert(addr, Box::new(handler));
     }
 
     /// Attach a boxed system handler to this system
-    pub fn attach_boxed<A: Into<Address>>(
+    pub fn attach_boxed(
         &mut self,
-        addr: A,
+        addr: Address,
         handler: Box<dyn SystemHandler<C, M> + Send + 'static>,
     ) {
-        self.map.insert(addr.into(), handler);
+        self.map.insert(addr, handler);
     }
 
     /// Specify an "entry point" address for this system
@@ -94,8 +93,8 @@ impl<C: Send + 'static, M: Message> WorkerSystem<C, M> {
     ///
     /// You can then start the handling process by calling
     /// `dispatch_entry()`.
-    pub fn set_entry<A: Into<Address>>(&mut self, addr: A) {
-        self.entry = Some(addr.into());
+    pub fn set_entry(&mut self, addr: Address) {
+        self.entry = Some(addr);
     }
 
     /// Get an optional reference to the entry point of this system

--- a/implementations/rust/ockam/ockam/src/workers/echoer.rs
+++ b/implementations/rust/ockam/ockam/src/workers/echoer.rs
@@ -14,7 +14,7 @@ impl Worker for Echoer {
     type Message = String;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        debug!("Address: {}, Received: {}", ctx.address(), msg);
+        debug!("Address: {:?}, Received: {}", ctx.address(), msg);
 
         // Echo the message body back on its return_route.
         ctx.send(msg.return_route(), msg.body()).await

--- a/implementations/rust/ockam/ockam_channel/src/lib.rs
+++ b/implementations/rust/ockam/ockam_channel/src/lib.rs
@@ -52,14 +52,14 @@ mod tests {
         let new_key_exchanger = XXNewKeyExchanger::new(vault.async_try_clone().await?);
         SecureChannel::create_listener_extended(
             ctx,
-            "secure_channel_listener".to_string(),
+            "secure_channel_listener",
             new_key_exchanger.async_try_clone().await?,
             vault.async_try_clone().await?,
         )
         .await?;
         let initiator = SecureChannel::create_extended(
             ctx,
-            Route::new().append("secure_channel_listener"),
+            Route::new().try_append("secure_channel_listener")?,
             None,
             new_key_exchanger.initiator().await?,
             vault,
@@ -68,7 +68,7 @@ mod tests {
 
         let test_msg = "Hello, channel".to_string();
         ctx.send(
-            Route::new().append(initiator.address()).append("app"),
+            Route::new().append(initiator.address()).try_append("app")?,
             test_msg.clone(),
         )
         .await?;

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
@@ -1,6 +1,5 @@
 use crate::{SecureChannelNewKeyExchanger, SecureChannelVault, SecureChannelWorker};
 use ockam_core::async_trait;
-use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{
     Address, Encodable, LocalMessage, Message, Result, Routed, TransportMessage, Worker,
@@ -69,12 +68,12 @@ impl<V: SecureChannelVault, N: SecureChannelNewKeyExchanger> Worker
         let reply = msg.return_route().clone();
         let msg = msg.body();
 
-        let address_remote: Address = random();
-        let address_local: Address = random();
+        let address_remote = Address::random_local();
+        let address_local = Address::random_local();
 
         debug!(
-            "Starting SecureChannel responder at local: {}, remote: {}",
-            &address_local, &address_remote
+            "Starting SecureChannel responder at local: {:?}, remote: {:?}",
+            address_local, address_remote
         );
 
         let responder = self.new_key_exchanger.responder().await?;

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_worker.rs
@@ -259,8 +259,8 @@ impl<V: SecureChannelVault, K: SecureChannelKeyExchanger> SecureChannelWorker<V,
             };
 
             info!(
-                "Started SecureChannel {} at local: {}, remote: {}",
-                role_str, &self.address_local, &self.address_remote
+                "Started SecureChannel {} at local: {:?}, remote: {:?}",
+                role_str, self.address_local, self.address_remote
             );
 
             // Notify interested worker about finished key exchange

--- a/implementations/rust/ockam/ockam_core/src/error/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/mod.rs
@@ -1,5 +1,6 @@
 //! Error and Result types
 #![allow(missing_docs, dead_code)] // FIXME DONOTLAND
+
 use crate::compat::{boxed::Box, error::Error as ErrorTrait};
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +18,7 @@ pub mod errcode {
 // significantly) more efficient in the success path.
 #[cfg(feature = "alloc")]
 type ErrorData = Box<inner::ErrorData>;
+
 // When an allocator is not available, we represent the internal error inline.
 // It should be smaller in this configuration, which avoids much of the cost.
 #[cfg(not(feature = "alloc"))]
@@ -36,6 +38,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 ///   lost over serialization).
 #[derive(Serialize, Deserialize)]
 pub struct Error(ErrorData);
+
 impl Error {
     /// Construct a new error given ErrorCodes and a cause.
     #[cold]
@@ -116,5 +119,11 @@ impl ErrorTrait for Error {
         } else {
             None
         }
+    }
+}
+
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Self {
+        match e {} // Infallible is uninhabited
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/old_error.rs
+++ b/implementations/rust/ockam/ockam_core/src/old_error.rs
@@ -84,6 +84,12 @@ impl Display for Error {
 
 impl crate::compat::error::Error for Error {}
 
+impl From<core::convert::Infallible> for Error {
+    fn from(e: core::convert::Infallible) -> Self {
+        match e {} // Infallible is uninhabited
+    }
+}
+
 #[cfg(feature = "alloc")]
 #[cfg(test)]
 mod std_test {

--- a/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
@@ -1,5 +1,4 @@
 use crate::{compat::vec::Vec, Message, Route};
-use core::fmt::{self, Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 /// A generic transport message type.
@@ -43,15 +42,5 @@ impl TransportMessage {
             return_route: return_route.into(),
             payload,
         }
-    }
-}
-
-impl Display for TransportMessage {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Message (onward route: {}, return route: {})",
-            self.onward_route, self.return_route
-        )
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -1,12 +1,12 @@
 use crate::{
     compat::{collections::VecDeque, string::String, vec::Vec},
-    Address, Result, RouteError, TransportType,
+    Address, AddressParseError, Result, RouteError, TransportType,
 };
-use core::fmt::{self, Display};
+use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// A full route to a peer.
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Route {
     inner: VecDeque<Address>,
 }
@@ -22,8 +22,9 @@ impl Route {
     /// // ["1#alice", "0#bob"]
     /// let route: Route = Route::new()
     ///     .append_t(TCP, "alice")
-    ///     .append("bob")
+    ///     .try_append("bob")?
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     #[allow(clippy::new_ret_no_self)]
@@ -41,17 +42,31 @@ impl Route {
     /// // ["1#alice", "0#bob"]
     /// let route: Route = vec![
     ///     Address::new(TCP, "alice"),
-    ///     "bob".into(),
+    ///     "bob".try_into()?,
     /// ]
     /// .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
-    pub fn create<T: Into<Address>>(vt: Vec<T>) -> Self {
+    pub fn create<A: Into<Address>>(vt: Vec<A>) -> Self {
         let mut route = Route::new();
         for addr in vt {
-            route = route.append(addr.into());
+            route = route.append(addr);
         }
         route.into()
+    }
+
+    /// Like [`create`] but for any type that may be convertible into [`Address`].
+    pub fn try_create<T>(vt: Vec<T>) -> Result<Self>
+    where
+        T: TryInto<Address>,
+        T::Error: Into<crate::Error>,
+    {
+        let mut route = Route::new();
+        for addr in vt {
+            route = route.try_append(addr)?;
+        }
+        Ok(route.into())
     }
 
     /// Parse a route from a string.
@@ -60,32 +75,29 @@ impl Route {
     ///
     /// ```
     /// # use ockam_core::Route;
-    /// if let Some(route) = Route::parse("1#alice => bob") {
+    /// if let Ok(route) = Route::parse("1#alice => bob") {
     ///     // ["1#alice", "0#bob"]
     ///     route
     /// # ;
     /// }
     /// ```
     ///
-    pub fn parse<S: Into<String>>(s: S) -> Option<Route> {
-        let s = s.into();
-        if s.is_empty() {
-            return None;
+    pub fn parse<S: AsRef<str>>(s: S) -> Result<Route> {
+        if s.as_ref().is_empty() {
+            return Err(RouteError::IncompleteRoute.into());
         }
 
-        let addrs = s.split("=>").collect::<Vec<_>>();
+        let mut r = Route::new();
 
-        // Invalid route
-        if addrs.is_empty() {
-            return None;
+        for addr in s.as_ref().split("=>") {
+            r = r.try_append(addr.trim())?
         }
 
-        Some(
-            addrs
-                .into_iter()
-                .fold(Route::new(), |r, addr| r.append(addr.trim()))
-                .into(),
-        )
+        if r.inner.is_empty() {
+            return Err(RouteError::IncompleteRoute.into());
+        }
+
+        Ok(r.into())
     }
 
     /// Create a new [`RouteBuilder`] from the current `Route`.
@@ -93,13 +105,14 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Route};
-    /// let mut route: Route = route!["1#alice", "bob"];
+    /// # use ockam_core::{try_route, Route};
+    /// let mut route: Route = try_route!["1#alice", "bob"]?;
     ///
     /// // ["1#alice", "0#bob", "0#carol"]
     /// let route: Route = route.modify()
-    ///     .append("carol")
+    ///     .try_append("carol")?
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     pub fn modify(&mut self) -> RouteBuilder {
@@ -114,18 +127,15 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Address, Result, Route};
-    /// # fn main() -> Result<()> {
-    /// let mut route: Route = route!["1#alice", "bob"];
+    /// # use ockam_core::{try_route, Address, Route};
+    /// let mut route: Route = try_route!["1#alice", "bob"]?;
     ///
     /// // "1#alice"
     /// let next_hop: Address = route.step()?;
     ///
     /// // ["0#bob"]
-    /// route
-    /// # ;
-    /// #     Ok(())
-    /// # }
+    /// route;
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     pub fn step(&mut self) -> Result<Address> {
@@ -139,20 +149,16 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Address, Result, Route};
-    /// # fn main() -> Result<()> {
-    /// let route: Route = route!["1#alice", "bob"];
+    /// # use ockam_core::{try_route, Address, Route};
+    /// let route: Route = try_route!["1#alice", "bob"]?;
     ///
     /// // "1#alice"
     /// let next_hop: &Address = route.next()?;
     ///
     /// // ["1#alice", "0#bob"]
-    /// route
-    /// # ;
-    /// #     Ok(())
-    /// # }
+    /// route;
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
-    ///
     pub fn next(&self) -> Result<&Address> {
         self.inner
             .front()
@@ -168,18 +174,15 @@ impl Route {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Address, Result, Route};
-    /// # fn main() -> Result<()> {
-    /// let route: Route = route!["1#alice", "bob"];
+    /// # use ockam_core::{try_route, Address, Route};
+    /// let route: Route = try_route!["1#alice", "bob"]?;
     ///
     /// // "0#bob"
     /// let final_hop: Address = route.recipient();
     ///
     /// // ["1#alice", "0#bob"]
-    /// route
-    /// # ;
-    /// #     Ok(())
-    /// # }
+    /// route;
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     /// `TODO` For consistency we should not panic and return a
@@ -192,14 +195,14 @@ impl Route {
     }
 }
 
-impl Display for Route {
+impl fmt::Debug for Route {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",
             self.inner
                 .iter()
-                .map(|a| format!("{}", a))
+                .map(|a| format!("{:?}", a))
                 .collect::<Vec<_>>()
                 .join(" => ")
         )
@@ -220,17 +223,18 @@ impl From<RouteBuilder<'_>> for Route {
 // A single address can represent a valid route.
 impl From<Address> for Route {
     fn from(address: Address) -> Self {
-        let addr: Address = address;
-        Route::new().append(addr).into()
+        Route::new().append(address).into()
     }
 }
 
 // Convert a `&str` into a `Route`.
 //
 // A string-slice reference can represent a valid route.
-impl From<&str> for Route {
-    fn from(s: &str) -> Self {
-        Address::from(s).into()
+impl TryFrom<&str> for Route {
+    type Error = AddressParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Address::try_from(s).map(Route::from)
     }
 }
 
@@ -240,11 +244,11 @@ impl From<&str> for Route {
 ///
 /// Note that this only holds if the vector index order is in the same
 /// order as the expected route.
-impl<T: Into<Address>> From<Vec<T>> for Route {
-    fn from(vt: Vec<T>) -> Self {
+impl From<Vec<Address>> for Route {
+    fn from(vt: Vec<Address>) -> Self {
         let mut route = Route::new();
         for t in vt {
-            route = route.append(t.into());
+            route = route.append(t);
         }
         route.into()
     }
@@ -276,18 +280,40 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{Route, RouteBuilder};
+    /// # use ockam_core::{Address, Route, RouteBuilder};
     /// let builder: RouteBuilder = Route::new()
-    ///     .append("1#alice")
-    ///     .append("bob");
+    ///     .append(Address::local("bob"));
     ///
-    /// // ["1#alice, "0#bob"]
+    /// // ["0#bob"]
     /// let route: Route = builder.into();
     /// ```
-    ///
     pub fn append<A: Into<Address>>(mut self, addr: A) -> Self {
         self.inner.push_back(addr.into());
         self
+    }
+
+    /// Like [`append`] but for any type that may be convertible into an [`Address`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ockam_core::{Route, RouteBuilder};
+    /// let builder: RouteBuilder = Route::new()
+    ///     .try_append("1#alice")?
+    ///     .try_append("bob")?;
+    ///
+    /// // ["1#alice, "0#bob"]
+    /// let route: Route = builder.into();
+    /// # Ok::<_, ockam_core::Error>(())
+    /// ```
+    pub fn try_append<A>(mut self, addr: A) -> Result<Self>
+    where
+        A: TryInto<Address>,
+        A::Error: Into<crate::Error>,
+    {
+        let a = addr.try_into().map_err(|e| e.into())?;
+        self.inner.push_back(a);
+        Ok(self)
     }
 
     /// Push an item with an explicit type to the back of the route.
@@ -310,17 +336,40 @@ impl RouteBuilder<'_> {
         self
     }
 
-    /// Push a new item to the front of the route.
+    /// Like [`prepend`] but for any type that may be convertible into an [`Address`].
     ///
     /// # Examples
     ///
     /// ```
     /// # use ockam_core::{Route, RouteBuilder};
     /// let builder: RouteBuilder = Route::new()
-    ///     .prepend("1#alice")
-    ///     .prepend("0#bob");
+    ///     .try_prepend("1#alice")?
+    ///     .try_prepend("0#bob")?;
     ///
     /// // ["0#bob", "1#alice"]
+    /// let route: Route = builder.into();
+    /// # Ok::<_, ockam_core::Error>(())
+    /// ```
+    pub fn try_prepend<A>(mut self, addr: A) -> Result<Self>
+    where
+        A: TryInto<Address>,
+        A::Error: Into<crate::Error>,
+    {
+        let a = addr.try_into().map_err(|e| e.into())?;
+        self.inner.push_front(a);
+        Ok(self)
+    }
+
+    /// Push a new item to the front of the route.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ockam_core::{Address, Route, RouteBuilder};
+    /// let builder: RouteBuilder = Route::new()
+    ///     .prepend(Address::local("bob"));
+    ///
+    /// // ["0#bob"]
     /// let route: Route = builder.into();
     /// ```
     ///
@@ -334,14 +383,15 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Route, RouteBuilder};
-    /// let mut route_a: Route = route!["1#alice", "bob"];
-    /// let route_b: Route = route!["1#carol", "dave"];
+    /// # use ockam_core::{try_route, Route, RouteBuilder};
+    /// let mut route_a: Route = try_route!["1#alice", "bob"]?;
+    /// let route_b: Route = try_route!["1#carol", "dave"]?;
     ///
     /// // ["1#carol", "0#dave", "1#alice", "0#bob"]
     /// let route: Route = route_a.modify()
     ///     .prepend_route(route_b)
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     pub fn prepend_route(mut self, route: Route) -> Self {
@@ -361,19 +411,24 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Route, RouteBuilder};
-    /// let mut route: Route = route!["1#alice", "bob"];
+    /// # use ockam_core::{try_route, Route, RouteBuilder};
+    /// let mut route: Route = try_route!["1#alice", "bob"]?;
     ///
     /// // ["1#carol", "0#bob"]
     /// let route: Route = route.modify()
-    ///     .replace("1#carol")
+    ///     .try_replace("1#carol")?
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
-    ///
-    pub fn replace<A: Into<Address>>(mut self, addr: A) -> Self {
+    pub fn try_replace<A>(mut self, addr: A) -> Result<Self>
+    where
+        A: TryInto<Address>,
+        A::Error: Into<crate::Error>,
+    {
+        let a = addr.try_into().map_err(|e| e.into())?;
         self.inner.pop_front();
-        self.inner.push_front(addr.into());
-        self
+        self.inner.push_front(a);
+        Ok(self)
     }
 
     /// Pop the front item from the route.
@@ -381,15 +436,15 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Address, Route};
-    /// let mut route: Route = route!["1#alice", "bob", "carol"];
+    /// # use ockam_core::{try_route, Address, Route};
+    /// let mut route: Route = try_route!["1#alice", "bob", "carol"]?;
     ///
     /// // ["0#bob", "carol"]
     /// let route: Route = route.modify()
     ///     .pop_front()
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
-    ///
     pub fn pop_front(mut self) -> Self {
         self.inner.pop_front();
         self
@@ -400,13 +455,14 @@ impl RouteBuilder<'_> {
     /// # Examples
     ///
     /// ```
-    /// # use ockam_core::{route, Address, Route};
-    /// let mut route: Route = route!["1#alice", "bob", "carol"];
+    /// # use ockam_core::{try_route, Address, Route};
+    /// let mut route: Route = try_route!["1#alice", "bob", "carol"]?;
     ///
     /// // ["1#alice", "0#bob"]
     /// let route: Route = route.modify()
     ///     .pop_back()
     ///     .into();
+    /// # Ok::<_, ockam_core::Error>(())
     /// ```
     ///
     pub fn pop_back(mut self) -> Self {
@@ -437,35 +493,41 @@ mod tests {
 
     #[test]
     fn test_route_from_vec() {
-        let address = Address::from_string("a");
-        let mut route: Route = vec![address, "b".into()].into();
-        assert_eq!(route.next().unwrap(), &Address::from_string("0#a"));
-        assert_eq!(route.next().unwrap(), &Address::from_string("0#a"));
-        assert_eq!(route.recipient(), Address::from_string("0#b"));
-        assert_eq!(route.step().unwrap(), Address::from_string("0#a"));
-        assert_eq!(route.step().unwrap(), Address::from_string("0#b"));
+        let address = Address::try_from("a").unwrap();
+        let mut route: Route = vec![address, Address::local("b")].into();
+        assert_eq!(route.next().unwrap(), &Address::try_from("0#a").unwrap());
+        assert_eq!(route.next().unwrap(), &Address::try_from("0#a").unwrap());
+        assert_eq!(route.recipient(), Address::try_from("0#b").unwrap());
+        assert_eq!(route.step().unwrap(), Address::try_from("0#a").unwrap());
+        assert_eq!(route.step().unwrap(), Address::try_from("0#b").unwrap());
     }
 
     #[test]
     fn test_route_create() {
         let addresses = vec!["node-1", "node-2"];
-        let route: Route = Route::create(addresses);
-        assert_eq!(route.recipient(), Address::from_string("0#node-2"));
+        let route: Route = Route::try_create(addresses).unwrap();
+        assert_eq!(route.recipient(), Address::try_from("0#node-2").unwrap());
     }
 
     #[test]
     fn test_route_parse_empty_string() {
-        assert_eq!(Route::parse(""), None);
+        assert!(Route::parse("").is_err())
     }
 
     #[test]
     fn test_route_parse_valid_input() {
         let s = " node-1 =>node-2=> node-3 ";
         let mut route = Route::parse(s).unwrap();
-        assert_eq!(route.next().unwrap(), &Address::from_string("0#node-1"));
-        assert_eq!(route.recipient(), Address::from_string("0#node-3"));
+        assert_eq!(
+            route.next().unwrap(),
+            &Address::try_from("0#node-1").unwrap()
+        );
+        assert_eq!(route.recipient(), Address::try_from("0#node-3").unwrap());
         let _ = route.step();
-        assert_eq!(route.next().unwrap(), &Address::from_string("0#node-2"));
+        assert_eq!(
+            route.next().unwrap(),
+            &Address::try_from("0#node-2").unwrap()
+        );
     }
 
     #[test]
@@ -488,10 +550,11 @@ mod tests {
 
     #[test]
     fn test_route_prepend_route() {
-        let mut r1: Route = vec!["a", "b", "c"].into();
-        let r2: Route = vec!["1", "2", "3"].into();
+        use crate::try_route;
+        let mut r1: Route = try_route!["a", "b", "c"].unwrap();
+        let r2: Route = try_route!["1", "2", "3"].unwrap();
 
         r1.modify().prepend_route(r2);
-        assert_eq!(r1, vec!["1", "2", "3", "a", "b", "c"].into());
+        assert_eq!(r1, try_route!["1", "2", "3", "a", "b", "c"].unwrap());
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -55,7 +55,7 @@ mod test {
     use crate::{Identity, IdentityTrait};
     use core::sync::atomic::{AtomicU8, Ordering};
     use ockam_core::compat::sync::Arc;
-    use ockam_core::{route, Any, Route, Routed, Worker};
+    use ockam_core::{route, try_route, Any, Route, Routed, Worker};
     use ockam_node::Context;
     use ockam_vault::Vault;
     use std::time::Duration;
@@ -76,7 +76,7 @@ mod test {
             .await?;
 
         let alice_channel = alice
-            .create_secure_channel(route!["bob_listener"], alice_trust_policy)
+            .create_secure_channel(try_route!["bob_listener"]?, alice_trust_policy)
             .await?;
 
         ctx.send(
@@ -118,7 +118,7 @@ mod test {
             .await?;
 
         let alice_channel = alice
-            .create_secure_channel(route!["bob_listener"], alice_trust_policy.clone())
+            .create_secure_channel(try_route!["bob_listener"]?, alice_trust_policy.clone())
             .await?;
 
         bob.create_secure_channel_listener("bob_another_listener", bob_trust_policy)
@@ -126,7 +126,7 @@ mod test {
 
         let alice_another_channel = alice
             .create_secure_channel(
-                route![alice_channel, "bob_another_listener"],
+                try_route![alice_channel, "bob_another_listener"]?,
                 alice_trust_policy,
             )
             .await?;
@@ -163,7 +163,7 @@ mod test {
             .await?;
 
         let alice_channel = alice
-            .create_secure_channel(route!["bob_listener"], alice_trust_policy.clone())
+            .create_secure_channel(try_route!["bob_listener"]?, alice_trust_policy.clone())
             .await?;
 
         bob.create_secure_channel_listener("bob_another_listener", bob_trust_policy.clone())
@@ -171,7 +171,7 @@ mod test {
 
         let alice_another_channel = alice
             .create_secure_channel(
-                route![alice_channel, "bob_another_listener"],
+                try_route![alice_channel, "bob_another_listener"]?,
                 alice_trust_policy.clone(),
             )
             .await?;
@@ -181,7 +181,7 @@ mod test {
 
         let alice_yet_another_channel = alice
             .create_secure_channel(
-                route![alice_another_channel, "bob_yet_another_listener"],
+                try_route![alice_another_channel, "bob_yet_another_listener"]?,
                 alice_trust_policy,
             )
             .await?;
@@ -221,9 +221,9 @@ mod test {
                 .await?;
             let channel_route: Route;
             if i > 0 {
-                channel_route = route![channels.pop().unwrap(), i.to_string()];
+                channel_route = try_route![channels.pop().unwrap(), i.to_string()]?;
             } else {
-                channel_route = route![i.to_string()];
+                channel_route = try_route![i.to_string()]?;
             }
             let alice_channel = alice
                 .create_secure_channel(channel_route, alice_trust_policy.clone())
@@ -295,8 +295,11 @@ mod test {
             .create_secure_channel("listener", TrustEveryonePolicy)
             .await?;
 
-        ctx.send(route![alice_channel, "receiver"], "Hello, Bob!".to_string())
-            .await?;
+        ctx.send(
+            try_route![alice_channel, "receiver"]?,
+            "Hello, Bob!".to_string(),
+        )
+        .await?;
 
         sleep(Duration::from_secs(1)).await;
 
@@ -331,8 +334,11 @@ mod test {
             .create_secure_channel("listener", TrustEveryonePolicy)
             .await?;
 
-        ctx.send(route![alice_channel, "receiver"], "Hello, Bob!".to_string())
-            .await?;
+        ctx.send(
+            try_route![alice_channel, "receiver"]?,
+            "Hello, Bob!".to_string(),
+        )
+        .await?;
 
         sleep(Duration::from_secs(1)).await;
 
@@ -357,7 +363,7 @@ mod test {
         ctx.start_worker_with_access_control("receiver", receiver, access_control)
             .await?;
 
-        ctx.send(route!["receiver"], "Hello, Bob!".to_string())
+        ctx.send(try_route!["receiver"]?, "Hello, Bob!".to_string())
             .await?;
 
         sleep(Duration::from_secs(1)).await;

--- a/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
@@ -1,6 +1,5 @@
 use crate::{IdentityTrait, SecureChannelWorker, TrustPolicy};
 use ockam_channel::{CreateResponderChannelMessage, SecureChannel};
-use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, sync::Arc};
 use ockam_core::{Address, Result, Routed, Worker};
 use ockam_key_exchange_xx::{XXNewKeyExchanger, XXVault};
@@ -15,7 +14,7 @@ pub(crate) struct IdentityChannelListener<I: IdentityTrait, V: XXVault> {
 
 impl<I: IdentityTrait, V: XXVault> IdentityChannelListener<I, V> {
     pub fn new(trust_policy: impl TrustPolicy, identity: I, vault: V) -> Self {
-        let listener_address: Address = random();
+        let listener_address = Address::random_local();
         IdentityChannelListener {
             trust_policy: Arc::new(trust_policy),
             identity,

--- a/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
@@ -9,7 +9,6 @@ use ockam_channel::{
     CreateResponderChannelMessage, KeyExchangeCompleted, SecureChannel, SecureChannelInfo,
 };
 use ockam_core::async_trait;
-use ockam_core::compat::rand::random;
 use ockam_core::compat::{boxed::Box, sync::Arc, vec::Vec};
 use ockam_core::{
     route, Address, Any, Decodable, Encodable, LocalMessage, Message, Result, Route, Routed,
@@ -95,8 +94,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
         // Generate 2 random fresh address for newly created SecureChannel.
         // One for local workers to encrypt their messages
         // Second for remote workers to decrypt their messages
-        let self_local_address: Address = random();
-        let self_remote_address: Address = random();
+        let self_local_address = Address::random_local();
+        let self_remote_address = Address::random_local();
 
         let initiator = XXNewKeyExchanger::new(vault.async_try_clone().await?)
             .initiator()
@@ -136,8 +135,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
         .await?;
 
         debug!(
-            "Starting IdentitySecureChannel Initiator at local: {}, remote: {}",
-            &self_local_address, &self_remote_address
+            "Starting IdentitySecureChannel Initiator at local: {:?}, remote: {:?}",
+            self_local_address, self_remote_address
         );
 
         let _ = child_ctx
@@ -169,8 +168,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
         // Generate 2 random fresh address for newly created SecureChannel.
         // One for local workers to encrypt their messages
         // Second for remote workers to decrypt their messages
-        let self_local_address: Address = random();
-        let self_remote_address: Address = random();
+        let self_local_address = Address::random_local();
+        let self_remote_address = Address::random_local();
 
         // Change completed callback address and forward message for regular key exchange to happen
         let body = CreateResponderChannelMessage::new(
@@ -200,8 +199,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
         .await?;
 
         debug!(
-            "Starting IdentitySecureChannel Responder at local: {}, remote: {}",
-            &self_local_address, &self_remote_address
+            "Starting IdentitySecureChannel Responder at local: {:?}, remote: {:?}",
+            self_local_address, self_remote_address
         );
 
         ctx.forward(LocalMessage::new(msg, Vec::new())).await?;
@@ -322,8 +321,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
             }));
 
             info!(
-                "Initialized IdentitySecureChannel Initiator at local: {}, remote: {}",
-                &self.self_local_address, &self.self_remote_address
+                "Initialized IdentitySecureChannel Initiator at local: {:?}, remote: {:?}",
+                self.self_local_address, self.self_remote_address
             );
 
             ctx.send(
@@ -407,8 +406,8 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
             }));
 
             info!(
-                "Initialized IdentitySecureChannel Responder at local: {}, remote: {}",
-                &self.self_local_address, &self.self_remote_address
+                "Initialized IdentitySecureChannel Responder at local: {:?}, remote: {:?}",
+                self.self_local_address, self.self_remote_address
             );
 
             Ok(())
@@ -515,7 +514,7 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
             Ok(_) => Ok(()),
             Err(err) => {
                 warn!(
-                    "{} forwarding decrypted message from {}",
+                    "{} forwarding decrypted message from {:?}",
                     err, self.self_local_address
                 );
                 Ok(())

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -67,8 +67,8 @@ impl fmt::Display for NodeError {
             f,
             "{}",
             match self {
-                Self::Address(addr) => format!("operation failed for address {}", addr),
-                Self::Recipient(route) => format!("operation failed for recipient {}", route),
+                Self::Address(addr) => format!("operation failed for address {:?}", addr),
+                Self::Recipient(route) => format!("operation failed for recipient {:?}", route),
                 Self::Data => "failed to load data".into(),
                 Self::NodeState(reason) => format!("failed because node state: {}", reason),
                 Self::WorkerState(reason) => format!("failed because worker state: {}", reason),

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -16,14 +16,14 @@ pub fn start_node() -> (Context, Executor) {
     info!("Initializing ockam node");
 
     let mut exe = Executor::new();
-    let addr: Address = "app".into();
+    let addr = Address::local("app");
 
     // The root application worker needs a mailbox and relay to accept
     // messages from workers, and to buffer incoming transcoded data.
     let (ctx, sender, _) = Context::new(exe.runtime(), exe.sender(), addr.into(), AllowAll);
 
     // Register this mailbox handle with the executor
-    exe.initialize_system("app", sender);
+    exe.initialize_system(Address::local("app"), sender);
 
     (ctx, exe)
 }

--- a/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
@@ -29,7 +29,7 @@ where
             Ok(()) => {}
             Err(e) => {
                 error!(
-                    "Failure during '{}' processor initialisation: {}",
+                    "Failure during '{:?}' processor initialisation: {}",
                     ctx.address(),
                     e
                 );
@@ -37,7 +37,10 @@ where
         }
 
         if let Err(e) = ctx.set_ready().await {
-            error!("Failed to mark processor '{}' as 'ready': {}", ctx_addr, e);
+            error!(
+                "Failed to mark processor '{:?}' as 'ready': {}",
+                ctx_addr, e
+            );
         }
 
         // This future encodes the main processor run loop logic
@@ -63,7 +66,7 @@ where
             // Then select over the two futures
             tokio::select! {
                 _ = shutdown_signal => {
-                    debug!("Shutting down processor {}", ctx_addr);
+                    debug!("Shutting down processor {:?}", ctx_addr);
                 },
                 _ = run_loop => {}
             };
@@ -72,7 +75,7 @@ where
         // TODO wait on run_loop until we have a no_std select! implementation
         #[cfg(not(feature = "std"))]
         match run_loop.await {
-            Ok(_) => trace!("Processor shut down cleanly {}", ctx_addr),
+            Ok(_) => trace!("Processor shut down cleanly {:?}", ctx_addr),
             Err(err) => error!("processor run loop aborted with error: {:?}", err),
         };
 
@@ -80,7 +83,7 @@ where
         match processor.shutdown(&mut ctx).await {
             Ok(()) => {}
             Err(e) => {
-                error!("Failure during '{}' processor shutdown: {}", ctx_addr, e);
+                error!("Failure during '{:?}' processor shutdown: {}", ctx_addr, e);
             }
         }
 

--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -44,7 +44,7 @@ where
 
         parser::message::<M>(payload)
             .map_err(|e| {
-                error!("Failed to decode message payload for worker {}", msg_addr);
+                error!("Failed to decode message payload for worker {:?}", msg_addr);
                 e
             })
             .map(|m| (m, return_route.clone()))
@@ -54,7 +54,7 @@ where
     fn handle_pre_router(msg: &[u8], msg_addr: Address) -> Result<M> {
         M::decode(msg).map_err(|e| {
             error!(
-                "Failed to decode wrapped router message for worker {}.  \
+                "Failed to decode wrapped router message for worker {:?}.  \
              Is your router accepting the correct message type? (ockam_core::RouterMessage)",
                 msg_addr
             );
@@ -70,7 +70,7 @@ where
         let RelayMessage { addr, data, .. } = match self.ctx.mailbox_next().await? {
             Some(msg) => msg,
             None => {
-                trace!("No more messages for worker {}", self.ctx.address());
+                trace!("No more messages for worker {:?}", self.ctx.address());
                 return Ok(false);
             }
         };
@@ -116,7 +116,7 @@ where
             Ok(()) => {}
             Err(e) => {
                 error!(
-                    "Failure during '{}' worker initialisation: {}",
+                    "Failure during '{:?}' worker initialisation: {}",
                     self.ctx.address(),
                     e
                 );
@@ -126,7 +126,7 @@ where
         let address = self.ctx.address();
 
         if let Err(e) = self.ctx.set_ready().await {
-            error!("Failed to mark worker '{}' as 'ready': {}", address, e);
+            error!("Failed to mark worker '{:?}' as 'ready': {}", address, e);
         }
 
         #[cfg(feature = "std")]
@@ -141,7 +141,7 @@ where
                             break;
                         },
                         // An error occurred -- log and continue
-                        Err(e) => error!("Error encountered during '{}' message handling: {}", address, e),
+                        Err(e) => error!("Error encountered during '{:?}' message handling: {}", address, e),
                     }
                 },
                 result = ctrl_rx.recv() => {
@@ -165,7 +165,7 @@ where
                 }
                 // An error occurred -- log and continue
                 Err(e) => error!(
-                    "Error encountered during '{}' message handling: {}",
+                    "Error encountered during '{:?}' message handling: {}",
                     address, e
                 ),
             }
@@ -176,7 +176,7 @@ where
             Ok(()) => {}
             Err(e) => {
                 error!(
-                    "Failure during '{}' worker shutdown: {}",
+                    "Failure during '{:?}' worker shutdown: {}",
                     self.ctx.address(),
                     e
                 );

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -173,7 +173,7 @@ impl Router {
             }
 
             StopAck(addr) if self.state.running() => {
-                debug!("Received shutdown ACK for address {}", addr);
+                debug!("Received shutdown ACK for address {:?}", addr);
                 if let Some(rec) = self.map.internal.remove(&addr) {
                     rec.address_set().iter().for_each(|addr| {
                         self.map.addr_map.remove(addr);
@@ -202,7 +202,7 @@ impl Router {
                 .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?,
 
             SetCluster(addr, label, reply) => {
-                debug!("Setting cluster on address {}", addr);
+                debug!("Setting cluster on address {:?}", addr);
                 let msg = self.map.set_cluster(label, addr);
                 reply
                     .send(msg)
@@ -211,7 +211,7 @@ impl Router {
             }
 
             SetReady(addr) => {
-                trace!("Marking address {} as ready!", addr);
+                trace!("Marking address {:?} as ready!", addr);
                 match self.map.set_ready(addr) {
                     Err(e) => warn!("Failed to set address as ready: {}", e),
                     Ok(waiting) => {

--- a/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
@@ -11,7 +11,7 @@ use ockam_core::{Address, Result};
 /// For every ACK we re-test whether the current cluster has stopped.
 /// If not, we do nothing. If so, we trigger the next cluster to stop.
 pub(super) async fn ack(router: &mut Router, addr: Address) -> Result<bool> {
-    debug!("Handling shutdown ACK for {}", addr);
+    debug!("Handling shutdown ACK for {:?}", addr);
 
     // Permanently remove the address and corresponding worker
     router.map.free_address(addr);
@@ -56,7 +56,7 @@ pub(super) async fn graceful(
     // Start by shutting down clusterless workers
     let mut cluster = vec![];
     for rec in router.map.non_cluster_workers().iter_mut() {
-        debug!("Stopping address {}", rec.address_set().first());
+        debug!("Stopping address {:?}", rec.address_set().first());
         rec.stop().await?;
         cluster.push(rec.address_set().first());
     }

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -27,7 +27,7 @@ async fn start(
     senders: SenderPair,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
-    debug!("Starting new processor '{}'", &addr);
+    debug!("Starting new processor '{:?}'", &addr);
     let SenderPair { msgs, ctrl } = senders;
 
     let record = AddressRecord::new(

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -29,7 +29,7 @@ async fn start(
     bare: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
-    debug!("Starting new worker '{}'", addrs.first());
+    debug!("Starting new worker '{:?}'", addrs.first());
     let SenderPair { msgs, ctrl } = senders;
 
     // Create an address record and insert it into the internal map

--- a/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
@@ -11,7 +11,7 @@ pub(super) async fn exec(
     main_addr: &Address,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
-    trace!("Stopping processor '{}'", main_addr);
+    trace!("Stopping processor '{:?}'", main_addr);
 
     // First check if the processor exists
     let mut record = match router.map.internal.remove(main_addr) {

--- a/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
@@ -11,7 +11,7 @@ pub(super) async fn exec(
     addr: &Address,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
-    trace!("Stopping worker '{}'", addr);
+    trace!("Stopping worker '{:?}'", addr);
 
     let primary_address = match router.map.addr_map.get(addr) {
         Some(p) => p.clone(),

--- a/implementations/rust/ockam/ockam_node/src/router/utils.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/utils.rs
@@ -17,7 +17,7 @@ pub(super) async fn resolve(
     reply: &Sender<NodeReplyResult>,
     wrap: bool,
 ) -> Result<()> {
-    let base = format!("Resolving worker address '{}'...", addr);
+    let base = format!("Resolving worker address '{:?}'...", addr);
 
     let primary_address = if let Some(p) = router.map.addr_map.get(addr) {
         p.clone()

--- a/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
@@ -1,6 +1,6 @@
 // This node routes a message, to a worker on a different node, over the ble transport.
 
-use ockam::{route, Context, Result};
+use ockam::{try_route, Context, Result};
 use ockam_transport_ble::{BleClient, BleTransport, BLE};
 
 use ockam_transport_ble::driver::btleplug::BleAdapter;
@@ -18,7 +18,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     ble.connect(ble_client, "ockam_ble_1".to_string()).await?;
 
     // Send a message to the "echoer" worker, on a different node, over a ble transport.
-    let r = route![(BLE, "ockam_ble_1"), "echoer"];
+    let r = try_route![(BLE, "ockam_ble_1"), "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -2,7 +2,7 @@
 
 use ockam::{
     identity::{Identity, TrustEveryonePolicy},
-    route,
+    try_route,
     vault::Vault,
     Context, Result,
 };
@@ -30,11 +30,11 @@ async fn main(mut ctx: Context) -> Result<()> {
     ble.connect(ble_client, "ockam_ble_1".to_string()).await?;
 
     // Connect to a secure channel listener and perform a handshake.
-    let r = route![(BLE, "ockam_ble_1"), "bob_listener"];
+    let r = try_route![(BLE, "ockam_ble_1"), "bob_listener"]?;
     let channel = alice.create_secure_channel(r, TrustEveryonePolicy).await?;
 
     // Send a message to the "echoer" worker, on a different node, via secure channel.
-    let r = route![channel, "echoer"];
+    let r = try_route![channel, "echoer"]?;
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
@@ -38,12 +38,12 @@ impl BleRouterHandle {
 impl BleRouterHandle {
     /// Register a new connection worker with this router
     pub async fn register(&self, pair: &WorkerPair) -> Result<()> {
-        let ble_address: Address = format!("{}#{}", crate::BLE, pair.peer()).into();
+        let ble_address = Address::new(crate::BLE, pair.peer().to_string());
         let mut accepts = vec![ble_address];
         accepts.extend(
             pair.servicenames()
                 .iter()
-                .map(|x| Address::from_string(format!("{}#{}", crate::BLE, x))),
+                .map(|x| Address::new(crate::BLE, x)),
         );
         let self_addr = pair.tx_addr();
 

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -48,7 +48,7 @@ impl BleRouter {
 
     async fn handle_register(&mut self, accepts: Vec<Address>, self_addr: Address) -> Result<()> {
         if let Some(f) = accepts.first().cloned() {
-            debug!("BLE registration request: {} => {}", f, self_addr);
+            debug!("BLE registration request: {:?} => {:?}", f, self_addr);
         } else {
             return Err(TransportError::InvalidAddress.into());
         }
@@ -137,7 +137,7 @@ impl BleRouter {
     pub(crate) async fn register(ctx: &Context) -> Result<BleRouterHandle> {
         let main_addr = Address::random_local();
         let api_addr = Address::random_local();
-        debug!("Registering new BleRouter with address {}", &main_addr);
+        debug!("Registering new BleRouter with address {:?}", main_addr);
 
         let child_ctx = ctx.new_context(Address::random_local()).await?;
         let router = Self {

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/receiver.rs
@@ -105,8 +105,8 @@ where
                 msg.return_route.modify().prepend(self.peer_addr.clone());
 
                 // Some verbose logging we may want to remove
-                debug!("Message onward route: {}", msg.onward_route);
-                debug!("Message return route: {}", msg.return_route);
+                debug!("Message onward route: {:?}", msg.onward_route);
+                debug!("Message return route: {:?}", msg.return_route);
 
                 // Forward the message to the final destination worker,
                 // which consumes the TransportMessage and yields the

--- a/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/workers/sender.rs
@@ -89,7 +89,7 @@ where
         if let Some(rx_stream) = self.rx_stream.take() {
             let rx_addr = Address::random_local();
             let receiver =
-                BleRecvProcessor::new(rx_stream, format!("{}#{}", crate::BLE, self.peer).into());
+                BleRecvProcessor::new(rx_stream, Address::new(crate::BLE, self.peer.to_string()));
             ctx.start_processor(rx_addr.clone(), receiver).await?;
             debug!("started receiver");
         } else {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
@@ -55,7 +55,7 @@ impl Worker for TcpOutletListenWorker {
             .connect_outlet(self.peer.clone(), return_route.clone())
             .await?;
 
-        debug!("Created Tcp Outlet at {}", &address);
+        debug!("Created Tcp Outlet at {:?}", address);
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
@@ -97,7 +97,7 @@ impl TcpPortalWorker {
         let receiver_address = Address::random_local();
 
         info!(
-            "Creating new {:?} at internal: {}, remote: {}",
+            "Creating new {:?} at internal: {:?}, remote: {:?}",
             type_name, internal_addr, remote_addr
         );
 
@@ -166,7 +166,7 @@ impl TcpPortalWorker {
             .await?;
 
             debug!(
-                "Notified the other side from {:?} at: {} about connection drop",
+                "Notified the other side from {:?} at: {:?} about connection drop",
                 self.type_name, self.internal_address
             );
 
@@ -194,7 +194,7 @@ impl TcpPortalWorker {
                 .is_ok()
             {
                 debug!(
-                    "{:?} at: {} stopped receiver due to connection drop",
+                    "{:?} at: {:?} stopped receiver due to connection drop",
                     self.type_name, self.internal_address
                 );
             }
@@ -203,7 +203,7 @@ impl TcpPortalWorker {
         ctx.stop_worker(self.internal_address.clone()).await?;
 
         info!(
-            "{:?} at: {} stopped due to connection drop",
+            "{:?} at: {:?} stopped due to connection drop",
             self.type_name, self.internal_address
         );
 
@@ -225,7 +225,7 @@ impl Worker for TcpPortalWorker {
                 ctx.send_from_address(ping_route, PortalMessage::Ping, self.remote_address.clone())
                     .await?;
 
-                debug!("Inlet at: {} sent ping", self.internal_address);
+                debug!("Inlet at: {:?} sent ping", self.internal_address);
 
                 self.state = Some(State::ReceivePong);
             }
@@ -249,12 +249,12 @@ impl Worker for TcpPortalWorker {
                     self.start_receiver(ctx).await?;
 
                     debug!(
-                        "Outlet at: {} successfully connected",
+                        "Outlet at: {:?} successfully connected",
                         self.internal_address
                     );
                 }
 
-                debug!("Outlet at: {} sent pong", self.internal_address);
+                debug!("Outlet at: {:?} sent pong", self.internal_address);
 
                 self.state = Some(State::Initialized {
                     onward_route: pong_route,
@@ -303,7 +303,7 @@ impl Worker for TcpPortalWorker {
 
                 self.start_receiver(ctx).await?;
 
-                debug!("Inlet at: {} received pong", self.internal_address);
+                debug!("Inlet at: {:?} received pong", self.internal_address);
 
                 self.state = Some(State::Initialized {
                     onward_route: return_route,
@@ -312,7 +312,7 @@ impl Worker for TcpPortalWorker {
             State::Initialized { onward_route } => {
                 if recipient == self.internal_address {
                     trace!(
-                        "{:?} at: {} received internal tcp packet",
+                        "{:?} at: {:?} received internal tcp packet",
                         self.type_name,
                         self.internal_address
                     );
@@ -330,7 +330,7 @@ impl Worker for TcpPortalWorker {
                         }
                         PortalInternalMessage::Disconnect => {
                             info!(
-                                "Tcp stream was dropped for {:?} at: {}",
+                                "Tcp stream was dropped for {:?} at: {:?}",
                                 self.type_name, self.internal_address
                             );
                             self.start_disconnection(ctx, Some(onward_route.clone()))
@@ -339,7 +339,7 @@ impl Worker for TcpPortalWorker {
                     }
                 } else {
                     trace!(
-                        "{:?} at: {} received remote tcp packet",
+                        "{:?} at: {:?} received remote tcp packet",
                         self.type_name,
                         self.internal_address
                     );

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -97,13 +97,9 @@ impl TcpRouterHandle {
 
     /// Register a new connection worker with this router
     pub async fn register(&self, pair: &WorkerPair) -> Result<()> {
-        let tcp_address: Address = format!("{}#{}", TCP, pair.peer()).into();
+        let tcp_address = Address::new(TCP, pair.peer().to_string());
         let mut accepts = vec![tcp_address];
-        accepts.extend(
-            pair.hostnames()
-                .iter()
-                .map(|x| Address::from_string(format!("{}#{}", TCP, x))),
-        );
+        accepts.extend(pair.hostnames().iter().map(|x| Address::new(TCP, x)));
         let self_addr = pair.tx_addr();
 
         let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
@@ -57,7 +57,7 @@ impl Processor for TcpRecvProcessor {
             Ok(len) => len,
             Err(_e) => {
                 info!(
-                    "Connection to peer '{}' was closed; dropping stream",
+                    "Connection to peer '{:?}' was closed; dropping stream",
                     self.peer_addr
                 );
 
@@ -91,15 +91,15 @@ impl Processor for TcpRecvProcessor {
 
         // Heartbeat message
         if msg.onward_route.next().is_err() {
-            trace!("Got heartbeat message from: {}", self.peer_addr);
+            trace!("Got heartbeat message from: {:?}", self.peer_addr);
         }
 
         // Insert the peer address into the return route so that
         // reply routing can be properly resolved
         msg.return_route.modify().prepend(self.peer_addr.clone());
 
-        trace!("Message onward route: {}", msg.onward_route);
-        trace!("Message return route: {}", msg.return_route);
+        trace!("Message onward route: {:?}", msg.onward_route);
+        trace!("Message return route: {:?}", msg.return_route);
 
         // Forward the message to the next hop in the route
         ctx.forward(LocalMessage::new(msg, Vec::new())).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -168,7 +168,7 @@ impl Worker for TcpSendWorker {
         let rx_addr = Address::random_local();
         let receiver = TcpRecvProcessor::new(
             rx,
-            format!("{}#{}", crate::TCP, self.peer).into(),
+            Address::new(crate::TCP, self.peer.to_string()),
             self.internal_addr.clone(),
         );
         ctx.start_processor(rx_addr.clone(), receiver).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
@@ -1,4 +1,4 @@
-use ockam_core::{route, Result};
+use ockam_core::{try_route, Result};
 use ockam_node::Context;
 use ockam_transport_tcp::TcpTransport;
 use rand::{random, Rng};
@@ -19,7 +19,7 @@ async fn setup(ctx: &Context) -> Result<(String, TcpListener)> {
 
     let inlet_port = rand::thread_rng().gen_range(10000, 65535);
     let inlet_addr = format!("127.0.0.1:{}", inlet_port);
-    tcp.create_inlet(inlet_addr.clone(), route!["outlet"])
+    tcp.create_inlet(inlet_addr.clone(), try_route!["outlet"]?)
         .await?;
 
     Ok((inlet_addr, listener))

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -1,6 +1,6 @@
 use core::iter;
 
-use ockam_core::{route, Address, Result, Routed, Worker};
+use ockam_core::{try_route, Address, Result, Routed, Worker};
 use ockam_node::Context;
 use rand::Rng;
 
@@ -27,7 +27,7 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
                 .take(10)
                 .collect()
         };
-        let r = route![(TCP, format!("localhost:{}", rand_port)), "echoer"];
+        let r = try_route![(TCP, format!("localhost:{}", rand_port)), "echoer"]?;
         ctx.send(r, msg.clone()).await?;
 
         let reply = ctx.receive::<String>().await?;
@@ -75,7 +75,7 @@ async fn tcp_lifecycle__reconnect__should_not_error(ctx: &mut Context) -> Result
 
     let tx_address = transport.connect(bind_address).await?;
 
-    let r = route![(TCP, format!("localhost:{}", rand_port)), "echoer"];
+    let r = try_route![(TCP, format!("localhost:{}", rand_port)), "echoer"]?;
     child_ctx.send(r.clone(), msg.clone()).await?;
 
     let reply = child_ctx.receive::<String>().await?;
@@ -96,7 +96,7 @@ async fn tcp_lifecycle__reconnect__should_not_error(ctx: &mut Context) -> Result
     // This should create new connection
     child_ctx
         .send(
-            route![(TCP, format!("localhost:{}", rand_port)), "echoer"],
+            try_route![(TCP, format!("localhost:{}", rand_port)), "echoer"]?,
             msg.clone(),
         )
         .await?;

--- a/implementations/rust/ockam/ockam_transport_websocket/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/transport.rs
@@ -104,8 +104,8 @@ pub(crate) struct WebSocketAddress {
 }
 
 impl From<WebSocketAddress> for Address {
-    fn from(other: WebSocketAddress) -> Self {
-        format!("{}#{}", WS, other.socket_addr).into()
+    fn from(a: WebSocketAddress) -> Self {
+        Address::new(WS, a.socket_addr.to_string())
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/receiver.rs
@@ -59,7 +59,7 @@ where
                 Ok(ws_msg) => ws_msg,
                 Err(_e) => {
                     info!(
-                        "Connection to peer '{}' was closed; dropping stream",
+                        "Connection to peer '{:?}' was closed; dropping stream",
                         self.peer_addr
                     );
                     return Ok(false);
@@ -67,7 +67,7 @@ where
             },
             None => {
                 info!(
-                    "Stream connected to peer '{}' is exhausted; dropping stream",
+                    "Stream connected to peer '{:?}' is exhausted; dropping stream",
                     self.peer_addr
                 );
                 return Ok(false);
@@ -83,7 +83,7 @@ where
 
         // Heartbeat message
         if msg.onward_route.next().is_err() {
-            trace!("Got heartbeat message from: {}", self.peer_addr);
+            trace!("Got heartbeat message from: {:?}", self.peer_addr);
         }
 
         // Insert the peer address into the return route so that
@@ -91,8 +91,8 @@ where
         msg.return_route.modify().prepend(self.peer_addr.clone());
 
         // Some verbose logging we may want to remove
-        trace!("Message onward route: {}", msg.onward_route);
-        trace!("Message return route: {}", msg.return_route);
+        trace!("Message onward route: {:?}", msg.onward_route);
+        trace!("Message return route: {:?}", msg.return_route);
 
         // Forward the message to the next hop in the route
         ctx.forward(LocalMessage::new(msg, Vec::new())).await?;

--- a/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
@@ -1,5 +1,5 @@
 use ockam_core::compat::rand::{self, Rng};
-use ockam_core::{route, Address, Result, Routed, Worker};
+use ockam_core::{try_route, Address, Result, Routed, Worker};
 use ockam_node::Context;
 use tracing::debug;
 
@@ -24,7 +24,7 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
             .take(256)
             .map(char::from)
             .collect();
-        let r = route![(WS, bind_address), "echoer"];
+        let r = try_route![(WS, bind_address), "echoer"]?;
         ctx.send(r, msg.clone()).await?;
 
         let reply = ctx.receive::<String>().await?;
@@ -45,7 +45,7 @@ impl Worker for Echoer {
     type Context = Context;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        debug!("Replying back to {}", &msg.return_route());
+        debug!("Replying back to {:?}", &msg.return_route());
         ctx.send(msg.return_route(), msg.body()).await
     }
 }


### PR DESCRIPTION
## Current Behaviour

Currently the `Address` type in `ockam_core` provides fallible and infallible conversions from string types, where the "infallible" ones panic on invalid input. In addition the type implements `Display`, even though it can not always guarantee to represent itself as UTF-8. 

For more context see #2634.

## Proposed Changes

All conversions from strings to `Address` are now fallible and the `Display` implementation is removed. String parsing is more lenient now, treating the suffix after the `#` separator as opaque. This ripples through the whole system, as the routing functionality frequently declared `Into<Address>` type variables which where substituted with plain string literals. Where necessary, `try_*` siblings have been introduced to allow for the relative convenient constructions of routes, e.g. there is a macro `try_route!` which mirrors `route!` but uses `RouteBuilder::try_append` instead of `RouteBuilder::append`.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor Licence Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/ockam-network/contributors/blob/master/CONTRIBUTORS.csv) file in a separate pull request to the [ockam-network/contributors](https://github.com/ockam-network/contributors) repository.
