### PR TITLE
feat(elixir): add is_authorized to the worker behaviour

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/api/client/discovery_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/client/discovery_client.ex
@@ -31,41 +31,25 @@ defmodule Ockam.API.Client.DiscoveryClient do
     end
   end
 
-  def list_services(access_route, discovery_route, timeout \\ 5_000, self_address \\ nil) do
+  def list_services(access_route, discovery_route, timeout \\ 5_000) do
     api_route = access_route ++ discovery_route
 
-    with_self_address(self_address, fn self_address ->
-      case Client.sync_request(:get, "", nil, api_route, timeout, self_address) do
-        {:ok, %Response{status: 200, body: service_infos}} ->
-          {:ok,
-           extend_routes_with_access_route(ServiceInfo.decode_list(service_infos), access_route)}
+    case Client.sync_request(:get, "", nil, api_route, timeout) do
+      {:ok, %Response{status: 200, body: service_infos}} ->
+        {:ok,
+         extend_routes_with_access_route(ServiceInfo.decode_list(service_infos), access_route)}
 
-        {:ok, %Response{status: status, body: error}} ->
-          {:error, {:api_error, status, error}}
+      {:ok, %Response{status: status, body: error}} ->
+        {:error, {:api_error, status, error}}
 
-        {:error, reason} ->
-          {:error, reason}
-      end
-    end)
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   def extend_routes_with_access_route(service_infos, access_route) do
     Enum.map(service_infos, fn %{route: route} = service_info ->
       Map.put(service_info, :relative_route, access_route ++ route)
     end)
-  end
-
-  def with_self_address(nil, fun) do
-    {:ok, call_address} = Ockam.Node.register_random_address()
-
-    try do
-      fun.(call_address)
-    after
-      Ockam.Node.unregister_address(call_address)
-    end
-  end
-
-  def with_self_address(address, fun) do
-    fun.(address)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/message.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/message.ex
@@ -59,6 +59,14 @@ defmodule Ockam.Message do
   @doc "Get payload from the message"
   def payload(%Message{payload: payload}), do: payload
 
+  @doc "Get local metadata from the message"
+  def local_metadata(%Message{local_metadata: local_metadata}), do: local_metadata
+
+  @doc "Get local metadata value for key from the message"
+  def local_metadata_value(%Message{local_metadata: local_metadata}, key) do
+    Map.get(local_metadata, key)
+  end
+
   def set_onward_route(%Message{} = message, onward_route) when is_list(onward_route) do
     %{message | onward_route: onward_route}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel.ex
@@ -19,11 +19,6 @@ defmodule Ockam.SecureChannel do
   defdelegate create(options), to: Channel
 
   @doc """
-  Send a message through a secure channel.
-  """
-  defdelegate send(channel, message), to: Channel
-
-  @doc """
   Returns a map of information about the peer responder or initiator of a
   channel.
   """

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
@@ -15,11 +15,13 @@ defmodule Ockam.SecureChannel.Listener do
   @doc false
   @impl true
   def setup(options, state) do
-    with {:ok, vault} <- get_from_options(:vault, options),
-         {:ok, identity_keypair} <- get_from_options(:identity_keypair, options) do
+    with {:ok, vault} <- Keyword.fetch(options, :vault),
+         {:ok, identity_keypair} <- Keyword.fetch(options, :identity_keypair) do
       state = Map.put(state, :vault, vault)
       state = Map.put(state, :identity_keypair, identity_keypair)
       {:ok, state}
+    else
+      :error -> {:error, {:required_options_missing, [:vault, :identity_keypair], options}}
     end
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/inlet_worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/inlet_worker.ex
@@ -14,6 +14,7 @@ defmodule Ockam.Transport.Portal.InletWorker do
 
   use Ockam.Worker
   alias Ockam.Message
+  alias Ockam.Router
   alias Ockam.Transport.Portal.TunnelProtocol
   require Logger
 
@@ -29,7 +30,7 @@ defmodule Ockam.Transport.Portal.InletWorker do
     # The listener process has set us as the socket' controlling process.
     # From this point on, it's safe to set the socket to active mode at any time.
     :ok =
-      Ockam.Router.route(%Message{
+      Router.route(%Message{
         payload: TunnelProtocol.encode(:ping),
         onward_route: state.peer_route,
         return_route: [state.address]
@@ -50,7 +51,7 @@ defmodule Ockam.Transport.Portal.InletWorker do
     :ok = :inet.setopts(socket, active: :once)
 
     :ok =
-      Ockam.Router.route(%Message{
+      Router.route(%Message{
         payload: TunnelProtocol.encode({:payload, data}),
         onward_route: peer_route
       })
@@ -62,7 +63,7 @@ defmodule Ockam.Transport.Portal.InletWorker do
     Logger.info("Socket closed")
 
     :ok =
-      Ockam.Router.route(%Message{
+      Router.route(%Message{
         payload: TunnelProtocol.encode(:disconnect),
         onward_route: peer_route
       })

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/outlet_worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/outlet_worker.ex
@@ -5,6 +5,7 @@ defmodule Ockam.Transport.Portal.OutletWorker do
 
   use Ockam.Worker
   alias Ockam.Message
+  alias Ockam.Router
   alias Ockam.Transport.Portal.TunnelProtocol
 
   require Logger

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp.ex
@@ -72,7 +72,8 @@ defmodule Ockam.Transport.TCP do
                  {:destination, destination},
                  {:restart_type, :temporary} | client_options
                ]) do
-          Ockam.Node.send(client_address, message)
+          [_tcp_address | onward_route] = Message.onward_route(message)
+          Router.route(Message.set_onward_route(message, [client_address | onward_route]))
         end
 
       e ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
@@ -1,0 +1,129 @@
+defmodule Ockam.Worker.Authorization do
+  @moduledoc """
+  Helper functions to configure worker message authorization.
+
+  Usage:
+  ```
+  def is_authorized(message, _state)
+    Authorization.from_addresses(message, ["one", "two"])
+  end
+  ```
+
+  Pipelining helpers:
+  ```
+  def is_authorized(message, state)
+    Authorization.from_addresses(message, ["one", "two"])
+    |> Authorization.to_my_address(message, state)
+  end
+  ```
+  """
+  alias Ockam.Message
+
+  @doc """
+  Allow any messages to be handled by the worker
+  """
+  def allow_all(prev \\ :ok) do
+    chain(prev, fn -> :ok end)
+  end
+
+  @doc """
+  Deny all messages from being handled by the worker
+  """
+  def deny_all(prev \\ :ok) do
+    chain(prev, fn -> {:error, :deny_all} end)
+  end
+
+  @doc """
+  Only allow messages from a set of addresses to be handled by the worker.
+
+  Message address is taken from return_route in that case
+  """
+  def from_addresses(prev, message, addresses) when is_list(addresses) do
+    chain(prev, fn ->
+      from_addresses(message, addresses)
+    end)
+  end
+
+  def from_addresses(message, addresses) do
+    case Message.return_route(message) do
+      [return_address | _rest] ->
+        case Enum.member?(addresses, return_address) do
+          true -> :ok
+          false -> {:error, {:from_address, :invalid_source, return_address}}
+        end
+
+      [] ->
+        {:error, {:from_address, :empty_return_route}}
+    end
+  end
+
+  @doc """
+  Only allow messages sent to a certain addresses to be handled by the worker
+
+  Message address is taken from the message onward_route
+  """
+  def to_addresses(prev, message, addresses) when is_list(addresses) do
+    chain(prev, fn ->
+      to_addresses(message, addresses)
+    end)
+  end
+
+  def to_addresses(message, addresses) do
+    case Message.onward_route(message) do
+      [onward_address | _rest] ->
+        case Enum.member?(addresses, onward_address) do
+          true -> :ok
+          false -> {:error, {:to_address, :invalid_destination, onward_address}}
+        end
+
+      [] ->
+        {:error, {:to_address, :empty_onward_route}}
+    end
+  end
+
+  @doc """
+  Allow messages sent to the addresses stored in the `all_addresses` of the state
+  to be handled by the worker.
+
+  Message address is taken from the message onward_route
+  """
+  def to_my_address(prev \\ :ok, message, state) do
+    addresses = Map.get(state, :all_addresses, [])
+    to_addresses(prev, message, addresses)
+  end
+
+  @doc """
+  Allow messages which have `channel: :secure_channel` in their local metadata
+  to be handled by the worker.
+  """
+  def is_secure(prev \\ :ok, message) do
+    chain(prev, fn ->
+      case Message.local_metadata_value(message, :channel) do
+        :secure_channel -> :ok
+        ## TODO: error explanation
+        other -> {:error, {:is_secure, :invalid_channel, other}}
+      end
+    end)
+  end
+
+  @doc """
+  Allow messages which have `identity: identity` in their local metadata
+  to be handled by the worker.
+  """
+  def from_identity(prev \\ :ok, message, identity) do
+    chain(prev, fn ->
+      case Message.local_metadata_value(message, :identity) do
+        ^identity -> :ok
+        other -> {:error, {:from_identity, :invalid_identity, other}}
+      end
+    end)
+  end
+
+  def chain(:ok, fun) do
+    fun.()
+  end
+
+  def chain({:error, _reason} = error, _fun) do
+    error
+  end
+end

--- a/implementations/elixir/ockam/ockam/test/ockam/message_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/message_test.exs
@@ -3,9 +3,6 @@ defmodule Ockam.Message.Tests do
   doctest Ockam.Message
   alias Ockam.Message
 
-  alias Ockam.Transport.TCPAddress
-  alias Ockam.Transport.UDPAddress
-
   describe "Ockam.Message" do
     ## TODO: message tests
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/token_lease_manager.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/token_lease_manager.ex
@@ -2,7 +2,7 @@ defmodule Ockam.Services.TokenLeaseManager do
   @moduledoc false
   use Ockam.Worker
 
-  alias Ockam.Node
+  alias Ockam.Router
   alias Ockam.Services.TokenLeaseManager.Lease
 
   require Logger

--- a/implementations/elixir/ockam/ockam_services/lib/services/token_lease_manager/cloud_service.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/token_lease_manager/cloud_service.ex
@@ -55,6 +55,7 @@ defmodule Ockam.Services.TokenLeaseManager.CloudService do
       def handle_call({:revoke, lease_id}, _from, cloud_configuration),
         do: {:reply, handle_revoke(cloud_configuration, lease_id), cloud_configuration}
 
+      ## TODO: this conflicts with Ockam.Worker :get_address handler
       def handle_call(:get_address, _from, cloud_configuration),
         do: {:reply, handle_get_address(cloud_configuration), cloud_configuration}
     end

--- a/implementations/elixir/ockam/ockam_services/test/services/echo_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/echo_test.exs
@@ -35,6 +35,7 @@ defmodule Test.Services.EchoTestWorker do
   use Ockam.Worker
 
   alias Ockam.Message
+  alias Ockam.Router
   alias Test.Utils
 
   require Logger


### PR DESCRIPTION
Workers now can specify `is_authorized(message, state) :: :ok | {:error, reason}`
function to allow or deny some messages to be handled.

Added `Ockam.Worker.Authorization` module to provide some basic authorization helpers:

`allow_all()` - handle all messages
`deny_all()` - refuse all messages
`from_addresses(message, addresses)` - only handle messages with return route starting with one of the `addresses`
`to_addresses(message, addresses)` - only handle messages with onward route starting with one of the `addresses`
`to_my_address(message, state)` - only handle messages with onward route starting with one of the addresses from the state key `:all_addresses`
`is_secure(message)` - only handle message for which local metadata key `:transport` is set to `:secure_channel` TODO: add this key when message exiting secure channel
`from_identity(message, identity)` - only handle messages with local metadata key `:identity` set to `identity`

Authorization helpers can be chained with the `|>` pipe operator:

```
Authorization.from_addresses(message, ["one", "two"])
|> Authorization.to_my_addresses(message, state)
```

**NOTE**
Workers when registering additional address now have to use `Ockam.Worker.register_extra_addresses/3` or `Ockam.Worker.register_random_extra_address/2` to update `:all_addresses` in the worker state.

**BREAKING CHANGE**
Make all workers use `to_my_address` by default for `is_authorized/2`, which means that workers only handle messages sent to `:address` or addresses registered with `Ockam.Worker.register_extra_addresses/3`

Refactored `Ockam.Worker` `__using__` macro to delegate to `Ockam.Worker` functions.
This will help with debug to locate the right line and also allow to create workers without `use Ockam.Worker` e.g. from Erlang.

Removed `get_from_options/2` function

Added optional `timeout` to `Worker.create` function to allow creating process to wait longer for the worker to start

**BREAKING CHANGE**
Removed aliases from the `Ockam.Worker` `__using__` macro. Not `Node` and `Router` aliases will not be automatically created for the workers.

Added `Message.local_metadata/1` `Message.local_metadata_value/2` getters to fetch message metadata

Make `Ockam.Node.register_address/1,2` return `:ok` if the address is already registered for the current process.

Make `Ockam.Node.register_random_address/0,1,2,3` only retry registering if the error is `already_registered`

<!-- Thank you for sending a pull request :heart: -->


<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
