### PR TITLE
chore(rust): fix `no_std` build

### DIFF
--- a/implementations/rust/ockam/ockam/src/nodeman.rs
+++ b/implementations/rust/ockam/ockam/src/nodeman.rs
@@ -1,6 +1,7 @@
 //! Node Manager (Node Man, the superhero that we deserve)
 
 use crate::{Context, Message, Result, Routed, Worker};
+use ockam_core::compat::{boxed::Box, string::String};
 use serde::{Deserialize, Serialize};
 
 /// Messaging commands sent to node manager

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -2,7 +2,7 @@ use crate::{
     KeyExchangeCompleted, SecureChannelDecryptor, SecureChannelKeyExchanger, SecureChannelListener,
     SecureChannelNewKeyExchanger, SecureChannelVault,
 };
-use ockam_core::compat::rand::random;
+use ockam_core::compat::{rand::random, vec::Vec};
 use ockam_core::{Address, Result, Route};
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_decryptor.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_decryptor.rs
@@ -2,7 +2,7 @@ use crate::{
     ChannelKeys, CreateResponderChannelMessage, KeyExchangeCompleted, Role, SecureChannelEncryptor,
     SecureChannelError, SecureChannelKeyExchanger, SecureChannelLocalInfo, SecureChannelVault,
 };
-use ockam_core::compat::{boxed::Box, vec::Vec};
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{async_trait, route};
 use ockam_core::{
     Address, Any, Decodable, LocalMessage, Result, Route, Routed, TransportMessage, Worker,

--- a/implementations/rust/ockam/ockam_executor/src/lib.rs
+++ b/implementations/rust/ockam/ockam_executor/src/lib.rs
@@ -37,6 +37,9 @@ pub mod tokio {
         pub mod mpsc {
             pub use crate::channel::*;
         }
+        pub mod oneshot {
+            pub use futures::channel::oneshot::*;
+        }
     }
     pub mod task {
         pub use crate::runtime;

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/initiator.rs
@@ -1,4 +1,5 @@
 use crate::{PreKeyBundle, X3DHError, X3dhVault, CSUITE};
+use alloc::vec;
 use ockam_core::compat::{
     string::{String, ToString},
     vec::Vec,

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/responder.rs
@@ -1,4 +1,5 @@
 use crate::{PreKeyBundle, Signature, X3DHError, X3dhVault, CSUITE};
+use alloc::vec;
 use arrayref::array_ref;
 use ockam_core::compat::{
     string::{String, ToString},

--- a/implementations/rust/ockam/ockam_node/src/channel_types.rs
+++ b/implementations/rust/ockam/ockam_node/src/channel_types.rs
@@ -1,31 +1,31 @@
 /// Sender used to send payload messages
-pub type MessageSender<T> = tokio::sync::mpsc::Sender<T>;
+pub type MessageSender<T> = crate::tokio::sync::mpsc::Sender<T>;
 /// Receiver used to receive payload messages
-pub type MessageReceiver<T> = tokio::sync::mpsc::Receiver<T>;
+pub type MessageReceiver<T> = crate::tokio::sync::mpsc::Receiver<T>;
 
 /// Create message channel
 pub fn message_channel<T>() -> (MessageSender<T>, MessageReceiver<T>) {
-    tokio::sync::mpsc::channel(16)
+    crate::tokio::sync::mpsc::channel(16)
 }
 
 /// Router sender
-pub type RouterSender<T> = tokio::sync::mpsc::Sender<T>;
+pub type RouterSender<T> = crate::tokio::sync::mpsc::Sender<T>;
 /// Router receiver
-pub type RouterReceiver<T> = tokio::sync::mpsc::Receiver<T>;
+pub type RouterReceiver<T> = crate::tokio::sync::mpsc::Receiver<T>;
 
 /// Create router channel
 pub fn router_channel<T>() -> (RouterSender<T>, RouterReceiver<T>) {
-    tokio::sync::mpsc::channel(64)
+    crate::tokio::sync::mpsc::channel(64)
 }
 
 // TODO: Consider replacing with oneshot
 
 /// Sender for small channels
-pub type SmallSender<T> = tokio::sync::mpsc::Sender<T>;
+pub type SmallSender<T> = crate::tokio::sync::mpsc::Sender<T>;
 /// Receiver for small channels
-pub type SmallReceiver<T> = tokio::sync::mpsc::Receiver<T>;
+pub type SmallReceiver<T> = crate::tokio::sync::mpsc::Receiver<T>;
 
 /// Create small channel (size 1)
 pub fn small_channel<T>() -> (SmallSender<T>, SmallReceiver<T>) {
-    tokio::sync::mpsc::channel(1)
+    crate::tokio::sync::mpsc::channel(1)
 }


### PR DESCRIPTION
Minor fixes to get the `no_std` build working again:

```
cd implementations/rust/ockam/ockam
RUSTFLAGS='-Dwarnings' cargo check --no-default-features --features 'no_std alloc software_vault'
```

Also see: https://github.com/build-trust/ockam/pull/2764#issuecomment-1144251940