### PR TITLE
test(rust): make tests compatible with cargo nextest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "cfg-if",
  "hashbrown 0.12.1",
  "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1532,7 +1532,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "serial_test",
 ]
 
 [[package]]
@@ -2560,37 +2559,12 @@ checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3205,30 +3179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
-dependencies = [
- "lazy_static",
- "parking_lot 0.11.2",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,7 +3461,6 @@ version = "0.1.0"
 dependencies = [
  "example_test_helper",
  "ockam",
- "serial_test",
 ]
 
 [[package]]
@@ -3627,7 +3576,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/documentation/guides/rust/get-started/04-transport/README.md
+++ b/documentation/guides/rust/get-started/04-transport/README.md
@@ -37,7 +37,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;
@@ -70,7 +72,9 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over a tcp transport.
-    let r = route![(TCP, "localhost:4000"), "echoer"];
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    let r = route![(TCP, &format!("localhost:{port}")), "echoer"];
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.
@@ -128,7 +132,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;
@@ -163,7 +169,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:3000").await?;
+    // Use port 3000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("3000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())
@@ -193,7 +201,14 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over two tcp hops.
-    let r = route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"];
+    // Use ports 3000 & 4000, unless otherwise specified by command line arguments.
+    let port_middle = std::env::args().nth(1).unwrap_or("3000".to_string());
+    let port_responder = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let r = route![
+        (TCP, &format!("localhost:{port_middle}")),
+        (TCP, &format!("localhost:{port_responder}")),
+        "echoer"
+    ];
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/documentation/use-cases/secure-remote-access-tunnels/README.md
+++ b/documentation/use-cases/secure-remote-access-tunnels/README.md
@@ -122,7 +122,7 @@ async fn main(ctx: Context) -> Result<()> {
     // The Inlet will:
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
-    //    be set to the route to a TCP Transport Outlet. This route is provided as the 2nd
+    //    be set to the route to a TCP Transport Outlet. This route is provided as the second
     //    argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
@@ -205,7 +205,11 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.create_outlet("outlet", outlet_target).await?;
 
     // Create a TCP listener to receive Ockam Routing Messages from other ockam nodes.
-    tcp.listen("127.0.0.1:4000").await?;
+    //
+    // Use port 4000, unless otherwise specified by second command line argument.
+
+    let port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.
@@ -225,10 +229,14 @@ async fn main(ctx: Context) -> Result<()> {
     // Initialize the TCP Transport.
     let tcp = TcpTransport::create(&ctx).await?;
 
-    // We know the network address of the node with an Outlet, we also know that the Outlet is
-    // running at Ockam Worker address "outlet" on that node.
+    // We know that the Outlet node is listening for Ockam Routing Messages
+    // over TCP and is running at Ockam Worker address "outlet".
+    //
+    // We assume the Outlet node is listening on port 4000, unless otherwise specified
+    // by a second command line argument.
 
-    let route_to_outlet = route![(TCP, "127.0.0.1:4000"), "outlet"];
+    let outlet_port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let route_to_outlet = route![(TCP, &format!("127.0.0.1:{outlet_port}")), "outlet"];
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001
@@ -239,7 +247,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.
@@ -344,7 +352,11 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.create_outlet("outlet", outlet_target).await?;
 
     // Create a TCP listener to receive Ockam Routing Messages from other ockam nodes.
-    tcp.listen("127.0.0.1:4000").await?;
+    //
+    // Use port 4000, unless otherwise specified by second command line argument.
+
+    let port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.
@@ -371,12 +383,15 @@ async fn main(ctx: Context) -> Result<()> {
     // TCP Transport Outlet.
     //
     // For this example, we know that the Outlet node is listening for Ockam Routing Messages
-    // over TCP at "127.0.0.1:4000" and its secure channel listener is
-    // at address: "secure_channel_listener".
+    // over TCP and its secure channel listener is at address: "secure_channel_listener".
+    //
+    // We assume the Outlet node is listening on port 4000, unless otherwise specified
+    // by a second command line argument.
 
     let vault = Vault::create();
     let e = Identity::create(&ctx, &vault).await?;
-    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"];
+    let outlet_port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let r = route![(TCP, &format!("127.0.0.1:{outlet_port}")), "secure_channel_listener"];
     let storage = InMemoryStorage::new();
     let channel = e.create_secure_channel(r, TrustEveryonePolicy, &storage).await?;
 
@@ -394,7 +409,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.
@@ -571,7 +586,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.

--- a/examples/rust/file_transfer/Cargo.toml
+++ b/examples/rust/file_transfer/Cargo.toml
@@ -17,4 +17,4 @@ anyhow = "1.0.45"
 [dev-dependencies]
 example_test_helper = { path = "../../../tools/docs/example_test_helper" }
 file_diff = "1"
-rand = "0.8.5"
+rand = "0.8"

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -35,4 +35,3 @@ hex = "0.4"
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["std_rng"], default-features = false }
 example_test_helper = { path = "../../../tools/docs/example_test_helper" }
-serial_test = "0.6.0"

--- a/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
@@ -8,7 +8,9 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over a tcp transport.
-    let r = route![(TCP, "localhost:4000"), "echoer"];
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    let r = route![(TCP, &format!("localhost:{port}")), "echoer"];
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/examples/rust/get_started/examples/04-routing-over-transport-responder.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-responder.rs
@@ -10,7 +10,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
@@ -8,7 +8,14 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     // Send a message to the "echoer" worker, on a different node, over two tcp hops.
-    let r = route![(TCP, "localhost:3000"), (TCP, "localhost:4000"), "echoer"];
+    // Use ports 3000 & 4000, unless otherwise specified by command line arguments.
+    let port_middle = std::env::args().nth(1).unwrap_or("3000".to_string());
+    let port_responder = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let r = route![
+        (TCP, &format!("localhost:{port_middle}")),
+        (TCP, &format!("localhost:{port_responder}")),
+        "echoer"
+    ];
     ctx.send(r, "Hello Ockam!".to_string()).await?;
 
     // Wait to receive a reply and print it.

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
@@ -10,7 +10,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:3000").await?;
+    // Use port 3000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("3000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-responder.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-responder.rs
@@ -10,7 +10,9 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    // Use port 4000, unless otherwise specified by command line argument.
+    let port = std::env::args().nth(1).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // Create an echoer worker
     ctx.start_worker("echoer", Echoer).await?;

--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -1,5 +1,9 @@
 use example_test_helper::{CmdBuilder, Error};
-use serial_test::serial;
+
+// Avoid TCP port clashes when tests run in parallel
+const PORT_RUN_04_ROUTING_OVER_TRANSPORT: u32 = 4000;
+const PORT_MIDDLE_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS: u32 = 4001;
+const PORT_RESPONDER_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS: u32 = 4002;
 
 #[test]
 fn run_01_node() -> Result<(), Error> {
@@ -38,14 +42,19 @@ fn run_03_routing_many_hops() -> Result<(), Error> {
 }
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_04_routing_over_transport() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-responder").spawn()?;
+    let resp = CmdBuilder::new(&format!(
+        "cargo run --example 04-routing-over-transport-responder {PORT_RUN_04_ROUTING_OVER_TRANSPORT}"
+    ))
+    .spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Run initiator to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-routing-over-transport-initiator").run()?;
+    let (exitcode, stdout) = CmdBuilder::new(&format!(
+        "cargo run --example 04-routing-over-transport-initiator {PORT_RUN_04_ROUTING_OVER_TRANSPORT}",
+    ))
+    .run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -54,19 +63,27 @@ fn run_04_routing_over_transport() -> Result<(), Error> {
 }
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-responder").spawn()?;
+    let resp = CmdBuilder::new(&format!(
+        "cargo run --example 04-routing-over-transport-two-hops-responder {PORT_RESPONDER_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS}"
+    ))
+    .spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Launch middle, wait for it to start up
-    let mid = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-middle").spawn()?;
+    let mid = CmdBuilder::new(&format!(
+        "cargo run --example 04-routing-over-transport-two-hops-middle {PORT_MIDDLE_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS}"
+    ))
+    .spawn()?;
     mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Run initiator to completion
     let (exitcode, stdout) =
-        CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-initiator").run()?;
+        CmdBuilder::new(&format!(
+            "cargo run --example 04-routing-over-transport-two-hops-initiator {PORT_MIDDLE_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS} {PORT_RESPONDER_RUN_04_ROUTING_OVER_TRANSPORT_TWO_HOPS}"
+        ))
+        .run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);

--- a/examples/rust/tcp_inlet_and_outlet/Cargo.toml
+++ b/examples/rust/tcp_inlet_and_outlet/Cargo.toml
@@ -12,4 +12,3 @@ ockam = { path = "../../../implementations/rust/ockam/ockam" }
 
 [dev-dependencies]
 example_test_helper = { path = "../../../tools/docs/example_test_helper" }
-serial_test = "0.6.0"

--- a/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
@@ -32,7 +32,7 @@ async fn main(ctx: Context) -> Result<()> {
     // The Inlet will:
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
-    //    be set to the route to a TCP Transport Outlet. This route is provided as the 2nd
+    //    be set to the route to a TCP Transport Outlet. This route is provided as the second
     //    argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
@@ -5,10 +5,14 @@ async fn main(ctx: Context) -> Result<()> {
     // Initialize the TCP Transport.
     let tcp = TcpTransport::create(&ctx).await?;
 
-    // We know the network address of the node with an Outlet, we also know that the Outlet is
-    // running at Ockam Worker address "outlet" on that node.
+    // We know that the Outlet node is listening for Ockam Routing Messages
+    // over TCP and is running at Ockam Worker address "outlet".
+    //
+    // We assume the Outlet node is listening on port 4000, unless otherwise specified
+    // by a second command line argument.
 
-    let route_to_outlet = route![(TCP, "127.0.0.1:4000"), "outlet"];
+    let outlet_port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let route_to_outlet = route![(TCP, &format!("127.0.0.1:{outlet_port}")), "outlet"];
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001
@@ -19,7 +23,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
@@ -25,7 +25,11 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.create_outlet("outlet", outlet_target).await?;
 
     // Create a TCP listener to receive Ockam Routing Messages from other ockam nodes.
-    tcp.listen("127.0.0.1:4000").await?;
+    //
+    // Use port 4000, unless otherwise specified by second command line argument.
+
+    let port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
@@ -12,12 +12,15 @@ async fn main(ctx: Context) -> Result<()> {
     // TCP Transport Outlet.
     //
     // For this example, we know that the Outlet node is listening for Ockam Routing Messages
-    // over TCP at "127.0.0.1:4000" and its secure channel listener is
-    // at address: "secure_channel_listener".
+    // over TCP and its secure channel listener is at address: "secure_channel_listener".
+    //
+    // We assume the Outlet node is listening on port 4000, unless otherwise specified
+    // by a second command line argument.
 
     let vault = Vault::create();
     let e = Identity::create(&ctx, &vault).await?;
-    let r = route![(TCP, "127.0.0.1:4000"), "secure_channel_listener"];
+    let outlet_port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    let r = route![(TCP, &format!("127.0.0.1:{outlet_port}")), "secure_channel_listener"];
     let storage = InMemoryStorage::new();
     let channel = e.create_secure_channel(r, TrustEveryonePolicy, &storage).await?;
 
@@ -35,7 +38,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
@@ -39,7 +39,11 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.create_outlet("outlet", outlet_target).await?;
 
     // Create a TCP listener to receive Ockam Routing Messages from other ockam nodes.
-    tcp.listen("127.0.0.1:4000").await?;
+    //
+    // Use port 4000, unless otherwise specified by second command line argument.
+
+    let port = std::env::args().nth(2).unwrap_or("4000".to_string());
+    tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
@@ -40,7 +40,7 @@ async fn main(ctx: Context) -> Result<()> {
     // 1. Wrap any raw TCP data it receives from a TCP client as payload of a new
     //    Ockam Routing Message. This Ockam Routing Message will have its onward_route
     //    be set to the route to a TCP Transport Outlet. This route_to_outlet is provided as
-    //    the 2nd argument of the create_inlet() function.
+    //    the second argument of the create_inlet() function.
     //
     // 2. Unwrap the payload of any Ockam Routing Message it receives back from the Outlet
     //    and send it as raw TCP data to q connected TCP client.

--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -1,15 +1,27 @@
 use example_test_helper::{CmdBuilder, Error};
-use serial_test::serial;
+
+// Avoid tests clashing on TCP ports when run in parallel
+const RUN_01_PORT: u32 = 4000;
+const RUN_02_INLET_PORT: u32 = 4001;
+const RUN_02_ROUTING_PORT: u32 = 4002;
+const RUN_03_INLET_PORT: u32 = 4003;
+const RUN_03_ROUTING_PORT: u32 = 4004;
+const RUN_04_INLET_PORT: u32 = 4005;
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
     // Spawn example, wait for it to start up
-    let runner = CmdBuilder::new("cargo run --example 01-inlet-outlet 127.0.0.1:4001 ockam.io:80").spawn()?;
+    let runner = CmdBuilder::new(&format!(
+        "cargo run --example 01-inlet-outlet 127.0.0.1:{RUN_01_PORT} ockam.io:80"
+    ))
+    .spawn()?;
     runner.match_stdout(r"(?i)Starting new processor")?;
 
     // Run curl and check for a successful run
-    let (exitcode, stdout) = CmdBuilder::new("curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    let (exitcode, stdout) = CmdBuilder::new(&format!(
+        "curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:{RUN_01_PORT}/"
+    ))
+    .run()?;
     assert_eq!(Some(0), exitcode);
     println!("curl stdout...");
     println!("{stdout}");
@@ -18,18 +30,26 @@ fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
 }
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_02_inlet_outlet_seperate_processes() -> Result<(), Error> {
     // Spawn outlet, wait for it to start up
-    let outlet = CmdBuilder::new("cargo run --example 02-outlet ockam.io:80").spawn()?;
+    let outlet = CmdBuilder::new(&format!(
+        "cargo run --example 02-outlet ockam.io:80 {RUN_02_ROUTING_PORT}"
+    ))
+    .spawn()?;
     outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Spawn inlet, wait for it to start up
-    let inlet = CmdBuilder::new("cargo run --example 02-inlet 127.0.0.1:4001").spawn()?;
-    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+    let inlet = CmdBuilder::new(&format!(
+        "cargo run --example 02-inlet 127.0.0.1:{RUN_02_INLET_PORT} {RUN_02_ROUTING_PORT}"
+    ))
+    .spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
 
     // Run curl and check for a successful run
-    let (exitcode, stdout) = CmdBuilder::new("curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    let (exitcode, stdout) = CmdBuilder::new(&format!(
+        "curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:{RUN_02_INLET_PORT}/"
+    ))
+    .run()?;
     assert_eq!(Some(0), exitcode);
     println!("curl stdout...");
     println!("{stdout}");
@@ -38,18 +58,26 @@ fn run_02_inlet_outlet_seperate_processes() -> Result<(), Error> {
 }
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_03_inlet_outlet_seperate_processes_secure_channel() -> Result<(), Error> {
     // Spawn outlet, wait for it to start up
-    let outlet = CmdBuilder::new("cargo run --example 03-outlet ockam.io:80").spawn()?;
+    let outlet = CmdBuilder::new(&format!(
+        "cargo run --example 03-outlet ockam.io:80 {RUN_03_ROUTING_PORT}"
+    ))
+    .spawn()?;
     outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Spawn inlet, wait for it to start up
-    let inlet = CmdBuilder::new("cargo run --example 03-inlet 127.0.0.1:4001").spawn()?;
-    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+    let inlet = CmdBuilder::new(&format!(
+        "cargo run --example 03-inlet 127.0.0.1:{RUN_03_INLET_PORT} {RUN_03_ROUTING_PORT}"
+    ))
+    .spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
 
     // Run curl and check for a successful run
-    let (exitcode, stdout) = CmdBuilder::new("curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    let (exitcode, stdout) = CmdBuilder::new(&format!(
+        "curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:{RUN_03_INLET_PORT}/"
+    ))
+    .run()?;
     assert_eq!(Some(0), exitcode);
     println!("curl stdout...");
     println!("{stdout}");
@@ -58,7 +86,6 @@ fn run_03_inlet_outlet_seperate_processes_secure_channel() -> Result<(), Error> 
 }
 
 #[test]
-#[serial] // Serialise tests that may clash on TCP ports
 fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_hub() -> Result<(), Error> {
     // Spawn outlet, wait for it to start up, grab dynamic forwarding address
     let outlet = CmdBuilder::new("cargo run --example 04-outlet ockam.io:80").spawn()?;
@@ -67,11 +94,17 @@ fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_hub() -> Resu
     println!("Forwarding address: {fwd_address}");
 
     // Spawn inlet, wait for it to start up
-    let inlet = CmdBuilder::new(&format!("cargo run --example 04-inlet 127.0.0.1:4001 {fwd_address}")).spawn()?;
-    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1:4001")?;
+    let inlet = CmdBuilder::new(&format!(
+        "cargo run --example 04-inlet 127.0.0.1:{RUN_04_INLET_PORT} {fwd_address}"
+    ))
+    .spawn()?;
+    inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
 
     // // Run curl and check for a successful run
-    let (exitcode, stdout) = CmdBuilder::new("curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:4001/").run()?;
+    let (exitcode, stdout) = CmdBuilder::new(&format!(
+        "curl -s -L -H \"Host: ockam.io\" http://127.0.0.1:{RUN_04_INLET_PORT}/"
+    ))
+    .run()?;
     assert_eq!(Some(0), exitcode);
     println!("curl stdout...");
     println!("{stdout}");


### PR DESCRIPTION
## Current Behaviour

#2923 found that some `examples/rust/*` test cases fail if `cargo nextest` is used to run tests. 

#2924 proposes using `cargo nextest` for CI builds in the hope that it will speed up CI processes. 

## Proposed Changes

Modified tests so that _**all**_ Ockam tests are compatiable with `nextest`...

- Compared to the default cargo test runner, `nextest` handles test cases individually and achieves more parallelism ([more details](https://nexte.st/book/how-it-works.html)). 

- Some of the `examples/rust/*` tests used the `serial_test` crate to serialise tests that would clash on TCP ports or filenames if run in parallel. `serial_test` (and having mutable variables shared by multiple test cases) is not compatible with `nextest`.

- This PR hardcodes tests to use different TCP ports and filenames so they do not clash if run in parallel, regardless of whether test cases are run in the same or different threads.

- Some `examples/rust/*` source files are changed to allow command line configuration of TCP ports. As a result, those `documentation/*/README.md` files which use the changed source files as embedded code snippets are also updated.

Fixes #2923.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.
