### PR TITLE
feat(rust): add example_test_helper and ockam/examples/... tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
  "cfg-if",
  "hashbrown 0.12.1",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1147,6 +1147,20 @@ dependencies = [
  "rand 0.8.5",
  "ron",
  "serde",
+]
+
+[[package]]
+name = "example_test_helper"
+version = "0.1.0"
+dependencies = [
+ "duct",
+ "libc",
+ "regex",
+ "shellwords",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1520,6 +1534,7 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 name = "hello_ockam"
 version = "0.1.0"
 dependencies = [
+ "example_test_helper",
  "hex",
  "ockam",
  "ockam_transport_udp",
@@ -1527,6 +1542,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -2314,6 +2330,7 @@ dependencies = [
 name = "ockam_kafka"
 version = "0.1.0"
 dependencies = [
+ "example_test_helper",
  "ockam",
 ]
 
@@ -2598,12 +2615,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3223,6 +3265,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.11.2",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3344,16 @@ checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "shellwords"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -3575,7 +3651,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 name = "tcp_inlet_and_outlet"
 version = "0.1.0"
 dependencies = [
+ "example_test_helper",
  "ockam",
+ "serial_test",
 ]
 
 [[package]]
@@ -3678,7 +3756,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "examples/rust/*/examples/..",
 
     "tools/docs/example_runner",
+    "tools/docs/example_test_helper",
     "tools/docs/example_blocks",
 ]
 

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -34,3 +34,5 @@ hex = "0.4"
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["std_rng"], default-features = false }
+example_test_helper = { path = "../../../tools/docs/example_test_helper" }
+serial_test = "0.6.0"

--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -1,0 +1,75 @@
+use example_test_helper::{CmdBuilder, Error};
+use serial_test::serial;
+
+#[test]
+fn run_01_node() -> Result<(), Error> {
+    // Run 01-node to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 01-node").run()?;
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.contains("Goodbye"));
+    Ok(())
+}
+
+#[test]
+fn run_02_worker() -> Result<(), Error> {
+    // Run to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 02-worker").run()?;
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.contains("Goodbye"));
+    Ok(())
+}
+
+#[test]
+fn run_03_routing() -> Result<(), Error> {
+    // Run to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing").run()?;
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.contains("Goodbye"));
+    Ok(())
+}
+
+#[test]
+fn run_03_routing_many_hops() -> Result<(), Error> {
+    // Run to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing-many-hops").run()?;
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.contains("Goodbye"));
+    Ok(())
+}
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_04_routing_over_transport() -> Result<(), Error> {
+    // Launch responder, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-responder").spawn()?;
+    resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Run initiator to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-routing-over-transport-initiator").run()?;
+
+    // Assert successful run conditions
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.to_lowercase().contains("goodbye"));
+    Ok(())
+}
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
+    // Launch responder, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-responder").spawn()?;
+    resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Launch middle, wait for it to start up
+    let mid = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-middle").spawn()?;
+    mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Run initiator to completion
+    let (exitcode, stdout) =
+        CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-initiator").run()?;
+
+    // Assert successful run conditions
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.to_lowercase().contains("goodbye"));
+    Ok(())
+}

--- a/examples/rust/ockam_kafka/Cargo.toml
+++ b/examples/rust/ockam_kafka/Cargo.toml
@@ -10,3 +10,6 @@ rust-version = "1.56.0"
 
 [dependencies]
 ockam = { path = "../../../implementations/rust/ockam/ockam" }
+
+[dev-dependencies]
+example_test_helper = { path = "../../../tools/docs/example_test_helper" }

--- a/examples/rust/ockam_kafka/tests/tests.rs
+++ b/examples/rust/ockam_kafka/tests/tests.rs
@@ -1,0 +1,24 @@
+use example_test_helper::{CmdBuilder, Error};
+
+#[test]
+fn alice_bob_securechannel() -> Result<(), Error> {
+    // Spawn BOB and get the dynamic stream addresses
+    let bob = CmdBuilder::new("cargo run --example ockam_kafka_bob").spawn()?;
+    let regex = r"(?im)^bob_to_alice stream address is: (\w+)$";
+    let addr_bob_to_alice = bob.match_stdout(regex)?.swap_remove(1).unwrap();
+    let regex = r"(?im)^alice_to_bob stream address is: (\w+)$";
+    let addr_alice_to_bob = bob.match_stdout(regex)?.swap_remove(1).unwrap();
+    println!("Address bob -> alice: {addr_bob_to_alice}");
+    println!("Address alice -> bob: {addr_alice_to_bob}");
+
+    // Prepare stdin for ALICE
+    let stdin = format!("{addr_bob_to_alice}\n{addr_alice_to_bob}\n");
+
+    // Spawn ALICE and wait for 'success'
+    let alice = CmdBuilder::new("cargo run --example ockam_kafka_alice")
+        .set_stdin(stdin.as_bytes())
+        .spawn()?;
+    alice.match_stdout(r"(?i)End-to-end encrypted secure channel was established.")?;
+
+    Ok(())
+}

--- a/examples/rust/tcp_inlet_and_outlet/Cargo.toml
+++ b/examples/rust/tcp_inlet_and_outlet/Cargo.toml
@@ -9,3 +9,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 ockam = { path = "../../../implementations/rust/ockam/ockam" }
+
+[dev-dependencies]
+example_test_helper = { path = "../../../tools/docs/example_test_helper" }
+serial_test = "0.6.0"

--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -1,0 +1,80 @@
+use example_test_helper::{CmdBuilder, Error};
+use serial_test::serial;
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
+    // Spawn example, wait for it to start up
+    let runner = CmdBuilder::new("cargo run --example 01-inlet-outlet 127.0.0.1:4001 ockam.io:80").spawn()?;
+    runner.match_stdout(r"(?i)Starting new processor")?;
+
+    // Run curl and check for a successful run
+    let (exitcode, stdout) = CmdBuilder::new("curl -s -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    assert_eq!(Some(0), exitcode);
+    println!("curl stdout...");
+    println!("{stdout}");
+    assert!(stdout.to_lowercase().contains("<html"));
+    Ok(())
+}
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_02_inlet_outlet_seperate_processes() -> Result<(), Error> {
+    // Spawn outlet, wait for it to start up
+    let outlet = CmdBuilder::new("cargo run --example 02-outlet ockam.io:80").spawn()?;
+    outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Spawn inlet, wait for it to start up
+    let inlet = CmdBuilder::new("cargo run --example 02-inlet 127.0.0.1:4001").spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+
+    // Run curl and check for a successful run
+    let (exitcode, stdout) = CmdBuilder::new("curl -s -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    assert_eq!(Some(0), exitcode);
+    println!("curl stdout...");
+    println!("{stdout}");
+    assert!(stdout.to_lowercase().contains("<html"));
+    Ok(())
+}
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_03_inlet_outlet_seperate_processes_secure_channel() -> Result<(), Error> {
+    // Spawn outlet, wait for it to start up
+    let outlet = CmdBuilder::new("cargo run --example 03-outlet ockam.io:80").spawn()?;
+    outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Spawn inlet, wait for it to start up
+    let inlet = CmdBuilder::new("cargo run --example 03-inlet 127.0.0.1:4001").spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+
+    // Run curl and check for a successful run
+    let (exitcode, stdout) = CmdBuilder::new("curl -s -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    assert_eq!(Some(0), exitcode);
+    println!("curl stdout...");
+    println!("{stdout}");
+    assert!(stdout.to_lowercase().contains("<html"));
+    Ok(())
+}
+
+#[test]
+#[serial] // Serialise tests that may clash on TCP ports
+fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_hub() -> Result<(), Error> {
+    // Spawn outlet, wait for it to start up, grab dynamic forwarding address
+    let outlet = CmdBuilder::new("cargo run --example 04-outlet ockam.io:80").spawn()?;
+    outlet.match_stdout(r"(?i)RemoteForwarder was created on the node")?;
+    let fwd_address = outlet.match_stdout(r"(?m)^FWD_(\w+)$")?.swap_remove(0).unwrap();
+    println!("Forwarding address: {fwd_address}");
+
+    // Spawn inlet, wait for it to start up
+    let inlet = CmdBuilder::new(&format!("cargo run --example 04-inlet 127.0.0.1:4001 {fwd_address}")).spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+
+    // // Run curl and check for a successful run
+    let (exitcode, stdout) = CmdBuilder::new("curl -s -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    assert_eq!(Some(0), exitcode);
+    println!("curl stdout...");
+    println!("{stdout}");
+    assert!(stdout.to_lowercase().contains("<html"));
+    Ok(())
+}

--- a/tools/docs/example_test_helper/Cargo.toml
+++ b/tools/docs/example_test_helper/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "example_test_helper"
+license = "Apache-2.0"
+version = "0.1.0"
+edition = "2021"
+publish = false
+rust-version = "1.56.0"
+
+[dependencies]
+duct = "0.13"
+shellwords = "1.1"
+regex = "1.5"
+libc = "0.2"
+thiserror = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tempfile = "3"

--- a/tools/docs/example_test_helper/src/lib.rs
+++ b/tools/docs/example_test_helper/src/lib.rs
@@ -1,0 +1,408 @@
+//! Helper for the test code of Ockam Examples.
+//!
+//! Allows test code to spawn or run-to-completeion child processes
+//! described by command lines.
+//!
+//! Processes have these environment variables set...
+//! - `OCKAM_LOG=trace`
+//!
+//! Some functions will timeout if [`DEFAULT_TIMEOUT_MS`] milliseconds
+//! pass. In parituclar [`CmdBuilder::run()`], but not [`CmdBuilder::spawn()`].
+//!
+//! Processes which have not completed are killed (or signalled) when their
+//! [`CmdRunner`] is dropped.
+//!
+//! The stdout of processes are written to temporary files. Those temporary files
+//! are left for the operating system to clear up.
+//!
+//! # Examples
+//!
+//! Run a command to completion and assert a successful run.
+//! ```
+//! use example_test_helper::{CmdBuilder};
+//!
+//! let (exitcode, stdout) = CmdBuilder::new("rustup --version").run().unwrap();
+//!
+//! assert_eq!(Some(0), exitcode);
+//! assert!(stdout.contains("rustup"));
+//! ```
+//!
+//! Spawn a command to run in the background and wait to match a regex on its stdout.
+//! If the process is still running when the CmdRunner is dropped it will be killed.
+//! Can use [`CmdRunner::wait()`] to wait for a process to complete.
+//! ```
+//! use example_test_helper::{CmdBuilder};
+//!
+//! let cmd = CmdBuilder::new("rustup --version").spawn().unwrap();
+//!
+//! let mut captures = cmd.match_stdout(r"(?im)^rustup (\d+\.\d+.\d+)").unwrap();
+//! let version = captures.swap_remove(1).unwrap();
+//!
+//! assert_eq!(version.matches(".").count(), 2);
+//! ```
+//!
+use duct::unix::HandleExt;
+use duct::{cmd, Handle};
+use regex::Regex;
+use std::time::SystemTime;
+use std::{fs, io};
+use std::{fs::File, io::Read, thread::sleep, time::Duration};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+use tracing::info;
+use tracing_subscriber::fmt::TestWriter;
+use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
+
+const POLL_MS: u32 = 250;
+const ENVIRONMENT_VARIABLES: &[(&str, &str)] = &[("OCKAM_LOG", "trace")];
+
+/// Default timeout value in milliseconds.
+pub const DEFAULT_TIMEOUT_MS: u32 = 180_000;
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("timed out")]
+    Timeout,
+    #[error("io error")]
+    Io(#[from] io::Error),
+    #[error("regex error")]
+    Regex(#[from] regex::Error),
+    #[error("shellwords error")]
+    Shellwords(#[from] shellwords::MismatchedQuotes),
+    #[error("exitcode was non-zero")]
+    NonzeroExitcode,
+    #[error("command has already exited")]
+    ExitedCmd,
+    #[error("failed to create temporary file for stdout")]
+    StdoutTempfile,
+}
+
+pub struct CmdBuilder {
+    cmd_line: String,
+    timeout_ms: u32,
+    stdin: Option<Vec<u8>>,
+}
+
+impl std::fmt::Debug for CmdBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CmdBuilder")
+            .field("cmd_line", &self.cmd_line)
+            .field("timeout_ms", &self.timeout_ms)
+            .field("stdin", &self.stdin)
+            .finish()
+    }
+}
+
+impl CmdBuilder {
+    /// Create a new instance.
+    pub fn new(cmd_line: &str) -> Self {
+        // Configure our tracing
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            let filter = EnvFilter::default().add_directive(LevelFilter::INFO.into());
+
+            // Ignore errors. Logging is not crucial here.
+            // Use TestWriter so 'cargo test' can choose to capture logging as it wants.
+            let _ = fmt()
+                .with_env_filter(filter)
+                .with_writer(TestWriter::new())
+                .try_init();
+        });
+
+        CmdBuilder {
+            cmd_line: String::from(cmd_line),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            stdin: None,
+        }
+    }
+
+    /// Set timeout value in milliseconds.
+    /// By default, timeout is [`DEFAULT_TIMEOUT_MS`].
+    pub fn set_timeout(mut self, value_ms: u32) -> Self {
+        self.timeout_ms = value_ms;
+        self
+    }
+
+    /// Set stdin for command.
+    pub fn set_stdin<T: Into<Vec<u8>>>(mut self, bytes: T) -> Self {
+        self.stdin = Some(bytes.into());
+        self
+    }
+
+    /// Run command to completion.
+    ///
+    /// May timeout.
+    ///
+    /// On success, returns command's exit code and stdout.
+    ///
+    /// Consumes the [`CmdBuilder`].
+    pub fn run(self) -> Result<(Option<i32>, String)> {
+        info!("Running '{}'", self.cmd_line);
+
+        // Spawn command
+        let runner = self.spawn()?;
+
+        // Wait on command
+        let res = runner.wait()?;
+
+        info!("Run complete '{}'", runner.cmd_line);
+
+        Ok(res)
+    }
+
+    /// Spawn command to run in the background.
+    ///
+    /// Consumes the [`CmdBuilder`].
+    pub fn spawn(self) -> Result<CmdRunner> {
+        // Create temp file for stdout
+        let (stdout_file, stdout_path) = NamedTempFile::new()?
+            .keep()
+            .map_err(|_| Error::StdoutTempfile)?;
+        let stdout_path = String::from(stdout_path.to_str().ok_or(Error::StdoutTempfile)?);
+
+        // Build expression to spawn
+        let split = shellwords::split(&self.cmd_line)?;
+        let mut expr = cmd(&split[0], &split[1..]);
+        expr = expr.stdout_file(stdout_file);
+        expr = expr.unchecked();
+        for (key, val) in ENVIRONMENT_VARIABLES {
+            expr = expr.env(key, val);
+        }
+        if let Some(bytes) = self.stdin {
+            expr = expr.stdin_bytes(bytes);
+        }
+
+        // Spawn
+        let handle = expr.start()?;
+        info!(
+            "Spawned '{}' (stdout path: '{}')",
+            self.cmd_line, stdout_path
+        );
+
+        Ok(CmdRunner {
+            cmd_line: self.cmd_line,
+            timeout_ms: self.timeout_ms,
+            handle,
+            stdout_path,
+        })
+    }
+
+    // Helper function
+    fn stdout_modified(path: &str) -> Option<SystemTime> {
+        fs::metadata(path).ok().and_then(|x| x.modified().ok())
+    }
+
+    // Helper function
+    fn stdout_contents(path: &str) -> Result<String> {
+        let mut output = String::new();
+        let mut f = File::open(path)?;
+        f.read_to_string(&mut output)?;
+        Ok(output)
+    }
+}
+
+pub struct CmdRunner {
+    cmd_line: String,
+    timeout_ms: u32,
+    handle: Handle,
+    stdout_path: String,
+}
+
+impl std::fmt::Debug for CmdRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CmdRunner")
+            .field("cmd_line", &self.cmd_line)
+            .field("timeout_ms", &self.timeout_ms)
+            .field("stdout_path", &self.stdout_path)
+            .finish()
+    }
+}
+
+impl Drop for CmdRunner {
+    /// Cleanup spwaned process.
+    ///
+    /// On unix, send SIGINT (Ctrl-C) to process to allow it the possibility
+    /// of shutting itself down and saving its llvm coverage data.
+    ///
+    /// On non-unix, kill process.
+    fn drop(&mut self) {
+        if cfg!(unix) {
+            let _ = self.handle.send_signal(libc::SIGINT);
+        } else {
+            let _ = self.handle.kill();
+        }
+    }
+}
+
+impl CmdRunner {
+    /// Wait until a given regular expression matches the command's stdout.
+    ///
+    /// May timeout.
+    ///
+    /// If the regular expression is not found in stdout and the command has
+    /// exited, will return Error::CmdExited.
+    ///
+    /// Function uses [`regex::Regex::captures()`] to find the capture groups
+    /// corresponding to the leftmost-first match in stdout of the given regular
+    /// expression. Capture groups are returned as `String`s.
+    /// See [`regex::Regex::captures()`] for more information.
+    pub fn match_stdout(&self, regex: &str) -> Result<Vec<Option<String>>> {
+        let regex_obj = Regex::new(regex)?;
+
+        info!(
+            "Waiting to match regex on stdout (regex: '{regex}', cmd: '{}')",
+            self.cmd_line
+        );
+
+        let mut modified_prev = None;
+
+        for _ in 1..=(self.timeout_ms / POLL_MS) {
+            // Get stdout contents from file and regex it
+            let stdout = CmdBuilder::stdout_contents(&self.stdout_path)?;
+
+            // Log tail of stdout, but not if we think it has not changed since the last time.
+            let modified = CmdBuilder::stdout_modified(&self.stdout_path);
+            if !stdout.is_empty() {
+                if modified_prev.is_none() || modified_prev != modified {
+                    info!(
+                        "stdout tail (regex: '{}', cmd: '{}')...",
+                        regex, self.cmd_line
+                    );
+                    let lines = stdout.as_str().lines().collect::<Vec<_>>();
+                    for l in &lines[lines.len().saturating_sub(10)..] {
+                        info!("  {l}");
+                    }
+                }
+                modified_prev = modified;
+            }
+
+            // Try to match regex
+            if let Some(captures) = regex_obj.captures(&stdout) {
+                let mut v = Vec::new();
+                for cap in captures.iter() {
+                    let cap_string = cap.map(|tmp| String::from(tmp.as_str()));
+                    v.push(cap_string);
+                }
+                return Ok(v);
+            }
+
+            // Bail if command has already exited
+            if self.handle.try_wait()?.is_some() {
+                return Err(Error::ExitedCmd);
+            }
+
+            // Sleep till next poll
+            sleep(Duration::from_millis(POLL_MS as u64));
+        }
+        Err(Error::Timeout)
+    }
+
+    /// Wait for command to complete.
+    /// May timeout.
+    /// On success, returns command's exit code and stdout.
+    pub fn wait(&self) -> Result<(Option<i32>, String)> {
+        info!("Waiting for command (cmd: '{}')", self.cmd_line);
+        for _ in 1..=(self.timeout_ms / POLL_MS) {
+            if let Some(result) = self.handle.try_wait()? {
+                info!(
+                    "Command completed (cmd: '{}', exitcode: {:?})",
+                    self.cmd_line,
+                    result.status.code()
+                );
+
+                // Return exitcode, stdout contents
+                let stdout = CmdBuilder::stdout_contents(&self.stdout_path)?;
+                return Ok((result.status.code(), stdout));
+            }
+            sleep(Duration::from_millis(POLL_MS as u64));
+        }
+        Err(Error::Timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_not_found() {
+        let res = CmdBuilder::new("iDoNotExist arg1 arg2").run();
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn curl_http_ockam() {
+        let (exitcode, stdout) = CmdBuilder::new("curl -s http://ockam.io/").run().unwrap();
+        assert_eq!(Some(0), exitcode);
+        assert!(stdout.to_lowercase().contains("<html"));
+    }
+
+    #[test]
+    fn bash_exitcode() {
+        let (exitcode, stdout) = CmdBuilder::new("bash")
+            .set_stdin("sleep 1; echo \"failed\"; exit 99")
+            .run()
+            .unwrap();
+        assert_eq!(Some(99), exitcode);
+        assert!(stdout.to_lowercase().contains("failed"));
+    }
+
+    #[test]
+    fn bash_echo_sleep_match_on_stdout() {
+        // Spawn to run for a few seconds
+        let alice = CmdBuilder::new("bash")
+            .set_stdin("echo \"Start: `date +%s`\"; sleep 3; echo \"End\"")
+            .spawn()
+            .unwrap();
+
+        // Match on stdout, expect near start
+        let tmp = alice
+            .match_stdout(r"(?im)^Start: (\d+)")
+            .unwrap()
+            .swap_remove(1)
+            .unwrap();
+        assert!(tmp.chars().all(char::is_numeric));
+
+        // Wait for completion
+        let (exitcode, stdout) = alice.wait().unwrap();
+        assert_eq!(Some(0), exitcode);
+        assert!(stdout.contains("End"));
+    }
+
+    #[test]
+    fn bash_echo_sleep_concurrent_commands() {
+        // Spawn a command
+        let alice = CmdBuilder::new("bash")
+            .set_stdin("sleep 3; echo goodbye")
+            .spawn()
+            .unwrap();
+
+        // Run another command
+        let (exitcode, stdout) = CmdBuilder::new("echo hello").run().unwrap();
+        assert_eq!(Some(0), exitcode);
+        assert_eq!("hello", stdout.trim()); // Trim line endings
+
+        // Wait on spawned
+        let (exitcode, stdout) = alice.wait().unwrap();
+        assert_eq!(Some(0), exitcode);
+        assert!(stdout.contains("goodbye"));
+    }
+
+    #[test]
+    fn bash_echo_sleep_concurrent_commands_donotwaitforspawned() {
+        // Spawn a command
+        let _alice = CmdBuilder::new("bash")
+            .set_stdin("sleep 3; echo goodbye")
+            .spawn()
+            .unwrap();
+
+        // Run another command
+        let (exitcode, stdout) = CmdBuilder::new("echo hello").run().unwrap();
+        assert_eq!(Some(0), exitcode);
+        assert_eq!("hello", stdout.trim()); // Trim line endings
+
+        // Don't wait on spawned command. It should get killed when dropped.
+    }
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

To test Ockam example code (in `ockam/examples/...`) there is the `ockam/tools/docs/example_runner` utility plus some config and script files. 

#2653 talks about a wish to improve testing and test coverage in general. 

## Proposed Changes

This PR adds a new `ockam/tools/docs/example_test_helper` which is intended to replace `example_runner` and its config and script files. 

`example_test_helper` provides helper code to allow the Ockam examples to code their own tests alongside their main code. This alleviates the need for config and script files and allows the tests to be part of the `cargo test` infrastructure. 

This PR also adds tests to the Ockam examples `get_started`, `ockam_kafka`, and `tcp_inlet_and_outlet`. (Tests for `file_transfer` are not included here because, I think, `file_transfer` has a seperate issue which needs resolving.)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
