### PR TITLE
refactor(rust): use same variable names on some ockam_command commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
@@ -15,11 +15,11 @@ use crate::old::identity::load_or_create_identity;
 use crate::util::embedded_node;
 
 #[derive(Clone, Debug, Args)]
-pub(crate) struct EnrollAuth0Command;
+pub struct EnrollAuth0Command;
 
 impl EnrollAuth0Command {
-    pub fn run(command: EnrollCommand) {
-        embedded_node(enroll, command);
+    pub fn run(cmd: EnrollCommand) {
+        embedded_node(enroll, cmd);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/email.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/email.rs
@@ -13,14 +13,14 @@ use crate::util::embedded_node;
 const API_SECRET: &str = "DNYsEfhe]ms]ET]yQIthmhSOIvCkWOnb";
 
 #[derive(Clone, Debug, Args)]
-pub(crate) struct EnrollEmailCommand;
+pub struct EnrollEmailCommand;
 
 impl EnrollEmailCommand {
-    pub fn run(command: EnrollCommand) {
+    pub fn run(cmd: EnrollCommand) {
         println!("\nThank you for trying Ockam. We are working towards a developer release of Ockam Orchestrator in September.
 Please tell us your email and we'll let you know when we're ready to enroll new users to Ockam Orchestrator.\n");
         let email = read_user_input().expect("couldn't read user input");
-        embedded_node(enroll, (command, email));
+        embedded_node(enroll, (cmd, email));
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
@@ -13,8 +13,8 @@ use crate::util::embedded_node;
 pub struct AuthenticateEnrollmentTokenCommand;
 
 impl AuthenticateEnrollmentTokenCommand {
-    pub fn run(command: EnrollCommand) {
-        embedded_node(authenticate, command);
+    pub fn run(cmd: EnrollCommand) {
+        embedded_node(authenticate, cmd);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -1,13 +1,13 @@
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use clap::Args;
 
-use crate::IdentityOpts;
 use ockam::TcpTransport;
 use ockam_api::auth::types::Attributes;
 use ockam_multiaddr::MultiAddr;
 
 use crate::old::identity::load_or_create_identity;
 use crate::util::embedded_node;
+use crate::IdentityOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct GenerateEnrollmentTokenCommand {
@@ -21,17 +21,17 @@ pub struct GenerateEnrollmentTokenCommand {
     #[clap(display_order = 1002, long, default_value = "default")]
     identity: String,
 
-    /// Comma-separated list of attributes
-    #[clap(last = true, required = true)]
-    attributes: Vec<String>,
+    /// Attributes (use '=' to separate key from value)
+    #[clap(value_delimiter('='), last = true, required = true)]
+    attrs: Vec<String>,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl GenerateEnrollmentTokenCommand {
-    pub fn run(command: GenerateEnrollmentTokenCommand) {
-        embedded_node(generate, command);
+    pub fn run(cmd: GenerateEnrollmentTokenCommand) {
+        embedded_node(generate, cmd);
     }
 }
 
@@ -47,20 +47,11 @@ async fn generate(
         .ok_or_else(|| anyhow!("failed to parse address: {}", cmd.address))?;
 
     let mut attributes = Attributes::new();
-    for kv in &cmd.attributes {
-        let mut s = kv.split(',');
-        let k = s.next().context(format!(
-            "failed to parse key from pair: {kv:?}. Expected a \"key,value\" pair."
-        ))?;
-        let v = s
-            .next()
-            .context(format!("no value found on pair: {kv:?}"))?;
-        if k.is_empty() {
-            anyhow::bail!("attribute name can't be empty at pair {kv:?}")
-        } else if v.is_empty() {
-            anyhow::bail!("attribute value can't be empty at pair {kv:?}")
-        } else {
+    for entry in cmd.attrs.chunks(2) {
+        if let [k, v] = entry {
             attributes.put(k, v.as_bytes());
+        } else {
+            return Err(anyhow!("{entry:?} is not a key-value pair"));
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -41,13 +41,13 @@ pub struct EnrollCommand {
 }
 
 impl EnrollCommand {
-    pub fn run(command: EnrollCommand) {
-        if command.token.is_some() {
-            AuthenticateEnrollmentTokenCommand::run(command)
-        } else if command.auth0 {
-            EnrollAuth0Command::run(command)
+    pub fn run(cmd: EnrollCommand) {
+        if cmd.token.is_some() {
+            AuthenticateEnrollmentTokenCommand::run(cmd)
+        } else if cmd.auth0 {
+            EnrollAuth0Command::run(cmd)
         } else {
-            EnrollEmailCommand::run(command)
+            EnrollEmailCommand::run(cmd)
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -14,7 +14,7 @@ use crate::OckamConfig;
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Ockam's cloud node address.
-    address: MultiAddr,
+    addr: MultiAddr,
 
     /// Forwarder alias. Optional{n}
     /// If set, a static forwarder named after the passed alias will be created{n}
@@ -39,7 +39,7 @@ impl CreateCommand {
     }
 
     pub fn address(&self) -> &MultiAddr {
-        &self.address
+        &self.addr
     }
 
     pub fn alias(&self) -> Option<&str> {

--- a/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
@@ -20,9 +20,9 @@ pub enum ForwarderSubCommand {
 }
 
 impl ForwarderCommand {
-    pub fn run(cfg: &OckamConfig, command: ForwarderCommand) {
-        match command.subcommand {
-            ForwarderSubCommand::Create(command) => CreateCommand::run(cfg, command),
+    pub fn run(cfg: &OckamConfig, cmd: ForwarderCommand) {
+        match cmd.subcommand {
+            ForwarderSubCommand::Create(cmd) => CreateCommand::run(cfg, cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
@@ -19,8 +19,8 @@ pub struct AcceptCommand {
 }
 
 impl AcceptCommand {
-    pub fn run(command: AcceptCommand, cloud_addr: MultiAddr) {
-        embedded_node(accept, (cloud_addr, command));
+    pub fn run(cmd: AcceptCommand, cloud_addr: MultiAddr) {
+        embedded_node(accept, (cloud_addr, cmd));
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/invitation/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/create.rs
@@ -28,8 +28,8 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(command: CreateCommand, cloud_addr: MultiAddr) {
-        embedded_node(create, (cloud_addr, command));
+    pub fn run(cmd: CreateCommand, cloud_addr: MultiAddr) {
+        embedded_node(create, (cloud_addr, cmd));
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/invitation/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/list.rs
@@ -17,8 +17,8 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(command: ListCommand, cloud_addr: MultiAddr) {
-        embedded_node(list, (cloud_addr, command));
+    pub fn run(cmd: ListCommand, cloud_addr: MultiAddr) {
+        embedded_node(list, (cloud_addr, cmd));
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
@@ -48,18 +48,12 @@ pub enum InvitationSubcommand {
 }
 
 impl InvitationCommand {
-    pub fn run(inv_cmd: InvitationCommand) {
-        match inv_cmd.subcommand {
-            InvitationSubcommand::Create(command) => {
-                CreateCommand::run(command, inv_cmd.cloud_addr)
-            }
-            InvitationSubcommand::List(command) => ListCommand::run(command, inv_cmd.cloud_addr),
-            InvitationSubcommand::Accept(command) => {
-                AcceptCommand::run(command, inv_cmd.cloud_addr)
-            }
-            InvitationSubcommand::Reject(command) => {
-                RejectCommand::run(command, inv_cmd.cloud_addr)
-            }
+    pub fn run(cmd: InvitationCommand) {
+        match cmd.subcommand {
+            InvitationSubcommand::Create(command) => CreateCommand::run(command, cmd.cloud_addr),
+            InvitationSubcommand::List(command) => ListCommand::run(command, cmd.cloud_addr),
+            InvitationSubcommand::Accept(command) => AcceptCommand::run(command, cmd.cloud_addr),
+            InvitationSubcommand::Reject(command) => RejectCommand::run(command, cmd.cloud_addr),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
@@ -19,8 +19,8 @@ pub struct RejectCommand {
 }
 
 impl RejectCommand {
-    pub fn run(command: RejectCommand, cloud_addr: MultiAddr) {
-        embedded_node(reject, (cloud_addr, command));
+    pub fn run(cmd: RejectCommand, cloud_addr: MultiAddr) {
+        embedded_node(reject, (cloud_addr, cmd));
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -91,7 +91,7 @@ pub struct OckamCommand {
     // if test_argument_parser is true, command arguments are checked
     // but the command is not executed.
     #[clap(global = true, long, hide = true)]
-    pub test_argument_parser: bool,
+    test_argument_parser: bool,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -1,8 +1,8 @@
-mod send;
-
 use crate::HELP_TEMPLATE;
 use clap::{Args, Subcommand};
 use send::SendCommand;
+
+mod send;
 
 #[derive(Clone, Debug, Args)]
 pub struct MessageCommand {
@@ -18,9 +18,9 @@ pub enum MessageSubcommand {
 }
 
 impl MessageCommand {
-    pub fn run(command: MessageCommand) {
-        match command.subcommand {
-            MessageSubcommand::Send(command) => SendCommand::run(command),
+    pub fn run(cmd: MessageCommand) {
+        match cmd.subcommand {
+            MessageSubcommand::Send(cmd) => SendCommand::run(cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -1,26 +1,29 @@
-use crate::util::embedded_node;
+use std::time::Duration;
+
 use clap::Args;
+
 use ockam::{Context, TcpTransport};
 use ockam_multiaddr::MultiAddr;
-use std::time::Duration;
+
+use crate::util::embedded_node;
 
 #[derive(Clone, Debug, Args)]
 pub struct SendCommand {
-    pub address: MultiAddr,
-    pub message: String,
+    addr: MultiAddr,
+    message: String,
 }
 
 impl SendCommand {
-    pub fn run(command: SendCommand) {
-        embedded_node(send_message, command)
+    pub fn run(cmd: SendCommand) {
+        embedded_node(send_message, cmd)
     }
 }
 
-async fn send_message(mut ctx: Context, command: SendCommand) -> anyhow::Result<()> {
+async fn send_message(mut ctx: Context, cmd: SendCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    if let Some(route) = ockam_api::multiaddr_to_route(&command.address) {
-        ctx.send(route, command.message).await?
+    if let Some(route) = ockam_api::multiaddr_to_route(&cmd.addr) {
+        ctx.send(route, cmd.message).await?
     }
 
     // TODO: find a way to wait for send to complete

--- a/implementations/rust/ockam/ockam_command/src/old/cmd/inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/cmd/inlet.rs
@@ -1,6 +1,7 @@
-use clap::Args;
 use std::sync::Arc;
 use std::time::Duration;
+
+use clap::Args;
 
 use ockam::access_control::LocalOriginOnly;
 use ockam::authenticated_storage::InMemoryStorage;

--- a/implementations/rust/ockam/ockam_command/src/old/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/identity.rs
@@ -1,6 +1,7 @@
-use anyhow::Context;
 use std::path::Path;
 use std::sync::Arc;
+
+use anyhow::Context;
 
 use ockam::identity::change_history::IdentityChangeHistory;
 use ockam::identity::*;

--- a/implementations/rust/ockam/ockam_command/src/old/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/mod.rs
@@ -1,10 +1,11 @@
+use std::collections::BTreeSet;
+
 use anyhow::Context;
 use anyhow::Result;
 use clap::Args;
-use identity::load_identity;
 
+use identity::load_identity;
 use ockam::{identity::IdentityIdentifier, NodeBuilder};
-use std::collections::BTreeSet;
 use storage::{ensure_identity_exists, get_ockam_dir};
 
 pub mod identity;
@@ -161,7 +162,7 @@ where
     }
 }
 
-pub(crate) fn print_error_and_exit(v: bool, e: anyhow::Error) -> ! {
+pub fn print_error_and_exit(v: bool, e: anyhow::Error) -> ! {
     tracing::trace!("Exiting with error {:?}", e);
     eprintln!("Error: {}", message(v, &e));
     for cause in e.chain().skip(1) {
@@ -170,7 +171,7 @@ pub(crate) fn print_error_and_exit(v: bool, e: anyhow::Error) -> ! {
     std::process::exit(1);
 }
 
-pub(crate) fn exit_with_result(verbose: bool, result: Result<()>) -> ! {
+pub fn exit_with_result(verbose: bool, result: Result<()>) -> ! {
     if let Err(e) = result {
         print_error_and_exit(verbose, e);
     } else {

--- a/implementations/rust/ockam/ockam_command/src/old/session/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/error.rs
@@ -1,8 +1,9 @@
 #![deny(missing_docs)]
 #![allow(missing_docs)] // Contents are self describing for now.
 
-use ockam_core::errcode::{Kind, Origin};
 use std::{error::Error as StdError, fmt};
+
+use ockam_core::errcode::{Kind, Origin};
 
 #[derive(Clone, Copy, Debug)]
 pub enum SessionManagementError {

--- a/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/initiator.rs
@@ -1,11 +1,14 @@
-use crate::old::session::error::SessionManagementError;
-use crate::old::session::msg::{RequestId, SessionMsg};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
 use ockam::access_control::{AccessControl, LocalOriginOnly};
 use ockam::{Address, Context, DelayedEvent, Result, Route, Routed, Worker, WorkerBuilder};
 use ockam_core::{Mailbox, Mailboxes};
-use std::sync::Arc;
-use std::time::Duration;
-use tracing::{error, info, warn};
+
+use crate::old::session::error::SessionManagementError;
+use crate::old::session::msg::{RequestId, SessionMsg};
 
 #[ockam::worker]
 pub trait SessionManager: Send + 'static {

--- a/implementations/rust/ockam/ockam_command/src/old/session/msg.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/msg.rs
@@ -1,6 +1,7 @@
-use ockam::Message;
 use rand::random;
 use serde::{Deserialize, Serialize};
+
+use ockam::Message;
 
 #[derive(Serialize, Deserialize, Message, Debug, Clone, PartialEq)]
 pub struct RequestId(pub String);

--- a/implementations/rust/ockam/ockam_command/src/old/session/responder.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/responder.rs
@@ -1,7 +1,9 @@
+use tracing::info;
+
+use ockam::{Context, Result, Routed, Worker};
+
 use crate::old::session::error::SessionManagementError;
 use crate::old::session::msg::SessionMsg;
-use ockam::{Context, Result, Routed, Worker};
-use tracing::info;
 
 pub struct SessionResponder;
 

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -25,15 +25,15 @@ pub struct CreateCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, last = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl CreateCommand {
-    pub fn run(command: CreateCommand) {
-        embedded_node(create, command);
+    pub fn run(cmd: CreateCommand) {
+        embedded_node(create, cmd);
     }
 }
 
@@ -43,7 +43,7 @@ async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let request = CreateProject::new(cmd.project_name, &cmd.services);

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -21,15 +21,15 @@ pub struct DeleteCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
-    pub fn run(command: DeleteCommand) {
-        embedded_node(delete, command);
+    pub fn run(cmd: DeleteCommand) {
+        embedded_node(delete, cmd);
     }
 }
 
@@ -39,12 +39,11 @@ async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     api.delete_project(&cmd.space_id, &cmd.project_id).await?;
     println!("Project deleted");
-
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -17,15 +17,15 @@ pub struct ListCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl ListCommand {
-    pub fn run(command: ListCommand) {
-        embedded_node(list, command);
+    pub fn run(cmd: ListCommand) {
+        embedded_node(list, cmd);
     }
 }
 
@@ -35,7 +35,7 @@ async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let res = api.list_projects(&cmd.space_id).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -38,12 +38,12 @@ pub enum ProjectSubcommand {
 }
 
 impl ProjectCommand {
-    pub fn run(command: ProjectCommand) {
-        match command.subcommand {
-            ProjectSubcommand::Create(command) => CreateCommand::run(command),
-            ProjectSubcommand::Delete(command) => DeleteCommand::run(command),
-            ProjectSubcommand::List(command) => ListCommand::run(command),
-            ProjectSubcommand::Show(command) => ShowCommand::run(command),
+    pub fn run(cmd: ProjectCommand) {
+        match cmd.subcommand {
+            ProjectSubcommand::Create(cmd) => CreateCommand::run(cmd),
+            ProjectSubcommand::Delete(cmd) => DeleteCommand::run(cmd),
+            ProjectSubcommand::List(cmd) => ListCommand::run(cmd),
+            ProjectSubcommand::Show(cmd) => ShowCommand::run(cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -21,15 +21,15 @@ pub struct ShowCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl ShowCommand {
-    pub fn run(command: ShowCommand) {
-        embedded_node(show, command);
+    pub fn run(cmd: ShowCommand) {
+        embedded_node(show, cmd);
     }
 }
 
@@ -39,7 +39,7 @@ async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let res = api.get_project(&cmd.space_id, &cmd.project_id).await?;

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -17,15 +17,15 @@ pub struct CreateCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl CreateCommand {
-    pub fn run(command: CreateCommand) {
-        embedded_node(create, command);
+    pub fn run(cmd: CreateCommand) {
+        embedded_node(create, cmd);
     }
 }
 
@@ -35,7 +35,7 @@ async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let request = CreateSpace::new(cmd.name);

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -17,15 +17,15 @@ pub struct DeleteCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
-    pub fn run(command: DeleteCommand) {
-        embedded_node(delete, command);
+    pub fn run(cmd: DeleteCommand) {
+        embedded_node(delete, cmd);
     }
 }
 
@@ -35,12 +35,11 @@ async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     api.delete_space(&cmd.id).await?;
     println!("Space deleted");
-
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -13,15 +13,15 @@ use crate::IdentityOpts;
 pub struct ListCommand {
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl ListCommand {
-    pub fn run(command: ListCommand) {
-        embedded_node(list, command);
+    pub fn run(cmd: ListCommand) {
+        embedded_node(list, cmd);
     }
 }
 
@@ -31,7 +31,7 @@ async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let res = api.list_spaces().await?;

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -38,12 +38,12 @@ pub enum SpaceSubcommand {
 }
 
 impl SpaceCommand {
-    pub fn run(command: SpaceCommand) {
-        match command.subcommand {
-            SpaceSubcommand::Create(command) => CreateCommand::run(command),
-            SpaceSubcommand::Delete(command) => DeleteCommand::run(command),
-            SpaceSubcommand::List(command) => ListCommand::run(command),
-            SpaceSubcommand::Show(command) => ShowCommand::run(command),
+    pub fn run(cmd: SpaceCommand) {
+        match cmd.subcommand {
+            SpaceSubcommand::Create(cmd) => CreateCommand::run(cmd),
+            SpaceSubcommand::Delete(cmd) => DeleteCommand::run(cmd),
+            SpaceSubcommand::List(cmd) => ListCommand::run(cmd),
+            SpaceSubcommand::Show(cmd) => ShowCommand::run(cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -17,15 +17,15 @@ pub struct ShowCommand {
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    address: MultiAddr,
+    addr: MultiAddr,
 
     #[clap(flatten)]
     identity_opts: IdentityOpts,
 }
 
 impl ShowCommand {
-    pub fn run(command: ShowCommand) {
-        embedded_node(show, command);
+    pub fn run(cmd: ShowCommand) {
+        embedded_node(show, cmd);
     }
 }
 
@@ -35,7 +35,7 @@ async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
+    let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
     let mut api = MessagingClient::new(route, identity, &ctx).await?;
     let res = api.get_space(&cmd.id).await?;

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -33,7 +33,7 @@ pub enum CreateTypeCommand {
     /// the given peer address and port
     TcpConnector {
         /// Transport connection or bind address
-        address: String,
+        addr: String,
     },
 }
 
@@ -55,9 +55,7 @@ impl CreateCommand {
         // still bad and should be fixed
         let node = command.api_node.unwrap_or_else(|| cfg.get_api_node());
         match command.create_subcommand {
-            CreateTypeCommand::TcpConnector { address } => {
-                cfg.add_transport(&node, false, true, address)
-            }
+            CreateTypeCommand::TcpConnector { addr } => cfg.add_transport(&node, false, true, addr),
             CreateTypeCommand::TcpListener { bind } => cfg.add_transport(&node, true, true, bind),
         };
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -27,7 +27,7 @@ pub(crate) fn query_transports() -> Result<Vec<u8>> {
 pub(crate) fn create_transport(cmd: &crate::transport::CreateCommand) -> Result<Vec<u8>> {
     // FIXME: this should not rely on CreateCommand internals!
     let (tt, addr) = match &cmd.create_subcommand {
-        transport::CreateTypeCommand::TcpConnector { address } => (TransportMode::Connect, address),
+        transport::CreateTypeCommand::TcpConnector { addr } => (TransportMode::Connect, addr),
         transport::CreateTypeCommand::TcpListener { bind } => (TransportMode::Listen, bind),
     };
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    // email
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("enroll")
@@ -14,6 +15,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--overwrite");
     cmd.assert().success();
 
+    // auth0
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("enroll")
@@ -26,6 +28,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--auth0");
     cmd.assert().success();
 
+    // token
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("enroll")

--- a/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
@@ -13,8 +13,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("idt")
         .arg("--overwrite")
         .arg("--")
-        .arg("k1,v1")
-        .arg("k2,v2");
+        .arg("k1=v1")
+        .arg("k2=v2");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
The `ockam_command` crate is currently under active development by several people and we have some commands that differ in structure and common variable naming.

This PR adds some minor changes to make commands that are more stable look as similar as possible.