### PR TITLE
add enroll, space and project subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "btleplug"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +433,12 @@ dependencies = [
  "uuid",
  "windows",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -769,6 +800,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +874,12 @@ dependencies = [
  "libc",
  "tokio",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -855,6 +927,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "duct"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +948,17 @@ dependencies = [
  "once_cell",
  "os_pipe",
  "shared_child",
+]
+
+[[package]]
+name = "dummy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5ff6f74150b0bbb6e6057718a903b3d8f3fc7096c9190fc162ca99d3b2273"
+dependencies = [
+ "darling",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -916,6 +1011,15 @@ checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
  "nb 0.1.3",
  "void",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -973,6 +1077,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a8531dd3a64fd1cfbe92fad4160bc2060489c6195fe847e045e5788f710bae"
+dependencies = [
+ "dummy",
+ "http",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1116,15 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1030,6 +1163,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d758e60b45e8d749c89c1b389ad8aee550f86aa12e2b9298b546dda7a82ab1"
 
 [[package]]
 name = "funty"
@@ -1218,6 +1357,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.2",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,10 +1520,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes 1.1.0",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.1.0",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1389,6 +1607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1623,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -1411,6 +1644,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1487,6 +1729,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minicbor"
@@ -1567,6 +1815,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1885,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1926,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -1727,13 +2026,21 @@ name = "ockam_api"
 version = "0.2.0"
 dependencies = [
  "cddl-cat",
+ "fake",
  "minicbor",
+ "mockall",
  "ockam_api",
  "ockam_core",
  "ockam_macros",
  "ockam_node",
+ "ockam_transport_tcp",
+ "open",
  "quickcheck",
+ "reqwest",
+ "serde",
+ "serde_json",
  "tinyvec",
+ "tokio-retry",
  "tracing",
 ]
 
@@ -1761,6 +2068,7 @@ name = "ockam_command"
 version = "0.59.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-recursion",
  "async-trait",
  "clap 3.1.18",
@@ -2046,6 +2354,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "open"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0524af9508f9b5c4eb41dce095860456727748f63b478d625f119a70e0d764a"
+dependencies = [
+ "pathdiff",
+ "winapi",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_pipe"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2496,26 @@ checksum = "b9c86f6c9cdae70b425c52a269bbb4b6aa3758a7c566eaf5b2c9a9aca9c29584"
 dependencies = [
  "mips-mcu",
  "vcell",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2164,6 +2553,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2376,6 +2795,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+dependencies = [
+ "base64",
+ "bytes 1.1.0",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "riscv"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,10 +2917,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2545,6 +3042,18 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2892,6 +3401,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +3422,12 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
@@ -3002,6 +3531,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,7 +3560,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -3040,6 +3590,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3611,12 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
@@ -3119,6 +3689,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
@@ -3253,6 +3829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,6 +3872,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3907,82 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
+name = "web-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -3423,6 +4100,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wyz"

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -15,7 +15,12 @@ tag = []
 
 [dependencies]
 minicbor = { version = "0.16.0", features = ["alloc", "derive"] }
+open = "2"
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tinyvec  = { version = "1.6.0", features = ["rustc_1_57"] }
+tokio-retry = "0.3"
 tracing  = { version = "0.1.34", default-features = false }
 
 [dependencies.ockam_core]
@@ -32,6 +37,9 @@ features         = ["std"] # FIXME: required because of unbounded channels in oc
 
 [dev-dependencies]
 cddl-cat     = "0.6.1"
+fake = { version = "2", features=['derive', 'http']}
+mockall = "0.11"
 ockam_api    = { path = ".", features = ["std"] }
 ockam_macros = { version = "0.15.0", path = "../ockam_macros", features = ["std"] }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0" }
 quickcheck   = "1.0.1"

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -1,0 +1,265 @@
+#[cfg(test)]
+use fake::{Dummy, Fake};
+use minicbor::Encode;
+use tracing::warn;
+
+#[cfg(test)]
+use ockam_core::compat::rand;
+use ockam_core::{self, async_trait};
+
+pub enum Authenticator {
+    Auth0,
+    EnrollmentToken,
+}
+
+impl core::fmt::Display for Authenticator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Authenticator::Auth0 => "Auth0".fmt(f),
+            Authenticator::EnrollmentToken => "EnrollmentToken".fmt(f),
+        }
+    }
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait::async_trait]
+pub trait AuthenticatorClientTrait {
+    async fn auth0(&self) -> ockam_core::Result<auth0::Auth0Tokens>;
+}
+
+pub struct AuthenticatorClient;
+
+pub(crate) mod auth0 {
+    use reqwest::StatusCode;
+    use tokio_retry::{strategy::ExponentialBackoff, Retry};
+
+    use ockam_node::tokio;
+
+    use crate::error::ApiError;
+
+    use super::*;
+
+    const DOMAIN: &str = "dev-w5hdnpc2.us.auth0.com";
+    const CLIENT_ID: &str = "sGyXBwQfU6fjfW1gopphdV9vCLec060b";
+    const API_AUDIENCE: &str = "https://dev-w5hdnpc2.us.auth0.com/api/v2/";
+    const SCOPES: &str = "profile";
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct DeviceCodeResponse {
+        device_code: String,
+        user_code: String,
+        verification_uri: String,
+        verification_uri_complete: String,
+        expires_in: usize,
+        interval: usize,
+    }
+
+    #[derive(serde::Deserialize, Debug, PartialEq)]
+    struct TokensErrorResponse {
+        error: String,
+        error_description: String,
+    }
+
+    #[derive(serde::Deserialize, Encode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(map)]
+    pub struct Auth0Tokens {
+        #[n(0)]
+        pub token_type: TokenType,
+        #[n(1)]
+        pub access_token: AccessToken,
+    }
+
+    #[derive(serde::Deserialize, Encode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(index_only)]
+    pub enum TokenType {
+        #[n(0)]
+        Bearer,
+    }
+
+    #[derive(serde::Deserialize, Encode, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cbor(transparent)]
+    pub struct AccessToken(#[n(0)] String);
+
+    #[async_trait::async_trait]
+    impl AuthenticatorClientTrait for AuthenticatorClient {
+        async fn auth0(&self) -> ockam_core::Result<Auth0Tokens> {
+            // Request device code
+            // More on how to use scope and audience in https://auth0.com/docs/quickstart/native/device#device-code-parameters
+            let device_code_res = {
+                let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
+                let res = Retry::spawn(retry_strategy, move || {
+                    let client = reqwest::Client::new();
+                    client
+                        .post(format!("https://{DOMAIN}/oauth/device/code"))
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .form(&[
+                            ("client_id", CLIENT_ID),
+                            ("scope", SCOPES),
+                            ("audience", API_AUDIENCE),
+                        ])
+                        .send()
+                })
+                .await
+                .map_err(ApiError::from)?;
+                match res.status() {
+                    StatusCode::OK => {
+                        let res = res
+                            .json::<DeviceCodeResponse>()
+                            .await
+                            .map_err(ApiError::from)?;
+                        tracing::info!("device code received: {res:#?}");
+                        res
+                    }
+                    _ => {
+                        let res = res.text().await.map_err(ApiError::from)?;
+                        let err = format!("couldn't get device code [response={:#?}]", res);
+                        return Err(ApiError::generic(&err));
+                    }
+                }
+            };
+
+            // Request device activation
+            // Note that we try to open the verification uri **without** the code.
+            // After the code is entered, if the user closes the tab (because they
+            // want to open it on another browser, for example), the uri gets
+            // invalidated and the user would have to restart the process (i.e.
+            // rerun the command).
+            if open::that(&device_code_res.verification_uri).is_err() {
+                warn!(
+                    "couldn't open verification url automatically [url={}]",
+                    device_code_res.verification_uri
+                );
+            }
+
+            println!(
+                "Open the following url in your browser to authorize your device with code {}:\n{}",
+                device_code_res.user_code, device_code_res.verification_uri_complete,
+            );
+
+            // Request tokens
+            let client = reqwest::Client::new();
+            let tokens_res;
+            loop {
+                let res = client
+                    .post(format!("https://{DOMAIN}/oauth/token"))
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .form(&[
+                        ("client_id", CLIENT_ID),
+                        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                        ("device_code", &device_code_res.device_code),
+                    ])
+                    .send()
+                    .await
+                    .map_err(ApiError::from)?;
+                match res.status() {
+                    StatusCode::OK => {
+                        tokens_res = res.json::<Auth0Tokens>().await.map_err(ApiError::from)?;
+                        tracing::info!("tokens received [tokes={tokens_res:#?}]");
+                        return Ok(tokens_res);
+                    }
+                    _ => {
+                        let err_res = res
+                            .json::<TokensErrorResponse>()
+                            .await
+                            .map_err(ApiError::from)?;
+                        match err_res.error.as_str() {
+                            "authorization_pending" | "invalid_request" | "slow_down" => {
+                                tracing::debug!("tokens not yet received [err={err_res:#?}]");
+                                tokio::time::sleep(tokio::time::Duration::from_secs(
+                                    device_code_res.interval as u64,
+                                ))
+                                .await;
+                                continue;
+                            }
+                            _ => {
+                                let err_msg =
+                                    format!("failed to receive tokens [err={err_res:#?}]");
+                                tracing::debug!("{}", err_msg);
+                                return Err(ApiError::generic(&err_msg));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fake::{Fake, Faker};
+
+    use ockam_core::route;
+    use ockam_node::Context;
+    use ockam_transport_tcp::{TcpTransport, TCP};
+
+    use crate::cloud::tests::TestCloudWorker;
+    use crate::cloud::Client;
+
+    use super::*;
+
+    mod auth0 {
+        use crate::cloud::enroll::auth0::Auth0Tokens;
+
+        use super::*;
+
+        // TODO: add tests for the auth0 internals using mockito
+        // async fn internals__happy_path() {}
+        // async fn internals__err_if_device_token_request_fails() {}
+        // async fn internals__err_if_tokens_request_fails() {}
+
+        #[ockam_macros::test]
+        async fn happy_path(ctx: &mut Context) -> ockam_core::Result<()> {
+            // Initiate cloud TCP listener
+            let transport = TcpTransport::create(ctx).await?;
+            let server_address = transport.listen("127.0.0.1:0").await?.to_string();
+            let server_route = route![(TCP, server_address), "cloud"];
+            ctx.start_worker("cloud", TestCloudWorker).await?;
+
+            // Mock authenticator
+            let expected_creds: Auth0Tokens = Faker.fake();
+            let mut auth_client = MockAuthenticatorClientTrait::new();
+            let moved_expected_creds = expected_creds.clone();
+            auth_client
+                .expect_auth0()
+                .times(1)
+                .return_once(move || Ok(moved_expected_creds));
+
+            // Execute enroll
+            let mut api_client = Client::new(server_route, ctx).await?;
+            let _res = api_client
+                .enroll(&Authenticator::Auth0, auth_client)
+                .await?;
+
+            ctx.stop().await
+        }
+
+        /// This test points to an ockam cloud to test the integration with elixir workers.
+        /// The local machine must have access to cloud.ockam.io.
+        #[ockam_macros::test]
+        #[ignore]
+        async fn cloud(ctx: &mut Context) -> ockam_core::Result<()> {
+            // Mock authenticator
+            let expected_creds: Auth0Tokens = Faker.fake();
+            let mut auth_client = MockAuthenticatorClientTrait::new();
+            let moved_expected_creds = expected_creds.clone();
+            auth_client
+                .expect_auth0()
+                .times(1)
+                .return_once(move || Ok(moved_expected_creds));
+
+            // Enroll sending mocked tokens to cloud node
+            TcpTransport::create(ctx).await?;
+            let server_route = route![(TCP, "127.0.0.1:4001"), "authenticator"];
+            let mut api_client = Client::new(server_route, ctx).await?;
+            let _res = api_client
+                .enroll(&Authenticator::Auth0, auth_client)
+                .await?;
+
+            ctx.stop().await
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -1,0 +1,335 @@
+use minicbor::{Decoder, Encode};
+use tracing::{trace, warn};
+
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{self, Address, Route};
+use ockam_node::Context;
+
+use crate::cloud::enroll::{Authenticator, AuthenticatorClientTrait};
+use crate::cloud::project::{CreateProject, Project};
+use crate::cloud::space::{CreateSpace, Space};
+use crate::{Error, Response};
+use crate::{Request, RequestBuilder, Status};
+
+pub mod enroll;
+pub mod project;
+pub mod space;
+
+pub struct Client {
+    ctx: Context,
+    route: Route,
+    buf: Vec<u8>,
+}
+
+impl Client {
+    pub async fn new(r: Route, ctx: &Context) -> ockam_core::Result<Self> {
+        let ctx = ctx.new_detached(Address::random_local()).await?;
+        Ok(Client {
+            ctx,
+            route: r,
+            buf: Vec::new(),
+        })
+    }
+
+    /// Executes an enrollment process to generate a new set of access tokens.
+    pub async fn enroll<Auth>(
+        &mut self,
+        auth: &Authenticator,
+        auth_client: Auth,
+    ) -> ockam_core::Result<()>
+    where
+        Auth: AuthenticatorClientTrait,
+    {
+        let target = "ockam_api::cloud::enroll";
+        let label = "enroll";
+        trace!(target = %target, auth = %auth, "generating tokens");
+
+        let req = Request::post("/authenticators/auth0/authenticate");
+        let req = match auth {
+            Authenticator::Auth0 => {
+                let tokens = auth_client.auth0().await?;
+                tracing::info!("tokens received {tokens:?}");
+                req.body(tokens)
+            }
+            Authenticator::EnrollmentToken => unimplemented!(),
+        };
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            Ok(())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn create_space(&mut self, body: CreateSpace<'_>) -> ockam_core::Result<Space<'_>> {
+        let target = "ockam_api::cloud::create_space";
+        let label = "create_space";
+        trace!(target = %target, space = %body.name, "creating space");
+
+        let req = Request::post("/v0").body(body);
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn list_spaces(&mut self) -> ockam_core::Result<Vec<Space<'_>>> {
+        let target = "ockam_api::cloud::list_spaces";
+        let label = "list_spaces";
+        trace!(target = %target, "listing spaces");
+
+        let req = Request::get("/v0");
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn get_space(&mut self, space_id: &str) -> ockam_core::Result<Space<'_>> {
+        let target = "ockam_api::cloud::get_space";
+        let label = "get_space";
+        trace!(target = %target, space = %space_id, space = %space_id, "getting space");
+
+        let req = Request::get(format!("/v0/{space_id}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn get_space_by_name(&mut self, space_name: &str) -> ockam_core::Result<Space<'_>> {
+        let target = "ockam_api::cloud::get_space_by_name";
+        let label = "get_space_by_name";
+        trace!(target = %target, space = %space_name, "getting space");
+
+        let req = Request::post(format!("/v0/name/{space_name}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn delete_space(&mut self, space_id: &str) -> ockam_core::Result<()> {
+        let target = "ockam_api::cloud::delete_space";
+        let label = "delete_space";
+        trace!(target = %target, space = %space_id, "deleting space");
+
+        let req = Request::delete(format!("/v0/{space_id}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            Ok(())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn create_project(
+        &mut self,
+        space_id: &str,
+        body: CreateProject<'_>,
+    ) -> ockam_core::Result<Project<'_>> {
+        let target = "ockam_api::cloud::create_project";
+        let label = "create_project";
+        trace!(target = %target, space = %space_id, project = %body.name, "creating project");
+
+        let req = Request::post(format!("/v0/{space_id}")).body(body);
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn list_projects(&mut self, space_id: &str) -> ockam_core::Result<Vec<Project<'_>>> {
+        let target = "ockam_api::cloud::list_projects";
+        let label = "list_projects";
+        trace!(target = %target, space = %space_id, "listing projects");
+
+        let req = Request::get(format!("/v0/{space_id}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn get_project(
+        &mut self,
+        space_id: &str,
+        project_id: &str,
+    ) -> ockam_core::Result<Project<'_>> {
+        let target = "ockam_api::cloud::get_project";
+        let label = "get_project";
+        trace!(target = %target, space = %space_id, project = %project_id, "getting project");
+
+        let req = Request::get(format!("/v0/{space_id}/{project_id}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn get_project_by_name(
+        &mut self,
+        space_id: &str,
+        project_name: &str,
+    ) -> ockam_core::Result<Project<'_>> {
+        let target = "ockam_api::cloud::get_project_by_name";
+        let label = "get_project_by_name";
+        trace!(target = %target, space = %space_id, project = %project_name, "getting project");
+
+        let req = Request::post(format!("/v0/{space_id}/name/{project_name}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            d.decode().map_err(|e| e.into())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    pub async fn delete_project(
+        &mut self,
+        space_id: &str,
+        project_id: &str,
+    ) -> ockam_core::Result<()> {
+        let target = "ockam_api::cloud::delete_project";
+        let label = "delete_project";
+        trace!(target = %target, space = %space_id, project = %project_id, "deleting project");
+
+        let req = Request::delete(format!("/v0/{space_id}/{project_id}"));
+        self.buf = self.request(target, label, &req).await?;
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            Ok(())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+
+    /// Encode request header and body (if any), send the package to the server and returns its response.
+    async fn request<T>(
+        &mut self,
+        target: &str,
+        label: &str,
+        req: &RequestBuilder<'_, T>,
+    ) -> ockam_core::Result<Vec<u8>>
+    where
+        T: Encode<()>,
+    {
+        let mut buf = Vec::new();
+        req.encode(&mut buf)?;
+        trace!(target = %target, label = %label, id = %req.header().id(), "-> req");
+        let vec: Vec<u8> = self.ctx.send_and_receive(self.route.clone(), buf).await?;
+        Ok(vec)
+    }
+}
+
+/// Decode and log response header.
+pub(crate) fn response(
+    target: &str,
+    label: &str,
+    dec: &mut Decoder<'_>,
+) -> ockam_core::Result<Response> {
+    let res: Response = dec.decode()?;
+    trace! {
+        target = target,
+        label  = %label,
+        id     = %res.id(),
+        re     = %res.re(),
+        status = ?res.status(),
+        body   = %res.has_body(),
+        "<- res"
+    }
+    Ok(res)
+}
+
+/// Decode, log and mape response error to ockam_core error.
+pub(crate) fn error(
+    target: &str,
+    label: &str,
+    res: &Response,
+    dec: &mut Decoder<'_>,
+) -> ockam_core::Error {
+    if res.has_body() {
+        let err = match dec.decode::<Error>() {
+            Ok(e) => e,
+            Err(e) => return e.into(),
+        };
+        warn! {
+            target = target,
+            label  = %label,
+            id     = %res.id(),
+            re     = %res.re(),
+            status = ?res.status(),
+            error  = ?err.message(),
+            "<- err"
+        }
+        let msg = err.message().unwrap_or(label);
+        ockam_core::Error::new(Origin::Application, Kind::Protocol, msg)
+    } else {
+        ockam_core::Error::new(Origin::Application, Kind::Protocol, label)
+    }
+}
+
+mod tests {
+    use ockam_core::{Routed, Worker};
+    use ockam_node::Context;
+
+    use super::*;
+    use crate::{Request, Response};
+
+    pub struct TestCloudWorker;
+
+    #[ockam_core::worker]
+    impl Worker for TestCloudWorker {
+        type Message = Vec<u8>;
+        type Context = Context;
+
+        async fn handle_message(
+            &mut self,
+            ctx: &mut Context,
+            msg: Routed<Self::Message>,
+        ) -> ockam_core::Result<()> {
+            let mut buf = Vec::new();
+            {
+                let mut dec = Decoder::new(msg.as_body());
+                let req: Request = dec.decode()?;
+                Response::ok(req.id()).encode(&mut buf)?;
+            }
+            ctx.send(msg.return_route(), buf).await
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,0 +1,37 @@
+use minicbor::{Decode, Encode};
+use std::borrow::Cow;
+
+#[derive(Decode, Debug)]
+#[cbor(map)]
+pub struct Project<'a> {
+    #[b(0)]
+    pub id: Cow<'a, str>,
+    #[b(1)]
+    pub name: Cow<'a, str>,
+    #[b(2)]
+    pub services: Vec<Cow<'a, str>>,
+    #[b(3)]
+    pub access_route: Vec<u8>,
+}
+
+#[derive(Encode)]
+#[cbor(map)]
+pub struct CreateProject<'a> {
+    #[b(0)]
+    pub name: Cow<'a, str>,
+    #[b(1)]
+    pub services: Vec<Cow<'a, str>>,
+}
+
+impl<'a> CreateProject<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(name: S, services: &'a [String]) -> Self {
+        Self {
+            name: name.into(),
+            services: services
+                .iter()
+                .map(String::as_str)
+                .map(Cow::Borrowed)
+                .collect(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -1,0 +1,24 @@
+use minicbor::{Decode, Encode};
+use std::borrow::Cow;
+
+#[derive(Decode, Debug)]
+#[cbor(map)]
+pub struct Space<'a> {
+    #[b(0)]
+    pub id: Cow<'a, str>,
+    #[b(1)]
+    pub name: Cow<'a, str>,
+}
+
+#[derive(Encode)]
+#[cbor(map)]
+pub struct CreateSpace<'a> {
+    #[b(0)]
+    pub name: Cow<'a, str>,
+}
+
+impl<'a> CreateSpace<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(name: S) -> Self {
+        Self { name: name.into() }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/error.rs
@@ -1,0 +1,75 @@
+use core::fmt;
+
+use ockam_core::compat::io;
+use ockam_core::errcode::{Kind, Origin};
+
+/// Potential API errors
+#[derive(Debug)]
+pub struct ApiError(ErrorImpl);
+
+impl ApiError {
+    pub fn generic(cause: &str) -> ockam_core::Error {
+        ockam_core::Error::new(Origin::Application, Kind::Invalid, cause)
+    }
+}
+
+#[derive(Debug)]
+enum ErrorImpl {
+    CborDecode(minicbor::decode::Error),
+    CborEncode(minicbor::encode::Error<io::Error>),
+    SerdeJson(serde_json::Error),
+    Http(reqwest::Error),
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            ErrorImpl::CborEncode(e) => e.fmt(f),
+            ErrorImpl::CborDecode(e) => e.fmt(f),
+            ErrorImpl::SerdeJson(e) => e.fmt(f),
+            ErrorImpl::Http(e) => e.fmt(f),
+        }
+    }
+}
+
+impl ockam_core::compat::error::Error for ApiError {
+    #[cfg(feature = "std")]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.0 {
+            ErrorImpl::CborDecode(e) => Some(e),
+            ErrorImpl::CborEncode(e) => Some(e),
+            ErrorImpl::SerdeJson(e) => Some(e),
+            ErrorImpl::Http(e) => Some(e),
+        }
+    }
+}
+
+impl From<minicbor::decode::Error> for ApiError {
+    fn from(e: minicbor::decode::Error) -> Self {
+        ApiError(ErrorImpl::CborDecode(e))
+    }
+}
+
+impl From<minicbor::encode::Error<io::Error>> for ApiError {
+    fn from(e: minicbor::encode::Error<io::Error>) -> Self {
+        ApiError(ErrorImpl::CborEncode(e))
+    }
+}
+
+impl From<serde_json::Error> for ApiError {
+    fn from(e: serde_json::Error) -> Self {
+        ApiError(ErrorImpl::SerdeJson(e))
+    }
+}
+
+impl From<reqwest::Error> for ApiError {
+    fn from(e: reqwest::Error) -> Self {
+        ApiError(ErrorImpl::Http(e))
+    }
+}
+
+impl From<ApiError> for ockam_core::Error {
+    fn from(e: ApiError) -> Self {
+        ockam_core::Error::new(Origin::Application, Kind::Invalid, e)
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod cloud;
+pub(crate) mod error;
 pub mod nodes;
 
 use core::fmt;
@@ -111,6 +113,7 @@ pub enum Method {
 pub enum Status {
     #[n(200)] Ok,
     #[n(400)] BadRequest,
+    #[n(401)] Unauthorized,
     #[n(404)] NotFound,
     #[n(405)] MethodNotAllowed,
     #[n(500)] InternalServerError,

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -48,3 +48,6 @@ ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.54.0"}
+
+[dev-dependencies]
+assert_cmd = "2"

--- a/implementations/rust/ockam/ockam_command/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/cloud/enroll.rs
@@ -1,0 +1,66 @@
+use anyhow::anyhow;
+use clap::Args;
+
+use ockam_api::cloud::enroll::AuthenticatorClient;
+use ockam_core::route;
+use ockam_multiaddr::MultiAddr;
+
+use crate::old::identity::load_or_create_identity;
+use crate::util::multiaddr_to_route;
+use crate::IdentityOpts;
+
+pub async fn run(args: EnrollCommandArgs, ctx: &mut ockam::Context) -> anyhow::Result<()> {
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let _identity = load_or_create_identity(&IdentityOpts::from(&args), ctx).await?;
+
+    let addr = multiaddr_to_route(&args.cloud_addr)
+        .ok_or_else(|| anyhow!("failed to parse address: {}", args.cloud_addr))?;
+    let route = route![addr.to_string(), "authenticator"];
+    let mut api_client = ockam_api::cloud::Client::new(route, ctx).await?;
+    let auth_client = AuthenticatorClient;
+    api_client
+        .enroll(&args.authenticator.into(), auth_client)
+        .await?;
+    println!("Enrolled successfully");
+    Ok(())
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct EnrollCommandArgs {
+    /// Ockam's cloud node address
+    #[clap(display_order = 1000)]
+    pub cloud_addr: MultiAddr,
+    #[clap(display_order = 1001, arg_enum, default_value = "auth0")]
+    pub authenticator: Authenticator,
+    #[clap(display_order = 1002, long, default_value = "default")]
+    pub vault: String,
+    #[clap(display_order = 1003, long, default_value = "default")]
+    pub identity: String,
+    #[clap(display_order = 1004, long)]
+    pub overwrite: bool,
+}
+
+impl<'a> From<&'a EnrollCommandArgs> for IdentityOpts {
+    fn from(other: &'a EnrollCommandArgs) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
+}
+
+#[derive(clap::ArgEnum, Clone, Debug)]
+pub enum Authenticator {
+    Auth0,
+    EnrollmentToken,
+}
+
+impl From<Authenticator> for ockam_api::cloud::enroll::Authenticator {
+    fn from(other: Authenticator) -> Self {
+        match other {
+            Authenticator::Auth0 => ockam_api::cloud::enroll::Authenticator::Auth0,
+            Authenticator::EnrollmentToken => {
+                ockam_api::cloud::enroll::Authenticator::EnrollmentToken
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/cloud/mod.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+
+use ockam::{Context, TcpTransport};
+
+pub(crate) mod enroll;
+pub(crate) mod project;
+pub(crate) mod space;
+
+#[derive(Clone, Debug, Parser)]
+pub struct CloudCommand {
+    #[clap(subcommand)]
+    pub subcommand: CloudSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum CloudSubCommand {
+    /// Enroll identity in ockam.cloud.
+    #[clap(display_order = 1000)]
+    Enroll(enroll::EnrollCommandArgs),
+    /// Space subcommands.
+    #[clap(display_order = 1001)]
+    Space(space::SpaceCommand),
+    /// Project subcommands.
+    #[clap(display_order = 1002)]
+    Project(project::ProjectCommand),
+}
+
+impl CloudCommand {
+    pub async fn run(mut ctx: Context, command: CloudCommand) -> anyhow::Result<()> {
+        TcpTransport::create(&ctx).await?;
+        match command.subcommand {
+            CloudSubCommand::Enroll(arg) => enroll::run(arg, &mut ctx).await,
+            CloudSubCommand::Space(arg) => space::run(arg, &mut ctx).await,
+            CloudSubCommand::Project(arg) => project::run(arg, &mut ctx).await,
+        }?;
+        ctx.stop().await?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_command/src/cloud/project.rs
@@ -1,0 +1,96 @@
+use clap::Parser;
+
+use ockam::TCP;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::project::CreateProject;
+use ockam_core::route;
+
+use crate::old::storage;
+
+pub async fn run(args: ProjectCommand, ctx: &mut Context) -> anyhow::Result<()> {
+    storage::ensure_identity_exists(true)?;
+    let _ockam_dir = storage::get_ockam_dir()?;
+
+    TcpTransport::create(ctx).await?;
+
+    let addr = "cloud.ockam.io:62526"; //TODO
+    let route = route![(TCP, addr), "projects"]; //TODO
+    let mut api_client = ockam_api::cloud::Client::new(route, ctx).await?;
+
+    match args.command {
+        ProjectsSubCommand::Create {
+            space_id,
+            project_name,
+            services,
+        } => {
+            let res = api_client
+                .create_project(&space_id, CreateProject::new(project_name, &services))
+                .await?;
+            println!("{res:?}")
+        }
+        ProjectsSubCommand::List { space_id } => {
+            let res = api_client.list_projects(&space_id).await?;
+            println!("{res:?}")
+        }
+        ProjectsSubCommand::Show {
+            space_id,
+            project_id,
+        } => {
+            let res = api_client.get_project(&space_id, &project_id).await?;
+            println!("{res:?}")
+        }
+        ProjectsSubCommand::Delete {
+            space_id,
+            project_id,
+        } => {
+            let res = api_client.delete_project(&space_id, &project_id).await?;
+            println!("{res:?}")
+        }
+    };
+    ctx.stop().await?;
+    Ok(())
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct ProjectCommand {
+    #[clap(subcommand)]
+    pub command: ProjectsSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum ProjectsSubCommand {
+    /// Creates a new project.
+    #[clap(display_order = 1000)]
+    Create {
+        /// Id of the space the project belongs to.
+        space_id: String,
+        /// Name of the project.
+        project_name: String,
+        /// Services enabled for this project.
+        services: Vec<String>,
+    },
+    /// List all projects.
+    #[clap(display_order = 1001)]
+    List {
+        /// Id of the space.
+        space_id: String,
+    },
+    /// Shows a single project.
+    #[clap(display_order = 1002)]
+    Show {
+        /// Id of the space.
+        space_id: String,
+        /// Id of the project.
+        project_id: String,
+    },
+    /// Delete a project.
+    #[clap(display_order = 1003)]
+    Delete {
+        /// Id of the space.
+        space_id: String,
+        /// Id of the project.
+        project_id: String,
+    },
+}

--- a/implementations/rust/ockam/ockam_command/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_command/src/cloud/space.rs
@@ -1,0 +1,75 @@
+use clap::Parser;
+
+use ockam::TCP;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::space::CreateSpace;
+use ockam_core::route;
+
+use crate::old::storage;
+
+pub async fn run(args: SpaceCommand, ctx: &mut Context) -> anyhow::Result<()> {
+    storage::ensure_identity_exists(true)?;
+    let _ockam_dir = storage::get_ockam_dir()?;
+
+    TcpTransport::create(ctx).await?;
+
+    let addr = "cloud.ockam.io:62526"; //TODO
+    let route = route![(TCP, addr), "spaces"]; //TODO
+    let mut api_client = ockam_api::cloud::Client::new(route, ctx).await?;
+
+    match args.command {
+        SpacesSubCommand::Create { name: space_name } => {
+            let res = api_client
+                .create_space(CreateSpace::new(space_name))
+                .await?;
+            println!("{res:?}")
+        }
+        SpacesSubCommand::List => {
+            let res = api_client.list_spaces().await?;
+            println!("{res:?}")
+        }
+        SpacesSubCommand::Show { id: space_id } => {
+            let res = api_client.get_space(&space_id).await?;
+            println!("{res:?}")
+        }
+        SpacesSubCommand::Delete { id: space_id } => {
+            let res = api_client.delete_space(&space_id).await?;
+            println!("{res:?}")
+        }
+    };
+    ctx.stop().await?;
+    Ok(())
+}
+
+#[derive(Clone, Debug, Parser)]
+pub struct SpaceCommand {
+    #[clap(subcommand)]
+    pub command: SpacesSubCommand,
+    #[clap(long, short, parse(from_occurrences))]
+    pub verbose: u8,
+}
+
+#[derive(Clone, Debug, Parser)]
+pub enum SpacesSubCommand {
+    /// Creates a new space.
+    #[clap(display_order = 1000)]
+    Create {
+        /// Name of the space.
+        name: String,
+    },
+    /// List all spaces.
+    #[clap(display_order = 1001)]
+    List,
+    /// Shows a single space.
+    #[clap(display_order = 1002)]
+    Show {
+        /// Id of the space.
+        id: String,
+    },
+    /// Delete a space.
+    #[clap(display_order = 1003)]
+    Delete {
+        /// Id of the space.
+        id: String,
+    },
+}

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -1,6 +1,6 @@
 use crate::util::{embedded_node, multiaddr_to_route};
 use clap::Args;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, TcpTransport};
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
@@ -15,7 +15,7 @@ impl SendCommand {
     }
 }
 
-async fn send_message(ctx: Context, command: SendCommand) -> Result<()> {
+async fn send_message(ctx: Context, command: SendCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     if let Some(route) = multiaddr_to_route(&command.address) {

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -36,7 +36,7 @@ impl StartCommand {
     }
 }
 
-async fn setup(ctx: Context, c: StartCommand) -> Result<()> {
+async fn setup(ctx: Context, c: StartCommand) -> anyhow::Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
     tcp.listen("127.0.0.1:62526").await?;
 
@@ -46,5 +46,7 @@ async fn setup(ctx: Context, c: StartCommand) -> Result<()> {
             node_name: c.node_name,
         },
     )
-    .await
+    .await?;
+
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/old/cmd/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/cmd/identity.rs
@@ -1,9 +1,8 @@
-use crate::old::{identity::save_identity, storage, OckamVault};
-use anyhow::Context as Ctx;
 use clap::Args;
-use ockam::{identity::*, Context};
-use ockam_vault::storage::FileStorage;
-use std::sync::Arc;
+
+use ockam::Context;
+
+use crate::old::identity::create_identity;
 
 #[derive(Clone, Debug, Args)]
 pub struct IdentityOpts {
@@ -19,36 +18,7 @@ pub struct IdentityOpts {
 }
 
 pub async fn run(args: IdentityOpts, mut ctx: Context) -> anyhow::Result<()> {
-    let ockam_dir = storage::init_ockam_dir()?;
-    let id_path = ockam_dir.join("identity.json");
-    if id_path.exists() {
-        if !args.overwrite {
-            anyhow::bail!(
-                "An identity or vault already exists in {:?}. Pass `--overwrite` to continue anyway",
-                ockam_dir
-            );
-        }
-        if id_path.exists() {
-            std::fs::remove_file(&id_path)
-                .with_context(|| format!("Failed to remove {:?}", id_path))?;
-        }
-    }
-    let vault_storage = FileStorage::create(
-        &ockam_dir.join("vault.json"),
-        &ockam_dir.join("vault.json.temp"),
-    )
-    .await?;
-    let vault = OckamVault::new(Some(Arc::new(vault_storage)));
-    let identity = Identity::create(&ctx, &vault).await?;
-    let exported = identity.export().await;
-    let identifier = exported.id.clone();
-    tracing::info!("Saving new identity: {:?}", identifier.key_id());
-    save_identity(&ockam_dir, &exported).await?;
-    println!(
-        "Initialized {:?} with identity {:?}.",
-        ockam_dir,
-        identifier.key_id()
-    );
+    create_identity(&args, &ctx).await?;
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/old/storage.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/storage.rs
@@ -1,8 +1,10 @@
 //! In theory this is the file that operates on the config dir itself, but this
 //! is all a bit messy.
-use anyhow::{Context, Result};
-use ockam::identity::*;
 use std::path::PathBuf;
+
+use anyhow::Context;
+
+use ockam::identity::*;
 
 fn config_home() -> Option<PathBuf> {
     if cfg!(target_os = "macos") {
@@ -17,7 +19,7 @@ fn config_home() -> Option<PathBuf> {
     }
 }
 
-pub fn get_ockam_dir() -> Result<PathBuf> {
+pub fn get_ockam_dir() -> anyhow::Result<PathBuf> {
     // TODO: ideally we'd use `$OCKAM_HOME` but all of our build tools assume
     // that's the repo...
     let ockam_dir = if let Some(s) = std::env::var_os("OCKAM_DIR") {
@@ -46,7 +48,7 @@ pub fn get_ockam_dir() -> Result<PathBuf> {
     Ok(ockam_dir)
 }
 
-pub fn ensure_identity_exists(expect_trusted: bool) -> Result<()> {
+pub fn ensure_identity_exists(expect_trusted: bool) -> anyhow::Result<()> {
     let dir = get_ockam_dir()?;
     if !dir.exists() {
         anyhow::bail!(
@@ -73,7 +75,7 @@ pub fn ensure_identity_exists(expect_trusted: bool) -> Result<()> {
 }
 
 #[tracing::instrument(level = "debug", err)]
-pub fn init_ockam_dir() -> Result<std::path::PathBuf> {
+pub fn init_ockam_dir() -> anyhow::Result<std::path::PathBuf> {
     use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
     let path = get_ockam_dir()?;
     tracing::debug!("Ockam dir will be at: {:?}", path);

--- a/implementations/rust/ockam/ockam_command/src/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/util.rs
@@ -14,7 +14,7 @@ pub fn embedded_node<A, F, Fut>(f: F, a: A)
 where
     A: Send + Sync + 'static,
     F: FnOnce(ockam::Context, A) -> Fut + Send + Sync + 'static,
-    Fut: core::future::Future<Output = ockam::Result<()>> + Send + 'static,
+    Fut: core::future::Future<Output = anyhow::Result<()>> + Send + 'static,
 {
     let (ctx, mut executor) = ockam::start_node();
     let res = executor.execute(async move {

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -1,0 +1,19 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--dry-run")
+        .arg("cloud")
+        .arg("enroll")
+        .arg("/ip4/127.0.0.1/tcp/8080") // cloud_addr
+        .arg("auth0") // authenticator
+        .arg("--vault")
+        .arg("vt")
+        .arg("--identity")
+        .arg("idt")
+        .arg("--overwrite");
+    cmd.assert().success();
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -1,0 +1,35 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix_args = ["--dry-run", "cloud", "project"];
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args)
+        .arg("create")
+        .arg("space-id")
+        .arg("project-name")
+        .arg("service-a service-b");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("list").arg("space-id");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args)
+        .arg("show")
+        .arg("space-id")
+        .arg("project-id");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args)
+        .arg("delete")
+        .arg("space-id")
+        .arg("project-id");
+    cmd.assert().success();
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -1,0 +1,25 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix_args = ["--dry-run", "cloud", "space"];
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("create").arg("space-name");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("list");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("show").arg("space-id");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(&prefix_args).arg("delete").arg("space-id");
+    cmd.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
- https://github.com/build-trust/codebase/issues/235

## Summary

Adds CLI commands for enroll, spaces and projects.

TODOS:
- [ ] The `enroll` payload is going to change in the coming days, so we'll have to adapt the rust side when it's ready
- [ ] The CBOR schema differs between the rust and elixir codebases. We have to synchronize them
- [ ] This PR duplicates some code from `ockam_api/src/nodes.rs` (exactly or with small modifications). We could refactor a little this crate to remove this duplication 