### PR TITLE
fix(elixir): proper handling of trust policy errors for secure channel

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
@@ -73,6 +73,10 @@ defmodule Ockam.Session.Pluggable.Initiator do
          :ok <- wait_for_session(address, interval, timeout) do
       {:ok, address}
     end
+  catch
+    type, reason ->
+      ## TODO: match Worker not found error?
+      {:error, {type, reason}}
   end
 
   @impl true
@@ -169,6 +173,8 @@ defmodule Ockam.Session.Pluggable.Initiator do
         {:ok, RoutingSession.update_handshake_state(state, handshake_state)}
 
       {:error, err} ->
+        ## TODO: should we return :shutdown error here?
+        ## Non-shutdown error will cause a resstart
         {:stop, {:handshake_error, err}, state}
     end
   end


### PR DESCRIPTION
## Current Behaviour

Failing trust policy checks cause random failures because of not properly configured restarts.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Pass trust_policies from spawner to responder
Fix restart_type for responders, so they don't restart
Move dynamic identity to spawner

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
