### PR TITLE
define ockam multiaddr publish state

### DIFF
--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -7,6 +7,7 @@ edition     = "2021"
 homepage    = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_multiaddr"
 repository  = "https://github.com/ockam-network/ockam"
 description = "An implementation of multiformats.io/multiaddr"
+publish = true
 
 [features]
 std = ["unsigned-varint/std"]


### PR DESCRIPTION
This PR defines the publish state for ockam_multiaddr crate, this allow our release script differentiate crates that are to be/not published.