### PR TITLE
chore(rust): fix no_std build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,10 +154,9 @@ jobs:
       - uses: ./.github/actions/gradle_cache
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
-      # TODO: re-enable features after no_std has an unbounded channel.
       - run: |
           cd implementations/rust/ockam/ockam
-          RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
+          RUSTFLAGS='-Dwarnings' cargo check --no-default-features --features 'no_std alloc software_vault'
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   check_cargo_update:

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
@@ -61,6 +61,7 @@ fn entry() -> ! {
 // - ockam::node entrypoint ---------------------------------------------------
 
 use ockam::{
+    authenticated_storage::InMemoryStorage,
     identity::{Identity, TrustEveryonePolicy},
     route,
     vault::Vault,
@@ -75,18 +76,24 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create an Identity to represent Bob.
     let bob = Identity::create(&ctx, &vault).await?;
 
+    // Create an AuthenticatedStorage to store info about Bob's known Identities.
+    let bob_storage = InMemoryStorage::new();
+
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.
-    bob.create_secure_channel_listener("bob", TrustEveryonePolicy)
+    bob.create_secure_channel_listener("bob", TrustEveryonePolicy, &bob_storage)
         .await?;
 
     // Create an Identity to represent Alice.
     let alice = Identity::create(&ctx, &vault).await?;
 
+    // Create an AuthenticatedStorage to store info about Alice's known Identities.
+    let alice_storage = InMemoryStorage::new();
+
     // As Alice, connect to Bob's secure channel listener and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.
     let channel = alice
-        .create_secure_channel("bob", TrustEveryonePolicy)
+        .create_secure_channel("bob", TrustEveryonePolicy, &alice_storage)
         .await?;
 
     // Send a message, ** THROUGH ** the secure channel,

--- a/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
+++ b/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
@@ -1,4 +1,5 @@
 use ockam_core::async_trait;
+use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{AsyncTryClone, Result};
 
 /// Storage for Authenticated data

--- a/implementations/rust/ockam/ockam_identity/src/authenticated_storage/mem.rs
+++ b/implementations/rust/ockam/ockam_identity/src/authenticated_storage/mem.rs
@@ -1,7 +1,12 @@
 use super::AuthenticatedStorage;
 use ockam_core::async_trait;
-use ockam_core::compat::collections::BTreeMap;
-use ockam_core::compat::sync::{Arc, RwLock};
+use ockam_core::compat::{
+    boxed::Box,
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::{Arc, RwLock},
+    vec::Vec,
+};
 use ockam_core::Result;
 
 type Attributes = BTreeMap<String, Vec<u8>>;

--- a/implementations/rust/ockam/ockam_identity/src/change_history.rs
+++ b/implementations/rust/ockam/ockam_identity/src/change_history.rs
@@ -4,12 +4,12 @@ use crate::change::{IdentityChangeEvent, SignatureType};
 use crate::{
     EventIdentifier, IdentityError, IdentityIdentifier, IdentityStateConst, IdentityVault,
 };
+use core::cmp::Ordering;
 use minicbor::{Decode, Encode};
 use ockam_core::compat::vec::Vec;
 use ockam_core::{allow, deny, Encodable, Result};
 use ockam_vault::PublicKey;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
 #[cbor(index_only)]

--- a/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
@@ -1,5 +1,6 @@
 use crate::{IdentityIdentifier, IdentitySecureChannelLocalInfo};
 use ockam_core::access_control::AccessControl;
+use ockam_core::compat::vec::Vec;
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{LocalMessage, Result};
 

--- a/implementations/rust/ockam/ockam_identity/src/channel/local_info.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/local_info.rs
@@ -1,4 +1,5 @@
 use crate::{IdentityError, IdentityIdentifier};
+use ockam_core::compat::vec::Vec;
 use ockam_core::{Decodable, Encodable, LocalInfo, LocalMessage, Result};
 use serde::{Deserialize, Serialize};
 

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -5,10 +5,11 @@ use crate::{
     EventIdentifier, IdentityError, IdentityEventAttributes, IdentityIdentifier, IdentityVault,
     KeyAttributes, MetaKeyAttributes,
 };
-use ockam_core::compat::rand::{thread_rng, CryptoRng, RngCore};
-use ockam_core::compat::sync::Arc;
 use ockam_core::compat::{
+    boxed::Box,
+    rand::{thread_rng, CryptoRng, RngCore},
     string::{String, ToString},
+    sync::Arc,
     vec::Vec,
 };
 use ockam_core::vault::{SecretPersistence, SecretType, Signature, CURVE25519_SECRET_LENGTH};

--- a/implementations/rust/ockam/ockam_node/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_node/src/access_control.rs
@@ -1,6 +1,10 @@
 use crate::ExternalLocalInfo;
 use ockam_core::access_control::AccessControl;
-use ockam_core::{async_trait, compat::boxed::Box, TransportType};
+use ockam_core::{
+    async_trait,
+    compat::{boxed::Box, vec::Vec},
+    TransportType,
+};
 use ockam_core::{LocalMessage, Result};
 
 /// Allows only messages that originate from this node

--- a/implementations/rust/ockam/ockam_node/src/local_info.rs
+++ b/implementations/rust/ockam/ockam_node/src/local_info.rs
@@ -1,4 +1,5 @@
 use ockam_core::{
+    compat::vec::Vec,
     errcode::{Kind, Origin},
     Decodable, Encodable, Error, LocalInfo, LocalMessage, Result, TransportType,
 };


### PR DESCRIPTION
Minor fixes to get the `no_std` build working again.

Test with:

    cd implementations/rust/ockam/ockam_examples/example_projects/no_std
    cargo +nightly run --example hello --target thumbv7em-none-eabihf --no-default-features --features="qemu"

And:

    cd implementations/rust/ockam/ockam
    RUSTFLAGS='-Dwarnings' cargo check --no-default-features --features 'no_std alloc software_vault'