### PR TITLE
fix(rust): share context in scheduled hearbeats

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -14,6 +14,12 @@ pub(super) async fn exec(
     bare: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
+    trace! {
+        internal = router.map.internal.len(),
+        external = router.external.len(),
+        aliases = router.map.addr_map.len(),
+        "router tables sizes"
+    };
     match router.state.node_state() {
         NodeState::Running => start(router, addrs, senders, bare, reply).await,
         NodeState::Stopping(_) => reject(reply).await,


### PR DESCRIPTION
As mentioned in #2716, every `DelayedEvent::schedule` creates a new context which is registered with the router. Contrary to what I wrote in #2716 it is not the context creation as such that uses a lot of memory, but the fact that ― AFAICS ― the routing table entries are not cleaned up when the context is no longer used, creating a memory leak. To mitigate this (as a lot of scheduling takes place ), this PR re-uses a single context instead.
