### PR TITLE
add distroless ockam cloud node

### DIFF
--- a/tools/docker/cloud-node/Dockerfile
+++ b/tools/docker/cloud-node/Dockerfile
@@ -1,8 +1,27 @@
-ARG BUILDER_IMAGE=ghcr.io/build-trust/ockam-builder@sha256:3ea4c222da220c69b62a60d42d83769286e07bf8e41ef7cfdbeba18b7f22a488
-ARG BASE_IMAGE=ghcr.io/build-trust/ockam-base@sha256:40fcb081b6cf56d1e306d859d010a8a4c7b9a02e6b9bc468848c09653f714b74
+# Stage 1 - Download neccesary packages
+FROM debian:11.1-slim@sha256:312218c8dae688bae4e9d12926704fa9af6f7307a6edb4f66e479702a9af5a0c as debian-packages
 
-# Stage 1
-FROM ${BUILDER_IMAGE}
+# Download all debian packages into this image so we can later copy them into the final runtime image.
+WORKDIR /tmp
+RUN set -xe; \
+    apt-get update; \
+    apt-get download \
+        libc-bin; \
+    mkdir -p /dpkg/var/lib/dpkg/status.d/ && \
+    for deb in *.deb; do \
+        package_name=$(dpkg-deb -I ${deb} | awk '/^ Package: .*$/ {print $2}'); \
+        echo "Processing: ${package_name}"; \
+        dpkg --ctrl-tarfile $deb | tar -Oxf - ./control > /dpkg/var/lib/dpkg/status.d/${package_name}; \
+        dpkg --extract $deb /dpkg || exit 10; \
+    done
+
+# Remove unnecessary files extracted from deb packages like man pages and docs etc.
+RUN find /dpkg/ -type d -empty -delete && \
+    rm -r /dpkg/usr/share/doc/
+
+
+# Stage 2 - Build elixir release of ockam_cloud_node elixir app
+FROM ghcr.io/build-trust/ockam-builder@sha256:3ea4c222da220c69b62a60d42d83769286e07bf8e41ef7cfdbeba18b7f22a488 as elixir-app-release-build
 COPY . /work
 RUN set -xe; \
     cd implementations/elixir; \
@@ -10,9 +29,33 @@ RUN set -xe; \
     cd ockam/ockam_cloud_node; \
     MIX_ENV=prod mix release;
 
-# Stage 2
-FROM ${BASE_IMAGE}
-COPY --from=0 /work/implementations/elixir/ockam/ockam_cloud_node/_build/prod/rel/ockam_cloud_node /opt/ockam_cloud_node
+
+# Stage 3 - Create distroless container and copy executables and packages in above steps
+FROM gcr.io/distroless/cc@sha256:3ca297cd5426268b5ad21e3fbe5c568411e0dec49dbae8e2967d33207bc99773
+
+COPY --from=elixir-app-release-build /work/implementations/elixir/ockam/ockam_cloud_node/_build/prod/rel/ockam_cloud_node /opt/ockam_cloud_node
+
+# Copy the libraries from the extractor stage into root
+COPY --from=debian-packages /dpkg /
+
+# We copy all shared libraries needed for elixir VM to function.
+COPY --from=debian-packages /lib/x86_64-linux-gnu /lib
+COPY --from=debian-packages /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib
+COPY --from=debian-packages /usr/lib/x86_64-linux-gnu/libacl.so.1 /lib
+# We copy all programs needed for elixir VM to function.
+COPY --from=debian-packages /bin/sh /bin/sh
+COPY --from=debian-packages /bin/rm /bin/rm
+COPY --from=debian-packages /usr/bin/cut /bin/cut
+COPY --from=debian-packages /bin/readlink /bin/readlink
+COPY --from=debian-packages /bin/sed /bin/sed
+COPY --from=debian-packages /bin/cat /bin/cat
+COPY --from=debian-packages /bin/grep /bin/grep
+COPY --from=debian-packages /usr/bin/dirname /bin/dirname
+COPY --from=debian-packages /usr/bin/basename /bin/basename
+
+ENV LANG=C.UTF-8
+
+EXPOSE 4000
 
 ENTRYPOINT ["/opt/ockam_cloud_node/bin/ockam_cloud_node"]
 CMD ["start"]


### PR DESCRIPTION
This PR allows us use distroless container to host our ockam-cloud-node program, this reduces our package size from 129MB to 57.7MB
Grype report
```bash
$ grype ghcr.io/ockam/ockam-cloud-node
✔ Vulnerability DB        [no update available]
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [10 packages]
 ✔ Scanned image           [20 vulnerabilities]
NAME       INSTALLED         FIXED-IN     TYPE  VULNERABILITY     SEVERITY   
libc-bin   2.31-13+deb11u3                deb   CVE-2019-1010024  Negligible  
libc-bin   2.31-13+deb11u3                deb   CVE-2018-20796    Negligible  
libc-bin   2.31-13+deb11u3                deb   CVE-2019-1010022  Negligible  
libc-bin   2.31-13+deb11u3                deb   CVE-2019-9192     Negligible  
libc-bin   2.31-13+deb11u3                deb   CVE-2010-4756     Negligible  
libc-bin   2.31-13+deb11u3                deb   CVE-2019-1010025  Negligible  
libc-bin   2.31-13+deb11u3   (won't fix)  deb   CVE-2021-3999     Unknown     
libc-bin   2.31-13+deb11u3                deb   CVE-2019-1010023  Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2018-20796    Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2019-1010023  Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2019-1010024  Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2019-1010025  Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2010-4756     Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2019-1010022  Negligible  
libc6      2.31-13+deb11u3                deb   CVE-2019-9192     Negligible  
libc6      2.31-13+deb11u3   (won't fix)  deb   CVE-2021-3999     Unknown     
libssl1.1  1.1.1n-0+deb11u2               deb   CVE-2010-0928     Negligible  
libssl1.1  1.1.1n-0+deb11u2               deb   CVE-2007-6755     Negligible  
openssl    1.1.1n-0+deb11u2               deb   CVE-2007-6755     Negligible  
openssl    1.1.1n-0+deb11u2               deb   CVE-2010-0928     Negligible  
```

Dive report
```bash
$ dive ghcr.io/ockam/ockam-cloud-node
Image name: ghcr.io/ockam/ockam-cloud-node                                                                                 
Total Image size: 58 MB                                                                            
Potential wasted space: 0 B                                                                        
Image efficiency score: 100 %                                                                    
```                            