### PR TITLE
feat(elixir): authorization control for services

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/message.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/message.ex
@@ -79,6 +79,10 @@ defmodule Ockam.Message do
     %{message | payload: payload}
   end
 
+  def set_local_metadata(%Message{} = message, metadata) when is_map(metadata) do
+    %{message | local_metadata: metadata}
+  end
+
   def put_local_metadata(%Message{} = message, key, value) when is_atom(key) do
     Map.update(message, :local_metadata, %{key => value}, fn metadata ->
       Map.put(metadata, key, value)

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/wrapper.ex
@@ -21,7 +21,7 @@ defmodule Ockam.Messaging.ConfirmPipe.Wrapper do
 
   def unwrap_message(wrapped) do
     with {:ok, %{ref: ref, data: encoded_message}, ""} <- :bare.decode(wrapped, @bare_schema),
-         {:ok, message} <- Ockam.Wire.decode(encoded_message) do
+         {:ok, message} <- Ockam.Wire.decode(encoded_message, :confirm_pipe) do
       {:ok, ref, message}
     else
       {:ok, _decoded, _rest} = bare_result ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/wrapper.ex
@@ -23,7 +23,7 @@ defmodule Ockam.Messaging.IndexPipe.Wrapper do
   def unwrap_message(payload) do
     with {:ok, %{index: index, message: encoded_message}, ""} <-
            :bare.decode(payload, @schema),
-         {:ok, message} <- Ockam.Wire.decode(encoded_message) do
+         {:ok, message} <- Ockam.Wire.decode(encoded_message, :index_pipe) do
       {:ok, index, message}
     else
       {:ok, _decoded, _rest} = bare_result ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
@@ -86,7 +86,6 @@ defmodule Ockam.SecureChannel.Channel do
     return_value
   end
 
-  ## TODO: better name to not collide with Ockam.Worker.handle_message
   defp handle_message({:call, from}, :established?, state, data) do
     established = {:encrypted_transport, :ready} === state
     {:next_state, state, data, [{:reply, from, established}]}

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/encrypted_transport_protocol/aead_aes_gcm.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/encrypted_transport_protocol/aead_aes_gcm.ex
@@ -69,8 +69,10 @@ defmodule Ockam.SecureChannel.EncryptedTransportProtocol.AeadAesGcm do
     {:ok, encrypted, ""} = :bare.decode(payload, :data)
 
     with {:ok, decrypted, data} <- decrypt(encrypted, data),
-         {:ok, decoded} <- Wire.decode(decrypted) do
-      message = Message.trace(decoded, data.plaintext_address)
+         {:ok, decoded} <- Wire.decode(decrypted, :secure_channel) do
+      message =
+        decoded
+        |> Message.trace(data.plaintext_address)
 
       Router.route(message)
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
@@ -88,7 +88,7 @@ defmodule Ockam.Stream.Client.BiDirectional do
   def decode_message(data) do
     case :bare.decode(data, @bare_message) do
       {:ok, %{return_stream: stream, message: wire_message}, ""} ->
-        case Ockam.Wire.decode(wire_message) do
+        case Ockam.Wire.decode(wire_message, :stream) do
           {:ok, message} ->
             {:ok, %{return_stream: stream, message: message}}
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
@@ -60,6 +60,7 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
     binary_message =
       Ockam.Protocol.encode_payload(Ockam.Protocol.Binary, :request, encoded_message)
 
+    ## TODO: should we forward metadta here?
     Ockam.Router.route(%{
       payload: binary_message,
       onward_route: [publisher_address],

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -61,9 +61,12 @@ defmodule Ockam.Transport.TCP.Client do
   @impl true
   def handle_info({:tcp, socket, data}, %{socket: socket} = state) do
     ## TODO: send/receive message in multiple TCP packets
-    case Wire.decode(data) do
+    case Wire.decode(data, :tcp) do
       {:ok, message} ->
-        forwarded_message = Message.trace(message, state.address)
+        forwarded_message =
+          message
+          |> Message.trace(state.address)
+
         Ockam.Router.route(forwarded_message)
 
       {:error, %Wire.DecodeError{} = e} ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/handler.ex
@@ -58,9 +58,12 @@ defmodule Ockam.Transport.TCP.Handler do
       metadata: %{address: address}
     )
 
-    case Ockam.Wire.decode(data) do
+    case Ockam.Wire.decode(data, :tcp) do
       {:ok, decoded} ->
-        forwarded_message = Message.trace(decoded, address)
+        forwarded_message =
+          decoded
+          |> Message.trace(address)
+
         send_to_router(forwarded_message)
         Telemetry.emit_event(function_name, metadata: %{name: "decoded_data"})
 
@@ -112,6 +115,7 @@ defmodule Ockam.Transport.TCP.Handler do
   end
 
   defp send_to_router(message) do
+    ## TODO: do we want to handle that?
     Ockam.Router.route(message)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/workers/call.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/workers/call.ex
@@ -67,11 +67,8 @@ defmodule Ockam.Workers.Call do
   end
 
   def send_call(call, state) do
-    Ockam.Router.route(%{
-      payload: Map.get(call, :payload),
-      onward_route: Map.get(call, :onward_route),
-      return_route: [state.address]
-    })
+    call = struct(Ockam.Message, call)
+    Ockam.Router.route(Ockam.Message.set_return_route(call, [state.address]))
   end
 
   @impl true

--- a/implementations/elixir/ockam/ockam_services/lib/services/authorization_config.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/authorization_config.ex
@@ -1,0 +1,12 @@
+defmodule Ockam.Services.AuthorizationConfig do
+  @moduledoc """
+  Predefined configs for services authorization
+  """
+  def secure_channel() do
+    [:to_my_address, :is_secure]
+  end
+
+  def local() do
+    [:to_my_address, :is_local]
+  end
+end

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/routing.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/routing.ex
@@ -7,6 +7,7 @@ defmodule Ockam.Services.Provider.Routing do
   @behaviour Ockam.Services.Provider
 
   alias Ockam.Services.API.StaticForwarding, as: StaticForwardingAPI
+  alias Ockam.Services.AuthorizationConfig
   alias Ockam.Services.Echo, as: EchoService
   alias Ockam.Services.Forwarding, as: ForwardingService
   alias Ockam.Services.PubSub, as: PubSubService
@@ -54,7 +55,8 @@ defmodule Ockam.Services.Provider.Routing do
     {StaticForwardingAPI,
      Keyword.merge(args,
        address: "static_forwarding_api",
-       prefix: "forward_to"
+       prefix: "forward_to",
+       authorization: AuthorizationConfig.secure_channel()
      )}
   end
 

--- a/implementations/elixir/ockam/ockam_services/test/authorization_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/authorization_test.exs
@@ -1,0 +1,113 @@
+defmodule Ockam.Services.Authorization.Tests do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Ockam.Message
+  alias Ockam.Router
+
+  alias Ockam.Services.AuthorizationConfig
+  alias Ockam.Services.Echo
+
+  require Logger
+
+  setup_all do
+    {:ok, vault} = Ockam.Vault.Software.init()
+    {:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+
+    {:ok, channel_listener} =
+      Ockam.SecureChannel.create_listener(vault: vault, identity_keypair: identity)
+
+    on_exit(fn ->
+      Ockam.Node.stop(channel_listener)
+    end)
+
+    [vault: vault, channel_listener: channel_listener]
+  end
+
+  test "Worker requiring secure channel", %{vault: vault, channel_listener: channel_listener} do
+    {:ok, echoer} = Echo.create(authorization: AuthorizationConfig.secure_channel())
+
+    {:ok, me} = Ockam.Node.register_random_address()
+
+    Router.route(%Message{
+      payload: "Hello fake secure channel",
+      onward_route: [echoer],
+      return_route: [me],
+      local_metadata: %{source: :channel, channel: :secure_channel}
+    })
+
+    assert_receive(%Message{onward_route: [^me], payload: "Hello fake secure channel"}, 500)
+
+    Router.route(%Message{
+      payload: "Hello local",
+      onward_route: [echoer],
+      return_route: [me]
+    })
+
+    refute_receive(%Message{onward_route: [^me], payload: "Hello local"}, 500)
+
+    {:ok, kp} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+
+    {:ok, channel} =
+      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], identity_keypair: kp)
+
+    wait_for_channel(channel)
+
+    Router.route(%Message{
+      payload: "Hello secure channel",
+      onward_route: [channel, echoer],
+      return_route: [me]
+    })
+
+    assert_receive(%Message{onward_route: [^me], payload: "Hello secure channel"}, 500)
+  end
+
+  test "Worker requiring local message", %{vault: vault, channel_listener: channel_listener} do
+    {:ok, echoer} = Echo.create(authorization: AuthorizationConfig.local())
+
+    {:ok, me} = Ockam.Node.register_random_address()
+
+    Router.route(%Message{
+      payload: "Hello local",
+      onward_route: [echoer],
+      return_route: [me]
+    })
+
+    assert_receive(%Message{onward_route: [^me], payload: "Hello local"}, 500)
+
+    Router.route(%Message{
+      payload: "Hello transport",
+      onward_route: [echoer],
+      return_route: [me],
+      local_metadata: %{source: :channel, channel: :some_transport}
+    })
+
+    refute_receive(%Message{onward_route: [^me], payload: "Hello transport"}, 500)
+
+    {:ok, kp} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+
+    {:ok, channel} =
+      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], identity_keypair: kp)
+
+    wait_for_channel(channel)
+
+    Router.route(%Message{
+      payload: "Hello secure channel",
+      onward_route: [channel, echoer],
+      return_route: [me]
+    })
+
+    refute_receive(%Message{onward_route: [^me], payload: "Hello secure channel"}, 500)
+  end
+
+  def wait_for_channel(channel) do
+    case Ockam.SecureChannel.established?(channel) do
+      true ->
+        :ok
+
+      false ->
+        :timer.sleep(100)
+        wait_for_channel(channel)
+    end
+  end
+end


### PR DESCRIPTION
To control message authorization for services on start, added `with_config` authorization
rule, which will check the `:authorization` option in the worker state to get the
rules.

This lets us do something like: `MyWorker.create(authorization: :is_local)`

Added `Ockam.Services.AuthorizationConfig` with `secure_channel/0` and `local/0` predefined
authorization configs to use in services

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
