### PR TITLE
fix(elixir) encode req-resp protocol using bare encoding

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
@@ -24,14 +24,19 @@ defmodule Ockam.API.Request do
 
     base = MiniCBOR.encode(request, @schema)
 
-    case has_body do
-      true -> base <> body
-      false -> base
-    end
+    payload =
+      case has_body do
+        true -> base <> body
+        false -> base
+      end
+
+    :bare.encode(payload, :data)
   end
 
   def decode(data) when is_binary(data) do
-    case MiniCBOR.decode(data, @schema) do
+    {:ok, payload, ""} = :bare.decode(data, :data)
+
+    case MiniCBOR.decode(payload, @schema) do
       {:ok, decoded, body} ->
         has_body = Map.get(decoded, :has_body)
         body_present = byte_size(body) > 0

--- a/implementations/elixir/ockam/ockam/lib/ockam/api/response.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/response.ex
@@ -25,14 +25,19 @@ defmodule Ockam.API.Response do
 
     base = MiniCBOR.encode(response, @schema)
 
-    case has_body do
-      true -> base <> body
-      false -> base
-    end
+    payload =
+      case has_body do
+        true -> base <> body
+        false -> base
+      end
+
+    :bare.encode(payload, :data)
   end
 
   def decode(data) when is_binary(data) do
-    case MiniCBOR.decode(data, @schema) do
+    {:ok, payload, ""} = :bare.decode(data, :data)
+
+    case MiniCBOR.decode(payload, @schema) do
       {:ok, decoded, body} ->
         has_body = Map.get(decoded, :has_body)
         body_present = byte_size(body) > 0


### PR DESCRIPTION
## Current Behaviour
Rust side is expecting the message' body to be encoded using bare.  Elixir side was placing the raw CBOR encoded payload.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Change elixir side to act as rust, and basically do bare(cbor(req/resp struct)).

This likely would change in the future, but let us be interoperable between rust and elixir client meantime.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
