### PR TITLE
feat(rust): add `message-format` global arg

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/config/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/config/get.rs
@@ -1,4 +1,4 @@
-use crate::util::OckamConfig;
+use crate::CommandGlobalOpts;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -8,7 +8,8 @@ pub struct GetCommand {
 }
 
 impl GetCommand {
-    pub fn run(cfg: &OckamConfig, command: GetCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: GetCommand) {
+        let cfg = &opts.config;
         let msg = match command.value.as_deref() {
             Some("api-node") => cfg.get_api_node(),
             // FIXME: needs to take an additional parameter

--- a/implementations/rust/ockam/ockam_command/src/config/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/config/list.rs
@@ -1,11 +1,11 @@
-use crate::util::OckamConfig;
+use crate::{CommandGlobalOpts, OckamConfig};
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {}
 
 impl ListCommand {
-    pub fn run(_: &OckamConfig, _: ListCommand) {
+    pub fn run(_: CommandGlobalOpts, _: ListCommand) {
         OckamConfig::values()
             .iter()
             .for_each(|val| println!("{}", val));

--- a/implementations/rust/ockam/ockam_command/src/config/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/config/mod.rs
@@ -6,7 +6,7 @@ use get::GetCommand;
 use list::ListCommand;
 use set::SetCommand;
 
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -31,11 +31,11 @@ pub enum ConfigSubcommand {
 }
 
 impl ConfigCommand {
-    pub fn run(cfg: &OckamConfig, command: ConfigCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: ConfigCommand) {
         match command.subcommand {
-            ConfigSubcommand::Set(command) => SetCommand::run(cfg, command),
-            ConfigSubcommand::Get(command) => GetCommand::run(cfg, command),
-            ConfigSubcommand::List(command) => ListCommand::run(cfg, command),
+            ConfigSubcommand::Set(command) => SetCommand::run(opts, command),
+            ConfigSubcommand::Get(command) => GetCommand::run(opts, command),
+            ConfigSubcommand::List(command) => ListCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/config/set.rs
+++ b/implementations/rust/ockam/ockam_command/src/config/set.rs
@@ -1,4 +1,4 @@
-use crate::util::OckamConfig;
+use crate::CommandGlobalOpts;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -10,7 +10,8 @@ pub struct SetCommand {
 }
 
 impl SetCommand {
-    pub fn run(cfg: &OckamConfig, command: SetCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: SetCommand) {
+        let cfg = &opts.config;
         match command.value.as_str() {
             "api-node" => cfg.set_api_node(&command.payload),
             //"log-path" => cfg.set_log_path(&command.payload),

--- a/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 
 pub(crate) use create::CreateCommand;
 
-use crate::{OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
 
@@ -20,9 +20,9 @@ pub enum ForwarderSubCommand {
 }
 
 impl ForwarderCommand {
-    pub fn run(cfg: &OckamConfig, cmd: ForwarderCommand) {
-        match cmd.subcommand {
-            ForwarderSubCommand::Create(cmd) => CreateCommand::run(cfg, cmd),
+    pub fn run(opts: CommandGlobalOpts, command: ForwarderCommand) {
+        match command.subcommand {
+            ForwarderSubCommand::Create(command) => CreateCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_api::Status;
@@ -12,7 +13,8 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(cfg: &OckamConfig, command: CreateCommand) -> anyhow::Result<()> {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
+        let cfg = opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -2,7 +2,7 @@ mod create;
 
 pub(crate) use create::CreateCommand;
 
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -19,9 +19,9 @@ pub enum IdentitySubcommand {
 }
 
 impl IdentityCommand {
-    pub fn run(cfg: &OckamConfig, command: IdentityCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: IdentityCommand) {
         match command.subcommand {
-            IdentitySubcommand::Create(command) => CreateCommand::run(cfg, command),
+            IdentitySubcommand::Create(command) => CreateCommand::run(opts, command),
         }
         .unwrap()
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -4,6 +4,7 @@ use std::{env::current_exe, fs::OpenOptions, process::Command, time::Duration};
 use crate::{
     node::show::query_status,
     util::{connect_to, embedded_node, OckamConfig, DEFAULT_TCP_PORT},
+    CommandGlobalOpts,
 };
 use ockam::{Context, TcpTransport};
 use ockam_api::{
@@ -29,7 +30,8 @@ pub struct CreateCommand {
     no_watchdog: bool,
 }
 impl CreateCommand {
-    pub fn run(cfg: &OckamConfig, command: CreateCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
+        let cfg = &opts.config;
         if command.foreground {
             // HACK: try to get the current node dir.  If it doesn't
             // exist the user PROBABLY started a non-detached node.

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,4 +1,4 @@
-use crate::util::OckamConfig;
+use crate::CommandGlobalOpts;
 use clap::Args;
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
@@ -13,12 +13,13 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(cfg: &OckamConfig, command: DeleteCommand) {
-        delete_node(cfg, &command.node_name, command.sigkill);
+    pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
+        delete_node(&opts, &command.node_name, command.sigkill);
     }
 }
 
-pub fn delete_node(cfg: &OckamConfig, node_name: &String, sigkill: bool) {
+pub fn delete_node(opts: &CommandGlobalOpts, node_name: &String, sigkill: bool) {
+    let cfg = &opts.config;
     let pid = match cfg.get_node_pid(node_name) {
         Ok(pid) => pid,
         Err(e) => {

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
-use crate::util::{self, api, connect_to, OckamConfig};
+use crate::util::{self, api, connect_to};
+use crate::{CommandGlobalOpts, OckamConfig};
 use clap::Args;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use crossbeam_channel::{bounded, Sender};
@@ -11,7 +12,8 @@ use ockam_api::nodes::NODEMAN_ADDR;
 pub struct ListCommand {}
 
 impl ListCommand {
-    pub fn run(cfg: &OckamConfig, _: ListCommand) {
+    pub fn run(opts: CommandGlobalOpts, _: ListCommand) {
+        let cfg = &opts.config;
         let node_names = {
             let inner = cfg.get_inner();
 

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -10,7 +10,7 @@ use list::ListCommand;
 use purge::PurgeCommand;
 use show::ShowCommand;
 
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -43,13 +43,13 @@ pub enum NodeSubcommand {
 }
 
 impl NodeCommand {
-    pub fn run(cfg: &OckamConfig, command: NodeCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: NodeCommand) {
         match command.subcommand {
-            NodeSubcommand::Create(command) => CreateCommand::run(cfg, command),
-            NodeSubcommand::Delete(command) => DeleteCommand::run(cfg, command),
-            NodeSubcommand::List(command) => ListCommand::run(cfg, command),
-            NodeSubcommand::Show(command) => ShowCommand::run(cfg, command),
-            NodeSubcommand::Purge(command) => PurgeCommand::run(cfg, command),
+            NodeSubcommand::Create(command) => CreateCommand::run(opts, command),
+            NodeSubcommand::Delete(command) => DeleteCommand::run(opts, command),
+            NodeSubcommand::List(command) => ListCommand::run(opts, command),
+            NodeSubcommand::Show(command) => ShowCommand::run(opts, command),
+            NodeSubcommand::Purge(command) => PurgeCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/purge.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/purge.rs
@@ -1,6 +1,6 @@
 //! A simple command to purge existing configuration
 
-use crate::util::OckamConfig;
+use crate::CommandGlobalOpts;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -11,7 +11,8 @@ pub struct PurgeCommand {
 }
 
 impl PurgeCommand {
-    pub fn run(cfg: &OckamConfig, command: PurgeCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: PurgeCommand) {
+        let cfg = &opts.config;
         let nodes: Vec<_> = cfg
             .get_inner()
             .nodes
@@ -20,7 +21,7 @@ impl PurgeCommand {
             .collect();
 
         for node_name in nodes {
-            crate::node::delete::delete_node(cfg, &node_name, command.sigkill);
+            crate::node::delete::delete_node(&opts, &node_name, command.sigkill);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,4 +1,5 @@
-use crate::util::{self, api, connect_to, OckamConfig};
+use crate::util::{self, api, connect_to};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{Context, Route};
 use ockam_api::nodes::{types::NodeStatus, NODEMAN_ADDR};
@@ -10,7 +11,8 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(cfg: &OckamConfig, command: ShowCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: ShowCommand) {
+        let cfg = &opts.config;
         let port = match cfg.get_inner().nodes.get(&command.node_name) {
             Some(cfg) => cfg.port,
             None => {
@@ -18,7 +20,6 @@ impl ShowCommand {
                 std::process::exit(-1);
             }
         };
-
         connect_to(port, (), query_status);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use ockam::{Context, Route};
 use ockam_api::{
@@ -40,7 +41,8 @@ pub enum CreateTypeCommand {
 }
 
 impl CreateCommand {
-    pub fn run(cfg: &OckamConfig, command: CreateCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
+        let cfg = &opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {
@@ -48,7 +50,6 @@ impl CreateCommand {
                 std::process::exit(-1);
             }
         };
-
         connect_to(port, command, create_portal)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/mod.rs
@@ -3,7 +3,7 @@ pub(crate) use create::{CreateCommand, CreateTypeCommand};
 
 // TODO: add delete, list, show subcommands
 
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -20,9 +20,9 @@ pub enum PortalSubCommand {
 }
 
 impl PortalCommand {
-    pub fn run(cfg: &OckamConfig, cmd: PortalCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: PortalCommand) {
         match cmd.subcommand {
-            PortalSubCommand::Create(cmd) => CreateCommand::run(cfg, cmd),
+            PortalSubCommand::Create(cmd) => CreateCommand::run(opts, cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use ockam::Context;
 use ockam_api::error::ApiError;
@@ -35,7 +36,8 @@ pub enum CreateSubCommand {
 }
 
 impl CreateCommand {
-    pub fn run(cfg: &OckamConfig, command: CreateCommand) -> anyhow::Result<()> {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
+        let cfg = opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -1,7 +1,8 @@
 pub(crate) mod create;
 
-use crate::secure_channel::create::CreateCommand;
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+pub(crate) use create::CreateCommand;
+
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -18,9 +19,9 @@ pub enum SecureChannelSubcommand {
 }
 
 impl SecureChannelCommand {
-    pub fn run(cfg: &OckamConfig, command: SecureChannelCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: SecureChannelCommand) {
         match command.subcommand {
-            SecureChannelSubcommand::Create(command) => CreateCommand::run(cfg, command),
+            SecureChannelSubcommand::Create(command) => CreateCommand::run(opts, command),
         }
         .unwrap()
     }

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use ockam::{Context, Route, TCP};
 use ockam_api::{
@@ -38,7 +39,8 @@ pub enum CreateTypeCommand {
 }
 
 impl CreateCommand {
-    pub fn run(cfg: &OckamConfig, command: CreateCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
+        let cfg = &opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {

--- a/implementations/rust/ockam/ockam_command/src/transport/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/delete.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{Context, Route};
 use ockam_api::{nodes::NODEMAN_ADDR, Response, Status};
@@ -18,7 +19,8 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(cfg: &OckamConfig, command: DeleteCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
+        let cfg = &opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {
@@ -26,7 +28,6 @@ impl DeleteCommand {
                 std::process::exit(-1);
             }
         };
-
         connect_to(port, command, delete_transport);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/transport/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/list.rs
@@ -1,4 +1,5 @@
-use crate::util::{api, connect_to, stop_node, OckamConfig};
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::{Context, Route};
@@ -15,7 +16,8 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(cfg: &OckamConfig, command: ListCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: ListCommand) {
+        let cfg = &opts.config;
         let port = match cfg.select_node(&command.api_node) {
             Some(cfg) => cfg.port,
             None => {
@@ -23,7 +25,6 @@ impl ListCommand {
                 std::process::exit(-1);
             }
         };
-
         connect_to(port, (), query_transports);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use create::{CreateCommand, CreateTypeCommand};
 pub(crate) use delete::DeleteCommand;
 use list::ListCommand;
 
-use crate::{util::OckamConfig, HELP_TEMPLATE};
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
@@ -31,11 +31,11 @@ pub enum TransportSubCommand {
 }
 
 impl TransportCommand {
-    pub fn run(cfg: &OckamConfig, command: TransportCommand) {
+    pub fn run(opts: CommandGlobalOpts, command: TransportCommand) {
         match command.subcommand {
-            TransportSubCommand::Create(command) => CreateCommand::run(cfg, command),
-            TransportSubCommand::Delete(command) => DeleteCommand::run(cfg, command),
-            TransportSubCommand::List(command) => ListCommand::run(cfg, command),
+            TransportSubCommand::Create(command) => CreateCommand::run(opts, command),
+            TransportSubCommand::Delete(command) => DeleteCommand::run(opts, command),
+            TransportSubCommand::List(command) => ListCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/dog/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/dog/mod.rs
@@ -8,7 +8,8 @@ use clap::Args;
 use std::path::PathBuf;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
-pub fn socket_path(cfg: &OckamConfig, node_name: &str) -> PathBuf {
+pub fn socket_path(opts: CommandGlobalOpts, node_name: &str) -> PathBuf {
+    let cfg = &opts.config;
     let node_dir = cfg
         .get_node_dir(node_name)
         .expect("this shouldn't happen, is there a race condition? (there always is)");
@@ -21,7 +22,8 @@ pub struct WatchdogCommand {
 }
 
 impl WatchdogCommand {
-    pub fn run(cfg: &OckamConfig, cmd: WatchdogCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: WatchdogCommand) {
+        let cfg = &opts.config;
         let socket_path = socket_path(cfg, &cmd.node_name);
 
         Watchdog { socket_path }.run()


### PR DESCRIPTION
This argument is only used in one command as an example right now. In future PR's, this argument
will be used to control the format of the command output. This can be helpful to pipe commands,
process the output in json format and select the variables we need as input for the next
command.

As part of this PR, a small refactor has been done to pass a `CommandGlobalOpts` object to
subcommands, which includes the global command arguments as well as the `OckamConfig` instance.
Ideally, all commands should receive this object, so we can handle how the `message-format`
applies to each command individually, for example.