### PR TITLE
mrinal/spacekookie/command improvements fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2081,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "clap 3.1.18",
+ "directories",
  "dirs",
  "hex",
  "ockam",
@@ -2082,6 +2092,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-error",

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -35,6 +35,7 @@ mod forwarder;
 mod lease;
 mod metadata;
 mod monotonic;
+mod nodeman;
 mod system;
 mod unique;
 

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -43,6 +43,7 @@ pub use error::OckamError;
 pub use forwarder::ForwardingService;
 pub use lease::Lease;
 pub use metadata::OckamMessage;
+pub use nodeman::{NodeMan, NodeManMessage, NodeManReply};
 pub use system::{SystemBuilder, SystemHandler, WorkerSystem};
 pub use unique::unique_with_prefix;
 

--- a/implementations/rust/ockam/ockam/src/nodeman.rs
+++ b/implementations/rust/ockam/ockam/src/nodeman.rs
@@ -1,0 +1,67 @@
+//! Node Manager (Node Man, the superhero that we deserve)
+
+use crate::{Context, Message, Result, Routed, Worker};
+use serde::{Deserialize, Serialize};
+
+/// Messaging commands sent to node manager
+#[derive(Serialize, Deserialize, Message)]
+pub enum NodeManMessage {
+    /// Query this node for its status
+    Status,
+}
+
+/// Reply messages from node manager
+#[derive(Serialize, Deserialize, Message)]
+pub enum NodeManReply {
+    /// Reply with node status information
+    Status {
+        /// Contains the node
+        node_name: String,
+        /// Current runtime status
+        status: String,
+        /// Number of registered workers
+        workers: u32,
+    },
+}
+
+/// Node manager provides a messaging API to interact with the current node
+pub struct NodeMan {
+    node_name: String,
+}
+
+impl NodeMan {
+    /// Create a new NodeMan with the node name from the ockam CLI
+    pub fn new(node_name: String) -> Self {
+        Self { node_name }
+    }
+}
+
+#[crate::worker]
+impl Worker for NodeMan {
+    type Message = NodeManMessage;
+    type Context = Context;
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<NodeManMessage>,
+    ) -> Result<()> {
+        let return_route = msg.return_route();
+
+        match msg.body() {
+            NodeManMessage::Status => {
+                ctx.send(
+                    return_route,
+                    NodeManReply::Status {
+                        node_name: self.node_name.clone(),
+                        status: "[✓]".into(), // TODO: figure out if the current node is "healthy"
+                        workers: ctx.list_workers().await?.len() as u32,
+                    },
+                )
+                .await?
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -30,6 +30,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
+thiserror = "1"
 dirs = "4.0.0"
 clap = { version = "3", features = ["derive", "cargo"] }
 tracing = { version = "0.1.31", features = ["attributes"] }
@@ -42,6 +43,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 async-recursion = { version = "1.0.0" }
+directories = "4"
 
 ockam = { path = "../ockam", version = "^0.59.0", features = ["software_vault"] }
 ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }

--- a/implementations/rust/ockam/ockam_command/src/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/config.rs
@@ -1,0 +1,107 @@
+//! Handle local node configuration
+
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fs::{create_dir_all, File, OpenOptions},
+    io::{Read, Write},
+    path::PathBuf,
+};
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct OckamConfig {
+    nodes: BTreeMap<String, NodeConfig>,
+}
+
+/// A set of errors that occur when trying to update the configuration
+///
+/// Importantly these errors do not cover the I/O, creation, or
+/// saving, only "user error".  While these errors are fatal, they
+/// MUST NOT crash the CLI but instead terminate gracefully with a
+/// message.
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigError {
+    #[error("node with name {} already exists", 0)]
+    NodeExists(String),
+    #[error("node with name {} does not exist", 0)]
+    NodeNotFound(String),
+}
+
+fn get_config_path() -> PathBuf {
+    let proj = ProjectDirs::from("io", "ockam", "ockam-cli").expect(
+        "failed to determine configuration storage location.
+Verify that your XDG_CONFIG_HOME and XDG_DATA_HOME environment variables are correctly set.
+Otherwise your OS or OS configuration may not be supported!",
+    );
+
+    let cfg_home = proj.config_dir();
+    let _ = create_dir_all(&cfg_home);
+
+    cfg_home.join("config.json")
+}
+
+impl OckamConfig {
+    /// Attempt to load an ockam config.  If none exists, one is
+    /// created and then returned.
+    pub fn load() -> Self {
+        let config_path = get_config_path();
+
+        match File::open(&config_path) {
+            Ok(ref mut f) => {
+                let mut buf = String::new();
+                f.read_to_string(&mut buf).expect("failed to read config");
+                serde_json::from_str(&buf).expect("failed to parse config")
+            }
+            Err(_) => {
+                let new = Self::default();
+                let json: String =
+                    serde_json::to_string_pretty(&new).expect("failed to serialise config");
+                let mut f =
+                    File::create(config_path).expect("failed to create default config file");
+                f.write_all(json.as_bytes())
+                    .expect("failed to write config");
+                new
+            }
+        }
+    }
+
+    /// Save the current config state
+    pub fn save(&self) {
+        let config_path = get_config_path();
+
+        let mut file = OpenOptions::new()
+            .create(false)
+            .truncate(true)
+            .write(true)
+            .open(config_path)
+            .expect("failed to open config for writing");
+
+        let json: String = serde_json::to_string_pretty(self).expect("failed to serialise config");
+        file.write_all(json.as_bytes())
+            .expect("failed to write config");
+    }
+
+    /// Add a new node to the configuration for future lookup
+    pub fn create_node(&mut self, name: &str, port: u16) -> Result<(), ConfigError> {
+        if self.nodes.contains_key(name) {
+            return Err(ConfigError::NodeExists(name.to_string()));
+        }
+
+        self.nodes.insert(name.to_string(), NodeConfig { port });
+        Ok(())
+    }
+
+    /// Delete an existing node
+    pub fn delete_node(&mut self, name: &str) -> Result<(), ConfigError> {
+        match self.nodes.remove(name) {
+            Some(_) => Ok(()),
+            None => Err(ConfigError::NodeExists(name.to_string())),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NodeConfig {
+    port: u16,
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -1,5 +1,6 @@
 //! This library is used by the `ockam` CLI (in `./bin/ockam.rs`).
 
+mod config;
 mod enroll;
 mod message;
 mod node;
@@ -22,6 +23,8 @@ use old::cmd::inlet::InletOpts;
 use old::cmd::outlet::OutletOpts;
 use old::AddTrustedIdentityOpts;
 use old::{add_trusted, exit_with_result, node_subcommand, print_identity, print_ockam_dir};
+
+use crate::config::OckamConfig;
 
 const HELP_TEMPLATE: &str = "\
 {before-help}
@@ -145,10 +148,12 @@ pub fn run() {
 
     tracing::debug!("Parsed {:?}", ockam_command);
 
+    let mut cfg = OckamConfig::load();
+
     match ockam_command.subcommand {
         OckamSubcommand::Enroll(command) => EnrollCommand::run(command),
         OckamSubcommand::Message(command) => MessageCommand::run(command),
-        OckamSubcommand::Node(command) => NodeCommand::run(command),
+        OckamSubcommand::Node(command) => NodeCommand::run(&mut cfg, command),
         OckamSubcommand::Project(command) => ProjectCommand::run(command),
         OckamSubcommand::Space(command) => SpaceCommand::run(command),
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use std::process::Command;
+use std::{env::current_exe, process::Command};
 
 use crate::util::embedded_node;
 use ockam::{Context, Result, Routed, TcpTransport, Worker};
@@ -38,7 +38,11 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(command: CreateCommand) {
         if command.spawn {
-            Command::new("ockam")
+            // On systems with non-obvious path setups (or during
+            // development) re-executing the current binary is a more
+            // deterministic way of starting a node.
+            let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
+            Command::new(ockam)
                 .args(["node", "create", &command.node_name])
                 .spawn()
                 .expect("could not spawn node");

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,42 +1,28 @@
 use clap::Args;
-use std::{env::current_exe, process::Command};
+use std::{env::current_exe, process::Command, time::Duration};
 
-use crate::util::embedded_node;
-use ockam::{Context, Result, Routed, TcpTransport, Worker};
-
-struct Status {
-    node_name: String,
-}
-
-#[ockam::worker]
-impl Worker for Status {
-    type Message = String;
-    type Context = Context;
-
-    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
-        println!(
-            "\n[✓] Node: {}, Address: {}, Received: {}",
-            self.node_name,
-            ctx.address(),
-            msg
-        );
-        Ok(())
-    }
-}
+use crate::{
+    config::OckamConfig,
+    util::{self, connect_to, embedded_node, DEFAULT_TCP_PORT},
+};
+use ockam::{Context, NodeMan, NodeManMessage, NodeManReply, Route, TcpTransport};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the node.
     #[clap(default_value_t = String::from("default"))]
-    pub node_name: String,
+    node_name: String,
 
     /// Spawn a node in the background.
     #[clap(display_order = 900, long, short)]
     spawn: bool,
+
+    #[clap(default_value_t = DEFAULT_TCP_PORT, long, short)]
+    port: u16,
 }
 
 impl CreateCommand {
-    pub fn run(command: CreateCommand) {
+    pub fn run(cfg: &mut OckamConfig, command: CreateCommand) {
         if command.spawn {
             // On systems with non-obvious path setups (or during
             // development) re-executing the current binary is a more
@@ -46,23 +32,56 @@ impl CreateCommand {
                 .args(["node", "create", &command.node_name])
                 .spawn()
                 .expect("could not spawn node");
+
+            // Wait a bit
+            std::thread::sleep(Duration::from_millis(500));
+
+            // Then query the node manager for the status
+            connect_to(command.port, (), query_status);
         } else {
-            embedded_node(setup, command)
+            if let Err(e) = cfg.create_node(&command.node_name, DEFAULT_TCP_PORT) {
+                eprintln!(
+                    "failed to spawn node with name '{}': {:?}",
+                    command.node_name, e
+                );
+                std::process::exit(-1);
+            }
+            embedded_node(setup, command);
         }
     }
 }
 
+async fn query_status(ctx: Context, _: (), mut base_route: Route) -> anyhow::Result<()> {
+    let reply: NodeManReply = ctx
+        .send_and_receive(
+            base_route.modify().append("_internal.nodeman"),
+            NodeManMessage::Status,
+        )
+        .await
+        .unwrap();
+
+    match reply {
+        NodeManReply::Status {
+            node_name,
+            status,
+            workers,
+        } => println!(
+            "Node: {}, Status: {}, Worker count: {}",
+            node_name, status, workers
+        ),
+        // _ => eprintln!("Received invalid reply format!"),
+    }
+
+    util::stop_node(ctx).await
+}
+
 async fn setup(ctx: Context, c: CreateCommand) -> anyhow::Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
-    tcp.listen("127.0.0.1:62526").await?;
+    tcp.listen(format!("127.0.0.1:{}", DEFAULT_TCP_PORT))
+        .await?;
 
-    ctx.start_worker(
-        "status",
-        Status {
-            node_name: c.node_name,
-        },
-    )
-    .await?;
+    ctx.start_worker("_internal.nodeman", NodeMan::new(c.node_name))
+        .await?;
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,3 +1,4 @@
+use crate::config::OckamConfig;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -7,7 +8,7 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(command: DeleteCommand) {
+    pub fn run(_cfg: &mut OckamConfig, command: DeleteCommand) {
         println!("deleting {:?}", command)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,10 +1,11 @@
+use crate::config::OckamConfig;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {}
 
 impl ListCommand {
-    pub fn run(command: ListCommand) {
+    pub fn run(_cfg: &mut OckamConfig, command: ListCommand) {
         println!("listing {:?}", command)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -8,7 +8,7 @@ use delete::DeleteCommand;
 use list::ListCommand;
 use show::ShowCommand;
 
-use crate::HELP_TEMPLATE;
+use crate::{config::OckamConfig, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -37,12 +37,12 @@ pub enum NodeSubcommand {
 }
 
 impl NodeCommand {
-    pub fn run(command: NodeCommand) {
+    pub fn run(cfg: &mut OckamConfig, command: NodeCommand) {
         match command.subcommand {
-            NodeSubcommand::Create(command) => CreateCommand::run(command),
-            NodeSubcommand::Delete(command) => DeleteCommand::run(command),
-            NodeSubcommand::List(command) => ListCommand::run(command),
-            NodeSubcommand::Show(command) => ShowCommand::run(command),
+            NodeSubcommand::Create(command) => CreateCommand::run(cfg, command),
+            NodeSubcommand::Delete(command) => DeleteCommand::run(cfg, command),
+            NodeSubcommand::List(command) => ListCommand::run(cfg, command),
+            NodeSubcommand::Show(command) => ShowCommand::run(cfg, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,3 +1,4 @@
+use crate::config::OckamConfig;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -7,7 +8,7 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(command: ShowCommand) {
+    pub fn run(_cfg: &mut OckamConfig, command: ShowCommand) {
         println!("showing {:?}", command)
     }
 }


### PR DESCRIPTION
- feat(rust): allow ockam_command to call its own binary path
- feat(rust): implement basic ockam_command config module
- feat(rust): add basic node manager service
- refactor(rust): integrate configuration and remote messaging
