### PR TITLE
feat(rust): ensure command-line args are not empty

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes.rs
@@ -48,6 +48,7 @@ impl Server {
             id     = %req.id(),
             method = ?req.method(),
             path   = %req.path(),
+            body   = %req.has_body(),
             "request"
         }
 

--- a/implementations/rust/ockam/ockam_command/src/args.rs
+++ b/implementations/rust/ockam/ockam_command/src/args.rs
@@ -113,13 +113,13 @@ pub enum Nodes {
     Create {
         #[clap(long)]
         addr: MultiAddr,
-        #[clap(long)]
+        #[clap(long, validator(non_empty))]
         name: String,
     },
     Get {
         #[clap(long)]
         addr: MultiAddr,
-        #[clap(long)]
+        #[clap(long, validator(non_empty))]
         id: String,
     },
     List {
@@ -129,7 +129,14 @@ pub enum Nodes {
     Delete {
         #[clap(long)]
         addr: MultiAddr,
-        #[clap(long)]
+        #[clap(long, validator(non_empty))]
         id: String,
     },
+}
+
+fn non_empty(arg: &str) -> Result<(), String> {
+    if arg.is_empty() {
+        return Err("value must not be empty".to_string());
+    }
+    Ok(())
 }


### PR DESCRIPTION
Some command-line arguments should not be empty.