### PR TITLE
feat(rust): add ockam_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
+name = "cddl-cat"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259c8f43c4c804869941ba6869864ccd8283fd23beb13b328a65dd77ff780cf6"
+dependencies = [
+ "base64",
+ "escape8259",
+ "float-ord",
+ "hex",
+ "nom",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "strum_macros",
+ "thiserror",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.16"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52d4f8e4a1419219935762e32913b4430f37cb0c0200ad17a89ee18c0188a9f"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
@@ -495,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -834,9 +853,9 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ed25519"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5c4b5e5959dc2c2b89918d8e2cc40fcdd623cef026ed09d2f0ee05199dc8e4"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "signature",
 ]
@@ -899,6 +918,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "escape8259"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8edd65c008c6e97290e463c336e0c3fe109a91accb0e6b3e9e353d1605bd58b8"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "example_blocks"
 version = "0.1.0"
 
@@ -934,6 +972,12 @@ dependencies = [
  "structopt",
  "tokio",
 ]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "fnv"
@@ -1153,6 +1197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,12 +1235,13 @@ checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heapless"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
+checksum = "8a08e755adbc0ad283725b29f4a4883deee15336f372d5f61fae59efec40f983"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version 0.4.0",
  "spin",
  "stable_deref_trait",
 ]
@@ -1336,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "lazy_static"
@@ -1348,9 +1399,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libdbus-sys"
@@ -1417,6 +1468,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "minicbor"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08de72a57f15d959ab3a3b73fc94572eb954bfcfeb3809cf83cc1bd7d0aa774b"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd6ff7dbe1a10938f8b72c6d0dd81c28fc68283aa79d7ba97c99a96a8e5823"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,25 +1504,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1495,12 +1561,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
-name = "ntapi"
-version = "0.3.7"
+name = "nom"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "winapi",
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1543,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
 dependencies = [
  "memchr",
 ]
@@ -1591,6 +1658,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ockam_api"
+version = "0.1.0"
+dependencies = [
+ "cddl-cat",
+ "minicbor",
+ "ockam_api",
+ "ockam_core",
+ "quickcheck",
+ "tinyvec",
+]
+
+[[package]]
 name = "ockam_channel"
 version = "0.52.0"
 dependencies = [
@@ -1616,7 +1695,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "async-trait",
- "clap 3.1.16",
+ "clap 3.1.18",
  "dirs",
  "hex",
  "ockam",
@@ -1892,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "pairing"
@@ -2026,11 +2105,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2255,10 +2345,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.9"
+name = "rustversion"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "scopeguard"
@@ -2323,6 +2419,16 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 
@@ -2635,6 +2741,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,13 +2761,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2746,9 +2865,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.1"
+version = "1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
+checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -2812,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -2951,6 +3070,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"

--- a/deny.toml
+++ b/deny.toml
@@ -22,5 +22,12 @@ unmaintained = "deny"
 vulnerability = "deny"
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2020-0159"
+    "RUSTSEC-2020-0159",
+
+    # `serde_cbor` is unmaintained
+    # (https://rustsec.org/advisories/RUSTSEC-2021-0127.html)
+    #
+    # Pulled-in by `cddl-cat` which is used for validating
+    # CDDL schema conformance in tests.
+    "RUSTSEC-2021-0127"
 ]

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name        = "ockam_api"
+version     = "0.1.0"
+edition     = "2021"
+authors     = ["Ockam Developers"]
+license     = "Apache-2.0"
+homepage    = "https://github.com/ockam-network/ockam"
+repository  = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_api"
+description = "A set of common API types"
+
+[features]
+std = ["minicbor/std", "ockam_core/std"]
+tag = []
+
+[dependencies]
+minicbor = { version = "0.16.0", features = ["alloc", "derive"] }
+tinyvec  = { version = "1.6.0", features = ["rustc_1_57"] }
+
+[dependencies.ockam_core]
+version          = "0.54.0"
+path             = "../ockam_core"
+default-features = false
+features         = ["no_std", "alloc"]
+
+[dev-dependencies]
+cddl-cat   = "0.6.1"
+ockam_api  = { path = ".", features = ["std"] }
+quickcheck = "1.0.1"
+

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -1,0 +1,324 @@
+use core::fmt;
+use minicbor::decode::{self, Decoder};
+use minicbor::encode::{self, Encoder, Write};
+use minicbor::{Decode, Encode};
+use ockam_core::compat::borrow::Cow;
+use ockam_core::compat::rand;
+use tinyvec::ArrayVec;
+
+/// CDDL schema or request and response headers as well as errors.
+pub const SCHEMA: &str = r#"
+    request  = { ?0: 7586022, 1: id, 2: path, 3: method, 4: has_body }
+    response = { ?0: 9750358, 1: id, 2: re, 3: status, 4: has_body }
+    error    = { ?0: 5359172, 1: path, ?2: method, ?3: message }
+    id       = uint
+    re       = uint
+    path     = text
+    method   = 0   ;; GET
+             / 1   ;; POST
+             / 2   ;; PUT
+             / 3   ;; DELETE
+             / 4   ;; PATCH
+    status   = 200 ;; OK
+             / 400 ;; Bad request
+             / 404 ;; Not found
+             / 405 ;; Method not allowed
+             / 500 ;; Internal server error
+             / 501 ;; Not implemented
+    message  = text
+    has_body = bool
+"#;
+
+/// A request header.
+#[derive(Debug, Clone, Encode, Decode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct Request<'a> {
+    /// Nominal type tag.
+    ///
+    /// If the "tag" feature is enabled, the resulting CBOR will contain a
+    /// unique numeric value that identifies this type to help catching type
+    /// errors. Otherwise this tag will not be produced and is ignored during
+    /// decoding if present.
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<7586022>,
+    /// The request identifier.
+    #[n(1)] id: Id,
+    /// The resource path.
+    #[b(2)] path: Cow<'a, str>,
+    /// The request method.
+    ///
+    /// It is wrapped in an `Option` to be forwards compatible, i.e. adding
+    /// methods will not cause decoding errors and client code can decide
+    /// how to handle unknown methods.
+    #[n(3)] method: Option<Method>,
+    /// Indicator if a request body is expected after this header.
+    #[n(4)] has_body: bool
+}
+
+/// The response header.
+#[derive(Debug, Clone, Encode, Decode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct Response {
+    /// Nominal type tag.
+    ///
+    /// If the "tag" feature is enabled, the resulting CBOR will contain a
+    /// unique numeric value that identifies this type to help catching type
+    /// errors. Otherwise this tag will not be produced and is ignored during
+    /// decoding if present.
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<9750358>,
+    /// The response identifier.
+    #[n(1)] id: Id,
+    /// The identifier of the request corresponding to this response.
+    #[n(2)] re: Id,
+    /// A status code.
+    ///
+    /// It is wrapped in an `Option` to be forwards compatible, i.e. adding
+    /// status codes will not cause decoding errors and client code can decide
+    /// how to handle unknown codes.
+    #[n(3)] status: Option<Status>,
+    /// Indicator if a response body is expected after this header.
+    #[n(4)] has_body: bool
+}
+
+/// A request/response identifier.
+#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord)]
+#[cbor(transparent)]
+pub struct Id(#[n(0)] u32);
+
+/// Request methods.
+#[derive(Debug, Copy, Clone, Encode, Decode)]
+#[non_exhaustive]
+#[rustfmt::skip]
+#[cbor(index_only)]
+pub enum Method {
+    #[n(0)] Get,
+    #[n(1)] Post,
+    #[n(2)] Put,
+    #[n(3)] Delete,
+    #[n(4)] Patch
+}
+
+/// The response status codes.
+#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+#[rustfmt::skip]
+#[cbor(index_only)]
+pub enum Status {
+    #[n(200)] Ok,
+    #[n(400)] BadRequest,
+    #[n(404)] NotFound,
+    #[n(405)] MethodNotAllowed,
+    #[n(500)] InternalServerError,
+    #[n(501)] NotImplemented
+}
+
+/// A type tag represents a type as a unique numeric value.
+///
+/// This zero-sized type is meant to help catching type errors in cases where
+/// CBOR items structurally match various nominal types. It will end up as an
+/// unsigned integer in CBOR and decoding checks that the value is expected.
+#[derive(Clone, Copy, Default)]
+pub struct TypeTag<const N: usize>;
+
+// Custom `Debug` impl to include the tag number.
+impl<const N: usize> fmt::Debug for TypeTag<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TypeTag").field(&N).finish()
+    }
+}
+
+impl<C, const N: usize> Encode<C> for TypeTag<N> {
+    fn encode<W: Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _: &mut C,
+    ) -> Result<(), encode::Error<W::Error>> {
+        e.u64(N as u64)?.ok()
+    }
+}
+
+impl<'b, C, const N: usize> Decode<'b, C> for TypeTag<N> {
+    fn decode(d: &mut Decoder<'b>, _: &mut C) -> Result<Self, decode::Error> {
+        let n = d.u64()?;
+        if N as u64 == n {
+            return Ok(TypeTag);
+        }
+        let msg = format!("type tag mismatch (expected {N}, got {n})");
+        Err(decode::Error::message(msg))
+    }
+}
+
+impl Id {
+    pub fn fresh() -> Self {
+        Id(rand::random())
+    }
+}
+
+impl From<Id> for u32 {
+    fn from(n: Id) -> Self {
+        n.0
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:08x}", self.0)
+    }
+}
+
+impl<'a> Request<'a> {
+    pub fn new<P: Into<Cow<'a, str>>>(method: Method, path: P, has_body: bool) -> Self {
+        Request {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            id: Id(rand::random()),
+            method: Some(method),
+            path: path.into(),
+            has_body,
+        }
+    }
+
+    pub fn get<P: Into<Cow<'a, str>>>(path: P, has_body: bool) -> Self {
+        Request::new(Method::Get, path, has_body)
+    }
+
+    pub fn post<P: Into<Cow<'a, str>>>(path: P, has_body: bool) -> Self {
+        Request::new(Method::Post, path, has_body)
+    }
+
+    pub fn put<P: Into<Cow<'a, str>>>(path: P, has_body: bool) -> Self {
+        Request::new(Method::Put, path, has_body)
+    }
+
+    pub fn delete<P: Into<Cow<'a, str>>>(path: P, has_body: bool) -> Self {
+        Request::new(Method::Delete, path, has_body)
+    }
+
+    pub fn patch<P: Into<Cow<'a, str>>>(path: P, has_body: bool) -> Self {
+        Request::new(Method::Patch, path, has_body)
+    }
+
+    pub fn id(&self) -> Id {
+        self.id
+    }
+
+    pub fn path(&self) -> &str {
+        &*self.path
+    }
+
+    pub fn path_segments<const N: usize>(&self) -> Segments<N> {
+        Segments::parse(self.path())
+    }
+
+    pub fn method(&self) -> Option<Method> {
+        self.method
+    }
+
+    pub fn has_body(&self) -> bool {
+        self.has_body
+    }
+}
+
+impl Response {
+    pub fn new(re: Id, status: Status, has_body: bool) -> Self {
+        Response {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            id: Id(rand::random()),
+            re,
+            status: Some(status),
+            has_body,
+        }
+    }
+
+    pub fn id(&self) -> Id {
+        self.id
+    }
+
+    pub fn re(&self) -> Id {
+        self.re
+    }
+
+    pub fn status(&self) -> Option<Status> {
+        self.status
+    }
+
+    pub fn has_body(&self) -> bool {
+        self.has_body
+    }
+}
+
+/// An error type used in response bodies.
+#[derive(Debug, Clone, Encode, Decode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct Error<'a> {
+    /// Nominal type tag.
+    ///
+    /// If the "tag" feature is enabled, the resulting CBOR will contain a
+    /// unique numeric value that identifies this type to help catching type
+    /// errors. Otherwise this tag will not be produced and is ignored during
+    /// decoding if present.
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<5359172>,
+    /// The resource path of this error.
+    #[b(1)] path: Cow<'a, str>,
+    /// The request method of this error.
+    #[n(2)] method: Option<Method>,
+    /// The actual error message.
+    #[b(3)] message: Option<Cow<'a, str>>,
+}
+
+impl<'a> Error<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(path: S) -> Self {
+        Error {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            method: None,
+            path: path.into(),
+            message: None,
+        }
+    }
+
+    pub fn with_method(mut self, m: Method) -> Self {
+        self.method = Some(m);
+        self
+    }
+
+    pub fn with_message<S: Into<Cow<'a, str>>>(mut self, m: S) -> Self {
+        self.message = Some(m.into());
+        self
+    }
+
+    pub fn path(&self) -> &str {
+        &*self.path
+    }
+
+    pub fn method(&self) -> Option<Method> {
+        self.method
+    }
+
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+/// Path segments, i.e. '/'-separated string slices.
+pub struct Segments<'a, const N: usize>(ArrayVec<[&'a str; N]>);
+
+impl<'a, const N: usize> Segments<'a, N> {
+    pub fn parse(s: &'a str) -> Self {
+        if s.starts_with('/') {
+            Self(s.trim_start_matches('/').splitn(N, '/').collect())
+        } else {
+            Self(s.splitn(N, '/').collect())
+        }
+    }
+
+    pub fn as_slice(&self) -> &[&'a str] {
+        &self.0[..]
+    }
+}

--- a/implementations/rust/ockam/ockam_api/tests/schema.rs
+++ b/implementations/rust/ockam/ockam_api/tests/schema.rs
@@ -1,0 +1,101 @@
+use cddl_cat::validate_cbor_bytes;
+use ockam_api::{Error, Id, Method, Request, Response, Status, SCHEMA};
+use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
+
+const METHODS: &[Method] = &[
+    Method::Get,
+    Method::Post,
+    Method::Put,
+    Method::Delete,
+    Method::Patch,
+];
+
+const STATUS: &[Status] = &[
+    Status::Ok,
+    Status::BadRequest,
+    Status::NotFound,
+    Status::MethodNotAllowed,
+    Status::InternalServerError,
+    Status::NotImplemented,
+];
+
+#[derive(Debug, Clone)]
+struct Req(Request<'static>);
+
+#[derive(Debug, Clone)]
+struct Res(Response);
+
+#[derive(Debug, Clone)]
+struct Er(Error<'static>);
+
+impl Arbitrary for Req {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Req(Request::new(
+            *g.choose(METHODS).unwrap(),
+            String::arbitrary(g),
+            bool::arbitrary(g),
+        ))
+    }
+}
+
+impl Arbitrary for Res {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Res(Response::new(
+            Id::fresh(),
+            *g.choose(STATUS).unwrap(),
+            bool::arbitrary(g),
+        ))
+    }
+}
+
+impl Arbitrary for Er {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let mut e = Error::new(String::arbitrary(g));
+        if bool::arbitrary(g) {
+            e = e.with_method(*g.choose(METHODS).unwrap())
+        }
+        if bool::arbitrary(g) {
+            e = e.with_message(String::arbitrary(g))
+        }
+        Er(e)
+    }
+}
+
+quickcheck! {
+    fn request_schema(a: Req) -> TestResult {
+        let cbor = minicbor::to_vec(&a.0).unwrap();
+        if let Err(e) = validate_cbor_bytes("request", SCHEMA, &cbor) {
+            return TestResult::error(e.to_string())
+        }
+        TestResult::passed()
+    }
+
+    fn response_schema(a: Res) -> TestResult {
+        let cbor = minicbor::to_vec(&a.0).unwrap();
+        if let Err(e) = validate_cbor_bytes("response", SCHEMA, &cbor) {
+            return TestResult::error(e.to_string())
+        }
+        TestResult::passed()
+    }
+
+    fn error_schema(a: Er) -> TestResult {
+        let cbor = minicbor::to_vec(&a.0).unwrap();
+        if let Err(e) = validate_cbor_bytes("error", SCHEMA, &cbor) {
+            return TestResult::error(e.to_string())
+        }
+        TestResult::passed()
+    }
+
+    fn type_check(a: Req, b: Res, c: Er) -> TestResult {
+        let cbor_a = minicbor::to_vec(&a.0).unwrap();
+        let cbor_b = minicbor::to_vec(&b.0).unwrap();
+        let cbor_c = minicbor::to_vec(&c.0).unwrap();
+        assert!(minicbor::decode::<Response>(&cbor_a).is_err());
+        assert!(minicbor::decode::<Error>(&cbor_a).is_err());
+        assert!(minicbor::decode::<Request>(&cbor_b).is_err());
+        assert!(minicbor::decode::<Error>(&cbor_b).is_err());
+        assert!(minicbor::decode::<Request>(&cbor_c).is_err());
+        assert!(minicbor::decode::<Response>(&cbor_c).is_err());
+        TestResult::passed()
+    }
+}


### PR DESCRIPTION
Add definitions of core request-response types to be shared with API implementations.

The schema includes optional type tags which are put into the resulting CBOR if the cargo feature "tag" is given. This should help catching type errors across implementations. If the feature is disabled (the default), no tag will be produced any if any are present when decoding CBOR bytes, they are ignored. If not desired I can remove this functionality.