### PR TITLE
feat(rust): add enrollment token + fixes for cloud commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,8 +1156,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a8531dd3a64fd1cfbe92fad4160bc2060489c6195fe847e045e5788f710bae"
 dependencies = [
  "dummy",
- "http",
  "rand 0.8.5",
+ "uuid",
 ]
 
 [[package]]
@@ -1831,6 +1831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,17 +2166,16 @@ dependencies = [
  "mockall",
  "ockam_api",
  "ockam_core",
+ "ockam_identity",
  "ockam_macros",
  "ockam_node",
  "ockam_transport_tcp",
- "open",
  "quickcheck",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "tinyvec",
- "tokio-retry",
  "tracing",
 ]
 
@@ -2213,11 +2218,14 @@ dependencies = [
  "ockam_core",
  "ockam_multiaddr",
  "ockam_vault",
+ "open",
  "rand 0.8.5",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -2551,9 +2559,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
  "autocfg",
  "cc",
@@ -3223,6 +3231,21 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.3",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -3969,6 +3992,11 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.6",
+ "md5",
+ "sha1",
+]
 
 [[package]]
 name = "valuable"

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -16,12 +16,10 @@ lmdb = ["std", "lmdb-rkv"]
 
 [dependencies]
 minicbor    = { version = "0.17.1", features = ["alloc", "derive"] }
-open        = "2"
-reqwest     = { version = "0.11", features = ["json"] }
+reqwest     = { version = "0.11", default-features = false }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 tinyvec     = { version = "1.6.0", features = ["rustc_1_57"] }
-tokio-retry = "0.3"
 tracing     = { version = "0.1.34", default-features = false }
 lmdb-rkv    = { version = "0.14.0", optional = true }
 
@@ -37,9 +35,15 @@ path             = "../ockam_node"
 default-features = false
 features         = ["std"] # FIXME: required because of unbounded channels in ockam_node
 
+[dependencies.ockam_identity]
+version          = "0.47.0"
+path             = "../ockam_identity"
+default-features = false
+features         = ["std"]
+
 [dev-dependencies]
 cddl-cat            = "0.6.1"
-fake                = { version = "2", features=['derive', 'http']}
+fake                = { version = "2", features=['derive', 'uuid']}
 mockall             = "0.11"
 ockam_api           = { path = ".", features = ["std"] }
 ockam_macros        = { version = "0.15.0", path = "../ockam_macros", features = ["std"] }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -1,11 +1,13 @@
-#[cfg(test)]
-use fake::{Dummy, Fake};
-use minicbor::Encode;
-use tracing::warn;
+use std::borrow::Cow;
 
-#[cfg(test)]
-use ockam_core::compat::rand;
+use minicbor::{Decode, Decoder, Encode};
+
 use ockam_core::{self, async_trait};
+
+use crate::cloud::{error, response, MessagingClient};
+#[cfg(feature = "tag")]
+use crate::TypeTag;
+use crate::{Request, Status};
 
 pub enum Authenticator {
     Auth0,
@@ -21,245 +23,527 @@ impl core::fmt::Display for Authenticator {
     }
 }
 
-#[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
-pub trait AuthenticatorClientTrait {
-    async fn auth0(&self) -> ockam_core::Result<auth0::Auth0Tokens>;
+pub trait TokenProvider<'a> {
+    type T;
+
+    async fn token(&mut self, identity: &Identity<'a>) -> ockam_core::Result<Self::T>;
 }
 
-pub struct AuthenticatorClient;
+#[async_trait::async_trait]
+pub trait TokenAuthenticatorService {
+    async fn authenticate<'a>(&mut self, body: AuthorizedToken<'a>) -> ockam_core::Result<()>;
+}
 
-pub(crate) mod auth0 {
-    use reqwest::StatusCode;
-    use tokio_retry::{strategy::ExponentialBackoff, Retry};
+#[derive(Encode, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[cbor(map)]
+pub struct RequestEnrollment<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    pub tag: TypeTag<5136510>,
+    #[n(1)]
+    pub identity: Identity<'a>,
+    #[n(2)]
+    pub token: Token<'a>,
+}
 
-    use ockam_node::tokio;
+impl<'a> RequestEnrollment<'a> {
+    pub fn new<I: Into<Identity<'a>>>(identity: I, token: Token<'a>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            identity: identity.into(),
+            token,
+        }
+    }
+}
 
-    use crate::error::ApiError;
+#[derive(serde::Deserialize, Encode, Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Decode))]
+#[cbor(transparent)]
+pub struct Identity<'a>(#[n(0)] Cow<'a, str>);
 
+impl<'a> From<&'static str> for Identity<'a> {
+    fn from(v: &'static str) -> Self {
+        Self(v.into())
+    }
+}
+
+impl<'a> From<String> for Identity<'a> {
+    fn from(v: String) -> Self {
+        Self(v.into())
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Encode, Decode, Debug)]
+#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cbor(transparent)]
+pub struct Token<'a>(#[n(0)] pub Cow<'a, str>);
+
+pub enum AuthorizedToken<'a> {
+    Auth0(auth0::AuthorizedAuth0Token<'a>),
+    EnrollmentToken(enrollment_token::AuthorizedEnrollmentToken<'a>),
+}
+
+#[async_trait::async_trait]
+impl TokenAuthenticatorService for MessagingClient {
+    async fn authenticate<'a>(&mut self, body: AuthorizedToken<'a>) -> ockam_core::Result<()> {
+        let target = "ockam_api::cloud::enroll::authenticate";
+        let label = "authenticate";
+
+        match body {
+            AuthorizedToken::Auth0(body) => {
+                let route = self.route.modify().append("auth0_authenticator").into();
+                let req = Request::post("v0/enroll").body(body);
+                self.buf = self.request(target, label, route, &req).await?;
+            }
+            AuthorizedToken::EnrollmentToken(body) => {
+                let route = self
+                    .route
+                    .modify()
+                    .append("enrollment_token_authenticator")
+                    .into();
+                let req = Request::post("v0/enroll").body(body);
+                self.buf = self.request(target, label, route, &req).await?;
+            }
+        };
+
+        let mut d = Decoder::new(&self.buf);
+        let res = response(target, label, &mut d)?;
+        if res.status() == Some(Status::Ok) {
+            Ok(())
+        } else {
+            Err(error(target, label, &res, &mut d))
+        }
+    }
+}
+
+pub mod auth0 {
     use super::*;
 
-    const DOMAIN: &str = "dev-w5hdnpc2.us.auth0.com";
-    const CLIENT_ID: &str = "sGyXBwQfU6fjfW1gopphdV9vCLec060b";
-    const API_AUDIENCE: &str = "https://dev-w5hdnpc2.us.auth0.com/api/v2/";
-    const SCOPES: &str = "profile";
+    pub const DOMAIN: &str = "dev-w5hdnpc2.us.auth0.com";
+    pub const CLIENT_ID: &str = "sGyXBwQfU6fjfW1gopphdV9vCLec060b";
+    pub const API_AUDIENCE: &str = "https://dev-w5hdnpc2.us.auth0.com/api/v2/";
+    pub const SCOPES: &str = "profile openid email";
+
+    // Req/Res types
 
     #[derive(serde::Deserialize, Debug, PartialEq)]
-    struct DeviceCodeResponse {
-        device_code: String,
-        user_code: String,
-        verification_uri: String,
-        verification_uri_complete: String,
-        expires_in: usize,
-        interval: usize,
+    pub struct DeviceCode<'a> {
+        pub device_code: Cow<'a, str>,
+        pub user_code: Cow<'a, str>,
+        pub verification_uri: Cow<'a, str>,
+        pub verification_uri_complete: Cow<'a, str>,
+        pub expires_in: usize,
+        pub interval: usize,
     }
 
     #[derive(serde::Deserialize, Debug, PartialEq)]
-    struct TokensErrorResponse {
-        error: String,
-        error_description: String,
+    pub struct TokensError<'a> {
+        pub error: Cow<'a, str>,
+        pub error_description: Cow<'a, str>,
     }
 
-    #[derive(serde::Deserialize, Encode, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-    #[cbor(map)]
-    pub struct Auth0Tokens {
-        #[n(0)]
+    #[derive(serde::Deserialize, Debug)]
+    #[cfg_attr(test, derive(PartialEq, Clone))]
+    pub struct Auth0Token<'a> {
         pub token_type: TokenType,
-        #[n(1)]
-        pub access_token: AccessToken,
+        pub access_token: Token<'a>,
     }
 
+    #[derive(Encode, Debug)]
+    #[cfg_attr(test, derive(Decode, Clone))]
+    #[cbor(map)]
+    pub struct AuthorizedAuth0Token<'a> {
+        #[cfg(feature = "tag")]
+        #[n(0)]
+        pub tag: TypeTag<1058055>,
+        #[n(1)]
+        pub identity: Identity<'a>,
+        #[n(2)]
+        pub token_type: TokenType,
+        #[n(3)]
+        pub access_token: Token<'a>,
+    }
+
+    impl<'a> AuthorizedAuth0Token<'a> {
+        pub fn new(identity: Identity<'a>, token: Auth0Token<'a>) -> Self {
+            Self {
+                #[cfg(feature = "tag")]
+                tag: TypeTag,
+                identity,
+                token_type: token.token_type,
+                access_token: token.access_token,
+            }
+        }
+    }
+
+    // Auxiliary types
+
     #[derive(serde::Deserialize, Encode, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
+    #[cfg_attr(test, derive(PartialEq, Decode, Clone))]
     #[cbor(index_only)]
     pub enum TokenType {
         #[n(0)]
         Bearer,
     }
+}
 
-    #[derive(serde::Deserialize, Encode, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Clone, Dummy))]
-    #[cbor(transparent)]
-    pub struct AccessToken(#[n(0)] String);
+pub(crate) mod enrollment_token {
+    use super::*;
+
+    // Main req/res types
+
+    #[derive(Encode, Debug)]
+    #[cfg_attr(test, derive(Decode, Clone))]
+    #[cbor(map)]
+    pub struct RequestEnrollmentToken<'a> {
+        #[cfg(feature = "tag")]
+        #[n(0)]
+        pub tag: TypeTag<8560526>,
+        #[n(1)]
+        pub identity: Identity<'a>,
+        #[n(2)]
+        pub attributes: Vec<Attribute<'a>>,
+    }
+
+    impl<'a> RequestEnrollmentToken<'a> {
+        pub fn new<I: Into<Identity<'a>>>(identity: I, attributes: &[Attribute<'a>]) -> Self {
+            Self {
+                #[cfg(feature = "tag")]
+                tag: TypeTag,
+                identity: identity.into(),
+                attributes: attributes.to_vec(),
+            }
+        }
+    }
+
+    #[derive(Decode, Debug)]
+    #[cfg_attr(test, derive(Encode, Clone))]
+    #[cbor(map)]
+    pub struct EnrollmentToken<'a> {
+        #[cfg(feature = "tag")]
+        #[n(0)]
+        pub tag: TypeTag<8932763>,
+        #[n(1)]
+        pub token: Token<'a>,
+    }
+
+    impl<'a> EnrollmentToken<'a> {
+        pub fn new(token: Token<'a>) -> Self {
+            Self {
+                #[cfg(feature = "tag")]
+                tag: TypeTag,
+                token,
+            }
+        }
+    }
+    #[derive(Encode, Debug)]
+    #[cfg_attr(test, derive(Decode, Clone))]
+    #[cbor(map)]
+    pub struct AuthorizedEnrollmentToken<'a> {
+        #[cfg(feature = "tag")]
+        #[n(0)]
+        pub tag: TypeTag<9463780>,
+        #[n(1)]
+        pub identity: Identity<'a>,
+        #[n(2)]
+        pub token: Token<'a>,
+    }
+
+    impl<'a> AuthorizedEnrollmentToken<'a> {
+        pub fn new(identity: Identity<'a>, token: EnrollmentToken<'a>) -> Self {
+            Self {
+                #[cfg(feature = "tag")]
+                tag: TypeTag,
+                identity,
+                token: token.token,
+            }
+        }
+    }
+
+    // Auxiliary types
+
+    #[derive(serde::Deserialize, Encode, Debug, Clone)]
+    #[cfg_attr(test, derive(PartialEq, Decode))]
+    #[cbor(map)]
+    pub struct Attribute<'a> {
+        #[n(0)]
+        pub name: Cow<'a, str>,
+        #[n(1)]
+        pub value: Cow<'a, str>,
+    }
+
+    impl<'a> Attribute<'a> {
+        pub fn new<S: Into<Cow<'a, str>>>(name: S, value: S) -> Self {
+            Self {
+                name: name.into(),
+                value: value.into(),
+            }
+        }
+    }
+
+    // Trait impl
 
     #[async_trait::async_trait]
-    impl AuthenticatorClientTrait for AuthenticatorClient {
-        async fn auth0(&self) -> ockam_core::Result<Auth0Tokens> {
-            // Request device code
-            // More on how to use scope and audience in https://auth0.com/docs/quickstart/native/device#device-code-parameters
-            let device_code_res = {
-                let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
-                let res = Retry::spawn(retry_strategy, move || {
-                    let client = reqwest::Client::new();
-                    client
-                        .post(format!("https://{DOMAIN}/oauth/device/code"))
-                        .header("content-type", "application/x-www-form-urlencoded")
-                        .form(&[
-                            ("client_id", CLIENT_ID),
-                            ("scope", SCOPES),
-                            ("audience", API_AUDIENCE),
-                        ])
-                        .send()
-                })
-                .await
-                .map_err(ApiError::from)?;
-                match res.status() {
-                    StatusCode::OK => {
-                        let res = res
-                            .json::<DeviceCodeResponse>()
-                            .await
-                            .map_err(ApiError::from)?;
-                        tracing::info!("device code received: {res:#?}");
-                        res
-                    }
-                    _ => {
-                        let res = res.text().await.map_err(ApiError::from)?;
-                        let err = format!("couldn't get device code [response={:#?}]", res);
-                        return Err(ApiError::generic(&err));
-                    }
-                }
-            };
+    impl<'a> TokenProvider<'a> for MessagingClient {
+        type T = EnrollmentToken<'a>;
 
-            // Request device activation
-            // Note that we try to open the verification uri **without** the code.
-            // After the code is entered, if the user closes the tab (because they
-            // want to open it on another browser, for example), the uri gets
-            // invalidated and the user would have to restart the process (i.e.
-            // rerun the command).
-            if open::that(&device_code_res.verification_uri).is_err() {
-                warn!(
-                    "couldn't open verification url automatically [url={}]",
-                    device_code_res.verification_uri
-                );
-            }
+        async fn token(&mut self, identity: &Identity) -> ockam_core::Result<Self::T> {
+            let target = "ockam_api::cloud::enroll::token";
+            let label = "token";
 
-            println!(
-                "Open the following url in your browser to authorize your device with code {}:\n{}",
-                device_code_res.user_code, device_code_res.verification_uri_complete,
+            let route = self
+                .route
+                .modify()
+                .append("enrollment_token_authenticator")
+                .into();
+            let body = RequestEnrollmentToken::new(
+                identity.clone(),
+                &[
+                    Attribute::new("attr1", "value"),
+                    Attribute::new("attr2", "value"),
+                ], // TODO: define default attributes
             );
+            let req = Request::post("v0/").body(body);
+            self.buf = self.request(target, label, route, &req).await?;
 
-            // Request tokens
-            let client = reqwest::Client::new();
-            let tokens_res;
-            loop {
-                let res = client
-                    .post(format!("https://{DOMAIN}/oauth/token"))
-                    .header("content-type", "application/x-www-form-urlencoded")
-                    .form(&[
-                        ("client_id", CLIENT_ID),
-                        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
-                        ("device_code", &device_code_res.device_code),
-                    ])
-                    .send()
-                    .await
-                    .map_err(ApiError::from)?;
-                match res.status() {
-                    StatusCode::OK => {
-                        tokens_res = res.json::<Auth0Tokens>().await.map_err(ApiError::from)?;
-                        tracing::info!("tokens received [tokes={tokens_res:#?}]");
-                        return Ok(tokens_res);
-                    }
-                    _ => {
-                        let err_res = res
-                            .json::<TokensErrorResponse>()
-                            .await
-                            .map_err(ApiError::from)?;
-                        match err_res.error.as_str() {
-                            "authorization_pending" | "invalid_request" | "slow_down" => {
-                                tracing::debug!("tokens not yet received [err={err_res:#?}]");
-                                tokio::time::sleep(tokio::time::Duration::from_secs(
-                                    device_code_res.interval as u64,
-                                ))
-                                .await;
-                                continue;
-                            }
-                            _ => {
-                                let err_msg =
-                                    format!("failed to receive tokens [err={err_res:#?}]");
-                                tracing::debug!("{}", err_msg);
-                                return Err(ApiError::generic(&err_msg));
-                            }
-                        }
-                    }
-                }
+            let mut d = Decoder::new(&self.buf);
+            let res = response(target, label, &mut d)?;
+            if res.status() == Some(Status::Ok) {
+                d.decode().map_err(|e| e.into())
+            } else {
+                Err(error(target, label, &res, &mut d))
             }
         }
     }
 }
 
 #[cfg(test)]
+#[allow(non_snake_case)]
 mod tests {
-    use fake::{Fake, Faker};
+    use quickcheck::{Arbitrary, Gen};
 
+    use ockam_core::compat::rand::{self, Rng};
     use ockam_core::route;
+    use ockam_core::{Routed, Worker};
+    use ockam_identity::IdentityIdentifier;
     use ockam_node::Context;
     use ockam_transport_tcp::{TcpTransport, TCP};
 
-    use crate::cloud::tests::TestCloudWorker;
-    use crate::cloud::Client;
+    use crate::cloud::enroll::auth0::AuthorizedAuth0Token;
+    use crate::cloud::enroll::enrollment_token::{
+        AuthorizedEnrollmentToken, EnrollmentToken, RequestEnrollmentToken,
+    };
+    use crate::cloud::enroll::Token;
+    use crate::cloud::MessagingClient;
+    use crate::{Method, Request, Response};
 
     use super::*;
 
     mod auth0 {
-        use crate::cloud::enroll::auth0::Auth0Tokens;
+        use crate::cloud::enroll::auth0::*;
 
         use super::*;
 
         // TODO: add tests for the auth0 internals using mockito
-        // async fn internals__happy_path() {}
-        // async fn internals__err_if_device_token_request_fails() {}
-        // async fn internals__err_if_tokens_request_fails() {}
+        // async fn token__happy_path() {}
+        // async fn token__err_if_device_token_request_fails() {}
+        // async fn token__err_if_tokens_request_fails() {}
 
         #[ockam_macros::test]
-        async fn happy_path(ctx: &mut Context) -> ockam_core::Result<()> {
+        async fn authenticate__happy_path(ctx: &mut Context) -> ockam_core::Result<()> {
             // Initiate cloud TCP listener
             let transport = TcpTransport::create(ctx).await?;
             let server_address = transport.listen("127.0.0.1:0").await?.to_string();
             let server_route = route![(TCP, server_address), "cloud"];
-            ctx.start_worker("cloud", TestCloudWorker).await?;
+            ctx.start_worker("cloud", EnrollHandler).await?;
 
-            // Mock authenticator
-            let expected_creds: Auth0Tokens = Faker.fake();
-            let mut auth_client = MockAuthenticatorClientTrait::new();
-            let moved_expected_creds = expected_creds.clone();
-            auth_client
-                .expect_auth0()
-                .times(1)
-                .return_once(move || Ok(moved_expected_creds));
-
-            // Execute enroll
-            let mut api_client = Client::new(server_route, ctx).await?;
-            let _res = api_client
-                .enroll(&Authenticator::Auth0, auth_client)
-                .await?;
+            // Execute token
+            let mut rng = Gen::new(32);
+            let t = RandomAuthorizedAuth0Token::arbitrary(&mut rng);
+            let token = AuthorizedToken::Auth0(t.0);
+            let mut client = MessagingClient::new(server_route, ctx).await?;
+            client.authenticate(token).await?;
 
             ctx.stop().await
         }
 
-        /// This test points to an ockam cloud to test the integration with elixir workers.
-        /// The local machine must have access to cloud.ockam.io.
-        #[ockam_macros::test]
-        #[ignore]
-        async fn cloud(ctx: &mut Context) -> ockam_core::Result<()> {
-            // Mock authenticator
-            let expected_creds: Auth0Tokens = Faker.fake();
-            let mut auth_client = MockAuthenticatorClientTrait::new();
-            let moved_expected_creds = expected_creds.clone();
-            auth_client
-                .expect_auth0()
-                .times(1)
-                .return_once(move || Ok(moved_expected_creds));
+        #[derive(Debug, Clone)]
+        struct RandomAuthorizedAuth0Token(AuthorizedAuth0Token<'static>);
 
-            // Enroll sending mocked tokens to cloud node
-            TcpTransport::create(ctx).await?;
-            let server_route = route![(TCP, "127.0.0.1:4001"), "authenticator"];
-            let mut api_client = Client::new(server_route, ctx).await?;
-            let _res = api_client
-                .enroll(&Authenticator::Auth0, auth_client)
+        impl Arbitrary for RandomAuthorizedAuth0Token {
+            fn arbitrary(g: &mut Gen) -> Self {
+                RandomAuthorizedAuth0Token(AuthorizedAuth0Token::new(
+                    Identity::arbitrary(g),
+                    Auth0Token {
+                        token_type: TokenType::Bearer,
+                        access_token: Token::arbitrary(g),
+                    },
+                ))
+            }
+        }
+    }
+
+    mod enrollment_token {
+        use crate::cloud::enroll::enrollment_token::*;
+
+        use super::*;
+
+        #[ockam_macros::test]
+        async fn token__happy_path(ctx: &mut Context) -> ockam_core::Result<()> {
+            // Initiate cloud TCP listener
+            let transport = TcpTransport::create(ctx).await?;
+            let server_address = transport.listen("127.0.0.1:0").await?.to_string();
+            let server_route = route![(TCP, server_address)];
+            ctx.start_worker("enrollment_token_authenticator", EnrollHandler)
                 .await?;
 
+            // Execute token
+            let mut rng = Gen::new(32);
+            let identity = Identity::arbitrary(&mut rng);
+            let mut client = MessagingClient::new(server_route, ctx).await?;
+            let res = client.token(&identity).await?;
+            let expected_token = EnrollmentToken::new(Token("ok".into()));
+            assert_eq!(res.token, expected_token.token);
+
             ctx.stop().await
+        }
+
+        #[ockam_macros::test]
+        async fn authenticate__happy_path(ctx: &mut Context) -> ockam_core::Result<()> {
+            // Initiate cloud TCP listener
+            let transport = TcpTransport::create(ctx).await?;
+            let server_address = transport.listen("127.0.0.1:0").await?.to_string();
+            let server_route = route![(TCP, server_address)];
+            ctx.start_worker("enrollment_token_authenticator", EnrollHandler)
+                .await?;
+
+            // Execute token
+            let mut rng = Gen::new(32);
+            let t = RandomAuthorizedEnrollmentToken::arbitrary(&mut rng);
+            let token = AuthorizedToken::EnrollmentToken(t.0);
+            let mut client = MessagingClient::new(server_route, ctx).await?;
+            client.authenticate(token).await?;
+
+            ctx.stop().await
+        }
+
+        #[ockam_macros::test]
+        #[ignore]
+        async fn cloud__token(ctx: &mut Context) -> ockam_core::Result<()> {
+            TcpTransport::create(ctx).await?;
+            let server_route = route![(TCP, "127.0.0.1:4001")];
+            let mut rng = Gen::new(32);
+            let identity = Identity::arbitrary(&mut rng);
+            let mut client = MessagingClient::new(server_route, ctx).await?;
+            client.token(&identity).await?;
+            ctx.stop().await
+        }
+
+        #[ockam_macros::test]
+        #[ignore]
+        async fn cloud__authenticate(ctx: &mut Context) -> ockam_core::Result<()> {
+            TcpTransport::create(ctx).await?;
+            let server_route = route![(TCP, "127.0.0.1:4001")];
+            let mut rng = Gen::new(32);
+            let t = RandomAuthorizedEnrollmentToken::arbitrary(&mut rng);
+            let token = AuthorizedToken::EnrollmentToken(t.0);
+            let mut client = MessagingClient::new(server_route, ctx).await?;
+            client.authenticate(token).await?;
+            ctx.stop().await
+        }
+
+        #[ockam_macros::test]
+        #[ignore]
+        async fn cloud__enroll(ctx: &mut Context) -> ockam_core::Result<()> {
+            TcpTransport::create(ctx).await?;
+            let server_route = route![(TCP, "127.0.0.1:4001")];
+            let mut api_client = MessagingClient::new(server_route, ctx).await?;
+            let identifier = random_identifier();
+            let _res = api_client.enroll_enrollment_token(identifier).await?;
+            ctx.stop().await
+        }
+
+        #[derive(Debug, Clone)]
+        struct RandomAuthorizedEnrollmentToken(AuthorizedEnrollmentToken<'static>);
+
+        impl Arbitrary for RandomAuthorizedEnrollmentToken {
+            fn arbitrary(g: &mut Gen) -> Self {
+                RandomAuthorizedEnrollmentToken(AuthorizedEnrollmentToken::new(
+                    Identity::arbitrary(g),
+                    EnrollmentToken::new(Token::arbitrary(g)),
+                ))
+            }
+        }
+    }
+
+    impl Arbitrary for Identity<'static> {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Identity(String::arbitrary(g).into())
+        }
+    }
+
+    impl Arbitrary for Token<'static> {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Token(String::arbitrary(g).into())
+        }
+    }
+
+    fn random_identifier() -> IdentityIdentifier {
+        let id: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect();
+        IdentityIdentifier::from_key_id(id)
+    }
+
+    pub struct EnrollHandler;
+
+    #[ockam_core::worker]
+    impl Worker for EnrollHandler {
+        type Message = Vec<u8>;
+        type Context = Context;
+
+        async fn handle_message(
+            &mut self,
+            ctx: &mut Context,
+            msg: Routed<Self::Message>,
+        ) -> ockam_core::Result<()> {
+            let mut buf = Vec::new();
+            {
+                let mut dec = Decoder::new(msg.as_body());
+                let req: Request = dec.decode()?;
+                match (req.method(), req.path(), req.has_body()) {
+                    (Some(Method::Post), "v0/", true) => {
+                        if dec.decode::<RequestEnrollmentToken>().is_ok() {
+                            Response::ok(req.id())
+                                .body(EnrollmentToken::new(Token("ok".into())))
+                                .encode(&mut buf)?;
+                        } else {
+                            dbg!();
+                            Response::bad_request(req.id()).encode(&mut buf)?;
+                        }
+                    }
+                    (Some(Method::Post), "v0/enroll", true) => {
+                        if dec.clone().decode::<AuthorizedAuth0Token>().is_ok()
+                            || dec.decode::<AuthorizedEnrollmentToken>().is_ok()
+                        {
+                            Response::ok(req.id()).encode(&mut buf)?;
+                        } else {
+                            dbg!();
+                            Response::bad_request(req.id()).encode(&mut buf)?;
+                        }
+                    }
+                    _ => {
+                        dbg!();
+                        Response::bad_request(req.id()).encode(&mut buf)?;
+                    }
+                }
+            }
+            ctx.send(msg.return_route(), buf).await
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,37 +1,197 @@
-use minicbor::{Decode, Encode};
 use std::borrow::Cow;
 
+use minicbor::{Decode, Encode};
+
+#[cfg(feature = "tag")]
+use crate::TypeTag;
+
 #[derive(Decode, Debug)]
+#[cfg_attr(test, derive(Encode))]
 #[cbor(map)]
 pub struct Project<'a> {
-    #[b(0)]
-    pub id: Cow<'a, str>,
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    pub tag: TypeTag<2764235>,
     #[b(1)]
-    pub name: Cow<'a, str>,
+    pub id: Cow<'a, str>, // TODO: str or Vec<u8>?
     #[b(2)]
-    pub services: Vec<Cow<'a, str>>,
+    pub name: Cow<'a, str>,
     #[b(3)]
+    pub space_name: Cow<'a, str>,
+    #[b(4)]
+    pub services: Vec<Cow<'a, str>>,
+    #[b(5)]
     pub access_route: Vec<u8>,
 }
 
 #[derive(Encode)]
+#[cfg_attr(test, derive(Decode))]
 #[cbor(map)]
 pub struct CreateProject<'a> {
-    #[b(0)]
-    pub name: Cow<'a, str>,
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    pub tag: TypeTag<6593388>,
     #[b(1)]
+    pub name: Cow<'a, str>,
+    #[b(2)]
     pub services: Vec<Cow<'a, str>>,
 }
 
 impl<'a> CreateProject<'a> {
     pub fn new<S: Into<Cow<'a, str>>>(name: S, services: &'a [String]) -> Self {
         Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
             name: name.into(),
             services: services
                 .iter()
                 .map(String::as_str)
                 .map(Cow::Borrowed)
                 .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use minicbor::encode::Write;
+    use minicbor::{encode, Decoder};
+    use quickcheck::{Arbitrary, Gen};
+
+    use ockam_core::compat::collections::HashMap;
+    use ockam_core::{Route, Routed, Worker};
+    use ockam_node::Context;
+
+    use crate::cloud::MessagingClient;
+    use crate::{Method, Request, Response};
+
+    use super::*;
+
+    #[ockam_macros::test]
+    async fn basic_api_usage(ctx: &mut Context) -> ockam_core::Result<()> {
+        ctx.start_worker("projects", ProjectServer::default())
+            .await?;
+
+        let s_id = "space-id";
+        let mut client = MessagingClient::new(Route::new().into(), ctx).await?;
+
+        let p1 = client
+            .create_project(s_id, CreateProject::new("p1", &["service".to_string()]))
+            .await?;
+        assert_eq!(&p1.name, "p1");
+        assert_eq!(&p1.services, &["service"]);
+        let p1_id = p1.id.to_string();
+
+        let p1_retrieved = client.get_project(s_id, &p1_id).await?;
+        assert_eq!(p1_retrieved.id, p1_id);
+
+        let p2 = client
+            .create_project(s_id, CreateProject::new("p2", &["service".to_string()]))
+            .await?;
+        assert_eq!(&p2.name, "p2");
+        let p2_id = p2.id.to_string();
+
+        let list = client.list_projects(s_id).await?;
+        assert_eq!(list.len(), 2);
+
+        client.delete_project(s_id, &p1_id).await?;
+
+        let list = client.list_projects(s_id).await?;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, p2_id);
+
+        ctx.stop().await
+    }
+
+    #[derive(Debug, Default)]
+    pub struct ProjectServer(HashMap<String, Project<'static>>);
+
+    #[ockam_core::worker]
+    impl Worker for ProjectServer {
+        type Message = Vec<u8>;
+        type Context = Context;
+
+        async fn handle_message(
+            &mut self,
+            ctx: &mut Context,
+            msg: Routed<Self::Message>,
+        ) -> ockam_core::Result<()> {
+            let mut buf = Vec::new();
+            self.on_request(msg.as_body(), &mut buf)?;
+            ctx.send(msg.return_route(), buf).await
+        }
+    }
+
+    impl ProjectServer {
+        fn on_request<W>(&mut self, data: &[u8], buf: W) -> ockam_core::Result<()>
+        where
+            W: Write<Error = io::Error>,
+        {
+            let mut rng = Gen::new(32);
+            let mut dec = Decoder::new(data);
+            let req: Request = dec.decode()?;
+            match req.method() {
+                Some(Method::Get) => match req.path_segments::<3>().as_slice() {
+                    // Get all nodes:
+                    [_, _] => Response::ok(req.id())
+                        .body(encode::ArrayIter::new(self.0.values()))
+                        .encode(buf)?,
+                    // Get a single node:
+                    [_, _, id] => {
+                        if let Some(n) = self.0.get(*id) {
+                            Response::ok(req.id()).body(n).encode(buf)?
+                        } else {
+                            Response::not_found(req.id()).encode(buf)?
+                        }
+                    }
+                    _ => {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                },
+                Some(Method::Post) if req.has_body() => {
+                    if let Ok(project) = dec.decode::<CreateProject>() {
+                        let obj = Project {
+                            #[cfg(feature = "tag")]
+                            tag: TypeTag,
+                            id: u32::arbitrary(&mut rng).to_string().into(),
+                            name: project.name.to_string().into(),
+                            space_name: String::arbitrary(&mut rng).into(),
+                            services: project
+                                .services
+                                .iter()
+                                .map(|x| x.to_string().into())
+                                .collect(),
+                            access_route: vec![],
+                        };
+                        Response::ok(req.id()).body(&obj).encode(buf)?;
+                        self.0.insert(obj.id.to_string(), obj);
+                    } else {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                }
+                Some(Method::Delete) => match req.path_segments::<3>().as_slice() {
+                    [_, _, id] => {
+                        if self.0.remove(*id).is_some() {
+                            Response::ok(req.id()).encode(buf)?
+                        } else {
+                            Response::not_found(req.id()).encode(buf)?
+                        }
+                    }
+                    _ => {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                },
+                _ => {
+                    dbg!(&req);
+                    Response::bad_request(req.id()).encode(buf)?;
+                }
+            }
+            Ok(())
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -1,24 +1,170 @@
-use minicbor::{Decode, Encode};
 use std::borrow::Cow;
 
+use minicbor::{Decode, Encode};
+
+#[cfg(feature = "tag")]
+use crate::TypeTag;
+
 #[derive(Decode, Debug)]
+#[cfg_attr(test, derive(Encode))]
 #[cbor(map)]
 pub struct Space<'a> {
-    #[b(0)]
-    pub id: Cow<'a, str>,
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    pub tag: TypeTag<9625590>,
     #[b(1)]
+    pub id: Cow<'a, str>, // TODO: str or Vec<u8>?
+    #[b(2)]
     pub name: Cow<'a, str>,
 }
 
 #[derive(Encode)]
+#[cfg_attr(test, derive(Decode))]
 #[cbor(map)]
 pub struct CreateSpace<'a> {
-    #[b(0)]
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    pub tag: TypeTag<3663171>,
+    #[b(1)]
     pub name: Cow<'a, str>,
 }
 
 impl<'a> CreateSpace<'a> {
     pub fn new<S: Into<Cow<'a, str>>>(name: S) -> Self {
-        Self { name: name.into() }
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            name: name.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::io;
+
+    use minicbor::encode::Write;
+    use minicbor::{encode, Decoder};
+    use quickcheck::{Arbitrary, Gen};
+
+    use ockam_core::compat::collections::HashMap;
+    use ockam_core::{Route, Routed, Worker};
+    use ockam_node::Context;
+
+    use crate::cloud::space::CreateSpace;
+    use crate::cloud::MessagingClient;
+    use crate::{Method, Request, Response};
+
+    use super::*;
+
+    #[ockam_macros::test]
+    async fn basic_api_usage(ctx: &mut Context) -> ockam_core::Result<()> {
+        ctx.start_worker("spaces", SpaceServer::default()).await?;
+        let mut client = MessagingClient::new(Route::new().into(), ctx).await?;
+
+        let s1 = client.create_space(CreateSpace::new("s1")).await?;
+        assert_eq!(&s1.name, "s1");
+        let s1_id = s1.id.to_string();
+
+        let s1_retrieved = client.get_space(&s1_id).await?;
+        assert_eq!(s1_retrieved.id, s1_id);
+
+        let s2 = client.create_space(CreateSpace::new("s2")).await?;
+        assert_eq!(&s2.name, "s2");
+        let s2_id = s2.id.to_string();
+
+        let list = client.list_spaces().await?;
+        assert_eq!(list.len(), 2);
+
+        client.delete_space(&s1_id).await?;
+
+        let list = client.list_spaces().await?;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, s2_id);
+
+        ctx.stop().await
+    }
+
+    #[derive(Debug, Default)]
+    pub struct SpaceServer(HashMap<String, Space<'static>>);
+
+    #[ockam_core::worker]
+    impl Worker for SpaceServer {
+        type Message = Vec<u8>;
+        type Context = Context;
+
+        async fn handle_message(
+            &mut self,
+            ctx: &mut Context,
+            msg: Routed<Self::Message>,
+        ) -> ockam_core::Result<()> {
+            let mut buf = Vec::new();
+            self.on_request(msg.as_body(), &mut buf)?;
+            ctx.send(msg.return_route(), buf).await
+        }
+    }
+
+    impl SpaceServer {
+        fn on_request<W>(&mut self, data: &[u8], buf: W) -> ockam_core::Result<()>
+        where
+            W: Write<Error = io::Error>,
+        {
+            let mut rng = Gen::new(32);
+            let mut dec = Decoder::new(data);
+            let req: Request = dec.decode()?;
+            match req.method() {
+                Some(Method::Get) => match req.path_segments::<2>().as_slice() {
+                    // Get all nodes:
+                    [_, ""] => Response::ok(req.id())
+                        .body(encode::ArrayIter::new(self.0.values()))
+                        .encode(buf)?,
+                    // Get a single node:
+                    [_, id] => {
+                        if let Some(n) = self.0.get(*id) {
+                            Response::ok(req.id()).body(n).encode(buf)?
+                        } else {
+                            Response::not_found(req.id()).encode(buf)?
+                        }
+                    }
+                    _ => {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                },
+                Some(Method::Post) if req.has_body() => {
+                    if let Ok(space) = dec.decode::<CreateSpace>() {
+                        let obj = Space {
+                            #[cfg(feature = "tag")]
+                            tag: TypeTag,
+                            id: u32::arbitrary(&mut rng).to_string().into(),
+                            name: space.name.to_string().into(),
+                        };
+                        Response::ok(req.id()).body(&obj).encode(buf)?;
+                        self.0.insert(obj.id.to_string(), obj);
+                    } else {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                }
+                Some(Method::Delete) => match req.path_segments::<2>().as_slice() {
+                    [_, id] => {
+                        if self.0.remove(*id).is_some() {
+                            Response::ok(req.id()).encode(buf)?
+                        } else {
+                            Response::not_found(req.id()).encode(buf)?
+                        }
+                    }
+                    _ => {
+                        dbg!(&req);
+                        Response::bad_request(req.id()).encode(buf)?;
+                    }
+                },
+                _ => {
+                    dbg!(&req);
+                    Response::bad_request(req.id()).encode(buf)?;
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -2,7 +2,7 @@ pub mod auth;
 pub mod cloud;
 pub mod nodes;
 
-pub(crate) mod error;
+pub mod error;
 
 use core::fmt;
 use core::ops::{Deref, DerefMut};
@@ -14,13 +14,10 @@ use ockam_core::compat::rand;
 use tinyvec::ArrayVec;
 
 /// CDDL schema or request and response headers as well as errors.
-// request  = { ?0: 7586022, 1: id, 2: path, 3: method, 4: has_body }
-// response = { ?0: 9750358, 1: id, 2: re, 3: status, 4: has_body }
-// error    = { ?0: 5359172, 1: path, ?2: method, ?3: message }
 pub const SCHEMA: &str = r#"
-   request  = { 0: id, 1: path, 2: method, 3: has_body }
-   response = { 0: id, 1: re, 2: status, 3: has_body }
-   error    = { 0: path, ?1: method, ?2: message }
+    request  = { ?0: 7586022, 1: id, 2: path, 3: method, 4: has_body }
+    response = { ?0: 9750358, 1: id, 2: re, 3: status, 4: has_body }
+    error    = { ?0: 5359172, 1: path, ?2: method, ?3: message }
     id       = uint
     re       = uint
     path     = text
@@ -50,20 +47,20 @@ pub struct Request<'a> {
     /// unique numeric value that identifies this type to help catching type
     /// errors. Otherwise this tag will not be produced and is ignored during
     /// decoding if present.
-    /// #[cfg(feature = "tag")]
-    /// #[n(0)] tag: TypeTag<7586022>,
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<7586022>,
     /// The request identifier.
-    #[n(0)] id: Id,
+    #[n(1)] id: Id,
     /// The resource path.
-    #[b(1)] path: Cow<'a, str>,
+    #[b(2)] path: Cow<'a, str>,
     /// The request method.
     ///
     /// It is wrapped in an `Option` to be forwards compatible, i.e. adding
     /// methods will not cause decoding errors and client code can decide
     /// how to handle unknown methods.
-    #[n(2)] method: Option<Method>,
+    #[n(3)] method: Option<Method>,
     /// Indicator if a request body is expected after this header.
-    #[n(3)] has_body: bool
+    #[n(4)] has_body: bool
 }
 
 /// The response header.
@@ -77,20 +74,20 @@ pub struct Response {
     /// unique numeric value that identifies this type to help catching type
     /// errors. Otherwise this tag will not be produced and is ignored during
     /// decoding if present.
-    /// #[cfg(feature = "tag")]
-    /// #[n(0)] tag: TypeTag<9750358>,
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<9750358>,
     /// The response identifier.
-    #[n(0)] id: Id,
+    #[n(1)] id: Id,
     /// The identifier of the request corresponding to this response.
-    #[n(1)] re: Id,
+    #[n(2)] re: Id,
     /// A status code.
     ///
     /// It is wrapped in an `Option` to be forwards compatible, i.e. adding
     /// status codes will not cause decoding errors and client code can decide
     /// how to handle unknown codes.
-    #[n(2)] status: Option<Status>,
+    #[n(3)] status: Option<Status>,
     /// Indicator if a response body is expected after this header.
-    #[n(3)] has_body: bool
+    #[n(4)] has_body: bool
 }
 
 /// A request/response identifier.
@@ -303,14 +300,14 @@ pub struct Error<'a> {
     /// unique numeric value that identifies this type to help catching type
     /// errors. Otherwise this tag will not be produced and is ignored during
     /// decoding if present.
-    /// #[cfg(feature = "tag")]
-    /// #[n(0)] tag: TypeTag<5359172>,
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<5359172>,
     /// The resource path of this error.
-    #[b(0)] path: Cow<'a, str>,
+    #[b(1)] path: Cow<'a, str>,
     /// The request method of this error.
-    #[n(1)] method: Option<Method>,
+    #[n(2)] method: Option<Method>,
     /// The actual error message.
-    #[b(2)] message: Option<Cow<'a, str>>,
+    #[b(3)] message: Option<Cow<'a, str>>,
 }
 
 impl<'a> Error<'a> {

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -30,23 +30,26 @@ test = false
 
 [dependencies]
 anyhow = "1"
-thiserror = "1"
-dirs = "4.0.0"
-clap = { version = "3", features = ["derive", "cargo"] }
-tracing = { version = "0.1.31", features = ["attributes"] }
-tracing-subscriber = "0.3.9"
-tracing-error = "0.2"
-tokio = { version="1", features = ["full"] }
-async-trait = "0.1"
-hex = "0.4"
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
-rand = "0.8"
 async-recursion = { version = "1.0.0" }
-directories = "4"
+async-trait = "0.1"
+clap = { version = "3", features = ["derive", "cargo"] }
 cli-table = "0.4"
-nix = "0.24"
 crossbeam-channel = "0.5"
+directories = "4"
+dirs = "4.0.0"
+hex = "0.4"
+nix = "0.24"
+open = "2"
+rand = "0.8"
+reqwest = { version = "0.11", default-features = false, features = ["json", "default-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version="1", features = ["full"] }
+tracing = { version = "0.1.31", features = ["attributes"] }
+tracing-error = "0.2"
+tokio-retry = "0.3"
+tracing-subscriber = "0.3.9"
 
 ockam = { path = "../ockam", version = "^0.59.0", features = ["software_vault", "ockam_command"] }
 ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -2,8 +2,6 @@ use anyhow::anyhow;
 use clap::Args;
 
 use ockam::{Context, TcpTransport};
-use ockam_api::cloud::enroll::AuthenticatorClient;
-use ockam_core::route;
 use ockam_multiaddr::MultiAddr;
 
 use crate::old::identity::load_or_create_identity;
@@ -12,21 +10,21 @@ use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollCommand {
-    /// Ockam's cloud node address
+    /// Ockam's cloud address
     #[clap(display_order = 1000)]
-    pub cloud_addr: MultiAddr,
+    address: MultiAddr,
 
     #[clap(display_order = 1001, arg_enum, default_value = "auth0")]
-    pub authenticator: Authenticator,
+    authenticator: Authenticator,
 
     #[clap(display_order = 1002, long, default_value = "default")]
-    pub vault: String,
+    vault: String,
 
     #[clap(display_order = 1003, long, default_value = "default")]
-    pub identity: String,
+    identity: String,
 
     #[clap(display_order = 1004, long)]
-    pub overwrite: bool,
+    overwrite: bool,
 }
 
 impl EnrollCommand {
@@ -39,17 +37,20 @@ async fn enroll(mut ctx: Context, command: EnrollCommand) -> anyhow::Result<()> 
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let _identity = load_or_create_identity(&IdentityOpts::from(&command), &ctx).await?;
+    let identity = load_or_create_identity(&IdentityOpts::from(&command), &ctx).await?;
 
-    let mut r = multiaddr_to_route(&command.cloud_addr)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", command.cloud_addr))?;
-    r = route![r.to_string(), "authenticator"];
+    let route = multiaddr_to_route(&command.address)
+        .ok_or_else(|| anyhow!("failed to parse address: {}", command.address))?;
 
-    let mut api_client = ockam_api::cloud::Client::new(r, &ctx).await?;
-    let auth_client = AuthenticatorClient;
-    api_client
-        .enroll(&command.authenticator.into(), auth_client)
-        .await?;
+    let mut api_client = ockam_api::cloud::MessagingClient::new(route, &ctx).await?;
+    match command.authenticator {
+        Authenticator::Auth0 => {
+            api_client
+                .enroll_auth0(identity.id, auth0::Auth0Service)
+                .await?
+        }
+        Authenticator::EnrollmentToken => api_client.enroll_enrollment_token(identity.id).await?,
+    }
     println!("Enrolled successfully");
 
     ctx.stop().await?;
@@ -76,6 +77,122 @@ impl From<Authenticator> for ockam_api::cloud::enroll::Authenticator {
             Authenticator::Auth0 => ockam_api::cloud::enroll::Authenticator::Auth0,
             Authenticator::EnrollmentToken => {
                 ockam_api::cloud::enroll::Authenticator::EnrollmentToken
+            }
+        }
+    }
+}
+
+pub(crate) mod auth0 {
+    use reqwest::StatusCode;
+    use std::borrow::Borrow;
+    use tokio_retry::{strategy::ExponentialBackoff, Retry};
+    use tracing::{debug, warn};
+
+    use ockam_api::cloud::enroll::auth0::*;
+    use ockam_api::cloud::enroll::{Identity, TokenProvider};
+    use ockam_api::error::ApiError;
+
+    pub const DOMAIN: &str = "dev-w5hdnpc2.us.auth0.com";
+    pub const CLIENT_ID: &str = "sGyXBwQfU6fjfW1gopphdV9vCLec060b";
+    pub const API_AUDIENCE: &str = "https://dev-w5hdnpc2.us.auth0.com/api/v2/";
+    pub const SCOPES: &str = "profile openid email";
+
+    pub struct Auth0Service;
+
+    #[async_trait::async_trait]
+    impl<'a> TokenProvider<'a> for Auth0Service {
+        type T = Auth0Token<'a>;
+
+        async fn token(&mut self, _identity: &Identity) -> ockam_core::Result<Self::T> {
+            // Request device code
+            // More on how to use scope and audience in https://auth0.com/docs/quickstart/native/device#device-code-parameters
+            let device_code_res = {
+                let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
+                let res = Retry::spawn(retry_strategy, move || {
+                    let client = reqwest::Client::new();
+                    client
+                        .post(format!("https://{}/oauth/device/code", DOMAIN))
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .form(&[
+                            ("client_id", CLIENT_ID),
+                            ("scope", SCOPES),
+                            ("audience", API_AUDIENCE),
+                        ])
+                        .send()
+                })
+                .await
+                .map_err(ApiError::from)?;
+                match res.status() {
+                    StatusCode::OK => {
+                        let res = res.json::<DeviceCode>().await.map_err(ApiError::from)?;
+                        debug!("device code received: {res:#?}");
+                        res
+                    }
+                    _ => {
+                        let res = res.text().await.map_err(ApiError::from)?;
+                        let err = format!("couldn't get device code [response={:#?}]", res);
+                        return Err(ApiError::generic(&err));
+                    }
+                }
+            };
+
+            // Request device activation
+            // Note that we try to open the verification uri **without** the code.
+            // After the code is entered, if the user closes the tab (because they
+            // want to open it on another browser, for example), the uri gets
+            // invalidated and the user would have to restart the process (i.e.
+            // rerun the command).
+            let uri: &str = device_code_res.verification_uri.borrow();
+            if open::that(uri).is_err() {
+                warn!("couldn't open verification url automatically [url={uri}]",);
+            }
+
+            println!(
+                "Open the following url in your browser to authorize your device with code {}:\n{}",
+                device_code_res.user_code, device_code_res.verification_uri_complete,
+            );
+
+            // Request tokens
+            let client = reqwest::Client::new();
+            let tokens_res;
+            loop {
+                let res = client
+                    .post(format!("https://{}/oauth/token", DOMAIN))
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .form(&[
+                        ("client_id", CLIENT_ID),
+                        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                        ("device_code", &device_code_res.device_code),
+                    ])
+                    .send()
+                    .await
+                    .map_err(ApiError::from)?;
+                match res.status() {
+                    StatusCode::OK => {
+                        tokens_res = res.json::<Auth0Token>().await.map_err(ApiError::from)?;
+                        debug!("tokens received [tokens={tokens_res:#?}]");
+                        return Ok(tokens_res);
+                    }
+                    _ => {
+                        let err_res = res.json::<TokensError>().await.map_err(ApiError::from)?;
+                        match err_res.error.borrow() {
+                            "authorization_pending" | "invalid_request" | "slow_down" => {
+                                debug!("tokens not yet received [err={err_res:#?}]");
+                                tokio::time::sleep(tokio::time::Duration::from_secs(
+                                    device_code_res.interval as u64,
+                                ))
+                                .await;
+                                continue;
+                            }
+                            _ => {
+                                let err_msg =
+                                    format!("failed to receive tokens [err={err_res:#?}]");
+                                debug!("{}", err_msg);
+                                return Err(ApiError::generic(&err_msg));
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::util::{embedded_node, multiaddr_to_route};
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::Client;
+use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
@@ -28,7 +28,7 @@ async fn accept(mut ctx: Context, args: (MultiAddr, AcceptCommand)) -> anyhow::R
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
-    let mut api = Client::new(route, &ctx).await?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.accept_invitations(&cmd.email, &cmd.invitation).await?;
     println!("{res:?}");
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/invitation/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/create.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::util::{embedded_node, multiaddr_to_route};
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::{invitation::CreateInvitation, Client};
+use ockam_api::cloud::{invitation::CreateInvitation, MessagingClient};
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
@@ -34,7 +34,7 @@ async fn create(mut ctx: Context, args: (MultiAddr, CreateCommand)) -> anyhow::R
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
-    let mut api = Client::new(route, &ctx).await?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateInvitation::new("1", &cmd.email, &cmd.space_id, cmd.project_id.as_deref());
     let res = api.create_invitation(request).await?;
     println!("{res:?}");

--- a/implementations/rust/ockam/ockam_command/src/invitation/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/list.rs
@@ -4,7 +4,7 @@ use crate::util::{embedded_node, multiaddr_to_route};
 use anyhow::anyhow;
 use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::Client;
+use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
@@ -26,7 +26,7 @@ async fn list(mut ctx: Context, args: (MultiAddr, ListCommand)) -> anyhow::Resul
     let cloud_addr = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![cloud_addr.to_string(), "invitations"];
-    let mut api = Client::new(route, &ctx).await?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let invitations = api.list_invitations(&cmd.email).await?;
     let table = invitations
         .iter()

--- a/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::util::{embedded_node, multiaddr_to_route};
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::Client;
+use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
@@ -28,7 +28,7 @@ async fn reject(mut ctx: Context, args: (MultiAddr, RejectCommand)) -> anyhow::R
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
-    let mut api = Client::new(route, &ctx).await?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.reject_invitations(&cmd.email, &cmd.invitation).await?;
     println!("{res:?}");
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,19 +1,29 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::{project::CreateProject, Client};
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::{project::CreateProject, MessagingClient};
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Id of the space the project belongs to.
+    #[clap(display_order = 1001)]
     space_id: String,
 
     /// Name of the project.
+    #[clap(display_order = 1002)]
     project_name: String,
 
     /// Services enabled for this project.
+    #[clap(display_order = 1003)]
     services: Vec<String>,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, last = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl CreateCommand {
@@ -25,13 +35,12 @@ impl CreateCommand {
 async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "projects"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateProject::new(cmd.project_name, &cmd.services);
     let res = api.create_project(&cmd.space_id, request).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -1,16 +1,25 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Id of the space.
+    #[clap(display_order = 1001)]
     space_id: String,
 
     /// Id of the project.
+    #[clap(display_order = 1002)]
     project_id: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl DeleteCommand {
@@ -22,12 +31,11 @@ impl DeleteCommand {
 async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "projects"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.delete_project(&cmd.space_id, &cmd.project_id).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,13 +1,21 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
     /// Id of the space.
+    #[clap(display_order = 1001)]
     space_id: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl ListCommand {
@@ -19,12 +27,11 @@ impl ListCommand {
 async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "projects"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.list_projects(&cmd.space_id).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,7 +1,4 @@
-mod create;
-mod delete;
-mod list;
-mod show;
+use clap::{Args, Subcommand};
 
 use create::CreateCommand;
 use delete::DeleteCommand;
@@ -9,7 +6,11 @@ use list::ListCommand;
 use show::ShowCommand;
 
 use crate::HELP_TEMPLATE;
-use clap::{Args, Subcommand};
+
+mod create;
+mod delete;
+mod list;
+mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct ProjectCommand {

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -1,16 +1,25 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Id of the space.
+    #[clap(display_order = 1001)]
     space_id: String,
 
     /// Id of the project.
+    #[clap(display_order = 1002)]
     project_id: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl ShowCommand {
@@ -22,12 +31,11 @@ impl ShowCommand {
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "projects"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.get_project(&cmd.space_id, &cmd.project_id).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,13 +1,21 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::{space::CreateSpace, Client};
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::{space::CreateSpace, MessagingClient};
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the space.
+    #[clap(display_order = 1001)]
     name: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl CreateCommand {
@@ -19,13 +27,12 @@ impl CreateCommand {
 async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "spaces"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateSpace::new(cmd.name);
     let res = api.create_space(request).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,13 +1,21 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Id of the space.
+    #[clap(display_order = 1001)]
     id: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl DeleteCommand {
@@ -19,12 +27,11 @@ impl DeleteCommand {
 async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "spaces"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.delete_space(&cmd.id).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -1,11 +1,18 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
-pub struct ListCommand;
+pub struct ListCommand {
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
+}
 
 impl ListCommand {
     pub fn run(command: ListCommand) {
@@ -13,15 +20,14 @@ impl ListCommand {
     }
 }
 
-async fn list(mut ctx: Context, _cmd: ListCommand) -> anyhow::Result<()> {
+async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "spaces"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.list_spaces().await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -1,7 +1,4 @@
-mod create;
-mod delete;
-mod list;
-mod show;
+use clap::{Args, Subcommand};
 
 use create::CreateCommand;
 use delete::DeleteCommand;
@@ -9,7 +6,11 @@ use list::ListCommand;
 use show::ShowCommand;
 
 use crate::HELP_TEMPLATE;
-use clap::{Args, Subcommand};
+
+mod create;
+mod delete;
+mod list;
+mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct SpaceCommand {

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,13 +1,21 @@
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::util::embedded_node;
-use ockam::{route, Context, TcpTransport, TCP};
-use ockam_api::cloud::Client;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
+
+use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Id of the space.
+    #[clap(display_order = 1001)]
     id: String,
+
+    /// Ockam's cloud address. Argument used for testing purposes.
+    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
+    address: MultiAddr,
 }
 
 impl ShowCommand {
@@ -19,12 +27,11 @@ impl ShowCommand {
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    let cloud_address = "cloud.ockam.io:62526"; //TODO
-    let route = route![(TCP, cloud_address), "spaces"]; //TODO
-
-    let mut api = Client::new(route, &ctx).await?;
+    let route =
+        multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
+    let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api.get_space(&cmd.id).await?;
-    println!("{res:?}");
+    println!("{res:#?}");
 
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/util.rs
@@ -10,6 +10,7 @@ use ockam_core::LOCAL;
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Ockam, Tcp};
 use ockam_multiaddr::{MultiAddr, Protocol};
 
+pub const DEFAULT_CLOUD_ADDRESS: &str = "/dnsaddr/cloud.ockam.io/tcp/62526";
 pub const DEFAULT_TCP_PORT: u16 = 62526;
 
 /// A simple wrapper for shutting down the local embedded node (for

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -6,7 +6,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("enroll")
-        .arg("/ip4/127.0.0.1/tcp/8080") // cloud_addr
+        .arg("/ip4/127.0.0.1/tcp/8080") // address
         .arg("auth0") // authenticator
         .arg("--vault")
         .arg("vt")

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -10,7 +10,9 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("create")
         .arg("space-id")
         .arg("project-name")
-        .arg("service-a service-b");
+        .arg("service-a service-b")
+        .arg("--")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
@@ -21,14 +23,16 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.args(&prefix_args)
         .arg("show")
         .arg("space-id")
-        .arg("project-id");
+        .arg("project-id")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("delete")
         .arg("space-id")
-        .arg("project-id");
+        .arg("project-id")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -6,7 +6,10 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "space"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("create").arg("space-name");
+    cmd.args(&prefix_args)
+        .arg("create")
+        .arg("space-name")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
@@ -14,11 +17,17 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("show").arg("space-id");
+    cmd.args(&prefix_args)
+        .arg("show")
+        .arg("space-id")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("delete").arg("space-id");
+    cmd.args(&prefix_args)
+        .arg("delete")
+        .arg("space-id")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
https://github.com/build-trust/codebase/issues/203

This PR includes a lot of changes on spaces/project/enroll commands:
1. refactors the cloud `MessagingClient` to handle all cloud commands
2. spaces and projects commands: fixes CBOR support and adds tests for every command
3. auth0: fixes CBOR support
4. enrollment token: adds the command to authenticate a token

## Todo's
- [x] Complete the `enroll_token` flow: we need to add another command to create a token with a set of attributes (https://github.com/build-trust/ockam/pull/2834)