### PR TITLE
refactor(rust): send cloud node address from cloud commands to nodes

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -79,6 +79,7 @@ mod node {
     use ockam_node::Context;
 
     use crate::cloud::enroll::auth0::Auth0TokenProvider;
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
     use crate::{decode, is_ok, request};
     use crate::{Request, Response, Status};
@@ -101,7 +102,10 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
-            let req_body: CreateInvitation = dec.decode()?;
+            let req_wrapper: CloudRequestWrapper<CreateInvitation> = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+            let req_body = req_wrapper.req;
+
             let label = "create_invitation";
             trace! {
                 target: TARGET,
@@ -111,7 +115,7 @@ mod node {
                 "creating invitation"
             };
 
-            let route = self.api_service_route("invitations");
+            let route = self.api_service_route(&cloud_address, "invitations");
             let req_builder = Request::post("v0/").body(req_body);
             match request(ctx, label, "create_invitation", route, req_builder).await {
                 Ok(r) => {
@@ -132,15 +136,19 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "list_invitations";
             trace!(target: TARGET, "listing invitations");
 
-            let route = self.api_service_route("invitations");
+            let route = self.api_service_route(&cloud_address, "invitations");
             let req_builder = Request::post("v0/");
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -161,16 +169,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             id: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "accept_invitation";
             trace!(target: TARGET, %id, "accepting invitation");
 
-            let route = self.api_service_route("invitations");
+            let route = self.api_service_route(&cloud_address, "invitations");
             let req_builder = Request::put(format!("v0/{id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -191,16 +203,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             id: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "reject_invitation";
             trace!(target: TARGET, %id, "rejecting invitation");
 
-            let route = self.api_service_route("invitations");
+            let route = self.api_service_route(&cloud_address, "invitations");
             let req_builder = Request::delete(format!("v0/{id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -58,6 +58,7 @@ mod node {
     use ockam_node::Context;
 
     use crate::cloud::enroll::auth0::Auth0TokenProvider;
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
     use crate::{decode, is_ok, request};
     use crate::{Request, Response, Status};
@@ -81,12 +82,14 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
-            let req_body: CreateProject = dec.decode()?;
+            let req_wrapper: CloudRequestWrapper<CreateProject> = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+            let req_body = req_wrapper.req;
 
             let label = "create_project";
             trace!(target: TARGET, %space_id, project_name = %req_body.name, "creating project");
 
-            let route = self.api_service_route("projects");
+            let route = self.api_service_route(&cloud_address, "projects");
             let req_builder = Request::post("v0/").body(req_body);
             match request(ctx, label, "create_project", route, req_builder).await {
                 Ok(r) => {
@@ -107,16 +110,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             space_id: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "list_projects";
             trace!(target: TARGET, %space_id, "listing projects");
 
-            let route = self.api_service_route("projects");
+            let route = self.api_service_route(&cloud_address, "projects");
             let req_builder = Request::post("v0/");
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -137,6 +144,7 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             space_id: &str,
             project_id: &str,
@@ -144,10 +152,13 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "get_project";
             trace!(target: TARGET, %space_id, %project_id, "getting project");
 
-            let route = self.api_service_route("projects");
+            let route = self.api_service_route(&cloud_address, "projects");
             let req_builder = Request::get(format!("v0/{project_id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -168,6 +179,7 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             space_id: &str,
             project_name: &str,
@@ -175,10 +187,13 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "get_project_by_name";
             trace!(target: TARGET, %space_id, %project_name, "getting project");
 
-            let route = self.api_service_route("projects");
+            let route = self.api_service_route(&cloud_address, "projects");
             let req_builder = Request::get(format!("v0/name/{project_name}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -199,6 +214,7 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             space_id: &str,
             project_id: &str,
@@ -206,10 +222,13 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "delete_project";
             trace!(target: TARGET, %space_id, %project_id, "deleting project");
 
-            let route = self.api_service_route("projects");
+            let route = self.api_service_route(&cloud_address, "projects");
             let req_builder = Request::delete(format!("v0/{project_id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -48,6 +48,7 @@ mod node {
 
     use crate::cloud::enroll::auth0::Auth0TokenProvider;
     use crate::cloud::space::{CreateSpace, Space};
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
     use crate::{decode, is_ok, request};
     use crate::{Request, Response, Status};
@@ -68,12 +69,14 @@ mod node {
         where
             W: Write<Error = Infallible>,
         {
-            let req_body: CreateSpace = dec.decode()?;
+            let req_wrapper: CloudRequestWrapper<CreateSpace> = dec.decode()?;
+            let req_body = req_wrapper.req;
+            let cloud_address = req_wrapper.cloud_address;
 
             let label = "create_space";
             trace!(target: TARGET, space = %req_body.name, "creating space");
 
-            let route = self.api_service_route("spaces");
+            let route = self.api_service_route(&cloud_address, "spaces");
             let req_builder = Request::post("v0/").body(req_body);
             match request(ctx, label, "create_space", route, req_builder).await {
                 Ok(r) => {
@@ -94,15 +97,19 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "list_spaces";
             trace!(target: TARGET, "listing spaces");
 
-            let route = self.api_service_route("spaces");
+            let route = self.api_service_route(&cloud_address, "spaces");
             let req_builder = Request::post("v0/");
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -123,16 +130,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             id: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "get_space";
             trace!(target: TARGET, space = %id, space = %id, "getting space");
 
-            let route = self.api_service_route("spaces");
+            let route = self.api_service_route(&cloud_address, "spaces");
             let req_builder = Request::get(format!("v0/{id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -153,16 +164,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             name: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "get_space_by_name";
             trace!(target: TARGET, space = %name, "getting space");
 
-            let route = self.api_service_route("spaces");
+            let route = self.api_service_route(&cloud_address, "spaces");
             let req_builder = Request::get(format!("v0/name/{name}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {
@@ -183,16 +198,20 @@ mod node {
             &mut self,
             ctx: &mut Context,
             req: &Request<'_>,
+            dec: &mut Decoder<'_>,
             enc: W,
             id: &str,
         ) -> Result<()>
         where
             W: Write<Error = Infallible>,
         {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_address = req_wrapper.cloud_address;
+
             let label = "delete_space";
             trace!(target: TARGET, space = %id, "deleting space");
 
-            let route = self.api_service_route("spaces");
+            let route = self.api_service_route(&cloud_address, "spaces");
             let req_builder = Request::delete(format!("v0/{id}"));
             match request(ctx, label, None, route, req_builder).await {
                 Ok(r) => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/secure_channel.rs
@@ -1,8 +1,10 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
+use ockam_core::Address;
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use ockam_multiaddr::MultiAddr;
 
 /// Request body when instructing a node to create a Secure Channel
 #[derive(Debug, Clone, Decode, Encode)]
@@ -15,11 +17,11 @@ pub struct CreateSecureChannelRequest<'a> {
 }
 
 impl<'a> CreateSecureChannelRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: MultiAddr) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.into(),
+            addr: addr.to_string().into(),
         }
     }
 }
@@ -35,11 +37,11 @@ pub struct CreateSecureChannelResponse<'a> {
 }
 
 impl<'a> CreateSecureChannelResponse<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.into(),
+            addr: addr.to_string().into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
@@ -40,7 +40,7 @@ async fn enroll(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::enroll::auth0(&cmd)?)
+        .send_and_receive(route, api::enroll::auth0(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/enroll/email.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/email.rs
@@ -7,17 +7,13 @@ use validator::validate_email;
 
 use ockam_api::error::ApiError;
 
-use crate::node::NodeOpts;
 use crate::util::embedded_node;
 use crate::{CommandGlobalOpts, EnrollCommand};
 
 const API_SECRET: &str = "DNYsEfhe]ms]ET]yQIthmhSOIvCkWOnb";
 
 #[derive(Clone, Debug, Args)]
-pub struct EnrollEmailCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-}
+pub struct EnrollEmailCommand;
 
 impl EnrollEmailCommand {
     pub fn run(_opts: CommandGlobalOpts, cmd: EnrollCommand) {

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
@@ -6,15 +6,11 @@ use tracing::debug;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
 
-use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
-pub struct AuthenticateEnrollmentTokenCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-}
+pub struct AuthenticateEnrollmentTokenCommand;
 
 impl AuthenticateEnrollmentTokenCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: EnrollCommand) {
@@ -39,7 +35,7 @@ async fn authenticate(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::enroll::token_authenticate(&cmd)?)
+        .send_and_receive(route, api::enroll::token_authenticate(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -6,24 +6,23 @@ use tracing::debug;
 use ockam_api::cloud::enroll::enrollment_token::EnrollmentToken;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct GenerateEnrollmentTokenCommand {
-    /// Ockam's cloud address
-    #[clap(display_order = 1000)]
-    address: MultiAddr,
-
     /// Attributes (use '=' to separate key from value)
     #[clap(value_delimiter('='), last = true, required = true)]
     pub attrs: Vec<String>,
 
     #[clap(flatten)]
     node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
 }
 
 impl GenerateEnrollmentTokenCommand {
@@ -49,7 +48,7 @@ async fn generate(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::enroll::token_generate(&cmd)?)
+        .send_and_receive(route, api::enroll::token_generate(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -4,10 +4,10 @@ pub use auth0::Auth0Service;
 use auth0::*;
 use enrollment_token_authenticate::*;
 pub use enrollment_token_generate::GenerateEnrollmentTokenCommand;
-use ockam_multiaddr::MultiAddr;
 
 use crate::enroll::email::EnrollEmailCommand;
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::CommandGlobalOpts;
 
 mod auth0;
@@ -17,13 +17,6 @@ mod enrollment_token_generate;
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollCommand {
-    /// Ockam's cloud secure channel address
-    #[clap(
-        display_order = 1000,
-        default_value = "/dnsaddr/ockam.cloud.io/tcp/4000"
-    )]
-    address: MultiAddr,
-
     /// Authenticates an enrollment token
     #[clap(display_order = 1003, long, group = "enroll_params")]
     pub token: Option<String>,
@@ -34,6 +27,9 @@ pub struct EnrollCommand {
 
     #[clap(flatten)]
     node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
 }
 
 impl EnrollCommand {

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -10,12 +10,13 @@ use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Ockam's cloud node address.
+    /// Ockam's cloud address.
+    #[clap(default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
 
     /// Forwarder alias. Optional{n}

--- a/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/accept.rs
@@ -7,6 +7,7 @@ use ockam_api::{Response, Status};
 use ockam_core::Route;
 
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::CommandGlobalOpts;
 
@@ -15,35 +16,36 @@ pub struct AcceptCommand {
     /// The invitation id.
     #[clap(display_order = 1002)]
     pub id: String,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
 }
 
 impl AcceptCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: AcceptCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: AcceptCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), accept);
+        connect_to(port, (opts, cloud_opts, cmd), accept);
     }
 }
 
 async fn accept(
     ctx: ockam::Context,
-    (_opts, cmd): (CommandGlobalOpts, AcceptCommand),
+    (_opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, AcceptCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::invitations::accept(&cmd)?)
+        .send_and_receive(route, api::invitations::accept(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/invitation/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/list.rs
@@ -8,39 +8,41 @@ use ockam_api::{Response, Status};
 use ockam_core::Route;
 
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
-pub struct ListCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-}
+pub struct ListCommand;
 
 impl ListCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: ListCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), list);
+        connect_to(port, (opts, cloud_opts, cmd), list);
     }
 }
 
 async fn list(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, ListCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::invitations::list(&cmd)?)
+        .send_and_receive(route, api::invitations::list(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
@@ -3,9 +3,10 @@ use clap::{Args, Subcommand};
 pub use accept::AcceptCommand;
 pub use create::CreateCommand;
 pub use list::ListCommand;
-use ockam_multiaddr::MultiAddr;
 pub use reject::RejectCommand;
 
+use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod accept;
@@ -18,14 +19,11 @@ pub struct InvitationCommand {
     #[clap(subcommand)]
     subcommand: InvitationSubcommand,
 
-    /// Ockam's cloud node address
-    #[clap(
-        global = true,
-        display_order = 1000,
-        long,
-        default_value = "/dnsaddr/cloud.ockam.io/tcp/62526/ockam/api"
-    )]
-    pub cloud_addr: MultiAddr,
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -50,10 +48,18 @@ pub enum InvitationSubcommand {
 impl InvitationCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: InvitationCommand) {
         match cmd.subcommand {
-            InvitationSubcommand::Create(command) => CreateCommand::run(opts, command),
-            InvitationSubcommand::List(command) => ListCommand::run(opts, command),
-            InvitationSubcommand::Accept(command) => AcceptCommand::run(opts, command),
-            InvitationSubcommand::Reject(command) => RejectCommand::run(opts, command),
+            InvitationSubcommand::Create(scmd) => {
+                CreateCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            InvitationSubcommand::List(scmd) => {
+                ListCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            InvitationSubcommand::Accept(scmd) => {
+                AcceptCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            InvitationSubcommand::Reject(scmd) => {
+                RejectCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -6,10 +6,10 @@ use tracing::debug;
 use ockam_api::cloud::project::Project;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::api::CloudOpts;
+use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -25,39 +25,36 @@ pub struct CreateCommand {
     /// Services enabled for this project.
     #[clap(display_order = 1003)]
     pub services: Vec<String>,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Ockam's cloud address. Argument used for testing purposes.
-    #[clap(hide = true, last = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    addr: MultiAddr,
 }
 
 impl CreateCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: CreateCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), create);
+        connect_to(port, (opts, cloud_opts, cmd), create);
     }
 }
 
 async fn create(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, CreateCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::create(&cmd)?)
+        .send_and_receive(route, api::project::create(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -5,6 +5,8 @@ pub use delete::DeleteCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 
+use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
@@ -16,6 +18,12 @@ mod show;
 pub struct ProjectCommand {
     #[clap(subcommand)]
     subcommand: ProjectSubcommand,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -40,10 +48,18 @@ pub enum ProjectSubcommand {
 impl ProjectCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ProjectCommand) {
         match cmd.subcommand {
-            ProjectSubcommand::Create(cmd) => CreateCommand::run(opts, cmd),
-            ProjectSubcommand::Delete(cmd) => DeleteCommand::run(opts, cmd),
-            ProjectSubcommand::List(cmd) => ListCommand::run(opts, cmd),
-            ProjectSubcommand::Show(cmd) => ShowCommand::run(opts, cmd),
+            ProjectSubcommand::Create(scmd) => {
+                CreateCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            ProjectSubcommand::Delete(scmd) => {
+                DeleteCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            ProjectSubcommand::List(scmd) => {
+                ListCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            ProjectSubcommand::Show(scmd) => {
+                ShowCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -73,7 +73,7 @@ pub async fn create_connector(
     let response: Vec<u8> = ctx
         .send_and_receive(
             base_route.modify().append("_internal.nodeman"),
-            api::create_secure_channel(&addr)?,
+            api::create_secure_channel(addr)?,
         )
         .await
         .context("Failed to process request")?;

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -6,10 +6,10 @@ use tracing::debug;
 use ockam_api::cloud::space::Space;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::api::CloudOpts;
+use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -17,39 +17,36 @@ pub struct CreateCommand {
     /// Name of the space.
     #[clap(display_order = 1001)]
     pub name: String,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Ockam's cloud address. Argument used for testing purposes.
-    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    addr: MultiAddr,
 }
 
 impl CreateCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: CreateCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), create);
+        connect_to(port, (opts, cloud_opts, cmd), create);
     }
 }
 
 async fn create(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, CreateCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::create(&cmd)?)
+        .send_and_receive(route, api::space::create(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -6,10 +6,10 @@ use tracing::debug;
 
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::api::CloudOpts;
+use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -17,39 +17,37 @@ pub struct DeleteCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
     pub id: String,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Ockam's cloud address. Argument used for testing purposes.
-    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    addr: MultiAddr,
 }
 
 impl DeleteCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: DeleteCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), delete);
+        connect_to(port, (opts, cloud_opts, cmd), delete);
     }
 }
 
 async fn delete(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, DeleteCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
+    let space_id = cmd.id.clone();
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::delete(&cmd)?)
+        .send_and_receive(route, api::space::delete(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);
@@ -61,7 +59,7 @@ async fn delete(
             let output = match opts.global_args.message_format {
                 MessageFormat::Plain => "Space deleted".to_string(),
                 MessageFormat::Json => json!({
-                    "id": cmd.id,
+                    "id": space_id,
                 })
                 .to_string(),
             };

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -6,46 +6,43 @@ use tracing::debug;
 use ockam_api::cloud::space::Space;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::api::CloudOpts;
+use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
-pub struct ListCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Ockam's cloud address. Argument used for testing purposes.
-    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    addr: MultiAddr,
-}
+pub struct ListCommand;
 
 impl ListCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: ListCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), list);
+        connect_to(port, (opts, cloud_opts, cmd), list);
     }
 }
 
 async fn list(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, ListCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::list(&cmd)?)
+        .send_and_receive(route, api::space::list(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -5,6 +5,8 @@ pub use delete::DeleteCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 
+use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
@@ -16,6 +18,12 @@ mod show;
 pub struct SpaceCommand {
     #[clap(subcommand)]
     subcommand: SpaceSubcommand,
+
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -40,10 +48,18 @@ pub enum SpaceSubcommand {
 impl SpaceCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: SpaceCommand) {
         match cmd.subcommand {
-            SpaceSubcommand::Create(cmd) => CreateCommand::run(opts, cmd),
-            SpaceSubcommand::Delete(cmd) => DeleteCommand::run(opts, cmd),
-            SpaceSubcommand::List(cmd) => ListCommand::run(opts, cmd),
-            SpaceSubcommand::Show(cmd) => ShowCommand::run(opts, cmd),
+            SpaceSubcommand::Create(scmd) => {
+                CreateCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            SpaceSubcommand::Delete(scmd) => {
+                DeleteCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            SpaceSubcommand::List(scmd) => {
+                ListCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
+            SpaceSubcommand::Show(scmd) => {
+                ShowCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -6,10 +6,10 @@ use tracing::debug;
 use ockam_api::cloud::space::Space;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::api::CloudOpts;
+use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -17,39 +17,36 @@ pub struct ShowCommand {
     /// Id of the space.
     #[clap(display_order = 1001)]
     pub id: String,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Ockam's cloud address. Argument used for testing purposes.
-    #[clap(hide = true, display_order = 1100, default_value = DEFAULT_CLOUD_ADDRESS)]
-    addr: MultiAddr,
 }
 
 impl ShowCommand {
-    pub fn run(opts: CommandGlobalOpts, cmd: ShowCommand) {
+    pub fn run(
+        opts: CommandGlobalOpts,
+        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
+        cmd: ShowCommand,
+    ) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
+        let port = match cfg.select_node(&node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cmd), show);
+        connect_to(port, (opts, cloud_opts, cmd), show);
     }
 }
 
 async fn show(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, ShowCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append("_internal.nodeman").into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::show(&cmd)?)
+        .send_and_receive(route, api::space::show(cmd, cloud_opts)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -3,34 +3,28 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    let prefix_args = [
+        "--test-argument-parser",
+        "enroll",
+        "--addr",
+        "/dnsaddr/localhost/tcp/4000",
+        "-a",
+        "node-name",
+    ];
+
     // email
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.arg("--test-argument-parser")
-        .arg("enroll")
-        .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("-a")
-        .arg("node-name");
+    cmd.args(&prefix_args);
     cmd.assert().success();
 
     // auth0
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.arg("--test-argument-parser")
-        .arg("enroll")
-        .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("-a")
-        .arg("node-name")
-        .arg("--auth0");
+    cmd.args(&prefix_args).arg("--auth0");
     cmd.assert().success();
 
     // token
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.arg("--test-argument-parser")
-        .arg("enroll")
-        .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("-a")
-        .arg("node-name")
-        .arg("--token")
-        .arg("token-value");
+    cmd.args(&prefix_args).arg("--token").arg("token-value");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
@@ -3,7 +3,14 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--test-argument-parser", "invitation"];
+    let prefix_args = [
+        "--test-argument-parser",
+        "invitation",
+        "--addr",
+        "/dnsaddr/localhost/tcp/4000",
+        "-a",
+        "node-name",
+    ];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
@@ -15,8 +22,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     // With custom cloud address
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
-        .arg("--cloud-addr")
-        .arg("/dnsaddr/localhost/tcp/4000")
         .arg("create")
         .arg("space-id")
         .arg("invitee@test.com");

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -3,16 +3,21 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--test-argument-parser", "project"];
+    let prefix_args = [
+        "--test-argument-parser",
+        "project",
+        "--addr",
+        "/dnsaddr/localhost/tcp/4000",
+        "-a",
+        "node-name",
+    ];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-id")
         .arg("project-name")
-        .arg("service-a service-b")
-        .arg("--")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+        .arg("service-a service-b");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
@@ -23,16 +28,14 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.args(&prefix_args)
         .arg("show")
         .arg("space-id")
-        .arg("project-id")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+        .arg("project-id");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("delete")
         .arg("space-id")
-        .arg("project-id")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+        .arg("project-id");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -3,13 +3,17 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--test-argument-parser", "space"];
+    let prefix_args = [
+        "--test-argument-parser",
+        "space",
+        "--addr",
+        "/dnsaddr/localhost/tcp/4000",
+        "-a",
+        "node-name",
+    ];
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("create")
-        .arg("space-name")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+    cmd.args(&prefix_args).arg("create").arg("space-name");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
@@ -17,17 +21,11 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("show")
-        .arg("space-id")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+    cmd.args(&prefix_args).arg("show").arg("space-id");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("delete")
-        .arg("space-id")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+    cmd.args(&prefix_args).arg("delete").arg("space-id");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
@@ -6,6 +6,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("token")
+        .arg("--addr")
         .arg("/ip4/127.0.0.1/tcp/8080")
         .arg("-a")
         .arg("node-name")


### PR DESCRIPTION
This address should be a valid secure channel address. This address is now used to send the
requests received by the nodes from cloud commands to the cloud api through the secure channel
that has been previously established between node/cloud.

All that's left to do now is remove the old cloud's `MessagingClient` and rewrite the tests that I had in place.

Merge after https://github.com/build-trust/ockam/pull/2947
Next: https://github.com/build-trust/ockam/pull/2955
