### PR TITLE
ockam_command node lifecycle management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -572,6 +573,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "cli-table-derive",
+ "csv",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "cli-table-derive"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +753,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
@@ -775,6 +810,28 @@ checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.5",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1525,7 +1582,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1566,7 +1623,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1647,6 +1704,12 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1738,6 +1801,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1927,6 +1999,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
+name = "nix"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,9 +2166,12 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "clap 3.1.18",
+ "cli-table",
+ "crossbeam-channel",
  "directories",
  "dirs",
  "hex",
+ "nix",
  "ockam",
  "ockam_api",
  "ockam_core",
@@ -3054,7 +3141,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -3066,7 +3153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,6 +1997,7 @@ dependencies = [
  "bls12_381_plus",
  "dyn-clone",
  "hex",
+ "ockam_api",
  "ockam_channel",
  "ockam_core",
  "ockam_identity",

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -32,6 +32,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["std", "ockam_transport_tcp", "software_vault", "software_vault_storage", "noise_xx"]
+ockam_command = ["ockam_api"]
 software_vault = [
     "ockam_vault",
     "ockam_channel/software_vault",
@@ -102,6 +103,7 @@ ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", op
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.47.0", default_features = false }
+ockam_api = { path = "../ockam_api", version = "^0.2.0", default_features = false, optional = true }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.37.0", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/src/nodeman.rs
+++ b/implementations/rust/ockam/ockam/src/nodeman.rs
@@ -22,6 +22,8 @@ pub enum NodeManReply {
         status: String,
         /// Number of registered workers
         workers: u32,
+        /// Current pid
+        pid: i32,
     },
 }
 
@@ -57,6 +59,7 @@ impl Worker for NodeMan {
                         node_name: self.node_name.clone(),
                         status: "[✓]".into(), // TODO: figure out if the current node is "healthy"
                         workers: ctx.list_workers().await?.len() as u32,
+                        pid: std::process::id() as i32,
                     },
                 )
                 .await?

--- a/implementations/rust/ockam/ockam_api/src/nodes/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/types.rs
@@ -5,6 +5,16 @@ use ockam_core::compat::borrow::Cow;
 #[cfg(feature = "tag")]
 use crate::TypeTag;
 
+/// Request body when asking a node for its status
+#[derive(Debug, Clone, Encode, Decode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct QueryStatus {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<1407961>,
+}
+
 /// Request body when creating a new node.
 #[derive(Debug, Clone, Encode, Decode)]
 #[rustfmt::skip]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -44,8 +44,11 @@ serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 async-recursion = { version = "1.0.0" }
 directories = "4"
+cli-table = "0.4"
+nix = "0.24"
+crossbeam-channel = "0.5"
 
-ockam = { path = "../ockam", version = "^0.59.0", features = ["software_vault"] }
+ockam = { path = "../ockam", version = "^0.59.0", features = ["software_vault", "ockam_command"] }
 ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -75,6 +75,14 @@ pub struct OckamCommand {
     // but the command is not executed.
     #[clap(global = true, long, hide = true)]
     pub test_argument_parser: bool,
+
+    /// A marker to indicate that this instance was spawned
+    ///
+    /// This is a quick work-around to avoid spamming the user with
+    /// irrelevant log messages from embedded nodes, while letting
+    /// spawned nodes log their full potential into their log files.
+    #[clap(display_order = 1006, long, hide = true)]
+    spawn_marker: bool,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -144,9 +152,10 @@ pub fn run() {
     }
 
     let verbose = ockam_command.verbose;
-    setup_logging(verbose);
-
-    tracing::debug!("Parsed {:?}", ockam_command);
+    if ockam_command.spawn_marker {
+        setup_logging(verbose);
+        tracing::debug!("Parsed {:?}", ockam_command);
+    }
 
     let mut cfg = OckamConfig::load();
 

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,14 +1,49 @@
 use crate::config::OckamConfig;
 use clap::Args;
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Name of the node.
     pub node_name: String,
+    /// Should the node be terminated with SIGKILL instead of SIGTERM
+    #[clap(display_order = 900, long, short)]
+    sigkill: bool,
 }
 
 impl DeleteCommand {
-    pub fn run(_cfg: &mut OckamConfig, command: DeleteCommand) {
-        println!("deleting {:?}", command)
+    pub fn run(cfg: &mut OckamConfig, command: DeleteCommand) {
+        delete_node(cfg, &command.node_name, command.sigkill);
     }
+}
+
+pub fn delete_node(cfg: &mut OckamConfig, node_name: &String, sigkill: bool) {
+    let node_cfg = match cfg.get_nodes().get(node_name) {
+        Some(node_cfg) => node_cfg,
+        None => {
+            eprintln!("No such node registired");
+            std::process::exit(-1);
+        }
+    };
+
+    if let Some(pid) = node_cfg.pid {
+        if let Err(e) = signal::kill(
+            Pid::from_raw(pid),
+            if sigkill {
+                Signal::SIGKILL
+            } else {
+                Signal::SIGTERM
+            },
+        ) {
+            eprintln!("Error occured while terminating node process: {}", e);
+        }
+    }
+
+    if let Err(e) = cfg.delete_node(node_name) {
+        eprintln!("failed to remove node from config: {}", e);
+    }
+
+    cfg.save();
+    println!("Deleted node '{}'", node_name);
 }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,11 +1,107 @@
+use std::time::Duration;
+
 use crate::config::OckamConfig;
+use crate::util::{self, connect_to};
 use clap::Args;
+use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
+use crossbeam_channel::{bounded, Sender};
+use ockam::{Context, NodeManMessage, NodeManReply, Route};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {}
 
 impl ListCommand {
-    pub fn run(_cfg: &mut OckamConfig, command: ListCommand) {
-        println!("listing {:?}", command)
+    pub fn run(cfg: &mut OckamConfig, _: ListCommand) {
+        let nodes = cfg.get_nodes();
+
+        if nodes.is_empty() {
+            println!("No nodes registered on this system!");
+            std::process::exit(0);
+        }
+
+        // Before printing node state we have to verify it.  This
+        // happens by sending a QueryStatus request to every node on
+        // record.  If the function fails, then it is assumed not to
+        // be up.  Also, if the function returns, but yields a
+        // different pid, then we update the pid stored in the config.
+        let node_names = nodes.iter().map(|(name, _)| name.clone()).collect();
+        verify_pids(cfg, node_names);
+
+        let table = cfg
+            .get_nodes()
+            .iter()
+            .fold(vec![], |mut acc, (name, node_cfg)| {
+                let row = vec![
+                    name.cell(),
+                    node_cfg.port.cell().justify(Justify::Right),
+                    match node_cfg.pid {
+                        Some(pid) => format!("Yes (pid: {})", pid),
+                        None => "No".into(),
+                    }
+                    .cell()
+                    .justify(Justify::Left),
+                    cfg.log_path(name).cell(),
+                ];
+                acc.push(row);
+                acc
+            })
+            .table()
+            .title(vec![
+                "Node name".cell().bold(true),
+                "API port".cell().bold(true),
+                "Running".cell().bold(true),
+                "Log path".cell().bold(true),
+            ]);
+
+        if let Err(e) = print_stdout(table) {
+            eprintln!("failed to print node status: {}", e);
+        }
     }
+}
+
+fn verify_pids(cfg: &mut OckamConfig, nodes: Vec<String>) {
+    for node_name in nodes {
+        let node_cfg = cfg.get_nodes().get(&node_name).unwrap();
+
+        let (tx, rx) = bounded(1);
+        println!("Checking state for node '{}'", node_name);
+        connect_to(node_cfg.port, tx, query_pid);
+        let verified_pid = rx.recv().unwrap();
+
+        if node_cfg.pid != verified_pid {
+            if let Err(e) = cfg.update_pid(&node_name, verified_pid) {
+                eprintln!("failed to update pid for node {}: {}", node_name, e);
+            }
+        }
+    }
+}
+
+pub async fn query_pid(
+    mut ctx: Context,
+    tx: Sender<Option<i32>>,
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    ctx.send(
+        base_route.modify().append("_internal.nodeman"),
+        NodeManMessage::Status,
+    )
+    .await?;
+
+    let reply = match ctx
+        .receive_duration_timeout::<NodeManReply>(Duration::from_millis(200))
+        .await
+    {
+        Ok(r) => r.take().body(),
+        Err(_) => {
+            tx.send(None).unwrap();
+            return util::stop_node(ctx).await;
+        }
+    };
+
+    let pid = match reply {
+        NodeManReply::Status { pid, .. } => pid,
+    };
+
+    tx.send(Some(pid)).unwrap();
+    util::stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -1,11 +1,13 @@
 mod create;
 mod delete;
 mod list;
+mod purge;
 mod show;
 
 use create::CreateCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
+use purge::PurgeCommand;
 use show::ShowCommand;
 
 use crate::{config::OckamConfig, HELP_TEMPLATE};
@@ -34,6 +36,10 @@ pub enum NodeSubcommand {
     /// Show nodes.
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Show(ShowCommand),
+
+    /// Purge all node configuration (great for development)
+    #[clap(display_order = 1005, hide = true)]
+    Purge(PurgeCommand),
 }
 
 impl NodeCommand {
@@ -43,6 +49,7 @@ impl NodeCommand {
             NodeSubcommand::Delete(command) => DeleteCommand::run(cfg, command),
             NodeSubcommand::List(command) => ListCommand::run(cfg, command),
             NodeSubcommand::Show(command) => ShowCommand::run(cfg, command),
+            NodeSubcommand::Purge(command) => PurgeCommand::run(cfg, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/purge.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/purge.rs
@@ -1,0 +1,25 @@
+//! A simple command to purge existing configuration
+
+use crate::config::OckamConfig;
+use clap::Args;
+
+#[derive(Clone, Debug, Args)]
+pub struct PurgeCommand {
+    /// Should nodes be terminated with SIGKILL instead of SIGTERM
+    #[clap(display_order = 900, long, short)]
+    sigkill: bool,
+}
+
+impl PurgeCommand {
+    pub fn run(cfg: &mut OckamConfig, command: PurgeCommand) {
+        let nodes: Vec<_> = cfg
+            .get_nodes()
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        for node_name in nodes {
+            crate::node::delete::delete_node(cfg, &node_name, command.sigkill);
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,5 +1,9 @@
-use crate::config::OckamConfig;
+use crate::{
+    config::OckamConfig,
+    util::{self, connect_to},
+};
 use clap::Args;
+use ockam::{Context, NodeManMessage, NodeManReply, Route};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -8,7 +12,40 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(_cfg: &mut OckamConfig, command: ShowCommand) {
-        println!("showing {:?}", command)
+    pub fn run(cfg: &mut OckamConfig, command: ShowCommand) {
+        let port = match cfg.get_nodes().get(&command.node_name) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+
+        connect_to(port, (), query_status);
     }
+}
+
+pub async fn query_status(ctx: Context, _: (), mut base_route: Route) -> anyhow::Result<()> {
+    let reply: NodeManReply = ctx
+        .send_and_receive(
+            base_route.modify().append("_internal.nodeman"),
+            NodeManMessage::Status,
+        )
+        .await
+        .unwrap();
+
+    match reply {
+        NodeManReply::Status {
+            node_name,
+            status,
+            workers,
+            ..
+        } => println!(
+            "Node: {}, Status: {}, Worker count: {}",
+            node_name, status, workers
+        ),
+        // _ => eprintln!("Received invalid reply format!"),
+    }
+
+    util::stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/util.rs
@@ -50,8 +50,6 @@ where
                 .expect("failed to connect to node");
             let route = route![(TCP, format!("localhost:{}", port))];
 
-            println!("{:?}", route);
-
             lambda(ctx, a, route)
                 .await
                 .expect("encountered an error in command handler code");
@@ -160,6 +158,6 @@ pub fn setup_logging(verbose: u8) {
         .with(fmt::layer())
         .try_init();
     if result.is_err() {
-        eprintln!("Failed to initialise logging.");
+        eprintln!("Failed to initialise tracing logging.");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/util.rs
@@ -160,6 +160,6 @@ pub fn setup_logging(verbose: u8) {
         .with(fmt::layer())
         .try_init();
     if result.is_err() {
-        tracing::warn!("Failed to initialise logging.");
+        eprintln!("Failed to initialise logging.");
     }
 }


### PR DESCRIPTION
This PR adds a few ways of managing the lifecycle of nodes, listing nodes that have previously been registered, and show their runtime state by sending a message to the `nodeman` worker on the remote node