### PR TITLE
fix(elixir): fix mini_cbor formatting for non-structures, improve api errors

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/mini_cbor.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/mini_cbor.ex
@@ -103,7 +103,7 @@ defmodule MiniCBOR do
   def rekey_struct(struct, {:map, schema_map}) do
     struct
     # because enum is not implemented for structs
-    |> Map.from_struct()
+    |> as_map()
     |> Enum.flat_map(fn {key, val} ->
       case Map.get(schema_map, key) do
         nil ->
@@ -151,5 +151,13 @@ defmodule MiniCBOR do
 
   def rekey_optimized(index, {:enum, option_map}) when is_integer(index) do
     Map.fetch!(option_map, index)
+  end
+
+  defp as_map(map) when is_struct(map) do
+    Map.from_struct(map)
+  end
+
+  defp as_map(map) when is_map(map) do
+    map
   end
 end

--- a/implementations/elixir/ockam/ockam_services/lib/services/api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api.ex
@@ -72,7 +72,7 @@ defmodule Ockam.Services.API do
     400
   end
 
-  def status_code({:bad_request, _}) do
+  def status_code({:bad_request, _reason}) do
     400
   end
 
@@ -80,8 +80,25 @@ defmodule Ockam.Services.API do
     404
   end
 
+  def status_code(:resource_exists) do
+    409
+  end
+
+  def status_code({:resource_exists, _reason}) do
+    409
+  end
+
   def status_code(_unknown_error) do
     500
+  end
+
+  ## TODO: better standard error messages
+  def error_message({:bad_request, data}) do
+    inspect(data)
+  end
+
+  def error_message({:resource_exists, data}) do
+    inspect(data)
   end
 
   def error_message(message) do


### PR DESCRIPTION

## Current Behaviour

Currently calling `MiniCBOR.encode/2` fails with non-structure maps

## Proposed Changes

Only call `from_structure` for maps which are structures

Support more error codes in the API helper

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
