### PR TITLE
feat(elixir): proxy worker to set up local aliases to remote services

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
@@ -62,7 +62,10 @@ defmodule Ockam.Transport.TCP do
       {:ok, destination} ->
         ## TODO: reuse clients when using tcp address
         with {:ok, client_address} <-
-               Client.create([{:destination, destination} | client_options]) do
+               Client.create([
+                 {:destination, destination},
+                 {:restart_type, :temporary} | client_options
+               ]) do
           Ockam.Node.send(client_address, message)
         end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/address.ex
@@ -42,6 +42,14 @@ defmodule Ockam.Transport.TCPAddress do
     %Address{type: @address_type, value: format_host_port(host, port)}
   end
 
+  @spec new(String.t()) :: t()
+  def new(host_port) when is_binary(host_port) or is_list(host_port) do
+    case parse_host_port(host_port) do
+      {:ok, {host, port}} -> new(host, port)
+      error -> raise "Invalid host port string: #{inspect(error)}"
+    end
+  end
+
   def format_host_port(host, port) when is_binary(host) do
     "#{host}:#{port}"
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/routing.ex
@@ -14,7 +14,14 @@ defmodule Ockam.Services.Provider.Routing do
   alias Ockam.Services.Tracing, as: TracingService
 
   ## TODO: API to start all services in a provider?
-  @services [:echo, :forwarding, :static_forwarding, :static_forwarding_api, :pub_sub, :tracing]
+  @services [
+    :echo,
+    :forwarding,
+    :static_forwarding,
+    :static_forwarding_api,
+    :pub_sub,
+    :tracing
+  ]
 
   @impl true
   def services() do

--- a/implementations/elixir/ockam/ockam_services/lib/services/proxy.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/proxy.ex
@@ -1,0 +1,116 @@
+defmodule Ockam.Services.Proxy do
+  @moduledoc """
+  Proxy worker to set up static aliases to workers
+  (potentially on other nodes)
+
+  Forwards messages to the `forward_route`, tracing own inner_address in the return route
+  Forwards messages from the inner address, replacing return route with own outer address
+
+  -OR:[outer_address],RR:return_route-> proxy -OR:forward_route,RR:[inner_address] ; return_route->
+  -OR:[inner_address] ; onward_route,RR:return_route-> proxy -OR:onward_route;RR:[outer_address]->
+
+  Limitations:
+  - proxy worker address should be terminal in the forwarding messages, onward_route will be ignored
+  - return route of inner messages is replaced with the proxy outer address
+
+  Due to these limitations, it may be not possible to establish sessions over the proxy workers.
+  Please use `Ockam.Services.Forwarding` or `Ockam.Services.StaticForwarding` to set up sessions.
+
+  Forwarding to TCP addresses:
+
+  If the first address of the route is a TCP, forwarding might cause TCP clients leak, because each
+  new message will create a new TCP client.
+
+  To prevent that, there is an `over_tcp` option, which creates
+  a `Ockam.Transport.TCP.RecoverableClient` instance, and replaces the TCP address
+  with this client address
+
+  Options:
+
+  - forward_route: route (list or string formatted) to forward messages to
+  - over_tcp: boolean,
+      if the first address in forward_route is TCP - create a static client to forward through
+      if the first address is not a TCP - worker setup fails
+  """
+
+  use Ockam.AsymmetricWorker
+
+  alias Ockam.Address
+  alias Ockam.Message
+  alias Ockam.Router
+
+  alias Ockam.Transport.TCP.RecoverableClient
+  alias Ockam.Transport.TCPAddress
+
+  @impl true
+  def inner_setup(options, state) do
+    with {:ok, forward_route} <- forward_route_config(options) do
+      case Keyword.get(options, :over_tcp, false) do
+        true ->
+          setup_with_tcp_client(forward_route, state)
+
+        false ->
+          {:ok, Map.put(state, :forward_route, forward_route)}
+      end
+    end
+  end
+
+  def setup_with_tcp_client(forward_route, state) do
+    [first_address | route_tail] = forward_route
+
+    case TCPAddress.is_tcp_address(first_address) do
+      true ->
+        client_address = "PROXY_CLIENT_" <> state.address
+
+        with {:ok, _pid, client_address} <-
+               RecoverableClient.start_link(destination: first_address, address: client_address) do
+          forward_route = [client_address | route_tail]
+          {:ok, Map.merge(state, %{forward_route: forward_route, client_address: client_address})}
+        end
+
+      false ->
+        {:error,
+         {:invalid_options,
+          ":over_tcp requires TCP address as a first address in the forward route"}}
+    end
+  end
+
+  def forward_route_config(options) do
+    forward_route = Keyword.fetch!(options, :forward_route)
+
+    case forward_route do
+      string when is_binary(string) ->
+        try do
+          {:ok, Address.parse_route!(string)}
+        catch
+          _type, _error ->
+            {:error, :cannot_parse_forward_route}
+        end
+
+      route when is_list(route) ->
+        {:ok, route}
+    end
+  end
+
+  @impl true
+  def handle_outer_message(message, state) do
+    forward_route = Map.get(state, :forward_route)
+    inner_address = Map.get(state, :inner_address)
+
+    forwarded_message = Message.forward_trace(message, forward_route, inner_address)
+
+    Router.route(forwarded_message)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_inner_message(message, state) do
+    outer_address = Map.get(state, :address)
+    return_route = [outer_address]
+
+    forwarded_message = Message.forward(message) |> Map.put(:return_route, return_route)
+
+    Router.route(forwarded_message)
+    {:ok, state}
+  end
+end

--- a/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
@@ -1,0 +1,98 @@
+defmodule Test.Services.ProxyTest do
+  use ExUnit.Case
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  alias Ockam.Transport.TCPAddress
+
+  alias Ockam.Services.Echo, as: EchoService
+  alias Ockam.Services.Proxy
+
+  alias Ockam.Workers.Call
+
+  alias Test.Utils
+
+  @tcp_port 5000
+
+  ## Helper function to count TCP clients
+  def tcp_clients() do
+    Ockam.Node.list_addresses()
+    |> Enum.filter(fn address ->
+      String.starts_with?(address, "TCP_C_") and not String.starts_with?(address, "TCP_C_R")
+    end)
+  end
+
+  test "echo proxy" do
+    {:ok, echo_address} = EchoService.create([])
+
+    on_exit(fn ->
+      Ockam.Node.stop(echo_address)
+    end)
+
+    forward_route = [echo_address]
+
+    {:ok, proxy_address} = Proxy.create(forward_route: forward_route)
+
+    on_exit(fn ->
+      Ockam.Node.stop(proxy_address)
+    end)
+
+    my_address = "test_me"
+    {:ok, my_address} = Ockam.Node.register_random_address()
+
+    Router.route("Hi echo proxy!", [proxy_address], [my_address])
+
+    assert_receive %Message{
+                     onward_route: [my_address],
+                     return_route: [proxy_address],
+                     payload: "Hi echo proxy!"
+                   },
+                   2000
+  end
+
+  test "echo proxy over tcp" do
+    {:ok, echo_address} = EchoService.create([])
+
+    on_exit(fn ->
+      Ockam.Node.stop(echo_address)
+    end)
+
+    {:ok, listener} = Ockam.Transport.TCP.start(listen: [port: @tcp_port])
+
+    tcp_clients_count = Enum.count(tcp_clients())
+
+    forward_route = [TCPAddress.new("localhost", @tcp_port), echo_address]
+
+    {:ok, proxy_address} = Proxy.create(forward_route: forward_route, over_tcp: true)
+
+    on_exit(fn ->
+      Ockam.Node.stop(proxy_address)
+    end)
+
+    {:ok, my_address} = Ockam.Node.register_random_address()
+
+    Router.route("Hi echo proxy!", [proxy_address], [my_address])
+
+    assert_receive %Message{
+                     onward_route: [my_address],
+                     return_route: [proxy_address],
+                     payload: "Hi echo proxy!"
+                   },
+                   2000
+
+    assert Enum.count(tcp_clients()) == tcp_clients_count + 1
+
+    ## Make sure we don't leak the TCP connections
+    Router.route("Hi echo proxy take2!", [proxy_address], [my_address])
+
+    assert_receive %Message{
+                     onward_route: [my_address],
+                     return_route: [proxy_address],
+                     payload: "Hi echo proxy take2!"
+                   },
+                   2000
+
+    assert Enum.count(tcp_clients()) == tcp_clients_count + 1
+  end
+end


### PR DESCRIPTION
Main purpose of the proxy worker is to create a local alias to a remote service
An alias can work on a static address with a static TCP client
allowing to simplify routes and exchange messages with remote workers like
with local ones.

Let's say we have a sidecar node accessible to our node on port `1234`

Then we can make a proxy to an `echo` worker on the sidecar node with something like this:

```
defmodule Ockam.Services.Provider.Sidecar do

  alias Ockam.Services.Proxy
  alias Ockam.Transport.TCPAddress

  @behaviour Ockam.Services.Provider

  @impl true
  def services() do
    [:echo_on_sidecar]
  end

  @impl true
  def child_spec(:echo_on_sidecar, args) do
    sidecar_host = "localhost"
    sidecar_port = 4000
    {Proxy, Keyword.merge(
      [forward_route: [TCPAddress.new(sidecar_host, sidecar_port), "echo"], address: "echo_on_sidecar"],
      args)}
  end
end
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
