### PR TITLE
refactor(rust): cloud commands to send requests through nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
@@ -1,42 +1,73 @@
-use std::borrow::Borrow;
-
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
 use reqwest::StatusCode;
+use std::borrow::Borrow;
 use tokio_retry::{strategy::ExponentialBackoff, Retry};
 use tracing::{debug, warn};
 
-use ockam::{Context, TcpTransport};
 use ockam_api::cloud::enroll::auth0::*;
 use ockam_api::error::ApiError;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 
-use crate::enroll::EnrollCommand;
-use crate::old::identity::load_or_create_identity;
-use crate::util::embedded_node;
+use crate::util::{api, connect_to, stop_node};
+use crate::{CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollAuth0Command;
 
 impl EnrollAuth0Command {
-    pub fn run(cmd: EnrollCommand) {
-        embedded_node(enroll, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: EnrollCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), enroll);
     }
 }
 
-async fn enroll(mut ctx: Context, cmd: EnrollCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn enroll(
+    ctx: ockam::Context,
+    (_opts, cmd): (CommandGlobalOpts, EnrollCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::enroll::auth0(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", cmd.address))?;
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let output = "Enrolled successfully".to_string();
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    let mut api_client = ockam_api::cloud::MessagingClient::new(route, identity, &ctx).await?;
-    api_client.enroll_auth0(Auth0Service).await?;
-    println!("Enrolled successfully");
-
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }
 
 pub struct Auth0Service;

--- a/implementations/rust/ockam/ockam_command/src/enroll/email.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/email.rs
@@ -7,16 +7,20 @@ use validator::validate_email;
 
 use ockam_api::error::ApiError;
 
-use crate::enroll::EnrollCommand;
+use crate::node::NodeOpts;
 use crate::util::embedded_node;
+use crate::{CommandGlobalOpts, EnrollCommand};
 
 const API_SECRET: &str = "DNYsEfhe]ms]ET]yQIthmhSOIvCkWOnb";
 
 #[derive(Clone, Debug, Args)]
-pub struct EnrollEmailCommand;
+pub struct EnrollEmailCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+}
 
 impl EnrollEmailCommand {
-    pub fn run(cmd: EnrollCommand) {
+    pub fn run(_opts: CommandGlobalOpts, cmd: EnrollCommand) {
         println!("\nThank you for trying Ockam. We are working towards a developer release of Ockam Orchestrator in September.
 Please tell us your email and we'll let you know when we're ready to enroll new users to Ockam Orchestrator.\n");
         let email = read_user_input().expect("couldn't read user input");
@@ -37,9 +41,10 @@ fn read_user_input() -> anyhow::Result<String> {
     }
 }
 
-async fn enroll(mut ctx: ockam::Context, args: (EnrollCommand, String)) -> anyhow::Result<()> {
-    let (_cmd, email) = args;
-
+async fn enroll(
+    mut ctx: ockam::Context,
+    (_cmd, email): (EnrollCommand, String),
+) -> anyhow::Result<()> {
     let retry_strategy = ExponentialBackoff::from_millis(10).take(5);
     let res = Retry::spawn(retry_strategy, move || {
         let client = reqwest::Client::new();

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
@@ -1,39 +1,70 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::enroll::enrollment_token::EnrollmentToken;
-use ockam_api::cloud::enroll::Token;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 
-use crate::enroll::EnrollCommand;
-use crate::old::identity::load_or_create_identity;
-use crate::util::embedded_node;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node};
+use crate::{CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
-pub struct AuthenticateEnrollmentTokenCommand;
+pub struct AuthenticateEnrollmentTokenCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+}
 
 impl AuthenticateEnrollmentTokenCommand {
-    pub fn run(cmd: EnrollCommand) {
-        embedded_node(authenticate, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: EnrollCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), authenticate);
     }
 }
 
-async fn authenticate(mut ctx: Context, cmd: EnrollCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn authenticate(
+    ctx: ockam::Context,
+    (_opts, cmd): (CommandGlobalOpts, EnrollCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::enroll::token_authenticate(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.address)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", cmd.address))?;
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let output = "Token authenticated".to_string();
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    let token = cmd.token.ok_or_else(|| anyhow!("Token was not passed"))?;
-
-    let mut api_client = ockam_api::cloud::MessagingClient::new(route, identity, &ctx).await?;
-    api_client
-        .authenticate_enrollment_token(EnrollmentToken::new(Token(token.into())))
-        .await?;
-    println!("Token authenticated");
-
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -7,7 +7,8 @@ pub use enrollment_token_generate::GenerateEnrollmentTokenCommand;
 use ockam_multiaddr::MultiAddr;
 
 use crate::enroll::email::EnrollEmailCommand;
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::CommandGlobalOpts;
 
 mod auth0;
 mod email;
@@ -16,39 +17,33 @@ mod enrollment_token_generate;
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollCommand {
-    /// Ockam's cloud address
+    /// Ockam's cloud secure channel address
     #[clap(
         display_order = 1000,
         default_value = "/dnsaddr/ockam.cloud.io/tcp/4000"
     )]
     address: MultiAddr,
 
-    #[clap(display_order = 1001, long, default_value = "default")]
-    vault: String,
-
-    #[clap(display_order = 1002, long, default_value = "default")]
-    identity: String,
-
     /// Authenticates an enrollment token
     #[clap(display_order = 1003, long, group = "enroll_params")]
-    token: Option<String>,
+    pub token: Option<String>,
 
     /// Enroll using the Auth0 flow
     #[clap(display_order = 1004, long, group = "enroll_params")]
     auth0: bool,
 
     #[clap(flatten)]
-    identity_opts: IdentityOpts,
+    node_opts: NodeOpts,
 }
 
 impl EnrollCommand {
-    pub fn run(cmd: EnrollCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: EnrollCommand) {
         if cmd.token.is_some() {
-            AuthenticateEnrollmentTokenCommand::run(cmd)
+            AuthenticateEnrollmentTokenCommand::run(opts, cmd)
         } else if cmd.auth0 {
-            EnrollAuth0Command::run(cmd)
+            EnrollAuth0Command::run(opts, cmd)
         } else {
-            EnrollEmailCommand::run(cmd)
+            EnrollEmailCommand::run(opts, cmd)
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
@@ -7,15 +8,14 @@ use ockam_core::Route;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Override the default API node
-    #[clap(short, long)]
-    pub api_node: Option<String>,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 }
 
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
         let cfg = opts.config;
-        let port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/invitation/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/create.rs
@@ -1,51 +1,87 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::{invitation::CreateInvitation, MessagingClient};
-use ockam_multiaddr::MultiAddr;
+use ockam_api::cloud::invitation::Invitation;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::embedded_node;
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Id of the space to invite for
     #[clap(display_order = 1001)]
-    space_id: String,
+    pub space_id: String,
 
     /// Email to sent the invite
     #[clap(display_order = 1003)]
-    email: String,
+    pub email: String,
 
-    /// project id to invite to, optional.
+    /// Project id to invite to, optional.
     #[clap(display_order = 1002, long)]
-    project_id: Option<String>,
+    pub project_id: Option<String>,
 
     #[clap(flatten)]
-    identity_opts: IdentityOpts,
+    node_opts: NodeOpts,
 }
 
 impl CreateCommand {
-    pub fn run(cmd: CreateCommand, cloud_addr: MultiAddr) {
-        embedded_node(create, (cloud_addr, cmd));
+    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), create);
     }
 }
 
-async fn create(mut ctx: Context, args: (MultiAddr, CreateCommand)) -> anyhow::Result<()> {
-    let (cloud_addr, cmd) = args;
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn create(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::invitations::create(cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let r = ockam_api::multiaddr_to_route(&cloud_addr)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
-    let route = route![r.to_string(), "invitations"];
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let request = CreateInvitation::new(cmd.email, cmd.space_id, cmd.project_id);
-    let res = api.create_invitation(request).await?;
-    println!("{res:?}");
-    ctx.stop().await?;
-    Ok(())
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Invitation>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => "Invitation created".to_string(),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/list.rs
@@ -1,60 +1,75 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
-use cli_table::{print_stdout, Cell, Style, Table};
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
-use ockam_multiaddr::MultiAddr;
+use ockam_api::cloud::invitation::Invitation;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::embedded_node;
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
     #[clap(flatten)]
-    identity_opts: IdentityOpts,
+    node_opts: NodeOpts,
 }
 
 impl ListCommand {
-    pub fn run(cmd: ListCommand, cloud_addr: MultiAddr) {
-        embedded_node(list, (cloud_addr, cmd));
+    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), list);
     }
 }
 
-async fn list(mut ctx: Context, args: (MultiAddr, ListCommand)) -> anyhow::Result<()> {
-    let (cloud_addr, cmd) = args;
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn list(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::invitations::list(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let cloud_addr = ockam_api::multiaddr_to_route(&cloud_addr)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
-    let route = route![cloud_addr.to_string(), "invitations"];
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let invitations = api.list_invitations().await?;
-    let table = invitations
-        .iter()
-        .map(|i| {
-            vec![
-                format!("{:?}", i.id).cell(),
-                format!("{:?}", i.space_id).cell(),
-                format!("{:?}", i.project_id).cell(),
-                format!("{:?}", i.inviter).cell(),
-                format!("{:?}", i.state).cell(),
-            ]
-        })
-        .table()
-        .title(vec![
-            "Invitation ID".cell().bold(true),
-            "Space".cell().bold(true),
-            "Project".cell().bold(true),
-            "Inviter".cell().bold(true),
-            "State".cell().bold(true),
-        ]);
-    if let Err(e) = print_stdout(table) {
-        eprintln!("failed to print node status: {}", e);
-    }
-    ctx.stop().await?;
-    Ok(())
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Vec<Invitation>>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => format!("{body:#?}"),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
@@ -1,12 +1,12 @@
 use clap::{Args, Subcommand};
 
-use accept::AcceptCommand;
-use create::CreateCommand;
-use list::ListCommand;
+pub use accept::AcceptCommand;
+pub use create::CreateCommand;
+pub use list::ListCommand;
 use ockam_multiaddr::MultiAddr;
-use reject::RejectCommand;
+pub use reject::RejectCommand;
 
-use crate::HELP_TEMPLATE;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod accept;
 mod create;
@@ -48,12 +48,12 @@ pub enum InvitationSubcommand {
 }
 
 impl InvitationCommand {
-    pub fn run(cmd: InvitationCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: InvitationCommand) {
         match cmd.subcommand {
-            InvitationSubcommand::Create(command) => CreateCommand::run(command, cmd.cloud_addr),
-            InvitationSubcommand::List(command) => ListCommand::run(command, cmd.cloud_addr),
-            InvitationSubcommand::Accept(command) => AcceptCommand::run(command, cmd.cloud_addr),
-            InvitationSubcommand::Reject(command) => RejectCommand::run(command, cmd.cloud_addr),
+            InvitationSubcommand::Create(command) => CreateCommand::run(opts, command),
+            InvitationSubcommand::List(command) => ListCommand::run(opts, command),
+            InvitationSubcommand::Accept(command) => AcceptCommand::run(opts, command),
+            InvitationSubcommand::Reject(command) => RejectCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/reject.rs
@@ -1,42 +1,71 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{route, Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
-use ockam_multiaddr::MultiAddr;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::embedded_node;
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct RejectCommand {
+    /// The invitation id.
     #[clap(display_order = 1002)]
-    invitation: String,
+    pub id: String,
 
     #[clap(flatten)]
-    identity_opts: IdentityOpts,
+    node_opts: NodeOpts,
 }
 
 impl RejectCommand {
-    pub fn run(cmd: RejectCommand, cloud_addr: MultiAddr) {
-        embedded_node(reject, (cloud_addr, cmd));
+    pub fn run(opts: CommandGlobalOpts, cmd: RejectCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), reject);
     }
 }
 
-async fn reject(mut ctx: Context, args: (MultiAddr, RejectCommand)) -> anyhow::Result<()> {
-    let (cloud_addr, cmd) = args;
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn reject(
+    ctx: ockam::Context,
+    (_opts, cmd): (CommandGlobalOpts, RejectCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::invitations::reject(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let r = ockam_api::multiaddr_to_route(&cloud_addr)
-        .ok_or_else(|| anyhow!("failed to parse address: {}", cloud_addr))?;
-    let route = route![r.to_string(), "invitations"];
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    api.reject_invitations(&cmd.invitation).await?;
-    println!("Invitation rejected");
-    ctx.stop().await?;
-    Ok(())
+    let res = match header.status() {
+        Some(Status::Ok) => Ok("Invitation rejected".to_string()),
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -241,16 +241,16 @@ pub fn run() {
 
     match ockam_command.subcommand {
         OckamSubcommand::Authenticated(command) => AuthenticatedCommand::run(command),
-        OckamSubcommand::Invitation(command) => InvitationCommand::run(command),
-        OckamSubcommand::Enroll(command) => EnrollCommand::run(command),
+        OckamSubcommand::Invitation(command) => InvitationCommand::run(opts, command),
+        OckamSubcommand::Enroll(command) => EnrollCommand::run(opts, command),
         OckamSubcommand::GenerateEnrollmentToken(command) => {
-            GenerateEnrollmentTokenCommand::run(command)
+            GenerateEnrollmentTokenCommand::run(opts, command)
         }
         OckamSubcommand::Forwarder(command) => ForwarderCommand::run(opts, command),
         OckamSubcommand::Message(command) => MessageCommand::run(command),
         OckamSubcommand::Node(command) => NodeCommand::run(opts, command),
-        OckamSubcommand::Project(command) => ProjectCommand::run(command),
-        OckamSubcommand::Space(command) => SpaceCommand::run(command),
+        OckamSubcommand::Project(command) => ProjectCommand::run(opts, command),
+        OckamSubcommand::Space(command) => SpaceCommand::run(opts, command),
         OckamSubcommand::Transport(command) => TransportCommand::run(opts, command),
         OckamSubcommand::Portal(command) => PortalCommand::run(opts, command),
         OckamSubcommand::Config(command) => ConfigCommand::run(opts, command),

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::CommandGlobalOpts;
 use clap::Args;
 use nix::sys::signal::{self, Signal};
@@ -5,8 +6,9 @@ use nix::unistd::Pid;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    /// Name of the node to delete
-    pub node_name: String,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
     /// Should the node be terminated with SIGKILL instead of SIGTERM
     #[clap(display_order = 900, long, short)]
     sigkill: bool,
@@ -14,7 +16,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
-        delete_node(&opts, &command.node_name, command.sigkill);
+        delete_node(&opts, &command.node_opts.api_node, command.sigkill);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -53,3 +53,10 @@ impl NodeCommand {
         }
     }
 }
+
+#[derive(Clone, Debug, Args)]
+pub struct NodeOpts {
+    /// Override the default API node
+    #[clap(short, long, default_value = "default")]
+    pub api_node: String,
+}

--- a/implementations/rust/ockam/ockam_command/src/old/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/identity.rs
@@ -65,16 +65,6 @@ pub async fn create_identity(
     Ok(identity)
 }
 
-pub async fn load_or_create_identity(
-    ctx: &ockam::Context,
-    overwrite: bool,
-) -> anyhow::Result<Identity<OckamVault>> {
-    match load_identity(ctx, &storage::get_ockam_dir()?).await {
-        Ok(identity) => Ok(identity),
-        Err(_) => create_identity(ctx, overwrite).await,
-    }
-}
-
 pub async fn load_identity(
     ctx: &ockam::Context,
     ockam_dir: &Path,

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
@@ -11,9 +12,8 @@ use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Override the default API node
-    #[clap(short, long)]
-    pub api_node: Option<String>,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Select a creation variant
     #[clap(subcommand)]
@@ -43,7 +43,7 @@ pub enum CreateTypeCommand {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,55 +1,92 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::{project::CreateProject, MessagingClient};
+use ockam_api::cloud::project::Project;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Id of the space the project belongs to.
     #[clap(display_order = 1001)]
-    space_id: String,
+    pub space_id: String,
 
     /// Name of the project.
     #[clap(display_order = 1002)]
-    project_name: String,
+    pub project_name: String,
 
     /// Services enabled for this project.
     #[clap(display_order = 1003)]
-    services: Vec<String>,
+    pub services: Vec<String>,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, last = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl CreateCommand {
-    pub fn run(cmd: CreateCommand) {
-        embedded_node(create, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), create);
     }
 }
 
-async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn create(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::project::create(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let request = CreateProject::new(cmd.project_name, &cmd.services);
-    let res = api.create_project(&cmd.space_id, request).await?;
-    println!("{res:#?}");
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Project>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => "Project created".to_string(),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -1,49 +1,90 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use serde_json::json;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
-    space_id: String,
+    pub space_id: String,
 
     /// Id of the project.
     #[clap(display_order = 1002)]
-    project_id: String,
+    pub project_id: String,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
-    pub fn run(cmd: DeleteCommand) {
-        embedded_node(delete, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), delete);
     }
 }
 
-async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn delete(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::project::delete(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    api.delete_project(&cmd.space_id, &cmd.project_id).await?;
-    println!("Project deleted");
-    ctx.stop().await?;
-    Ok(())
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => "Project deleted".to_string(),
+                MessageFormat::Json => json!({
+                    "id": cmd.project_id,
+                })
+                .to_string(),
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,46 +1,84 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
+use ockam_api::cloud::project::Project;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
-    space_id: String,
+    pub space_id: String,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl ListCommand {
-    pub fn run(cmd: ListCommand) {
-        embedded_node(list, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), list);
     }
 }
 
-async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn list(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::project::list(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let res = api.list_projects(&cmd.space_id).await?;
-    println!("{res:#?}");
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Vec<Project>>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => format!("{body:#?}"),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
 
-use create::CreateCommand;
-use delete::DeleteCommand;
-use list::ListCommand;
-use show::ShowCommand;
+pub use create::CreateCommand;
+pub use delete::DeleteCommand;
+pub use list::ListCommand;
+pub use show::ShowCommand;
 
-use crate::HELP_TEMPLATE;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
 mod delete;
@@ -38,12 +38,12 @@ pub enum ProjectSubcommand {
 }
 
 impl ProjectCommand {
-    pub fn run(cmd: ProjectCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: ProjectCommand) {
         match cmd.subcommand {
-            ProjectSubcommand::Create(cmd) => CreateCommand::run(cmd),
-            ProjectSubcommand::Delete(cmd) => DeleteCommand::run(cmd),
-            ProjectSubcommand::List(cmd) => ListCommand::run(cmd),
-            ProjectSubcommand::Show(cmd) => ShowCommand::run(cmd),
+            ProjectSubcommand::Create(cmd) => CreateCommand::run(opts, cmd),
+            ProjectSubcommand::Delete(cmd) => DeleteCommand::run(opts, cmd),
+            ProjectSubcommand::List(cmd) => ListCommand::run(opts, cmd),
+            ProjectSubcommand::Show(cmd) => ShowCommand::run(opts, cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -1,50 +1,93 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
+use ockam_api::cloud::project::Project;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
-    space_id: String,
+    pub space_id: String,
 
     /// Id of the project.
     #[clap(display_order = 1002)]
-    project_id: String,
+    pub project_id: String,
+
+    // TODO: add project_name arg that conflicts with project_id
+    //  so we can call the get_project_by_name api method
+    // /// Name of the project.
+    // #[clap(display_order = 1002)]
+    // pub project_name: String,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl ShowCommand {
-    pub fn run(cmd: ShowCommand) {
-        embedded_node(show, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: ShowCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), show);
     }
 }
 
-async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn show(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::project::show(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let res = api.get_project(&cmd.space_id, &cmd.project_id).await?;
-    println!("{res:#?}");
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Project>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => format!("{body:#?}"),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,47 +1,84 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::{space::CreateSpace, MessagingClient};
+use ockam_api::cloud::space::Space;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the space.
     #[clap(display_order = 1001)]
-    name: String,
+    pub name: String,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl CreateCommand {
-    pub fn run(cmd: CreateCommand) {
-        embedded_node(create, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), create);
     }
 }
 
-async fn create(mut ctx: Context, cmd: CreateCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn create(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::space::create(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let request = CreateSpace::new(cmd.name);
-    let res = api.create_space(request).await?;
-    println!("{res:#?}");
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Space>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => "Space created".to_string(),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,45 +1,86 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use serde_json::json;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
-    id: String,
+    pub id: String,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl DeleteCommand {
-    pub fn run(cmd: DeleteCommand) {
-        embedded_node(delete, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), delete);
     }
 }
 
-async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn delete(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::space::delete(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    api.delete_space(&cmd.id).await?;
-    println!("Space deleted");
-    ctx.stop().await?;
-    Ok(())
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => "Space deleted".to_string(),
+                MessageFormat::Json => json!({
+                    "id": cmd.id,
+                })
+                .to_string(),
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
+
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -1,42 +1,80 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
+use ockam_api::cloud::space::Space;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::old::identity::load_or_create_identity;
-use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
-use crate::IdentityOpts;
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
     /// Ockam's cloud address. Argument used for testing purposes.
     #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
-
-    #[clap(flatten)]
-    identity_opts: IdentityOpts,
 }
 
 impl ListCommand {
-    pub fn run(cmd: ListCommand) {
-        embedded_node(list, cmd);
+    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
+        let cfg = &opts.config;
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+        connect_to(port, (opts, cmd), list);
     }
 }
 
-async fn list(mut ctx: Context, cmd: ListCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn list(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append("_internal.nodeman").into();
+    debug!(?cmd, %route, "Sending request");
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
-    let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::space::list(&cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec.decode::<Response>()?;
+    debug!(?header, "Received response");
 
-    let route = ockam_api::multiaddr_to_route(&cmd.addr)
-        .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let res = api.list_spaces().await?;
-    println!("{res:#?}");
+    let res = match header.status() {
+        Some(Status::Ok) => {
+            let body = dec.decode::<Vec<Space>>()?;
+            let output = match opts.global_args.message_format {
+                MessageFormat::Plain => format!("{body:#?}"),
+                MessageFormat::Json => serde_json::to_string(&body)?,
+            };
+            Ok(output)
+        }
+        Some(Status::InternalServerError) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    ctx.stop().await?;
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -1,11 +1,11 @@
 use clap::{Args, Subcommand};
 
-use create::CreateCommand;
-use delete::DeleteCommand;
-use list::ListCommand;
-use show::ShowCommand;
+pub use create::CreateCommand;
+pub use delete::DeleteCommand;
+pub use list::ListCommand;
+pub use show::ShowCommand;
 
-use crate::HELP_TEMPLATE;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
 mod delete;
@@ -38,12 +38,12 @@ pub enum SpaceSubcommand {
 }
 
 impl SpaceCommand {
-    pub fn run(cmd: SpaceCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: SpaceCommand) {
         match cmd.subcommand {
-            SpaceSubcommand::Create(cmd) => CreateCommand::run(cmd),
-            SpaceSubcommand::Delete(cmd) => DeleteCommand::run(cmd),
-            SpaceSubcommand::List(cmd) => ListCommand::run(cmd),
-            SpaceSubcommand::Show(cmd) => ShowCommand::run(cmd),
+            SpaceSubcommand::Create(cmd) => CreateCommand::run(opts, cmd),
+            SpaceSubcommand::Delete(cmd) => DeleteCommand::run(opts, cmd),
+            SpaceSubcommand::List(cmd) => ListCommand::run(opts, cmd),
+            SpaceSubcommand::Show(cmd) => ShowCommand::run(opts, cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/transport/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/create.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
@@ -9,9 +10,8 @@ use ockam_api::{
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Override the default API node
-    #[clap(short, long)]
-    pub api_node: Option<String>,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Select a creation variant
     #[clap(subcommand)]
@@ -41,7 +41,7 @@ pub enum CreateTypeCommand {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
@@ -55,7 +55,7 @@ impl CreateCommand {
         // went OK if we reach this point because embedded_node
         // crashes the process if something went wrong?  But idk,
         // still bad and should be fixed
-        let node = command.api_node.unwrap_or_else(|| cfg.get_api_node());
+        let node = command.node_opts.api_node;
         match command.create_subcommand {
             CreateTypeCommand::TcpConnector { addr } => cfg.add_transport(&node, false, true, addr),
             CreateTypeCommand::TcpListener { bind } => cfg.add_transport(&node, true, true, bind),

--- a/implementations/rust/ockam/ockam_command/src/transport/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/delete.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
@@ -6,9 +7,8 @@ use ockam_api::{nodes::NODEMAN_ADDR, Response, Status};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    /// Override the default API node
-    #[clap(short, long)]
-    pub api_node: Option<String>,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 
     /// Transport ID
     pub id: String,
@@ -21,7 +21,7 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/transport/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/transport/list.rs
@@ -1,3 +1,4 @@
+use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
@@ -10,15 +11,14 @@ use ockam_api::nodes::{
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    /// Name of the node.
-    #[clap(short, long)]
-    pub api_node: Option<String>,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
 }
 
 impl ListCommand {
     pub fn run(opts: CommandGlobalOpts, command: ListCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.api_node) {
+        let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/util/config/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config/mod.rs
@@ -175,12 +175,9 @@ Otherwise your OS or OS configuration may not be supported!",
     }
 
     /// Get the current version the selected node configuration
-    pub fn select_node<'a>(&'a self, o: &'a Option<String>) -> Option<NodeConfig> {
+    pub fn select_node<'a>(&'a self, o: &'a str) -> Option<NodeConfig> {
         let inner = self.inner.read().unwrap();
-        inner
-            .nodes
-            .get(o.as_ref().unwrap_or(&inner.api_node))
-            .map(Clone::clone)
+        inner.nodes.get(o).map(Clone::clone)
     }
 
     /// Get the log path for a specific node

--- a/implementations/rust/ockam/ockam_command/src/util/dog/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/dog/mod.rs
@@ -24,7 +24,7 @@ pub struct WatchdogCommand {
 impl WatchdogCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: WatchdogCommand) {
         let cfg = &opts.config;
-        let socket_path = socket_path(cfg, &cmd.node_name);
+        let socket_path = socket_path(cfg, &cmd.node_opts.api_node);
 
         Watchdog { socket_path }.run()
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -8,11 +8,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("enroll")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
-        .arg("--overwrite");
+        .arg("-a")
+        .arg("node-name");
     cmd.assert().success();
 
     // auth0
@@ -20,11 +17,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("enroll")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
-        .arg("--overwrite")
+        .arg("-a")
+        .arg("node-name")
         .arg("--auth0");
     cmd.assert().success();
 
@@ -33,11 +27,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("enroll")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
-        .arg("--overwrite")
+        .arg("-a")
+        .arg("node-name")
         .arg("--token")
         .arg("token-value");
     cmd.assert().success();

--- a/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
@@ -9,8 +9,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("create")
         .arg("/ip4/127.0.0.1/tcp/8080")
         .arg("forwarder_alias")
-        .arg("--node-name")
-        .arg("node");
+        .arg("-a")
+        .arg("node-name");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
@@ -7,11 +7,8 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("token")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--vault")
-        .arg("vt")
-        .arg("--identity")
-        .arg("idt")
-        .arg("--overwrite")
+        .arg("-a")
+        .arg("node-name")
         .arg("--")
         .arg("k1=v1")
         .arg("k2=v2");


### PR DESCRIPTION
Refactor cloud commands so they send their requests to spawned nodes.

It also refactors the `api_node`/`node_name` argument. Now, all commands use the same
argument: `api_node`.

It may look like a lot of changes, but it's the same thing repeated 15 times.

Note: merge after https://github.com/build-trust/ockam/pull/2945
Next: https://github.com/build-trust/ockam/pull/2948