### PR TITLE
WIP: add `enroll`, `space` and `proejct` subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "btleplug"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +427,12 @@ dependencies = [
  "uuid",
  "windows",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -735,6 +766,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +834,12 @@ dependencies = [
  "libc",
  "tokio",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -815,6 +887,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "duct"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +908,17 @@ dependencies = [
  "once_cell",
  "os_pipe",
  "shared_child",
+]
+
+[[package]]
+name = "dummy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5ff6f74150b0bbb6e6057718a903b3d8f3fc7096c9190fc162ca99d3b2273"
+dependencies = [
+ "darling",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -879,6 +974,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1018,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8531dd3a64fd1cfbe92fad4160bc2060489c6195fe847e045e5788f710bae"
+dependencies = [
+ "dummy",
+ "http",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +1057,15 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -965,6 +1098,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d758e60b45e8d749c89c1b389ad8aee550f86aa12e2b9298b546dda7a82ab1"
 
 [[package]]
 name = "funty"
@@ -1153,6 +1292,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.1",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,10 +1454,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes 1.1.0",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.1.0",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1317,6 +1541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1557,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1339,6 +1578,15 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "js-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1417,6 +1665,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minicbor"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08de72a57f15d959ab3a3b73fc94572eb954bfcfeb3809cf83cc1bd7d0aa774b"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd6ff7dbe1a10938f8b72c6d0dd81c28fc68283aa79d7ba97c99a96a8e5823"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1754,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1812,12 @@ name = "nb"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -1614,18 +1939,27 @@ name = "ockam_command"
 version = "0.58.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-recursion",
  "async-trait",
  "clap 3.1.16",
  "dirs",
+ "fake",
  "hex",
+ "minicbor",
+ "mockall",
  "ockam",
  "ockam_core",
  "ockam_vault",
+ "open",
+ "predicates",
  "rand 0.8.5",
+ "reqwest",
  "serde",
+ "serde_cbor",
  "serde_json",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1881,6 +2215,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0524af9508f9b5c4eb41dce095860456727748f63b478d625f119a70e0d764a"
+dependencies = [
+ "pathdiff",
+ "winapi",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f3916d46d9d813a62d7b7d2724d7b14785ac999fb623d990ee4603f9122742"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +2324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2357,26 @@ checksum = "b9c86f6c9cdae70b425c52a269bbb4b6aa3758a7c566eaf5b2c9a9aca9c29584"
 dependencies = [
  "mips-mcu",
  "vcell",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1999,6 +2414,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2190,6 +2635,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+dependencies = [
+ "base64",
+ "bytes 1.1.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "riscv"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,10 +2751,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2327,6 +2850,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2876,18 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2677,6 +3222,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +3243,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -2787,6 +3352,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +3381,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -2825,6 +3411,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,6 +3432,12 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -2904,6 +3510,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
@@ -3026,6 +3638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,6 +3681,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3716,82 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
+name = "web-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -3196,6 +3909,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -32,16 +32,27 @@ test = false
 anyhow = "1"
 dirs = "4.0.0"
 clap = { version = "3", features = ["derive", "cargo"] }
+minicbor = { version = "0.16", features = ["std", "derive"] }
+open = "2"
+reqwest = { version = "0.11", features = ["json"] }
 tracing = { version = "0.1.31", features = ["attributes"] }
 tracing-subscriber = "0.3.9"
-tokio = { version="1", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
+tokio-retry = "0.3"
 async-trait = "0.1"
 hex = "0.4"
-serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_cbor = "0.11"
 rand = "0.8"
 async-recursion = { version = "1.0.0" }
 
 ockam = { path = "../ockam", version = "^0.58.0", features = ["software_vault"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.48.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.54.0"}
+
+[dev-dependencies]
+assert_cmd = "2"
+fake = { version = "2", features=['derive', 'http']}
+predicates = "2"
+mockall = "0.11"

--- a/implementations/rust/ockam/ockam_command/src/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/api.rs
@@ -12,15 +12,15 @@ use ockam_core::{route, Route};
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait CloudApi {
-    async fn send<Params: 'static, Payload: 'static, Response: 'static>(
+    async fn send<Params: 'static, Body: 'static, Response: 'static>(
         &mut self,
         method: RequestMethod, //TODO: replace by a proper type after CBOR support is ready
         params: Params,
-        payload: Payload,
+        body: Body,
     ) -> ockam::Result<Option<Response>>
     where
         Params: Send,
-        Payload: Message + serde::Serialize + serde::de::DeserializeOwned,
+        Body: Message + serde::Serialize + serde::de::DeserializeOwned,
         Response: serde::de::DeserializeOwned;
 }
 
@@ -144,7 +144,7 @@ pub mod enroll {
     #[derive(Message, serde::Serialize, serde::Deserialize, Encode, Decode, Debug)]
     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
     #[cbor(map)]
-    pub struct Auth0Payload {
+    pub struct Auth0Tokens {
         #[n(0)]
         pub token_type: TokenType,
         #[n(1)]
@@ -165,82 +165,82 @@ pub mod enroll {
     pub struct AccessToken(#[n(0)] String);
 }
 
-// pub mod project {
-//     use super::*;
-//
-//     pub mod create {
-//         use super::*;
-//
-//         #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//         pub struct RequestParams {
-//             pub space_name: String,
-//         }
-//
-//         #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//         pub struct RequestBody {
-//             pub project_name: String,
-//             pub services: Vec<String>,
-//         }
-//
-//         #[derive(serde::Serialize, serde::Deserialize, Debug)]
-//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//         pub struct ResponseBody {
-//             pub id: String,
-//             pub name: String,
-//             pub services: Vec<String>,
-//             pub access_route: Vec<u8>,
-//         }
-//     }
-//
-//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//     pub struct CreateProjectPayload {
-//         pub project_name: String,
-//         // pub services: Vec<String>,
-//     }
-//
-//     impl From<ProjectOpts> for CreateProjectPayload {
-//         fn from(args: ProjectOpts) -> Self {
-//             Self {
-//                 project_name: args.project_name,
-//             }
-//         }
-//     }
-//
-//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//     pub struct ShowProjectRequestPayload {
-//         pub project_name: String,
-//     }
-//
-//     impl From<ProjectOpts> for ShowProjectRequestPayload {
-//         fn from(args: ProjectOpts) -> Self {
-//             Self {
-//                 project_name: args.project_name,
-//             }
-//         }
-//     }
-//
-//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//     pub struct ListProjectsRequestPayload;
-//
-//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
-//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-//     pub struct DeleteProjectRequestPayload {
-//         pub project_name: String,
-//     }
-//
-//     impl From<ProjectOpts> for DeleteProjectRequestPayload {
-//         fn from(args: ProjectOpts) -> Self {
-//             Self {
-//                 project_name: args.project_name,
-//             }
-//         }
-//     }
-// }
+pub mod project {
+    use super::*;
+
+    pub mod create {
+        use super::*;
+
+        #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+        #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+        pub struct RequestParams {
+            pub space_name: String,
+        }
+
+        #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+        #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+        pub struct RequestBody {
+            pub project_name: String,
+            pub services: Vec<String>,
+        }
+
+        #[derive(serde::Serialize, serde::Deserialize, Debug)]
+        #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+        pub struct ResponseBody {
+            pub id: String,
+            pub name: String,
+            pub services: Vec<String>,
+            pub access_route: Vec<u8>,
+        }
+    }
+
+    // #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+    // #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    // pub struct CreateProjectPayload {
+    //     pub project_name: String,
+    //     // pub services: Vec<String>,
+    // }
+    //
+    // impl From<ProjectOpts> for CreateProjectPayload {
+    //     fn from(args: ProjectOpts) -> Self {
+    //         Self {
+    //             project_name: args.project_name,
+    //         }
+    //     }
+    // }
+    //
+    // #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+    // #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    // pub struct ShowProjectRequestPayload {
+    //     pub project_name: String,
+    // }
+    //
+    // impl From<ProjectOpts> for ShowProjectRequestPayload {
+    //     fn from(args: ProjectOpts) -> Self {
+    //         Self {
+    //             project_name: args.project_name,
+    //         }
+    //     }
+    // }
+    //
+    // #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+    // #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    // pub struct ListProjectsRequestPayload;
+    //
+    // #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+    // #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    // pub struct DeleteProjectRequestPayload {
+    //     pub project_name: String,
+    // }
+    //
+    // impl From<ProjectOpts> for DeleteProjectRequestPayload {
+    //     fn from(args: ProjectOpts) -> Self {
+    //         Self {
+    //             project_name: args.project_name,
+    //         }
+    //     }
+    // }
+}
 
 // mod space {
 //     use super::*;
@@ -319,14 +319,14 @@ pub mod enroll {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use ockam::TcpTransport;
-
     use super::*;
 
     pub(crate) mod node_api {
-        use rand::Rng;
         use std::marker::PhantomData;
 
+        use rand::Rng;
+
+        use ockam::TcpTransport;
         use ockam::{Routed, Worker};
 
         use super::*;

--- a/implementations/rust/ockam/ockam_command/src/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/api.rs
@@ -1,0 +1,418 @@
+use anyhow::anyhow;
+#[cfg(test)]
+use fake::{Dummy, Fake, Faker};
+use minicbor::{Decode, Encode};
+
+pub use enroll::*;
+use ockam::{Message, TCP};
+use ockam_core::{route, Route};
+// pub use project::*;
+// pub use space::*;
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait CloudApi {
+    async fn send<Params: 'static, Payload: 'static, Response: 'static>(
+        &mut self,
+        method: RequestMethod, //TODO: replace by a proper type after CBOR support is ready
+        params: Params,
+        payload: Payload,
+    ) -> ockam::Result<Option<Response>>
+    where
+        Params: Send,
+        Payload: Message + serde::Serialize + serde::de::DeserializeOwned,
+        Response: serde::de::DeserializeOwned;
+}
+
+#[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+#[cfg_attr(test, derive(Clone, PartialEq))]
+pub enum RequestMethod {
+    Put,
+}
+
+//TODO: replace by CBOR-type after CBOR support is ready
+#[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+#[cfg_attr(test, derive(Clone, PartialEq, Dummy))]
+pub struct CloudApiResponse {
+    id: String,
+    request_id: String,
+    #[cfg_attr(test, dummy(faker = "100..600"))]
+    status: u16,
+    // This can be a JSON structure or a String, which known in advanced but dependant on the status.
+    // We can decode it as needed ad-hoc instead of enriching this struct with generics to avoid
+    // cluttering the code as much as possible.
+    body: Option<String>,
+    from_route: Option<String>,
+    to_route: Option<String>,
+}
+
+#[allow(clippy::from_over_into)]
+impl<Response> Into<ockam::Result<Option<Response>>> for CloudApiResponse
+where
+    Response: serde::de::DeserializeOwned,
+{
+    fn into(self) -> ockam_core::Result<Option<Response>> {
+        if self.failed() {
+            let body = match self.body {
+                Some(b) => b,
+                None => "error has no error description".to_string(),
+            };
+            Err(ockam::Error::new(
+                ockam::errcode::Origin::Application,
+                ockam::errcode::Kind::Other,
+                anyhow!(body),
+            ))
+        } else {
+            let body = self
+                .body
+                .map(|b| serde_json::from_str::<Response>(&b).unwrap()); // FIXME: remove unwrap
+            Ok(body)
+        }
+    }
+}
+
+impl CloudApiResponse {
+    // Converting this struct to a Result<T>, would make it very verbose to work with all
+    // possible error sources. This method is used to react to different errors,
+    // trying to recover if possible.
+    pub fn failed(&self) -> bool {
+        self.status >= 300
+    }
+}
+
+pub struct NodeCloudApi<'a> {
+    cloud_node_route: Route,
+    pub ctx: &'a mut ockam::Context,
+}
+
+impl<'a> NodeCloudApi<'a> {
+    const DEFAULT_CLOUD_ADDR: &'static str = "cloud.ockam.io";
+    const DEFAULT_CLOUD_NODE_WORKER_NAME: &'static str = "cloud"; // TODO: to be confirmed
+
+    fn new(ctx: &'a mut ockam::Context, cloud_addr: &str, cloud_node_worker_name: &str) -> Self {
+        Self {
+            cloud_node_route: route![(TCP, cloud_addr), cloud_node_worker_name],
+            ctx,
+        }
+    }
+}
+
+impl<'a> From<&'a mut ockam::Context> for NodeCloudApi<'a> {
+    fn from(ctx: &'a mut ockam::Context) -> Self {
+        NodeCloudApi::new(
+            ctx,
+            Self::DEFAULT_CLOUD_ADDR,
+            Self::DEFAULT_CLOUD_NODE_WORKER_NAME,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a> CloudApi for NodeCloudApi<'a> {
+    async fn send<Params, Payload, Response: 'static>(
+        &mut self,
+        _method: RequestMethod,
+        _params: Params,
+        payload: Payload,
+    ) -> ockam::Result<Option<Response>>
+    where
+        Params: Send,
+        Payload: Message + serde::Serialize + serde::de::DeserializeOwned,
+        Response: serde::de::DeserializeOwned,
+    {
+        // TODO: build CBOR message out of method + params + payload
+        //   e.g: https://docs.google.com/document/d/1yo4GbGhzor3vsD6eRRF-EB6sgwkDTct-yLG33ST3FL0/edit#heading=h.so1yd03v36uh
+        self.ctx
+            .send(self.cloud_node_route.clone(), payload)
+            .await?;
+        self.ctx
+            .receive::<CloudApiResponse>()
+            .await?
+            .take()
+            .body()
+            .into()
+    }
+}
+
+pub mod enroll {
+    use super::*;
+
+    #[derive(serde::Serialize, serde::Deserialize, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    pub struct RequestParams;
+
+    #[derive(Message, serde::Serialize, serde::Deserialize, Encode, Decode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(map)]
+    pub struct Auth0Payload {
+        #[n(0)]
+        pub token_type: TokenType,
+        #[n(1)]
+        pub access_token: AccessToken,
+    }
+
+    #[derive(Message, serde::Serialize, serde::Deserialize, Encode, Decode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(index_only)]
+    pub enum TokenType {
+        #[n(0)]
+        Bearer,
+    }
+
+    #[derive(Message, serde::Serialize, serde::Deserialize, Encode, Decode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(transparent)]
+    pub struct AccessToken(#[n(0)] String);
+}
+
+// pub mod project {
+//     use super::*;
+//
+//     pub mod create {
+//         use super::*;
+//
+//         #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//         pub struct RequestParams {
+//             pub space_name: String,
+//         }
+//
+//         #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//         pub struct RequestBody {
+//             pub project_name: String,
+//             pub services: Vec<String>,
+//         }
+//
+//         #[derive(serde::Serialize, serde::Deserialize, Debug)]
+//         #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//         pub struct ResponseBody {
+//             pub id: String,
+//             pub name: String,
+//             pub services: Vec<String>,
+//             pub access_route: Vec<u8>,
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct CreateProjectPayload {
+//         pub project_name: String,
+//         // pub services: Vec<String>,
+//     }
+//
+//     impl From<ProjectOpts> for CreateProjectPayload {
+//         fn from(args: ProjectOpts) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//             }
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct ShowProjectRequestPayload {
+//         pub project_name: String,
+//     }
+//
+//     impl From<ProjectOpts> for ShowProjectRequestPayload {
+//         fn from(args: ProjectOpts) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//             }
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct ListProjectsRequestPayload;
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct DeleteProjectRequestPayload {
+//         pub project_name: String,
+//     }
+//
+//     impl From<ProjectOpts> for DeleteProjectRequestPayload {
+//         fn from(args: ProjectOpts) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//             }
+//         }
+//     }
+// }
+
+// mod space {
+//     use super::*;
+//     use crate::cmd::cloud::space::{SpaceCommandArgs, SpaceListCommandArgs};
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct CreateSpaceRequestPayload {
+//         pub project_name: String,
+//         pub space_name: String,
+//     }
+//
+//     #[derive(serde::Serialize, serde::Deserialize)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct CreateSpaceResponseBody {
+//         pub id: String,
+//         pub project_name: String,
+//         pub space_name: String,
+//     }
+//
+//     impl From<SpaceCommandArgs> for CreateSpaceRequestPayload {
+//         fn from(args: SpaceCommandArgs) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//                 space_name: args.space_name,
+//             }
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct ShowSpacePayload {
+//         pub project_name: String,
+//         pub space_name: String,
+//     }
+//
+//     impl From<SpaceCommandArgs> for ShowSpacePayload {
+//         fn from(args: SpaceCommandArgs) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//                 space_name: args.space_name,
+//             }
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct ListSpacesPayload {
+//         pub project_name: String,
+//     }
+//
+//     impl From<SpaceListCommandArgs> for ListSpacesPayload {
+//         fn from(args: SpaceListCommandArgs) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//             }
+//         }
+//     }
+//
+//     #[derive(Message, serde::Serialize, serde::Deserialize, Debug)]
+//     #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+//     pub struct DeleteSpacePayload {
+//         pub project_name: String,
+//         pub space_name: String,
+//     }
+//
+//     impl From<SpaceCommandArgs> for DeleteSpacePayload {
+//         fn from(args: SpaceCommandArgs) -> Self {
+//             Self {
+//                 project_name: args.project_name,
+//                 space_name: args.space_name,
+//             }
+//         }
+//     }
+// }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use ockam::TcpTransport;
+
+    use super::*;
+
+    pub(crate) mod node_api {
+        use rand::Rng;
+        use std::marker::PhantomData;
+
+        use ockam::{Routed, Worker};
+
+        use super::*;
+
+        pub(crate) async fn setup_node_api(
+            ctx: &mut ockam::Context,
+        ) -> ockam::Result<(NodeCloudApi<'_>, String)> {
+            // Initiate cloud TCP listener
+            let transport = TcpTransport::create(ctx).await?;
+            let listener_address = transport.listen("127.0.0.1:0").await?.to_string();
+
+            // Create Node API instance
+            let worker_name: String = rand::thread_rng()
+                .sample_iter(&rand::distributions::Alphanumeric)
+                .take(32)
+                .map(char::from)
+                .collect();
+            Ok((
+                NodeCloudApi::new(ctx, &listener_address, &worker_name),
+                worker_name,
+            ))
+        }
+
+        pub(crate) async fn send_payload<'a, Payload>(
+            node_api: &mut NodeCloudApi<'a>,
+            worker_name: &str,
+            payload: Payload,
+        ) -> ockam::Result<()>
+        where
+            Payload: Message + serde::Serialize + serde::de::DeserializeOwned + Sync,
+        {
+            // Initiate cloud worker
+            let cloud_response: CloudApiResponse = Faker.fake();
+            let cloud_worker = TestCloudWorker::<Payload>::new(cloud_response.clone());
+            node_api.ctx.start_worker(worker_name, cloud_worker).await?;
+
+            let response = node_api
+                .send::<_, _, ()>(RequestMethod::Put, (), payload)
+                .await;
+            if cloud_response.failed() {
+                assert!(response.is_err());
+            } else {
+                assert!(response.is_ok());
+            }
+
+            node_api.ctx.stop_worker(worker_name).await?;
+            tokio::time::sleep(tokio::time::Duration::from_nanos(100)).await;
+
+            Ok(())
+        }
+
+        pub struct TestCloudWorker<T>
+        where
+            T: Message + serde::Serialize + serde::de::DeserializeOwned,
+        {
+            response: CloudApiResponse,
+            _marker: PhantomData<T>,
+        }
+
+        impl<T> TestCloudWorker<T>
+        where
+            T: Message + serde::Serialize + serde::de::DeserializeOwned,
+        {
+            pub fn new(response: CloudApiResponse) -> Self {
+                Self {
+                    response,
+                    _marker: PhantomData::default(),
+                }
+            }
+        }
+
+        #[ockam::worker]
+        impl<T> Worker for TestCloudWorker<T>
+        where
+            T: Message + serde::Serialize + serde::de::DeserializeOwned + Send + Sync,
+        {
+            type Message = T;
+            type Context = ockam::Context;
+
+            async fn handle_message(
+                &mut self,
+                ctx: &mut ockam::Context,
+                msg: Routed<Self::Message>,
+            ) -> ockam::Result<()> {
+                ctx.send(msg.return_route(), self.response.clone()).await
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/args.rs
+++ b/implementations/rust/ockam/ockam_command/src/args.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 
+use crate::cmd::cloud::CloudCommand;
+
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "ockam", version)]
 pub struct CliArgs {
@@ -12,6 +14,10 @@ pub struct CliArgs {
     ///   `-vvv` => Trace level.
     #[clap(long, short, parse(from_occurrences))]
     pub verbose: u8,
+    /// Parse command's arguments without running it.
+    /// Useful for testing purposes.
+    #[clap(display_order = 1100, long)]
+    pub dry_run: bool,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -42,15 +48,18 @@ pub enum Command {
     /// code that `$OCKAM_DIR/trusted` if overwritten).
     #[clap(display_order = 1003)]
     AddTrustedIdentity(AddTrustedIdentityOpts),
+    /// Cloud subcommands.
+    #[clap(display_order = 1010)]
+    Cloud(CloudCommand),
     /// Print the identifier for the currently configured identity.
-    #[clap(display_order = 1004)]
+    #[clap(display_order = 1030)]
     PrintIdentity,
     /// Print path to the ockam directory.
     ///
     /// This is usually `$OCKAM_DIR` or `~/.config/ockam`, but in some cases can
     /// be different, such as on Windows, unixes where `$XDG_CONFIG_HOME` has
     /// been modified, etc.
-    #[clap(display_order = 1005)]
+    #[clap(display_order = 1040)]
     PrintPath,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/enroll.rs
@@ -77,7 +77,7 @@ pub enum Authenticator {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub(crate) trait AuthenticatorClientTrait {
-    async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Payload>;
+    async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Tokens>;
 }
 
 pub(crate) struct AuthenticatorClient;
@@ -111,7 +111,7 @@ mod auth0 {
 
     #[async_trait::async_trait]
     impl AuthenticatorClientTrait for AuthenticatorClient {
-        async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Payload> {
+        async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Tokens> {
             // Request device code
             // More on how to use scope and audience in https://auth0.com/docs/quickstart/native/device#device-code-parameters
             let device_code_res = {
@@ -182,7 +182,7 @@ mod auth0 {
                 match res.status() {
                     StatusCode::OK => {
                         tokens_res =
-                            res.json::<api::enroll::Auth0Payload>()
+                            res.json::<api::enroll::Auth0Tokens>()
                                 .await
                                 .map_err(|err| {
                                     anyhow!("failed to deserialize tokens response [err={err}]")
@@ -233,8 +233,8 @@ mod tests {
         #[ockam::test(crate = "ockam")]
         async fn auth0__can_send_payload(ctx: &mut ockam::Context) -> ockam::Result<()> {
             let (mut node_api, worker_name) = setup_node_api(ctx).await?;
-            let payload: api::enroll::Auth0Payload = Faker.fake();
-            send_payload::<api::enroll::Auth0Payload>(&mut node_api, &worker_name, payload).await?;
+            let payload: api::enroll::Auth0Tokens = Faker.fake();
+            send_payload::<api::enroll::Auth0Tokens>(&mut node_api, &worker_name, payload).await?;
             ctx.stop().await?;
             Ok(())
         }
@@ -251,7 +251,7 @@ mod tests {
         #[tokio::test]
         async fn happy_path() -> anyhow::Result<()> {
             let req_params = api::enroll::RequestParams;
-            let expected_creds: api::enroll::Auth0Payload = Faker.fake();
+            let expected_creds: api::enroll::Auth0Tokens = Faker.fake();
             let mut auth_client = MockAuthenticatorClientTrait::new();
             let moved_expected_creds = expected_creds.clone();
             auth_client
@@ -281,7 +281,7 @@ mod tests {
 
             let mut api_client = MockCloudApi::new();
             api_client
-                .expect_send::<api::enroll::RequestParams, api::enroll::Auth0Payload, ()>()
+                .expect_send::<api::enroll::RequestParams, api::enroll::Auth0Tokens, ()>()
                 .never();
 
             authenticate(&Authenticator::Auth0, auth_client, api_client)
@@ -294,7 +294,7 @@ mod tests {
         #[tokio::test]
         async fn err_if_authentication_fails() -> anyhow::Result<()> {
             let req_params = api::enroll::RequestParams;
-            let expected_creds: api::enroll::Auth0Payload = Faker.fake();
+            let expected_creds: api::enroll::Auth0Tokens = Faker.fake();
             let mut auth_client = MockAuthenticatorClientTrait::new();
             let moved_expected_creds = expected_creds.clone();
             auth_client

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/enroll.rs
@@ -1,0 +1,324 @@
+use anyhow::anyhow;
+use clap::Args;
+
+use crate::api::{self, CloudApi, NodeCloudApi, RequestMethod};
+use crate::identity::load_or_create_identity_and_vault;
+use crate::{storage, IdentityOpts};
+
+pub async fn run(args: EnrollCommandArgs, mut ctx: ockam::Context) -> anyhow::Result<()> {
+    // TODO: The identity created below will be later used to create a secure channel.
+    let ockam_dir = storage::init_ockam_dir()?;
+    let (_identity, _vault) =
+        load_or_create_identity_and_vault(&IdentityOpts::from(&args), &ctx, &ockam_dir).await?;
+    let api_client = NodeCloudApi::from(&mut ctx);
+    let auth_client = AuthenticatorClient;
+    authenticate(&args.authenticator, auth_client, api_client).await?;
+    ctx.stop().await?;
+    Ok(())
+}
+
+async fn authenticate<Auth, Api>(
+    auth: &Authenticator,
+    auth_client: Auth,
+    mut api_client: Api,
+) -> anyhow::Result<()>
+where
+    Auth: AuthenticatorClientTrait,
+    Api: CloudApi,
+{
+    let method = RequestMethod::Put;
+    let params = api::enroll::RequestParams;
+    let enroll_tokens = match auth {
+        Authenticator::Auth0 => auth_client.auth0().await?,
+    };
+    match api_client
+        .send::<_, _, ()>(method, params, enroll_tokens)
+        .await
+    {
+        Ok(_) => {
+            println!("Enrolled successfully");
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to complete enrollment process"))
+        }
+    }
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct EnrollCommandArgs {
+    /// Ockam's cloud node address
+    #[clap(display_order = 1000)]
+    pub cloud_addr: String,
+    #[clap(display_order = 1001, arg_enum, default_value = "auth0")]
+    pub authenticator: Authenticator,
+    #[clap(display_order = 1002, long, default_value = "default")]
+    pub vault: String,
+    #[clap(display_order = 1003, long, default_value = "default")]
+    pub identity: String,
+    #[clap(display_order = 1004, long)]
+    pub overwrite: bool,
+}
+
+impl<'a> From<&'a EnrollCommandArgs> for IdentityOpts {
+    fn from(other: &'a EnrollCommandArgs) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
+}
+
+#[derive(clap::ArgEnum, Clone, Debug)]
+pub enum Authenticator {
+    Auth0,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub(crate) trait AuthenticatorClientTrait {
+    async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Payload>;
+}
+
+pub(crate) struct AuthenticatorClient;
+
+mod auth0 {
+    use reqwest::StatusCode;
+    use tokio_retry::{strategy::ExponentialBackoff, Retry};
+
+    use super::*;
+
+    const DOMAIN: &str = "dev-w5hdnpc2.us.auth0.com";
+    const CLIENT_ID: &str = "sGyXBwQfU6fjfW1gopphdV9vCLec060b";
+    const API_AUDIENCE: &str = "https://dev-w5hdnpc2.us.auth0.com/api/v2/";
+    const SCOPES: &str = "profile";
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct DeviceCodeResponse {
+        device_code: String,
+        user_code: String,
+        verification_uri: String,
+        verification_uri_complete: String,
+        expires_in: usize,
+        interval: usize,
+    }
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct TokensErrorResponse {
+        error: String,
+        error_description: String,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthenticatorClientTrait for AuthenticatorClient {
+        async fn auth0(&self) -> anyhow::Result<api::enroll::Auth0Payload> {
+            // Request device code
+            // More on how to use scope and audience in https://auth0.com/docs/quickstart/native/device#device-code-parameters
+            let device_code_res = {
+                let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
+                let res = Retry::spawn(retry_strategy, move || {
+                    let client = reqwest::Client::new();
+                    client
+                        .post(format!("https://{DOMAIN}/oauth/device/code"))
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .form(&[
+                            ("client_id", CLIENT_ID),
+                            ("scope", SCOPES),
+                            ("audience", API_AUDIENCE),
+                        ])
+                        .send()
+                })
+                .await?;
+                match res.status() {
+                    StatusCode::OK => {
+                        let res = res.json::<DeviceCodeResponse>().await.map_err(|err| {
+                            anyhow!("failed to deserialize device code response [err={err}]")
+                        })?;
+                        tracing::info!("device code received: {res:#?}");
+                        res
+                    }
+                    _ => {
+                        let err = anyhow!(
+                            "couldn't get device code [response={:#?}]",
+                            res.text().await?
+                        );
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Request device activation
+            // Note that we try to open the verification uri **without** the code.
+            // After the code is entered, if the user closes the tab (because they
+            // want to open it on another browser, for example), the uri gets
+            // invalidated and the user would have to restart the process (i.e.
+            // rerun the command).
+            if open::that(&device_code_res.verification_uri).is_err() {
+                tracing::warn!(
+                    "couldn't open verification url automatically [url={}]",
+                    device_code_res.verification_uri
+                );
+            }
+
+            println!(
+                "Open the following url in your browser to authorize your device with code {}:\n{}",
+                device_code_res.user_code, device_code_res.verification_uri_complete,
+            );
+
+            // Request tokens
+            let client = reqwest::Client::new();
+            let tokens_res;
+            loop {
+                let res = client
+                    .post(format!("https://{DOMAIN}/oauth/token"))
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .form(&[
+                        ("client_id", CLIENT_ID),
+                        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                        ("device_code", &device_code_res.device_code),
+                    ])
+                    .send()
+                    .await?;
+                match res.status() {
+                    StatusCode::OK => {
+                        tokens_res =
+                            res.json::<api::enroll::Auth0Payload>()
+                                .await
+                                .map_err(|err| {
+                                    anyhow!("failed to deserialize tokens response [err={err}]")
+                                })?;
+                        tracing::info!("tokens received [tokes={tokens_res:#?}]");
+                        return Ok(tokens_res);
+                    }
+                    _ => {
+                        let err_res = res.json::<TokensErrorResponse>().await?;
+                        match err_res.error.as_str() {
+                            "authorization_pending" | "invalid_request" | "slow_down" => {
+                                tracing::info!("tokens not yet received [err={err_res:#?}]",);
+                                tokio::time::sleep(tokio::time::Duration::from_secs(
+                                    device_code_res.interval as u64,
+                                ))
+                                .await;
+                                continue;
+                            }
+                            _ => {
+                                let err_msg =
+                                    format!("failed to receive tokens [err={err_res:#?}]",);
+                                tracing::debug!("{}", err_msg);
+                                return Err(anyhow!(err_msg));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use fake::{Fake, Faker};
+    use mockall::predicate::*;
+
+    use crate::api::MockCloudApi;
+
+    use super::*;
+
+    mod node_api {
+        use crate::api::tests::node_api::*;
+
+        use super::*;
+
+        #[ockam::test(crate = "ockam")]
+        async fn auth0__can_send_payload(ctx: &mut ockam::Context) -> ockam::Result<()> {
+            let (mut node_api, worker_name) = setup_node_api(ctx).await?;
+            let payload: api::enroll::Auth0Payload = Faker.fake();
+            send_payload::<api::enroll::Auth0Payload>(&mut node_api, &worker_name, payload).await?;
+            ctx.stop().await?;
+            Ok(())
+        }
+    }
+
+    mod auth0 {
+        use super::*;
+
+        // TODO: add tests for the auth0 internals using mockito
+        // async fn internals__happy_path() {}
+        // async fn internals__err_if_device_token_request_fails() {}
+        // async fn internals__err_if_tokens_request_fails() {}
+
+        #[tokio::test]
+        async fn happy_path() -> anyhow::Result<()> {
+            let req_params = api::enroll::RequestParams;
+            let expected_creds: api::enroll::Auth0Payload = Faker.fake();
+            let mut auth_client = MockAuthenticatorClientTrait::new();
+            let moved_expected_creds = expected_creds.clone();
+            auth_client
+                .expect_auth0()
+                .times(1)
+                .return_once(move || Ok(moved_expected_creds));
+
+            let mut api_client = MockCloudApi::new();
+            api_client
+                .expect_send::<_, _, ()>()
+                .with(eq(RequestMethod::Put), eq(req_params), eq(expected_creds))
+                .times(1)
+                .returning(|_, _, _| Ok(Some(())));
+
+            authenticate(&Authenticator::Auth0, auth_client, api_client).await?;
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn err_if_auth0_flow_fails() -> anyhow::Result<()> {
+            let mut auth_client = MockAuthenticatorClientTrait::new();
+            auth_client
+                .expect_auth0()
+                .times(1)
+                .return_once(move || Err(anyhow!("error")));
+
+            let mut api_client = MockCloudApi::new();
+            api_client
+                .expect_send::<api::enroll::RequestParams, api::enroll::Auth0Payload, ()>()
+                .never();
+
+            authenticate(&Authenticator::Auth0, auth_client, api_client)
+                .await
+                .expect_err("should fail");
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn err_if_authentication_fails() -> anyhow::Result<()> {
+            let req_params = api::enroll::RequestParams;
+            let expected_creds: api::enroll::Auth0Payload = Faker.fake();
+            let mut auth_client = MockAuthenticatorClientTrait::new();
+            let moved_expected_creds = expected_creds.clone();
+            auth_client
+                .expect_auth0()
+                .times(1)
+                .return_once(move || Ok(moved_expected_creds));
+
+            let mut api_client = MockCloudApi::new();
+            api_client
+                .expect_send::<_, _, ()>()
+                .with(eq(RequestMethod::Put), eq(req_params), eq(expected_creds))
+                .times(1)
+                .returning(|_, _, _| {
+                    Err(ockam::Error::new_unknown(
+                        ockam::errcode::Origin::Application,
+                        anyhow!("error"),
+                    ))
+                });
+
+            authenticate(&Authenticator::Auth0, auth_client, api_client)
+                .await
+                .expect_err("should fail");
+
+            Ok(())
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/mod.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ockam::Context;
 
 pub(crate) mod enroll;
-// pub(crate) mod project;
+pub(crate) mod project;
 // pub(crate) mod space;
 
 #[derive(Clone, Debug, Parser)]
@@ -22,15 +22,15 @@ pub enum CloudSubCommand {
     // /// Space subcommands.
     // #[clap(display_order = 1001)]
     // Space(space::SpaceCommand),
-    // /// Project subcommands.
-    // #[clap(display_order = 1002)]
-    // Project(project::ProjectCommand),
+    /// Project subcommands.
+    #[clap(display_order = 1002)]
+    Project(project::ProjectCommand),
 }
 
 pub async fn run(args: CloudCommand, ctx: Context) -> anyhow::Result<()> {
     match args.command {
         CloudSubCommand::Enroll(arg) => enroll::run(arg, ctx).await,
         // CloudSubCommand::Space(arg) => space::run(arg, ctx).await,
-        // CloudSubCommand::Project(arg) => project::run(arg, ctx).await,
+        CloudSubCommand::Project(arg) => project::run(arg, ctx).await,
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/mod.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+
+use ockam::Context;
+
+pub(crate) mod enroll;
+// pub(crate) mod project;
+// pub(crate) mod space;
+
+#[derive(Clone, Debug, Parser)]
+pub struct CloudCommand {
+    #[clap(subcommand)]
+    pub command: CloudSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum CloudSubCommand {
+    /// Enroll identity in ockam.cloud.
+    #[clap(display_order = 1000)]
+    Enroll(enroll::EnrollCommandArgs),
+    // /// Space subcommands.
+    // #[clap(display_order = 1001)]
+    // Space(space::SpaceCommand),
+    // /// Project subcommands.
+    // #[clap(display_order = 1002)]
+    // Project(project::ProjectCommand),
+}
+
+pub async fn run(args: CloudCommand, ctx: Context) -> anyhow::Result<()> {
+    match args.command {
+        CloudSubCommand::Enroll(arg) => enroll::run(arg, ctx).await,
+        // CloudSubCommand::Space(arg) => space::run(arg, ctx).await,
+        // CloudSubCommand::Project(arg) => project::run(arg, ctx).await,
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/project.rs
@@ -1,0 +1,311 @@
+use anyhow::anyhow;
+use clap::{Args, Parser};
+#[cfg(test)]
+use fake::{Dummy, Fake, Faker};
+
+use ockam::Context;
+
+use crate::api;
+use crate::api::{
+    CloudApi, CreateProjectPayload, DeleteProjectRequestPayload, ListProjectsRequestPayload,
+    RequestMethod, ShowProjectRequestPayload,
+};
+
+#[derive(Clone, Debug, Parser)]
+pub struct ProjectCommand {
+    #[clap(subcommand)]
+    pub command: ProjectsSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum ProjectsSubCommand {
+    /// Creates a new project.
+    #[clap(display_order = 1000)]
+    Create(ProjectCommandArgs),
+    /// List all projects.
+    #[clap(display_order = 1001)]
+    List(ProjectListOpts),
+    /// Shows a single project.
+    #[clap(display_order = 1002)]
+    Show(ProjectCommandArgs),
+    /// Delete a project.
+    #[clap(display_order = 1003)]
+    Delete(ProjectCommandArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+#[cfg_attr(test, derive(Dummy))]
+pub struct ProjectCommandArgs {
+    /// Name of the project.
+    pub project_name: String,
+}
+
+#[derive(Clone, Debug, Args)]
+#[cfg_attr(test, derive(Dummy))]
+pub struct ProjectListOpts;
+
+pub async fn run(args: ProjectCommand, mut ctx: Context) -> anyhow::Result<()> {
+    let mut api_client = api::NodeCloudApi::from(&mut ctx);
+    let res = match args.command {
+        ProjectsSubCommand::Create(arg) => create(arg, &mut api_client).await,
+        ProjectsSubCommand::List(arg) => list(arg, &mut api_client).await,
+        ProjectsSubCommand::Show(arg) => show(arg, &mut api_client).await,
+        ProjectsSubCommand::Delete(arg) => delete(arg, &mut api_client).await,
+    };
+    api_client.ctx.stop().await?;
+    res
+}
+
+pub async fn create<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<api::project::create::RequestParams, api::project::create::RequestBody>,
+{
+    match api_client
+        .send::<api::project::create::ResponseBody>(
+            RequestMethod::Put,
+            api::project::create::RequestParams::from(args),
+            api::project::create::RequestBody::from(args),
+        )
+        .await
+    {
+        Ok(r) => {
+            tracing::info!("{:?}", r);
+            println!("Project created successfully");
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to create project"))
+        }
+    }
+}
+
+pub async fn list<T>(_args: ProjectListOpts, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<ListProjectsRequestPayload>,
+{
+    //TODO: return type should be a struct representing the list of items.
+    match api_client.send::<()>(ListProjectsRequestPayload).await {
+        Ok(_res) => {
+            // TODO
+            // if let Some(res) = res {
+            // println!("{res}");
+            // };
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to retrieve projects"))
+        }
+    }
+}
+
+pub async fn show<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<ShowProjectRequestPayload>,
+{
+    //TODO: return type should be a struct representing the retrieved item.
+    match api_client
+        .send::<()>(ShowProjectRequestPayload::from(args))
+        .await
+    {
+        Ok(_res) => {
+            // TODO
+            // if let Some(res) = res {
+            // println!("{res}");
+            // };
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to retrieve project"))
+        }
+    }
+}
+
+pub async fn delete<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<DeleteProjectRequestPayload>,
+{
+    match api_client
+        .send::<()>(DeleteProjectRequestPayload::from(args))
+        .await
+    {
+        Ok(_) => {
+            println!("Project deleted successfully");
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to delete project"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use mockall::predicate::*;
+
+    use crate::api::MockCloudApi;
+
+    use super::*;
+
+    mod node_api {
+        use api::tests::node_api::*;
+
+        use super::*;
+
+        #[ockam::test(crate = "ockam")]
+        async fn can_send_payloads(ctx: &mut ockam::Context) -> ockam::Result<()> {
+            let (mut node_api, worker_name) = setup_node_api(ctx).await?;
+
+            let payload: CreateProjectPayload = Faker.fake();
+            send_payload::<CreateProjectPayload>(&mut node_api, &worker_name, payload).await?;
+
+            let payload: ShowProjectRequestPayload = Faker.fake();
+            send_payload::<ShowProjectRequestPayload>(&mut node_api, &worker_name, payload).await?;
+
+            let payload: ListProjectsRequestPayload = Faker.fake();
+            send_payload::<ListProjectsRequestPayload>(&mut node_api, &worker_name, payload)
+                .await?;
+
+            let payload: DeleteProjectRequestPayload = Faker.fake();
+            send_payload::<DeleteProjectRequestPayload>(&mut node_api, &worker_name, payload)
+                .await?;
+
+            ctx.stop().await?;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn create_project__happy_path() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(CreateProjectPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = create(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_project__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(CreateProjectPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = create(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn show_project__happy_path() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = show(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn show_project__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = show(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_project__happy_path() -> anyhow::Result<()> {
+        let command_args: ProjectListOpts = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ListProjectsRequestPayload))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = list(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_project__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: ProjectListOpts = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ListProjectsRequestPayload))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = list(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_project__happy_path() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = delete(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_project__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: ProjectCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = delete(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/project.rs
@@ -5,11 +5,7 @@ use fake::{Dummy, Fake, Faker};
 
 use ockam::Context;
 
-use crate::api;
-use crate::api::{
-    CloudApi, CreateProjectPayload, DeleteProjectRequestPayload, ListProjectsRequestPayload,
-    RequestMethod, ShowProjectRequestPayload,
-};
+use crate::api::{project, CloudApi, NodeCloudApi, RequestMethod};
 
 #[derive(Clone, Debug, Parser)]
 pub struct ProjectCommand {
@@ -38,8 +34,12 @@ pub enum ProjectsSubCommand {
 #[derive(Clone, Debug, Args)]
 #[cfg_attr(test, derive(Dummy))]
 pub struct ProjectCommandArgs {
+    /// Name of the space the project belongs to.
+    pub space_name: String,
     /// Name of the project.
     pub project_name: String,
+    /// Services enabled for this project.
+    pub services: Vec<String>,
 }
 
 #[derive(Clone, Debug, Args)]
@@ -47,27 +47,34 @@ pub struct ProjectCommandArgs {
 pub struct ProjectListOpts;
 
 pub async fn run(args: ProjectCommand, mut ctx: Context) -> anyhow::Result<()> {
-    let mut api_client = api::NodeCloudApi::from(&mut ctx);
+    let mut api_client = NodeCloudApi::from(&mut ctx);
     let res = match args.command {
         ProjectsSubCommand::Create(arg) => create(arg, &mut api_client).await,
-        ProjectsSubCommand::List(arg) => list(arg, &mut api_client).await,
-        ProjectsSubCommand::Show(arg) => show(arg, &mut api_client).await,
-        ProjectsSubCommand::Delete(arg) => delete(arg, &mut api_client).await,
+        // ProjectsSubCommand::List(arg) => list(arg, &mut api_client).await,
+        // ProjectsSubCommand::Show(arg) => show(arg, &mut api_client).await,
+        // ProjectsSubCommand::Delete(arg) => delete(arg, &mut api_client).await,
+        _ => Ok(()),
     };
     api_client.ctx.stop().await?;
     res
 }
 
-pub async fn create<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+pub async fn create<Api>(args: ProjectCommandArgs, api_client: &mut Api) -> anyhow::Result<()>
 where
-    T: CloudApi<api::project::create::RequestParams, api::project::create::RequestBody>,
+    Api: CloudApi,
 {
+    let ProjectCommandArgs {
+        space_name,
+        project_name,
+        services,
+    } = args;
+    let params = project::create::RequestParams { space_name };
+    let body = project::create::RequestBody {
+        project_name,
+        services,
+    };
     match api_client
-        .send::<api::project::create::ResponseBody>(
-            RequestMethod::Put,
-            api::project::create::RequestParams::from(args),
-            api::project::create::RequestBody::from(args),
-        )
+        .send::<_, _, project::create::ResponseBody>(RequestMethod::Put, params, body)
         .await
     {
         Ok(r) => {
@@ -82,67 +89,67 @@ where
     }
 }
 
-pub async fn list<T>(_args: ProjectListOpts, api_client: &mut T) -> anyhow::Result<()>
-where
-    T: CloudApi<ListProjectsRequestPayload>,
-{
-    //TODO: return type should be a struct representing the list of items.
-    match api_client.send::<()>(ListProjectsRequestPayload).await {
-        Ok(_res) => {
-            // TODO
-            // if let Some(res) = res {
-            // println!("{res}");
-            // };
-            Ok(())
-        }
-        Err(err) => {
-            tracing::error!("{:?}", err);
-            Err(anyhow!("Failed to retrieve projects"))
-        }
-    }
-}
-
-pub async fn show<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
-where
-    T: CloudApi<ShowProjectRequestPayload>,
-{
-    //TODO: return type should be a struct representing the retrieved item.
-    match api_client
-        .send::<()>(ShowProjectRequestPayload::from(args))
-        .await
-    {
-        Ok(_res) => {
-            // TODO
-            // if let Some(res) = res {
-            // println!("{res}");
-            // };
-            Ok(())
-        }
-        Err(err) => {
-            tracing::error!("{:?}", err);
-            Err(anyhow!("Failed to retrieve project"))
-        }
-    }
-}
-
-pub async fn delete<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
-where
-    T: CloudApi<DeleteProjectRequestPayload>,
-{
-    match api_client
-        .send::<()>(DeleteProjectRequestPayload::from(args))
-        .await
-    {
-        Ok(_) => {
-            println!("Project deleted successfully");
-            Ok(())
-        }
-        Err(err) => {
-            tracing::error!("{:?}", err);
-            Err(anyhow!("Failed to delete project"))
-        }
-    }
-}
+// pub async fn list<T>(_args: ProjectListOpts, api_client: &mut T) -> anyhow::Result<()>
+// where
+//     T: CloudApi<ListProjectsRequestPayload>,
+// {
+//     //TODO: return type should be a struct representing the list of items.
+//     match api_client.send::<()>(ListProjectsRequestPayload).await {
+//         Ok(_res) => {
+//             // TODO
+//             // if let Some(res) = res {
+//             // println!("{res}");
+//             // };
+//             Ok(())
+//         }
+//         Err(err) => {
+//             tracing::error!("{:?}", err);
+//             Err(anyhow!("Failed to retrieve projects"))
+//         }
+//     }
+// }
+//
+// pub async fn show<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+// where
+//     T: CloudApi<ShowProjectRequestPayload>,
+// {
+//     //TODO: return type should be a struct representing the retrieved item.
+//     match api_client
+//         .send::<()>(ShowProjectRequestPayload::from(args))
+//         .await
+//     {
+//         Ok(_res) => {
+//             // TODO
+//             // if let Some(res) = res {
+//             // println!("{res}");
+//             // };
+//             Ok(())
+//         }
+//         Err(err) => {
+//             tracing::error!("{:?}", err);
+//             Err(anyhow!("Failed to retrieve project"))
+//         }
+//     }
+// }
+//
+// pub async fn delete<T>(args: ProjectCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+// where
+//     T: CloudApi<DeleteProjectRequestPayload>,
+// {
+//     match api_client
+//         .send::<()>(DeleteProjectRequestPayload::from(args))
+//         .await
+//     {
+//         Ok(_) => {
+//             println!("Project deleted successfully");
+//             Ok(())
+//         }
+//         Err(err) => {
+//             tracing::error!("{:?}", err);
+//             Err(anyhow!("Failed to delete project"))
+//         }
+//     }
+// }
 
 #[cfg(test)]
 #[allow(non_snake_case)]
@@ -154,7 +161,7 @@ mod tests {
     use super::*;
 
     mod node_api {
-        use api::tests::node_api::*;
+        use crate::api::tests::node_api::*;
 
         use super::*;
 
@@ -162,19 +169,20 @@ mod tests {
         async fn can_send_payloads(ctx: &mut ockam::Context) -> ockam::Result<()> {
             let (mut node_api, worker_name) = setup_node_api(ctx).await?;
 
-            let payload: CreateProjectPayload = Faker.fake();
-            send_payload::<CreateProjectPayload>(&mut node_api, &worker_name, payload).await?;
-
-            let payload: ShowProjectRequestPayload = Faker.fake();
-            send_payload::<ShowProjectRequestPayload>(&mut node_api, &worker_name, payload).await?;
-
-            let payload: ListProjectsRequestPayload = Faker.fake();
-            send_payload::<ListProjectsRequestPayload>(&mut node_api, &worker_name, payload)
+            let payload: project::create::RequestBody = Faker.fake();
+            send_payload::<project::create::RequestBody>(&mut node_api, &worker_name, payload)
                 .await?;
 
-            let payload: DeleteProjectRequestPayload = Faker.fake();
-            send_payload::<DeleteProjectRequestPayload>(&mut node_api, &worker_name, payload)
-                .await?;
+            // let payload: ShowProjectRequestPayload = Faker.fake();
+            // send_payload::<ShowProjectRequestPayload>(&mut node_api, &worker_name, payload).await?;
+            //
+            // let payload: ListProjectsRequestPayload = Faker.fake();
+            // send_payload::<ListProjectsRequestPayload>(&mut node_api, &worker_name, payload)
+            //     .await?;
+            //
+            // let payload: DeleteProjectRequestPayload = Faker.fake();
+            // send_payload::<DeleteProjectRequestPayload>(&mut node_api, &worker_name, payload)
+            //     .await?;
 
             ctx.stop().await?;
             Ok(())
@@ -184,15 +192,24 @@ mod tests {
     #[tokio::test]
     async fn create_project__happy_path() -> anyhow::Result<()> {
         let command_args: ProjectCommandArgs = Faker.fake();
+        let ProjectCommandArgs {
+            space_name,
+            project_name,
+            services,
+        } = command_args.clone();
+        let params = project::create::RequestParams { space_name };
+        let body = project::create::RequestBody {
+            project_name,
+            services,
+        };
         let mut api_client = MockCloudApi::new();
         api_client
-            .expect_send::<()>()
-            .with(eq(CreateProjectPayload::from(command_args.clone())))
+            .expect_send::<_, _, project::create::ResponseBody>()
+            .with(eq(RequestMethod::Put), eq(params), eq(body))
             .times(1)
-            .returning(|_| Ok(Some(())));
+            .returning(|_, _, _| Ok(None));
 
-        let res = create(command_args, &mut api_client).await?;
-        // assert_eq!((), res); //TODO
+        create(command_args, &mut api_client).await?;
 
         Ok(())
     }
@@ -200,12 +217,22 @@ mod tests {
     #[tokio::test]
     async fn create_project__err_if_api_client_fails() -> anyhow::Result<()> {
         let command_args: ProjectCommandArgs = Faker.fake();
+        let ProjectCommandArgs {
+            space_name,
+            project_name,
+            services,
+        } = command_args.clone();
+        let params = project::create::RequestParams { space_name };
+        let body = project::create::RequestBody {
+            project_name,
+            services,
+        };
         let mut api_client = MockCloudApi::new();
         api_client
-            .expect_send::<()>()
-            .with(eq(CreateProjectPayload::from(command_args.clone())))
+            .expect_send::<_, _, project::create::ResponseBody>()
+            .with(eq(RequestMethod::Put), eq(params), eq(body))
             .times(1)
-            .returning(|_| Err(ockam::OckamError::BareError.into()));
+            .returning(|_, _, _| Err(ockam::OckamError::BareError.into()));
 
         let res = create(command_args, &mut api_client).await;
         assert!(res.is_err());
@@ -213,99 +240,99 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn show_project__happy_path() -> anyhow::Result<()> {
-        let command_args: ProjectCommandArgs = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
-            .times(1)
-            .returning(|_| Ok(Some(())));
-
-        let res = show(command_args, &mut api_client).await?;
-        // assert_eq!((), res); //TODO
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn show_project__err_if_api_client_fails() -> anyhow::Result<()> {
-        let command_args: ProjectCommandArgs = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
-            .times(1)
-            .returning(|_| Err(ockam::OckamError::BareError.into()));
-
-        let res = show(command_args, &mut api_client).await;
-        assert!(res.is_err());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn list_project__happy_path() -> anyhow::Result<()> {
-        let command_args: ProjectListOpts = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(ListProjectsRequestPayload))
-            .times(1)
-            .returning(|_| Ok(Some(())));
-
-        let res = list(command_args, &mut api_client).await?;
-        // assert_eq!((), res); //TODO
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn list_project__err_if_api_client_fails() -> anyhow::Result<()> {
-        let command_args: ProjectListOpts = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(ListProjectsRequestPayload))
-            .times(1)
-            .returning(|_| Err(ockam::OckamError::BareError.into()));
-
-        let res = list(command_args, &mut api_client).await;
-        assert!(res.is_err());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn delete_project__happy_path() -> anyhow::Result<()> {
-        let command_args: ProjectCommandArgs = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
-            .times(1)
-            .returning(|_| Ok(Some(())));
-
-        let res = delete(command_args, &mut api_client).await?;
-        // assert_eq!((), res); //TODO
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn delete_project__err_if_api_client_fails() -> anyhow::Result<()> {
-        let command_args: ProjectCommandArgs = Faker.fake();
-        let mut api_client = MockCloudApi::new();
-        api_client
-            .expect_send::<()>()
-            .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
-            .times(1)
-            .returning(|_| Err(ockam::OckamError::BareError.into()));
-
-        let res = delete(command_args, &mut api_client).await;
-        assert!(res.is_err());
-
-        Ok(())
-    }
+    //     #[tokio::test]
+    //     async fn show_project__happy_path() -> anyhow::Result<()> {
+    //         let command_args: ProjectCommandArgs = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
+    //             .times(1)
+    //             .returning(|_| Ok(Some(())));
+    //
+    //         let res = show(command_args, &mut api_client).await?;
+    //         // assert_eq!((), res); //TODO
+    //
+    //         Ok(())
+    //     }
+    //
+    //     #[tokio::test]
+    //     async fn show_project__err_if_api_client_fails() -> anyhow::Result<()> {
+    //         let command_args: ProjectCommandArgs = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(ShowProjectRequestPayload::from(command_args.clone())))
+    //             .times(1)
+    //             .returning(|_| Err(ockam::OckamError::BareError.into()));
+    //
+    //         let res = show(command_args, &mut api_client).await;
+    //         assert!(res.is_err());
+    //
+    //         Ok(())
+    //     }
+    //
+    //     #[tokio::test]
+    //     async fn list_project__happy_path() -> anyhow::Result<()> {
+    //         let command_args: ProjectListOpts = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(ListProjectsRequestPayload))
+    //             .times(1)
+    //             .returning(|_| Ok(Some(())));
+    //
+    //         let res = list(command_args, &mut api_client).await?;
+    //         // assert_eq!((), res); //TODO
+    //
+    //         Ok(())
+    //     }
+    //
+    //     #[tokio::test]
+    //     async fn list_project__err_if_api_client_fails() -> anyhow::Result<()> {
+    //         let command_args: ProjectListOpts = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(ListProjectsRequestPayload))
+    //             .times(1)
+    //             .returning(|_| Err(ockam::OckamError::BareError.into()));
+    //
+    //         let res = list(command_args, &mut api_client).await;
+    //         assert!(res.is_err());
+    //
+    //         Ok(())
+    //     }
+    //
+    //     #[tokio::test]
+    //     async fn delete_project__happy_path() -> anyhow::Result<()> {
+    //         let command_args: ProjectCommandArgs = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
+    //             .times(1)
+    //             .returning(|_| Ok(Some(())));
+    //
+    //         let res = delete(command_args, &mut api_client).await?;
+    //         // assert_eq!((), res); //TODO
+    //
+    //         Ok(())
+    //     }
+    //
+    //     #[tokio::test]
+    //     async fn delete_project__err_if_api_client_fails() -> anyhow::Result<()> {
+    //         let command_args: ProjectCommandArgs = Faker.fake();
+    //         let mut api_client = MockCloudApi::new();
+    //         api_client
+    //             .expect_send::<()>()
+    //             .with(eq(DeleteProjectRequestPayload::from(command_args.clone())))
+    //             .times(1)
+    //             .returning(|_| Err(ockam::OckamError::BareError.into()));
+    //
+    //         let res = delete(command_args, &mut api_client).await;
+    //         assert!(res.is_err());
+    //
+    //         Ok(())
+    //     }
 }

--- a/implementations/rust/ockam/ockam_command/src/cmd/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/cloud/space.rs
@@ -1,0 +1,302 @@
+use anyhow::anyhow;
+use clap::{Args, Parser};
+#[cfg(test)]
+use fake::{Dummy, Fake, Faker};
+
+use ockam::Context;
+
+use crate::api;
+use crate::api::{
+    CloudApi, CreateSpaceRequestPayload, DeleteSpacePayload, ListSpacesPayload, ShowSpacePayload,
+};
+
+#[derive(Clone, Debug, Parser)]
+pub struct SpaceCommand {
+    #[clap(subcommand)]
+    pub command: SpacesSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum SpacesSubCommand {
+    /// Creates a new space.
+    #[clap(display_order = 1000)]
+    Create(SpaceCommandArgs),
+    /// List all spaces.
+    #[clap(display_order = 1001)]
+    List(SpaceListCommandArgs),
+    /// Shows a single space.
+    #[clap(display_order = 1002)]
+    Show(SpaceCommandArgs),
+    /// Delete a space.
+    #[clap(display_order = 1003)]
+    Delete(SpaceCommandArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+#[cfg_attr(test, derive(Dummy))]
+pub struct SpaceCommandArgs {
+    /// Name of the project that the space belongs to.
+    pub project_name: String,
+    /// Name of the space.
+    pub space_name: String,
+}
+
+#[derive(Clone, Debug, Args)]
+#[cfg_attr(test, derive(Dummy))]
+pub struct SpaceListCommandArgs {
+    /// Name of the project that the space belongs to.
+    pub project_name: String,
+}
+
+pub async fn run(args: SpaceCommand, mut ctx: Context) -> anyhow::Result<()> {
+    let mut api_client = api::NodeCloudApi::from(&mut ctx);
+    let res = match args.command {
+        SpacesSubCommand::Create(arg) => create(arg, &mut api_client).await,
+        SpacesSubCommand::List(arg) => list(arg, &mut api_client).await,
+        SpacesSubCommand::Show(arg) => show(arg, &mut api_client).await,
+        SpacesSubCommand::Delete(arg) => delete(arg, &mut api_client).await,
+    };
+    api_client.ctx.stop().await?;
+    res
+}
+
+pub async fn create<T>(args: SpaceCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<CreateSpaceRequestPayload>,
+{
+    match api_client
+        .send::<()>(CreateSpaceRequestPayload::from(args))
+        .await
+    {
+        Ok(_) => {
+            println!("Space created successfully");
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to create space"))
+        }
+    }
+}
+
+pub async fn list<T>(args: SpaceListCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<ListSpacesPayload>,
+{
+    //TODO: return type should be a struct representing the list of items.
+    match api_client.send::<()>(ListSpacesPayload::from(args)).await {
+        Ok(_res) => {
+            // TODO
+            // if let Some(res) = res {
+            // println!("{res}");
+            // };
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to retrieve spaces"))
+        }
+    }
+}
+
+pub async fn show<T>(args: SpaceCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<ShowSpacePayload>,
+{
+    //TODO: return type should be a struct representing the retrieved item.
+    match api_client.send::<()>(ShowSpacePayload::from(args)).await {
+        Ok(_res) => {
+            // TODO
+            // if let Some(res) = res {
+            // println!("{res}");
+            // };
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to retrieve space"))
+        }
+    }
+}
+
+pub async fn delete<T>(args: SpaceCommandArgs, api_client: &mut T) -> anyhow::Result<()>
+where
+    T: CloudApi<DeleteSpacePayload>,
+{
+    match api_client.send::<()>(DeleteSpacePayload::from(args)).await {
+        Ok(_) => {
+            println!("Space deleted successfully");
+            Ok(())
+        }
+        Err(err) => {
+            tracing::error!("{:?}", err);
+            Err(anyhow!("Failed to delete space"))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use mockall::predicate::*;
+
+    use crate::api::MockCloudApi;
+
+    use super::*;
+
+    mod node_api {
+        use api::tests::node_api::*;
+
+        use super::*;
+
+        #[ockam::test(crate = "ockam")]
+        async fn can_send_payloads(ctx: &mut ockam::Context) -> ockam::Result<()> {
+            let (mut node_api, worker_name) = setup_node_api(ctx).await?;
+
+            let payload: CreateSpaceRequestPayload = Faker.fake();
+            send_payload::<CreateSpaceRequestPayload>(&mut node_api, &worker_name, payload).await?;
+
+            let payload: ShowSpacePayload = Faker.fake();
+            send_payload::<ShowSpacePayload>(&mut node_api, &worker_name, payload).await?;
+
+            let payload: ListSpacesPayload = Faker.fake();
+            send_payload::<ListSpacesPayload>(&mut node_api, &worker_name, payload).await?;
+
+            let payload: DeleteSpacePayload = Faker.fake();
+            send_payload::<DeleteSpacePayload>(&mut node_api, &worker_name, payload).await?;
+
+            ctx.stop().await?;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn create_space__happy_path() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(CreateSpaceRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = create(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_space__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(CreateSpaceRequestPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = create(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn show_space__happy_path() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ShowSpacePayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = show(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn show_space__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ShowSpacePayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = show(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_space__happy_path() -> anyhow::Result<()> {
+        let command_args: SpaceListCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ListSpacesPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = list(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_space__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: SpaceListCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(ListSpacesPayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = list(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_space__happy_path() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(DeleteSpacePayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Ok(Some(())));
+
+        let res = delete(command_args, &mut api_client).await?;
+        // assert_eq!((), res); //TODO
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_space__err_if_api_client_fails() -> anyhow::Result<()> {
+        let command_args: SpaceCommandArgs = Faker.fake();
+        let mut api_client = MockCloudApi::new();
+        api_client
+            .expect_send::<()>()
+            .with(eq(DeleteSpacePayload::from(command_args.clone())))
+            .times(1)
+            .returning(|_| Err(ockam::OckamError::BareError.into()));
+
+        let res = delete(command_args, &mut api_client).await;
+        assert!(res.is_err());
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cmd/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/cmd/identity.rs
@@ -1,38 +1,10 @@
-use crate::{args::IdentityOpts, identity::save_identity, storage};
-use anyhow::Context as Ctx;
-use ockam::{identity::*, vault::*, Context};
+use ockam::Context;
+
+use crate::{args::IdentityOpts, identity::create_identity, storage};
 
 pub async fn run(args: IdentityOpts, mut ctx: Context) -> anyhow::Result<()> {
     let ockam_dir = storage::init_ockam_dir()?;
-    let id_path = ockam_dir.join("identity.json");
-    let vault_path = ockam_dir.join("vault.json");
-    if id_path.exists() || vault_path.exists() {
-        if !args.overwrite {
-            anyhow::bail!(
-                "An identity or vault already exists in {:?}. Pass `--overwrite` to continue anyway",
-                ockam_dir
-            );
-        }
-        if vault_path.exists() {
-            std::fs::remove_file(&vault_path)
-                .with_context(|| format!("Failed to remove {:?}", vault_path))?;
-        }
-        if id_path.exists() {
-            std::fs::remove_file(&id_path)
-                .with_context(|| format!("Failed to remove {:?}", id_path))?;
-        }
-    }
-    let vault = Vault::create();
-    let identity = Identity::create(&ctx, &vault).await?;
-    let exported = identity.export().await;
-    let identifier = exported.id.clone();
-    tracing::info!("Saving new identity: {:?}", identifier.key_id());
-    save_identity(&ockam_dir, &exported, &vault).await?;
-    println!(
-        "Initialized {:?} with identity {:?}.",
-        ockam_dir,
-        identifier.key_id()
-    );
+    create_identity(&args, &ctx, ockam_dir).await?;
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -15,10 +15,13 @@ use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 pub(crate) type OckamVault = ockam::vault::Vault;
 
+pub(crate) mod api;
 pub(crate) mod args;
 pub(crate) mod identity;
 pub(crate) mod storage;
+
 pub(crate) mod cmd {
+    pub(crate) mod cloud;
     pub(crate) mod identity;
     pub(crate) mod inlet;
     pub(crate) mod outlet;
@@ -37,11 +40,19 @@ pub fn run_main() {
     let verbose = args.verbose;
     init_logging(verbose);
     tracing::debug!("Parsed arguments (outlet) {:?}", args);
+
+    // Command arguments are checked but the command is not executed.
+    // This is useful to test arguments without having to execute their logic.
+    if args.dry_run {
+        return;
+    }
+
     // Note: We don't force all commands to start the node.
     match args.command {
         args::Command::CreateIdentity(arg) => node_subcommand(verbose > 0, arg, cmd::identity::run),
         args::Command::CreateInlet(arg) => node_subcommand(verbose > 0, arg, cmd::inlet::run),
         args::Command::CreateOutlet(arg) => node_subcommand(verbose > 0, arg, cmd::outlet::run),
+        args::Command::Cloud(arg) => node_subcommand(verbose > 0, arg, cmd::cloud::run),
         args::Command::AddTrustedIdentity(arg) => exit_with_result(verbose > 0, add_trusted(arg)),
         args::Command::PrintIdentity => exit_with_result(verbose > 0, print_identity()),
         args::Command::PrintPath => exit_with_result(verbose > 0, print_ockam_dir()),

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -1,0 +1,19 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--dry-run")
+        .arg("cloud")
+        .arg("enroll")
+        .arg("127.0.0.1") // cloud_addr
+        .arg("auth0") // authenticator
+        .arg("--vault")
+        .arg("vt")
+        .arg("--identity")
+        .arg("idt")
+        .arg("--overwrite");
+    cmd.assert().success();
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -1,0 +1,25 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix_args = ["--dry-run", "cloud", "project"];
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("create").arg("p1"); // project_name
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("list");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("show").arg("p1");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("delete").arg("p1");
+    cmd.assert().success();
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -1,0 +1,28 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix_args = ["--dry-run", "cloud", "space"];
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args)
+        .arg("create")
+        .arg("p1") // project_name
+        .arg("s1"); // space_name
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("list").arg("p1");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("show").arg("p1").arg("s1");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("delete").arg("p1").arg("s1");
+    cmd.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
- https://github.com/build-trust/codebase/issues/235

## Structure

The code is structured in 3 layers.

### 1. CLI Command

An entry function `run` receives the arguments the user passed as part of the command.

### 2. Cloud API

Since the cloud API can be accessed through at least two ways (node messaging and HTTP), there is a simple trait with one method to send requests. The arguments of this method define how to build the request and the type of the expected response.

The command creates an instance that implements this trait (now it's hardcoded to the node messaging) and calls the trait's method to send the request, waits for the result, and does something with it.

```rust
pub trait CloudApi {
    async fn send<Params: 'static, Payload: 'static, Response: 'static>(
        &mut self,
        method: RequestMethod,
        params: Params,
        payload: Payload,
    ) -> ockam::Result<Option<Response>>
    where
        Params: Send,
        Payload: Message + serde::Serialize + serde::de::DeserializeOwned,
        Response: serde::de::DeserializeOwned;
}
```
- The `RequestMethod` will be replaced by the `Method` described in the [CBOR schema](https://github.com/build-trust/ockam/pull/2767/files#diff-ab4fbfc6a56e72f5884b2c866992a2ec5f32c8a84a98b69aa10f1e915f16ee23R10).
- The `Params` object can hold information about how to build the request (e.g. API endpoint) but that it's not part of the payload.
- The `Payload` is the message that will be sent by the nodes or as the body of an HTTP request.

### 3. Command-specific services

The `enroll` command accesses a third-party API to retrieve the Auth0 tokens. To facilitate tests, this layer is also modeled using a trait that can be mocked.