### PR TITLE
fix(elixir): don't use over_tcp option in proxy worker, always create client for tcp address

### DIFF
--- a/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
@@ -64,7 +64,7 @@ defmodule Test.Services.ProxyTest do
 
     forward_route = [TCPAddress.new("localhost", @tcp_port), echo_address]
 
-    {:ok, proxy_address} = Proxy.create(forward_route: forward_route, over_tcp: true)
+    {:ok, proxy_address} = Proxy.create(forward_route: forward_route)
 
     on_exit(fn ->
       Ockam.Node.stop(proxy_address)


### PR DESCRIPTION
Continuation of #2769 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
