### PR TITLE
chore(elixir): fix flaky test

### DIFF
--- a/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/proxy_test.exs
@@ -9,10 +9,6 @@ defmodule Test.Services.ProxyTest do
   alias Ockam.Services.Echo, as: EchoService
   alias Ockam.Services.Proxy
 
-  alias Ockam.Workers.Call
-
-  alias Test.Utils
-
   @tcp_port 5000
 
   ## Helper function to count TCP clients
@@ -38,14 +34,13 @@ defmodule Test.Services.ProxyTest do
       Ockam.Node.stop(proxy_address)
     end)
 
-    my_address = "test_me"
     {:ok, my_address} = Ockam.Node.register_random_address()
 
     Router.route("Hi echo proxy!", [proxy_address], [my_address])
 
     assert_receive %Message{
-                     onward_route: [my_address],
-                     return_route: [proxy_address],
+                     onward_route: [^my_address],
+                     return_route: [^proxy_address],
                      payload: "Hi echo proxy!"
                    },
                    2000
@@ -58,7 +53,7 @@ defmodule Test.Services.ProxyTest do
       Ockam.Node.stop(echo_address)
     end)
 
-    {:ok, listener} = Ockam.Transport.TCP.start(listen: [port: @tcp_port])
+    {:ok, _listener} = Ockam.Transport.TCP.start(listen: [port: @tcp_port])
 
     tcp_clients_count = Enum.count(tcp_clients())
 
@@ -75,8 +70,8 @@ defmodule Test.Services.ProxyTest do
     Router.route("Hi echo proxy!", [proxy_address], [my_address])
 
     assert_receive %Message{
-                     onward_route: [my_address],
-                     return_route: [proxy_address],
+                     onward_route: [^my_address],
+                     return_route: [^proxy_address],
                      payload: "Hi echo proxy!"
                    },
                    2000
@@ -87,8 +82,8 @@ defmodule Test.Services.ProxyTest do
     Router.route("Hi echo proxy take2!", [proxy_address], [my_address])
 
     assert_receive %Message{
-                     onward_route: [my_address],
-                     return_route: [proxy_address],
+                     onward_route: [^my_address],
+                     return_route: [^proxy_address],
                      payload: "Hi echo proxy take2!"
                    },
                    2000

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
@@ -8,11 +8,7 @@ defmodule Test.Services.StaticForwardingTest do
   alias Ockam.Router
 
   test "static forwarding" do
-    {:ok, _forwarding, service_address} =
-      StaticForwardingService.start_link(
-        address: "static_forwarding_service_address",
-        prefix: "forward_to"
-      )
+    {:ok, service_address} = StaticForwardingService.create(prefix: "forward_to")
 
     {:ok, test_address} = Node.register_random_address()
 
@@ -57,11 +53,7 @@ defmodule Test.Services.StaticForwardingTest do
   end
 
   test "forwarding route override" do
-    {:ok, _forwarding, service_address} =
-      StaticForwardingService.start_link(
-        address: "static_forwarding_service_address",
-        prefix: "forward_to"
-      )
+    {:ok, service_address} = StaticForwardingService.create(prefix: "forward_to")
 
     {:ok, test_address} = Node.register_random_address()
 


### PR DESCRIPTION
https://github.com/build-trust/ockam/issues/2889

<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour
The static forwarder tests starts the forwarder worker  with the same name on different tests cases, terminating it at the end of each one through the `on_exit()`  callback.
But since  the `Registry` processes the actual unregistration  asynchronously (when receiving the `DOWN` message),  we might run into a race condition when the next test try to reuse the name while the register hasn't processed the `DOWN` message yet.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Let ockam decide the name under which to register the service (like other tests on this suite already do).
Alternatively we could have explicitly unregister the name on the `on_exit`   , or modify `Node.stop/1` to wait till the name is not registered anymore (but that is more intrusive and had to be done with care itself).

Also fixed a couple warnings for unpinned variables on the test suite.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
