### PR TITLE
fix(rust): ockam command spawn marker option

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -77,14 +77,6 @@ pub struct OckamCommand {
     // but the command is not executed.
     #[clap(global = true, long, hide = true)]
     pub test_argument_parser: bool,
-
-    /// A marker to indicate that this instance was spawned
-    ///
-    /// This is a quick work-around to avoid spamming the user with
-    /// irrelevant log messages from embedded nodes, while letting
-    /// spawned nodes log their full potential into their log files.
-    #[clap(display_order = 1006, long, hide = true)]
-    spawn_marker: bool,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -158,7 +150,7 @@ pub fn run() {
     }
 
     let verbose = ockam_command.verbose;
-    if ockam_command.spawn_marker {
+    if ockam_command.quiet {
         setup_logging(verbose);
         tracing::debug!("Parsed {:?}", ockam_command);
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -42,7 +42,7 @@ impl CreateCommand {
             std::env::set_var("OCKAM_LOG", "debug");
             let child = Command::new(ockam)
                 .args([
-                    "--spawn-marker",
+                    "--quiet",
                     "node",
                     "create",
                     "--port",


### PR DESCRIPTION
@spacekookie 93e0585df4ebc946f80128887b024c58a8f51b9c introduced a strange rendering bug in clap's help rendering.

a4b7b5055fd17822844d8f544d648e9711379a89 replaces use of `--spawn-marker` with `--quiet` .. at least for now.  

Before https://github.com/build-trust/ockam/pull/2817/commits/a4b7b5055fd17822844d8f544d648e9711379a89 - note the line breaks.
<img width="812" alt="Screen Shot 2022-06-02 at 6 07 01 PM" src="https://user-images.githubusercontent.com/159583/171768954-20b17161-d14d-4688-8b95-46ec45c04725.png">

---

After https://github.com/build-trust/ockam/pull/2817/commits/a4b7b5055fd17822844d8f544d648e9711379a89 - it goes back to the intended rendering.
<img width="803" alt="Screen Shot 2022-06-02 at 6 07 20 PM" src="https://user-images.githubusercontent.com/159583/171768957-fde32ef1-7c71-4688-bc70-0c64f09b5a47.png">
