### PR TITLE
feat(elixir): support multiple identity channel api endpoints, add additional metadata to channels

### DIFF
--- a/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
@@ -84,4 +84,46 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       payload: "PING!"
     }
   end
+
+  test "additional metadata" do
+    {:ok, vault} = SoftwareVault.init()
+    {:ok, alice, _alice_id} = Identity.create(@identity_impl)
+
+    {:ok, listener} =
+      SecureChannel.create_listener(
+        identity: alice,
+        encryption_options: [vault: vault],
+        additional_metadata: %{foo: :bar}
+      )
+
+    {:ok, bob, _bob_id} = Identity.create(@identity_impl)
+
+    {:ok, channel} =
+      SecureChannel.create_channel(
+        identity: bob,
+        encryption_options: [vault: vault],
+        route: [listener],
+        additional_metadata: %{bar: :foo}
+      )
+
+    {:ok, me} = Ockam.Node.register_random_address()
+    Logger.info("Channel: #{inspect(channel)} me: #{inspect(me)}")
+    Ockam.Router.route("PING!", [channel, me], [me])
+
+    assert_receive %Ockam.Message{
+      onward_route: [^me],
+      payload: "PING!",
+      return_route: return_route,
+      local_metadata: %{identity: _id, channel: :identity_secure_channel, foo: :bar}
+    }
+
+    Ockam.Router.route("PONG!", return_route, [me])
+
+    assert_receive %Ockam.Message{
+      onward_route: [^me],
+      payload: "PONG!",
+      return_route: [^channel | _],
+      local_metadata: %{identity: _id, channel: :identity_secure_channel, bar: :foo}
+    }
+  end
 end

--- a/implementations/elixir/ockam/ockam_services/lib/services.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services.ex
@@ -40,6 +40,6 @@ defmodule Ockam.Services do
   end
 
   def start_service(name, options \\ []) do
-    Ockam.Services.Provider.start_service({name, options}, __MODULE__)
+    Ockam.Services.Provider.start_service({name, options}, Ockam.Services.Provider)
   end
 end

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
@@ -82,15 +82,20 @@ defmodule Ockam.Services.Provider do
         {:error, {:unknown_service, service_name}}
 
       provider_mod ->
-        case provider_mod.child_spec(service_name, service_args) do
-          multiple_specs when is_list(multiple_specs) ->
-            {:ok, multiple_specs}
+        try do
+          case provider_mod.child_spec(service_name, service_args) do
+            multiple_specs when is_list(multiple_specs) ->
+              {:ok, multiple_specs}
 
-          %{id: _id} = single_spec_map ->
-            {:ok, [single_spec_map]}
+            %{id: _id} = single_spec_map ->
+              {:ok, [single_spec_map]}
 
-          single_spec ->
-            {:ok, [Supervisor.child_spec(single_spec, id: service_name)]}
+            single_spec ->
+              {:ok, [Supervisor.child_spec(single_spec, id: service_name)]}
+          end
+        rescue
+          err ->
+            {:error, err}
         end
     end
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/sidecar.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/sidecar.ex
@@ -41,7 +41,7 @@ defmodule Ockam.Services.Provider.Sidecar do
     options = Keyword.merge(extra_options, forward_route: forward_route, address: api_address)
 
     %{
-      id: __MODULE__,
+      id: :identity_sidecar,
       start: {Ockam.Services.Proxy, :start_link, [options]}
     }
   end


### PR DESCRIPTION
## Current Behaviour

Currently only one identity secure channel service can be started

## Proposed Changes

In order to have multiple identities on the node, make it so identity channel services with different addresses can be running at the same time.

Also add additional metadata to identity secure channel service to be added to the messages coming from secure channels created by this service. This allows to distinguish between different services without checking identity_id.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
