### PR TITLE
feat(rust): node command usability improvements

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -36,6 +36,12 @@ impl CreateCommand {
             // deterministic way of starting a node.
             let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
 
+            // FIXME: not really clear why this is causing issues
+            if cfg.port_is_used(command.port) {
+                eprintln!("Another node is listening on the provided port!");
+                std::process::exit(-1);
+            }
+
             // First we create a new node in the configuration so that
             // we can ask it for the correct log path, as well as
             // making sure the watchdog can do its job later on.
@@ -94,12 +100,6 @@ impl CreateCommand {
             // Then query the node manager for the status
             connect_to(command.port, (), query_status);
         } else {
-            // FIXME: not really clear why this is causing issues
-            // if cfg.port_is_used(command.port) {
-            //     eprintln!("Another node is listening on the provided port!");
-            //     std::process::exit(-1);
-            // }
-
             // HACK: try to get the current node dir.  If it doesn't
             // exist the user PROBABLY started a non-detached node.
             // Thus we need to create the node dir so that subsequent

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -28,16 +28,18 @@ pub fn delete_node(cfg: &OckamConfig, node_name: &String, sigkill: bool) {
     };
 
     if let Some(pid) = pid {
-        if let Err(e) = signal::kill(
+        let _ = signal::kill(
             Pid::from_raw(pid),
             if sigkill {
                 Signal::SIGKILL
             } else {
                 Signal::SIGTERM
             },
-        ) {
-            eprintln!("Error occurred while terminating node process: {}", e);
-        }
+        );
+    }
+
+    if let Err(e) = cfg.get_node_dir(node_name).map(std::fs::remove_dir_all) {
+        eprintln!("Failed to delete node directory: {}", e);
     }
 
     if let Err(e) = cfg.delete_node(node_name) {


### PR DESCRIPTION
* Check whether a given API port is already in-use and prevent the
  user from spawning a node if it is.  For foreground nodes this check
  is not performed for two reasons:

1. we would have to distinguish between whether a node was
   foregrounded by the user, or is actually a spawned instance which
   has already had this check applied

2. when creating a foreground node it is much easier to see the log
   output which will inform the user that the given port is not
   avalaible

* deleting a node now also deletes the state directory
* deleting a node that was not running no longer prints an error from
  killing it.
* spawning a node is now the default. If you would like to keep a node
  attached to your terminal you must pass `--foreground` instead!
  (@hairyhum @polvorin feels like relevant information for you!)