### PR TITLE
feat(elixir): make it possible to create proxy services from env variables

### DIFF
--- a/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
@@ -32,9 +32,12 @@ config :ockam_services, :token_manager,
 
 ## Transports config
 
+tcp_port = String.to_integer(System.get_env("TCP_PORT", "4000"))
+udp_port = String.to_integer(System.get_env("UDP_PORT", "7000"))
+
 config :ockam_services,
-  tcp_transport_port: 4000,
-  udp_transport_port: 7000
+  tcp_transport_port: tcp_port,
+  udp_transport_port: udp_port
 
 ## Kafka default config
 
@@ -124,7 +127,9 @@ config :ockam_services,
     # secure channel services
     Ockam.Services.Provider.SecureChannel,
     # discovery service
-    Ockam.Services.Provider.Discovery
+    Ockam.Services.Provider.Discovery,
+    # proxies for remote services
+    Ockam.Services.Provider.Proxy
   ],
   services_config_source: services_config_source,
   # JSON version of the services definition
@@ -142,7 +147,8 @@ config :ockam_services,
     :stream,
     :stream_index,
     :secure_channel,
-    :tracing
+    :tracing,
+    :proxy
   ]
 
 # Ockam Cloud Node application config

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/proxy.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/proxy.ex
@@ -1,0 +1,44 @@
+defmodule Ockam.Services.Provider.Proxy do
+  @moduledoc """
+  Implementation for Ockam.Services.Provider
+  providing the proxy service which can be used
+  to set up proxies to remote services
+
+  Configuration:
+  "SERVICE_PROXY_{name}"="route_to_remote_service"
+
+  For example:
+  "SERVICE_PROXY_remote_echo"="1#localhost:4000;0#echo"
+  """
+  @behaviour Ockam.Services.Provider
+
+  alias Ockam.Services.Proxy
+
+  @impl true
+  def services() do
+    [:proxy]
+  end
+
+  @impl true
+  def child_spec(:proxy, args) do
+    :os.env()
+    |> Enum.map(fn {name, val} -> {to_string(name), to_string(val)} end)
+    |> Enum.filter(fn {name, _val} -> String.starts_with?(name, "SERVICE_PROXY_") end)
+    |> Enum.map(fn {name, val} ->
+      proxy_name = String.trim(name, "SERVICE_PROXY_")
+      init_args = make_init_args(proxy_name, val, args)
+
+      %{
+        id: String.to_atom("proxy_#{proxy_name}"),
+        start: {Proxy, :start_link, [init_args]}
+      }
+    end)
+  end
+
+  def make_init_args(proxy_name, val, args) do
+    Keyword.merge(args,
+      address: proxy_name,
+      forward_route: val
+    )
+  end
+end

--- a/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
@@ -95,4 +95,16 @@ defmodule Test.Services.ProxyTest do
 
     assert Enum.count(tcp_clients()) == tcp_clients_count + 1
   end
+
+  test "proxy provider" do
+    System.put_env("SERVICE_PROXY_remote_echo", "1#localhost:4000;0#echo")
+    [spec] = Ockam.Services.Provider.Proxy.child_spec(:proxy, [])
+
+    assert %{
+             id: :proxy_remote_echo,
+             start:
+               {Ockam.Services.Proxy, :start_link,
+                [[address: "remote_echo", forward_route: "1#localhost:4000;0#echo"]]}
+           } = spec
+  end
 end


### PR DESCRIPTION
## Current Behaviour

Proxy creates named proxies to remote services.
Important configuraion for proxies is an address and a remote route.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Added proxy service provider to create proxies from environment.

To configure a node to start proxies we use prefixed environment variables:
`SERVICE_PROXY_{name}="route_to_remote_service"`
For example:
`SERVICE_PROXY_remote_echo="1#localhost:4000;0#echo"`

When proxy service is loaded it will create service worker:
```
%{id: :proxy_remote_echo,
  start: {Proxy, :start_link, [forward_route: "1#localhost:4000;0#echo", address: "remote_echo"]}}
```

With multiple "SERVICE_PROXY_*" variables, proxy service will create multiple
proxy workers

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
