### PR TITLE
fix(elixir): do not restart identity channel workers in loop

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
@@ -173,9 +173,8 @@ defmodule Ockam.Session.Pluggable.Initiator do
         {:ok, RoutingSession.update_handshake_state(state, handshake_state)}
 
       {:error, err} ->
-        ## TODO: should we return :shutdown error here?
-        ## Non-shutdown error will cause a resstart
-        {:stop, {:handshake_error, err}, state}
+        ## Use a {:shutdown, term()} reason, so we don't get restarted in loop
+        {:stop, {:shutdown, {:handshake_error, err}}, state}
     end
   end
 


### PR DESCRIPTION
If a secure channel can't be initiated because of being rejected by the trust_policy,  do not attempt to restart the process,
it should be transient.

Avoiding this fixes some flakiness on the test suite

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
