### PR TITLE
docs: remove code of conduct and contributing guide files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,0 @@
-Thank you for participating in the [Ockam Community](https://github.com/build-trust/ockam/discussions).
-
-We have several documents on [Ockam.io](https://www.ockam.io/) that will help to guide you.
-
-You can find Ockam's collection of contributing guides, along with our **Code of Conduct Covenant**, here:
-[ockam.io/learn/how-to-guides/high-performance-team/conduct/](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,0 @@
-Thank you for your interest in contributing to the Ockam open source projects.
-
-We have several documents on [Ockam.io](https://www.ockam.io/) that will help to guide you.
-
-You can find Ockam's library of contributing guides here:
-[https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING)


### PR DESCRIPTION
Remove CODE_OF_CONDUCT.md and CONTRIBUTING.md from this
repository so Github users are shown the organization default
files at https://github.com/build-trust/.github
