### PR TITLE
ci: fix mergify configuration file name

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,6 +2,7 @@
 
 queue_rules:
   - name: default
+    conditions: []
 
 pull_request_rules:
   - name: automatic rebase and queue on approval


### PR DESCRIPTION
The expected path is .github/mergify.yml instead of
.github/.mergify.yml
