### PR TITLE
fix(elixir) Fix expected return on channel setup

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
@@ -59,9 +59,9 @@ defmodule Ockam.SecureChannel.Channel do
          {:ok, data} <- setup_vault(options, data),
          {:ok, data} <- setup_peer(options, data),
          {:ok, data} <- setup_initiating_message(options, data),
-         {:ok, initial, data} <- setup_key_establishment_protocol(options, data),
+         {:ok, initial, data, next_events} <- setup_key_establishment_protocol(options, data),
          {:ok, initial, data} <- setup_encrypted_transport_protocol(options, initial, data) do
-      return_value = {:ok, initial, data}
+      return_value = {:ok, initial, data, next_events}
 
       metadata = Map.put(metadata, :return_value, return_value)
       Telemetry.emit_stop_event([__MODULE__, :init], start_time, metadata: metadata)


### PR DESCRIPTION

<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
The return from both[ Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Initiator.setup/2](https://github.com/build-trust/ockam/blob/9a75441a17673c4c2a004404d52125b0806c45ea/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/initiator.ex#L10-L12) and [Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Responder.setup/2](https://github.com/build-trust/ockam/blob/9a75441a17673c4c2a004404d52125b0806c45ea/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/responder.ex#L17) are 4-element tuples containing the next events to run.

The `with` statement on `channel` init was[ failing to match at that point](https://github.com/build-trust/ockam/blob/9a75441a17673c4c2a004404d52125b0806c45ea/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex#L62), and was just returning the non-matched value.

This (I think accidentally) *did* worked as:
        * The remaining clauses of the `with` statement are basically noop right now
        * The body of the `with` statement only contains instrumentation code

So for practical purposes the only visible thing at this point was the instrumentation not being excecuted.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Fix the pattern of the `with`  clause.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
