### PR TITLE
feat(rust): remove `AsRef` from `PublicKey` to avoid confusion

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/vault/test_support/secret_impl.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/test_support/secret_impl.rs
@@ -18,7 +18,7 @@ pub async fn new_public_keys(vault: &mut impl SecretVault) {
     let res = vault.secret_public_key_get(&ed_ctx_1).await;
     assert!(res.is_ok());
     let pk_1 = res.unwrap();
-    assert_eq!(pk_1.as_ref().len(), CURVE25519_PUBLIC_LENGTH);
+    assert_eq!(pk_1.data().len(), CURVE25519_PUBLIC_LENGTH);
 
     let attributes = SecretAttributes::new(
         SecretType::X25519,
@@ -31,7 +31,7 @@ pub async fn new_public_keys(vault: &mut impl SecretVault) {
     let res = vault.secret_public_key_get(&x25519_ctx_1).await;
     assert!(res.is_ok());
     let pk_1 = res.unwrap();
-    assert_eq!(pk_1.as_ref().len(), CURVE25519_PUBLIC_LENGTH);
+    assert_eq!(pk_1.data().len(), CURVE25519_PUBLIC_LENGTH);
 }
 
 pub async fn new_secret_keys(vault: &mut impl SecretVault) {

--- a/implementations/rust/ockam/ockam_core/src/vault/types.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/types.rs
@@ -115,12 +115,6 @@ impl PublicKey {
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        &self.data
-    }
-}
-
 /// Binary representation of Signature.
 #[derive(Serialize, Deserialize, Clone, Debug, Zeroize)]
 #[zeroize(drop)]

--- a/implementations/rust/ockam/ockam_ffi/src/vault.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/vault.rs
@@ -237,17 +237,13 @@ pub extern "C" fn ockam_vault_secret_publickey_get(
             let entry = get_vault_entry(context).await?;
             let key_id = entry.get(secret).await?;
             let key = entry.vault.secret_public_key_get(&key_id).await?;
-            if output_buffer_size < key.as_ref().len() as u32 {
+            if output_buffer_size < key.data().len() as u32 {
                 return Err(FfiError::BufferTooSmall.into());
             }
-            *output_buffer_length = key.as_ref().len() as u32;
+            *output_buffer_length = key.data().len() as u32;
 
             unsafe {
-                std::ptr::copy_nonoverlapping(
-                    key.as_ref().as_ptr(),
-                    output_buffer,
-                    key.as_ref().len(),
-                );
+                std::ptr::copy_nonoverlapping(key.data().as_ptr(), output_buffer, key.data().len());
             };
             Ok::<(), Error>(())
         })?;

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
@@ -99,8 +99,8 @@ impl<V: X3dhVault> KeyExchanger for Initiator<V> {
                 self.state = InitiatorState::ProcessPreKeyBundle;
 
                 let mut response = Vec::new();
-                response.extend_from_slice(pubkey.as_ref());
-                response.extend_from_slice(ephemeral_pubkey.as_ref());
+                response.extend_from_slice(pubkey.data());
+                response.extend_from_slice(ephemeral_pubkey.data());
                 Ok(response)
             }
             InitiatorState::ProcessPreKeyBundle | InitiatorState::Done => {
@@ -126,7 +126,7 @@ impl<V: X3dhVault> KeyExchanger for Initiator<V> {
                     .verify(
                         &GenericSignature::new(prekey_bundle.signature_prekey.as_ref().to_vec()),
                         &prekey_bundle.identity_key,
-                        prekey_bundle.signed_prekey.as_ref(),
+                        prekey_bundle.signed_prekey.data(),
                     )
                     .await?;
 

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -68,10 +68,10 @@ impl PreKeyBundle {
     /// Convert the prekey bundle to a byte array
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut output = Vec::new();
-        output.extend_from_slice(self.identity_key.as_ref());
-        output.extend_from_slice(self.signed_prekey.as_ref());
+        output.extend_from_slice(self.identity_key.data());
+        output.extend_from_slice(self.signed_prekey.data());
         output.extend_from_slice(self.signature_prekey.0.as_ref());
-        output.extend_from_slice(self.one_time_prekey.as_ref());
+        output.extend_from_slice(self.one_time_prekey.data());
         output
     }
 }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
@@ -103,7 +103,7 @@ impl<V: X3dhVault> KeyExchanger for Responder<V> {
                 let signed_prekey_pub = self.vault.secret_public_key_get(signed_prekey).await?;
                 let signature = self
                     .vault
-                    .sign(identity_secret_key, signed_prekey_pub.as_ref())
+                    .sign(identity_secret_key, signed_prekey_pub.data())
                     .await?;
                 let identity_key = self
                     .vault

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
@@ -212,10 +212,10 @@ impl<V: XXVault> State<V> {
             .clone();
 
         let payload = payload.as_ref();
-        self.h = Some(self.mix_hash(ephemeral_public_key.as_ref()).await?);
+        self.h = Some(self.mix_hash(ephemeral_public_key.data()).await?);
         self.h = Some(self.mix_hash(payload).await?);
 
-        let mut output = ephemeral_public_key.as_ref().to_vec();
+        let mut output = ephemeral_public_key.data().to_vec();
         output.extend_from_slice(payload);
         Ok(output)
     }
@@ -239,7 +239,7 @@ impl<V: XXVault> State<V> {
         let encrypted_rs_and_tag = &message[index_l..index_r];
         let encrypted_payload_and_tag = &message[index_r..];
 
-        self.h = Some(self.mix_hash(re.as_ref()).await?);
+        self.h = Some(self.mix_hash(re.data()).await?);
         self.dh_state.dh(&ephemeral_secret_handle, &re).await?;
         self.remote_ephemeral_public_key = Some(re);
         let (rs, h) = self.decrypt_and_mix_hash(encrypted_rs_and_tag).await?;
@@ -269,8 +269,7 @@ impl<V: XXVault> State<V> {
             .clone()
             .ok_or(XXError::InvalidState)?;
 
-        let (mut encrypted_s_and_tag, h) =
-            self.encrypt_and_mix_hash(static_public.as_ref()).await?;
+        let (mut encrypted_s_and_tag, h) = self.encrypt_and_mix_hash(static_public.data()).await?;
         self.h = Some(h);
         self.dh_state
             .dh(&static_secret, &remote_ephemeral_public_key)
@@ -304,7 +303,7 @@ impl<V: XXVault> State<V> {
 
         let re = &message_1[..public_key_size];
         let re = PublicKey::new(re.to_vec(), SecretType::X25519);
-        self.h = Some(self.mix_hash(re.as_ref()).await?);
+        self.h = Some(self.mix_hash(re.data()).await?);
         self.h = Some(self.mix_hash(&message_1[public_key_size..]).await?);
         self.remote_ephemeral_public_key = Some(re);
         Ok(message_1[public_key_size..].to_vec())
@@ -324,13 +323,12 @@ impl<V: XXVault> State<V> {
             .clone()
             .ok_or(XXError::InvalidState)?;
 
-        self.h = Some(self.mix_hash(ephemeral_public.as_ref()).await?);
+        self.h = Some(self.mix_hash(ephemeral_public.data()).await?);
         self.dh_state
             .dh(&ephemeral_secret, &remote_ephemeral_public_key)
             .await?;
 
-        let (mut encrypted_s_and_tag, h) =
-            self.encrypt_and_mix_hash(static_public.as_ref()).await?;
+        let (mut encrypted_s_and_tag, h) = self.encrypt_and_mix_hash(static_public.data()).await?;
         self.h = Some(h);
         self.dh_state
             .dh(&static_secret, &remote_ephemeral_public_key)
@@ -340,7 +338,7 @@ impl<V: XXVault> State<V> {
         self.h = Some(h);
         self.nonce += 1;
 
-        let mut output = ephemeral_public.as_ref().to_vec();
+        let mut output = ephemeral_public.data().to_vec();
         output.append(&mut encrypted_s_and_tag);
         output.append(&mut encrypted_payload_and_tag);
         Ok(output)

--- a/implementations/rust/ockam/ockam_vault/src/asymmetric_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/asymmetric_impl.rs
@@ -12,7 +12,7 @@ impl Vault {
         let key = vault_entry.key();
         match vault_entry.key_attributes().stype() {
             SecretType::X25519 => {
-                if peer_public_key.as_ref().len() != CURVE25519_PUBLIC_LENGTH
+                if peer_public_key.data().len() != CURVE25519_PUBLIC_LENGTH
                     || key.as_ref().len() != CURVE25519_SECRET_LENGTH
                 {
                     return Err(VaultError::UnknownEcdhKeyType.into());
@@ -24,7 +24,7 @@ impl Vault {
                     CURVE25519_SECRET_LENGTH
                 ));
                 let pk_t = x25519_dalek::PublicKey::from(*array_ref!(
-                    peer_public_key.as_ref(),
+                    peer_public_key.data(),
                     0,
                     CURVE25519_PUBLIC_LENGTH
                 ));
@@ -61,7 +61,7 @@ impl AsymmetricVault for Vault {
     }
 
     async fn compute_key_id_for_public_key(&self, public_key: &PublicKey) -> Result<KeyId> {
-        let key_id = self.sha256(public_key.as_ref()).await?;
+        let key_id = self.sha256(public_key.data()).await?;
         Ok(hex::encode(key_id))
     }
 }

--- a/implementations/rust/ockam/ockam_vault/src/verifier_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/verifier_impl.rs
@@ -14,7 +14,7 @@ impl Verifier for Vault {
     ) -> Result<bool> {
         match public_key.stype() {
             SecretType::X25519 => {
-                if public_key.as_ref().len() != CURVE25519_PUBLIC_LENGTH
+                if public_key.data().len() != CURVE25519_PUBLIC_LENGTH
                     || signature.as_ref().len() != 64
                 {
                     return Err(VaultError::InvalidPublicKey.into());
@@ -25,14 +25,14 @@ impl Verifier for Vault {
 
                 let signature_array = array_ref!(signature.as_ref(), 0, 64);
                 let public_key = x25519_dalek::PublicKey::from(*array_ref!(
-                    public_key.as_ref(),
+                    public_key.data(),
                     0,
                     CURVE25519_PUBLIC_LENGTH
                 ));
                 Ok(public_key.xeddsa_verify(data.as_ref(), signature_array))
             }
             SecretType::Ed25519 => {
-                if public_key.as_ref().len() != CURVE25519_PUBLIC_LENGTH
+                if public_key.data().len() != CURVE25519_PUBLIC_LENGTH
                     || signature.as_ref().len() != 64
                 {
                     return Err(VaultError::InvalidPublicKey.into());
@@ -40,12 +40,12 @@ impl Verifier for Vault {
                 use ed25519_dalek::Verifier;
 
                 let signature = ed25519_dalek::Signature::from_bytes(signature.as_ref()).unwrap();
-                let public_key = ed25519_dalek::PublicKey::from_bytes(public_key.as_ref()).unwrap();
+                let public_key = ed25519_dalek::PublicKey::from_bytes(public_key.data()).unwrap();
                 Ok(public_key.verify(data.as_ref(), &signature).is_ok())
             }
             #[cfg(feature = "bls")]
             SecretType::Bls => {
-                if public_key.as_ref().len() != 96 && signature.as_ref().len() != 112 {
+                if public_key.data().len() != 96 && signature.as_ref().len() != 112 {
                     return Err(VaultError::InvalidPublicKey.into());
                 }
 


### PR DESCRIPTION
Remove public_key.as_ref(), since PublicKey struct also has type information, and it was not obvious that as_ref() returns only binary part