### PR TITLE
refactor(rust): flatten overwrite field

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/email.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/email.rs
@@ -38,7 +38,7 @@ fn read_user_input() -> anyhow::Result<String> {
 }
 
 async fn enroll(mut ctx: ockam::Context, args: (EnrollCommand, String)) -> anyhow::Result<()> {
-    let (_command, email) = args;
+    let (_cmd, email) = args;
 
     let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
     let res = Retry::spawn(retry_strategy, move || {

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -28,16 +28,16 @@ pub struct EnrollCommand {
     #[clap(display_order = 1002, long, default_value = "default")]
     identity: String,
 
-    #[clap(display_order = 1003, long)]
-    overwrite: bool,
-
     /// Authenticates an enrollment token
-    #[clap(display_order = 1004, long, group = "enroll_params")]
+    #[clap(display_order = 1003, long, group = "enroll_params")]
     token: Option<String>,
 
     /// Enroll using the Auth0 flow
     #[clap(display_order = 1004, long, group = "enroll_params")]
     auth0: bool,
+
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl EnrollCommand {
@@ -48,14 +48,6 @@ impl EnrollCommand {
             EnrollAuth0Command::run(command)
         } else {
             EnrollEmailCommand::run(command)
-        }
-    }
-}
-
-impl<'a> From<&'a EnrollCommand> for IdentityOpts {
-    fn from(other: &'a EnrollCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
@@ -1,28 +1,22 @@
+use anyhow::anyhow;
 use clap::Args;
+
+use ockam::identity::IdentityTrait;
+use ockam::{route, Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
 
 use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route};
 use crate::IdentityOpts;
-use anyhow::anyhow;
-use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
-use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct AcceptCommand {
     #[clap(display_order = 1002)]
     invitation: String,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
-}
-
-impl<'a> From<&'a AcceptCommand> for IdentityOpts {
-    fn from(other: &'a AcceptCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl AcceptCommand {
@@ -36,14 +30,15 @@ async fn accept(mut ctx: Context, args: (MultiAddr, AcceptCommand)) -> anyhow::R
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
     let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api
-        .accept_invitations(&identity.id.to_string(), &cmd.invitation)
+        .accept_invitations(identifier.key_id(), &cmd.invitation)
         .await?;
     println!("{res:?}");
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
@@ -1,16 +1,17 @@
-mod accept;
-mod create;
-mod list;
-mod reject;
+use clap::{Args, Subcommand};
 
 use accept::AcceptCommand;
 use create::CreateCommand;
 use list::ListCommand;
+use ockam_multiaddr::MultiAddr;
 use reject::RejectCommand;
 
 use crate::HELP_TEMPLATE;
-use clap::{Args, Subcommand};
-use ockam_multiaddr::MultiAddr;
+
+mod accept;
+mod create;
+mod list;
+mod reject;
 
 #[derive(Clone, Debug, Args)]
 pub struct InvitationCommand {

--- a/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
@@ -1,20 +1,22 @@
+use anyhow::anyhow;
 use clap::Args;
+
+use ockam::identity::IdentityTrait;
+use ockam::{route, Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
 
 use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route};
 use crate::IdentityOpts;
-use anyhow::anyhow;
-use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
-use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct RejectCommand {
     #[clap(display_order = 1002)]
     invitation: String,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl RejectCommand {
@@ -23,27 +25,20 @@ impl RejectCommand {
     }
 }
 
-impl<'a> From<&'a RejectCommand> for IdentityOpts {
-    fn from(other: &'a RejectCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
-}
-
 async fn reject(mut ctx: Context, args: (MultiAddr, RejectCommand)) -> anyhow::Result<()> {
     let (cloud_addr, cmd) = args;
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let r = multiaddr_to_route(&cloud_addr)
         .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
     let route = route![r.to_string(), "invitations"];
     let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api
-        .reject_invitations(&identity.id.to_string(), &cmd.invitation)
+        .reject_invitations(identifier.key_id(), &cmd.invitation)
         .await?;
     println!("{res:?}");
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -220,7 +220,7 @@ pub fn run() {
             node_subcommand(verbose > 0, arg, old::cmd::identity::run)
         }
         OckamSubcommand::AddTrustedIdentity(arg) => exit_with_result(verbose > 0, add_trusted(arg)),
-        OckamSubcommand::PrintIdentity => exit_with_result(verbose > 0, print_identity()),
+        OckamSubcommand::PrintIdentity => node_subcommand(verbose > 0, (), print_identity),
         OckamSubcommand::PrintPath => exit_with_result(verbose > 0, print_ockam_dir()),
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/old/cmd/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/cmd/identity.rs
@@ -18,7 +18,7 @@ pub struct IdentityOpts {
 }
 
 pub async fn run(args: IdentityOpts, mut ctx: Context) -> anyhow::Result<()> {
-    create_identity(&args, &ctx).await?;
+    create_identity(&ctx, args.overwrite).await?;
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/old/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
 use identity::load_identity;
+use ockam::identity::IdentityTrait;
 use ockam::{identity::IdentityIdentifier, NodeBuilder};
 use std::collections::BTreeSet;
 use storage::{ensure_identity_exists, get_ockam_dir};
@@ -26,11 +27,13 @@ pub mod session {
 
 pub type OckamVault = ockam::vault::Vault;
 
-pub fn print_identity() -> anyhow::Result<()> {
+pub async fn print_identity(_arg: (), mut ctx: ockam::Context) -> anyhow::Result<()> {
     ensure_identity_exists(false)?;
     let dir = get_ockam_dir()?;
-    let identity = load_identity(&dir)?;
-    println!("{}", identity.id.key_id());
+    let identity = load_identity(&ctx, &dir).await?;
+    let identifier = identity.identifier().await?;
+    println!("{}", identifier.key_id());
+    ctx.stop().await?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use clap::Args;
 
+use ockam::identity::IdentityTrait;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
@@ -23,16 +24,8 @@ pub struct DeleteCommand {
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
-}
-
-impl<'a> From<&'a DeleteCommand> for IdentityOpts {
-    fn from(other: &'a DeleteCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
@@ -45,13 +38,14 @@ async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api
-        .delete_project(&cmd.space_id, &cmd.project_id, &identity.id.to_string())
+        .delete_project(&cmd.space_id, &cmd.project_id, identifier.key_id())
         .await?;
     println!("{res:#?}");
 

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use clap::Args;
 
+use ockam::identity::IdentityTrait;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
@@ -19,16 +20,8 @@ pub struct ListCommand {
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
-}
-
-impl<'a> From<&'a ListCommand> for IdentityOpts {
-    fn from(other: &'a ListCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl ListCommand {
@@ -41,13 +34,14 @@ async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
     let res = api
-        .list_projects(&cmd.space_id, &identity.id.to_string())
+        .list_projects(&cmd.space_id, identifier.key_id())
         .await?;
     println!("{res:#?}");
 

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use clap::Args;
 
+use ockam::identity::IdentityTrait;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::{space::CreateSpace, MessagingClient};
 use ockam_multiaddr::MultiAddr;
@@ -19,16 +20,8 @@ pub struct CreateCommand {
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
-}
-
-impl<'a> From<&'a CreateCommand> for IdentityOpts {
-    fn from(other: &'a CreateCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl CreateCommand {
@@ -41,13 +34,14 @@ async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
     let request = CreateSpace::new(cmd.name);
-    let res = api.create_space(request, &identity.id.to_string()).await?;
+    let res = api.create_space(request, identifier.key_id()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,13 +1,14 @@
 use anyhow::anyhow;
 use clap::Args;
 
-use crate::old::identity::load_or_create_identity;
-use crate::IdentityOpts;
+use ockam::identity::IdentityTrait;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -19,16 +20,8 @@ pub struct DeleteCommand {
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
-}
-
-impl<'a> From<&'a DeleteCommand> for IdentityOpts {
-    fn from(other: &'a DeleteCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
@@ -41,12 +34,13 @@ async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.delete_space(&cmd.id, &identity.id.to_string()).await?;
+    let res = api.delete_space(&cmd.id, identifier.key_id()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,13 +1,14 @@
 use anyhow::anyhow;
 use clap::Args;
 
-use crate::old::identity::load_or_create_identity;
-use crate::IdentityOpts;
+use ockam::identity::IdentityTrait;
 use ockam::{Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
+use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, multiaddr_to_route, DEFAULT_CLOUD_ADDRESS};
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -19,8 +20,8 @@ pub struct ShowCommand {
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     address: MultiAddr,
 
-    #[clap(display_order = 1101, long)]
-    overwrite: bool,
+    #[clap(flatten)]
+    identity_opts: IdentityOpts,
 }
 
 impl ShowCommand {
@@ -29,24 +30,17 @@ impl ShowCommand {
     }
 }
 
-impl<'a> From<&'a ShowCommand> for IdentityOpts {
-    fn from(other: &'a ShowCommand) -> Self {
-        Self {
-            overwrite: other.overwrite,
-        }
-    }
-}
-
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&IdentityOpts::from(&cmd), &ctx).await?;
+    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let identifier = identity.identifier().await?;
 
     let route =
         multiaddr_to_route(&cmd.address).ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, &ctx).await?;
-    let res = api.get_space(&cmd.id, &identity.id.to_string()).await?;
+    let res = api.get_space(&cmd.id, identifier.key_id()).await?;
     println!("{res:#?}");
 
     ctx.stop().await?;


### PR DESCRIPTION
Flattens `overwrite` field so all subcommands using this field don't have to duplicate its configuration and description.

It also refactors the methods used to load identities, so it loads the full identity instead of the exported version. Having the full version saves us from doing an extra call to build it from the exported version. These changes are done in preparation for the `forwarders create` command.
