### PR TITLE
ci: fix typo in cargo_target_dir_cache key

### DIFF
--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -6,7 +6,7 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cache-cargo-target----${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:2d776ca29c80d080433ee255668b7897b8efd3a0773b80674cb345bda6d6b67e-${{ hashFiles('**/Cargo.lock') }}
+        key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:2d776ca29c80d080433ee255668b7897b8efd3a0773b80674cb345bda6d6b67e-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:2d776ca29c80d080433ee255668b7897b8efd3a0773b80674cb345bda6d6b67e-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html


### PR DESCRIPTION
## Current Behaviour

In `/ockam/.github/actions/cargo_target_dir_cache/action.yml` there is a mismatch between the `key` and the `restore-keys`.

The keys do not match the pattern suggested by GitHub [here](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action).

I believe, this was preventing the effective use of caching of the `/ockam/target/` directory during CI. 

(This was found while working on #2822)

## Proposed Changes

Changed keys to match recommended pattern.

Hopefully, this might speed up CI a bit. 🤞 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.
