### PR TITLE
feat(elixir):  minicbor typetags, cli-cloud advances

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api.ex
@@ -129,12 +129,12 @@ defmodule Ockam.Services.API do
 
             {:error, reason, state} ->
               ## TODO: handle errors differently to return error response
-              :ok = API.reply_error(request, reason, state)
+              :ok = API.reply_error(request, reason, state.address)
               {:ok, state}
 
             {:error, reason} ->
               ## TODO: handle errors differently to return error response
-              :ok = API.reply_error(request, reason, state)
+              :ok = API.reply_error(request, reason, state.address)
               {:ok, state}
           end
 

--- a/implementations/rust/ockam/ockam_api/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/schema.cddl
@@ -67,15 +67,15 @@ value = bytes
 
 ;;; Space ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: type tag?
 space = {
-    0: space_id
-    1: space_name
+   ?0: 7574645
+    1: space_id
+    2: space_name
 }
 
-;; TODO: type tag?
 create_space = {
-    0: space_name
+   ?0: 3888657,
+    1: space_name
 }
 
 space_id   = text
@@ -83,26 +83,24 @@ space_name = text
 
 ;;; Projects ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: type tag?
 project = {
-    0: project_id,
-    1: project_name,
-    2: [+ service_name],
-    3: access_route
+   ?0: 9056532,
+    1: project_id,
+    2: project_name,
+    3: [+ service_name],
+    4: access_route
 }
 
-;; TODO: type tag?
 create_project = {
-    0: project_name,
-    1: [+ service_name]
+    ?0: 8669570,
+    1: project_name,
+    2: [+ service_name]
 }
 
 project_id   = text
 project_name = text
 service_name = text
 access_route = bytes
-
-;;; Identity ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 identity_create_response = {
     ?0: 3500430,
@@ -164,3 +162,62 @@ identity_proof   = bytes
 peer_identity_id = text
 verified         = bool
 contact_id       = text
+
+
+;;; Enroll ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+request_enrollment = {
+    ?0: 5136510,
+     1: identity_id,
+     2: token
+ }
+identity_id     = text
+token        = text
+
+
+token_attribute = {
+    ?0: 8463780,
+     1: attr_name,
+     2: attr_value
+}
+
+attr_value   = text
+attr_name    = text
+
+;;; Invitation ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+invitation_scope = 0 ;; Space
+                 / 1 ;; Project
+
+invitation_state = 0 ;; Pending
+                / 1 ;; Accepted
+                / 2 ;; Rejected
+
+create_invitation = {
+    ?0: 1886440,
+     1: identity_id,
+     2: invitee,
+     3: scope,
+     4: space_id,
+    ?5: project_id
+}
+
+invitee = text
+scope = invitation_scope
+
+invitation = {
+    ?0: 7088378,
+     1: invitation_id,
+     3: inviter,
+     4: invitee,
+     5: scope,
+     6: state,
+     7: space_id,
+    ?8: project_id
+}
+
+invitation_id = text
+inviter = text
+state = invitation_state
+
+

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -151,11 +151,11 @@ pub mod enrollment_token {
         #[n(1)]
         pub identity: Identity<'a>,
         #[n(2)]
-        pub attributes: Vec<Attribute<'a>>,
+        pub attributes: Vec<TokenAttribute<'a>>,
     }
 
     impl<'a> RequestEnrollmentToken<'a> {
-        pub fn new<I: Into<Identity<'a>>>(identity: I, attributes: &[Attribute<'a>]) -> Self {
+        pub fn new<I: Into<Identity<'a>>>(identity: I, attributes: &[TokenAttribute<'a>]) -> Self {
             Self {
                 #[cfg(feature = "tag")]
                 tag: TypeTag,
@@ -211,19 +211,24 @@ pub mod enrollment_token {
 
     // Auxiliary types
 
-    #[derive(serde::Deserialize, Encode, Debug, Clone)]
-    #[cfg_attr(test, derive(PartialEq, Decode))]
+    #[derive(Debug, Clone, Default, Encode, Decode)]
     #[cbor(map)]
-    pub struct Attribute<'a> {
+    pub struct TokenAttribute<'a> {
+        #[cfg(feature = "tag")]
         #[n(0)]
-        pub name: Cow<'a, str>,
+        pub tag: TypeTag<8463780>,
+
         #[n(1)]
+        pub name: Cow<'a, str>,
+        #[n(2)]
         pub value: Cow<'a, str>,
     }
 
-    impl<'a> Attribute<'a> {
+    impl<'a> TokenAttribute<'a> {
         pub fn new<S: Into<Cow<'a, str>>>(name: S, value: S) -> Self {
             Self {
+                #[cfg(feature = "tag")]
+                tag: TypeTag,
                 name: name.into(),
                 value: value.into(),
             }

--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -1,6 +1,9 @@
 use minicbor::{Decode, Encode};
 use std::borrow::Cow;
 
+#[cfg(feature = "tag")]
+use crate::TypeTag;
+
 #[derive(serde::Deserialize, Encode, Decode, Debug)]
 #[cbor(index_only)]
 pub enum Scope {
@@ -24,34 +27,42 @@ pub enum State {
 #[derive(Decode, Encode, Debug)]
 #[cbor(map)]
 pub struct CreateInvitation<'a> {
-    #[b(0)]
-    pub identity: Cow<'a, str>,
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<1886440>,
+
     #[b(1)]
-    pub invitee: Cow<'a, str>,
+    pub identity: Cow<'a, str>,
     #[b(2)]
-    pub scope: Scope,
+    pub invitee: Cow<'a, str>,
     #[b(3)]
-    pub space_id: Cow<'a, str>,
+    pub scope: Scope,
     #[b(4)]
+    pub space_id: Cow<'a, str>,
+    #[b(5)]
     pub project_id: Option<Cow<'a, str>>,
 }
 
 #[derive(Decode, Encode, Debug)]
 #[cbor(map)]
 pub struct Invitation<'a> {
-    #[b(0)]
-    pub id: Cow<'a, str>,
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<7088378>,
+
     #[b(1)]
-    pub inviter: Cow<'a, str>,
+    pub id: Cow<'a, str>,
     #[b(2)]
-    pub invitee: Cow<'a, str>,
+    pub inviter: Cow<'a, str>,
     #[b(3)]
-    pub scope: Scope,
+    pub invitee: Cow<'a, str>,
     #[b(4)]
-    pub state: State,
+    pub scope: Scope,
     #[b(5)]
-    pub space_id: Cow<'a, str>,
+    pub state: State,
     #[b(6)]
+    pub space_id: Cow<'a, str>,
+    #[b(7)]
     pub project_id: Option<Cow<'a, str>>,
 }
 
@@ -63,6 +74,9 @@ impl<'a> CreateInvitation<'a> {
         project_id: Option<S>,
     ) -> Self {
         Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+
             identity: identity.into(),
             invitee: invitee.into(),
             scope: project_id

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -59,7 +59,7 @@ impl MessagingClient {
     pub async fn generate_enrollment_token<'a>(
         &mut self,
         identifier: &str,
-        attributes: &[Attribute<'a>],
+        attributes: &[TokenAttribute<'a>],
     ) -> ockam_core::Result<EnrollmentToken<'static>> {
         let target = "ockam_api::cloud::generate_enrollment_token";
         let label = "generate_enrollment_token";
@@ -177,7 +177,7 @@ impl MessagingClient {
 
     pub async fn accept_invitations(
         &mut self,
-        email: &str,
+        pubkey: &str,
         invitation_id: &str,
     ) -> ockam_core::Result<()> {
         let target = "ockam_api::cloud::accept_invitations";
@@ -185,7 +185,7 @@ impl MessagingClient {
         trace!(target = %target, "accept invitation");
 
         let route = self.route.modify().append("invitations").into();
-        let req = Request::put(format!("v0/{}/{}", invitation_id, email));
+        let req = Request::put(format!("v0/{}/{}", invitation_id, pubkey));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -198,7 +198,7 @@ impl MessagingClient {
 
     pub async fn reject_invitations(
         &mut self,
-        email: &str,
+        pubkey: &str,
         invitation_id: &str,
     ) -> ockam_core::Result<()> {
         let target = "ockam_api::cloud::reject_invitations";
@@ -206,7 +206,7 @@ impl MessagingClient {
         trace!(target = %target, "reject invitation");
 
         let route = self.route.modify().append("invitations").into();
-        let req = Request::delete(format!("v0/{}/{}", invitation_id, email));
+        let req = Request::delete(format!("v0/{}/{}", invitation_id, pubkey));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -217,13 +217,17 @@ impl MessagingClient {
         }
     }
 
-    pub async fn create_space(&mut self, body: CreateSpace<'_>) -> ockam_core::Result<Space<'_>> {
+    pub async fn create_space(
+        &mut self,
+        body: CreateSpace<'_>,
+        pubkey: &str,
+    ) -> ockam_core::Result<Space<'_>> {
         let target = "ockam_api::cloud::create_space";
         let label = "create_space";
         trace!(target = %target, space = %body.name, "creating space");
 
         let route = self.route.modify().append("spaces").into();
-        let req = Request::post("v0/").body(body);
+        let req = Request::post(format!("v0/{}", pubkey)).body(body);
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -234,13 +238,13 @@ impl MessagingClient {
         }
     }
 
-    pub async fn list_spaces(&mut self) -> ockam_core::Result<Vec<Space<'_>>> {
+    pub async fn list_spaces(&mut self, pubkey: &str) -> ockam_core::Result<Vec<Space<'_>>> {
         let target = "ockam_api::cloud::list_spaces";
         let label = "list_spaces";
         trace!(target = %target, "listing spaces");
 
         let route = self.route.modify().append("spaces").into();
-        let req = Request::get("v0/");
+        let req = Request::get(format!("v0/{}", pubkey));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -251,13 +255,17 @@ impl MessagingClient {
         }
     }
 
-    pub async fn get_space(&mut self, space_id: &str) -> ockam_core::Result<Space<'_>> {
+    pub async fn get_space(
+        &mut self,
+        space_id: &str,
+        pubkey: &str,
+    ) -> ockam_core::Result<Space<'_>> {
         let target = "ockam_api::cloud::get_space";
         let label = "get_space";
         trace!(target = %target, space = %space_id, space = %space_id, "getting space");
 
         let route = self.route.modify().append("spaces").into();
-        let req = Request::get(format!("v0/{space_id}"));
+        let req = Request::get(format!("v0/{pubkey}/{space_id}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -268,13 +276,17 @@ impl MessagingClient {
         }
     }
 
-    pub async fn get_space_by_name(&mut self, space_name: &str) -> ockam_core::Result<Space<'_>> {
+    pub async fn get_space_by_name(
+        &mut self,
+        space_name: &str,
+        pubkey: &str,
+    ) -> ockam_core::Result<Space<'_>> {
         let target = "ockam_api::cloud::get_space_by_name";
         let label = "get_space_by_name";
         trace!(target = %target, space = %space_name, "getting space");
 
         let route = self.route.modify().append("spaces").into();
-        let req = Request::get(format!("v0/name/{space_name}"));
+        let req = Request::get(format!("v0/{pubkey}/name/{space_name}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -285,13 +297,13 @@ impl MessagingClient {
         }
     }
 
-    pub async fn delete_space(&mut self, space_id: &str) -> ockam_core::Result<()> {
+    pub async fn delete_space(&mut self, space_id: &str, pubkey: &str) -> ockam_core::Result<()> {
         let target = "ockam_api::cloud::delete_space";
         let label = "delete_space";
         trace!(target = %target, space = %space_id, "deleting space");
 
         let route = self.route.modify().append("spaces").into();
-        let req = Request::delete(format!("v0/{space_id}"));
+        let req = Request::delete(format!("v0/{pubkey}/{space_id}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -306,13 +318,14 @@ impl MessagingClient {
         &mut self,
         space_id: &str,
         body: CreateProject<'_>,
+        pubkey: &str,
     ) -> ockam_core::Result<Project<'_>> {
         let target = "ockam_api::cloud::create_project";
         let label = "create_project";
         trace!(target = %target, space = %space_id, project = %body.name, "creating project");
 
         let route = self.route.modify().append("projects").into();
-        let req = Request::post(format!("v0/{space_id}")).body(body);
+        let req = Request::post(format!("v0/{pubkey}/{space_id}")).body(body);
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -323,13 +336,17 @@ impl MessagingClient {
         }
     }
 
-    pub async fn list_projects(&mut self, space_id: &str) -> ockam_core::Result<Vec<Project<'_>>> {
+    pub async fn list_projects(
+        &mut self,
+        space_id: &str,
+        pubkey: &str,
+    ) -> ockam_core::Result<Vec<Project<'_>>> {
         let target = "ockam_api::cloud::list_projects";
         let label = "list_projects";
         trace!(target = %target, space = %space_id, "listing projects");
 
         let route = self.route.modify().append("projects").into();
-        let req = Request::get(format!("v0/{space_id}"));
+        let req = Request::get(format!("v0/{pubkey}/{space_id}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -344,13 +361,14 @@ impl MessagingClient {
         &mut self,
         space_id: &str,
         project_id: &str,
+        pubkey: &str,
     ) -> ockam_core::Result<Project<'_>> {
         let target = "ockam_api::cloud::get_project";
         let label = "get_project";
         trace!(target = %target, space = %space_id, project = %project_id, "getting project");
 
         let route = self.route.modify().append("projects").into();
-        let req = Request::get(format!("v0/{space_id}/{project_id}"));
+        let req = Request::get(format!("v0/{pubkey}/{space_id}/{project_id}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -365,13 +383,14 @@ impl MessagingClient {
         &mut self,
         space_id: &str,
         project_name: &str,
+        pubkey: &str,
     ) -> ockam_core::Result<Project<'_>> {
         let target = "ockam_api::cloud::get_project_by_name";
         let label = "get_project_by_name";
         trace!(target = %target, space = %space_id, project = %project_name, "getting project");
 
         let route = self.route.modify().append("projects").into();
-        let req = Request::get(format!("v0/{space_id}/name/{project_name}"));
+        let req = Request::get(format!("v0/{pubkey}/{space_id}/name/{project_name}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;
@@ -386,13 +405,14 @@ impl MessagingClient {
         &mut self,
         space_id: &str,
         project_id: &str,
+        pubkey: &str,
     ) -> ockam_core::Result<()> {
         let target = "ockam_api::cloud::delete_project";
         let label = "delete_project";
         trace!(target = %target, space = %space_id, project = %project_id, "deleting project");
 
         let route = self.route.modify().append("projects").into();
-        let req = Request::delete(format!("v0/{space_id}/{project_id}"));
+        let req = Request::delete(format!("v0/{pubkey}/{space_id}/{project_id}"));
         self.buf = self.request(target, label, route, &req).await?;
         let mut d = Decoder::new(&self.buf);
         let res = response(target, label, &mut d)?;

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
@@ -16,12 +16,6 @@ pub struct AuthenticateEnrollmentTokenCommand {
     #[clap(display_order = 1000)]
     address: MultiAddr,
 
-    #[clap(display_order = 1001, long, default_value = "default")]
-    vault: String,
-
-    #[clap(display_order = 1002, long, default_value = "default")]
-    identity: String,
-
     #[clap(display_order = 1003, long)]
     overwrite: bool,
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context};
 use clap::Args;
 
 use ockam::TcpTransport;
-use ockam_api::cloud::enroll::enrollment_token::Attribute;
+use ockam_api::cloud::enroll::enrollment_token::TokenAttribute;
 use ockam_multiaddr::MultiAddr;
 
 use crate::old::identity::load_or_create_identity;
@@ -55,7 +55,7 @@ async fn generate(
     let route = multiaddr_to_route(&command.address)
         .ok_or_else(|| anyhow!("failed to parse address: {}", command.address))?;
 
-    let attributes: Vec<Attribute> = command
+    let attributes: Vec<TokenAttribute> = command
         .attributes
         .iter()
         .map(|kv| {
@@ -71,10 +71,10 @@ async fn generate(
             } else if v.is_empty() {
                 anyhow::bail!("attribute value can't be empty at pair {kv:?}")
             } else {
-                Ok(Attribute::new(k, v))
+                Ok(TokenAttribute::new(k, v))
             }
         })
-        .collect::<anyhow::Result<Vec<Attribute>>>()?;
+        .collect::<anyhow::Result<Vec<TokenAttribute>>>()?;
 
     let mut api_client = ockam_api::cloud::MessagingClient::new(route, &ctx).await?;
     let token = api_client

--- a/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route};
+use crate::IdentityOpts;
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
@@ -8,11 +10,19 @@ use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct AcceptCommand {
-    #[clap(display_order = 1001)]
-    email: String,
-
     #[clap(display_order = 1002)]
     invitation: String,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a AcceptCommand> for IdentityOpts {
+    fn from(other: &'a AcceptCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl AcceptCommand {
@@ -25,11 +35,16 @@ async fn accept(mut ctx: Context, args: (MultiAddr, AcceptCommand)) -> anyhow::R
     let (cloud_addr, cmd) = args;
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.accept_invitations(&cmd.email, &cmd.invitation).await?;
+    let res = api
+        .accept_invitations(&identity.id.to_string(), &cmd.invitation)
+        .await?;
     println!("{res:?}");
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/invitation/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/create.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route};
+use crate::IdentityOpts;
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
 use ockam_api::cloud::{invitation::CreateInvitation, MessagingClient};
@@ -19,6 +21,17 @@ pub struct CreateCommand {
     /// project id to invite to, optional.
     #[clap(display_order = 1002, long)]
     project_id: Option<String>,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a CreateCommand> for IdentityOpts {
+    fn from(other: &'a CreateCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl CreateCommand {
@@ -31,11 +44,16 @@ async fn create(mut ctx: Context, args: (MultiAddr, CreateCommand)) -> anyhow::R
     let (cloud_addr, cmd) = args;
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let request = CreateInvitation::new("1", &cmd.email, &cmd.space_id, cmd.project_id.as_deref());
+    let pubkey = identity.id.to_string();
+    let request =
+        CreateInvitation::new(&pubkey, &cmd.email, &cmd.space_id, cmd.project_id.as_ref());
     let res = api.create_invitation(request).await?;
     println!("{res:?}");
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route};
+use crate::IdentityOpts;
 use anyhow::anyhow;
 use ockam::{route, Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
@@ -8,11 +10,11 @@ use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct RejectCommand {
-    #[clap(display_order = 1001)]
-    email: String,
-
     #[clap(display_order = 1002)]
     invitation: String,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
 }
 
 impl RejectCommand {
@@ -21,15 +23,28 @@ impl RejectCommand {
     }
 }
 
+impl<'a> From<&'a RejectCommand> for IdentityOpts {
+    fn from(other: &'a RejectCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
+}
+
 async fn reject(mut ctx: Context, args: (MultiAddr, RejectCommand)) -> anyhow::Result<()> {
     let (cloud_addr, cmd) = args;
     let _tcp = TcpTransport::create(&ctx).await?;
+
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
 
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.reject_invitations(&cmd.email, &cmd.invitation).await?;
+    let res = api
+        .reject_invitations(&identity.id.to_string(), &cmd.invitation)
+        .await?;
     println!("{res:?}");
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -5,7 +5,9 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::{project::CreateProject, MessagingClient};
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -24,6 +26,17 @@ pub struct CreateCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, last = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a CreateCommand> for IdentityOpts {
+    fn from(other: &'a CreateCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl CreateCommand {
@@ -35,11 +48,16 @@ impl CreateCommand {
 async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateProject::new(cmd.project_name, &cmd.services);
-    let res = api.create_project(&cmd.space_id, request).await?;
+    let res = api
+        .create_project(&cmd.space_id, request, &identity.id.to_string())
+        .await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -5,7 +5,9 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -20,6 +22,17 @@ pub struct DeleteCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a DeleteCommand> for IdentityOpts {
+    fn from(other: &'a DeleteCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl DeleteCommand {
@@ -31,10 +44,15 @@ impl DeleteCommand {
 async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.delete_project(&cmd.space_id, &cmd.project_id).await?;
+    let res = api
+        .delete_project(&cmd.space_id, &cmd.project_id, &identity.id.to_string())
+        .await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -5,7 +5,9 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
@@ -16,6 +18,17 @@ pub struct ListCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a ListCommand> for IdentityOpts {
+    fn from(other: &'a ListCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl ListCommand {
@@ -27,10 +40,15 @@ impl ListCommand {
 async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.list_projects(&cmd.space_id).await?;
+    let res = api
+        .list_projects(&cmd.space_id, &identity.id.to_string())
+        .await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -5,7 +5,9 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -20,6 +22,17 @@ pub struct ShowCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a ShowCommand> for IdentityOpts {
+    fn from(other: &'a ShowCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl ShowCommand {
@@ -31,10 +44,15 @@ impl ShowCommand {
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.get_project(&cmd.space_id, &cmd.project_id).await?;
+    let res = api
+        .get_project(&cmd.space_id, &cmd.project_id, &identity.id.to_string())
+        .await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -5,7 +5,9 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::{space::CreateSpace, MessagingClient};
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -16,6 +18,17 @@ pub struct CreateCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a CreateCommand> for IdentityOpts {
+    fn from(other: &'a CreateCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl CreateCommand {
@@ -27,11 +40,14 @@ impl CreateCommand {
 async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateSpace::new(cmd.name);
-    let res = api.create_space(request).await?;
+    let res = api.create_space(request, &identity.id.to_string()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,6 +1,8 @@
 use anyhow::anyhow;
 use clap::Args;
 
+use crate::old::identity::load_or_create_identity;
+use crate::IdentityOpts;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
@@ -16,6 +18,17 @@ pub struct DeleteCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a DeleteCommand> for IdentityOpts {
+    fn from(other: &'a DeleteCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl DeleteCommand {
@@ -27,10 +40,13 @@ impl DeleteCommand {
 async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.delete_space(&cmd.id).await?;
+    let res = api.delete_space(&cmd.id, &identity.id.to_string()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -5,13 +5,26 @@ use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
+}
+
+impl<'a> From<&'a ListCommand> for IdentityOpts {
+    fn from(other: &'a ListCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
 }
 
 impl ListCommand {
@@ -23,10 +36,13 @@ impl ListCommand {
 async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.list_spaces().await?;
+    let res = api.list_spaces(&identity.id.to_string()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,6 +1,8 @@
 use anyhow::anyhow;
 use clap::Args;
 
+use crate::old::identity::load_or_create_identity;
+use crate::IdentityOpts;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
@@ -16,6 +18,9 @@ pub struct ShowCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
+
+    #[clap(display_order = 1101, long)]
+    overwrite: bool,
 }
 
 impl ShowCommand {
@@ -24,13 +29,24 @@ impl ShowCommand {
     }
 }
 
+impl<'a> From<&'a ShowCommand> for IdentityOpts {
+    fn from(other: &'a ShowCommand) -> Self {
+        Self {
+            overwrite: other.overwrite,
+        }
+    }
+}
+
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
+
+    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
+    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.get_space(&cmd.id).await?;
+    let res = api.get_space(&cmd.id, &identity.id.to_string()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -8,10 +8,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("enroll")
         .arg("auth0")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
         .arg("--overwrite");
     cmd.assert().success();
 
@@ -19,10 +15,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("token")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
         .arg("--overwrite")
         .arg("--")
         .arg("k1,v1")
@@ -35,10 +27,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("token")
         .arg("/ip4/127.0.0.1/tcp/8080")
         .arg("token-value")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
         .arg("--overwrite");
     cmd.assert().success();
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
@@ -23,21 +23,15 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list").arg("invitee@test.com");
+    cmd.args(&prefix_args).arg("list");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("accept")
-        .arg("invitee@test.com")
-        .arg("invitation-id");
+    cmd.args(&prefix_args).arg("accept").arg("invitation-id");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("reject")
-        .arg("invitee@test.com")
-        .arg("invitation-id");
+    cmd.args(&prefix_args).arg("reject").arg("invitation-id");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
* Let the field `0` reserved on the elixir implementation for use as TypeTag.
* Complete all TypeTags for structs.
* Pass the caller identity' pubkey on cloud commands (workaround until integrating with identity channels)
* Fix cli-cloud communication on
    - Spaces
    - Projects
    - Enrollment Tokens
    - Invitations
* Complete schema.cddl for missing commands/structs

<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

Cli-Cloud interaction broken because TypeTag and indexes shuffled by 1, and other minor inconsistencies between client and server expectations.
While enroll command do pass the identity (as workaround until identity channel integration), the other commands did not.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Fix cli-cloud interaction on the mentioned commands, pass identity, reserve field 0 on elixir for typetag usage.


<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
