### PR TITLE
refactor(rust): strategy to enable/disable logs in ockam_command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -84,14 +84,6 @@ pub struct OckamCommand {
     #[clap(global = true, long, short, default_value = "default")]
     node: String,
 
-    // A marker to indicate that this instance was spawned
-    //
-    // This is a quick work-around to avoid spamming the user with
-    // irrelevant log messages from embedded nodes, while letting
-    // spawned nodes log their full potential into their log files.
-    #[clap(global = true, long, hide = true)]
-    spawned: bool,
-
     // if test_argument_parser is true, command arguments are checked
     // but the command is not executed.
     #[clap(global = true, long, hide = true)]
@@ -178,7 +170,7 @@ pub enum OckamSubcommand {
 }
 
 pub fn run() {
-    let ockam_command = OckamCommand::parse();
+    let ockam_command: OckamCommand = OckamCommand::parse();
 
     // If test_argument_parser is true, command arguments are checked
     // but the command is not executed. This is useful to test arguments
@@ -188,10 +180,10 @@ pub fn run() {
     }
 
     let verbose = ockam_command.verbose;
-    if ockam_command.spawned {
+    if !ockam_command.quiet {
         setup_logging(verbose);
-        tracing::debug!("Parsed {:?}", ockam_command);
     }
+    tracing::debug!("Parsed {:?}", ockam_command);
 
     let mut cfg = OckamConfig::load();
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -42,12 +42,9 @@ impl CreateCommand {
                 .open(&cfg.log_path.join(format!("{}.log", command.node_name)))
                 .expect("failed to open log path");
 
-            // Override the log level for spawned nodes because debug
-            // logs are significantly more useful for debugging
-            std::env::set_var("OCKAM_LOG", "debug");
             let child = Command::new(ockam)
                 .args([
-                    "--spawned",
+                    "-vv", // Enable logs at DEBUG level
                     "node",
                     "create",
                     "--port",


### PR DESCRIPTION
Previously, we had the arguments `verbose`, `quiet`, `spawned` + the OCKAM_LOG env variable to
control how logs were enabled. The OCKAM_LOG was the highest priority parameter, making it
impossible to override with any of mentioned command arguments.
Also, the `quiet` argument was ignored.

Now, the `spawned` argument has been removed and the priority has been reversed. That is, if
`quiet` is set, logs are not enabled. If `verbose` is set, its value will be used to define
the log level; if not, it will try to read the log level from the OCKAM_LOG env variable.
Logs won't be enabled if both `verbose` and OCKAM_LOG are not set.

Some examples:
```bash
$ OCKAM_LOG=debug ockam node create -q # Logs not enabled because `quiet` is set
$ OCKAM_LOG=debug ockam node create -vvv # Logs enabled to INFO because of `verbose` preference
$ OCKAM_LOG=debug ockam node create # Logs enabled to DEBUG because of `OCKAM_LOG` value
$ ockam node create # Logs not enabled because neither `verbose` nor `OCKAM_LOG` are set
```