### PR TITLE
ockam CLI portal command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/base.rs
@@ -4,109 +4,11 @@
 
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
-use std::fmt::{self, Display};
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
 ///////////////////-!  REQUEST BODIES
-
-/// Request body when instructing a node to create a transport
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct CreateTransport<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1407961>,
-    /// The type of transport to create
-    #[n(1)] pub tt: TransportType,
-    /// The mode the transport should operate in
-    #[n(2)] pub tm: TransportMode,
-    /// The address payload for the transport
-    #[n(3)] pub addr: Cow<'a, str>,
-}
-
-impl<'a> CreateTransport<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(tt: TransportType, tm: TransportMode, addr: S) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            tt,
-            tm,
-            addr: addr.into(),
-        }
-    }
-}
-
-/// Request to delete a transport
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct DeleteTransport<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1407961>,
-    /// The transport ID to delete
-    #[n(1)] pub tid: Cow<'a, str>,
-    /// The user has indicated that deleting the API transport is A-OK
-    #[n(2)] pub force: bool,
-}
-
-impl<'a> DeleteTransport<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(tid: S, force: bool) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            tid: tid.into(),
-            force,
-        }
-    }
-}
-
-/// Encode which type of transport is being requested
-// TODO: we have a TransportType in ockam_core.  Do we really want to
-// mirror this kind of type here?
-#[derive(Copy, Clone, Debug, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(index_only)]
-pub enum TransportType {
-    /// Ockam TCP transport
-    #[n(0)] Tcp,
-    /// Embedded BLE transport
-    #[n(1)] Ble,
-    /// Websocket transport
-    #[n(2)] WebSocket,
-}
-
-impl Display for TransportType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Tcp => "TCP",
-            Self::Ble => "BLE",
-            Self::WebSocket => "Websocket",
-        })
-    }
-}
-
-/// Encode which type of transport is being requested
-#[derive(Copy, Clone, Debug, Decode, Encode, PartialEq)]
-#[rustfmt::skip]
-pub enum TransportMode {
-    /// Listen on a set address
-    #[n(0)] Listen,
-    /// Connect to a remote peer
-    #[n(1)] Connect,
-}
-
-impl Display for TransportMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Listen => "Listening",
-            Self::Connect => "Remote connection",
-        })
-    }
-}
 
 ///////////////////-!  RESPONSE BODIES
 
@@ -141,66 +43,6 @@ impl<'a> NodeStatus<'a> {
             workers,
             pid,
             transports,
-        }
-    }
-}
-
-/// Response body when interacting with a transport
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct TransportStatus<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1581592>,
-    /// The type of transport to create
-    #[n(2)] pub tt: TransportType,
-    /// The mode the transport should operate in
-    #[n(3)] pub tm: TransportMode,
-    /// The status payload
-    #[n(4)] pub payload: Cow<'a, str>,
-    /// Transport ID inside the node manager
-    ///
-    /// We use this as a kind of URI to be able to address a transport
-    /// by a unique value for specific updates and deletion events.
-    #[n(5)] pub tid: Cow<'a, str>,
-}
-
-impl<'a> TransportStatus<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(
-        tt: TransportType,
-        tm: TransportMode,
-        payload: S,
-        tid: S,
-    ) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            tt,
-            tm,
-            payload: payload.into(),
-            tid: tid.into(),
-        }
-    }
-}
-
-/// Respons body when interacting with a transport
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct TransportList<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<5212817>,
-    #[n(1)] pub list: Vec<TransportStatus<'a>>
-}
-
-impl<'a> TransportList<'a> {
-    pub fn new(list: Vec<TransportStatus<'a>>) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            list,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/base.rs
@@ -192,7 +192,6 @@ pub struct TransportList<'a> {
     #[cfg(feature = "tag")]
     #[n(0)]
     tag: TypeTag<5212817>,
-    /// The type of transport to create
     #[n(1)] pub list: Vec<TransportStatus<'a>>
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/iolets.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/iolets.rs
@@ -6,40 +6,70 @@ use ockam_core::compat::borrow::Cow;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
-/// Request body to create an inlet
-#[derive(Debug, Clone, Decode, Encode)]
+/// Distinguish between inlet and outlet portals in the API
+#[derive(Copy, Clone, Debug, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(index_only)]
+pub enum IoletType {
+    #[n(0)] Inlet,
+    #[n(1)] Outlet,
+}
+
+/// Request body to create an inlet or outlet
+#[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateInlet<'a> {
+pub struct CreateIolet<'a> {
     #[cfg(feature = "tag")]
     #[n(0)]
     tag: TypeTag<1407961>,
-    #[n(1)] pub addr: Cow<'a, str>,
+    #[n(1)] pub tt: IoletType,
+    #[n(2)] pub addr: Cow<'a, str>,
+    #[n(3)] pub alias: Option<Cow<'a, str>>,
 }
 
-/// Request body to create an outlet
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct CreateOutlet<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1407961>,
-    #[n(1)] pub addr: Cow<'a, str>,
-}
-
-/// Respons body when interacting with a transport
-#[derive(Debug, Clone, Decode, Encode)]
+/// Respons body when interacting with an inlet or outlet
+#[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct IoletStatus<'a> {
     #[cfg(feature = "tag")]
     #[n(0)]
     tag: TypeTag<1581592>,
-    #[n(1)] pub payload: Cow<'a, str>,
-    /// Iolet ID inside the node manager
-    ///
-    /// We use this as a kind of URI to be able to address a transport
-    /// by a unique value for specific updates and deletion events.
-    #[n(2)] pub ioid: Cow<'a, str>,
+    #[n(1)] pub tt: IoletType,
+    #[n(2)] pub addr: Cow<'a, str>,
+    #[n(3)] pub alias: Cow<'a, str>,
+}
+
+impl<'a> IoletStatus<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(tt: IoletType, addr: S, alias: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            tt,
+            addr: addr.into(),
+            alias: alias.into(),
+        }
+    }
+}
+
+/// Responsebody when returning a list of Iolets
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct IoletList<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<8401504>,
+    #[n(1)] pub list: Vec<IoletStatus<'a>>
+}
+
+impl<'a> IoletList<'a> {
+    pub fn new(list: Vec<IoletStatus<'a>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            list,
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/iolets.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/iolets.rs
@@ -26,16 +26,16 @@ pub struct CreateIolet<'a> {
     /// The type of portal endpoint to create
     #[n(1)] pub tt: IoletType,
     /// The address the portal should connect or bind to
-    #[n(2)] pub addr: Cow<'a, str>,
+    #[b(2)] pub addr: Cow<'a, str>,
     /// The forwarding address (must be ockam routing address)
     ///
     /// This field will be disregarded for portal outlets.  Portal
     /// inlets MUST set this value to configure their forwarding
     /// behaviour.  This can either be the address of an already
     /// created outlet, or a forwarding mechanism via ockam cloud.
-    #[n(3)] pub fwd: Option<Cow<'a, str>>,
+    #[b(3)] pub fwd: Option<Cow<'a, str>>,
     /// A human-friendly alias for this portal endpoint
-    #[n(4)] pub alias: Option<Cow<'a, str>>,
+    #[b(4)] pub alias: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateIolet<'a> {
@@ -65,10 +65,10 @@ pub struct IoletStatus<'a> {
     #[n(0)]
     tag: TypeTag<1581592>,
     #[n(1)] pub tt: IoletType,
-    #[n(2)] pub addr: Cow<'a, str>,
-    #[n(3)] pub alias: Cow<'a, str>,
+    #[b(2)] pub addr: Cow<'a, str>,
+    #[b(3)] pub alias: Cow<'a, str>,
     /// An optional status payload
-    #[n(4)] pub payload: Option<Cow<'a, str>>,
+    #[b(4)] pub payload: Option<Cow<'a, str>>,
 }
 
 impl<'a> IoletStatus<'a> {
@@ -97,7 +97,7 @@ pub struct IoletList<'a> {
     #[cfg(feature = "tag")]
     #[n(0)]
     tag: TypeTag<8401504>,
-    #[n(1)] pub list: Vec<IoletStatus<'a>>
+    #[b(1)] pub list: Vec<IoletStatus<'a>>
 }
 
 impl<'a> IoletList<'a> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -1,6 +1,6 @@
 mod base;
 mod forwarder;
-mod iolets;
+mod portal;
 mod secure_channel;
 mod service;
 mod transport;
@@ -12,7 +12,7 @@ mod transport;
 pub mod types {
     pub use super::base::*;
     pub use super::forwarder::*;
-    pub use super::iolets::*;
+    pub use super::portal::*;
     pub use super::secure_channel::*;
     pub use super::transport::*;
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -17,5 +17,8 @@ pub mod types {
     pub use super::transport::*;
 }
 
+/// A const address to bind and send messages to
+pub const NODEMAN_ADDR: &str = "_internal.nodeman";
+
 /// The main node-manager service running on remote nodes
 pub use service::NodeMan;

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -3,13 +3,19 @@ mod forwarder;
 mod iolets;
 mod secure_channel;
 mod service;
+mod transport;
 
 /// Messaging types for the node manager service
+///
+/// This module is only a type facade and should not have any logic of
+/// its own
 pub mod types {
     pub use super::base::*;
     pub use super::forwarder::*;
     pub use super::iolets::*;
     pub use super::secure_channel::*;
+    pub use super::transport::*;
 }
 
+/// The main node-manager service running on remote nodes
 pub use service::NodeMan;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -387,9 +387,9 @@ impl NodeMan {
             (Post, "/node/forwarder") => self.create_forwarder(ctx, req, dec, enc).await?,
 
             // ==*== Inlets & Outlets ==*==
-            (Get, "/node/iolets") => self.get_iolets(req).encode(enc)?,
-            (Post, "/node/iolets") => self.create_iolet(ctx, req, dec).await?.encode(enc)?,
-            (Delete, "/node/iolets") => todo!(),
+            (Get, "/node/portal") => self.get_iolets(req).encode(enc)?,
+            (Post, "/node/portal") => self.create_iolet(ctx, req, dec).await?.encode(enc)?,
+            (Delete, "/node/portal") => todo!(),
 
             // ==*== Catch-all for Unimplemented APIs ==*==
             (method, path) => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/transport.rs
@@ -112,8 +112,7 @@ impl Display for TransportMode {
 #[cbor(map)]
 pub struct TransportStatus<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1581592>,
+    #[n(0)] tag: TypeTag<1581592>,
     /// The type of transport to create
     #[n(2)] pub tt: TransportType,
     /// The mode the transport should operate in
@@ -151,8 +150,7 @@ impl<'a> TransportStatus<'a> {
 #[cbor(map)]
 pub struct TransportList<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<5212817>,
+    #[n(0)] tag: TypeTag<5212817>,
     #[n(1)] pub list: Vec<TransportStatus<'a>>
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/transport.rs
@@ -1,0 +1,167 @@
+use minicbor::{Decode, Encode};
+use ockam_core::compat::borrow::Cow;
+use std::fmt::{self, Display};
+
+#[cfg(feature = "tag")]
+use ockam_core::TypeTag;
+
+///////////////////-!  REQUEST BODIES
+
+/// Request body when instructing a node to create a transport
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct CreateTransport<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<1407961>,
+    /// The type of transport to create
+    #[n(1)] pub tt: TransportType,
+    /// The mode the transport should operate in
+    #[n(2)] pub tm: TransportMode,
+    /// The address payload for the transport
+    #[n(3)] pub addr: Cow<'a, str>,
+}
+
+impl<'a> CreateTransport<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(tt: TransportType, tm: TransportMode, addr: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            tt,
+            tm,
+            addr: addr.into(),
+        }
+    }
+}
+
+/// Request to delete a transport
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteTransport<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<1407961>,
+    /// The transport ID to delete
+    #[n(1)] pub tid: Cow<'a, str>,
+    /// The user has indicated that deleting the API transport is A-OK
+    #[n(2)] pub force: bool,
+}
+
+impl<'a> DeleteTransport<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(tid: S, force: bool) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            tid: tid.into(),
+            force,
+        }
+    }
+}
+
+/// Encode which type of transport is being requested
+// TODO: we have a TransportType in ockam_core.  Do we really want to
+// mirror this kind of type here?
+#[derive(Copy, Clone, Debug, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(index_only)]
+pub enum TransportType {
+    /// Ockam TCP transport
+    #[n(0)] Tcp,
+    /// Embedded BLE transport
+    #[n(1)] Ble,
+    /// Websocket transport
+    #[n(2)] WebSocket,
+}
+
+impl Display for TransportType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Tcp => "TCP",
+            Self::Ble => "BLE",
+            Self::WebSocket => "Websocket",
+        })
+    }
+}
+
+/// Encode which type of transport is being requested
+#[derive(Copy, Clone, Debug, Decode, Encode, PartialEq)]
+#[rustfmt::skip]
+pub enum TransportMode {
+    /// Listen on a set address
+    #[n(0)] Listen,
+    /// Connect to a remote peer
+    #[n(1)] Connect,
+}
+
+impl Display for TransportMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Listen => "Listening",
+            Self::Connect => "Remote connection",
+        })
+    }
+}
+
+///////////////////-!  RESPONSE BODIES
+
+/// Respons body when interacting with a transport
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct TransportStatus<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<1581592>,
+    /// The type of transport to create
+    #[n(2)] pub tt: TransportType,
+    /// The mode the transport should operate in
+    #[n(3)] pub tm: TransportMode,
+    /// The status payload
+    #[n(4)] pub payload: Cow<'a, str>,
+    /// Transport ID inside the node manager
+    ///
+    /// We use this as a kind of URI to be able to address a transport
+    /// by a unique value for specific updates and deletion events.
+    #[n(5)] pub tid: Cow<'a, str>,
+}
+
+impl<'a> TransportStatus<'a> {
+    pub fn new<S: Into<Cow<'a, str>>>(
+        tt: TransportType,
+        tm: TransportMode,
+        payload: S,
+        tid: S,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            tt,
+            tm,
+            payload: payload.into(),
+            tid: tid.into(),
+        }
+    }
+}
+
+/// Respons body when interacting with a transport
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct TransportList<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)]
+    tag: TypeTag<5212817>,
+    #[n(1)] pub list: Vec<TransportStatus<'a>>
+}
+
+impl<'a> TransportList<'a> {
+    pub fn new(list: Vec<TransportStatus<'a>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            list,
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -7,6 +7,7 @@ mod forwarder;
 mod invitation;
 mod message;
 mod node;
+mod portal;
 mod project;
 mod secure_channel;
 mod space;
@@ -20,6 +21,7 @@ use forwarder::ForwarderCommand;
 use invitation::InvitationCommand;
 use message::MessageCommand;
 use node::NodeCommand;
+use portal::PortalCommand;
 use project::ProjectCommand;
 use secure_channel::SecureChannelCommand;
 use space::SpaceCommand;
@@ -135,6 +137,10 @@ pub enum OckamSubcommand {
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Transport(TransportCommand),
 
+    /// Create, update, or delete portal endpoints
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    Portal(PortalCommand),
+
     /// Manage ockam CLI configuration values
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Config(ConfigCommand),
@@ -207,6 +213,7 @@ pub fn run() {
         OckamSubcommand::Project(command) => ProjectCommand::run(command),
         OckamSubcommand::Space(command) => SpaceCommand::run(command),
         OckamSubcommand::Transport(command) => TransportCommand::run(&mut cfg, command),
+        OckamSubcommand::Portal(command) => PortalCommand::run(&mut cfg, command),
         OckamSubcommand::Config(command) => ConfigCommand::run(&mut cfg, command),
         OckamSubcommand::SecureChannel(command) => SecureChannelCommand::run(&mut cfg, command),
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -11,7 +11,7 @@ use ockam_api::{
     auth,
     identity::IdentityService,
     nodes::types::{TransportMode, TransportType},
-    nodes::NodeMan,
+    nodes::{NodeMan, NODEMAN_ADDR},
 };
 
 #[derive(Clone, Debug, Args)]
@@ -96,7 +96,7 @@ async fn setup(ctx: Context, c: CreateCommand) -> anyhow::Result<()> {
     IdentityService::create(&ctx, "identity_service", vault.async_try_clone().await?).await?;
 
     ctx.start_worker(
-        "_internal.nodeman",
+        NODEMAN_ADDR,
         NodeMan::new(
             c.node_name,
             (TransportType::Tcp, TransportMode::Listen, bind),

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use crossbeam_channel::{bounded, Sender};
 use ockam::{Context, Route};
+use ockam_api::nodes::NODEMAN_ADDR;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {}
@@ -84,7 +85,7 @@ pub async fn query_pid(
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     ctx.send(
-        base_route.modify().append("_internal.nodeman"),
+        base_route.modify().append(NODEMAN_ADDR),
         api::query_status()?,
     )
     .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,7 +1,7 @@
 use crate::util::{self, api, connect_to, OckamConfig};
 use clap::Args;
 use ockam::{Context, Route};
-use ockam_api::nodes::types::NodeStatus;
+use ockam_api::nodes::{types::NodeStatus, NODEMAN_ADDR};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -26,7 +26,7 @@ impl ShowCommand {
 pub async fn query_status(ctx: Context, _: (), mut base_route: Route) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
-            base_route.modify().append("_internal.nodeman"),
+            base_route.modify().append(NODEMAN_ADDR),
             api::query_status()?,
         )
         .await

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,0 +1,40 @@
+use crate::util::{api, connect_to, stop_node, OckamConfig};
+use clap::Args;
+use ockam::{Context, Route, TCP};
+use ockam_api::{nodes::types::TransportStatus, Status};
+
+#[derive(Clone, Debug, Args)]
+pub struct CreateCommand {
+    /// Override the default API node
+    #[clap(short, long)]
+    pub api_node: Option<String>,
+
+    /// Create a listening transport
+    #[clap(short, long, conflicts_with("outlet"))]
+    pub inlet: bool,
+
+    /// Create a connection transport
+    #[clap(short, long, conflicts_with("inlet"))]
+    pub outlet: bool,
+
+    /// Transport connection or bind address
+    pub address: String,
+
+    /// Give this portal endpoint a name.  If none is provided a
+    /// random one will be generated.
+    pub alias: Option<String>,
+}
+
+impl CreateCommand {
+    pub fn run(cfg: &mut OckamConfig, command: CreateCommand) {
+        let port = match cfg.select_node(&command.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+
+        todo!()
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -2,7 +2,7 @@ use crate::util::{api, connect_to, stop_node, OckamConfig};
 use clap::{Args, Subcommand};
 use ockam::{Context, Route};
 use ockam_api::{
-    nodes::types::{IoletStatus, IoletType},
+    nodes::types::{PortalStatus, PortalType},
     Status,
 };
 
@@ -61,24 +61,23 @@ pub async fn create_portal(
             base_route.modify().append("_internal.nodeman"),
             api::create_portal(&cmd)?,
         )
-        .await
-        .unwrap();
+        .await?;
 
     let (
         response,
-        IoletStatus {
+        PortalStatus {
             tt, addr, alias, ..
         },
     ) = api::parse_portal_status(&resp)?;
 
     match response.status() {
-        Some(Status::Ok) if tt == IoletType::Inlet => {
+        Some(Status::Ok) if tt == PortalType::Inlet => {
             eprintln!(
                 "Portal inlet '{}' created! You can send messages to it on this bind:\n{}`",
                 alias, addr
             )
         }
-        Some(Status::Ok) if tt == IoletType::Outlet => {
+        Some(Status::Ok) if tt == PortalType::Outlet => {
             let r: Route = base_route
                 .modify()
                 .pop_back()

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -5,7 +5,6 @@ use ockam_api::{
     nodes::types::{IoletStatus, IoletType},
     Status,
 };
-use ockam_core::LOCAL;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -19,7 +18,6 @@ pub struct CreateCommand {
 
     /// Give this portal endpoint a name.  If none is provided a
     /// random one will be generated.
-    #[clap(short, long)]
     pub alias: Option<String>,
 }
 
@@ -84,7 +82,7 @@ pub async fn create_portal(
             let r: Route = base_route
                 .modify()
                 .pop_back()
-                .append_t(LOCAL, addr.to_string())
+                .append(addr.to_string())
                 .into();
             eprintln!(
                 "Portal outlet '{}' created! You can send messages through it via this route:\n{}`",

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use ockam::{Context, Route};
 use ockam_api::{
     nodes::types::{PortalStatus, PortalType},
+    nodes::NODEMAN_ADDR,
     Status,
 };
 
@@ -58,7 +59,7 @@ pub async fn create_portal(
 ) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
-            base_route.modify().append("_internal.nodeman"),
+            base_route.modify().append(NODEMAN_ADDR),
             api::create_portal(&cmd)?,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,7 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
-use clap::Args;
-use ockam::{Context, Route, TCP};
-use ockam_api::{nodes::types::TransportStatus, Status};
+use crate::util::OckamConfig;
+use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -9,25 +7,33 @@ pub struct CreateCommand {
     #[clap(short, long)]
     pub api_node: Option<String>,
 
-    /// Create an inlet portal
-    #[clap(short, long, conflicts_with("outlet"))]
-    pub inlet: bool,
-
-    /// Create an outlet portal
-    #[clap(short, long, conflicts_with("inlet"))]
-    pub outlet: bool,
-
-    /// Transport connection or bind address
-    pub address: String,
+    /// Select a creation variant
+    #[clap(subcommand)]
+    pub create_subcommand: CreateTypeCommand,
 
     /// Give this portal endpoint a name.  If none is provided a
     /// random one will be generated.
+    #[clap(short, long)]
     pub alias: Option<String>,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum CreateTypeCommand {
+    /// Create a TCP portal inlet
+    TcpInlet {
+        /// Portal inlet bind address
+        bind: String,
+    },
+    /// Create a TCP portal outlet
+    TcpOutlet {
+        /// Portal outlet connection address
+        address: String,
+    },
 }
 
 impl CreateCommand {
     pub fn run(cfg: &mut OckamConfig, command: CreateCommand) {
-        let port = match cfg.select_node(&command.api_node) {
+        let _port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,5 +1,11 @@
-use crate::util::OckamConfig;
+use crate::util::{api, connect_to, stop_node, OckamConfig};
 use clap::{Args, Subcommand};
+use ockam::{Context, Route};
+use ockam_api::{
+    nodes::types::{IoletStatus, IoletType},
+    Status,
+};
+use ockam_core::LOCAL;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -23,6 +29,8 @@ pub enum CreateTypeCommand {
     TcpInlet {
         /// Portal inlet bind address
         bind: String,
+        /// Forwarding point for the portal (ockam routing address)
+        forward: String,
     },
     /// Create a TCP portal outlet
     TcpOutlet {
@@ -33,7 +41,7 @@ pub enum CreateTypeCommand {
 
 impl CreateCommand {
     pub fn run(cfg: &mut OckamConfig, command: CreateCommand) {
-        let _port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
@@ -41,6 +49,51 @@ impl CreateCommand {
             }
         };
 
-        todo!()
+        connect_to(port, command, create_portal)
     }
+}
+
+pub async fn create_portal(
+    ctx: Context,
+    cmd: CreateCommand,
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let resp: Vec<u8> = ctx
+        .send_and_receive(
+            base_route.modify().append("_internal.nodeman"),
+            api::create_portal(&cmd)?,
+        )
+        .await
+        .unwrap();
+
+    let (
+        response,
+        IoletStatus {
+            tt, addr, alias, ..
+        },
+    ) = api::parse_portal_status(&resp)?;
+
+    match response.status() {
+        Some(Status::Ok) if tt == IoletType::Inlet => {
+            eprintln!(
+                "Portal inlet '{}' created! You can send messages to it on this bind:\n{}`",
+                alias, addr
+            )
+        }
+        Some(Status::Ok) if tt == IoletType::Outlet => {
+            let r: Route = base_route
+                .modify()
+                .pop_back()
+                .append_t(LOCAL, addr.to_string())
+                .into();
+            eprintln!(
+                "Portal outlet '{}' created! You can send messages through it via this route:\n{}`",
+                alias, r
+            );
+        }
+
+        _ => eprintln!("An unknown error occured while creating the portal component..."),
+    }
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -9,11 +9,11 @@ pub struct CreateCommand {
     #[clap(short, long)]
     pub api_node: Option<String>,
 
-    /// Create a listening transport
+    /// Create an inlet portal
     #[clap(short, long, conflicts_with("outlet"))]
     pub inlet: bool,
 
-    /// Create a connection transport
+    /// Create an outlet portal
     #[clap(short, long, conflicts_with("inlet"))]
     pub outlet: bool,
 

--- a/implementations/rust/ockam/ockam_command/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/mod.rs
@@ -2,7 +2,7 @@ mod create;
 // mod delete;
 // mod list;
 
-pub(crate) use create::CreateCommand;
+pub(crate) use create::{CreateCommand, CreateTypeCommand};
 // pub(crate) use delete::DeleteCommand;
 // use list::ListCommand;
 

--- a/implementations/rust/ockam/ockam_command/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/mod.rs
@@ -1,10 +1,7 @@
 mod create;
-// mod delete;
-// mod list;
-
 pub(crate) use create::{CreateCommand, CreateTypeCommand};
-// pub(crate) use delete::DeleteCommand;
-// use list::ListCommand;
+
+// TODO: add delete, list, show subcommands
 
 use crate::{util::OckamConfig, HELP_TEMPLATE};
 use clap::{Args, Subcommand};

--- a/implementations/rust/ockam/ockam_command/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/mod.rs
@@ -20,12 +20,12 @@ pub enum PortalSubCommand {
     /// Create portals on the selected node
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Create(CreateCommand),
+}
 
-    // /// Delete portals on the selected node
-    // #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
-    // Delete(DeleteCommand),
-
-    // /// List portals registered on the selected node
-    // #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
-    // List(ListCommand),
+impl PortalCommand {
+    pub fn run(cfg: &mut OckamConfig, cmd: PortalCommand) {
+        match cmd.subcommand {
+            PortalSubCommand::Create(cmd) => CreateCommand::run(cfg, cmd),
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/mod.rs
@@ -1,0 +1,31 @@
+mod create;
+// mod delete;
+// mod list;
+
+pub(crate) use create::CreateCommand;
+// pub(crate) use delete::DeleteCommand;
+// use list::ListCommand;
+
+use crate::{util::OckamConfig, HELP_TEMPLATE};
+use clap::{Args, Subcommand};
+
+#[derive(Clone, Debug, Args)]
+pub struct PortalCommand {
+    #[clap(subcommand)]
+    subcommand: PortalSubCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum PortalSubCommand {
+    /// Create portals on the selected node
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    Create(CreateCommand),
+
+    // /// Delete portals on the selected node
+    // #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    // Delete(DeleteCommand),
+
+    // /// List portals registered on the selected node
+    // #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    // List(ListCommand),
+}

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -1,7 +1,10 @@
 use crate::util::{api, connect_to, stop_node, OckamConfig};
 use clap::{Args, Subcommand};
 use ockam::{Context, Route, TCP};
-use ockam_api::{nodes::types::TransportStatus, Status};
+use ockam_api::{
+    nodes::{types::TransportStatus, NODEMAN_ADDR},
+    Status,
+};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -55,7 +58,7 @@ pub async fn create_transport(
 ) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
-            base_route.modify().append("_internal.nodeman"),
+            base_route.modify().append(NODEMAN_ADDR),
             api::create_transport(&cmd)?,
         )
         .await

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -1,34 +1,31 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig, AddonCommand};
-use clap::Args;
+use crate::util::{api, connect_to, stop_node, OckamConfig};
+use clap::{Args, Subcommand};
 use ockam::{Context, Route, TCP};
 use ockam_api::{nodes::types::TransportStatus, Status};
 
-// Creating transports has two sub-commands
-//
-// tcp-listener
-// tcp-connection
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Override the default API node
     #[clap(short, long)]
     pub api_node: Option<String>,
 
-    /// Specify the type of transport to create
-    pub addon_command: AddonCommand,
-    // /// Create a listening transport
-    // #[clap(short, long, conflicts_with("connect"))]
-    // pub listen: bool,
+    /// Select a creation variant
+    #[clap(subcommand)]
+    pub create_subcommand: CreateTypeCommand,
+}
 
-    // /// Create a connection transport
-    // #[clap(short, long, conflicts_with("listen"))]
-    // pub connect: bool,
-
-    // /// Create a TCP transport
-    // #[clap(long)]
-    // pub tcp: bool,
-
-    // /// Transport connection or bind address
-    // pub address: String,
+#[derive(Clone, Debug, Subcommand)]
+pub enum CreateTypeCommand {
+    /// Create a TCP listener transport
+    TcpListener {
+        /// Transport connection or bind address
+        bind: String,
+    },
+    /// Create a TCP connector transport
+    TcpConnector {
+        /// Transport connection or bind address
+        address: String,
+    },
 }
 
 impl CreateCommand {
@@ -41,14 +38,7 @@ impl CreateCommand {
             }
         };
 
-        // if !command.connect && !command.listen {
-        //     eprintln!("Either --connect or --listen must be provided!");
-        //     std::process::exit(-1);
-        // }
-
-        println!("Self: {:?}", command);
-
-        // connect_to(port, command, create_transport);
+        connect_to(port, command, create_transport);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -1,28 +1,34 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node, OckamConfig, AddonCommand};
 use clap::Args;
 use ockam::{Context, Route, TCP};
 use ockam_api::{nodes::types::TransportStatus, Status};
 
+// Creating transports has two sub-commands
+//
+// tcp-listener
+// tcp-connection
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Override the default API node
     #[clap(short, long)]
     pub api_node: Option<String>,
 
-    /// Create a listening transport
-    #[clap(short, long, conflicts_with("connect"))]
-    pub listen: bool,
+    /// Specify the type of transport to create
+    pub addon_command: AddonCommand,
+    // /// Create a listening transport
+    // #[clap(short, long, conflicts_with("connect"))]
+    // pub listen: bool,
 
-    /// Create a connection transport
-    #[clap(short, long, conflicts_with("listen"))]
-    pub connect: bool,
+    // /// Create a connection transport
+    // #[clap(short, long, conflicts_with("listen"))]
+    // pub connect: bool,
 
-    /// Create a TCP transport
-    #[clap(long)]
-    pub tcp: bool,
+    // /// Create a TCP transport
+    // #[clap(long)]
+    // pub tcp: bool,
 
-    /// Transport connection or bind address
-    pub address: String,
+    // /// Transport connection or bind address
+    // pub address: String,
 }
 
 impl CreateCommand {
@@ -35,12 +41,14 @@ impl CreateCommand {
             }
         };
 
-        if !command.connect && !command.listen {
-            eprintln!("Either --connect or --listen must be provided!");
-            std::process::exit(-1);
-        }
+        // if !command.connect && !command.listen {
+        //     eprintln!("Either --connect or --listen must be provided!");
+        //     std::process::exit(-1);
+        // }
 
-        connect_to(port, command, create_transport);
+        println!("Self: {:?}", command);
+
+        // connect_to(port, command, create_transport);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -16,12 +16,18 @@ pub struct CreateCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum CreateTypeCommand {
-    /// Create a TCP listener transport
+    /// Create a TCP transport listener
+    ///
+    /// Listens for incoming TCP connections on the given bind address
+    /// and port
     TcpListener {
         /// Transport connection or bind address
         bind: String,
     },
-    /// Create a TCP connector transport
+    /// Create a TCP transport connector
+    ///
+    /// Attempts to connect to an existing TCP transport listener on
+    /// the given peer address and port
     TcpConnector {
         /// Transport connection or bind address
         address: String,

--- a/implementations/rust/ockam/ockam_command/src/transport/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/delete.rs
@@ -1,7 +1,7 @@
 use crate::util::{api, connect_to, stop_node, OckamConfig};
 use clap::Args;
 use ockam::{Context, Route};
-use ockam_api::{Response, Status};
+use ockam_api::{nodes::NODEMAN_ADDR, Response, Status};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -38,7 +38,7 @@ pub async fn delete_transport(
 ) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
-            base_route.modify().append("_internal.nodeman"),
+            base_route.modify().append(NODEMAN_ADDR),
             api::delete_transport(&cmd)?,
         )
         .await

--- a/implementations/rust/ockam/ockam_command/src/transport/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/list.rs
@@ -2,7 +2,10 @@ use crate::util::{api, connect_to, stop_node, OckamConfig};
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::{Context, Route};
-use ockam_api::nodes::types::{TransportList, TransportStatus};
+use ockam_api::nodes::{
+    types::{TransportList, TransportStatus},
+    NODEMAN_ADDR,
+};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
@@ -28,7 +31,7 @@ impl ListCommand {
 pub async fn query_transports(ctx: Context, _: (), mut base_route: Route) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
-            base_route.modify().append("_internal.nodeman"),
+            base_route.modify().append(NODEMAN_ADDR),
             api::query_transports()?,
         )
         .await

--- a/implementations/rust/ockam/ockam_command/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/mod.rs
@@ -2,7 +2,7 @@ mod create;
 mod delete;
 mod list;
 
-pub(crate) use create::CreateCommand;
+pub(crate) use create::{CreateCommand, CreateTypeCommand};
 pub(crate) use delete::DeleteCommand;
 use list::ListCommand;
 

--- a/implementations/rust/ockam/ockam_command/src/util/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/addon.rs
@@ -1,20 +1,26 @@
+// This abstraction is currently not used because of the way that we
+// structure the main clap parser and the difficulties it brings with
+// generating meaningful but dynamic help pages.
+//
+// When we want to support add-on commands we will have to dig this
+// structure out again and likely re-build the way we currently parse
+// commandline sections and generate the help pages.
+
 use clap::Args;
 use std::str::FromStr;
 
 /// A plugin command type that can
 #[derive(Clone, Debug, Args)]
 pub struct AddonCommand {
-    /// The operation to perform
+    /// Operation to perform
     #[clap(possible_values = vec!["create", "delete", "show", "list"])]
     operation: String,
-    /// The name of the addon command.  Its full name must be
-    /// `ockam-<scope>-<name>`, so for example:
-    /// `ockam-transport-create-tcp-inlet`
+    /// Add-on subcommand to call
+    // Its full name must be `ockam-<scope>-<name>`, so for example:
+    // `ockam-transport-create-tcp-inlet`
     addon_name: Option<String>,
-    /// Everything else given to this command will be ignored by the
-    /// ockam CLI but forwarded to the plugin command
-    #[clap(hide = true)]
-    _proxy: Vec<String>,
+    /// Other options passed into the add-on command
+    options: Vec<String>,
 }
 
 impl FromStr for AddonCommand {
@@ -26,14 +32,7 @@ impl FromStr for AddonCommand {
         Ok(Self {
             operation: s.remove(0).into(),
             addon_name: Some(s.remove(0).into()),
-            _proxy: s.into_iter().map(Into::into).collect(),
+            options: s.into_iter().map(Into::into).collect(),
         })
-    }
-}
-
-impl AddonCommand {
-    /// Print the inner help text for this particular addon
-    pub fn get_help(&self) -> String {
-        todo!()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/addon.rs
@@ -1,0 +1,39 @@
+use clap::Args;
+use std::str::FromStr;
+
+/// A plugin command type that can
+#[derive(Clone, Debug, Args)]
+pub struct AddonCommand {
+    /// The operation to perform
+    #[clap(possible_values = vec!["create", "delete", "show", "list"])]
+    operation: String,
+    /// The name of the addon command.  Its full name must be
+    /// `ockam-<scope>-<name>`, so for example:
+    /// `ockam-transport-create-tcp-inlet`
+    addon_name: Option<String>,
+    /// Everything else given to this command will be ignored by the
+    /// ockam CLI but forwarded to the plugin command
+    #[clap(hide = true)]
+    _proxy: Vec<String>,
+}
+
+impl FromStr for AddonCommand {
+    // Errors are so meaningless in this process, we never emit any
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, &'static str> {
+        let mut s: Vec<_> = s.split_whitespace().collect();
+        Ok(Self {
+            operation: s.remove(0).into(),
+            addon_name: Some(s.remove(0).into()),
+            _proxy: s.into_iter().map(Into::into).collect(),
+        })
+    }
+}
+
+impl AddonCommand {
+    /// Print the inner help text for this particular addon
+    pub fn get_help(&self) -> String {
+        todo!()
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -94,13 +94,13 @@ pub(crate) fn create_portal(cmd: &portal::CreateCommand) -> Result<Vec<u8>> {
     // FIXME: this should not rely on CreateCommand internals!
     let (tt, addr, fwd) = match &cmd.create_subcommand {
         portal::CreateTypeCommand::TcpInlet { bind, forward } => {
-            (IoletType::Inlet, bind, Some(forward))
+            (PortalType::Inlet, bind, Some(forward))
         }
-        portal::CreateTypeCommand::TcpOutlet { address } => (IoletType::Outlet, address, None),
+        portal::CreateTypeCommand::TcpOutlet { address } => (PortalType::Outlet, address, None),
     };
     let alias = cmd.alias.as_ref().map(Into::into);
     let fwd = fwd.map(Into::into);
-    let payload = CreateIolet::new(tt, addr, fwd, alias);
+    let payload = CreatePortal::new(tt, addr, fwd, alias);
 
     let mut buf = vec![];
     Request::builder(Method::Post, "/node/portal")
@@ -153,8 +153,8 @@ pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Resu
 }
 
 /// Parse the returned status response
-pub(crate) fn parse_portal_status(resp: &[u8]) -> Result<(Response, IoletStatus<'_>)> {
+pub(crate) fn parse_portal_status(resp: &[u8]) -> Result<(Response, PortalStatus<'_>)> {
     let mut dec = Decoder::new(resp);
     let response = dec.decode::<Response>()?;
-    Ok((response, dec.decode::<IoletStatus>()?))
+    Ok((response, dec.decode::<PortalStatus>()?))
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -23,21 +23,23 @@ pub(crate) fn query_transports() -> Result<Vec<u8>> {
 
 /// Construct a request to create node transports
 pub(crate) fn create_transport(cmd: &crate::transport::CreateCommand) -> Result<Vec<u8>> {
-    let payload = CreateTransport::new(
-        TransportType::Tcp,
-        if cmd.connect {
-            TransportMode::Connect
-        } else {
-            TransportMode::Listen
-        },
-        &cmd.address,
-    );
+    // FIXME: this should not rely on CreateCommand internals!
+    // let payload = CreateTransport::new(
+    //     TransportType::Tcp,
+    //     if cmd.connect {
+    //         TransportMode::Connect
+    //     } else {
+    //         TransportMode::Listen
+    //     },
+    //     &cmd.address,
+    // );
 
-    let mut buf = vec![];
-    Request::builder(Method::Post, "/node/transport")
-        .body(payload)
-        .encode(&mut buf)?;
-    Ok(buf)
+    // let mut buf = vec![];
+    // Request::builder(Method::Post, "/node/transport")
+    //     .body(payload)
+    //     .encode(&mut buf)?;
+    // Ok(buf)
+    todo!()
 }
 
 /// Construct a request to delete node transports

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,5 +1,8 @@
 pub mod api;
 
+mod addon;
+pub use addon::AddonCommand;
+
 mod config;
 pub use config::{ConfigError, NodeConfig, OckamConfig};
 

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -61,7 +61,7 @@ pub struct Context {
 impl Drop for Context {
     fn drop(&mut self) {
         if let Some(sender) = self.async_drop_sender.take() {
-            debug!("De-allocated detached context {}", self.address());
+            trace!("De-allocated detached context {}", self.address());
             if let Err(e) = sender.send(self.address()) {
                 warn!("Encountered error while dropping detached context: {}", e);
             }

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -124,7 +124,7 @@ impl Router {
 
         use NodeMessage::*;
         #[cfg(feature = "metrics")]
-        debug!(
+        trace!(
             "Current router alloc: {} addresses",
             self.map.get_addr_count()
         );
@@ -193,7 +193,7 @@ impl Router {
             }
 
             StopAck(addr) if self.state.running() => {
-                debug!("Received shutdown ACK for address {}", addr);
+                trace!("Received shutdown ACK for address {}", addr);
                 if let Some(rec) = self.map.internal.remove(&addr) {
                     rec.address_set().iter().for_each(|addr| {
                         self.map.addr_map.remove(addr);


### PR DESCRIPTION
This PR adds the ability to create portal inlets and outlets in ockam command.

It also re-structures the transports command to use sub-commands for tcp-listener and tcp-connector creation. In the future we may want to re-implement these commands as "Addon Commands" (the basic structure is also included in this PR).

However to support both add-ons, and meaningful help text generation via clap, we will need to restructure the way we build the CLI fundamentally (i.e. use the builder patterns, not the magic derives)