### PR TITLE
feat(elixir): allow to start identity secure channel with sidecar from env variables

### DIFF
--- a/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
@@ -103,6 +103,23 @@ config :ockam_kafka,
   password: kafka_password,
   stream_prefix: kafka_stream_prefix
 
+## Identity secure channel config
+
+identity_module =
+  case System.get_env("IDENTITY_IMPLEMENTATION", "stub") do
+    "sidecar" ->
+      Ockam.Identity.Sidecar
+
+    "stub" ->
+      Ockam.Identity.Stub
+
+    other ->
+      IO.puts(:stderr, "Unknown identity implementation: #{inspect(other)}")
+      exit(:invalid_config)
+  end
+
+config :ockam_services, identity_module: identity_module
+
 ## Services config
 
 services_json = System.get_env("SERVICES_JSON")

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
@@ -22,6 +22,8 @@ defmodule Ockam.Services.Provider.SecureChannel do
 
   def child_spec(:identity_secure_channel, args) do
     options = service_options(:identity_secure_channel, args)
+    {extra_services, options} = Keyword.pop(options, :extra_services)
+
     ## TODO: make this more standard approach
     id =
       case Keyword.fetch(args, :address) do
@@ -33,7 +35,10 @@ defmodule Ockam.Services.Provider.SecureChannel do
           :identity_secure_channel
       end
 
-    Supervisor.child_spec(Ockam.Identity.SecureChannel.listener_child_spec(options), %{id: id})
+    extra_services ++
+      [
+        Supervisor.child_spec(Ockam.Identity.SecureChannel.listener_child_spec(options), %{id: id})
+      ]
   end
 
   def service_options(:secure_channel, args) do
@@ -47,9 +52,21 @@ defmodule Ockam.Services.Provider.SecureChannel do
   end
 
   def service_options(:identity_secure_channel, args) do
-    ## TODO: WARNING: These defaults are not for production use
     ## TODO: make it possible to read service identity from some storage
-    identity_module = Keyword.get(args, :identity_module, Ockam.Identity.Stub)
+    identity_module = Keyword.get(args, :identity_module, default_identity_module())
+
+    extra_services =
+      case identity_module do
+        Ockam.Identity.Sidecar ->
+          [
+            Ockam.Services.Provider.Sidecar.child_spec(:identity_sidecar,
+              authorization: [:is_local]
+            )
+          ]
+
+        _other ->
+          []
+      end
 
     trust_policies =
       Keyword.get(args, :trust_policies, [
@@ -66,7 +83,8 @@ defmodule Ockam.Services.Provider.SecureChannel do
           identity_module: identity_module,
           encryption_options: [vault: vault, identity_keypair: keypair],
           address: "identity_secure_channel",
-          trust_policies: trust_policies
+          trust_policies: trust_policies,
+          extra_services: extra_services
         ],
         other_args
       )
@@ -74,5 +92,10 @@ defmodule Ockam.Services.Provider.SecureChannel do
       error ->
         raise "error starting service options for identity secure channel: #{inspect(error)}"
     end
+  end
+
+  defp default_identity_module() do
+    ## TODO: WARNING: These defaults are not for production use
+    Application.get_env(:ockam_services, :identity_module, Ockam.Identity.Stub)
   end
 end


### PR DESCRIPTION
## Current Behaviour

Currently you need to configure services from application env files to start secure channel with sidecar identity service

## Proposed Changes

Add `IDENTITY_IMPLEMENTATION` variable to specify which implementation to use
If `IDENTITY_IMPLEMENTATION` is `sidecar`, start the sidecar service together with secure channel service

To run identity secure channel with a sidecar and some services:
```
SERVICES_CONFIG_SOURCE=list SERVICES_LIST=echo,static_forwarding,identity_secure_channel IDENTITY_IMPLEMENTATION=sidecar iex -S mix
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
