### PR TITLE
chore(rust): refactor code to use context::send_and_receive()

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -45,22 +45,15 @@ impl TcpRouterHandle {
 
     /// Establish an outgoing TCP connection on an existing transport
     pub async fn connect<S: AsRef<str>>(&self, peer: S) -> Result<Address> {
-        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
-
-        child_ctx
-            .send(
+        let response = self
+            .ctx
+            .send_and_receive(
                 self.api_addr.clone(),
                 TcpRouterRequest::Connect {
                     peer: peer.as_ref().to_string(),
                 },
             )
             .await?;
-
-        let response = child_ctx
-            .receive::<TcpRouterResponse>()
-            .await?
-            .take()
-            .body();
 
         if let TcpRouterResponse::Connect(res) = response {
             res
@@ -71,22 +64,15 @@ impl TcpRouterHandle {
 
     /// Disconnect an outgoing TCP connection on an existing transport
     pub async fn disconnect<S: AsRef<str>>(&self, peer: S) -> Result<()> {
-        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
-
-        child_ctx
-            .send(
+        let response = self
+            .ctx
+            .send_and_receive(
                 self.api_addr.clone(),
                 TcpRouterRequest::Disconnect {
                     peer: peer.as_ref().to_string(),
                 },
             )
             .await?;
-
-        let response = child_ctx
-            .receive::<TcpRouterResponse>()
-            .await?
-            .take()
-            .body();
 
         if let TcpRouterResponse::Disconnect(res) = response {
             res
@@ -129,20 +115,13 @@ impl TcpRouterHandle {
 
     /// Unregister the conenction worker for the given `Address`
     pub async fn unregister(&self, self_addr: Address) -> Result<()> {
-        let mut child_ctx = self.ctx.new_context(Address::random_local()).await?;
-
-        child_ctx
-            .send(
+        let response = self
+            .ctx
+            .send_and_receive(
                 self.api_addr.clone(),
                 TcpRouterRequest::Unregister { self_addr },
             )
             .await?;
-
-        let response = child_ctx
-            .receive::<TcpRouterResponse>()
-            .await?
-            .take()
-            .body();
 
         if let TcpRouterResponse::Unregister(res) = response {
             res

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -11,16 +11,16 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
     ctx.start_worker("echoer", Echoer).await?;
 
     let _sender = {
-        let mut ctx = ctx.new_context(Address::random_local()).await?;
         let msg: String = rand::thread_rng()
             .sample_iter(&rand::distributions::Alphanumeric)
             .take(256)
             .map(char::from)
             .collect();
-        let r = route![(TCP, listener_address.to_string()), "echoer"];
-        ctx.send(r, msg.clone()).await?;
 
-        let reply = ctx.receive::<String>().await?;
+        let r = route![(TCP, listener_address.to_string()), "echoer"];
+
+        let reply = ctx.send_and_receive::<_, _, String>(r, msg.clone()).await?;
+
         assert_eq!(reply, msg, "Should receive the same message");
     };
 


### PR DESCRIPTION

## Current Behaviour

#2628 determined there is a common request/response pattern in Ockam code. So #2666 added the function `Context::send_and_receive()` to help reduce repeated code.

## Proposed Changes

This PR refactors existing code to use `Context::send_and_receive()`.

Also some clippy messages were fixed (in remote.rs where `cloud_address` is initialised, and where `TcpTransport::create()` is called).

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.
