### PR TITLE
fix(elixir): treat empty services config as no services instead of one empty name service

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
@@ -164,7 +164,7 @@ defmodule Ockam.Services.Provider do
 
   def parse_services_list(services) do
     services
-    |> String.split(",")
+    |> String.split(",", trim: true)
     |> Enum.map(fn service_name -> service_name |> String.trim() |> String.to_atom() end)
     |> parse_services_config()
   end


### PR DESCRIPTION
## Current Behaviour

Empty services config is currently handled as a single "" service because of string parsing

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Fix parsing to return no services

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
