### PR TITLE
refactor(rust): rename dry_run command argument to test_argument_parser

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -29,10 +29,10 @@ pub struct OckamCommand {
     #[clap(long, short, parse(from_occurrences))]
     pub verbose: u8,
 
-    /// Parse command's arguments without running it.
-    /// Useful for testing purposes.
-    #[clap(display_order = 1100, long)]
-    pub dry_run: bool,
+    // if test_argument_parser is true, command arguments are checked
+    // but the command is not executed.
+    #[clap(global = true, long, hide = true)]
+    pub test_argument_parser: bool,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -86,16 +86,17 @@ pub enum OckamSubcommand {
 pub fn run() {
     let ockam_command = OckamCommand::parse();
 
+    // If test_argument_parser is true, command arguments are checked
+    // but the command is not executed. This is useful to test arguments
+    // without having to execute their logic.
+    if ockam_command.test_argument_parser {
+        return;
+    }
+
     let verbose = ockam_command.verbose;
     setup_logging(verbose);
 
     tracing::debug!("Parsed {:?}", ockam_command);
-
-    // Command arguments are checked but the command is not executed.
-    // This is useful to test arguments without having to execute their logic.
-    if ockam_command.dry_run {
-        return;
-    }
 
     match ockam_command.subcommand {
         OckamSubcommand::Node(command) => NodeCommand::run(command),

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.arg("--dry-run")
+    cmd.arg("--test-argument-parser")
         .arg("cloud")
         .arg("enroll")
         .arg("/ip4/127.0.0.1/tcp/8080") // cloud_addr

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--dry-run", "cloud", "project"];
+    let prefix_args = ["--test-argument-parser", "cloud", "project"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--dry-run", "cloud", "space"];
+    let prefix_args = ["--test-argument-parser", "cloud", "space"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args).arg("create").arg("space-name");


### PR DESCRIPTION
renaming dry_run command argument to test_argument_parser, we may need `--dry-run` for api dry runs later.cc: @adrianbenavides  