### PR TITLE
feat(rust): add support for message flow authorization within ockam nodes

### DIFF
--- a/examples/rust/get_started/examples/06-access-control-over-transport-initiator.rs
+++ b/examples/rust/get_started/examples/06-access-control-over-transport-initiator.rs
@@ -1,0 +1,24 @@
+// This node routes a message, to a worker on a different node, over the tcp transport.
+
+use ockam::access_control::{AllowedTransport, LocalOriginOnly};
+use ockam::{route, Context, Result, TcpTransport, TCP};
+
+#[ockam::node(access_control = "LocalOriginOnly")]
+async fn main(mut ctx: Context) -> Result<()> {
+    // Initialize the TCP Transport.
+    let _tcp = TcpTransport::create(&ctx).await?;
+
+    // A repeater Context is needed because the node Context has LocalOriginOnly AccessControl.
+    let mut repeater_ctx = ctx.new_repeater(AllowedTransport::single(TCP)).await?;
+
+    // Send a message to the "echoer" worker, on a different node, over a tcp transport.
+    let r = route![(TCP, "localhost:4000"), "echoer"];
+    repeater_ctx.send(r, "Hello Ockam!".to_string()).await?;
+
+    // Wait to receive a reply and print it.
+    let reply = repeater_ctx.receive::<String>().await?;
+    println!("App Received: {}", reply); // should print "Hello Ockam!"
+
+    // Stop all workers, stop the node, cleanup and return.
+    ctx.stop().await
+}

--- a/examples/rust/get_started/examples/06-access-control-over-transport-responder.rs
+++ b/examples/rust/get_started/examples/06-access-control-over-transport-responder.rs
@@ -1,0 +1,22 @@
+// This node starts a tcp listener and an echoer worker.
+// It then runs forever waiting for messages.
+
+use hello_ockam::Echoer;
+use ockam::access_control::{AllowedTransport, LocalOriginOnly};
+use ockam::{Context, Result, TcpTransport, TCP};
+
+#[ockam::node(access_control = "LocalOriginOnly")]
+async fn main(ctx: Context) -> Result<()> {
+    // Initialize the TCP Transport.
+    let tcp = TcpTransport::create(&ctx).await?;
+
+    // Create a TCP listener and wait for incoming connections.
+    tcp.listen("127.0.0.1:4000").await?;
+
+    // Create an echoer worker
+    ctx.start_worker_with_access_control("echoer", Echoer, AllowedTransport::single(TCP))
+        .await?;
+
+    // Don't call ctx.stop() here so this node runs forever.
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -58,8 +58,9 @@ pub mod workers;
 pub use ockam_identity as identity;
 
 pub use ockam_core::{
-    errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage, Mailbox, Mailboxes,
-    Message, Processor, ProtocolId, Result, Route, Routed, TransportMessage, Worker,
+    allow, deny, errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage,
+    Mailbox, Mailboxes, Message, Processor, ProtocolId, Result, Route, Routed, TransportMessage,
+    Worker,
 };
 
 /// Access Control

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -58,9 +58,16 @@ pub mod workers;
 pub use ockam_identity as identity;
 
 pub use ockam_core::{
-    errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage, Message, ProtocolId,
-    Result, Route, Routed, TransportMessage, Worker,
+    errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage, Mailbox, Mailboxes,
+    Message, Processor, ProtocolId, Result, Route, Routed, TransportMessage, Worker,
 };
+
+/// Access Control
+pub mod access_control {
+    pub use ockam_core::access_control::*;
+    pub use ockam_identity::access_control::*;
+    pub use ockam_node::access_control::*;
+}
 
 /// Mark an Ockam Worker implementation.
 ///

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -26,7 +26,7 @@ pub use ockam_macros::{node, test};
 // ---
 
 // Export node implementation
-pub use ockam_node::{start_node, Context, DelayedEvent, Executor};
+pub use ockam_node::{start_node, start_node_with_access_control, Context, DelayedEvent, Executor};
 // ---
 
 mod delay;

--- a/implementations/rust/ockam/ockam_command/src/old/cmd/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/cmd/outlet.rs
@@ -1,6 +1,7 @@
 use crate::old::session::responder::SessionResponder;
 use crate::old::{identity, storage, OckamVault};
 use clap::Args;
+use ockam::access_control::{AnyAccessControl, LocalOriginOnly};
 use ockam::{identity::Identity, remote::RemoteForwarder, Context, TcpTransport, TCP};
 use ockam_vault::storage::FileStorage;
 use std::sync::Arc;
@@ -28,7 +29,11 @@ pub async fn run(args: OutletOpts, ctx: Context) -> anyhow::Result<()> {
     let vault = OckamVault::new(Some(Arc::new(vault_storage)));
 
     let exported_ident = identity::load_identity(&ockam_dir)?;
-    let policy = storage::load_trust_policy(&ockam_dir)?;
+    let (policy, access_control) = storage::load_trust_policy(&ockam_dir)?;
+
+    let access_control = Arc::new(AnyAccessControl::new(access_control, LocalOriginOnly));
+
+    // TODO: AccessControl
 
     ctx.start_worker("session_responder", SessionResponder)
         .await?;
@@ -40,7 +45,8 @@ pub async fn run(args: OutletOpts, ctx: Context) -> anyhow::Result<()> {
         .create_secure_channel_listener("secure_channel_listener", policy)
         .await?;
 
-    tcp.create_outlet("outlet", &args.outlet_target).await?;
+    tcp.create_outlet_with_access_control("outlet", &args.outlet_target, access_control)
+        .await?;
 
     let _ = RemoteForwarder::create_static(&ctx, (TCP, &args.cloud_addr), &args.alias).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/old/cmd/outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/cmd/outlet.rs
@@ -31,7 +31,7 @@ pub async fn run(args: OutletOpts, ctx: Context) -> anyhow::Result<()> {
     let exported_ident = identity::load_identity(&ockam_dir)?;
     let (policy, access_control) = storage::load_trust_policy(&ockam_dir)?;
 
-    let access_control = Arc::new(AnyAccessControl::new(access_control, LocalOriginOnly));
+    let access_control = AnyAccessControl::new(access_control, LocalOriginOnly);
 
     // TODO: AccessControl
 

--- a/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
@@ -1,6 +1,9 @@
 use crate::old::session::error::SessionManagementError;
 use crate::old::session::msg::{RequestId, SessionMsg};
+use ockam::access_control::{AccessControl, LocalOriginOnly};
 use ockam::{Address, Context, DelayedEvent, Result, Route, Routed, Worker};
+use ockam_core::{Mailbox, Mailboxes};
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
@@ -24,7 +27,11 @@ pub struct SessionMaintainer<S: SessionManager> {
 }
 
 impl<S: SessionManager> SessionMaintainer<S> {
-    pub async fn start(ctx: &Context, manager: S) -> Result<Address> {
+    pub async fn start(
+        ctx: &Context,
+        manager: S,
+        access_control: Arc<dyn AccessControl>,
+    ) -> Result<Address> {
         let heartbeat_addr = Address::random_local();
         let main_addr = Address::random_local();
 
@@ -42,8 +49,11 @@ impl<S: SessionManager> SessionMaintainer<S> {
             main_addr: main_addr.clone(),
         };
 
-        ctx.start_worker(vec![main_addr.clone(), heartbeat_addr], manager)
-            .await?;
+        let main_mailbox = Mailbox::new(main_addr.clone(), access_control);
+        let heartbeat_mailbox = Mailbox::new(heartbeat_addr, Arc::new(LocalOriginOnly));
+        let mailboxes = Mailboxes::new(main_mailbox, vec![heartbeat_mailbox]);
+
+        ctx.start_worker_impl(mailboxes, manager).await?;
 
         Ok(main_addr)
     }

--- a/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
@@ -53,7 +53,7 @@ impl<S: SessionManager> SessionMaintainer<S> {
         let heartbeat_mailbox = Mailbox::new(heartbeat_addr, Arc::new(LocalOriginOnly));
         let mailboxes = Mailboxes::new(main_mailbox, vec![heartbeat_mailbox]);
 
-        ctx.start_worker_impl(mailboxes, manager).await?;
+        ctx.start_worker_with_mailboxes(mailboxes, manager).await?;
 
         Ok(main_addr)
     }

--- a/implementations/rust/ockam/ockam_command/src/old/storage.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/storage.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
+use ockam::access_control::IdentityIdAccessControl;
 
 use ockam::identity::*;
 
@@ -153,7 +154,7 @@ pub fn write(path: &std::path::Path, data: &[u8]) -> anyhow::Result<()> {
 
 pub fn load_trust_policy(
     ockam_dir: &std::path::Path,
-) -> anyhow::Result<TrustMultiIdentifiersPolicy> {
+) -> anyhow::Result<(TrustMultiIdentifiersPolicy, IdentityIdAccessControl)> {
     let path = ockam_dir.join("trusted");
     let idents = crate::old::identity::read_trusted_idents_from_file(&path)?;
     eprintln!(
@@ -162,5 +163,9 @@ pub fn load_trust_policy(
         path.display(),
     );
     tracing::debug!("Trusting identifiers: {:?}", idents);
-    Ok(TrustMultiIdentifiersPolicy::new(idents))
+
+    let trust_policy = TrustMultiIdentifiersPolicy::new(idents.clone());
+    let access_control = IdentityIdAccessControl::new(idents);
+
+    Ok((trust_policy, access_control))
 }

--- a/implementations/rust/ockam/ockam_core/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control.rs
@@ -30,106 +30,12 @@ pub trait AccessControl: Send + Sync + 'static {
     async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool>;
 }
 
-/// An Access Control type that allows all messages to pass through.
-pub struct AllowAll;
+mod all;
+mod allow_all;
+mod any;
+mod deny_all;
 
-#[async_trait]
-impl AccessControl for AllowAll {
-    async fn is_authorized(&self, _local_msg: &LocalMessage) -> Result<bool> {
-        crate::allow()
-    }
-}
-
-/// An Access Control type that blocks all messages from passing through.
-pub struct DenyAll;
-
-#[async_trait]
-impl AccessControl for DenyAll {
-    async fn is_authorized(&self, _local_msg: &LocalMessage) -> Result<bool> {
-        crate::deny()
-    }
-}
-
-#[cfg(feature = "alloc")]
-#[cfg(test)]
-mod tests {
-    use crate::{
-        errcode::{Kind, Origin},
-        route, LocalMessage, Result, TransportMessage,
-    };
-    use futures_util::future::{Future, FutureExt};
-
-    use super::{AccessControl, AllowAll, DenyAll};
-
-    #[test]
-    fn test_allow_all() {
-        let is_authorized = poll_once(async {
-            let local_message =
-                LocalMessage::new(TransportMessage::v1(route![], route![], vec![]), vec![]);
-            AllowAll.is_authorized(&local_message).await
-        });
-        assert!(
-            is_authorized.is_ok(),
-            "this implementation should never return Err"
-        );
-        let is_authorized = is_authorized.ok();
-        assert_eq!(is_authorized, crate::allow().ok());
-        assert_ne!(is_authorized, crate::deny().ok());
-    }
-
-    #[test]
-    fn test_deny_all() {
-        let is_authorized = poll_once(async {
-            let local_message =
-                LocalMessage::new(TransportMessage::v1(route![], route![], vec![]), vec![]);
-            DenyAll.is_authorized(&local_message).await
-        });
-        assert!(
-            is_authorized.is_ok(),
-            "this implementation should never return Err"
-        );
-        let is_authorized = is_authorized.ok();
-        assert_eq!(is_authorized, crate::deny().ok());
-        assert_ne!(is_authorized, crate::allow().ok());
-    }
-
-    /// TODO document
-    /// TODO move somewhere sensible
-    fn poll_once<'a, F, T>(future: F) -> Result<T>
-    where
-        F: Future<Output = Result<T>> + Send + 'a,
-    {
-        use core::task::{Context, Poll};
-        use core::task::{RawWaker, RawWakerVTable, Waker};
-
-        fn dummy_raw_waker() -> RawWaker {
-            fn no_op(_: *const ()) {}
-            fn clone(_: *const ()) -> RawWaker {
-                dummy_raw_waker()
-            }
-            let vtable = &RawWakerVTable::new(clone, no_op, no_op, no_op);
-            RawWaker::new(core::ptr::null(), vtable)
-        }
-
-        fn dummy_waker() -> Waker {
-            // The RawWaker's vtable only contains safe no-op
-            // functions which do not refer to the data field.
-            #[allow(unsafe_code)]
-            unsafe {
-                Waker::from_raw(dummy_raw_waker())
-            }
-        }
-
-        let waker = dummy_waker();
-        let mut context = Context::from_waker(&waker);
-        let result = future.boxed().poll_unpin(&mut context);
-        assert!(
-            result.is_ready(),
-            "poll_once() only accepts futures that resolve after being polled once"
-        );
-        match result {
-            Poll::Ready(value) => value,
-            Poll::Pending => Err(crate::Error::new_without_cause(Origin::Core, Kind::Unknown)),
-        }
-    }
-}
+pub use all::*;
+pub use allow_all::*;
+pub use any::*;
+pub use deny_all::*;

--- a/implementations/rust/ockam/ockam_core/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control.rs
@@ -1,5 +1,6 @@
 use crate::compat::boxed::Box;
 use crate::{LocalMessage, Result};
+use core::fmt::Debug;
 
 /// Defines the interface for message flow authorization.
 ///
@@ -8,6 +9,7 @@ use crate::{LocalMessage, Result};
 /// ```
 /// # use ockam_core::{Result, async_trait};
 /// # use ockam_core::{AccessControl, LocalMessage};
+/// #[derive(Debug)]
 /// pub struct IdentityIdAccessControl;
 ///
 /// #[async_trait]
@@ -25,7 +27,7 @@ use crate::{LocalMessage, Result};
 ///
 #[async_trait]
 #[allow(clippy::wrong_self_convention)]
-pub trait AccessControl: Send + Sync + 'static {
+pub trait AccessControl: Debug + Send + Sync + 'static {
     /// Return true if the message is allowed to pass, and false if not.
     async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool>;
 }

--- a/implementations/rust/ockam/ockam_core/src/access_control/all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/all.rs
@@ -1,0 +1,26 @@
+use crate::access_control::AccessControl;
+use crate::{async_trait, compat::boxed::Box, LocalMessage, Result};
+
+/// Allows message that are allowed buy both AccessControls
+pub struct AllAccessControl<F: AccessControl, S: AccessControl> {
+    // TODO: Extend for more than 2 policies
+    first: F,
+    second: S,
+}
+
+impl<F: AccessControl, S: AccessControl> AllAccessControl<F, S> {
+    /// Constructor
+    pub fn new(first: F, second: S) -> Self {
+        AllAccessControl { first, second }
+    }
+}
+
+#[async_trait]
+impl<F: AccessControl, S: AccessControl> AccessControl for AllAccessControl<F, S> {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        Ok(self.first.is_authorized(local_msg).await?
+            && self.second.is_authorized(local_msg).await?)
+    }
+}
+
+// TODO: Tests

--- a/implementations/rust/ockam/ockam_core/src/access_control/all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/all.rs
@@ -2,6 +2,7 @@ use crate::access_control::AccessControl;
 use crate::{async_trait, compat::boxed::Box, LocalMessage, Result};
 
 /// Allows message that are allowed buy both AccessControls
+#[derive(Debug)]
 pub struct AllAccessControl<F: AccessControl, S: AccessControl> {
     // TODO: Extend for more than 2 policies
     first: F,

--- a/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
@@ -1,0 +1,38 @@
+use crate::access_control::AccessControl;
+use crate::compat::boxed::Box;
+use crate::{LocalMessage, Result};
+
+/// An Access Control type that allows all messages to pass through.
+pub struct AllowAll;
+
+#[async_trait]
+impl AccessControl for AllowAll {
+    async fn is_authorized(&self, _local_msg: &LocalMessage) -> Result<bool> {
+        crate::allow()
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg(test)]
+mod tests {
+    use crate::compat::future::poll_once;
+    use crate::{route, LocalMessage, TransportMessage};
+
+    use super::{AccessControl, AllowAll};
+
+    #[test]
+    fn test_allow_all() {
+        let is_authorized = poll_once(async {
+            let local_message =
+                LocalMessage::new(TransportMessage::v1(route![], route![], vec![]), vec![]);
+            AllowAll.is_authorized(&local_message).await
+        });
+        assert!(
+            is_authorized.is_ok(),
+            "this implementation should never return Err"
+        );
+        let is_authorized = is_authorized.ok();
+        assert_eq!(is_authorized, crate::allow().ok());
+        assert_ne!(is_authorized, crate::deny().ok());
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
@@ -3,6 +3,7 @@ use crate::compat::boxed::Box;
 use crate::{LocalMessage, Result};
 
 /// An Access Control type that allows all messages to pass through.
+#[derive(Debug)]
 pub struct AllowAll;
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_core/src/access_control/any.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/any.rs
@@ -1,0 +1,26 @@
+use crate::access_control::AccessControl;
+use crate::{async_trait, compat::boxed::Box, LocalMessage, Result};
+
+/// Allows message that are allowed buy either AccessControls
+pub struct AnyAccessControl<F: AccessControl, S: AccessControl> {
+    // TODO: Extend for more than 2 policies
+    first: F,
+    second: S,
+}
+
+impl<F: AccessControl, S: AccessControl> AnyAccessControl<F, S> {
+    /// Constructor
+    pub fn new(first: F, second: S) -> Self {
+        AnyAccessControl { first, second }
+    }
+}
+
+#[async_trait]
+impl<F: AccessControl, S: AccessControl> AccessControl for AnyAccessControl<F, S> {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        Ok(self.first.is_authorized(local_msg).await?
+            || self.second.is_authorized(local_msg).await?)
+    }
+}
+
+// TODO: Tests

--- a/implementations/rust/ockam/ockam_core/src/access_control/any.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/any.rs
@@ -2,6 +2,7 @@ use crate::access_control::AccessControl;
 use crate::{async_trait, compat::boxed::Box, LocalMessage, Result};
 
 /// Allows message that are allowed buy either AccessControls
+#[derive(Debug)]
 pub struct AnyAccessControl<F: AccessControl, S: AccessControl> {
     // TODO: Extend for more than 2 policies
     first: F,

--- a/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
@@ -1,0 +1,38 @@
+use crate::access_control::AccessControl;
+use crate::compat::boxed::Box;
+use crate::{LocalMessage, Result};
+
+/// An Access Control type that blocks all messages from passing through.
+pub struct DenyAll;
+
+#[async_trait]
+impl AccessControl for DenyAll {
+    async fn is_authorized(&self, _local_msg: &LocalMessage) -> Result<bool> {
+        crate::deny()
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[cfg(test)]
+mod tests {
+    use crate::compat::future::poll_once;
+    use crate::{route, LocalMessage, TransportMessage};
+
+    use super::{AccessControl, DenyAll};
+
+    #[test]
+    fn test_deny_all() {
+        let is_authorized = poll_once(async {
+            let local_message =
+                LocalMessage::new(TransportMessage::v1(route![], route![], vec![]), vec![]);
+            DenyAll.is_authorized(&local_message).await
+        });
+        assert!(
+            is_authorized.is_ok(),
+            "this implementation should never return Err"
+        );
+        let is_authorized = is_authorized.ok();
+        assert_eq!(is_authorized, crate::deny().ok());
+        assert_ne!(is_authorized, crate::allow().ok());
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
@@ -3,6 +3,7 @@ use crate::compat::boxed::Box;
 use crate::{LocalMessage, Result};
 
 /// An Access Control type that blocks all messages from passing through.
+#[derive(Debug)]
 pub struct DenyAll;
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -48,7 +48,9 @@ pub use ockam_macros::{AsyncTryClone, Message};
 
 extern crate futures_util;
 
-mod access_control;
+/// Access control
+pub mod access_control;
+
 pub mod compat;
 mod error;
 mod message;

--- a/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
@@ -80,6 +80,10 @@ impl LocalMessage {
     pub fn local_info(&self) -> &[LocalInfo] {
         &self.local_info
     }
+    /// Dissolve
+    pub fn dissolve(self) -> (TransportMessage, Vec<LocalInfo>) {
+        (self.transport_message, self.local_info)
+    }
 }
 
 impl LocalMessage {

--- a/implementations/rust/ockam/ockam_core/src/worker.rs
+++ b/implementations/rust/ockam/ockam_core/src/worker.rs
@@ -29,6 +29,31 @@ pub trait Worker: Send + 'static {
         Ok(())
     }
 
+    /// Try to authorize an incoming message
+    ///
+    /// The authorization flow of an incoming message looks like this:
+    ///
+    /// 1. [`WorkerRelay::recv_message`] requests the next message from
+    ///    its associated `Context`.
+    /// 1. [`Context::receiver_next`] pulls the incoming message from
+    ///    its [`SmallReceiver`] channel.
+    /// 1. [`Context::receiver_next`] then verifies the `AccessControl` rules
+    ///    associated with its [`Mailboxes`] are valid before returning the
+    ///    message to `WorkerRelay`.
+    /// 1. [`WorkerRelay::recv_message`] invokes this `is_authorized` function
+    ///    and only invokes `Worker::handle_message` if `ockam_core::allowed()`
+    ///    is returned.
+    /// 1. If the message is not authorized it will be silently dropped and a
+    ///    warning message output to the worker log.
+    #[allow(clippy::wrong_self_convention)]
+    async fn is_authorized(
+        &mut self,
+        _context: &mut Self::Context,
+        _msg: Routed<Self::Message>,
+    ) -> Result<bool> {
+        crate::allow()
+    }
+
     /// Try to open and handle a typed message.
     async fn handle_message(
         &mut self,

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -1,7 +1,3 @@
-use crate::IdentityIdentifier;
-use ockam_core::{async_trait, compat::boxed::Box};
-use ockam_core::{AccessControl, LocalMessage, Result};
-
 mod encryptor;
 pub(crate) use encryptor::*;
 mod decryptor;
@@ -12,52 +8,18 @@ mod messages;
 pub(crate) use messages::*;
 mod trust_policy;
 pub use trust_policy::*;
+pub mod access_control;
 mod local_info;
 pub use local_info::*;
-
-pub struct IdentityAccessControlBuilder;
-
-impl IdentityAccessControlBuilder {
-    pub fn new_with_id(their_identity_id: IdentityIdentifier) -> IdentityIdAccessControl {
-        IdentityIdAccessControl { their_identity_id }
-    }
-
-    pub fn new_with_any_id() -> IdentityAnyIdAccessControl {
-        IdentityAnyIdAccessControl
-    }
-}
-
-pub struct IdentityAnyIdAccessControl;
-
-#[async_trait]
-impl AccessControl for IdentityAnyIdAccessControl {
-    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
-        Ok(IdentitySecureChannelLocalInfo::find_info(local_msg).is_ok())
-    }
-}
-
-pub struct IdentityIdAccessControl {
-    their_identity_id: IdentityIdentifier,
-}
-
-#[async_trait]
-impl AccessControl for IdentityIdAccessControl {
-    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
-        if let Ok(msg_identity_id) = IdentitySecureChannelLocalInfo::find_info(local_msg) {
-            Ok(msg_identity_id.their_identity_id() == &self.their_identity_id)
-        } else {
-            Ok(false)
-        }
-    }
-}
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::access_control::IdentityAccessControlBuilder;
     use crate::{Identity, IdentityTrait};
     use core::sync::atomic::{AtomicU8, Ordering};
     use ockam_core::compat::sync::Arc;
-    use ockam_core::{route, Any, Route, Routed, Worker};
+    use ockam_core::{route, Any, Mailboxes, Result, Route, Routed, Worker};
     use ockam_node::Context;
     use ockam_vault::Vault;
     use std::time::Duration;
@@ -288,8 +250,11 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
-            .await?;
+        ctx.start_worker_impl(
+            Mailboxes::main("receiver", Arc::new(access_control)),
+            receiver,
+        )
+        .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
             .await?;
@@ -324,8 +289,11 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
-            .await?;
+        ctx.start_worker_impl(
+            Mailboxes::main("receiver", Arc::new(access_control)),
+            receiver,
+        )
+        .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
             .await?;
@@ -357,8 +325,11 @@ mod test {
         let access_control = IdentityAccessControlBuilder::new_with_id(
             "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
-            .await?;
+        ctx.start_worker_impl(
+            Mailboxes::main("receiver", Arc::new(access_control)),
+            receiver,
+        )
+        .await?;
 
         ctx.send(route!["receiver"], "Hello, Bob!".to_string())
             .await?;

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -19,7 +19,7 @@ mod test {
     use crate::{Identity, IdentityTrait};
     use core::sync::atomic::{AtomicU8, Ordering};
     use ockam_core::compat::sync::Arc;
-    use ockam_core::{route, Any, Mailboxes, Result, Route, Routed, Worker};
+    use ockam_core::{route, Any, Result, Route, Routed, Worker};
     use ockam_node::Context;
     use ockam_vault::Vault;
     use std::time::Duration;
@@ -250,11 +250,8 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().await?);
-        ctx.start_worker_impl(
-            Mailboxes::main("receiver", Arc::new(access_control)),
-            receiver,
-        )
-        .await?;
+        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+            .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
             .await?;
@@ -289,11 +286,8 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().await?);
-        ctx.start_worker_impl(
-            Mailboxes::main("receiver", Arc::new(access_control)),
-            receiver,
-        )
-        .await?;
+        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+            .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
             .await?;
@@ -325,11 +319,8 @@ mod test {
         let access_control = IdentityAccessControlBuilder::new_with_id(
             "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
-        ctx.start_worker_impl(
-            Mailboxes::main("receiver", Arc::new(access_control)),
-            receiver,
-        )
-        .await?;
+        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+            .await?;
 
         ctx.send(route!["receiver"], "Hello, Bob!".to_string())
             .await?;

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -250,7 +250,7 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+        ctx.start_worker_with_access_control("receiver", receiver, access_control)
             .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -286,7 +286,7 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+        ctx.start_worker_with_access_control("receiver", receiver, access_control)
             .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -319,7 +319,7 @@ mod test {
         let access_control = IdentityAccessControlBuilder::new_with_id(
             "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
-        ctx.start_worker_with_access_control("receiver", receiver, Arc::new(access_control))
+        ctx.start_worker_with_access_control("receiver", receiver, access_control)
             .await?;
 
         ctx.send(route!["receiver"], "Hello, Bob!".to_string())

--- a/implementations/rust/ockam/ockam_identity/src/channel/access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/access_control.rs
@@ -1,0 +1,2 @@
+mod identity_access_control;
+pub use identity_access_control::*;

--- a/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
@@ -1,0 +1,60 @@
+use crate::{IdentityIdentifier, IdentitySecureChannelLocalInfo};
+use ockam_core::access_control::AccessControl;
+use ockam_core::{async_trait, compat::boxed::Box};
+use ockam_core::{LocalMessage, Result};
+
+pub struct IdentityAccessControlBuilder;
+
+impl IdentityAccessControlBuilder {
+    pub fn new_with_id(their_identity_id: IdentityIdentifier) -> IdentityIdAccessControl {
+        IdentityIdAccessControl::new(vec![their_identity_id])
+    }
+
+    pub fn new_with_ids(
+        identity_ids: impl Into<Vec<IdentityIdentifier>>,
+    ) -> IdentityIdAccessControl {
+        IdentityIdAccessControl::new(identity_ids.into())
+    }
+
+    pub fn new_with_any_id() -> IdentityAnyIdAccessControl {
+        IdentityAnyIdAccessControl
+    }
+}
+
+pub struct IdentityAnyIdAccessControl;
+
+#[async_trait]
+impl AccessControl for IdentityAnyIdAccessControl {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        Ok(IdentitySecureChannelLocalInfo::find_info(local_msg).is_ok())
+    }
+}
+
+#[derive(Clone)]
+pub struct IdentityIdAccessControl {
+    identity_ids: Vec<IdentityIdentifier>,
+}
+
+impl IdentityIdAccessControl {
+    pub fn new(identity_ids: Vec<IdentityIdentifier>) -> Self {
+        Self { identity_ids }
+    }
+    fn contains(&self, their_id: &IdentityIdentifier) -> bool {
+        let mut found = subtle::Choice::from(0);
+        for trusted_id in &self.identity_ids {
+            found |= trusted_id.ct_eq(their_id);
+        }
+        found.into()
+    }
+}
+
+#[async_trait]
+impl AccessControl for IdentityIdAccessControl {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        if let Ok(msg_identity_id) = IdentitySecureChannelLocalInfo::find_info(local_msg) {
+            Ok(self.contains(msg_identity_id.their_identity_id()))
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
@@ -21,6 +21,7 @@ impl IdentityAccessControlBuilder {
     }
 }
 
+#[derive(Debug)]
 pub struct IdentityAnyIdAccessControl;
 
 #[async_trait]
@@ -30,7 +31,7 @@ impl AccessControl for IdentityAnyIdAccessControl {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IdentityIdAccessControl {
     identity_ids: Vec<IdentityIdentifier>,
 }

--- a/implementations/rust/ockam/ockam_macros/src/internals/symbol.rs
+++ b/implementations/rust/ockam/ockam_macros/src/internals/symbol.rs
@@ -7,6 +7,7 @@ use syn::{Ident, Path};
 pub(crate) struct Symbol(&'static str);
 
 // Attributes
+pub(crate) const ACCESS_CONTROL: Symbol = Symbol("access_control");
 pub(crate) const NO_MAIN: Symbol = Symbol("no_main");
 pub(crate) const OCKAM_CRATE: Symbol = Symbol("crate");
 pub(crate) const TIMEOUT_MS: Symbol = Symbol("timeout");

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -64,6 +64,4 @@ tracing-subscriber = { version = "0.3", features = [
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
 ockam_executor = { path = "../ockam_executor", version = "^0.23.0", default-features = false, optional = true }
 serde_bare = { version = "0.5.0", default-features = false }
-
-[dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_node/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_node/src/access_control.rs
@@ -1,0 +1,49 @@
+use crate::ExternalLocalInfo;
+use ockam_core::access_control::AccessControl;
+use ockam_core::{async_trait, compat::boxed::Box, TransportType};
+use ockam_core::{LocalMessage, Result};
+
+/// Allows only messages that originate from this node
+pub struct LocalOriginOnly;
+
+#[async_trait]
+impl AccessControl for LocalOriginOnly {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        Ok(ExternalLocalInfo::find_info(local_msg).is_err())
+    }
+}
+
+/// Allows only messages coming from specified set of transport types. Also allows Local messages
+pub struct AllowedTransport {
+    allowed_transport: Vec<TransportType>,
+}
+
+impl AllowedTransport {
+    /// Constructor
+    pub fn multiple(allowed_transport: Vec<TransportType>) -> Self {
+        Self { allowed_transport }
+    }
+
+    /// Constructor
+    pub fn single(allowed_transport: TransportType) -> Self {
+        Self {
+            allowed_transport: vec![allowed_transport],
+        }
+    }
+}
+
+#[async_trait]
+impl AccessControl for AllowedTransport {
+    async fn is_authorized(&self, local_msg: &LocalMessage) -> Result<bool> {
+        for transport in ExternalLocalInfo::find_all(local_msg)?
+            .into_iter()
+            .map(|x| x.transport_type())
+        {
+            if !self.allowed_transport.contains(&transport) {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_node/src/access_control.rs
@@ -4,6 +4,7 @@ use ockam_core::{async_trait, compat::boxed::Box, TransportType};
 use ockam_core::{LocalMessage, Result};
 
 /// Allows only messages that originate from this node
+#[derive(Debug)]
 pub struct LocalOriginOnly;
 
 #[async_trait]
@@ -14,6 +15,7 @@ impl AccessControl for LocalOriginOnly {
 }
 
 /// Allows only messages coming from specified set of transport types. Also allows Local messages
+#[derive(Debug)]
 pub struct AllowedTransport {
     allowed_transport: Vec<TransportType>,
 }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -62,7 +62,7 @@ pub use executor::*;
 pub use local_info::*;
 pub use messages::*;
 
-pub use node::{start_node, NullWorker};
+pub use node::{start_node, start_node_with_access_control, NullWorker};
 
 #[cfg(feature = "std")]
 use core::future::Future;

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -38,12 +38,16 @@ pub mod channel_types;
 #[cfg(feature = "metrics")]
 mod metrics;
 
+/// Access Control
+pub mod access_control;
+
 mod async_drop;
 mod cancel;
 mod context;
 mod delayed;
 mod error;
 mod executor;
+mod local_info;
 mod messages;
 mod node;
 mod parser;
@@ -55,6 +59,7 @@ pub use context::*;
 pub use delayed::*;
 pub use error::*;
 pub use executor::*;
+pub use local_info::*;
 pub use messages::*;
 
 pub use node::{start_node, NullWorker};

--- a/implementations/rust/ockam/ockam_node/src/local_info.rs
+++ b/implementations/rust/ockam/ockam_node/src/local_info.rs
@@ -1,0 +1,74 @@
+use ockam_core::{
+    errcode::{Kind, Origin},
+    Decodable, Encodable, Error, LocalInfo, LocalMessage, Result, TransportType,
+};
+use serde::{Deserialize, Serialize};
+
+/// Node LocalInfo unique Identifier
+pub const EXTERNAL_IDENTIFIER: &str = "EXTERNAL_IDENTIFIER";
+
+/// Used for LocalMessage that originates from outside the node (e.g. received from transport)
+#[derive(Serialize, Deserialize)]
+pub struct ExternalLocalInfo {
+    transport_type: TransportType,
+}
+
+impl ExternalLocalInfo {
+    /// Convert from LocalInfo
+    pub fn from_local_info(value: &LocalInfo) -> Result<Self> {
+        if value.type_identifier() != EXTERNAL_IDENTIFIER {
+            return Err(Error::new_without_cause(Origin::Node, Kind::Invalid));
+        }
+
+        if let Ok(info) = ExternalLocalInfo::decode(value.data()) {
+            return Ok(info);
+        }
+
+        Err(Error::new_without_cause(Origin::Node, Kind::Invalid))
+    }
+
+    /// Convert to LocalInfo
+    pub fn to_local_info(&self) -> Result<LocalInfo> {
+        Ok(LocalInfo::new(EXTERNAL_IDENTIFIER.into(), self.encode()?))
+    }
+
+    /// Find first such instance in LocalMessage
+    pub fn find_info(local_msg: &LocalMessage) -> Result<Self> {
+        if let Some(local_info) = local_msg
+            .local_info()
+            .iter()
+            .find(|x| x.type_identifier() == EXTERNAL_IDENTIFIER)
+        {
+            Self::from_local_info(local_info)
+        } else {
+            Err(Error::new_without_cause(Origin::Node, Kind::Invalid))
+        }
+    }
+
+    /// Find all such instances in LocalMessage
+    pub fn find_all(local_msg: &LocalMessage) -> Result<Vec<Self>> {
+        Ok(local_msg
+            .local_info()
+            .iter()
+            .filter_map(|x| {
+                if x.type_identifier() == EXTERNAL_IDENTIFIER {
+                    Self::from_local_info(x).ok()
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+}
+
+impl ExternalLocalInfo {
+    /// Constructor
+    pub fn new(transport_type: TransportType) -> Self {
+        Self { transport_type }
+    }
+
+    /// Transport type
+    pub fn transport_type(&self) -> TransportType {
+        self.transport_type
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,5 +1,7 @@
+use crate::access_control::LocalOriginOnly;
 use crate::{Context, Executor};
-use ockam_core::{Address, AllowAll};
+use ockam_core::compat::sync::Arc;
+use ockam_core::{Address, Mailbox, Mailboxes};
 
 /// A minimal worker implementation that does nothing
 pub struct NullWorker;
@@ -20,7 +22,12 @@ pub fn start_node() -> (Context, Executor) {
 
     // The root application worker needs a mailbox and relay to accept
     // messages from workers, and to buffer incoming transcoded data.
-    let (ctx, sender, _) = Context::new(exe.runtime(), exe.sender(), addr.into(), None, AllowAll);
+    let (ctx, sender, _) = Context::new(
+        exe.runtime(),
+        exe.sender(),
+        Mailboxes::new(Mailbox::new(addr, Arc::new(LocalOriginOnly)), vec![]),
+        None,
+    );
 
     // Register this mailbox handle with the executor
     exe.initialize_system("app", sender);

--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -1,10 +1,9 @@
 use crate::channel_types::SmallReceiver;
-use crate::relay::{CtrlSignal, RelayMessage, RelayPayload};
+use crate::relay::CtrlSignal;
 use crate::tokio::runtime::Runtime;
 use crate::{parser, Context};
 use core::marker::PhantomData;
-use ockam_core::compat::vec::Vec;
-use ockam_core::{Address, LocalMessage, Message, Result, Route, Routed, TransportMessage, Worker};
+use ockam_core::{LocalMessage, Message, Result, Routed, Worker};
 
 /// Worker relay machinery
 ///
@@ -36,29 +35,9 @@ where
 
     /// Convenience function to handle an incoming direct message
     #[inline]
-    fn handle_direct(msg: &LocalMessage, msg_addr: Address) -> Result<(M, Route)> {
-        let TransportMessage {
-            ref payload,
-            ref return_route,
-            ..
-        } = msg.transport();
-
-        parser::message::<M>(payload)
-            .map_err(|e| {
-                error!("Failed to decode message payload for worker {}", msg_addr);
-                e
-            })
-            .map(|m| (m, return_route.clone()))
-    }
-
-    #[inline]
-    fn handle_pre_router(msg: &[u8], msg_addr: Address) -> Result<M> {
-        M::decode(msg).map_err(|e| {
-            error!(
-                "Failed to decode wrapped router message for worker {}.  \
-             Is your router accepting the correct message type? (ockam_core::RouterMessage)",
-                msg_addr
-            );
+    fn handle_direct(msg: &LocalMessage) -> Result<M> {
+        parser::message::<M>(msg.transport().payload.as_slice()).map_err(|e| {
+            error!("Failed to decode message payload for worker" /* FIXME */);
             e
         })
     }
@@ -68,7 +47,7 @@ where
     /// Report errors as they occur, and signal whether the loop should
     /// continue running or not
     async fn recv_message(&mut self) -> Result<bool> {
-        let RelayMessage { addr, data, .. } = match self.ctx.mailbox_next().await? {
+        let relay_msg = match self.ctx.receiver_next().await? {
             Some(msg) => msg,
             None => {
                 trace!("No more messages for worker {}", self.ctx.address());
@@ -80,28 +59,11 @@ where
         // wrap state.  Messages addressed to a router will be of
         // type `RouterMessage`, while generic userspace workers
         // can provide any type they want.
-        let (msg, _, local_msg) = (|data| -> Result<(M, Route, LocalMessage)> {
-            Ok(match data {
-                RelayPayload::Direct(local_msg) => Self::handle_direct(&local_msg, addr.clone())
-                    .map(|(msg, r)| (msg, r, local_msg))?,
-                RelayPayload::PreRouter(enc_msg, route) => {
-                    Self::handle_pre_router(&enc_msg, addr.clone()).map(|m| {
-                        (
-                            m,
-                            route.clone(),
-                            LocalMessage::new(
-                                TransportMessage::v1(Route::new(), route, enc_msg),
-                                Vec::new(),
-                            ),
-                        )
-                    })?
-                }
-            })
-        })(data)?;
+        let msg = Self::handle_direct(&relay_msg.local_msg)?;
 
         // Wrap the user message in a `Routed` to provide return
         // route information via a composition side-channel
-        let routed = Routed::new(msg, addr.clone(), local_msg);
+        let routed = Routed::new(msg, relay_msg.addr.clone(), relay_msg.local_msg);
 
         // Call the worker handle function - pass errors up
         self.worker.handle_message(&mut self.ctx, routed).await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -48,7 +48,8 @@ impl Processor for TcpInletListenProcessor {
 
     async fn process(&mut self, ctx: &mut Self::Context) -> Result<bool> {
         let (stream, peer) = self.inner.accept().await.map_err(TransportError::from)?;
-        TcpPortalWorker::new_inlet(ctx, stream, peer, self.outlet_listener_route.clone()).await?;
+        TcpPortalWorker::start_new_inlet(ctx, stream, peer, self.outlet_listener_route.clone())
+            .await?;
 
         Ok(true)
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
@@ -1,6 +1,5 @@
-use crate::{PortalMessage, TcpRouterHandle};
-use ockam_core::{async_trait, AsyncTryClone};
-use ockam_core::{Address, Result, Routed, Worker};
+use crate::{PortalMessage, TcpPortalWorker, TcpRouterHandle};
+use ockam_core::{async_trait, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 use tracing::debug;
@@ -11,25 +10,13 @@ use tracing::debug;
 /// after a call is made to
 /// [`TcpTransport::create_outlet`](crate::TcpTransport::create_outlet).
 pub(crate) struct TcpOutletListenWorker {
-    router_handle: TcpRouterHandle,
     peer: String,
 }
 
 impl TcpOutletListenWorker {
-    /// Start a new `TcpOutletListenWorker`
-    pub(crate) async fn start(
-        router_handle: &TcpRouterHandle,
-        address: Address,
-        peer: String,
-    ) -> Result<()> {
-        let worker = Self {
-            router_handle: router_handle.async_try_clone().await?,
-            peer,
-        };
-
-        router_handle.ctx().start_worker(address, worker).await?;
-
-        Ok(())
+    /// Create a new `TcpOutletListenWorker`
+    pub(crate) fn new(peer: String) -> Self {
+        Self { peer }
     }
 }
 
@@ -40,7 +27,7 @@ impl Worker for TcpOutletListenWorker {
 
     async fn handle_message(
         &mut self,
-        _ctx: &mut Self::Context,
+        ctx: &mut Self::Context,
         msg: Routed<Self::Message>,
     ) -> Result<()> {
         let return_route = msg.return_route();
@@ -50,10 +37,10 @@ impl Worker for TcpOutletListenWorker {
             return Err(TransportError::Protocol.into());
         }
 
-        let address = self
-            .router_handle
-            .connect_outlet(self.peer.clone(), return_route.clone())
-            .await?;
+        let (peer_addr, _) = TcpRouterHandle::resolve_peer(self.peer.clone())?;
+
+        let address =
+            TcpPortalWorker::start_new_outlet(ctx, peer_addr, return_route.clone()).await?;
 
         debug!("Created Tcp Outlet at {}", &address);
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
@@ -51,27 +51,25 @@ pub(crate) struct TcpPortalWorker {
 }
 
 impl TcpPortalWorker {
-    /// Create a new portal inlet
-    pub(crate) async fn new_inlet(
+    /// Start a new `TcpPortalWorker` of type [`TypeName::Inlet`]
+    pub(crate) async fn start_new_inlet(
         ctx: &Context,
         stream: TcpStream,
         peer: SocketAddr,
         ping_route: Route,
-    ) -> Result<()> {
-        let _ = Self::start(
+    ) -> Result<Address> {
+        Self::start(
             ctx,
             peer,
             State::SendPing { ping_route },
             Some(stream),
             TypeName::Inlet,
         )
-        .await?;
-
-        Ok(())
+        .await
     }
 
-    /// Create a new portal outlet
-    pub(crate) async fn new_outlet(
+    /// Start a new `TcpPortalWorker` of type [`TypeName::Outlet`]
+    pub(crate) async fn start_new_outlet(
         ctx: &Context,
         peer: SocketAddr,
         pong_route: Route,
@@ -86,7 +84,7 @@ impl TcpPortalWorker {
         .await
     }
 
-    /// Start a `TcpPortalWorker`
+    /// Start a new `TcpPortalWorker`
     async fn start(
         ctx: &Context,
         peer: SocketAddr,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    parse_socket_addr, TcpInletListenProcessor, TcpListenProcessor, TcpPortalWorker,
-    TcpRouterRequest, TcpRouterResponse, WorkerPair, TCP,
+    parse_socket_addr, TcpInletListenProcessor, TcpListenProcessor, TcpRouterRequest,
+    TcpRouterResponse, WorkerPair, TCP,
 };
 use ockam_core::compat::net::{SocketAddr, ToSocketAddrs};
 use ockam_core::{async_trait, compat::boxed::Box};
@@ -170,19 +170,6 @@ impl TcpRouterHandle {
     ) -> Result<(Address, SocketAddr)> {
         let socket_addr = addr.into();
         TcpInletListenProcessor::start(&self.ctx, outlet_listener_route.into(), socket_addr).await
-    }
-
-    /// Establish an outgoing TCP connection for Portal Outlet
-    pub async fn connect_outlet(
-        &self,
-        peer: impl Into<String>,
-        pong_route: Route,
-    ) -> Result<Address> {
-        let (peer_addr, _) = Self::resolve_peer(peer)?;
-
-        let address = TcpPortalWorker::new_outlet(&self.ctx, peer_addr, pong_route).await?;
-
-        Ok(address)
     }
 
     /// Stop the inlet's [`TcpInletListenProcessor`]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/tcp_router.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/tcp_router.rs
@@ -225,8 +225,7 @@ impl Worker for TcpRouter {
         let msg_addr = msg.msg_addr();
 
         if msg_addr == self.main_addr {
-            let msg = LocalMessage::decode(msg.payload())?;
-            self.handle_route(ctx, msg).await?;
+            self.handle_route(ctx, msg.into_local_message()).await?;
         } else if msg_addr == self.api_addr {
             let msg = TcpRouterRequest::decode(msg.payload())?;
             match msg {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,6 +1,6 @@
 use ockam_core::access_control::AccessControl;
 use ockam_core::compat::{boxed::Box, net::SocketAddr, sync::Arc};
-use ockam_core::{Address, AsyncTryClone, Mailboxes, Result, Route};
+use ockam_core::{Address, AsyncTryClone, Result, Route};
 use ockam_node::Context;
 
 use crate::{parse_socket_addr, TcpOutletListenWorker, TcpRouter, TcpRouterHandle};
@@ -201,12 +201,12 @@ impl TcpTransport {
     ) -> Result<()> {
         let worker = TcpOutletListenWorker::new(peer.into());
 
-        let mailboxes = Mailboxes::from_address_set(address.into().into(), access_control);
+        // TODO all mailboxes get the same access_control?
+        //let mailboxes = Mailboxes::from_address_set(address.into().into(), access_control);
 
         self.router_handle
             .ctx()
-            // TODO start_worker_impl should not need to be public
-            .start_worker_impl(mailboxes, worker)
+            .start_worker_with_access_control(address.into(), worker, access_control)
             .await?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,5 +1,5 @@
 use ockam_core::access_control::AccessControl;
-use ockam_core::compat::{boxed::Box, net::SocketAddr, sync::Arc};
+use ockam_core::compat::{boxed::Box, net::SocketAddr};
 use ockam_core::{Address, AsyncTryClone, Result, Route};
 use ockam_node::Context;
 
@@ -193,12 +193,15 @@ impl TcpTransport {
     }
 
     /// FIXME
-    pub async fn create_outlet_with_access_control(
+    pub async fn create_outlet_with_access_control<AC>(
         &self,
         address: impl Into<Address>,
         peer: impl Into<String>,
-        access_control: Arc<dyn AccessControl>,
-    ) -> Result<()> {
+        access_control: AC,
+    ) -> Result<()>
+    where
+        AC: AccessControl,
+    {
         let worker = TcpOutletListenWorker::new(peer.into());
 
         // TODO all mailboxes get the same access_control?

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,5 +1,6 @@
-use ockam_core::compat::{boxed::Box, net::SocketAddr};
-use ockam_core::{Address, AsyncTryClone, Result, Route};
+use ockam_core::access_control::AccessControl;
+use ockam_core::compat::{boxed::Box, net::SocketAddr, sync::Arc};
+use ockam_core::{Address, AsyncTryClone, Mailboxes, Result, Route};
 use ockam_node::Context;
 
 use crate::{parse_socket_addr, TcpOutletListenWorker, TcpRouter, TcpRouterHandle};
@@ -182,7 +183,31 @@ impl TcpTransport {
         address: impl Into<Address>,
         peer: impl Into<String>,
     ) -> Result<()> {
-        TcpOutletListenWorker::start(&self.router_handle, address.into(), peer.into()).await?;
+        let worker = TcpOutletListenWorker::new(peer.into());
+        self.router_handle
+            .ctx()
+            .start_worker(address.into(), worker)
+            .await?;
+
+        Ok(())
+    }
+
+    /// FIXME
+    pub async fn create_outlet_with_access_control(
+        &self,
+        address: impl Into<Address>,
+        peer: impl Into<String>,
+        access_control: Arc<dyn AccessControl>,
+    ) -> Result<()> {
+        let worker = TcpOutletListenWorker::new(peer.into());
+
+        let mailboxes = Mailboxes::from_address_set(address.into().into(), access_control);
+
+        self.router_handle
+            .ctx()
+            // TODO start_worker_impl should not need to be public
+            .start_worker_impl(mailboxes, worker)
+            .await?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
@@ -1,7 +1,7 @@
-use crate::TcpSendWorkerMsg;
+use crate::{TcpSendWorkerMsg, TCP};
 use ockam_core::async_trait;
 use ockam_core::{Address, Decodable, LocalMessage, Processor, Result, TransportMessage};
-use ockam_node::Context;
+use ockam_node::{Context, ExternalLocalInfo};
 use ockam_transport_core::TransportError;
 use tokio::{io::AsyncReadExt, net::tcp::OwnedReadHalf};
 use tracing::{error, info, trace};
@@ -102,8 +102,12 @@ impl Processor for TcpRecvProcessor {
         trace!("Message onward route: {}", msg.onward_route);
         trace!("Message return route: {}", msg.return_route);
 
+        // Mark that message originates from some other node
+        let local_info = ExternalLocalInfo::new(TCP).to_local_info()?;
+
         // Forward the message to the next hop in the route
-        ctx.forward(LocalMessage::new(msg, Vec::new())).await?;
+        ctx.forward(LocalMessage::new(msg, vec![local_info]))
+            .await?;
 
         Ok(true)
     }

--- a/implementations/rust/ockam/ockam_transport_udp/src/router/udp_router.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/router/udp_router.rs
@@ -165,8 +165,7 @@ impl Worker for UdpRouter {
         let msg_addr = msg.msg_addr();
 
         if msg_addr == self.main_addr {
-            let msg = LocalMessage::decode(msg.payload())?;
-            self.handle_route(ctx, msg).await?;
+            self.handle_route(ctx, msg.into_local_message()).await?;
         } else if msg_addr == self.api_addr {
             let msg = UdpRouterMessage::decode(msg.payload())?;
             match msg {

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
@@ -95,8 +95,7 @@ impl Worker for WebSocketRouter {
         let msg_addr = msg.msg_addr();
 
         if msg_addr == self.main_addr {
-            let msg = LocalMessage::decode(msg.payload())?;
-            self.handle_route(ctx, msg).await?;
+            self.handle_route(ctx, msg.into_local_message()).await?;
         } else if msg_addr == self.api_addr {
             let msg = WebSocketRouterMessage::decode(msg.payload())?;
             match msg {


### PR DESCRIPTION
## Summary

This PR provides initial support for message flow authorization within
Ockam nodes.

All incoming messages for an Ockam `Address` are now subject to an
authorization check implemented via the `AccessControl` trait before
it will be accepted for further processing.

Major new api's introduced are:

* `Context::start_worker_with_access_control(Address, Worker, AccessControl)`
* `Context::new_repeater(AccessControl) -> RepeaterContext`
* `Worker::is_authorized(&mut Self, Self::Context, Routed<Self::Message>)`
* A new `access_control` attribute for the `#[ockam::node]` macro

## Concepts

### `DetachedContext`, `RepeaterContext`

A `Context` with no associated worker or processor that can still send and receive messages.

A `DetachedContext` inherits the access control of the parent `Context` which created it.
A `RepeaterContext` requires that you specify access control for it on creation.

### `Mailbox`

A `Mailbox` is a single `Address` combined with `AccessControl`.

Previously a `Context` had a single `AccessControl` which was shared with all `Address`es.

### `Mailboxes`

Replaces `Context::address` with `Context::mailboxes`

A collection of `Mailbox`es (`Address` + `AccessControl`)


## Breaking changes

`Worker::handle_message` implementations that may have used a pattern like:

    let msg = LocalMessage::decode(msg.payload())?;
    self.handle_route(ctx, msg).await?;

Should now use:

    self.handle_route(ctx, msg.into_local_message()).await?;


## A word about defaults

At present message flow authorization defaults to an `AllowAll` policy.

This is set by:

* The `#[ockam::node]` macro creates the node's app `Context` with an
  `AllowAll` policy when one has not been specified.
* The `ockam::node::start_node()` function starts new nodes with an
  `AllowAll` policy. You can use
  `ockam::node::start_node_with_access_control()` to specify an
  alternate policy.

It is expected that this will migrate to a default of
`LocalOriginOnly` as we update the rest of the codebase to use message
flow authorization.

Another worthy goal may be to think about ways where we could set it
to `DenyAll` by default without complectifying the ockam api learning
process.


## The new `access_control` attribute for the `#[ockam::node]` macro

By default all nodes are started with an access control of `AllowAll`
for the `"app"` address.

While we could have used the more restrictive `LocalOriginOnly` by
default this would make our "getting started" examples more complex.

An example of overriding the default "app" access control is as
follows:

    use hello_ockam::Echoer;
    use ockam::access_control::{AllowedTransport, LocalOriginOnly};
    use ockam::{Context, Result, TcpTransport, TCP};
    use std::sync::Arc;

    #[ockam::node(access_control = "LocalOriginOnly")]
    async fn main(ctx: Context) -> Result<()> {
        // Initialize the TCP Transport.
        let tcp = TcpTransport::create(&ctx).await?;

        // Create a TCP listener and wait for incoming connections.
        tcp.listen("127.0.0.1:4000").await?;

        // Create an echoer worker
        ctx.start_worker_with_access_control(
            "echoer",
            Echoer,
            Arc::new(AllowedTransport::single(TCP))
        )
        .await?;

        // Don't call ctx.stop() here so this node runs forever.
        Ok(())
    }


## Custom worker authorization handling with `Worker::is_authorized`

The worker trait has been extended with an optional `is_authorized` method:

    async fn is_authorized(
        &mut self,
        _context: &mut Self::Context,
        _msg: Routed<Self::Message>,
    ) -> Result<bool> {
        crate::allow()
    }

This method will be invoked after any authorization performed on the
`Address` of the worker and before the message is forwarded to the
worker's `handle_message()` method is called.

The rationale for adding this trait instead of simply performing any
extended authorization within the `Worker::handle_message()` call is
twofold:

1. At some future point we may want to implement functionality to
   optionally disable authorization checks for trouble-shooting
   purposes.
1. Explicit often works out better in the long run than implicit.