### PR TITLE
feat(rust): add cowbytes and cowstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,18 +1747,18 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minicbor"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08de72a57f15d959ab3a3b73fc94572eb954bfcfeb3809cf83cc1bd7d0aa774b"
+checksum = "a5e575910763b21a0db7df5e142907fe944bff84d1dfc78e2ba92e7f3bdfd36b"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66dd6ff7dbe1a10938f8b72c6d0dd81c28fc68283aa79d7ba97c99a96a8e5823"
+checksum = "d0a86c5f04def8fb7735ae918bb589af82f985526f4c62e0249544b668b2f456"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -14,7 +14,7 @@ std = ["minicbor/std", "ockam_core/std", "ockam_node/std", "tinyvec/std", "traci
 tag = []
 
 [dependencies]
-minicbor = { version = "0.16.0", features = ["alloc", "derive"] }
+minicbor = { version = "0.17.1", features = ["alloc", "derive"] }
 open = "2"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod error;
 pub mod nodes;
 
 use core::fmt;
+use core::ops::{Deref, DerefMut};
 use minicbor::decode::{self, Decoder};
 use minicbor::encode::{self, Encoder, Write};
 use minicbor::{Decode, Encode};
@@ -467,5 +468,107 @@ impl<T: Encode<()>> ResponseBuilder<T> {
             e.encode(b)?;
         }
         Ok(())
+    }
+}
+
+/// A newtype around `Cow<'_, str>` that borrows from input.
+///
+/// Contrary to `Cow<_, str>` the `Decode` impl for this type will always borrow
+/// from input so using it in types like `Option`, `Vec<_>` etc will not produce
+/// owned element values.
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cbor(transparent)]
+pub struct CowStr<'a>(#[b(0)] pub Cow<'a, str>);
+
+impl CowStr<'_> {
+    pub fn is_borrowed(&self) -> bool {
+        matches!(self.0, Cow::Borrowed(_))
+    }
+
+    pub fn to_owned<'r>(&self) -> CowStr<'r> {
+        CowStr(Cow::Owned(self.0.to_string()))
+    }
+}
+
+impl<'a> From<&'a str> for CowStr<'a> {
+    fn from(s: &'a str) -> Self {
+        CowStr(Cow::Borrowed(s))
+    }
+}
+
+impl From<String> for CowStr<'_> {
+    fn from(s: String) -> Self {
+        CowStr(Cow::Owned(s))
+    }
+}
+
+impl<'a> From<CowStr<'a>> for Cow<'a, str> {
+    fn from(c: CowStr<'a>) -> Self {
+        c.0
+    }
+}
+
+impl<'a> Deref for CowStr<'a> {
+    type Target = Cow<'a, str>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for CowStr<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// A newtype around `Cow<'_, [u8]>` that borrows from input.
+///
+/// Contrary to `Cow<_, [u8]>` the `Decode` impl for this type will always borrow
+/// from input so using it in types like `Option`, `Vec<_>` etc will not produce
+/// owned element values.
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cbor(transparent)]
+pub struct CowBytes<'a>(#[cbor(b(0), with = "minicbor::bytes")] pub Cow<'a, [u8]>);
+
+impl CowBytes<'_> {
+    pub fn is_borrowed(&self) -> bool {
+        matches!(self.0, Cow::Borrowed(_))
+    }
+
+    pub fn to_owned<'r>(&self) -> CowBytes<'r> {
+        CowBytes(Cow::Owned(self.0.to_vec()))
+    }
+}
+
+impl<'a> From<&'a [u8]> for CowBytes<'a> {
+    fn from(s: &'a [u8]) -> Self {
+        CowBytes(Cow::Borrowed(s))
+    }
+}
+
+impl From<Vec<u8>> for CowBytes<'_> {
+    fn from(s: Vec<u8>) -> Self {
+        CowBytes(Cow::Owned(s))
+    }
+}
+
+impl<'a> From<CowBytes<'a>> for Cow<'a, [u8]> {
+    fn from(c: CowBytes<'a>) -> Self {
+        c.0
+    }
+}
+
+impl<'a> Deref for CowBytes<'a> {
+    type Target = Cow<'a, [u8]>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for CowBytes<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -65,7 +65,7 @@ hashbrown = { version = "0.11", default-features = false, features = [
 ] }
 heapless = { version = "0.7.1", optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
-minicbor = "0.16.0"
+minicbor = "0.17.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_bare = { version = "0.5.0", default-features = false }
 rand = { version = "0.8", default-features = false }


### PR DESCRIPTION
The `Cow<'_, T>` impl of `Decode` produces owned values. Types that derive `Decode` can declare fields as borrowing from input. This activates some special handling of `Cow`s, i.e. if they hold string or byte slices, the derived code will produce borrowed `Cow`s. This special handling does not kick in for types that do not derive `Decode`, e.g. `Vec`, `Option`, `BTreeMap` etc. `Cow`s as element types of such types will therefore not borrow from input data. To enable borrowing `Cow`s for such types, this PR adds two newtypes for `Cow<'_, str>` and `Cow<'_, [u8]>` that will always borrow from input, hence they are intended for use with `Vec`tors, `Option`s etc for cases where the usual `Cow` semantics are desired.