### PR TITLE
Ockam Node diagnostics module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,7 +157,7 @@ jobs:
       # TODO: re-enable features after no_std has an unbounded channel.
       - run: |
           cd implementations/rust/ockam/ockam
-          RUSTFLAGS='-Dwarnings' cargo check
+          RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   check_cargo_update:
@@ -176,7 +176,7 @@ jobs:
           cd examples/rust/get_started
           rm -rf Cargo.lock
           cargo update
-          RUSTFLAGS='-Dwarnings' cargo check
+          RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   check_nightly:
@@ -193,7 +193,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - run: rustup default nightly
       - run: rustup update nightly
-      - run: RUSTFLAGS='-Dwarnings' cargo check
+      - run: RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   build_nightly:

--- a/implementations/rust/DEVELOP.md
+++ b/implementations/rust/DEVELOP.md
@@ -83,7 +83,7 @@ Get a code coverage report:
 ```
 cargo +nightly install grcov
 
-env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort" RUSTDOCFLAGS="-Cpanic=abort" cargo +nightly test
+env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort --cfg tokio_unstable" RUSTDOCFLAGS="-Cpanic=abort" cargo +nightly test
 
 grcov --llvm . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
 

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -26,7 +26,7 @@ task lint_cargo_fmt_check {
   doLast {
     exec {
       if (ci) {
-        environment RUSTFLAGS: "-Dwarnings"
+        environment RUSTFLAGS: "--cfg tokio_unstable -Dwarnings"
       }
 
       commandLine cargo('fmt', '--all', '--', '--check')
@@ -57,7 +57,7 @@ task build_docs {
   doLast {
     exec {
       if (ci) {
-        environment RUSTFLAGS: "-Dwarnings"
+        environment RUSTFLAGS: "--cfg tokio_unstable -Dwarnings"
       }
 
       commandLine cargo('doc', '--no-deps')
@@ -69,7 +69,7 @@ task build {
   doLast {
     exec {
       if (ci) {
-        environment RUSTFLAGS: "-Cdebuginfo=0 -Dwarnings"
+        environment RUSTFLAGS: "--cfg tokio_unstable -Cdebuginfo=0 -Dwarnings"
         environment CARGO_INCREMENTAL: "0"
       }
 
@@ -82,7 +82,7 @@ task build_examples {
   doLast {
     exec {
       if (ci) {
-        environment RUSTFLAGS: "-Cdebuginfo=0 -Dwarnings"
+        environment RUSTFLAGS: "--cfg tokio_unstable -Cdebuginfo=0 -Dwarnings"
         environment CARGO_INCREMENTAL: "0"
       }
 
@@ -98,7 +98,7 @@ task test {
   doLast {
     exec {
       if (ci) {
-        environment RUSTFLAGS: "-Dwarnings"
+        environment RUSTFLAGS: "--cfg tokio_unstable -Dwarnings"
       }
 
       commandLine cargo('--locked', 'test')

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -45,7 +45,7 @@ dump_internals = []
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
-tokio = { version = "1.8", default-features = false, optional = true, features = [
+tokio = { version = "1.18", default-features = false, optional = true, features = [
     "sync",
     "time",
     "rt",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -25,11 +25,11 @@ publish = true
 rust-version = "1.56.0"
 
 [features]
-default = ["std", "metrics"]
+default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "tokio", "tracing-subscriber", "tracing-error", "alloc", "futures/std"]
+std = ["ockam_core/std", "tokio", "tracing-subscriber", "tracing-error", "alloc", "futures/std", "metrics"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -25,7 +25,7 @@ publish = true
 rust-version = "1.56.0"
 
 [features]
-default = ["std"]
+default = ["std", "metrics"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
@@ -41,6 +41,8 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "futures/alloc"]
 # Feature: "dump_internals" when set, will dump the internal state of
 # workers at startup via the trace! macro.
 dump_internals = []
+# TODO should these features be combined?
+metrics = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -1,8 +1,9 @@
 // use crate::message::BaseMessage;
 
-use crate::tokio::runtime::Runtime;
 use crate::{
+    metrics::Metrics,
     router::{Router, SenderPair},
+    tokio::runtime::Runtime,
     NodeMessage,
 };
 use core::future::Future;
@@ -26,13 +27,21 @@ pub struct Executor {
     rt: Arc<Runtime>,
     /// Main worker and application router
     router: Router,
+    /// Metrics collection endpoint
+    #[allow(unused)]
+    metrics: Metrics,
 }
 
 impl Default for Executor {
     fn default() -> Self {
         let rt = Arc::new(Runtime::new().unwrap());
         let router = Router::new();
-        Self { rt, router }
+        let metrics = Metrics::new(&rt);
+        Self {
+            rt,
+            router,
+            metrics,
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -10,12 +10,12 @@ use core::future::Future;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{Address, Result};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "metrics")]
 use crate::metrics::Metrics;
 
 // This import is available on emebedded but we don't use the metrics
 // collector, thus don't need it in scope.
-#[cfg(feature = "std")]
+#[cfg(feature = "metrics")]
 use core::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(feature = "std")]
@@ -87,7 +87,9 @@ impl Executor {
         F::Output: Send + 'static,
     {
         // Spawn the metrics collector first
+        #[cfg(feature = "metrics")]
         let alive = Arc::new(AtomicBool::from(true));
+        #[cfg(feature = "metrics")]
         self.rt
             .spawn(Arc::clone(&self.metrics).run(Arc::clone(&alive)));
 
@@ -99,6 +101,7 @@ impl Executor {
         crate::block_future(&rt, async move { self.router.run().await })?;
 
         // Shut down metrics collector
+        #[cfg(feature = "metrics")]
         alive.fetch_or(true, Ordering::Acquire);
 
         // Last join user code

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -83,6 +83,7 @@ impl Executor {
         let rt = Arc::clone(&self.rt);
         let join_body = rt.spawn(future);
 
+        // Then block on the execution of the router
         crate::block_future(&rt, async move { self.router.run().await })?;
 
         let res = crate::block_future(&rt, async move { join_body.await })

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -42,7 +42,7 @@ impl Default for Executor {
     fn default() -> Self {
         let rt = Arc::new(Runtime::new().unwrap());
         let router = Router::new();
-        let metrics = Metrics::new(&rt);
+        let metrics = Metrics::new(&rt, router.get_metrics_readout());
         Self {
             rt,
             router,

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -35,15 +35,16 @@ pub mod compat;
 /// MPSC channel type aliases
 pub mod channel_types;
 
-mod async_drop;
+#[cfg(feature = "std")]
+mod metrics;
 
+mod async_drop;
 mod cancel;
 mod context;
 mod delayed;
 mod error;
 mod executor;
 mod messages;
-mod metrics;
 mod node;
 mod parser;
 mod relay;

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -43,6 +43,7 @@ mod delayed;
 mod error;
 mod executor;
 mod messages;
+mod metrics;
 mod node;
 mod parser;
 mod relay;

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -35,7 +35,7 @@ pub mod compat;
 /// MPSC channel type aliases
 pub mod channel_types;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "metrics")]
 mod metrics;
 
 mod async_drop;

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -20,7 +20,7 @@ pub enum NodeMessage {
         /// A detached context/ "worker" runs no relay state
         detached: bool,
         /// A mechanism to read channel fill-state for a worker
-        metrics: Arc<AtomicUsize>,
+        mailbox_count: Arc<AtomicUsize>,
         /// Reply channel for command confirmation
         reply: SmallSender<NodeReplyResult>,
     },
@@ -83,7 +83,7 @@ impl NodeMessage {
         addrs: AddressSet,
         senders: SenderPair,
         detached: bool,
-        metrics: Arc<AtomicUsize>,
+        mailbox_count: Arc<AtomicUsize>,
     ) -> (Self, SmallReceiver<NodeReplyResult>) {
         let (reply, rx) = small_channel();
         (
@@ -91,7 +91,7 @@ impl NodeMessage {
                 addrs,
                 senders,
                 detached,
-                metrics,
+                mailbox_count,
                 reply,
             },
             rx,

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -4,8 +4,8 @@ use crate::{
     relay::RelayMessage,
     router::SenderPair,
 };
-use core::fmt;
-use ockam_core::compat::{string::String, vec::Vec};
+use core::{fmt, sync::atomic::AtomicUsize};
+use ockam_core::compat::{string::String, sync::Arc, vec::Vec};
 use ockam_core::{Address, AddressSet, Error, Result, TransportType};
 
 /// Messages sent from the Node to the Executor
@@ -19,6 +19,8 @@ pub enum NodeMessage {
         senders: SenderPair,
         /// A detached context/ "worker" runs no relay state
         detached: bool,
+        /// A mechanism to read channel fill-state for a worker
+        metrics: Arc<AtomicUsize>,
         /// Reply channel for command confirmation
         reply: SmallSender<NodeReplyResult>,
     },
@@ -81,6 +83,7 @@ impl NodeMessage {
         addrs: AddressSet,
         senders: SenderPair,
         detached: bool,
+        metrics: Arc<AtomicUsize>,
     ) -> (Self, SmallReceiver<NodeReplyResult>) {
         let (reply, rx) = small_channel();
         (
@@ -88,6 +91,7 @@ impl NodeMessage {
                 addrs,
                 senders,
                 detached,
+                metrics,
                 reply,
             },
             rx,

--- a/implementations/rust/ockam/ockam_node/src/metrics.rs
+++ b/implementations/rust/ockam/ockam_node/src/metrics.rs
@@ -1,18 +1,58 @@
 use crate::tokio::runtime::Runtime;
-use ockam_core::compat::sync::Arc;
+use ockam_core::compat::{collections::BTreeMap, sync::Arc};
 
 pub struct Metrics {
     rt: Arc<Runtime>,
 }
 
+pub struct MetricsReport {
+    tokio_workers: usize,
+    tokio_queue_depth: usize,
+    io_ready_count: u64,
+    worker_queues: BTreeMap<usize, usize>,
+}
+
+impl MetricsReport {
+    /// Generate a line of CSV for this report
+    pub fn to_csv(&self) -> String {
+        format!(
+            "{},{},{},({})",
+            self.tokio_workers,
+            self.tokio_queue_depth,
+            self.io_ready_count,
+            self.worker_queues
+                .iter()
+                .fold(String::new(), |acc, (wid, queue_depth)| {
+                    format!("{},({},{})", acc, wid, queue_depth)
+                })
+        )
+    }
+}
+
 impl Metrics {
     pub(crate) fn new(rt: &Arc<Runtime>) -> Self {
         Self {
-            rt: Arc::clone(&rt),
+            rt: Arc::clone(rt),
         }
     }
 
-    pub(crate) fn collect_metrics(self: &Arc<Self>) {
+    pub(crate) fn generate_report(self: &Arc<Self>) -> MetricsReport {
         let m = self.rt.metrics();
+
+        let tokio_workers = m.num_workers();
+        let tokio_queue_depth = m.injection_queue_depth();
+        let io_ready_count = m.io_driver_ready_count();
+
+        let mut worker_queues = BTreeMap::new();
+        for wid in 0..tokio_workers {
+            worker_queues.insert(wid, m.worker_local_queue_depth(wid));
+        }
+
+        MetricsReport {
+            tokio_workers,
+            tokio_queue_depth,
+            io_ready_count,
+            worker_queues,
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/metrics.rs
+++ b/implementations/rust/ockam/ockam_node/src/metrics.rs
@@ -1,58 +1,100 @@
-use crate::tokio::runtime::Runtime;
+use crate::tokio::{runtime::Runtime, time};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
 use ockam_core::compat::{collections::BTreeMap, sync::Arc};
+use std::{fs::OpenOptions, io::Write};
 
 pub struct Metrics {
     rt: Arc<Runtime>,
 }
 
+impl Metrics {
+    /// Create a new Metrics collector with access to the runtime
+    pub(crate) fn new(rt: &Arc<Runtime>) -> Arc<Self> {
+        Arc::new(Self { rt: Arc::clone(rt) })
+    }
+
+    /// Spawned by the Executor to periodically collect metrics
+    pub(crate) async fn run(self: Arc<Self>, alive: Arc<AtomicBool>) {
+        let path = match std::env::var("OCKAM_METRICS_PATH") {
+            Ok(path) => path,
+            Err(_) => {
+                debug!("Metrics collection disabled, set `OCKAM_METRICS_PATH` to collect metrics");
+                return;
+            }
+        };
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)
+            .expect("failed to open or create metrics collection file");
+
+        file.write_all(b"Worker busy time (% since last poll)\n")
+            .expect("failed to write metrics");
+
+        let freq_ms = 100;
+        let mut acc = MetricsReport::default();
+
+        loop {
+            if !alive.load(Ordering::Relaxed) {
+                debug!("Metrics collector shutting down...");
+                break;
+            }
+
+            let report = self.generate_report(freq_ms, &mut acc);
+
+            file.write_all(format!("{}\n", report.to_csv()).as_bytes())
+                .expect("failed to write metrics");
+            time::sleep(Duration::from_millis(freq_ms)).await;
+        }
+    }
+
+    pub(crate) fn generate_report(
+        self: &Arc<Self>,
+        freq: u64,
+        acc: &mut MetricsReport,
+    ) -> MetricsReport {
+        let m = self.rt.metrics();
+
+        let tokio_workers = m.num_workers();
+        // let io_ready_count = m.io_driver_ready_count();
+
+        let mut worker_busy_ms = BTreeMap::new();
+        for wid in 0..tokio_workers {
+            // Get the previously accumulated
+            let acc_ms = acc.worker_busy_ms.get(&wid).unwrap_or(&0);
+            let raw_ms = m.worker_total_busy_duration(wid).as_millis();
+
+            let diff_ms = raw_ms - acc_ms;
+            let percent = diff_ms as f32 / freq as f32;
+
+            worker_busy_ms.insert(wid, percent as u128);
+            acc.worker_busy_ms.insert(wid, raw_ms);
+        }
+
+        MetricsReport { worker_busy_ms }
+    }
+}
+
+#[derive(Default)]
 pub struct MetricsReport {
-    tokio_workers: usize,
-    tokio_queue_depth: usize,
-    io_ready_count: u64,
-    worker_queues: BTreeMap<usize, usize>,
+    worker_busy_ms: BTreeMap<usize, u128>,
 }
 
 impl MetricsReport {
     /// Generate a line of CSV for this report
     pub fn to_csv(&self) -> String {
         format!(
-            "{},{},{},({})",
-            self.tokio_workers,
-            self.tokio_queue_depth,
-            self.io_ready_count,
-            self.worker_queues
+            "{}",
+            self.worker_busy_ms
                 .iter()
-                .fold(String::new(), |acc, (wid, queue_depth)| {
-                    format!("{},({},{})", acc, wid, queue_depth)
-                })
+                .map(|(wid, depth)| format!("({}:{}%)", wid, depth))
+                .collect::<Vec<String>>()
+                .join(",")
         )
-    }
-}
-
-impl Metrics {
-    pub(crate) fn new(rt: &Arc<Runtime>) -> Self {
-        Self {
-            rt: Arc::clone(rt),
-        }
-    }
-
-    pub(crate) fn generate_report(self: &Arc<Self>) -> MetricsReport {
-        let m = self.rt.metrics();
-
-        let tokio_workers = m.num_workers();
-        let tokio_queue_depth = m.injection_queue_depth();
-        let io_ready_count = m.io_driver_ready_count();
-
-        let mut worker_queues = BTreeMap::new();
-        for wid in 0..tokio_workers {
-            worker_queues.insert(wid, m.worker_local_queue_depth(wid));
-        }
-
-        MetricsReport {
-            tokio_workers,
-            tokio_queue_depth,
-            io_ready_count,
-            worker_queues,
-        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/metrics.rs
+++ b/implementations/rust/ockam/ockam_node/src/metrics.rs
@@ -93,6 +93,7 @@ impl Metrics {
 }
 
 #[derive(Default)]
+#[allow(unused)]
 pub struct MetricsReport {
     tokio_busy_ms: BTreeMap<usize, u128>,
     router_addr_count: usize,
@@ -102,13 +103,10 @@ pub struct MetricsReport {
 impl MetricsReport {
     /// Generate a line of CSV for this report
     pub fn to_csv(&self) -> String {
-        format!(
-            "{}",
-            self.tokio_busy_ms
-                .iter()
-                .map(|(wid, depth)| format!("({}:{}%)", wid, depth))
-                .collect::<Vec<String>>()
-                .join(",")
-        )
+        self.tokio_busy_ms
+            .iter()
+            .map(|(wid, depth)| format!("({}:{}%)", wid, depth))
+            .collect::<Vec<String>>()
+            .join(",")
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/metrics.rs
+++ b/implementations/rust/ockam/ockam_node/src/metrics.rs
@@ -1,0 +1,18 @@
+use crate::tokio::runtime::Runtime;
+use ockam_core::compat::sync::Arc;
+
+pub struct Metrics {
+    rt: Arc<Runtime>,
+}
+
+impl Metrics {
+    pub(crate) fn new(rt: &Arc<Runtime>) -> Self {
+        Self {
+            rt: Arc::clone(&rt),
+        }
+    }
+
+    pub(crate) fn collect_metrics(self: &Arc<Self>) {
+        let m = self.rt.metrics();
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -72,6 +72,7 @@ impl Router {
         }
     }
 
+    #[cfg(feature = "metrics")]
     pub(crate) fn get_metrics_readout(&self) -> (Arc<AtomicUsize>, Arc<AtomicUsize>) {
         self.map.get_metrics()
     }
@@ -117,6 +118,9 @@ impl Router {
     }
 
     async fn handle_msg(&mut self, msg: NodeMessage) -> Result<bool> {
+        #[cfg(feature = "metrics")]
+        self.map.update_metrics(); // Possibly remove this from the hot path?
+
         use NodeMessage::*;
         debug!(
             "Current router alloc: {} addresses",

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -111,7 +111,7 @@ impl Router {
 
     async fn handle_msg(&mut self, msg: NodeMessage) -> Result<bool> {
         use NodeMessage::*;
-        debug!("Currently router has {} addresses", self.map.count());
+        debug!("Currently router has {} addresses", self.map.metrics().0);
         match msg {
             // Successful router registration command
             Router(tt, addr, sender) if !self.external.contains_key(&tt) => {

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -148,9 +148,9 @@ impl Router {
                 addrs,
                 senders,
                 detached,
-                metrics,
+                mailbox_count,
                 ref reply,
-            } => start_worker::exec(self, addrs, senders, detached, metrics, reply).await?,
+            } => start_worker::exec(self, addrs, senders, detached, mailbox_count, reply).await?,
             StopWorker(ref addr, ref detached, ref reply) => {
                 stop_worker::exec(self, addr, *detached, reply).await?
             }

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -29,15 +29,18 @@ pub struct InternalMap {
     /// Track stop information
     stopping: BTreeSet<Address>,
     /// Metrics collection and sharing
+    #[cfg(feature = "metrics")]
     metrics: (Arc<AtomicUsize>, Arc<AtomicUsize>),
 }
 
 impl InternalMap {
+    #[cfg(feature = "metrics")]
     pub(super) fn update_metrics(&self) {
         self.metrics.0.store(self.internal.len(), Ordering::Release);
         self.metrics.1.store(self.clusters.len(), Ordering::Release);
     }
 
+    #[cfg(feature = "metrics")]
     pub(super) fn get_metrics(&self) -> (Arc<AtomicUsize>, Arc<AtomicUsize>) {
         (Arc::clone(&self.metrics.0), Arc::clone(&self.metrics.1))
     }

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -29,9 +29,9 @@ pub struct InternalMap {
 }
 
 impl InternalMap {
-    /// Used for router diagnostics
-    pub(super) fn count(&self) -> usize {
-        self.internal.len()
+    /// Return map metrics: (address alloc count, cluster count)
+    pub(super) fn metrics(&self) -> (usize, usize) {
+        (self.internal.len(), self.clusters.len())
     }
 
     /// Add an address to a particular cluster

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{NodeError, NodeReason},
     NodeReplyResult, RouterReply,
 };
-use ockam_core::{Address, Result};
+use ockam_core::{compat::sync::Arc, Address, Result};
 
 /// Execute a `StartWorker` command
 pub(super) async fn exec(
@@ -34,6 +34,7 @@ async fn start(
         addr.clone().into(),
         msgs,
         ctrl,
+        Arc::new(0.into()), // don't track metrics
         AddressMeta {
             processor: true,
             detached: false,

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -34,7 +34,12 @@ async fn start(
         addr.clone().into(),
         msgs,
         ctrl,
-        Arc::new(0.into()), // don't track metrics
+        // We don't keep track of the mailbox count for processors
+        // because, while they are able to send and receive messages
+        // via their mailbox, most likely this metric is going to be
+        // irrelevant.  We may want to re-visit this decision in the
+        // future, if the way processors are used changes.
+        Arc::new(0.into()),
         AddressMeta {
             processor: true,
             detached: false,

--- a/implementations/rust/ockam/ockam_node/src/router/utils.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/utils.rs
@@ -34,6 +34,7 @@ pub(super) async fn resolve(
     match router.map.internal.get(&primary_address) {
         Some(record) if record.check() => {
             trace!("{} OK", base);
+            record.increment_msg_count();
             reply.send(RouterReply::sender(addr.clone(), record.sender(), wrap))
         }
         Some(_) => {


### PR DESCRIPTION
Some simple utilities to capture diagnostics information from ockam_node. The UX side of this module is yet to be determined. But I suggest we merge ASAP and then use ockam_command to expose different sets of metrics and diagnostics on the terminal