### PR TITLE
mrinal/release 06 06 2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_udp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes 1.1.0",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_multiaddr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "multiaddr",
  "ockam_multiaddr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_x3dh"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "arrayref",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "async-trait",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_tcp"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "hashbrown 0.9.1",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_channel"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "ockam_core",
  "ockam_key_exchange_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "ockam_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cddl-cat",
  "fake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_websocket"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "futures-util",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_core"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "ockam_core",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures 0.3.21",
  "heapless",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_key_exchange_xx"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "hex",
  "ockam_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_command"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "ockam-ffi"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "futures 0.3.21",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_identity"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "bls12_381_plus",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_ble"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "atsame54_xpro",
  "bluenrg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "aes-gcm",
  "arrayref",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "ockam"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "arrayref",
  "bls12_381_plus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-queue",
  "futures 0.3.21",

--- a/implementations/rust/ockam/ockam/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.60.0 - 2022-06-06
+
+### Added
+
+- Add basic node manager service
+- Add pid query to nodeman worker
+
+### Changed
+
+- Implement new `Vault` serialization
+- Rename new_context to new_detached
+- Implement basic ockam_command config module
+- Updated dependencies
+
 ## 0.59.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -96,7 +96,7 @@ path = "tests/main.rs"
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -103,7 +103,7 @@ ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", op
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.47.0", default_features = false }
-ockam_api = { path = "../ockam_api", version = "^0.2.0", default_features = false, optional = true }
+ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }
 signature_core = { version = "^0.37.0", path = "../signature_core", optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -97,7 +97,7 @@ path = "tests/main.rs"
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default-features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.55.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
@@ -118,7 +118,7 @@ hex = { version = "0.4", default-features = false }
 dyn-clone = "1.0"
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0" }
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -101,7 +101,7 @@ ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features =
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.48.0", default_features = false }
 ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }
 arrayref = "0.3"
@@ -119,7 +119,7 @@ dyn-clone = "1.0"
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0" }
 trybuild = { version = "1.0", features = ["diff"] }
 serde_json = "1.0"
 rand_xorshift = "0.3"

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -98,7 +98,7 @@ ockam_core = { path = "../ockam_core", version = "^0.54.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.53.0", default_features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -100,7 +100,7 @@ ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = f
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.48.0", default_features = false }
 ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -102,7 +102,7 @@ ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_featur
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
-ockam_identity = { path = "../ockam_identity", version = "^0.47.0", default_features = false }
+ockam_identity = { path = "../ockam_identity", version = "^0.48.0", default_features = false }
 ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }
 arrayref = "0.3"
 bls12_381_plus = { version = "0.5", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -94,7 +94,7 @@ name = "tests"
 path = "tests/main.rs"
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -99,7 +99,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default_features = false }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0", optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.55.0", optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default_features = false, optional = true }
 ockam_identity = { path = "../ockam_identity", version = "^0.48.0", default_features = false }

--- a/implementations/rust/ockam/ockam/Cargo.toml
+++ b/implementations/rust/ockam/ockam/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "ockam"
 readme = "README.md"
 repository = "https://github.com/build-trust/ockam/tree/develop/implementations/rust/ockam/ockam"
-version = "0.59.0"
+version = "0.60.0"
 rust-version = "1.56.0"
 publish = true
 

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -68,7 +68,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.59.0"
+ockam = "0.60.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_api/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_api/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2022-06-06
+
+### Added
+
+- Add builders to ockam_api
+- Add ockam_api_nodes
+- Add command-line interface for nodes api
+- Add cloud enroll, space and project subcommands
+- Add cowbytes and cowstr
+- Add `into_owned` for `CowStr` and `CowBytes`
+- Add pid query to nodeman worker
+- Add auth api
+- Add clould invitation subcommands
+- Add enrollment token + fixes to other commands
+
+### Changed
+
+- Ensure command-line args are not empty
+- Rename new_context to new_detached
+- Improve schema validation
+- Avoid `ockam_identity` dependency in `ockam_api`
+- Change `Defer` type for `CowStr` and `CowBytes`
+- Make `Method` enum exhaustive
+- Move `TypeTag` to `ockam_core`
+- Extend `Request` and `Response` encode api
+- Updated dependencies
+
+### Fixed
+
+- Rename subject to authenticated
+
+### Removed
+
+- Remove reqwest dependency in ockam_api
+
 ## 0.2.0 - 2022-05-23
 
 ### Added

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -30,7 +30,7 @@ default-features = false
 features         = ["no_std", "alloc"]
 
 [dependencies.ockam_node]
-version          = "0.56.0"
+version          = "0.57.0"
 path             = "../ockam_node"
 default-features = false
 features         = ["std"] # FIXME: required because of unbounded channels in ockam_node

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -24,7 +24,7 @@ tracing     = { version = "0.1.34", default-features = false }
 lmdb-rkv    = { version = "0.14.0", optional = true }
 
 [dependencies.ockam_core]
-version          = "0.54.0"
+version          = "0.55.0"
 path             = "../ockam_core"
 default-features = false
 features         = ["no_std", "alloc"]

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -41,6 +41,6 @@ fake                = { version = "2", features=['derive', 'uuid']}
 mockall             = "0.11"
 ockam_api           = { path = ".", features = ["std", "tag"] }
 ockam_macros        = { version = "0.15.0", path = "../ockam_macros", features = ["std"] }
-ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.54.0" }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.55.0" }
 quickcheck          = "1.0.1"
 tempfile            = "3.3.0"

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ockam_api"
-version     = "0.2.0"
+version     = "0.3.0"
 edition     = "2021"
 authors     = ["Ockam Developers"]
 license     = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_channel/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.54.0 - 2022-06-06
+
+### Added
+
+- Add doc comments to `SecureChannel`
+
+### Changed
+
+- Rename new_context to new_detached
+- Split worker into `Encryptor` and `Decryptor` in ockam_channel crate
+- Updated dependencies
+
 ## 0.53.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -69,7 +69,7 @@ ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default_features = false, optional = true }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_channel"
-version = "0.53.0"
+version = "0.54.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -67,7 +67,7 @@ alloc = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -65,7 +65,7 @@ alloc = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -68,7 +68,7 @@ alloc = [
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default_features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
@@ -78,7 +78,7 @@ tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0"}
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0" }
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.49.0" }
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -70,14 +70,14 @@ ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default_features
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default_features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default_features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0", default_features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0" }
 ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.49.0" }
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_channel/Cargo.toml
@@ -79,7 +79,7 @@ tracing = { version = "0.1", default_features = false }
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0"}
-ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.48.0"}
+ockam_key_exchange_x3dh = { path = "../ockam_key_exchange_x3dh", version = "^0.49.0" }
 trybuild = { version = "1.0", features = ["diff"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_channel/README.md
+++ b/implementations/rust/ockam/ockam_channel/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_channel = "0.53.0"
+ockam_channel = "0.54.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_command/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.60.0 - 2022-06-06
+
+### Added
+
+- Add command-line interface for nodes api
+- Add node subcommand
+- Add message subcommand
+- Add cloud enroll, space and project subcommands
+- Add auth api to ockam_command
+- Add clould invitation subcommands
+- Add enrollment token + fixes to other commands
+
+### Changed
+
+- Use multi-address in ockam command
+- Move old commands to a submodule
+- Hide old subcommands from command help
+- Rename dry_run command argument to test_argument_parser
+- Enroll, project and space commands
+- Improve ockam command help
+- Improve ockam node command help
+- Define command help template
+- Turn cloud commands into top level commands
+- Combine node start and spawn commands as create
+- Allow ockam_command to call its own binary path
+- Implement basic ockam_command config module
+- Integrate configuration and remote messaging
+- Basic node lifecycle management in ockam_command
+- Utility function to purge all nodes
+- Rename auth sub command to authenticated
+- Run the authenticated service on node create
+- Avoid `ockam_identity` dependency in `ockam_api`
+- Updated dependencies
+
+### Fixed
+
+- Spawn node with ockam node create
+- Log when tracing logging failed to initialise
+- Hide tracing logging on client-side ockam cli instance
+
+### Removed
+
+- Remove ockam command spawn marker option
+- Remove reqwest dependency in ockam_api
+
 ## 0.59.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_command"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 license = "Apache-2.0"
 publish = true

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -51,7 +51,7 @@ tracing-error = "0.2"
 tokio-retry = "0.3"
 tracing-subscriber = "0.3.9"
 
-ockam = { path = "../ockam", version = "^0.59.0", features = ["software_vault", "ockam_command"] }
+ockam = { path = "../ockam", version = "^0.60.0", features = ["software_vault", "ockam_command"] }
 ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -53,7 +53,7 @@ tracing-subscriber = "0.3.9"
 
 ockam = { path = "../ockam", version = "^0.60.0", features = ["software_vault", "ockam_command"] }
 ockam_api = { path = "../ockam_api", version = "0.3.0", features = ["std"] }
-ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
+ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.2.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -54,7 +54,7 @@ tracing-subscriber = "0.3.9"
 ockam = { path = "../ockam", version = "^0.60.0", features = ["software_vault", "ockam_command"] }
 ockam_api = { path = "../ockam_api", version = "0.3.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.2.0", features = ["std"] }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -52,7 +52,7 @@ tokio-retry = "0.3"
 tracing-subscriber = "0.3.9"
 
 ockam = { path = "../ockam", version = "^0.60.0", features = ["software_vault", "ockam_command"] }
-ockam_api = { path = "../ockam_api", version = "0.2.0", features = ["std"] }
+ockam_api = { path = "../ockam_api", version = "0.3.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }
 ockam_core = { path = "../ockam_core", version = "^0.54.0"}

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -55,7 +55,7 @@ ockam = { path = "../ockam", version = "^0.60.0", features = ["software_vault", 
 ockam_api = { path = "../ockam_api", version = "0.3.0", features = ["std"] }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.1.0", features = ["std"] }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", features = ["storage"] }
-ockam_core = { path = "../ockam_core", version = "^0.54.0"}
+ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/implementations/rust/ockam/ockam_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_core/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.55.0 - 2022-06-06
+
+### Added
+
+- Add ockam_api_nodes
+- Add simple `Vault` service
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Implement new `Vault` serialization
+- Move `TypeTag` to `ockam_core`
+- Partially add cbor support to `ockam_core/vault`
+- Updated dependencies
+
+### Removed
+
+- Remove `AsRef` from `PublicKey` to avoid confusion
+
 ## 0.54.0 - 2022-05-09
 
 ### Changed

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_core"
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.54.0"
+ockam_core = "0.55.0"
 ```
 
 ## Crate Features
@@ -32,7 +32,7 @@ be disabled as follows
 
 ```
 [dependencies]
-ockam_core = { version = "0.54.0" , default-features = false }
+ockam_core = { version = "0.55.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/implementations/rust/ockam/ockam_executor/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_executor/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.23.0 - 2022-06-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.22.0 - 2022-05-09
 
 ### Changed

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.15", default-features = false, features = [
     "async-await",
 ] }
 heapless = { version = "0.7", features = ["mpmc_large"] }
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 tracing = { version = "0.1", default_features = false }

--- a/implementations/rust/ockam/ockam_executor/Cargo.toml
+++ b/implementations/rust/ockam/ockam_executor/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/build-trust/ockam/tree/develop/implementations/
 keywords = ["ockam", "crypto", "encryption", "authentication"]
 license = "Apache-2.0"
 name = "ockam_executor"
-version = "0.22.0"
+version = "0.23.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_executor = "0.22.0"
+ockam_executor = "0.23.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_ffi/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.46.0 - 2022-06-06
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Updated dependencies
+
+### Fixed
+
+- Fix ffi after `Vault` updates
+
+### Removed
+
+- Remove `AsRef` from `PublicKey` to avoid confusion
+
 ## 0.45.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam-ffi"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -29,7 +29,7 @@ bls = ["ockam_core/bls"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0" }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }
 futures = { version = "0.3.21" }

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 bls = ["ockam_core/bls"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0"}
+ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
 lazy_static = "1.4"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.45.0"
+ockam-ffi = "0.46.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_identity/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_identity/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.48.0 - 2022-06-06
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Rename new_context to new_detached
+- Split secure channel worker in ockam_identity crate
+- Updated dependencies
+
 ## 0.47.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -72,7 +72,7 @@ credentials = [
 ]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default-features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -77,7 +77,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default-features = false }
-ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default-features = false, optional = true }
+ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_identity"
-version = "0.47.0"
+version = "0.48.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -76,7 +76,7 @@ ockam_core = { path = "../ockam_core", version = "^0.54.0", default-features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }
-ockam_channel = { path = "../ockam_channel", version = "^0.53.0", default-features = false }
+ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default-features = false }
 cfg-if = "1.0.0"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -75,7 +75,7 @@ credentials = [
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default-features = false }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default-features = false, optional = true }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default-features = false }
@@ -97,6 +97,6 @@ hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -78,7 +78,7 @@ ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = f
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.49.0", default-features = false, optional = true }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default-features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default-features = false }
 cfg-if = "1.0.0"
 group = { version = "0.10.0", default-features = false }
 heapless = "0.7"

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -74,7 +74,7 @@ credentials = [
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default-features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0", default-features = false, optional = true }
 ockam_channel = { path = "../ockam_channel", version = "^0.54.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.50.0", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_identity = "0.47.0"
+ockam_identity = "0.48.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.46.0 - 2022-06-06
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Updated dependencies
+
 ## 0.45.0 - 2022-05-09
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_core"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_core/Cargo.toml
@@ -34,5 +34,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_core/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_core/README.md
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_core = "0.45.0"
+ockam_key_exchange_core = "0.46.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.49.0 - 2022-06-06
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Updated dependencies
+
+### Removed
+
+- Remove `AsRef` from `PublicKey` to avoid confusion
+
 ## 0.48.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -42,5 +42,5 @@ zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 ockam_node = { path = "../ockam_node", version = "^0.57.0" }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -43,4 +43,4 @@ hex = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
-ockam_node = { path = "../ockam_node", version = "^0.56.0"}
+ockam_node = { path = "../ockam_node", version = "^0.57.0" }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "hex/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 hex = { version = "0.4", default-features = false }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc", "hex/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 arrayref = "0.3"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_x3dh"
-version = "0.48.0"
+version = "0.49.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_x3dh = "0.48.0"
+ockam_key_exchange_x3dh = "0.49.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.50.0 - 2022-06-06
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Updated dependencies
+
+### Removed
+
+- Remove `AsRef` from `PublicKey` to avoid confusion
+
 ## 0.49.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_key_exchange_xx"
-version = "0.49.0"
+version = "0.50.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -40,5 +40,5 @@ ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.4
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
-ockam_node = { path = "../ockam_node", version = "^0.56.0"}
+ockam_node = { path = "../ockam_node", version = "^0.57.0" }
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -35,7 +35,7 @@ no_std = ["ockam_core/no_std", "ockam_key_exchange_core/no_std"]
 alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["ockam_core/alloc", "ockam_key_exchange_core/alloc"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
-ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.45.0", default_features = false }
+ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}

--- a/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/Cargo.toml
@@ -39,6 +39,6 @@ ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = f
 ockam_key_exchange_core = { path = "../ockam_key_exchange_core", version = "^0.46.0", default_features = false }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 ockam_node = { path = "../ockam_node", version = "^0.57.0" }
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.49.0"
+ockam_key_exchange_xx = "0.50.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_multiaddr/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_multiaddr/CHANGELOG.md
@@ -3,3 +3,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - 2022-06-06
+
+### Added
+
+- Add pop_front to multi-address
+- Add ockam protocol
+- Add (inefficient) push_front
+
+### Changed
+
+- Initial implementation of multiaddr
+- Tweak protocols
+- Use multi-address in ockam command
+- Updated dependencies
+

--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "ockam_multiaddr"
-version     = "0.1.0"
+version     = "0.2.0"
 authors     = ["Ockam Developers"]
 license     = "Apache-2.0"
 edition     = "2021"

--- a/implementations/rust/ockam/ockam_node/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_node/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.57.0 - 2022-06-06
+
+### Added
+
+- Add an async_drop mechanism for bare context drop
+- Add dedicated channel types for ockam_node, switch back to bounded channels
+- Add timeout function to context that takes duration
+
+### Changed
+
+- Attempt to cut down memory usage via context drop
+- Rename new_context to new_detached
+- Updated dependencies
+
+### Fixed
+
+- Fix address de-allocation issues for bare contexts
+
 ## 0.56.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -60,7 +60,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 heapless = { version = "0.7", features = ["mpmc_large"], optional = true }
-ockam_executor = { path = "../ockam_executor", version = "^0.22.0", default-features = false, optional = true }
+ockam_executor = { path = "../ockam_executor", version = "^0.23.0", default-features = false, optional = true }
 serde_bare = { version = "0.5.0", default-features = false }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -43,7 +43,7 @@ alloc = ["ockam_core/alloc", "ockam_executor/alloc", "futures/alloc"]
 dump_internals = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "sync",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "Apache-2.0"
 name = "ockam_node"
-version = "0.56.0"
+version = "0.57.0"
 publish = true
 rust-version = "1.56.0"
 

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_node = "0.56.0"
+ockam_node = "0.57.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_ble/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.0 - 2022-06-06
+
+### Changed
+
+- Rename new_context to new_detached
+- Updated dependencies
+
 ## 0.14.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -124,7 +124,7 @@ cortex-m = "0.7.3"
 riscv = "0.7.0"
 
 [dev-dependencies]
-ockam_identity = { path = "../ockam_identity", version = "^0.47.0"}
+ockam_identity = { path = "../ockam_identity", version = "^0.48.0" }
 ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
 
 [[example]]

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_ble"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -84,7 +84,7 @@ pic32mx1xxfxxxb = ["pic32", "pic32-hal/pic32mx1xxfxxxb"]
 pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
 

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -125,7 +125,7 @@ riscv = "0.7.0"
 
 [dev-dependencies]
 ockam_identity = { path = "../ockam_identity", version = "^0.48.0" }
-ockam_vault = { path = "../ockam_vault", version = "^0.49.0"}
+ockam_vault = { path = "../ockam_vault", version = "^0.50.0" }
 
 [[example]]
 name = "04-routing-over-ble-transport-initiator"

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -85,7 +85,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_ble/Cargo.toml
@@ -86,7 +86,7 @@ pic32mx2xxfxxxb = ["pic32", "pic32-hal/pic32mx2xxfxxxb"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.28.0", default_features = false }
 
 futures = { version = "0.3.19", default-features = false }
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "async-await-macro", "sink"] }

--- a/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.28.0 - 2022-06-06
+
+### Changed
+
+- Updated dependencies
+
 ## 0.27.0 - 2022-05-09
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_core"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -31,5 +31,5 @@ no_std = ["ockam_core/no_std"]
 alloc = ["ockam_core/alloc"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_core = "0.27.0"
+ockam_transport_core = "0.28.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.55.0 - 2022-06-06
+
+### Changed
+
+- Rename new_context to new_detached
+- Updated dependencies
+
+### Removed
+
+- Remove messaging cycle from `TCP Portal`
+
 ## 0.54.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -28,7 +28,7 @@ std = ["ockam_macros/std"]
 alloc = []
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0"}
+ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 ockam_node = { path = "../ockam_node", version = "^0.56.0"}
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -29,7 +29,7 @@ alloc = []
 
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0" }
-ockam_node = { path = "../ockam_node", version = "^0.56.0"}
+ockam_node = { path = "../ockam_node", version = "^0.57.0" }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_tcp"
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 ockam_core = { path = "../ockam_core", version = "^0.55.0" }
 ockam_node = { path = "../ockam_node", version = "^0.57.0" }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.28.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio = { version = "1.8", features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -29,7 +29,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_tcp = "0.54.0"
+ockam_transport_tcp = "0.55.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_transport_udp/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_udp/CHANGELOG.md
@@ -1,4 +1,13 @@
-## v0.1.0 - 2022-05-22
-### Added
+# Changelog
+All notable changes to this project will be documented in this file.
 
-- `UdpTransport` - a high level management interface for UDP transports.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0 - 2022-06-06
+
+### Changed
+
+- Implement rust udp transport
+- Updated dependencies
+

--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -31,7 +31,7 @@ alloc = []
 bytes = "1.1.0"
 futures-util = "0.3"
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0"}
+ockam_node = { path = "../ockam_node", version = "^0.57.0" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}
 rand = "0.7"
 hashbrown = { version = "0.9" }

--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -32,7 +32,7 @@ bytes = "1.1.0"
 futures-util = "0.3"
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.57.0" }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.28.0" }
 rand = "0.7"
 hashbrown = { version = "0.9" }
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -30,7 +30,7 @@ alloc = []
 [dependencies]
 bytes = "1.1.0"
 futures-util = "0.3"
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0"}
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0"}
 rand = "0.7"

--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_udp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7.1", features = ["net", "codec"] }
 
 [dev-dependencies]
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0"}
-ockam = { path = "../ockam", version = "^0.59.0"}
+ockam = { path = "../ockam", version = "^0.60.0" }
 
 [[example]]
 name = "client"

--- a/implementations/rust/ockam/ockam_transport_udp/README.md
+++ b/implementations/rust/ockam/ockam_transport_udp/README.md
@@ -6,7 +6,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_udp = "0.1.0"
+ockam_transport_udp = "0.2.0"
 ```
 
 ## Test

--- a/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.46.0 - 2022-06-06
+
+### Changed
+
+- Rename new_context to new_detached
+- Updated dependencies
+
 ## 0.45.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_transport_websocket"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -48,7 +48,7 @@ futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "rt-multi-thread",

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -47,7 +47,7 @@ alloc = [
 futures-util = { version = "0.3", default-features = false, features = [
     "tokio-io",
 ] }
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
 tokio = { version = "1.8", default-features = false, optional = true, features = [

--- a/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_websocket/Cargo.toml
@@ -49,7 +49,7 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
-ockam_transport_core = { path = "../ockam_transport_core", version = "^0.27.0", default_features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.28.0", default_features = false }
 tokio = { version = "1.8", default-features = false, optional = true, features = [
     "rt-multi-thread",
     "sync",

--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_websocket = "0.45.0"
+ockam_transport_websocket = "0.46.0"
 ```
 
 This crate requires the rust standard library `"std"`.

--- a/implementations/rust/ockam/ockam_vault/CHANGELOG.md
+++ b/implementations/rust/ockam/ockam_vault/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.50.0 - 2022-06-06
+
+### Added
+
+- Add simple `Vault` service
+- Add simple vault service test
+
+### Changed
+
+- Switch `Vault` to `String` `KeyId` instead of integer `Secret`
+- Implement new `Vault` serialization
+- Improve file handling in `Vault` storage
+- Updated dependencies
+
+### Removed
+
+- Remove `AsRef` from `PublicKey` to avoid confusion
+
 ## 0.49.0 - 2022-05-23
 
 ### Changed

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -72,7 +72,7 @@ service = ["ockam_api", "minicbor"]
 [dependencies]
 ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
-ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
+ockam_node = { path = "../ockam_node", version = "^0.57.0", default_features = false }
 ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }
 signature_core = { path = "../signature_core", version = "^0.37.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.37.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -73,7 +73,7 @@ service = ["ockam_api", "minicbor"]
 ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
-ockam_api = { path = "../ockam_api", version = "^0.2.0", default_features = false, optional = true }
+ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }
 signature_core = { path = "../signature_core", version = "^0.37.0", optional = true }
 signature_bbs_plus = { path = "../signature_bbs_plus", version = "^0.37.0", optional = true }
 signature_bls = { path = "../signature_bls", version = "^0.35.0", optional = true }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_vault"
-version = "0.49.0"
+version = "0.50.0"
 authors = ["Ockam Developers"]
 edition = "2021"
 license = "Apache-2.0"

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -70,7 +70,7 @@ storage = ["std", "serde", "serde_json"]
 service = ["ockam_api", "minicbor"]
 
 [dependencies]
-ockam_core = { path = "../ockam_core", version = "^0.54.0", default_features = false }
+ockam_core = { path = "../ockam_core", version = "^0.55.0", default_features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.15.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.56.0", default_features = false }
 ockam_api = { path = "../ockam_api", version = "^0.3.0", default_features = false, optional = true }

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_vault = "0.49.0"
+ockam_vault = "0.50.0"
 ```
 
 ## Crate Features
@@ -33,7 +33,7 @@ disabled as follows
 
 ```
 [dependencies]
-ockam_vault = { version = "0.49.0" , default-features = false }
+ockam_vault = { version = "0.50.0" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency


### PR DESCRIPTION
- chore(rust): crate release ockam version 0.60.0
- chore(rust): crate release ockam_api version 0.3.0
- chore(rust): crate release ockam_channel version 0.54.0
- chore(rust): crate release ockam_command version 0.60.0
- chore(rust): crate release ockam_core version 0.55.0
- chore(rust): crate release ockam_executor version 0.23.0
- chore(rust): crate release ockam-ffi version 0.46.0
- chore(rust): crate release ockam_identity version 0.48.0
- chore(rust): crate release ockam_key_exchange_core version 0.46.0
- chore(rust): crate release ockam_key_exchange_x3dh version 0.49.0
- chore(rust): crate release ockam_key_exchange_xx version 0.50.0
- chore(rust): crate release ockam_multiaddr version 0.2.0
- chore(rust): crate release ockam_node version 0.57.0
- chore(rust): crate release ockam_transport_ble version 0.15.0
- chore(rust): crate release ockam_transport_tcp version 0.55.0
- chore(rust): crate release ockam_transport_udp version 0.2.0
- chore(rust): crate release ockam_transport_websocket version 0.46.0
- chore(rust): crate release ockam_vault version 0.50.0
- chore(rust): crate release ockam_transport_core version 0.28.0
