### PR TITLE
feat(elixir): use the space gateway route

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
@@ -110,8 +110,13 @@ defmodule Ockam.API.Request do
     }
   end
 
-  @spec caller_identity(%__MODULE__{}) :: :error | {:ok, identity :: String.t()}
+  @spec caller_identity(%__MODULE__{}) :: :error | {:ok, identity :: Ockam.Identity.t()}
   def caller_identity(%__MODULE__{local_metadata: meta}) do
     Map.fetch(meta, :identity)
+  end
+
+  @spec caller_identity(%__MODULE__{}) :: :error | {:ok, identity_id :: String.t()}
+  def caller_identity_id(%__MODULE__{local_metadata: meta}) do
+    Map.fetch(meta, :identity_id)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/trust_policy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/trust_policy.ex
@@ -54,7 +54,7 @@ defmodule Ockam.Identity.TrustPolicy do
         extra_arg \\ nil
       ) do
     case known_identities_mod.get_identity(contact_id, extra_arg) do
-      {:ok, known_contact} ->
+      {:ok, known_contact, _known_contact_id} ->
         case Identity.compare_identity_change_history(contact, known_contact) do
           {:ok, :equal} ->
             :ok
@@ -165,7 +165,9 @@ defmodule Ockam.Identity.TrustPolicy.KnownIdentities do
   Behaviour to implement modules to manage trust policy known identities table
   """
   @callback get_identity(contact_id :: binary(), extra_arg :: any()) ::
-              {:ok, contact :: binary()} | {:error, :not_found} | {:error, reason :: any()}
+              {:ok, contact :: Ockam.Identity.t(), contact_id :: binary()}
+              | {:error, :not_found}
+              | {:error, reason :: any()}
   @callback set_identity(contact_id :: binary(), contact :: binary(), extra_arg :: any()) ::
               :ok | {:error, reason :: any()}
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/initiator.ex
@@ -173,9 +173,8 @@ defmodule Ockam.Session.Pluggable.Initiator do
         {:ok, RoutingSession.update_handshake_state(state, handshake_state)}
 
       {:error, err} ->
-        ## TODO: should we return :shutdown error here?
-        ## Non-shutdown error will cause a resstart
-        {:stop, {:handshake_error, err}, state}
+        ## Use a {:shutdown, term()} reason, so we don't get restarted in loop
+        {:stop, {:shutdown, {:handshake_error, err}}, state}
     end
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
@@ -142,10 +142,10 @@ defmodule Ockam.Worker.Authorization do
   Allow messages which have `identity: identity` in their local metadata
   to be handled by the worker.
   """
-  def from_identity(prev \\ :ok, message, identity) do
+  def from_identity(prev \\ :ok, message, identity_id) do
     chain(prev, fn ->
-      case Message.local_metadata_value(message, :identity) do
-        ^identity -> :ok
+      case Message.local_metadata_value(message, :identity_id) do
+        ^identity_id -> :ok
         other -> {:error, {:from_identity, :invalid_identity, other}}
       end
     end)

--- a/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
@@ -37,7 +37,7 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       onward_route: [^me],
       payload: "PING!",
       return_route: return_route,
-      local_metadata: %{identity: id, channel: :identity_secure_channel}
+      local_metadata: %{identity_id: id, identity: _identity, channel: :identity_secure_channel}
     }
 
     assert id == bob_id
@@ -48,7 +48,7 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       onward_route: [^me],
       payload: "PONG!",
       return_route: [^channel | _],
-      local_metadata: %{identity: id, channel: :identity_secure_channel}
+      local_metadata: %{identity_id: id, identity: _identity, channel: :identity_secure_channel}
     }
 
     assert id == alice_id
@@ -114,7 +114,12 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       onward_route: [^me],
       payload: "PING!",
       return_route: return_route,
-      local_metadata: %{identity: _id, channel: :identity_secure_channel, foo: :bar}
+      local_metadata: %{
+        identity_id: _id,
+        identity: _identity,
+        channel: :identity_secure_channel,
+        foo: :bar
+      }
     }
 
     Ockam.Router.route("PONG!", return_route, [me])
@@ -123,7 +128,12 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       onward_route: [^me],
       payload: "PONG!",
       return_route: [^channel | _],
-      local_metadata: %{identity: _id, channel: :identity_secure_channel, bar: :foo}
+      local_metadata: %{
+        identity_id: _id,
+        identity: _identity,
+        channel: :identity_secure_channel,
+        bar: :foo
+      }
     }
   end
 

--- a/implementations/rust/ockam/ockam_api/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/schema.cddl
@@ -71,7 +71,11 @@ space = {
    ?0: 7574645
     1: space_id
     2: space_name
+    3: identity_id
+    4: gateway_route
 }
+
+gateway_route = text
 
 spaces = [* space]
 
@@ -105,7 +109,7 @@ create_project = {
 project_id   = text
 project_name = text
 service_name = text
-access_route = bytes
+access_route = text
 
 ;;; Identity ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,4 +1,3 @@
-use minicbor::bytes::ByteSlice;
 use minicbor::{Decode, Encode};
 
 use crate::CowStr;
@@ -16,7 +15,7 @@ pub struct Project<'a> {
     #[b(2)] pub name: CowStr<'a>,
     #[b(3)] pub space_name: CowStr<'a>,
     #[b(4)] pub services: Vec<CowStr<'a>>,
-    #[b(5)] pub access_route: &'a ByteSlice,
+    #[b(5)] pub access_route: CowStr<'a>,
 }
 
 #[derive(Encode, Debug)]
@@ -84,7 +83,7 @@ mod tests {
                     name: String::arbitrary(g).into(),
                     space_name: String::arbitrary(g).into(),
                     services: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
-                    access_route: b"route"[..].into(),
+                    access_route: String::arbitrary(g).into(),
                 })
             }
         }
@@ -254,7 +253,7 @@ mod tests {
                                 .iter()
                                 .map(|x| x.to_string().into())
                                 .collect(),
-                            access_route: b"route"[..].into(),
+                            access_route: String::arbitrary(&mut rng).into(),
                         };
                         Response::ok(req.id()).body(&obj).encode(buf)?;
                         self.0.insert(obj.id.to_string(), obj);

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -13,6 +13,8 @@ pub struct Space<'a> {
     #[n(0)] pub tag: TypeTag<7574645>,
     #[b(1)] pub id: CowStr<'a>,
     #[b(2)] pub name: CowStr<'a>,
+    #[b(3)] pub gateway_route: CowStr<'a>,
+    #[b(4)] pub identity_id: CowStr<'a>,
 }
 
 #[derive(Encode, Debug)]
@@ -73,6 +75,8 @@ pub mod tests {
                     tag: Default::default(),
                     id: String::arbitrary(g).into(),
                     name: String::arbitrary(g).into(),
+                    gateway_route: String::arbitrary(g).into(),
+                    identity_id: String::arbitrary(g).into(),
                 })
             }
         }
@@ -216,6 +220,8 @@ pub mod tests {
                             tag: TypeTag,
                             id: u32::arbitrary(&mut rng).to_string().into(),
                             name: space.name.to_string().into(),
+                            identity_id: u32::arbitrary(&mut rng).to_string().into(),
+                            gateway_route: "api".into(),
                         };
                         Response::ok(req.id()).body(&obj).encode(buf)?;
                         self.0.insert(obj.id.to_string(), obj);

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,13 +1,12 @@
 use anyhow::anyhow;
 use clap::Args;
 
-use ockam::{Context, TcpTransport};
-use ockam_api::cloud::MessagingClient;
-use ockam_multiaddr::MultiAddr;
-
 use crate::old::identity::load_or_create_identity;
 use crate::util::{embedded_node, DEFAULT_CLOUD_ADDRESS};
 use crate::IdentityOpts;
+use ockam::{AsyncTryClone, Context, TcpTransport};
+use ockam_api::cloud::MessagingClient;
+use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -32,14 +31,31 @@ impl DeleteCommand {
 async fn delete(mut ctx: Context, cmd: DeleteCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
     let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    api.delete_space(&cmd.id).await?;
-    println!("Space deleted");
+
+    // We built two different messaging clients, because the route they connect
+    // to is different.
+    // Both had to access the identity.
+    // Had to clone the identity here this is 100% ugly and should be a better way.
+    let identity_copy = identity.async_try_clone().await?;
+    let mut api = MessagingClient::new(route, identity_copy, &ctx).await?;
+    let spaces = api.list_spaces().await?;
+    match spaces.iter().find(|s| s.id == cmd.id) {
+        None => println!("Space {} not found", &cmd.id),
+        Some(space) => {
+            // TODO: Also use the provided identity_id on the space' list response
+            //       to authenticate the other end
+            let r: &str = space.gateway_route.as_ref();
+            let addr = MultiAddr::try_from(r)?;
+            let route = ockam_api::multiaddr_to_route(&addr)
+                .ok_or_else(|| anyhow!("failed to parse project route"))?;
+            let mut api = MessagingClient::new(route, identity, &ctx).await?;
+            api.delete_space(&cmd.id).await?;
+        }
+    }
     ctx.stop().await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use clap::Args;
 
-use ockam::{Context, TcpTransport};
+use ockam::{AsyncTryClone, Context, TcpTransport};
 use ockam_api::cloud::MessagingClient;
 use ockam_multiaddr::MultiAddr;
 
@@ -29,18 +29,41 @@ impl ShowCommand {
     }
 }
 
+//TODO: there is lot of repetition between this and the delete command for example.
+//      Ideally, would want to do something like
+//          through_space_gateway(ctx, cmd.identity_opts, |api| api.show(&cmd.id))
+//      on one, and
+//          through_space_gateway(ctx, cmd.identity_opts, |api| api.delete(&cmd.id))
+//      on the other, but hit a problem about "async clousures are unstable", so here is it.
 async fn show(mut ctx: Context, cmd: ShowCommand) -> anyhow::Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
-    // TODO: The identity below will be used to create a secure channel when cloud nodes support it.
     let identity = load_or_create_identity(&ctx, cmd.identity_opts.overwrite).await?;
 
     let route = ockam_api::multiaddr_to_route(&cmd.addr)
         .ok_or_else(|| anyhow!("failed to parse address"))?;
-    let mut api = MessagingClient::new(route, identity, &ctx).await?;
-    let res = api.get_space(&cmd.id).await?;
-    println!("{res:#?}");
 
+    // We built two different messaging clients, because the route they connect
+    // to is different.
+    // Both had to access the identity.
+    // Had to clone the identity here this is 100% ugly and should be a better way.
+    let identity_copy = identity.async_try_clone().await?;
+    let mut api = MessagingClient::new(route, identity_copy, &ctx).await?;
+    let spaces = api.list_spaces().await?;
+    match spaces.iter().find(|s| s.id == cmd.id) {
+        None => println!("Space {} not found", &cmd.id),
+        Some(space) => {
+            // TODO: Also use the provided identity_id on the space' list response
+            //       to authenticate the other end
+            let r: &str = space.gateway_route.as_ref();
+            let addr = MultiAddr::try_from(r)?;
+            let route = ockam_api::multiaddr_to_route(&addr)
+                .ok_or_else(|| anyhow!("failed to parse project route"))?;
+            let mut api = MessagingClient::new(route, identity, &ctx).await?;
+            let res = api.get_space(&cmd.id).await?;
+            println!("{res:#?}");
+        }
+    }
     ctx.stop().await?;
     Ok(())
 }


### PR DESCRIPTION
`show` and `delete` commands uses the new space-specific gateway route as returned by the `list` command. 
`list` and `create` uses the main gateway, as they aren't talking to any particular space.

This implements the ocam command part, as well as required changes on elixir lib.


<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [X] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
