### PR TITLE
feat(rust): allow blue-oak model license 1.0.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,8 @@ allow = [
     "BSD-3-Clause",
     "BSD-2-Clause",
     "0BSD",
-    "ISC"
+    "ISC",
+    "BlueOak-1.0.0"
 ]
 
 [advisories]


### PR DESCRIPTION
See https://blueoakcouncil.org/license/1.0.0 and https://spdx.org/licenses/BlueOak-1.0.0.html for details.
