### PR TITLE
feat(elixir): encode and decode for typed cbor without a typed struct

### DIFF
--- a/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor/plugin.ex
+++ b/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor/plugin.ex
@@ -74,42 +74,25 @@ defmodule Ockam.TypedCBOR.Plugin do
   @impl true
   def after_definition(_) do
     quote do
-      import Ockam.TypedCBOR, only: [from_cbor_term: 2, to_cbor_term: 2]
-
       def minicbor_schema(), do: {:struct, __MODULE__, @tt_fields |> Enum.into(%{})}
 
-      def encode!(%__MODULE__{} = d),
-        do: CBOR.encode(to_cbor_term(minicbor_schema(), d))
+      def encode!(%__MODULE__{} = d), do: Ockam.TypedCBOR.encode!(minicbor_schema(), d)
 
-      def encode(%__MODULE__{} = d), do: wrap_exception(&encode!/1, d)
+      def encode(%__MODULE__{} = d), do: Ockam.TypedCBOR.encode(minicbor_schema(), d)
 
-      def decode!(data) do
-        with {:ok, map, rest} <- CBOR.decode(data) do
-          {:ok, from_cbor_term(minicbor_schema(), map), rest}
-        end
-      end
+      def decode!(data), do: Ockam.TypedCBOR.decode!(minicbor_schema(), data)
 
-      def decode(data), do: wrap_exception(&decode!/1, data)
+      def decode(data), do: Ockam.TypedCBOR.decode(minicbor_schema(), data)
 
-      def encode_list!(l),
-        do: CBOR.encode(to_cbor_term({:list, minicbor_schema()}, l))
+      def decode_strict(data), do: Ockam.TypedCBOR.decode_strict(minicbor_schema(), data)
 
-      def encode_list(l), do: wrap_exception(&encode_list!/1, l)
+      def encode_list!(l), do: Ockam.TypedCBOR.encode!({:list, minicbor_schema()}, l)
 
-      def decode_list!(data) do
-        with {:ok, l, rest} <- CBOR.decode(data) do
-          {:ok, from_cbor_term({:list, minicbor_schema()}, l), rest}
-        end
-      end
+      def encode_list(l), do: Ockam.TypedCBOR.encode({:list, minicbor_schema()}, l)
 
-      def decode_list(l), do: wrap_exception(&decode_list!/1, l)
+      def decode_list!(data), do: Ockam.TypedCBOR.decode!({:list, minicbor_schema()}, data)
 
-      defp wrap_exception(f, arg) do
-        f.(arg)
-      rescue
-        e in Ockam.TypedCBOR.Exception ->
-          {:error, e.message}
-      end
+      def decode_list(data), do: Ockam.TypedCBOR.decode({:list, minicbor_schema()}, data)
     end
   end
 end


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

Currently TypedCBOR is only usable through the TypedStruct plugin

## Proposed Changes

Exspose `encode/2`, `decode/2` and `decode_strict/2` from `TypedCBOR` to be used with a custom schema.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
