### PR TITLE
ci: add cargo nextest to builder docker image

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -80,6 +80,7 @@ RUN set -xe; \
     rustup install nightly; \
     rustup component add clippy; \
     cargo install --locked cargo-deny; \
+    cargo install --locked cargo-nextest; \
     chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
 # Setup erlang
     apt-get update; \


### PR DESCRIPTION
## Current Behaviour

#2924 plans to use `cargo nextest` to replace `cargo test` in CI rust testing.  

## Checks

This PR is a step towards completing #2924.
This PR adds `cargo nextest` to the `builder` Docker image.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.
