### PR TITLE
fix(rust): strip pre-existing `IdentitySecureChannelLocalInfo` entries

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor.rs
@@ -468,7 +468,7 @@ impl<I: IdentityTrait> DecryptorWorker<I> {
         }
 
         let local_msg = msg.into_local_message();
-        let mut local_info = local_msg.local_info().to_vec();
+        let local_info = local_msg.local_info().to_vec();
         let payload = local_msg.into_transport_message().payload;
 
         // Forward to local workers
@@ -481,9 +481,10 @@ impl<I: IdentityTrait> DecryptorWorker<I> {
 
         let transport_msg = TransportMessage::v1(onward_route, return_route, payload);
 
-        local_info.push(
-            IdentitySecureChannelLocalInfo::new(state.their_identity_id.clone()).to_local_info()?,
-        );
+        // Mark message LocalInfo with IdentitySecureChannelLocalInfo,
+        // replacing any pre-existing entries
+        let local_info =
+            IdentitySecureChannelLocalInfo::mark(local_info, state.their_identity_id.clone())?;
 
         let msg = LocalMessage::new(transport_msg, local_info);
 

--- a/implementations/rust/ockam/ockam_identity/src/channel/local_info.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/local_info.rs
@@ -52,8 +52,18 @@ impl IdentitySecureChannelLocalInfo {
 }
 
 impl IdentitySecureChannelLocalInfo {
-    /// Constructor
-    pub fn new(their_identity_id: IdentityIdentifier) -> Self {
-        Self { their_identity_id }
+    /// Mark a `LocalInfo` vector with `IdentitySecureChannLocalInfo`
+    /// replacing any pre-existing entries
+    pub fn mark(
+        mut local_info: Vec<LocalInfo>,
+        their_identity_id: IdentityIdentifier,
+    ) -> Result<Vec<LocalInfo>> {
+        // strip out any pre-existing IdentitySecureChannLocalInfo
+        local_info.retain(|x| x.type_identifier() != IDENTITY_SECURE_CHANNEL_IDENTIFIER);
+
+        // mark the vector
+        local_info.push(Self { their_identity_id }.to_local_info()?);
+
+        Ok(local_info)
     }
 }


### PR DESCRIPTION
This PR introduces a new method:

    pub fn mark(
        mut local_info: Vec<LocalInfo>,
        their_identity_id: IdentityIdentifier,
    ) -> Result<Vec<LocalInfo>>

Calling this method will remove any pre-existing
`IdentitySecureChannelLocalInfo` entries from the given `LocalInfo` vector
before creating a new entry and appending it to the return vector.

This fix also removes the `IdentitySecureChannelLocalInfo` constructor to ensure that future code has to use the new `mark()` method.

This closes #2868
