### PR TITLE
refactor(rust): remove custom validator on authenticated command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -17,11 +17,10 @@ pub enum AuthenticatedSubcommand {
     /// Set authenticated attributes.
     Set {
         /// Address to connect to.
-        #[clap(long)]
         addr: MultiAddr,
 
         /// Subject identifier
-        #[clap(long, validator(non_empty))]
+        #[clap(long, forbid_empty_values = true)]
         id: String,
 
         /// Attributes (use '=' to separate key from value).
@@ -31,29 +30,27 @@ pub enum AuthenticatedSubcommand {
     /// Get attribute value.
     Get {
         /// Address to connect to.
-        #[clap(long)]
         addr: MultiAddr,
 
         /// Subject identifier
-        #[clap(long, validator(non_empty))]
+        #[clap(long, forbid_empty_values = true)]
         id: String,
 
         /// Attribute key.
-        #[clap(validator(non_empty))]
+        #[clap(forbid_empty_values = true)]
         key: String,
     },
     /// Delete attribute
     Del {
         /// Address to connect to.
-        #[clap(long)]
         addr: MultiAddr,
 
         /// Subject identifier
-        #[clap(long, validator(non_empty))]
+        #[clap(long, forbid_empty_values = true)]
         id: String,
 
         /// Attribute key.
-        #[clap(validator(non_empty))]
+        #[clap(forbid_empty_values = true)]
         key: String,
     },
 }
@@ -98,11 +95,4 @@ async fn client(addr: &MultiAddr, ctx: &Context) -> Result<auth::Client> {
         .ok_or_else(|| anyhow!("failed to parse address: {addr}"))?;
     let cl = auth::Client::new(to, ctx).await?;
     Ok(cl)
-}
-
-fn non_empty(arg: &str) -> Result<(), String> {
-    if arg.is_empty() {
-        return Err("value must not be empty".to_string());
-    }
-    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/tests/cmd_authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_authenticated.rs
@@ -1,0 +1,38 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("authenticated")
+        .arg("set")
+        .arg("/ip4/127.0.0.1/tcp/8080")
+        .arg("--id")
+        .arg("identifier")
+        .arg("k1=v1")
+        .arg("k2=v2");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("authenticated")
+        .arg("get")
+        .arg("/ip4/127.0.0.1/tcp/8080")
+        .arg("--id")
+        .arg("identifier")
+        .arg("key");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("authenticated")
+        .arg("del")
+        .arg("/ip4/127.0.0.1/tcp/8080")
+        .arg("--id")
+        .arg("identifier")
+        .arg("key");
+    cmd.assert().success();
+
+    Ok(())
+}


### PR DESCRIPTION
The `authenticated` command was using a custom validator to check if the passed arguments were empty strings. This can be done using clap's attribute `forbid_empty_values`.