### PR TITLE
feat(rust): create worker builder for cleaner worker init

### DIFF
--- a/examples/rust/get_started/examples/06-access-control-over-transport-responder.rs
+++ b/examples/rust/get_started/examples/06-access-control-over-transport-responder.rs
@@ -3,7 +3,7 @@
 
 use hello_ockam::Echoer;
 use ockam::access_control::{AllowedTransport, LocalOriginOnly};
-use ockam::{Context, Result, TcpTransport, TCP};
+use ockam::{Context, Result, TcpTransport, WorkerBuilder, TCP};
 
 #[ockam::node(access_control = "LocalOriginOnly")]
 async fn main(ctx: Context) -> Result<()> {
@@ -14,7 +14,8 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.listen("127.0.0.1:4000").await?;
 
     // Create an echoer worker
-    ctx.start_worker_with_access_control("echoer", Echoer, AllowedTransport::single(TCP))
+    WorkerBuilder::with_access_control(AllowedTransport::single(TCP), "echoer", Echoer)
+        .start(&ctx)
         .await?;
 
     // Don't call ctx.stop() here so this node runs forever.

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -26,7 +26,7 @@ pub use ockam_macros::{node, test};
 // ---
 
 // Export node implementation
-pub use ockam_node::{Context, DelayedEvent, Executor, NodeBuilder};
+pub use ockam_node::{Context, DelayedEvent, Executor, NodeBuilder, WorkerBuilder};
 // ---
 
 mod delay;

--- a/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
@@ -1,7 +1,7 @@
 use crate::old::session::error::SessionManagementError;
 use crate::old::session::msg::{RequestId, SessionMsg};
 use ockam::access_control::{AccessControl, LocalOriginOnly};
-use ockam::{Address, Context, DelayedEvent, Result, Route, Routed, Worker};
+use ockam::{Address, Context, DelayedEvent, Result, Route, Routed, Worker, WorkerBuilder};
 use ockam_core::{Mailbox, Mailboxes};
 use std::sync::Arc;
 use std::time::Duration;
@@ -53,7 +53,9 @@ impl<S: SessionManager> SessionMaintainer<S> {
         let heartbeat_mailbox = Mailbox::new(heartbeat_addr, Arc::new(LocalOriginOnly));
         let mailboxes = Mailboxes::new(main_mailbox, vec![heartbeat_mailbox]);
 
-        ctx.start_worker_with_mailboxes(mailboxes, manager).await?;
+        WorkerBuilder::with_mailboxes(mailboxes, manager)
+            .start(ctx)
+            .await?;
 
         Ok(main_addr)
     }

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
@@ -28,7 +28,8 @@ async fn main(ctx: Context) -> Result<()> {
     let vault_address = vault.address();
 
     let access_control = IdentityAccessControlBuilder::new_with_any_id();
-    ctx.start_worker_with_access_control(ECHOER, Echoer, access_control)
+    WorkerBuilder::with_access_control(access_control, ECHOER, Echoer)
+        .start(ctx)
         .await?;
 
     let mut bob = Identity::create(&ctx, &vault_address).await?;

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -20,7 +20,7 @@ mod test {
     use core::sync::atomic::{AtomicU8, Ordering};
     use ockam_core::compat::sync::Arc;
     use ockam_core::{route, Any, Result, Route, Routed, Worker};
-    use ockam_node::Context;
+    use ockam_node::{Context, WorkerBuilder};
     use ockam_vault::Vault;
     use std::time::Duration;
     use tokio::time::sleep;
@@ -250,7 +250,8 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
+        WorkerBuilder::with_access_control(access_control, "receiver", receiver)
+            .start(ctx)
             .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -286,7 +287,8 @@ mod test {
         let bob = Identity::create(ctx, &vault).await?;
 
         let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().await?);
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
+        WorkerBuilder::with_access_control(access_control, "receiver", receiver)
+            .start(ctx)
             .await?;
 
         bob.create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -319,7 +321,8 @@ mod test {
         let access_control = IdentityAccessControlBuilder::new_with_id(
             "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
-        ctx.start_worker_with_access_control("receiver", receiver, access_control)
+        WorkerBuilder::with_access_control(access_control, "receiver", receiver)
+            .start(ctx)
             .await?;
 
         ctx.send(route!["receiver"], "Hello, Bob!".to_string())

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -53,6 +53,7 @@ mod node;
 mod parser;
 mod relay;
 mod router;
+mod worker_builder;
 
 pub use cancel::*;
 pub use context::*;
@@ -61,6 +62,7 @@ pub use error::*;
 pub use executor::*;
 pub use local_info::*;
 pub use messages::*;
+pub use worker_builder::WorkerBuilder;
 
 pub use node::{NodeBuilder, NullWorker};
 

--- a/implementations/rust/ockam/ockam_node/src/worker_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/worker_builder.rs
@@ -1,0 +1,113 @@
+use crate::error::{NodeError, NodeReason};
+use crate::{relay::WorkerRelay, Context, NodeMessage};
+use ockam_core::compat::sync::Arc;
+use ockam_core::{
+    errcode::{Kind, Origin},
+    AccessControl, Address, AddressSet, AllowAll, Error, Mailboxes, Message, Result, Worker,
+};
+
+/// Start a [`Worker`] with a custom [`AccessControl`] configuration
+///
+/// Any incoming messages for the worker will first be subject to the
+/// configured `AccessControl` before it is passed on to
+/// [`Worker::handle_message`].
+///
+/// The [`Context::start_worker()`] function wraps this type and
+/// simply calls `WorkerBuilder::with_context_access_control()`.
+///
+/// Varying use-cases should use the builder API to customise the
+/// underlying worker that is created.
+pub struct WorkerBuilder<W> {
+    mailboxes: Mailboxes,
+    worker: W,
+}
+
+impl<M, W> WorkerBuilder<W>
+where
+    M: Message + Send + 'static,
+    W: Worker<Context = Context, Message = M>,
+{
+    /// Create a worker with `AllowAll` access control
+    pub fn without_access_control<AS>(address_set: AS, worker: W) -> Self
+    where
+        AS: Into<AddressSet>,
+    {
+        let mailboxes = Mailboxes::from_address_set(address_set.into(), Arc::new(AllowAll));
+
+        Self { mailboxes, worker }
+    }
+
+    /// Create a worker which inherits access control from the given context
+    pub fn with_inherited_access_control<AS>(context: &Context, address_set: AS, worker: W) -> Self
+    where
+        AS: Into<AddressSet>,
+    {
+        let address_set = address_set.into();
+
+        // Inherit access control from the given context's main mailbox
+        let access_control = context.mailboxes().main_mailbox().access_control().clone();
+
+        debug!(
+            "Worker '{}' inherits access control '{:?}' from: '{}'",
+            address_set.first(),
+            access_control,
+            context.address(),
+        );
+
+        let mailboxes = Mailboxes::from_address_set(address_set, access_control);
+
+        Self { mailboxes, worker }
+    }
+
+    /// Create a worker which uses the given access control
+    pub fn with_access_control<A, AC>(access_control: AC, address: A, worker: W) -> Self
+    where
+        A: Into<Address>,
+        AC: AccessControl,
+    {
+        let mailboxes = Mailboxes::main(address.into(), Arc::new(access_control));
+
+        Self { mailboxes, worker }
+    }
+
+    /// Create a worker which uses the access control from the given
+    /// [`Mailboxes`]
+    pub fn with_mailboxes(mailboxes: Mailboxes, worker: W) -> Self {
+        Self { mailboxes, worker }
+    }
+
+    /// Consume this builder and start a new Ockam [`Worker`] from the given context
+    #[inline]
+    pub async fn start(self, context: &Context) -> Result<()> {
+        info!(
+            "Initializing ockam worker with access control: {:?}",
+            self.mailboxes.main_mailbox().access_control(),
+        );
+
+        let mailboxes = self.mailboxes;
+        let addresses = mailboxes.addresses();
+
+        // Pass it to the context
+        let (ctx, sender, ctrl_rx) =
+            Context::new(context.runtime(), context.sender().clone(), mailboxes, None);
+
+        // Then initialise the worker message relay
+        WorkerRelay::<W, M>::init(&context.runtime(), self.worker, ctx, ctrl_rx);
+
+        // Send start request to router
+        let (msg, mut rx) =
+            NodeMessage::start_worker(addresses, sender, false, context.mailbox_count());
+        context
+            .sender()
+            .send(msg)
+            .await
+            .map_err(|e| Error::new(Origin::Node, Kind::Invalid, e))?;
+
+        // Wait for the actual return code
+        rx.recv()
+            .await
+            .ok_or_else(|| NodeError::NodeState(NodeReason::Unknown).internal())??;
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,7 +1,7 @@
 use ockam_core::access_control::AccessControl;
 use ockam_core::compat::{boxed::Box, net::SocketAddr};
 use ockam_core::{Address, AsyncTryClone, Result, Route};
-use ockam_node::Context;
+use ockam_node::{Context, WorkerBuilder};
 
 use crate::{parse_socket_addr, TcpOutletListenWorker, TcpRouter, TcpRouterHandle};
 
@@ -204,12 +204,8 @@ impl TcpTransport {
     {
         let worker = TcpOutletListenWorker::new(peer.into());
 
-        // TODO all mailboxes get the same access_control?
-        //let mailboxes = Mailboxes::from_address_set(address.into().into(), access_control);
-
-        self.router_handle
-            .ctx()
-            .start_worker_with_access_control(address.into(), worker, access_control)
+        WorkerBuilder::with_access_control(access_control, address.into(), worker)
+            .start(self.router_handle.ctx())
             .await?;
 
         Ok(())


### PR DESCRIPTION
This commit removes the following public methods and replaces them with the worker builder:

    Context::start_worker_with_access_control
    Context::start_worker_with_mailboxes

For example:

    ctx.start_worker_with_access_control("echoer", Echoer, AllowedTransport::single(TCP))

Becomes

    Builder::with_access_control(AllowedTransport::single(TCP), "echoer", Echoer) .start(&ctx)
