### PR TITLE
fix(rust): enable `SpanTrace` capture during tracing registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,6 +1706,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-error",
  "tracing-subscriber",
 ]
 
@@ -1847,6 +1848,7 @@ dependencies = [
  "serde_bare",
  "tokio",
  "tracing",
+ "tracing-error",
  "tracing-subscriber",
 ]
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "4.0.0"
 clap = { version = "3", features = ["derive", "cargo"] }
 tracing = { version = "0.1.31", features = ["attributes"] }
 tracing-subscriber = "0.3.9"
+tracing-error = "0.2"
 tokio = { version="1", features = ["full"] }
 async-trait = "0.1"
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -193,6 +193,7 @@ fn message(verbose: bool, e: impl std::fmt::Display + std::fmt::Debug) -> String
 
 // Not really ideal, but fine for now.
 fn init_logging(verbose: u8) {
+    use tracing_subscriber::prelude::*;
     let ockam_crates = [
         "ockam",
         "ockam_node",
@@ -222,7 +223,13 @@ fn init_logging(verbose: u8) {
                 .parse_lossy(""),
         },
     };
-    if fmt().with_env_filter(filter).try_init().is_err() {
+
+    let result = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_error::ErrorLayer::default())
+        .with(fmt::layer())
+        .try_init();
+    if result.is_err() {
         tracing::warn!("Failed to initialise logging.");
     }
 }

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -29,7 +29,7 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "tokio", "tracing-subscriber", "alloc", "futures/std"]
+std = ["ockam_core/std", "tokio", "tracing-subscriber", "tracing-error", "alloc", "futures/std"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
@@ -54,6 +54,7 @@ tokio = { version = "1.8", default-features = false, optional = true, features =
 ] }
 futures = { version = "0.3.21", default-features = false }
 tracing = { version = "0.1", default_features = false }
+tracing-error = { version = "0.2", optional = true }
 tracing-subscriber = { version = "0.3", features = [
     "fmt",
     "env-filter",

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -35,7 +35,7 @@ pub fn start_node() -> (Context, Executor) {
 fn setup_tracing() {
     #[cfg(feature = "std")]
     {
-        use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
+        use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
         static ONCE: std::sync::Once = std::sync::Once::new();
         ONCE.call_once(|| {
             let filter = EnvFilter::try_from_env("OCKAM_LOG").unwrap_or_else(|_| {
@@ -44,7 +44,11 @@ fn setup_tracing() {
                     .add_directive("ockam_node=info".parse().unwrap())
             });
             // Ignore failure, since we may init externally.
-            let _ = fmt().with_env_filter(filter).try_init();
+            let _ = tracing_subscriber::registry()
+                .with(filter)
+                .with(tracing_error::ErrorLayer::default())
+                .with(fmt::layer())
+                .try_init();
         });
     }
 }


### PR DESCRIPTION
I had thought this was already done, but maybe it got lost in one of the rebases.