### PR TITLE
Ockam node memory usage fixes

### DIFF
--- a/implementations/rust/ockam/ockam/src/channel/mod.rs
+++ b/implementations/rust/ockam/ockam/src/channel/mod.rs
@@ -49,7 +49,7 @@ impl ChannelBuilder {
     /// ```
     pub async fn new(ctx: &Context) -> Result<Self> {
         debug!("Creating new ChannelBuilder context...");
-        ctx.new_context(Address::random_local())
+        ctx.new_detached(Address::random_local())
             .await
             .map(|ctx| Self {
                 ctx,

--- a/implementations/rust/ockam/ockam/src/delay.rs
+++ b/implementations/rust/ockam/ockam/src/delay.rs
@@ -12,7 +12,7 @@ pub(crate) struct DelayedEvent<M: Message> {
 impl<M: Message> DelayedEvent<M> {
     /// Create a new 100ms delayed message event
     pub(crate) async fn new(ctx: &Context, route: Route, msg: M) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
 
         debug!(
             "Creating a delayed event with address '{}'",

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -100,7 +100,7 @@ impl RemoteForwarder {
         alias: impl Into<String>,
     ) -> Result<RemoteForwarderInfo> {
         let address: Address = random();
-        let mut child_ctx = ctx.new_context(address).await?;
+        let mut child_ctx = ctx.new_detached(address).await?;
 
         let addresses: Addresses = random();
 
@@ -136,7 +136,7 @@ impl RemoteForwarder {
         hub_addr: impl Into<Address>,
     ) -> Result<RemoteForwarderInfo> {
         let address: Address = random();
-        let mut child_ctx = ctx.new_context(address).await?;
+        let mut child_ctx = ctx.new_detached(address).await?;
 
         let addresses: Addresses = random();
 

--- a/implementations/rust/ockam/ockam/src/stream/mod.rs
+++ b/implementations/rust/ockam/ockam/src/stream/mod.rs
@@ -86,7 +86,7 @@ impl Stream {
     /// By default, the created stream will poll for new messages
     /// every 250 milliseconds.
     pub async fn new(ctx: &Context) -> Result<Self> {
-        ctx.new_context(Address::random(STREAM))
+        ctx.new_detached(Address::random(STREAM))
             .await
             .map(|ctx| Self {
                 ctx,
@@ -220,7 +220,7 @@ impl Stream {
             },
             ReceiverAddress {
                 _inner: receiver_address,
-                ctx: self.ctx.new_context(receiver_rx).await?,
+                ctx: self.ctx.new_detached(receiver_rx).await?,
             },
         ))
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes.rs
@@ -135,7 +135,7 @@ pub struct Client {
 
 impl Client {
     pub async fn new(r: Route, ctx: &Context) -> ockam_core::Result<Self> {
-        let ctx = ctx.new_context(Address::random_local()).await?;
+        let ctx = ctx.new_detached(Address::random_local()).await?;
         Ok(Client {
             ctx,
             route: r,

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -108,7 +108,7 @@ impl SecureChannel {
         let route = route.into();
 
         let address: Address = random();
-        let mut child_ctx = ctx.new_context(address).await?;
+        let mut child_ctx = ctx.new_detached(address).await?;
         let channel = SecureChannelWorker::new(
             true,
             route,

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_custom_context.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/examples/worker_custom_context.rs
@@ -28,7 +28,7 @@ impl Custom {
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
     // Create and run our non-worker
-    let ctx2 = ctx.new_context("some.address").await?;
+    let ctx2 = ctx.new_detached("some.address").await?;
     Custom(ctx2).run();
 
     assert_eq!(ctx.receive::<String>().await?, "Hello 1".to_string());

--- a/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/secure_channel_worker.rs
@@ -90,7 +90,7 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
         timeout: Duration,
     ) -> Result<Address> {
         let child_address = Address::random_local();
-        let mut child_ctx = ctx.new_context(child_address.clone()).await?;
+        let mut child_ctx = ctx.new_detached(child_address.clone()).await?;
 
         // Generate 2 random fresh address for newly created SecureChannel.
         // One for local workers to encrypt their messages
@@ -102,7 +102,7 @@ impl<I: IdentityTrait> SecureChannelWorker<I> {
             .initiator()
             .await?;
         // Create regular secure channel and set self address as first responder
-        let temp_ctx = ctx.new_context(Address::random_local()).await?;
+        let temp_ctx = ctx.new_detached(Address::random_local()).await?;
         let self_remote_address_clone = self_remote_address.clone();
         let channel_future = Box::pin(async move {
             SecureChannel::create_extended(

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity_credentials.rs
@@ -504,7 +504,7 @@ impl CredentialProtocol for Identity {
         let mut ctx = self
             .handle
             .ctx()
-            .new_context(Address::random_local())
+            .new_detached(Address::random_local())
             .await?;
 
         let worker = HolderWorker::new(
@@ -542,7 +542,7 @@ impl CredentialProtocol for Identity {
         let mut ctx = self
             .handle
             .ctx()
-            .new_context(Address::random_local())
+            .new_detached(Address::random_local())
             .await?;
         let worker = PresenterWorker::new(
             identity,
@@ -580,7 +580,7 @@ impl CredentialProtocol for Identity {
         let mut ctx = self
             .handle
             .ctx()
-            .new_context(Address::random_local())
+            .new_detached(Address::random_local())
             .await?;
         let worker = VerifierWorker::new(
             identity,

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -20,7 +20,7 @@ pub struct Identity<V: IdentityVault> {
 
 impl<V: IdentityVault> Identity<V> {
     pub async fn create(ctx: &Context, vault: &V) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
         let state = IdentityState::create(vault.async_try_clone().await?).await?;
         Ok(Self {
             ctx: child_ctx,
@@ -33,7 +33,7 @@ impl<V: IdentityVault> Identity<V> {
     }
 
     pub async fn import(ctx: &Context, vault: &V, exported: ExportedIdentity) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
         let state = IdentityState::import(vault.async_try_clone().await?, exported);
         Ok(Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
@@ -10,7 +10,7 @@ pub struct IdentityBuilder<V: IdentityVault> {
 
 impl<V: IdentityVault> IdentityBuilder<V> {
     pub async fn new(ctx: &Context, vault: &V) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
 
         Ok(Self {
             ctx: child_ctx,

--- a/implementations/rust/ockam/ockam_identity/src/worker/trust_policy_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/worker/trust_policy_worker.rs
@@ -21,7 +21,7 @@ impl TrustPolicyImpl {
 impl TrustPolicyImpl {
     pub async fn create_using_worker(ctx: &Context, address: &Address) -> Result<Self> {
         let handle = Handle::new(
-            ctx.new_context(Address::random_local()).await?,
+            ctx.new_detached(Address::random_local()).await?,
             address.clone(),
         );
 

--- a/implementations/rust/ockam/ockam_node/src/async_drop.rs
+++ b/implementations/rust/ockam/ockam_node/src/async_drop.rs
@@ -1,0 +1,60 @@
+use crate::tokio::runtime::Runtime;
+use crate::tokio::sync::{
+    mpsc::Sender as DefaultSender,
+    oneshot::{self, Receiver, Sender},
+};
+use crate::NodeMessage;
+use ockam_core::{compat::sync::Arc, Address};
+
+/// A helper to implement Drop mechanisms, but async
+///
+/// This mechanism uses a Oneshot channel, which doesn't require an
+/// async context to send into it (i.e. we can send a single message
+/// from a `Drop` handler without needing to block on a future!)
+///
+/// The receiver is then tasked to de-allocate the specified resource.
+///
+/// This is not a very generic interface, i.e. it will only generate
+/// stop_worker messages.  If we want to reuse this mechanism, we may
+/// also want to extend the API so that other resources can specify
+/// additional metadata to generate messages.
+pub struct AsyncDrop {
+    rx: Receiver<Address>,
+    sender: DefaultSender<NodeMessage>,
+}
+
+impl AsyncDrop {
+    /// Create a new AsyncDrop and AsyncDrop sender
+    ///
+    /// The `sender` parameter can simply be cloned from the parent
+    /// Context that creates this hook, while the `address` field must
+    /// refer to the address of the context that will be deallocated
+    /// this way.
+    pub fn new(sender: DefaultSender<NodeMessage>) -> (Self, Sender<Address>) {
+        let (tx, rx) = oneshot::channel();
+        (Self { rx, sender }, tx)
+    }
+
+    /// Wait for the cancellation of the channel and then send a
+    /// message to the router
+    ///
+    /// Because this code is run detached from its original context,
+    /// we can't handle any errors.
+    pub fn spawn(self, rt: &Arc<Runtime>) {
+        rt.spawn(async move {
+            if let Ok(addr) = self.rx.await {
+                debug!("Received AsyncDrop request for address: {}", addr);
+
+                let (msg, mut reply) = NodeMessage::stop_worker(addr, true);
+                if let Err(e) = self.sender.send(msg).await {
+                    warn!("Failed sending AsyncDrop request to router: {}", e);
+                }
+
+                // Then check that address was properly shut down
+                if reply.recv().await.is_none() {
+                    warn!("AsyncDrop router reply was None");
+                }
+            }
+        });
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/delayed.rs
+++ b/implementations/rust/ockam/ockam_node/src/delayed.rs
@@ -26,7 +26,7 @@ impl<M: Message + Clone> DelayedEvent<M> {
         destination_addr: impl Into<Address>,
         msg: M,
     ) -> Result<Self> {
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
 
         let heartbeat = Self {
             ctx: child_ctx,
@@ -51,7 +51,7 @@ impl<M: Message + Clone> DelayedEvent<M> {
     pub async fn schedule(&mut self, duration: Duration) -> Result<()> {
         self.cancel();
 
-        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let child_ctx = self.ctx.new_detached(Address::random_local()).await?;
         let destination_addr = self.destination_addr.clone();
         let msg = self.msg.clone();
 

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -32,6 +32,7 @@ mod tests;
 /// Async Mutex and RwLock
 pub mod compat;
 
+mod async_drop;
 mod cancel;
 mod context;
 mod delayed;

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -27,7 +27,7 @@ pub enum NodeMessage {
     /// Add an existing address to a cluster
     SetCluster(Address, String, Sender<NodeReplyResult>),
     /// Stop an existing worker
-    StopWorker(Address, Sender<NodeReplyResult>),
+    StopWorker(Address, bool, Sender<NodeReplyResult>),
     /// Start a new processor
     StartProcessor(Address, SenderPair, Sender<NodeReplyResult>),
     /// Stop an existing processor
@@ -54,7 +54,7 @@ impl fmt::Display for NodeMessage {
             NodeMessage::StartWorker { .. } => write!(f, "StartWorker"),
             NodeMessage::ListWorkers(_) => write!(f, "ListWorkers"),
             NodeMessage::SetCluster(_, _, _) => write!(f, "SetCluster"),
-            NodeMessage::StopWorker(_, _) => write!(f, "StopWorker"),
+            NodeMessage::StopWorker(_, _, _) => write!(f, "StopWorker"),
             NodeMessage::StartProcessor(_, _, _) => write!(f, "StartProcessor"),
             NodeMessage::StopProcessor(_, _) => write!(f, "StopProcessor"),
             NodeMessage::StopNode(_, _) => write!(f, "StopNode"),
@@ -122,9 +122,9 @@ impl NodeMessage {
     }
 
     /// Create a stop worker message and reply receiver
-    pub fn stop_worker(address: Address) -> (Self, Receiver<NodeReplyResult>) {
+    pub fn stop_worker(address: Address, bare: bool) -> (Self, Receiver<NodeReplyResult>) {
         let (tx, rx) = channel(1);
-        (Self::StopWorker(address, tx), rx)
+        (Self::StopWorker(address, bare, tx), rx)
     }
 
     /// Create a stop node message

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -17,8 +17,8 @@ pub enum NodeMessage {
         addrs: AddressSet,
         /// Pair of senders to the worker relay (msgs and ctrl)
         senders: SenderPair,
-        /// A bare worker runs no relay state
-        bare: bool,
+        /// A detached context/ "worker" runs no relay state
+        detached: bool,
         /// Reply channel for command confirmation
         reply: Sender<NodeReplyResult>,
     },
@@ -73,21 +73,21 @@ impl NodeMessage {
     ///
     /// * `senders`: message and command senders for the relay
     ///
-    /// * `bare`: indicate whether this worker address has a full
-    ///   relay behind it that can respond to shutdown commands.
-    ///   Setting this to `true` will disable stop ACK support in the
-    ///   router
+    /// * `detached`: indicate whether this worker address has a full
+    ///               relay behind it that can respond to shutdown
+    ///               commands.  Setting this to `true` will disable
+    ///               stop ACK support in the router
     pub fn start_worker(
         addrs: AddressSet,
         senders: SenderPair,
-        bare: bool,
+        detached: bool,
     ) -> (Self, Receiver<NodeReplyResult>) {
         let (reply, rx) = channel(1);
         (
             Self::StartWorker {
                 addrs,
                 senders,
-                bare,
+                detached,
                 reply,
             },
             rx,
@@ -122,9 +122,9 @@ impl NodeMessage {
     }
 
     /// Create a stop worker message and reply receiver
-    pub fn stop_worker(address: Address, bare: bool) -> (Self, Receiver<NodeReplyResult>) {
+    pub fn stop_worker(address: Address, detached: bool) -> (Self, Receiver<NodeReplyResult>) {
         let (tx, rx) = channel(1);
-        (Self::StopWorker(address, bare, tx), rx)
+        (Self::StopWorker(address, detached, tx), rx)
     }
 
     /// Create a stop node message

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -20,7 +20,7 @@ pub fn start_node() -> (Context, Executor) {
 
     // The root application worker needs a mailbox and relay to accept
     // messages from workers, and to buffer incoming transcoded data.
-    let (ctx, sender, _) = Context::new(exe.runtime(), exe.sender(), addr.into(), AllowAll);
+    let (ctx, sender, _) = Context::new(exe.runtime(), exe.sender(), addr.into(), None, AllowAll);
 
     // Register this mailbox handle with the executor
     exe.initialize_system("app", sender);

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -79,7 +79,7 @@ impl Router {
                 senders.ctrl,
                 AddressMeta {
                     processor: false,
-                    bare: true,
+                    detached: true,
                 },
             ),
         );
@@ -133,11 +133,11 @@ impl Router {
             StartWorker {
                 addrs,
                 senders,
-                bare,
+                detached,
                 ref reply,
-            } => start_worker::exec(self, addrs, senders, bare, reply).await?,
-            StopWorker(ref addr, ref bare, ref reply) => {
-                stop_worker::exec(self, addr, *bare, reply).await?
+            } => start_worker::exec(self, addrs, senders, detached, reply).await?,
+            StopWorker(ref addr, ref detached, ref reply) => {
+                stop_worker::exec(self, addr, *detached, reply).await?
             }
 
             //// ==! Basic processor control

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -136,7 +136,9 @@ impl Router {
                 bare,
                 ref reply,
             } => start_worker::exec(self, addrs, senders, bare, reply).await?,
-            StopWorker(ref addr, ref reply) => stop_worker::exec(self, addr, reply).await?,
+            StopWorker(ref addr, ref bare, ref reply) => {
+                stop_worker::exec(self, addr, *bare, reply).await?
+            }
 
             //// ==! Basic processor control
             StartProcessor(addr, senders, ref reply) => {

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -111,6 +111,7 @@ impl Router {
 
     async fn handle_msg(&mut self, msg: NodeMessage) -> Result<bool> {
         use NodeMessage::*;
+        debug!("Currently router has {} addresses", self.map.count());
         match msg {
             // Successful router registration command
             Router(tt, addr, sender) if !self.external.contains_key(&tt) => {

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -29,6 +29,11 @@ pub struct InternalMap {
 }
 
 impl InternalMap {
+    /// Used for router diagnostics
+    pub(super) fn count(&self) -> usize {
+        self.internal.len()
+    }
+
     /// Add an address to a particular cluster
     pub(super) fn set_cluster(&mut self, label: String, primary: Address) -> NodeReplyResult {
         let rec = self
@@ -121,7 +126,7 @@ impl InternalMap {
             .collect()
     }
 
-    /// Permanently free all remainin resources associated to a particular address
+    /// Permanently free all remaining resources associated to a particular address
     pub(super) fn free_address(&mut self, primary: Address) {
         self.stopping.remove(&primary);
         if let Some(record) = self.internal.remove(&primary) {

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -121,8 +121,8 @@ impl InternalMap {
                     Some(rec)
                 }
             })
-            // Filter all bare workers because they don't matter
-            .filter(|rec| !rec.meta.bare)
+            // Filter all detached workers because they don't matter :(
+            .filter(|rec| !rec.meta.detached)
             .collect()
     }
 
@@ -141,7 +141,7 @@ impl InternalMap {
 #[derive(Debug)]
 pub struct AddressMeta {
     pub processor: bool,
-    pub bare: bool,
+    pub detached: bool,
 }
 
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -36,7 +36,7 @@ async fn start(
         ctrl,
         AddressMeta {
             processor: true,
-            bare: false,
+            detached: false,
         },
     );
 

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -11,11 +11,11 @@ pub(super) async fn exec(
     router: &mut Router,
     addrs: AddressSet,
     senders: SenderPair,
-    bare: bool,
+    detached: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
     match router.state.node_state() {
-        NodeState::Running => start(router, addrs, senders, bare, reply).await,
+        NodeState::Running => start(router, addrs, senders, detached, reply).await,
         NodeState::Stopping(_) => reject(reply).await,
         NodeState::Dead => unreachable!(),
     }?;
@@ -26,7 +26,7 @@ async fn start(
     router: &mut Router,
     addrs: AddressSet,
     senders: SenderPair,
-    bare: bool,
+    detached: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
     debug!("Starting new worker '{}'", addrs.first());
@@ -40,7 +40,7 @@ async fn start(
         ctrl,
         AddressMeta {
             processor: false,
-            bare,
+            detached,
         },
     );
     router

--- a/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
@@ -9,10 +9,12 @@ use ockam_core::{Address, Result};
 pub(super) async fn exec(
     router: &mut Router,
     addr: &Address,
+    bare: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
     trace!("Stopping worker '{}'", addr);
 
+    // Resolve any secondary address to the primary address
     let primary_address = match router.map.addr_map.get(addr) {
         Some(p) => p.clone(),
         None => {
@@ -25,6 +27,7 @@ pub(super) async fn exec(
         }
     };
 
+    // Get the internal address record
     let record = match router.map.internal.get_mut(&primary_address) {
         Some(r) => r,
         None => {
@@ -38,6 +41,7 @@ pub(super) async fn exec(
         }
     };
 
+    // Remove all secondary addresses
     for addr in record.address_set().iter() {
         router.map.addr_map.remove(addr);
     }
@@ -47,9 +51,16 @@ pub(super) async fn exec(
         .await
         .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?;
 
-    // Drop worker's Sender to close the worker's mailbox channel
-    // and trigger the worker to start a graceful self-shutdown.
-    record.sender_drop();
+    // If we are dropping a real worker, then we simply close the
+    // mailbox channel to trigger a graceful worker self-shutdown.
+    //
+    // For bare workers (i.e. Context's without a mailbox relay
+    // running) we simply drop the record
+    if !bare {
+        record.sender_drop();
+    } else {
+        router.map.free_address(primary_address);
+    }
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_worker.rs
@@ -9,7 +9,7 @@ use ockam_core::{Address, Result};
 pub(super) async fn exec(
     router: &mut Router,
     addr: &Address,
-    bare: bool,
+    detached: bool,
     reply: &Sender<NodeReplyResult>,
 ) -> Result<()> {
     trace!("Stopping worker '{}'", addr);
@@ -54,9 +54,9 @@ pub(super) async fn exec(
     // If we are dropping a real worker, then we simply close the
     // mailbox channel to trigger a graceful worker self-shutdown.
     //
-    // For bare workers (i.e. Context's without a mailbox relay
+    // For detached workers (i.e. Context's without a mailbox relay
     // running) we simply drop the record
-    if !bare {
+    if !detached {
         record.sender_drop();
     } else {
         router.map.free_address(primary_address);

--- a/implementations/rust/ockam/ockam_node/src/tests.rs
+++ b/implementations/rust/ockam/ockam_node/src/tests.rs
@@ -19,7 +19,7 @@ fn start_and_shutdown_node__many_iterations__should_not_fail() {
         let (mut ctx, mut executor) = start_node();
         executor
             .execute(async move {
-                let mut child_ctx = ctx.new_context("child").await?;
+                let mut child_ctx = ctx.new_detached("child").await?;
                 ctx.send(route!["child"], "Hello".to_string()).await?;
 
                 let m = child_ctx.receive::<String>().await?.take().body();

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
@@ -24,7 +24,7 @@ pub(crate) struct BleRouterHandle {
 #[async_trait]
 impl AsyncTryClone for BleRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let child_ctx = self.ctx.new_detached(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -40,7 +40,7 @@ pub struct BleRouter {
 
 impl BleRouter {
     async fn create_self_handle(&self, ctx: &Context) -> Result<BleRouterHandle> {
-        let handle_ctx = ctx.new_context(Address::random_local()).await?;
+        let handle_ctx = ctx.new_detached(Address::random_local()).await?;
         let handle = BleRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }
@@ -138,7 +138,7 @@ impl BleRouter {
         let api_addr = Address::random_local();
         debug!("Registering new BleRouter with address {}", &main_addr);
 
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
         let router = Self {
             _ctx: child_ctx,
             main_addr: main_addr.clone(),

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -19,7 +19,7 @@ pub(crate) struct TcpRouterHandle {
 #[async_trait]
 impl AsyncTryClone for TcpRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let child_ctx = self.ctx.new_detached(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }
@@ -92,7 +92,7 @@ impl TcpRouterHandle {
         );
         let self_addr = pair.tx_addr();
 
-        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let mut child_ctx = self.ctx.new_detached(Address::random_local()).await?;
         child_ctx
             .send(
                 self.api_addr.clone(),

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/tcp_router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/tcp_router.rs
@@ -30,7 +30,7 @@ impl TcpRouter {
         let api_addr = Address::random_local();
         debug!("Initialising new TcpRouter with address {}", &main_addr);
 
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
 
         let router = Self {
             ctx: child_ctx,
@@ -52,7 +52,7 @@ impl TcpRouter {
 
     /// Create a new `TcpRouterHandle` representing this router
     async fn create_self_handle(&self) -> Result<TcpRouterHandle> {
-        let handle_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let handle_ctx = self.ctx.new_detached(Address::random_local()).await?;
         let handle = TcpRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -51,7 +51,7 @@ async fn tcp_lifecycle__reconnect__should_not_error(ctx: &mut Context) -> Result
     let transport = TcpTransport::create(ctx).await?;
     let listener_address = transport.listen("127.0.0.1:0").await?.to_string();
 
-    let mut child_ctx = ctx.new_context(Address::random_local()).await?;
+    let mut child_ctx = ctx.new_detached(Address::random_local()).await?;
     let msg: String = rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
         .take(256)

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
@@ -20,7 +20,7 @@ pub(crate) struct WebSocketRouterHandle {
 #[async_trait]
 impl AsyncTryClone for WebSocketRouterHandle {
     async fn async_try_clone(&self) -> Result<Self> {
-        let child_ctx = self.ctx.new_context(Address::random_local()).await?;
+        let child_ctx = self.ctx.new_detached(Address::random_local()).await?;
         Ok(Self::new(child_ctx, self.api_addr.clone()))
     }
 }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
@@ -55,7 +55,7 @@ impl WebSocketRouter {
         // Create the `WebSocketRouter` instance. Note that both the
         // router and the handle have independent contexts so that
         // they can manage their own lifecycle.
-        let child_ctx = ctx.new_context(Address::random_local()).await?;
+        let child_ctx = ctx.new_detached(Address::random_local()).await?;
         let router = Self {
             ctx: child_ctx,
             main_addr: main_addr.clone(),
@@ -75,7 +75,7 @@ impl WebSocketRouter {
     }
 
     async fn create_self_handle(&self, ctx: &Context) -> Result<WebSocketRouterHandle> {
-        let handle_ctx = ctx.new_context(Address::random_local()).await?;
+        let handle_ctx = ctx.new_detached(Address::random_local()).await?;
         let handle = WebSocketRouterHandle::new(handle_ctx, self.api_addr.clone());
         Ok(handle)
     }


### PR DESCRIPTION
This PR attempts to fix the memory leaks present in the current Inlet/Outlet demo.

Testing data is available here (maybe if you're logged in?): https://miro.com/app/board/uXjVO0PpZLg=/

## Rationale

We create "bare contexts" all over the codebase to send messages, wait for specific replies, etc. These don't have a worker relay behind them and thus are outside of the regular shutdown mechanism. When transferring a 132MB file across Ockam the Outlet router allocated up to 14 THOUSAND addresses that were never cleared.

This change:

1. adds some debug logging so that we can have a better understanding of how many addresses are registered on a system.  In the future we may also want to extend this metrics reporting to numbers of clusters, channel load, etc
2. side-steps the normal shutdown mechanism for bare context records, which don't have a relay and can't interact with the "new" shutdown ACK mechanism.

This seems to fix the memory leak present in the demo.