### PR TITLE
fix(elixir): better handling for big tcp messages

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
@@ -12,6 +12,12 @@ defmodule Ockam.Transport.TCP do
 
   require Logger
 
+  @packed_size_limit 65_000
+
+  def packed_size_limit() do
+    @packed_size_limit
+  end
+
   def child_spec(options) do
     id = id(options)
 

--- a/implementations/elixir/ockam/ockam_cloud_node/lib/cloud_node/metrics/telemetry_influxdb.ex
+++ b/implementations/elixir/ockam/ockam_cloud_node/lib/cloud_node/metrics/telemetry_influxdb.ex
@@ -47,6 +47,10 @@ defmodule Ockam.CloudNode.Metrics.TelemetryInfluxDB do
                 metadata_tag_keys: [:port]
               },
               %{
+                name: [:ockam, :tcp, :handler, :message],
+                metadata_tag_keys: [:address]
+              },
+              %{
                 name: [:vm, :total_run_queue_lengths],
                 metadata_tag_keys: [:total, :cpu, :io]
               },


### PR DESCRIPTION

## Current Behaviour

TCP packet size limit is 2^16, bigger messages break messaging, which may result in #2770 


<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Limit packet size for TCP client and handler to 65000 bytes
Report byte size of received messages as a metric

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
