### PR TITLE
build(elixir): rebuild missing NIFs if they were not downloaded from release

### DIFF
--- a/implementations/elixir/ockam/ockam_vault_software/.gitignore
+++ b/implementations/elixir/ockam/ockam_vault_software/.gitignore
@@ -1,3 +1,4 @@
 _build
 deps
 cmake-build-*
+priv/*

--- a/implementations/elixir/ockam/ockam_vault_software/mix.exs
+++ b/implementations/elixir/ockam/ockam_vault_software/mix.exs
@@ -111,6 +111,16 @@ defmodule Ockam.Vault.Software.MixProject do
           true -> :ok
           false -> download_native(args)
         end
+
+        ## Check again if download failed or file is missing
+        case prebuilt_lib_exists?() do
+          true ->
+            :ok
+
+          false ->
+            IO.puts("Could not download prebuilt lib. Recompiling.")
+            recompile_native(args)
+        end
     end
   end
 


### PR DESCRIPTION
## Current Behaviour

Currently if release is missing a prebuilt NIF for an architecture, `mix compile` might fail with `Please run mix recompile.native`.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Make a second check after downloading prebuilt NIFs from release if they are missing and need to be rebuilt.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
