### PR TITLE
feat(rust): improve schema validation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,6 @@ insert_final_newline = unset
 [Makefile]
 # Make requires tab.
 indent_style = tab
+
+[*.cddl]
+indent_size = unset

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -11,10 +11,11 @@ publish = true
 
 [features]
 std  = ["minicbor/std", "ockam_core/std", "ockam_node/std", "tinyvec/std", "tracing/std"]
-tag  = []
+tag  = ["cddl-cat"]
 lmdb = ["std", "lmdb-rkv"]
 
 [dependencies]
+cddl-cat    = { version = "0.6.1", optional = true }
 minicbor    = { version = "0.17.1", features = ["alloc", "derive"] }
 reqwest     = { version = "0.11", default-features = false }
 serde       = { version = "1", features = ["derive"] }
@@ -45,7 +46,7 @@ features         = ["std"]
 cddl-cat            = "0.6.1"
 fake                = { version = "2", features=['derive', 'uuid']}
 mockall             = "0.11"
-ockam_api           = { path = ".", features = ["std"] }
+ockam_api           = { path = ".", features = ["std", "tag"] }
 ockam_macros        = { version = "0.15.0", path = "../ockam_macros", features = ["std"] }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0" }
 quickcheck          = "1.0.1"

--- a/implementations/rust/ockam/ockam_api/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/schema.cddl
@@ -1,0 +1,105 @@
+;;; NOTE: Many types have at key 0 a type identifier (aka type tag). This is
+;;; a randomly generated number that helps in tests to ensure that the CBOR
+;;; item is the type expected.
+
+;;; Request Header ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+request = {
+    ?0: 7586022,
+     1: id,
+     2: path,
+     3: method,
+     4: has_body
+}
+
+id       = uint
+re       = uint
+path     = text
+has_body = bool
+
+method = 0 ;; GET
+       / 1 ;; POST
+       / 2 ;; PUT
+       / 3 ;; DELETE
+       / 4 ;; PATCH
+
+
+;;; Response Header ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+response = {
+    ?0: 9750358,
+     1: id,
+     2: re,
+     3: status,
+     4: has_body
+}
+
+status = 200 ;; OK
+       / 400 ;; Bad request
+       / 404 ;; Not found
+       / 405 ;; Method not allowed
+       / 500 ;; Internal server error
+       / 501 ;; Not implemented
+
+;;; Error ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+error = {
+    ?0: 5359172,
+     1: path,
+    ?2: method,
+    ?3: message
+}
+
+message = text
+
+;;; Authenticated attributes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+attributes = {
+    ?0: 4724285,
+     1: {+ text => bytes }
+}
+
+attribute = {
+    ?0: 6844116,
+     1: value
+}
+
+value = bytes
+
+;;; Space ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; TODO: type tag?
+space = {
+    0: space_id
+    1: space_name
+}
+
+;; TODO: type tag?
+create_space = {
+    0: space_name
+}
+
+space_id   = text
+space_name = text
+
+
+;;; Projects ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; TODO: type tag?
+project = {
+    0: project_id,
+    1: project_name,
+    2: [+ service_name],
+    3: access_route
+}
+
+;; TODO: type tag?
+create_project = {
+    0: project_name,
+    1: [+ service_name]
+}
+
+project_id   = text
+project_name = text
+service_name = text
+access_route = bytes


### PR DESCRIPTION
Move CDDL schema definitions into a single file and add functions to allow convenient validation of CBOR items against this schema. This functionality is feature gated behind cargo feature `tag` (enabled in tests).