### PR TITLE
chore(rust): remove restriction that file data must be valid utf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,11 +1228,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "file_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+
+[[package]]
 name = "file_transfer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "example_test_helper",
+ "file_diff",
  "ockam",
+ "rand 0.8.5",
  "serde",
  "structopt",
  "tokio",

--- a/examples/rust/file_transfer/Cargo.toml
+++ b/examples/rust/file_transfer/Cargo.toml
@@ -13,3 +13,8 @@ structopt = { version = "0.3.25", default-features = false }
 tokio = { version = "1.8.0", features = ["fs", "io-util"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 anyhow = "1.0.45"
+
+[dev-dependencies]
+example_test_helper = { path = "../../../tools/docs/example_test_helper" }
+file_diff = "1"
+rand = "0.8.5"

--- a/examples/rust/file_transfer/examples/receiver.rs
+++ b/examples/rust/file_transfer/examples/receiver.rs
@@ -9,7 +9,6 @@ use ockam::{
     vault::Vault,
     Context, Error, Result, Routed, TcpTransport, Worker, TCP,
 };
-use std::str;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
@@ -55,17 +54,7 @@ impl Worker for FileReception {
                     ));
                 }
                 if let Some(file) = &mut self.file {
-                    match file
-                        .write(
-                            str::from_utf8(data)
-                                .map_err(|e| {
-                                    Error::new_without_cause(Origin::Application, Kind::Unknown)
-                                        .context("msg", e.to_string())
-                                })?
-                                .as_bytes(),
-                        )
-                        .await
-                    {
+                    match file.write(data).await {
                         Ok(n) => {
                             self.written_size += n;
                             if self.written_size == self.size {

--- a/examples/rust/file_transfer/tests/tests.rs
+++ b/examples/rust/file_transfer/tests/tests.rs
@@ -1,0 +1,95 @@
+use example_test_helper::{CmdBuilder, Error};
+use file_diff::diff;
+use rand::Rng;
+use std::fs::{remove_file, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path;
+use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
+
+// These are all in bytes
+const SMALL_CHUNK_SIZE: u32 = 32;
+const LARGE_CHUNK_SIZE: u32 = 50 * 1024;
+const TINY_FILE_SIZE: u32 = 100;
+const MEDIUM_FILE_SIZE: u32 = 100 * 1024;
+
+#[test]
+fn tiny_file_transfer() -> Result<(), Error> {
+    do_file_transfer(TINY_FILE_SIZE, None)
+}
+
+#[test]
+fn tiny_file_transfer_small_chunks() -> Result<(), Error> {
+    do_file_transfer(TINY_FILE_SIZE, Some(SMALL_CHUNK_SIZE))
+}
+
+#[test]
+fn medium_file_transfer() -> Result<(), Error> {
+    do_file_transfer(MEDIUM_FILE_SIZE, None)
+}
+
+#[test]
+fn medium_file_transfer_small_chunks() -> Result<(), Error> {
+    do_file_transfer(MEDIUM_FILE_SIZE, Some(SMALL_CHUNK_SIZE))
+}
+
+#[test]
+fn medium_file_transfer_large_chunks() -> Result<(), Error> {
+    do_file_transfer(MEDIUM_FILE_SIZE, Some(LARGE_CHUNK_SIZE))
+}
+
+// Use an atomic to allow tests to have unique IDs when run in parallel
+static TMP_ID: AtomicU32 = AtomicU32::new(0);
+
+fn do_file_transfer(file_size: u32, chunk_size: Option<u32>) -> Result<(), Error> {
+    // Spawn receiver, wait for & grab dynamic forwarding address
+    let receiver = CmdBuilder::new("cargo run --example receiver").spawn()?;
+    let fwd_address = receiver.match_stdout(r"(?m)^FWD_(\w+)$")?.swap_remove(0).unwrap();
+    println!("Forwarding address: {fwd_address}");
+
+    // Create temporary binary file to transfer
+    // Use unique filenames to stop tests clashing when run in parallel
+    let filename = format!(
+        "{:x}_{}_{}_test.bin",
+        TMP_ID.fetch_add(1, Relaxed),
+        file_size,
+        chunk_size.unwrap_or(0)
+    );
+    let source_path = format!("tests{}{}", path::MAIN_SEPARATOR, filename);
+    let target_path = filename;
+    // Scope file and its writer so they are dropped before we continue
+    {
+        let f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&source_path)?;
+
+        let mut writer = BufWriter::new(f);
+        let mut rng = rand::thread_rng();
+        for _ in 0..file_size {
+            writer.write(&[rng.gen::<u8>()])?;
+        }
+        writer.flush()?;
+    }
+
+    // Spawn sender
+    let mut cmd_line = format!("cargo run --example sender {source_path} --address {fwd_address}");
+    if let Some(val) = chunk_size {
+        cmd_line.push_str(&format!(" --chunk-size {val}"));
+    }
+    let sender = CmdBuilder::new(&cmd_line).spawn()?;
+    sender.match_stdout(r"(?i)End-to-end encrypted secure channel was established")?;
+
+    // Wait for receiver to complete
+    let (exitcode, _) = receiver.wait()?;
+    assert_eq!(Some(0), exitcode);
+
+    // Check for a successful test
+    assert!(diff(&target_path, &source_path));
+
+    // Cleanup
+    remove_file(source_path)?;
+    remove_file(target_path)?;
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

In the File Transfer Ockam Example (`ockam/examples/rust/file_transfer`), the `receiver` checks the transferred data and errors if it is not valid UTF8.

https://github.com/build-trust/ockam/blob/c495918d6729956f76b16bd0014b3a783427c4bd/examples/rust/file_transfer/examples/receiver.rs#L58-L68

## Proposed Changes

- Remove the UTF8 restriction, so binary files can be transferred. 
- Add tests that transfer binary files.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
