### PR TITLE
chore(docs): review messaging docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ indent_style = space
 indent_size = 2
 
 # Let the corresponding language formatters deal with indent size
-[{*.{ex,exs,c,h,rs,cmake,cmake.in,stderr,ts},CMakeLists.txt,Cargo.lock}]
+[{{*.{ex,exs,c,h,rs,cmake,cmake.in,stderr,ts,md},CMakeLists.txt,Cargo.lock}}]
 indent_size = unset
 
 [*.{drawio,svg}]

--- a/documentation/architecture/messaging/Accessibility.md
+++ b/documentation/architecture/messaging/Accessibility.md
@@ -1,91 +1,84 @@
 # Accessibility
 
-Accessibility describes an ability of the route (and workers in this route) to deliver messages to the destination.
-
-It's related to [reliability](./Reliability.md), but describes the principal ability to reach the destination rather then fraction of messages which reach the destination.
-
+Accessibility describes an ability of the route (and workers in this route) to successfully deliver messages to the destination.
 
 Worker `B` is **accessible from** worker `A` **via** route `A->B` when:
+
 - a message sent by `A` to `A->B` can be received by `B`
 
 Route `A->B` **leads from** `A` **to** `B` if:
+
 - `B` is accessible from `A` via `A->B`
 
 Workers `A` and `B` are **mutually accessible** if there are routes:
+
 - `A->B` **via** which `B` is **accessible from** `A`
 - `B->A` **via** which `A` is **accessible from** `B`
 
 <img src="./images/accessibility.jpg" width="100%">
 
-**Notation `A->B` in future implies that `B` is accessible by `A` (route leads from `A` to `B`)**
+**Notation `A->B` in future mentions implies that `B` is accessible by `A` (route leads from `A` to `B`)**
 
 ## Local routes
 
-Local route is a route with a *single* local address, e.g. `[0#A]`
+Local route is a route with a *single* local address, e.g. `[0#A]`.
 
-Because all workers define how messages are handled
-and whether they are forwarded or not,
-**routes with multiple local addresses are not local routes**
+Because all workers define how messages are handled and whether they are forwarded or not,
+**routes with multiple local addresses are not local routes**.
 
-For example one local workers can send message to a remote node,
-hence all the following addressed in the onward route after it will
-be in the context of this remote node.
+For example, one local worker can send message to a remote node, hence all the following addresses in the onward route after it will be in
+the context of this remote node.
 
-If there is a worker with address `A`,
-it's **always accessible** via local route `[0#A]` by **all local workers**
+If there is a worker with address `A`, it's **always accessible** via local route `[0#A]` by **all local workers**
 as long as there are no [additional access control limitations](./Trust.md#access-control)
 
 **All node implementations should implement this behaviour.**
 
 <img src="./images/local_accessibility.jpg" width="100%">
 
-
 ## Forwarder workers
 
-In order to make workers accessible, delivery can be routed
-through additional workers.
-Such workers route all received messages based on some criteria
+In order to make workers accessible, delivery can be routed through additional workers. Such workers route all received messages based on
+some criteria.
 
-**Forwarding is the main instrument for workers accessibility**
+**Forwarding is the main instrument for workers accessibility**.
 
-Let's say we want `B` to be accessible by `A`
+Let's say we want `B` to be accessible by `A`:
 
 - there is a route `A->F` to a forwarding worker `F`
 - there is a route `F->B`
 
 Then `B` can be accessible by `A` via route `A->F` if:
+
 - Worker `F` upon receiving a message sends a message to onward route `F->B`
 
+There are many ways to decide the route `F->B` here:
 
-There are many ways to decide the route `F->B` here
+1. It can be part of the onward route, then `B` is accessible by `A` via `A->F ; F->B`. Such routing worker is called **route based
+   forwarder**:
 
-1. It can be a part of the onward route, then `B` is accessible by `A` via `A->F ; F->B`
-  Such routing worker is called **route based forwarder**
-
-    **If:**
+   **If:**
     - `F` is a route-based forwarder
     - and there is a route `A->F`
     - and there is a route `F->B`
 
-    **Then:**
+   **Then:**
     - `B` is accessible by `A` via route `A->F ; F->B`
 
 <img src="./images/route_forwarder.jpg" width="100%">
 
-2. If can be a part of the router worker state
-  Such worker is called **static forwarder**
+2. It can be part of the router worker state. Such worker is called **static forwarder**:
 
-    **If:**
+   **If:**
     - `Fst` is a static forwarder routing to `Fst->B`
     - and there is a route `A->Fst`
 
-    **Then:**
+   **Then:**
     - `B` is accessible by `A` via route `A->Fst`
 
 <img src="./images/static_forwarder.jpg" width="100%">
 
-3. It can be calculated from the message metadata
-  Such worker is called **metadata forwarder**
+3. It can be calculated from the message metadata. Such worker is called **metadata forwarder**:
 
 <img src="./images/metadata_forwarder.jpg" width="100%">
 
@@ -96,51 +89,51 @@ Forwarder workers can be used to create pipeline routes.
 For example
 
 **If:**
+
 - `F1` is a static forwarder routing to `F1->F2`
 - and `F2` is a route-based forwarder
 
 **Then:**
+
 - worker `B` is accessible by `A` via `A->F1 ; F2->B`
 
 <img src="./images/pipe.jpg" width="100%">
 
-This combination of workers is called a [routing pipe](./Pipes_Channels.md#pipe)
+This combination of workers is called a [routing pipe](./Pipes_Channels.md#pipe).
 
-From the perspective of `A`, routing pipe works the same as a single route-based forwarding worker,
-which allows an abstraction to hide `F1->F2` communication
+From the perspective of `A`, routing pipe works the same as a single route-based forwarding worker, which allows an abstraction to
+hide `F1->F2` communication.
 
-Pipes are widely used in Ockam messaging, more on pipes in [Pipes and Channels](./Pipes_Channels.md)
+Pipes are widely used in Ockam messaging, more on pipes in [Pipes and Channels](./Pipes_Channels.md).
 
 ## Mutual accessibility with return routes
 
 Ockam Routing protocol allows workers to trace return route of a message.
 
-Each time a message is sent by a worker, it may add a return route information.
-If the worker is forwarding the message, it may use the return route of the received message
-and append some additional information to that.
+Each time a message is sent by a worker, it may add a return route information. If the worker is forwarding the message, it may use the
+return route of the received message and append some additional information to that.
 
-Messages sent through a route `A->B` will have some return route when received by `B`, call it `trace(A->B)`
+Messages sent through a route `A->B` will have some return route when received by `B`, call it `trace(A->B)`.
 
-If return route `trace(A->B)` leads to `A`, then delivery on route `A->B` is **backtraceable**
-Such route `trace(A->B) = B->A` is called a **backtrace** of `A->B`
+If return route `trace(A->B)` leads to `A`, then delivery on route `A->B` is **backtraceable**. Such route `trace(A->B) = B->A` is called
+a **backtrace** of `A->B`.
 
-If delivery on a route `A->B` is backtraceable,
-then there is a route `B->A`, which is a backtrace of `A->B`,
-hence  `A` and `B` are mutually accessible.
+If delivery on a route `A->B` is backtraceable, then there is a route `B->A`, which is a backtrace of `A->B`, hence  `A` and `B` are
+mutually accessible.
 
 <img src="./images/return_routes.jpg" width="100%">
 
 **NOTE**:
 
-Route tracing and routes being backtraceable is **sufficient** to achieve mutual accessibility
-of workers, but **not necessary**
+Route tracing and routes being backtraceable is **sufficient** to achieve mutual accessibility of workers, but **not necessary**.
 
-If there is a way to discover return route other than route tracing, a delivery which is backtraceable may be extended or wrapped to inject this route. This extended delivery is now backtraceable.
+If there is a way to discover return route other than route tracing, a delivery which is backtraceable may be extended or wrapped to inject
+this route. This extended delivery is now backtraceable.
 
 ### Local route backtracing
 
-Since a local route `[0#A]` leads to `A` from any local worker,
-then this route is a backtrace for **any local route** used to send messages from `A`
+Since a local route `[0#A]` leads to `A` from any local worker, then this route is a backtrace for **any local route** used to send messages
+from `A`.
 
 **Local delivery is backtraceable as long as sending worker adds its local address to the return route.**
 
@@ -152,31 +145,29 @@ Backtracing is different for route-based, static and metadata based forwarders.
 
 #### For route-based forwarders.
 
-Let's say we want to send a message from `A` to `B` through forwarding worker `F`
+Let's say we want to send a message from `A` to `B` through forwarding worker `F`:
+
 - `F` is accessible to `A` via a local route `[0#F]`
 - `F` is accessible to `B` via a local route `[0#F']` (`F` may be different from `F'`)
 
-We have a backtraceable delivery `A->F` and backtraceable delivery `F'->B` with respective
-backtrace routes `F->A` and `B->F'`
+We have a backtraceable delivery `A->F` and backtraceable delivery `F'->B` with respective backtrace routes `F->A` and `B->F'`.
 
-Then
-- if the forwarder `F` receives the message from `A` with return route `F->A`,
-  it should forward the message with return route `[0#F'] ; F->A`
-- if the forwarder `F` receives the message from `B` with return route `F->B`,
-  it should forward the message with return route `[0#F] ; F->B`
+Then:
+
+- if the forwarder `F` receives the message from `A` with return route `F->A`, it should forward the message with return
+  route `[0#F'] ; F->A`
+- if the forwarder `F` receives the message from `B` with return route `F->B`, it should forward the message with return
+  route `[0#F] ; F->B`
 
 This makes worker `A` and `B` mutually accessible via routes `A->F ; F'->B` and backtrace `B->F' ; F->A`
 
 <img src="./images/proxy.jpg" width="100%">
 
-Such forwarding worker is called **proxy worker**
+Such forwarding worker is called **proxy worker**.
 
-Delivery through a proxy worker is backtraceable
-
-By induction, delivery through multiple proxy workers is also backtraceable
-
-
-Distributed proxy worker (two workers working together as proxy) is called a [Channel](./Pipes_Channels.md#channel):
+Delivery through a proxy worker is backtraceable. By induction, delivery through multiple
+proxy workers is also backtraceable. A distributed proxy worker (two workers working together as proxy) is called
+a [Channel](./Pipes_Channels.md#channel):
 
 <img src="./images/channel.jpg" width="100%">
 
@@ -184,13 +175,10 @@ Distributed proxy worker (two workers working together as proxy) is called a [Ch
 
 Static forwarders forward to a specific route and usually cannot trace return routes to themselves.
 
-As a general rule, **delivery through static forwarders and pipes is not backtraceable**,
-but additional forwarding workers can be used to manipulate routes and build backtraceable delivery
-over multiple static forwarders.
-
+As a general rule, **delivery through static forwarders and pipes is not backtraceable**, but additional forwarding workers can be used to
+manipulate routes and build backtraceable delivery over multiple static forwarders.
 
 Metadata forwarders may trace routes, but it depends on the specific implementation.
-
 
 **More on pipes and channels:** [Pipes and Channels](./Pipes_Channels.md)
 

--- a/documentation/architecture/messaging/Delivery.md
+++ b/documentation/architecture/messaging/Delivery.md
@@ -1,18 +1,17 @@
 # Delivery properties
 
-Delivery through routes of multiple workers and transports depends on those workers behaviour.
-Received sequences may be different from sent, messages may be missing, reordered or compromised.
+Delivery through routes of multiple workers and transports depends on those workers' behaviour. Received sequences may be different from
+sent, messages may be missing, reordered or compromised.
 
-The longer the pipeline of workers and transports between sender and receiver, harder it becomes to reason about delivery.
+The longer the pipeline of workers and transports between sender and receiver, the harder it becomes to reason about delivery.
 
-To simplify that, we are going formalize a set of properties, and describe how they can be combined.
+To simplify that, we are going to formalize a set of properties, and describe how they can be combined.
 
 ## End-to-end
 
 Delivery properties exist between two workers (sender and receiver) on a route.
 
-For example when worker `A` send messages to worker `D` via route `A->B;B->C;C->D`,
-we describe delivery on route `A->D = A->B;B->C;C->D`
+For example when worker `A` send messages to worker `D` via route `A->B;B->C;C->D`, we describe delivery on route `A->D = A->B;B->C;C->D`.
 
 Delivery properties on routes `B->C` and `C->D` may be different, but as long as we can validate properties of `A->D`, we can ignore that.
 
@@ -22,12 +21,12 @@ End-to-end approach allows us to abstract away complex parts of the message deli
 
 ## Core combination techniques
 
-In order to combine delivery over multiple steps, we use two main techniques:
+In order to combine delivery over multiple steps, we use the following techniques:
 
 ### Pipelining:
 
-If we have a delivery `A->B` and delivery `B->C`, and we know the properties of those deliveries, (we know how the workers forwarding messages work).
-Then we can tell how a pipelined delivery `A->B;B->C` would behave.
+If we have a delivery `A->B` and delivery `B->C`, and we know the properties of those deliveries (i.e. we know how each worker forwards
+messages), then we can tell how a pipelined delivery `A->B;B->C` would behave.
 
 <img src="./images/pipelining.jpg" width="100%">
 
@@ -35,47 +34,50 @@ Then we can tell how a pipelined delivery `A->B;B->C` would behave.
 
 If we know that a delivery from `A->C` has certain properties, we can extend logic of A and C to improve those properties.
 
-For example if we want to facilitate delivery between devices over cloud services, we would create a pipeline from one device through the cloud service and to the other device `D1->C;C->D2`.
+For example if we want to facilitate delivery between devices over cloud services, we would create a pipeline from one device through the
+cloud service and to the other device `D1->C;C->D2`.
 
-Then we would set up end-to-end coordination between devices by adding some messaging logic **on the devices** to make sure delivery properties are respected end-to-end.
+Then we would set up end-to-end coordination between devices by adding some messaging logic **on the devices** to make sure delivery
+properties are respected end-to-end.
 
-Special workers can be used to "wrap" unreliable delivery and provide reliable delivery over unreliable message pipelines, e.g. `D1->D1w ; D1w->C;C->D2w ; D2w->D2` where `D1w` and `D2w` are wrapper workers.
+Special workers can be used to "wrap" unreliable delivery and provide reliable delivery over unreliable message pipelines,
+e.g. `D1->D1w ; D1w->C;C->D2w ; D2w->D2` where `D1w` and `D2w` are wrapper workers.
 
 <img src="./images/wrapping.jpg" width="100%">
 
-Main tool to implement end-to-end wrapping is called Pipe,
-more on pipes in [Pipes and Channels](./Pipes_Channels.md)
+Main tool to implement end-to-end wrapping is called [Pipe](./Pipes_Channels.md).
 
-
-**When defining Delivery Properties we will highlight how they can be combined using those two techniques**
+**When defining Delivery Properties we will highlight how they can be combined using those two techniques**.
 
 ## Properties
 
 1. [Accessibility](./Accessibility.md)
 
-    Accessibility describes an ability to deliver messages to the destination. If messages sent from the sender worker to some route will be received by the receiver worker.
-    Accessibility is required property in messaging, since there is not delivery without it.
+   Accessibility describes an ability to deliver messages to the destination. If messages sent from the sender worker to some route will be
+   received by the receiver worker. Accessibility is required property in messaging, since there is no delivery without it.
 
 1. [Reliability and uniqueness](./Reliability.md)
 
-    Reliability describes how many sent messages were received and whether some messages were lost.
-    Uniqness describes whether messages received correspond to unique sent messages or are duplicates of the same sent message.
+   Reliability describes how many sent messages were received and whether some messages were lost. Uniqueness describes whether messages
+   received correspond to unique sent messages or are duplicates of the same sent message.
 
 1. [Ordering](./Ordering.md)
 
-    Ordering describes whether messages are received in the same order as they were sent.
-    Uniqness is related to Ordering in the sense that absolute ordering requires no duplicates, hence similar techniques are used to achieve those properties.
+   Ordering describes whether messages are received in the same order as they were sent. Uniqueness is related to Ordering in the sense that
+   absolute ordering requires no duplicates, hence similar techniques are used to achieve those properties.
 
 1. [Data Integrity](./Data_Integrity.md)
 
-    Data Integrity describes whether received messages carry the same data as sent messages, that they are not corrupted.
-    Delivery Integrity of multiple messages is related to ordering and reliability and often requires those properties.
+   Data Integrity describes whether received messages carry the same data as sent messages, that they are not corrupted. Delivery Integrity
+   of multiple messages is related to ordering and reliability and often requires those properties.
 
 1. [Confidentiality](./Confidentiality.md)
 
-    Confidentiality of messages describes which messaging participants have access to the messages data
+   Confidentiality of messages describes which messaging participants have access to the messages data
 
-1. [Autheniticity and authorization](./Trust.md)
+1. [Authenticity and authorization](./Trust.md)
 
-    Autheniticity describes whether messages received originated at the specific sender.
-    Authorization describes messages can be received by a certain receiver if they were send by a certain sender or went through a certain route.
+   Authenticity describes whether messages received originated at the specific sender. Authorization describes messages can be received by
+   a certain receiver if they were sent by a certain sender or went through a certain route.
+
+**Up next**: [Accessibility](./Accessibility.md)

--- a/documentation/architecture/messaging/Errors.md
+++ b/documentation/architecture/messaging/Errors.md
@@ -8,7 +8,6 @@ Persistent storage with idempotent worker operations
 
 Wrapping and injecting pipes over unreliable routes
 
-
 Reliable discovery and static routes
 
 

--- a/documentation/architecture/messaging/Ordering.md
+++ b/documentation/architecture/messaging/Ordering.md
@@ -7,54 +7,56 @@ Ordering of a delivery describes order in which messages are received in relatio
 #### Monotonic ordering
 
 Delivery is monotonically ordered when:
-  - In a sequence containing messages `m1, m2 ...`
-  - A message `m1` which was sent before message `m2`, cannot be received after `m2`
+
+- In a sequence containing messages `m1, m2 ...`
+- A message `m1` which was sent before message `m2`, cannot be received after `m2`
 
 <img src="./images/monotonic.jpg" width="100%">
 
 #### Strict monotonic ordering
 
 Delivery is strictly ordered when:
-  - In a sequence `m1, m2, ...`
-  - A message `m1` which was sent before message `m2`, cannot be received after `m2` or after `m1`
+
+- In a sequence `m1, m2, ...`
+- A message `m1` which was sent before message `m2`, cannot be received after `m2` or after `m1`
 
 <img src="./images/strict.jpg" width="100%">
 
-Difference between monotonic and strict ordering is that
-**strict ordering doesn't allow duplicates**
+The difference between monotonic and strict ordering is that
+**strict ordering doesn't allow duplicates**.
 
 #### Continuous ordering
 
 Delivery is continuously monotonic ordered when:
-  - In a sequence `m1, m2, ...`
-  - A message `m2` which was sent after `m1`, cannot be received before `m1`
+
+- In a sequence `m1, m2, ...`
+- A message `m2` which was sent after `m1`, cannot be received before `m1`
 
 <img src="./images/continuous.jpg" width="100%">
 
-Difference between monotonic and continuous ordering is that
-**continuous ordering doesn't allow message loss**
+The difference between monotonic and continuous ordering is that
+**continuous ordering doesn't allow message loss**.
 
 #### Continuous strict ordering (Absolute ordering)
 
 Delivery is absolute ordered when:
-  - In a sequence `m1, m2, ...`
-  - A message `m2` which was sent after `m1` can only be received after `m1`
+
+- In a sequence `m1, m2, ...`
+- A message `m2` which was sent after `m1` can only be received after `m1`
 
 <img src="./images/absolute.jpg" width="100%">
 
-**Absolute ordering doesn't allow neither message loss or duplicates**
+**Absolute ordering doesn't allow either message loss or duplicates**.
 
 **NOTE:**
 
-All ordering properties exist per delivery, which only applies for messages sent via same route
+All ordering properties exist per delivery, which only applies for messages sent via same route.
 
 <img src="./images/multi_route.jpg" width="100%">
 
 ## Local delivery
 
-Local delivery (delivery to local routes `[0#A]`) is **absolutely** ordered
-
-**This is a requirement for node implementations**
+Local delivery (delivery to local routes `[0#A]`) has an **absolute** ordering. **This is a requirement for node implementations**.
 
 <img src="./images/local_ordering.jpg" width="100%">
 
@@ -62,39 +64,36 @@ However, workers **may process** messages in different order.
 
 ## Ordering in complex routes
 
-When forwarding messages through an intermediate worker, it can process messages in different order, which might reorder messages in delivery.
+When forwarding messages through an intermediate worker, it can process messages in different order, which might reorder messages in
+delivery.
 
 ### Ordered processors
 
-**Ordered processor** is a worker which upon receiving a sequence of messages,
-sends a sequence of processing results in the same order.
+**Ordered processor** is a worker which upon receiving a sequence of messages, sends a sequence of processed results in the same order.
 
-Processors ordering has the same [ordering types](./Ordering.md#types-of-ordering) as delivery
+Processors ordering has the same [ordering types](./Ordering.md#types-of-ordering) as delivery.
 
-Delivery via local routes through an ordered processor has the same properties as the processor
+Delivery via local routes through an ordered processor has the same properties as the processor.
 
 <img src="./images/ordered_processor.jpg" width="100%">
 
 ### Pipelining ordering
 
-Similar to reliability, ordering guarantees are weakening when pipelining
+Similar to reliability, ordering guarantees are weakening when pipelining.
 
-Pipelining monotonic and continuous delivery results in monotonic delivery
+Pipelining monotonic and continuous delivery results in monotonic delivery.
 
-Pipelining strict and non-strict delivery results in non-strict delivery
+Pipelining strict and non-strict delivery results in non-strict delivery.
 
 <img src="./images/pipelining_ordering.jpg" width="100%">
 
-
 ### Ordered pipes
 
-A pipe in which receiver sends messages in the same order as sender receives them,
-can be viewed as an ordered processor
-
-More on pipes [here](./Pipes_Channels.md)
+A [pipe](./Pipes_Channels.md) in which receiver sends messages in the same order as sender receives them, can be viewed as an ordered
+processor.
 
 Ordered pipes can be injected to turn unordered delivery on a route (or multiple routes)
-into an ordered delivery
+into an ordered delivery.
 
 <img src="./images/ordered_pipe.jpg" width="100%">
 
@@ -102,30 +101,29 @@ into an ordered delivery
 
 ### Sequential processing pipe:
 
-Also known as **receive queue approach**
+Also known as **receive queue approach**:
 
-- `P2` send confirms for every sent message to `P1`
+- `P2` sends confirms for every sent message to `P1`
 - `P1` does not process a message before `P2` sends a previous message
 
 To enforce **continuity**, sender may re-send messages which were not confirmed.
 
-To enforce **strictness**, receiver may confirm duplicate messages without sending them
+To enforce **strictness**, receiver may confirm duplicate messages without sending them.
 
 <img src="./images/sequential_pipe.jpg" width="100%">
 
 ### Indexed processing pipe:
 
-Also known as **send queue approach**
+Also known as **send queue approach**:
 
 - `P1` assigns each message a monotonic continuous index
 - `P2` sends messages in index order
 
 To enforce **continuity**, receiver may request missing lower index messages when receiving non-consecutive index
 
-To enforce **strictness**, receiver doesn't send messages with the same index to already sent messages
+To enforce **strictness**, receiver sends the same message once
 
 <img src="./images/index_continuous_pipe.jpg" width="100%">
-
 
 **More on pipes and channels:** [Pipes and Channels](./Pipes_Channels.md)
 

--- a/documentation/architecture/messaging/Pipes_Channels.md
+++ b/documentation/architecture/messaging/Pipes_Channels.md
@@ -4,69 +4,75 @@
 
 ## Purpose
 
-Pipes and channels are main building blocks for end-to-end messaging.
+Pipes and channels are the main building blocks for end-to-end messaging.
 
-In order to provide end-to-end properties of message delivery, the "ends" need to be defined and have coordinated logic and state.
-This means we need groups of coordinated workers to achieve that.
-
+In order to provide end-to-end properties of message delivery, the "ends" need to be defined and have coordinated logic and state. This
+means we need groups of coordinated workers to achieve that.
 
 ## Definitions
 
 ## Pipe
 
 Pipe is a pair of coordinated workers, Sender and Receiver, such as:
-  - When sender receives a message with:
+
+- When sender receives a message with:
+
   ```
     OR: [sender] ; onward_route
     RR: return_route
   ```
-  - Sender forwards the message to receiver
-  - Receiver sends a message with:
+
+- Sender forwards the message to receiver
+- Receiver sends a message with:
+
   ```
     OR: onward_route
     RR: return_route
   ```
 
-Pipes facilitate unidirectional message delivery.
-Pipes preserve the return route of the original message BUT do not trace a return route
+Pipes facilitate unidirectional message delivery. Pipes preserve the return route of the original message BUT do not trace a return route.
 
-Pipes may use a coordinated state and send more messages between sender and receiver to provide
-additional message delivery properties.
+Pipes may use a coordinated state and send more messages between sender and receiver to provide additional message delivery properties.
 
 <img src="./images/pipe.jpg" width="100%">
 
 ## Channel
 
 Channel is a pair of coordinated workers, C1 and C2, such as:
-  - When C1 receives a message with:
+
+- When C1 receives a message with:
+
   ```
     OR: [C1] ; onward_route
     RR: return_route
   ```
-  - C1 forwards the message to C2
-  - C2 sends a message with:
+
+- C1 forwards the message to C2
+- C2 sends a message with:
+
   ```
     OR: onward_route
     RR: [C2] ; return_route
   ```
 
-  - When C2 receives a message with:
+- When C2 receives a message with:
+
   ```
     OR: [C2] ; onward_route
     RR: return_route
   ```
-  - C2 forwards the message to C1
-  - C1 sends a message with:
+
+- C2 forwards the message to C1
+- C1 sends a message with:
+
   ```
     OR: onward_route
     RR: [C1] ; return_route
   ```
 
-Channels facilitate bidirectional message exchange.
-Channels preserver the return route AND trace the return route with the channel address
+Channels facilitate bidirectional message exchange. Channels preserve the return route AND trace the return route with the channel address.
 
-Same as pipes, channels may provide additional messaging delivery properties and have more messages
-exchanged between C1 and C2.
+Same as pipes, channels may provide additional messaging delivery properties and have more messages exchanged between C1 and C2.
 
 <img src="./images/channel.jpg" width="100%">
 
@@ -74,23 +80,26 @@ exchanged between C1 and C2.
 
 ### Accessibility and session setup
 
-Pipes:
+#### Pipes
 
-In order to have coordinated state, sender and receiver must be accessible by each other. At least receiver should be accessible by the sender.
+In order to have coordinated state, sender and receiver must be accessible by each other. At least receiver should be accessible by the
+sender.
 
-Since messages are flowing from the sender, receiver does not initiate the communication and rarely needs to store a route to the sender in its state.
+Since messages are flowing from the sender, receiver does not initiate the communication and rarely needs to store a route to the sender in
+its state.
 
-1. Static pipe - a pipe in which sender is created with a known route to the receiver
-2. Session pipe - a pipe in which sender is created with a session init route and receiver may be created during the session establishment
+1. Static pipe: a pipe in which sender is created with a known route to the receiver
+2. Session pipe: a pipe in which sender is created with a session init route and receiver may be created during the session establishment
 
 <img src="./images/static_pipe.jpg" width="100%">
 
 <img src="./images/session_pipe.jpg" width="100%">
 
-Channels:
+#### Channels
 
-1. Static channel - a channel where both ends are created with routes to each other
-2. Session channel - a channel where one side is created with a session init route and another may be created during the session establishment
+1. Static channel: a channel where both ends are created with routes to each other
+2. Session channel: a channel where one side is created with a session init route and another may be created during the session
+   establishment
 
 ### Channels using pipes
 
@@ -98,52 +107,57 @@ A channel may use two pipes to deliver messages between channel workers
 
 <img src="./images/channel_pipes.jpg" width="100%">
 
+A channel using pipes as means to deliver messages should take into account that pipes do not trace return routes and just pass the incoming
+message route as a return route.
 
-A channel using pipes as means to deliver messages should take into account that pipes do not trace return routes and just pass the incoming message route as a return route.
+This means that the route scope inside and outside the pipe is different and routing messages through the channel workers either:
 
-This means that the route scope inside and outside of the pipe is different and to route messages through the channel workers either:
-- receiver needs to be configured to route messages through the channel
-OR
+- receiver needs to be configured to route messages through the channel, or
 - channel ends should be aware of each other and send messages to each other through the pipes
 
 Using the latter approach message route tracing looks like this:
 
-Given
+Given:
 
-Channel ends `C1` and `C2`
-Pipe workers `S1->2`, `R1->2`, `S2->1` and `R2->1`
-
+- Channel ends `C1` and `C2`
+- Pipe workers `S1->2`, `R1->2`, `S2->1` and `R2->1`
 
 Message sent to `C1` with the routes:
+
 ```
 OR: [C1] ; onward_route
 RR: return_route
 ```
 
 Will be forwarded to the pipe sender `S1->2` with:
+
 ```
 OR: [S1->2] ; [C2'] ; onward_route
 RR: return_route
 ```
 
 When `C2` receives the message from the pipe
+
 ```
 OR: [C2'] ; onward_route
 RR: return_route
 ```
 
 It sends the message with:
+
 ```
 OR: onward_route
 RR: [C2] ; return_route
 ```
 
-`C2'` is an address of worker C2 which is used for internal channel communication, it may be different from the address used for external communication.
+`C2'` is an address of worker C2 which is used for internal channel communication, it may be different from the address used for external
+communication.
 
-What happens here is the channel end which receives a message forwards it through the pipe and the channel end which is supposed to send that message.
+[//]: # (TODO: rephrase?)
+What happens here is the channel end which receives a message forwards it through the pipe and the channel end which is supposed to send
+that message.
 
 Pipe channels can be dynamically established using [pipe channel session process](https://github.com/build-trust/proposals/blob/main/design/0011-pipes-and-channels/pipe_channel_session.md)
-
 
 **Back to:** [Delivery properties](Delivery.md)
 

--- a/documentation/architecture/messaging/Pipes_Directory.md
+++ b/documentation/architecture/messaging/Pipes_Directory.md
@@ -4,7 +4,7 @@
 
 ### Re-send pipe
 
-- Sender attaches a unique ID to every message forwarded.
+- Sender attaches a unique ID to every message forwarded
 - Receiver after sending a message confirms send to Sender with the message ID
 - If Sender does not receive a confirmation in some time - it sends the message again
 - If there are unconfirmed messages - Sender buffers them until it gets confirm
@@ -14,25 +14,28 @@
 #### Requirements:
 
 State:
+
 - Sender must have a route Receiver
 - Sender must keep current unconfirmed message and it's id
 - Sender must keep a buffer of messages to be sent while waiting for confirm
 
 Internal Routes:
+
 - A route from Sender to Receiver should be backtraceable
 
 Delivery properties:
+
 - Delivery is at-least-once with possible duplicates
 
 Error tolerance:
-- Delivery tolerates failures in the route from Sender to Receiver as long as Receiver is accessible via Receiver route.
-- Delivery does not tolerate failures in the Sender worker.
-- Delivery tolerates failures in the Receiver worker
 
+- Delivery tolerates failures in the route from Sender to Receiver as long as Receiver is accessible via Receiver route
+- Delivery does not tolerate failures in the Sender worker
+- Delivery tolerates failures in the Receiver worker
 
 ### Re-send pipe with multiple unconfirmed messages
 
-Same behaviour as for [resend pipe](Pipes_Directory.md#re-send-pipe), but instead of buffering unsent messages and waiting for confirm
+Same behaviour as for [resend pipe](Pipes_Directory.md#re-send-pipe), but instead of buffering unsent messages and waiting for confirm,
 Sender sends all messages and tracks multiple unconfirmed messages.
 
 <img src="./images/resend_multi_pipe.jpg" width="100%">
@@ -40,13 +43,15 @@ Sender sends all messages and tracks multiple unconfirmed messages.
 #### Requirements:
 
 State:
+
 - Sender must have a route to Receiver
 - Sender must keep current unconfirmed messages and their IDs
 
 Internal Routes:
+
 - A route from Sender to Receiver should be backtraceable
 
-Delivery properties and error tolerance are the same as in [resend pipe](Pipes_Directory.md#re-send-pipe)
+Delivery properties and error tolerance are the same as in [resend pipe](Pipes_Directory.md#re-send-pipe).
 
 ### Stream pipe - pipe with persistent storage
 
@@ -62,19 +67,23 @@ Delivery properties and error tolerance are the same as in [resend pipe](Pipes_D
 #### Requirements:
 
 State:
+
 - Sender must have a route to stream
 - Receiver must have a route to stream
 - (optional) Receiver must have a route to index storage
 
 Internal Routes:
+
 - A route from sender to stream should be backtraceable
 - A route from receiver to stream should be backtraceable
 - (optional) A route from receiver to index storage should be backtraceable
 
 Delivery properties:
+
 - Delivery is at-least-once with possible duplicates
 
 Error tolerance:
+
 - Delivery tolerates errors in the routes from sender and receiver to stream
 - Delivery tolerates errors in the routes from receiver to index storage
 - Delivery tolerates errors in the receiver
@@ -95,17 +104,21 @@ Error tolerance:
 #### Requirements:
 
 State:
+
 - Sender must have a route to receiver
 - Sender keeps a buffer of unsent messages
 
 Internal Routes:
+
 - Route from sender to receiver must be backtraceable
 - Delivery from sender to receiver must be at-least-once (to not lose confirms)
 
 Delivery properties:
+
 - Delivery is continuously ordered
 
 Error tolerance:
+
 - Delivery does not tolerate errors in Sender or Receiver
 
 **Due to low error tolerance, low throughput and high inner route requirements, this implementation is not very useful**
@@ -113,7 +126,7 @@ Error tolerance:
 ### Strict monotonic index pipe
 
 - Sender assigns a consecutive index to each message
-- Receiver keeps track of messages indexes and only sends message if its index is higher then the current
+- Receiver keeps track of messages indexes and only sends message if its index is higher than the current
 - Receiver sets the current index to the last sent message index
 
 <img src="./images/index_pipe.jpg" width="100%">
@@ -121,26 +134,29 @@ Error tolerance:
 #### Requirements:
 
 State:
+
 - Sender keeps track of the last assigned index
 - Receiver keeps track of the last sent index
 
 Internal Routes:
+
 - Route from sender and receiver should be accessible
 
 Delivery properties:
+
 - Delivery is strictly monotonically ordered (may have message loss, cannot have duplicates)
 - This can be relaxed to monotonic with the check in Receiver changed from `<` to `=<`
 
 Error tolerance:
+
 - Delivery tolerates errors in the route from sender to receiver as long as it's eventually accessible
 - Delivery does not tolerate errors in the sender or receiver
 
-
-### Continous index pipe (send queue)
+### Continuous index pipe (send queue)
 
 - Sender assigns a consecutive index to each message
-- Receiver keeps track of messages indexes and if the message index is not consecutive to the current index,
-the message is put in the send queue
+- Receiver keeps track of messages indexes and if the message index is not consecutive to the current index, the message is put in the send
+  queue
 - If message is the right index, it's sent and current index is set to the message index
 - After sending a message with the right index, send queue is checked for the next index, which may be sent
 
@@ -149,18 +165,22 @@ the message is put in the send queue
 #### Requirements:
 
 State:
+
 - Sender keeps track of the last assigned index
 - Receiver keeps track of the current index
 - Receiver keeps the send queue
 
 Internal Routes:
+
 - Delivery from sender to receiver should be at-least-once
 
 Delivery properties:
+
 - Delivery is absolutely ordered (may not have message loss or duplicates)
 - This can be relaxed to just continuous ordering with the check in Receiver changed from `<` to `=<`
 
 Error tolerance:
+
 - Delivery does not tolerate errors in sender or receiver
 
 

--- a/documentation/architecture/messaging/README.md
+++ b/documentation/architecture/messaging/README.md
@@ -2,79 +2,85 @@
 
 ## Problem statement
 
-Ockam Routing provides a framework to send messages between Ockam Workers and allows workers to forward messages using onward routes and trace return routes.
+Ockam Routing provides a framework to send messages between Ockam Workers and allows workers to forward messages using onward routes and
+trace return routes.
 
-However, since it's up to the workers and transports to forward messages, Ockam Routing protocol does not guarantee that messages sent will be delivered.
+However, since it's up to the workers and transports to forward messages, Ockam Routing protocol does not guarantee that messages sent will
+be delivered.
 
-Different transports have different delivery properties, routes may forward a message through multiple machines over the network which makes it hard to reason about delivery over complex routes.
-
+Different transports have different delivery properties, routes may forward a message through multiple machines over the network which makes
+it hard to reason about delivery over complex routes.
 
 ## Definitions
 
 ### Message
+
 A piece of information which can be sent and received by Workers.
 
-Message names use lower case, usually starting with `m`, e.g. `m1`, `msg1`, `m_create`
+Message names use lower case, usually starting with `m`, e.g. `m1`, `msg1`, `m_create`.
 
 ### Worker
+
 A stateful system which can receive and send Messages.
 
-Workers are named staring with uppercase letters, e.g. `worker A`, `worker Sender`, `worker C1`
+Workers are named starting with uppercase letters, e.g. `worker A`, `worker Sender`, `worker C1`.
 
-Worker addresses use either worker names, shorter worker names or `<number>#<worker_name>` format
+Worker addresses use either worker names, shorter worker names or `<number>#<worker_name>` format.
 
-Worker addresses use uppercase letters numbers
+Worker addresses use uppercase letters numbers:
+
 - `A` is an address of `worker A`
 - `0#B` is an address of `worker B` (with address type `0`)
 - `S` is an address for `worker Sender`
 
 Workers can have multiple addresses:
+
 - `C1` is an address for `worker C1`
 - `C1'` is also an address for `worker C1`
 
-Format with address type, e.g `0#A`, `1#B` is used to distinguish
-transport addresses and local node addresses.
+Format with address type, e.g `0#A`, `1#B` is used to distinguish transport addresses and local node addresses.
+
 More on local addresses in [Accessibility](./Accessibility.md#local-routes)
 
 ### Route
 
-A destination that message can be sent to, a Route consists of one or multiple Addresses in order.
+A destination that a message can be sent to. A Route consists of a set of ordered Addresses.
 
-A Route represents a path that message should be sent through.
+A Route represents a path that a message should be sent through.
 
-- A route to `worker B` is written as `->B`, if `worker A` sends messages to this route,
-it can be written as `A->B`
-- Routes can be combined together, combination of `A->B` and `B->C` is written as `A->B ; B->C`
-`;` is a route combination operator
+- A route to `worker B` is written as `->B`, if `worker A` sends messages to this route, it can be written as `A->B`
+- Routes can be combined together: combination of `A->B` and `B->C` is written as `A->B ; B->C`, where
+  `;` is the route combination operator
 - Routes are lists of addresses and can be written as such `[A, B, C]`
 - We can use both `->` and list notation together, e.g. `[A] ; A->C`
 - Routes without specific addresses are written with lowercase names starting with `r`, e.g `r1`, `r_onward`, `r_return`
 
+*In Ockam Routing protocol, Messages, Workers and Routes have more specific definitions. This guide is using wider notion for abstraction
+purposes.*
 
-*In Ockam Routing protocol, Messages, Workers and Routes have more specific definitions.
-This guide is using wider notion for abstraction purposes.*
-
-*E.g. UDP datagram is not implemented as Ockam Routing Message and return address in the datagram is not implemented as Ockam Route, but they can be called Message and Route.*
+*E.g. UDP datagram is not implemented as Ockam Routing Message and return address in the datagram is not implemented as Ockam Route, but
+they can be called Message and Route.*
 
 ### Delivery
 
-A sequence of messages `m1,m2,m3...` send from `worker A` to route `A->B` and received by `worker B`
+A sequence of messages `m1,m2,m3...` send from `worker A` to route `A->B` and received by `worker B`.
 
-Deliveries may have multiple **delivery properties**, usually statistically measured
+Deliveries may have multiple **delivery properties**, usually statistically measured.
 
 More on delivery properties in [Delivery properties](./Delivery.md)
 
-Delivery exists per route, if messages `m1,m3` are sent over route `A->B` and messages `m2,m4` sent over route `A'->B'`, those are two different deliveries.
+Delivery exists per route, if messages `m1,m3` are sent over route `A->B` and messages `m2,m4` sent over route `A'->B'`, those are two
+different deliveries.
 
-We can use the route notation to identify deliveries, e.g. `delivery A->B`
+We can use the route notation to identify deliveries, e.g. `delivery A->B`.
 
 ### Pipe
 
-A pair of coordinated workers which provide end-to-end delivery with certain properties
+A pair of coordinated workers which provide end-to-end delivery with certain properties.
 
 ### Channel
 
-A pair of coordinated workers which provide end-to-end delivery with certain properties in both directions
+A pair of coordinated workers which provide end-to-end delivery with certain properties in both directions.
 
 **More on pipes and channels**: [Pipes and Channels](./Pipes_Channels.md)
 

--- a/documentation/architecture/messaging/Reliability.md
+++ b/documentation/architecture/messaging/Reliability.md
@@ -1,125 +1,126 @@
 # Reliability and uniqueness
 
-**Reliability** describe how many sent messages were received and whether some messages are lost
+**Reliability** describes how many sent messages were received and whether some messages were lost.
 
-Reliability can be described as a fraction of a number of unique messages received `Ru` to a number of messages sent `S`
+Reliability can be described as the proportion between the number of unique messages received `Ru` and the total number of messages sent `S`
+. When sending messages on `A->B`, `A` sends `SA` messages and `B` receives `RuB` unique messages, reliability of such delivery
+is `R(A->B) = RuB/SA =< 1`. Given that `Ru` cannot be higher than `S`, reliability is always `=< 1`.
 
-When sending messages on `A->B`, `A` sends `SA` messages and `B` receives `RuB` unique messages, reliability of such delivery is `R(A->B) = RuB/SA =< 1`
+**Uniqueness** describes whether a received message is unique or is a duplicate of a message that was already received.
 
-Given that `Ru` cannot be higher than `S`, reliability is always `=< 1`
+We can measure the duplication rate in a delivery by calculating a fraction of total messages received `R` to unique messages received `Ru`
+. `DR = R/Ru`. Duplication rate of `1` means each received message was received only once, rate of `2` means that messages were received two
+times on average, not necessary each message was duplicated though.
 
-**Uniqness** describes whether messages received correspond to unique sent messages or are duplicates of the same sent message
-
-We can measure duplication rate in a delivery by calculating a fraction of total messages received `R` to unique messages received `Ru`. `DR = R/Ru`.
-Duplication rate of `1` means each received message was received only once, rate of `2` means that messages were received two times on average, not necessary each message was duplicated though.
-
-For consistency with reliability we can use inverted duplication rate, call it **uniqueness rate** as `UR = 1/DR = Ru/R`
-
-If `UR = 1` when each message was received only one time, `UR = 0.5` when messages are received twice on average
+For consistency with reliability, we can use inverted duplication rate, call it **uniqueness rate** as `UR = 1/DR = Ru/R`. If `UR = 1` when
+each message was received only one time, `UR = 0.5` when messages are received twice on average.
 
 <img src="./images/reliability.jpg" width="100%">
 
-Reliability `R(A->B) = 3/4` - 1 message out of 4 was lost
+From the image above:
 
-Uniqness rate `UR(A->B) = 3/4` - 1 message out of 4 was duplicated
+* Reliability `R(A->B) = 3/4`: 1 message out of 4 was lost
+
+* Uniqueness rate `UR(A->B) = 3/4`: 1 message out of 4 was duplicated
 
 ## Delivery modes
 
-Reliability often described together with uniqueness as "delivery modes"
+Reliability is often described together with uniqueness as "delivery modes".
 
 If we have a delivery mode as a tuple of reliability and uniqueness rate: `DM(A->B) = {R(A->B), UR(A->B)}`
 then we can describe the following modes:
 
-1. Unreliable. When messages may be lost or duplicated `DM = {R < 1, UR < 1}`
-1. At-most-once. When all messages are unique, but may be missing `DM = {R < 1, UR = 1}`
-1. At-least-once. When all messages are received, but may have duplicates `DM = {R = 1, UR < 1}`
-1. Exactly-once. When all messages are received and only once `DM = {R = 1, UR = 1}`
+1. Unreliable: when messages may be lost or duplicated, `DM = {R < 1, UR < 1}`
+1. At-most-once: when all messages are unique, but may be missing, `DM = {R < 1, UR = 1}`
+1. At-least-once: when all messages are received, but may have duplicates, `DM = {R = 1, UR < 1}`
+1. Exactly-once: when all messages are received and only once, `DM = {R = 1, UR = 1}`
 
-Exactly-once delivery is controversal and hard to achieve in presence of errors.
-For practical purposes we're going to use more relaxed version of this definition
-where both values **approach one** `-> 1` instead of **equal one** `= 1`.
+Exactly-once delivery is controversial and hard to achieve in presence of errors. For practical purposes we're going to use a more relaxed
+version of this definition where both values **approach one** `-> 1` instead of **equal one** `= 1`.
 
-Then for relaxed exactly-once: `DM = {R -> 1, UR -> 1}`
+Then for relaxed exactly-once we have `DM = {R -> 1, UR -> 1}`.
 
 <img src="./images/delivery_modes.jpg" width="100%">
 
-
 ## Pipeline reliability
 
-When pipelining deliveries, e.g. `A->B ; B->C`, reliability and uniqueness rates are multiplying, because they are probabilities of dependent events.
+When pipelining deliveries, e.g. `A->B ; B->C`, reliability and uniqueness rates are multiplying, because they are probabilities of
+dependent events.
 
 <img src="./images/pipeline_delivery.jpg" width="100%">
 
 Which means that:
+
 - `R(A->B ; B->C) = R(A->B) * R(B->C)`
 - and `UR(A->B ; B->C) = UR(A->B) * UR(B->C)`
 
-If we pipeline deliveries:
+If we pipeline deliveries, the most relaxed delivery mode will dominate:
 
-- at-most-once with at-least-once - the pipeline will be unreliable
-- exactly-once with at-least-once - the pipeline will be at-least-once
-- exactly-once with at-most-once - the pipeline will be at-most-once
-- unreliable to anything - the pipeline will be unreliable
+- at-most-once with at-least-once: the pipeline will be unreliable
+- exactly-once with at-least-once: the pipeline will be at-least-once
+- exactly-once with at-most-once: the pipeline will be at-most-once
+- unreliable to anything: the pipeline will be unreliable
 
-As you can see preserving high reliability in pipelined delivery is problematic,
-therefore reliability should be ensured by end-to-end wrapping
+As you can see preserving high reliability in pipelined delivery is problematic and, therefore, reliability should be ensured
+by [end-to-end wrapping](./Delivery.md#end-to-end-wrapping).
 
 ## Local delivery
 
-**Local delivery is supposed to be implemented as highly reliable**
+**Local delivery is supposed to be implemented as highly reliable**.
 
-Workers supposed to have delivery mode close to exactly-once **as long as both workers are alive and don't have errors**
-
-For practical purposes delivery mode over a route with single local address `DM([0#B])` is assumed `{R->1, UR->1}`
+Workers are supposed to have delivery mode close to exactly-once **as long as both workers are alive and don't have errors**. For practical
+purposes delivery mode over a route with single local address `DM([0#B])` is assumed `{R->1, UR->1}`.
 
 ## Pipe reliability
 
 If we have a pipe `P1->P2`, which connects to endpoints `A` and `B` on local routes `A->0#P1 ; P1->P2 ; P2->0#B`.
 
-Since we assume delivery on `[0#P1]` and `[0#B]` to be exactly-once, we can assume that delivery between `A` sending and `B` receiving messages has the same mode as delivery between `P1` receiving messages and `P2` sending messages.
+Since we assume delivery on `[0#P1]` and `[0#B]` to be exactly-once, we can assume that delivery between `A` sending and `B` receiving
+messages has the same mode as delivery between `P1` receiving messages and `P2` sending messages.
 
 <img src="./images/delivery_pipe.jpg" width="100%">
 
-We call that **pipe reliability**
+We call that **pipe reliability**. Same for uniqueness rate we can define **pipe uniqueness rate**.
 
-Same for uniqueness rate we can define **pipe uniqueness rate**
+This allows us to design the pipes as building blocks to achieve reliable delivery, **with the caveat of having actual endpoints and pipe
+workers always running and not having errors*.
 
-This allows us to design the pipes as building blocks to achieve reliable delivery, **with a caveat of having actual endpoints and pipe workers always running and not having errors**
-
-**A difference between pipe reliability and delivery reliability is that pipe does not take into account delivery between pipe workers and application workers**
-
+**A difference between pipe reliability and delivery reliability is that pipe does not take into account delivery between pipe workers and
+application workers**.
 
 ## Improving reliability
 
-Retries can be used to improve delivery reliability.
+**Retries** can be used to improve delivery reliability.
 
-Given a chance to deliver message from `A` to `B`: `R(A->B) = 0.5`
+- Given a chance to deliver message from `A` to `B`: `R(A->B) = 0.5`.
+- If we retry delivery on missing message,
+- Then it becomes `R1 = R + (1- R) * R = 0.75` on first retry, `R2 = 0.875` on second, etc.
+- If retries `-> ∞`,
+- Then `R∞->1`.
 
-If we retry delivery on missing message, it becomes `R1 = R + (1- R) * R = 0.75` on first retry, `R2 = 0.875` on second, etc.
+Retries **decrease the uniqueness rate**.
 
-If retries `-> ∞`, then `R∞->1`
+- Given `DM(A->B) = {0.5, 1}`.
+- If we enable retries for this delivery,
+- Then `DMr∞(A->B) = {->1, ->0.5}`, where reliability increased at the expense of reducing the uniqueness rate.
 
-Retries decrease uniqueness rate
-Given `DM(A->B) = {0.5, 1}`
-`DMr(A->B)` - delivery mode of `A->B` with retries
-`DMr∞(A->B) = {->1, ->0.5}`
-
-To control retries, confirmation messages and timeouts are used
+To control retries, confirmation messages and timeouts are used:
 
 <img src="./images/retries.jpg" width="100%">
 
-To provide at-least-once delivery between workers which don't have additional logic,
-at-least-once pipe can be used:
+To provide at-least-once delivery between workers which don't have additional logic, at-least-once pipe can be used:
 
 <img src="./images/resend_pipe.jpg" width="100%">
 
 ## Improving uniqueness rate
 
-Improving uniqness rate of a delivery is not possible, because we measure already received message and we can't un-receive it.
+Improving delivery uniqueness rate is not possible, because we measure already received messages, and we can't un-receive them.
 
-For **pipe uniqueness rates** we can use some techniques to make sure that pipe sender does not send the duplicates for messages already sent.
+However, for **pipe uniqueness rates**, we can use some techniques to make sure that the pipe sender does not send the duplicates for
+messages already sent.
 
-This is called **deduplication**, when we ignore some received messages based on some knowledge of which messages we already sent.
+This is called **deduplication**, which consists of ignoring some received messages based on some knowledge of which messages we already
+sent.
 
 #### ID Deduplication:
 
@@ -131,70 +132,65 @@ This is called **deduplication**, when we ignore some received messages based on
 #### Index deduplication:
 
 - Sender assigns each message next monotonic index
-- Receiver discards messages with lower index then already processed.
+- Receiver discards messages with lower index than already processed
 - **Optionally receiver only processes next consecutive index**
 
 <img src="./images/index_pipe.jpg" width="100%">
 
 ## Reliable message delivery in presence of errors in the pipeline
 
-Previously we assumed that workers are always alive and have no errors, in that case given worker forwards all messages exactly-once it's internal delivery mode will be exactly-once.
+Previously we assumed that workers are always alive and have no errors. In that case, given that a worker forwards all messages
+exactly-once, its internal delivery mode will be also exactly-once.
 
-If it's not so, then we should consider reliability of delivery from worker receiving a message to it sending this message.
+Otherwise, we should consider reliability of delivery from worker receiving a message to it sending this message.
 
-If we have a pipeline of routes `A->X; X->B`, in which `R(A->X) -> 1` and `R(X->B) -> 1`
-then `R(A->B) = R(A->X)xR(X)xR(X->B)`
-
-If X has errors, then `R(X) < 1`
+- If we have a pipeline of routes `A->X; X->B`, in which `R(A->X) -> 1`
+- and `R(X->B) -> 1`,
+- Then `R(A->B) = R(A->X)xR(X)xR(X->B)`. If X has errors, then `R(X) < 1`.
 
 <img src="./images/reliability_errors.jpg" width="100%">
 
 ### Pipe injection
 
-In order to achieve reliable delivery, we can inject a reliable delivery pipe between `A->B`,
-such that the messages will go via `A->P1 ; P1->X ; X->P2 ; P2->B`.
+In order to achieve reliable delivery, we can inject a reliable delivery pipe between `A->B`, such that the messages will go
+via `A->P1 ; P1->X ; X->P2 ; P2->B`.
 
-Then if `P1` and `P2` can achieve `R(P1->P2) = 1`, `R(A->B)` will also be `1`
+Then if `P1` and `P2` can achieve `R(P1->P2) = 1`, `R(A->B)` will also be `1`.
 
 <img src="./images/pipe_injection.jpg" width="100%">
 
 ### Cascade confirmation
 
-In case we don't have a reliable delivery to the last step or we can have errors processing the message,
-then the pipe receiver may be configured to send confirms to the pipe sender only after it gets a confirm from the next worker in the pipeline
+In case we don't have a reliable delivery to the last step, or if we can have errors processing the message, then the pipe receiver may be
+configured to send confirms to the pipe sender only after it gets a confirmation from the next worker in the pipeline.
 
-For example if we have a pipeline `A->P1; P1->P2; P2->B` and delivery `P2->B` is not reliable, then `P2` should only send confirms to `P1` when it receives a confirm from `B`
+For example, if we have a pipeline `A->P1; P1->P2; P2->B` and delivery `P2->B` is not reliable, then `P2` should only send confirmations
+to `P1` when it receives a confirmation from `B`.
 
-There can be multiple confirming workers in this pipeline, e.g. `A->P1; P1->P2; P2->P3; P3->B` etc
+There can be multiple confirming workers in this pipeline, e.g. `A->P1; P1->P2; P2->P3; P3->B`.
 
 <img src="./images/cascade_confirm.jpg" width="100%">
 
-Cascade confirmations can be used to implement reliable **processing**
-
-Reliable processing is when the processing worker `B` sends confirmation when the message was processed and not when it was received.
+Cascade confirmations can be used to implement **reliable processing**, which happens when the processing worker `B` sends confirmation
+right after the message was processed and not when it was received.
 
 <img src="./images/reliable_processing.jpg" width="100%">
 
-
 ### Persistent storage
 
-Cascade confirmation may require long chains and lots of messages exchanged
-
-To optimize that, persistent storage can be used.
+Cascade confirmation may require long chains and lots of messages exchanged. To optimize that, **persistent storage** can be used. This
+technique is also time dependent, but as long as message delay tolerance is lower than data storage time, it's practical.
 
 Persistent storage `S` has `R(S) = ->1` as long as it does not delete data.
 
-This is also time dependent, but as long as message delay tolerance is lower then data storage time - it's practical
+- Because `R(S) = ->1`,
+- Given `R(A->S) = ->1` (with confirmations),
+- And `R(S->B) = ->1` (reading from the start in case of errors),
+- Then `R(A->B) = ->1`
 
 <img src="./images/persistent_storage.jpg" width="100%">
 
-- Because `R(S) = ->1`
-- Given `R(A->S) = ->1` (with confirmations)
-- And `R(S->B) = ->1` (reading from the start in case of errors)
-- Then `R(A->B) = ->1`
-
-
-Persistent storage is also useful in case of errors on `B` as long as `B` can recover and retry reading from the storage
+Persistent storage is also useful in case of errors on `B`, as long as `B` can recover and retry reading from the storage:
 
 <img src="./images/persistent_storage_recovery.jpg" width="100%">
 

--- a/documentation/architecture/messaging/Routing.md
+++ b/documentation/architecture/messaging/Routing.md
@@ -4,12 +4,10 @@
 
 Pipes and channels rely on internal routing to deliver messages.
 
-Internal message exchange between pipe workers for each pipe has a certain API,
-different from an external exchange with other workers.
-In order for pipe workers to distinguish between external and internal API messages,
-they can use different addresses.
+Internal message exchange between pipe workers for each pipe has a certain API, different from an external exchange with other workers. In
+order for pipe workers to distinguish between external and internal API messages, they can use different addresses.
 
-Each pipe worker would have `internal` address, to talk to another pipe end and an
+Each pipe worker would have `internal` address to talk to another pipe end, and an
 `external` address to communicate to other workers.
 
 All messages received on the `internal` address are handled as pipe internal API messages.
@@ -26,11 +24,10 @@ For example, for the confirm pipe:
 
 Pipes (and especially channels) often use bidirectional communication and rely on coordinated state.
 
-Simplest approach to get it is to provide this state on worker start.
-However sometimes it's not possible because routes between workers can be dynamic (contain workers with random addresses) or state needs to be dynamically generated.
+Simplest approach to get it is to provide this state on worker start. However, sometimes it's not possible because routes between workers
+can be dynamic (contain workers with random addresses) or state needs to be dynamically generated.
 
-In order to coordinate this state workers can echange some handshake messages before starting to run the
-main pipe or channel logic.
+In order to coordinate this state workers can exchange some handshake messages before starting to run the main pipe or channel logic.
 
 We call this approach Sessions and such pipes and channels **session pipes** and **session channels**
 

--- a/documentation/architecture/messaging/Sessions.md
+++ b/documentation/architecture/messaging/Sessions.md
@@ -8,99 +8,95 @@ Basic session concepts are described here: [Sessions discussion thread](https://
 
 ## Terminology
 
-- Session - coordinated state between two or more workers
-- Initiator - worker starting the session
-- Responder - worker participating in the session, which is not an initiator
-- Handshake stage - a stage in a session state machine during which handshake messages are sent
-- Data stage - a stage in a session state machine when session is established
-- Handshake message - message sent in handshake stage
-- Data message - message sent in data stage
-- Init route - a route used to send a first handshake to
-- Data route or Session route - a route used to send data messages
-- Session state - coordinated state of workers
+- Session: coordinated state between two or more workers
+- Initiator: worker starting the session
+- Responder: worker participating in the session, which is not an initiator
+- Handshake stage: a stage in a session state machine during which handshake messages are sent
+- Data stage: a stage in a session state machine when session is established
+- Handshake message: message sent in handshake stage
+- Data message: message sent in data stage
+- Init route: a route used to send a first handshake to
+- Data route or Session route: a route used to send data messages
+- Session state: coordinated state of workers
 
 <img src="./images/session_terminology.jpg" width="100%">
 
 ## Session routes and discovery
 
-Basic component of coordinated workers is routing. Each worker in the session should know a route to other workers.
+Basic component of coordinated workers is routing. Each worker in the session [should know a route to other workers](./Accessibility.md).
 
 ### Static routes
 
-Session routes may be static, when all workers know a route to each other in advance.
+Session routes may be static when all workers know a route to each other in advance.
 
-In static sessions init route and data route are usually the same.
+In static sessions, init route and data route are usually the same.
 
 <img src="./images/session_static.jpg" width="100%">
 
 ### Dynamic routes
 
-But usually session handshake can be used to discover the routes.
-Sessions are often used just to discover the routes between workers.
+But, usually, session handshake can be used to discover the routes. Sessions are often used just to discover the routes between workers.
 
-To discover a responder, initiator uses discovery worker route to which is known in advance to initiator.
-Discovery worker then forwards the handshake to responder, which can send a handshake back to initiator.
+To discover a responder, initiator uses discovery worker route that is known in advance to initiator. Discovery worker then forwards the
+handshake to responder, which can send a handshake back to initiator.
 
-Such discovery often relies on routes being **backtraceable**
+Such discovery often relies on routes being **backtraceable**.
 
 In this case init route is a route to discovery worker and data route is created dynamically using backtracing of the handshake messages.
 
 <img src="./images/session_discovery.jpg" width="100%">
 
-Discovery workers may either serve as proxies for the handshake messages or hand over routing by tracing or not tracing its return address in the handshake messages.
+Discovery workers may either serve as proxies for the handshake messages or hand over routing by tracing or not tracing its return address
+in the handshake messages.
 
-Hand-over workers require A to be mutually accessible from B via rrA and rrB
+Hand-over workers require `A` to be mutually accessible from `B` via `rrA` and `rrB`.
 
 <img src="./images/session_proxy.jpg" width="100%">
 
 <img src="./images/session_hand_over.jpg" width="100%">
 
-
 ## Spawners
 
 Spawner is a type of worker which creates new workers on demand.
 
-Spawners create new workers when receiving a "create" message.
-Newly spawned workers send the "create_ok" message when initialized to "reply route" to populate the address of a new worker
+Spawners create new workers when receiving a "create" message. Newly spawned workers send the "create_ok" message when initialized to "reply
+route" to populate the address of a new worker.
 
 <img src="./images/spawner.jpg" width="60%">
 
-Reply route may lead to some discovery worker, which will save the spawned worker route and make it awailable to other workers.
+Reply route may lead to some discovery worker, which will save the spawned worker route and make it available to other workers.
 
 <img src="./images/spawner_separate_discovery.jpg" width="80%">
 
-Spawner worker may serve as a discovery worker if reply route leads back to the spawner
+Spawner worker may serve as a discovery worker if reply route leads back to the spawner.
 
 <img src="./images/spawner_discovery.jpg" width="50%">
 
 If "create" message route is backtraced, reply route can be a backtrace to the original message.
 
-In this case the worker which sent "create" message will receive "create_ok" message
-
-This type of spawning can be used to spawn Responders using session handshake.
+In this case the worker which sent "create" message will receive "create_ok" message. This type of spawning can be used to spawn Responders
+using session handshake.
 
 Session init route leads to the spawner.
 
 Session data route will be traced with "create_ok" message
-"create_ok" message would carry a handshake response from newly spawned Responder
+"create_ok" message would carry a handshake response from newly spawned Responder.
 
 <img src="./images/spawner_session.jpg" width="60%">
 
-Pipe and channel sessions can be established using discovery and spawners
+Pipe and channel sessions can be established using discovery and spawners.
 
 <img src="./images/spawner_pipe_session.jpg" width="80%">
-
 
 ## Routing session handshakes
 
 Ping handshake:
 
-- Given routes between I and R are backtraceable and workers can use return routes.
+- Given routes between `I` and `R` are backtraceable and workers can use return routes.
 - Initiator sends a traceable ping to responder with backtraceable message.
 - Responder makes a return route from the ping message and sends pong to it.
 
 <img src="./images/session_handshake_simple.jpg" width="80%">
-
 
 Ping handshake with discovery worker or spawner:
 
@@ -110,36 +106,32 @@ Ping handshake with discovery worker or spawner:
 
 <img src="./images/session_handshake_discovery.jpg" width="100%">
 
+Multi-stage handshake with discovery, which can be used if init route is not backtraceable:
 
-Multi-stage handshake with discovery:
-
-Can be used if init route is not backtraceable
-
-- Initiator sends a init to responder
+- Initiator sends an init to responder
 - Responder gets a backtraceable route to initiator from somewhere (e.g. additional metadata)
 - Responder sends a ping to initiator on this route
 - Initiator replies with pong on the return route
-- (Optionaly) initiator and responder may continue sending handshakes
+- (Optionally) initiator and responder may continue sending handshakes
 
-Example: responder is listening to stream events and establishes a TCP connection on init message
+Example: responder is listening to stream events and establishes a TCP connection on init message.
 
 <img src="./images/session_handshake_multi.jpg" width="100%">
 
-
 ## Session state machines
 
-Here are some state machine diagrams for diffrent kinds of sessions:
+Here are some state machine diagrams for different kinds of sessions:
 
 ### Simple session
 
-In this session Initiator and Responder establish a session state and move to the data stage.
-Session state is final and not re-negotiated after establishment
+In this session Initiator and Responder establish a session state and move to the data stage. Session state is final and not re-negotiated
+after establishment.
 
 Initiator:
 
 <img src="./images/session_diagram_simple_initiator.jpg" width="40%">
 
-Static responder (waiting for handshake from initiator)
+Static responder (waiting for handshake from initiator):
 
 <img src="./images/session_diagram_simple_responder_static.jpg" width="40%">
 
@@ -147,10 +139,9 @@ Spawned responder (created by spawner with handshake as create message):
 
 <img src="./images/session_diagram_simple_responder_dynamic.jpg" width="40%">
 
-
 ### Recoverable session
 
-This behaviour can re-negotiate the session after data stage error
+This behaviour can re-negotiate the session after data stage error.
 
 Initiator:
 
@@ -160,10 +151,9 @@ Static Responder:
 
 <img src="./images/session_diagram_recoverable_responder.jpg" width="100%">
 
-Spawned recoverable responder would look the same as simple responder because it's created anew on session establishment
+Spawned recoverable responder would look the same as simple responder because it's created anew on session establishment.
 
-
-## Resetable session
+## Resettable session
 
 This behaviour allows re-negotiation on-demand.
 
@@ -174,6 +164,3 @@ Initiator:
 Spawned Responder:
 
 <img src="./images/session_diagram_resettable_responder_dynamic.jpg" width="40%">
-
-
-


### PR DESCRIPTION
This PR includes a bunch of typo fixes as well as some rephrasings of some sentences that seemed confusing to me.

The [first commit](https://github.com/ockam-network/ockam/pull/2660/commits/74c021f8fd87fb0cb8e4ed5e0caa5c902c8c4dd3) includes the fixes, the second commit applies the formatting, so I'd recommend checking the first commit in isolation to see the fixes more clearly.