### PR TITLE
add draft release support

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -6,6 +6,9 @@ on:
       git_tag:
         description: Git Tag To Release From. Last Git Tag Is Used If Omitted
         required: false
+      branch_name:
+        description: New Branch To Bump Crates
+        required: true
       modified_release:
         description: Crates That Are To Follow A Different Release Version
         required: false
@@ -45,30 +48,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Branch Name
-        id: branch
-        run: echo "::set-output name=name::release_$(date +'%d-%m-%Y')"
-
       - name: Checkout To New Release Branch
         id: commit
         run: |
-          git checkout -B ${{ steps.branch.outputs.name }}
+          git checkout -B ${{ github.event.inputs.branch_name }}
           sha=$(git rev-parse HEAD)
           echo "::set-output name=sha::$sha"
 
-
       - name: Import GPG key
-        id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba
-        env:
-          GPG_PRIVATE_KEY: '${{ secrets.GPG_PRIVATE_KEY }}'
-          PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'
-
-      - name: Add GPG Key
-        run: |
-          git config --global user.email "${{ secrets.GPG_EMAIL }}"
-          git config --global user.name "${{ secrets.GPG_USER_NAME }}"
-          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
+        uses: build-trust/.github/actions/import_gpg@custom-actions
+        with:
+          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
+          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
+          gpg_name: '${{ secrets.GPG_USER_NAME }}'
+          gpg_email: '${{ secrets.GPG_EMAIL }}'
 
       - name: Bump Ockam
         shell: bash
@@ -93,4 +86,4 @@ jobs:
           git add .
           git commit -S -m "ci: crate release $(date +'%d-%m-%Y')"
 
-          git push --set-upstream origin ${{ steps.branch.outputs.name }}
+          git push --set-upstream origin ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/ockam-package.yml
+++ b/.github/workflows/ockam-package.yml
@@ -1,0 +1,142 @@
+name: Ockam Package Publish
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Ockam tag to build'
+        required: true
+      binaries_sha:
+        description: 'Ockam Release Assets SHA'
+        required: false
+      is_release:
+        description: 'Indicate If Workflow Is To Release Ockam Package Or Be A Draft'
+        type: choice
+        default: false
+        options:
+        - false
+        - true
+
+permissions: write-all
+  # contents: read
+
+env:
+  DEPLOYMENT_NAME: ockam
+  ARTIFACT_NAME: ockam
+
+jobs:
+  build-and-publish-artifact:
+    if: github.event.inputs.is_release == 'false'
+    name: "Build & publish Artifact"
+    runs-on: ubuntu-20.04
+    environment: release
+
+    steps:
+      - name: Checker
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -ex
+          mkdir assets && cd assets
+          gh release download ${{ github.event.inputs.tag }} -R build-trust/ockam
+
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        with:
+          path: ockam
+
+      - id: image
+        shell: bash
+        run: |
+          tag_name="${{ github.event.inputs.tag }}"
+          version=${tag_name:6}
+          echo ::set-output name=image::"ghcr.io/build-trust/$ARTIFACT_NAME:${version}-draft"
+
+      - name: Update Docker Template
+        shell: bash
+        run: |
+          set -x
+          temp_dir=$(mktemp -d)
+          cp ./ockam/tools/templates/ockam.dockerfile $temp_dir/Dockerfile
+          cd $temp_dir
+
+          binaries=(${{ github.event.inputs.binaries_sha }})
+
+          for binary in ${binaries[@]}; do
+            echo "$binary"
+            file=(${binary//:/ })
+            echo "${file[@]}"
+
+            if [[ ${file[0]} == *".so"* || ${file[0]} == *".sig"* ]]; then
+              echo "elixir nif library found, skipping."
+              continue
+            fi
+
+            sed -i "s/${file[0]}_sha256_value/${file[1]}/g" Dockerfile
+          done
+
+          cat Dockerfile
+          cp Dockerfile $GITHUB_WORKSPACE/ockam/tools/templates
+
+      - uses: docker/login-action@25c0ca8bab9893f0962d4ffd043f2b7ab90e9a3f
+        with:
+          registry: ghcr.io
+          username: build-trust
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v2
+
+      - id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build And Publish As Draft
+        run: |
+          tag_name="${{ github.event.inputs.tag }}"
+          version=${tag_name:6}
+
+          docker buildx build --push \
+            --tag ghcr.io/build-trust/ockam:${version}-draft \
+            --file ./ockam/tools/templates/Dockerfile \
+            --platform linux/amd64,linux/arm64/v8 .
+
+
+  make-latest:
+    if: github.event.inputs.is_release == 'true'
+    name: "Make version of ockam also latest"
+    runs-on: ubuntu-20.04
+    environment: release
+    steps:
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - uses: docker/login-action@25c0ca8bab9893f0962d4ffd043f2b7ab90e9a3f
+        with:
+          registry: ghcr.io
+          username: build-trust
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Version
+        id: image
+        run: |
+          tag_name="${{ github.event.inputs.tag }}"
+          version=${tag_name:6}
+          echo ::set-output name=version::"${version}"
+
+      - name: Deploy Latest Image
+        shell: bash
+        run: |
+          set -o xtrace
+
+          docker pull ghcr.io/build-trust/ockam:${{ steps.image.outputs.version }}-draft
+
+          manifest=$(docker manifest inspect -v ghcr.io/build-trust/ockam:${{ steps.image.outputs.version }}-draft)
+          refs=$(echo $manifest | jq -r .[].Descriptor.digest)
+
+          amended_refs=""
+          for ref in ${refs[@]}; do
+            amended_refs=" ${amended_refs[@]} --amend ghcr.io/build-trust/ockam@$ref"
+          done
+
+          docker manifest create ghcr.io/build-trust/ockam:${{ steps.image.outputs.version }} $amended_refs
+          docker manifest push ghcr.io/build-trust/ockam:${{ steps.image.outputs.version }}
+
+          docker manifest create ghcr.io/build-trust/ockam:latest $amended_refs
+          docker manifest push ghcr.io/build-trust/ockam:latest

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -9,6 +9,9 @@ on:
       exclude_crates:
         description: Exclude Specific Crates From Being Published
         required: false
+      release_branch:
+        description: Release Branch Where Recent Bump Occured
+        required: true
       recent_failure:
         description: Indicate A Recent Failure
         type: choice
@@ -24,14 +27,15 @@ permissions:
 jobs:
   publish_crates:
     runs-on: ubuntu-20.04
-    environment: release
     container:
       image: ghcr.io/build-trust/ockam-builder@sha256:a04b6a0aa01a93ba9a5c67392872893b261772dedfcd58f72a1addacf7535c09
+    environment: release
     steps:
       - name: Checkout Ockam
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_branch }}
 
       - name: Publish Ockam Crates
         shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,6 +6,9 @@ on:
       git_tag:
         description: Git Tag To Release From. Last Git Tag Is Used If Omitted
         required: false
+      release_branch:
+        description: Release Branch Where Recent Bump Occured
+        required: true
 
 permissions:
   # Contents permission allows us write to this repository.
@@ -24,6 +27,15 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_branch }}
+
+      - name: Import GPG key
+        uses: build-trust/.github/actions/import_gpg@custom-actions
+        with:
+          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
+          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
+          gpg_name: '${{ secrets.GPG_USER_NAME }}'
+          gpg_email: '${{ secrets.GPG_EMAIL }}'
 
       - name: Get Release Text
         shell: bash
@@ -149,23 +161,8 @@ jobs:
           echo "$text" > release_note.md
           cat release_note.md
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba
-        env:
-          GPG_PRIVATE_KEY: '${{ secrets.GPG_PRIVATE_KEY }}'
-          PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'
-
-      - name: Ensure Tags Are Signed
-        run: |
-          git config --global user.email "${{ secrets.GPG_EMAIL }}"
-          git config --global user.name "${{ secrets.GPG_USER_NAME }}"
-          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
-          git config --global commit.gpgsign true
-
-      - name: Create Signed Tag
-        run: |
-          git tag -s ${{ steps.release_version.outputs.tag_name }} -m "Ockam Release"
+          # Add tag
+          git tag -s ockam_v$ockam_version -m "Ockam Release"
           git push --tags
 
       - name: Create GitHub release
@@ -212,8 +209,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      with:
+        ref: ${{ github.event.inputs.release_branch }}
+
     - name: Echo Link
       run: echo "${{ needs.create_release.outputs.upload_url }}"
+
     - name: Install Rust
       uses: actions-rs/toolchain@b3ea035039aa8cb07d1f4a5168b0f8065c4a2eeb
       with:
@@ -307,6 +308,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ github.event.inputs.release_branch }}
 
       - name: Install Rust
         uses: actions-rs/toolchain@b3ea035039aa8cb07d1f4a5168b0f8065c4a2eeb
@@ -384,7 +387,7 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release download ${{ needs.create_release.outputs.tag_name }} -R build-trust/ockam
+        run: gh release download ${{ needs.create_release.outputs.tag_name }} -R ${{ github.repository_owner }}/ockam
 
       - name: Generate File SHASum
         shell: bash

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -13,16 +13,57 @@ if [[ -z $RECENT_FAILURE ]]; then
   RECENT_FAILURE=false
 fi
 
+function approve_deployment() {
+  set -e
+  local repository="$1"
+  local run_id="$2"
+  local runner=$(date +'%s')
+
+  # completed waiting queued in_progress
+  while true; do
+    status=$(gh api -H "Accept: application/vnd.github+json" /repos/$owner/$repository/actions/runs/$run_id | jq -r '.status')
+    if [[ $status == "completed" ]]; then
+      echo "Run ID $run_id completed"
+      return
+    elif [[ $status == "waiting" ]]; then
+      # Get actions that need to be approved
+      pending_deployments=$(gh api -H "Accept: application/vnd.github+json" /repos/$owner/$repository/actions/runs/$run_id/pending_deployments)
+      pending_length=$(echo "$pending_deployments" | jq '. | length')
+
+      environments=""
+      for (( c=0; c<$pending_length; c++ )); do
+        environment=$(echo "$pending_deployments" | jq -r ".[$c].environment.id" )
+        environments="$environments $environment"
+      done
+
+      if [[ ! -z $environments ]]; then
+        jq -n  "{environment_ids: [$environments], state: \"approved\", comment: \"Ship It\"}" | gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/$owner/$repository/actions/runs/$run_id/pending_deployments --input -
+      fi
+      sleep 120
+    else
+      sleep 120
+      continue
+    fi
+  done
+}
+
 function ockam_bump() {
+  set -e
   gh workflow run create-release-pull-request.yml --ref develop\
-    -F git_tag="$GIT_TAG" -F modified_release="$MODIFIED_RELEASE"\
+    -F branch_name="$release_name" -F git_tag="$GIT_TAG" -F modified_release="$MODIFIED_RELEASE"\
     -F release_version="$RELEASE_VERSION" -F bumped_dep_crates_version="$BUMPED_DEP_CRATES_VERSION"\
     -R $owner/ockam
 
+  workflow_file_name="create-release-pull-request.yml"
   # Sleep for 10 seconds to ensure we are not affected by Github API downtime.
   sleep 10
   # Wait for workflow run
-  run_id=$(gh run list --workflow=create-release-pull-request.yml -b develop -u $GITHUB_USERNAME -L 1 -R $owner/ockam --json databaseId | jq -r .[0].databaseId)
+  run_id=$(gh run list --workflow="$workflow_file_name" -b develop -u $GITHUB_USERNAME -L 1 -R $owner/ockam --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/ockam
 
   # Merge PR to a new branch to kickstart workflow
@@ -31,37 +72,57 @@ function ockam_bump() {
 }
 
 function ockam_crate_release() {
+  set -e
   gh workflow run publish-crates.yml --ref develop \
-    -F git_tag="$GIT_TAG" -F exclude_crates="$EXCLUDE_CRATES" \
+    -F release_branch="$release_name" -F git_tag="$GIT_TAG" -F exclude_crates="$EXCLUDE_CRATES" \
     -F recent_failure="$RECENT_FAILURE" -R $owner/ockam
   # Sleep for 10 seconds to ensure we are not affected by Github API downtime.
   sleep 10
   # Wait for workflow run
   run_id=$(gh run list --workflow=publish-crates.yml -b develop -u $GITHUB_USERNAME -L 1 -R $owner/ockam --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/ockam
 }
 
 function release_ockam_binaries() {
-  gh workflow run release-binaries.yml --ref develop -F git_tag="$GIT_TAG" -R $owner/ockam
+  set -e
+  gh workflow run release-binaries.yml --ref develop -F git_tag="$GIT_TAG" -F release_branch="$release_name" -R $owner/ockam
   # Wait for workflow run
   sleep 10
   run_id=$(gh run list --workflow=release-binaries.yml -b develop -u $GITHUB_USERNAME -L 1 -R $owner/ockam --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/ockam
 }
 
 function release_ockam_package() {
-  gh workflow run docker_ockam.yml --ref docker -F tag=$1 -R $owner/artifacts
+  set -e
+  tag="$1"
+  file_and_sha="$2"
+  is_release="$3"
+
+
+  gh workflow run ockam-package.yml --ref develop -F tag="$tag" -F binaries_sha="$file_and_sha" -F is_release=$is_release  -R $owner/ockam
   # Wait for workflow run
   sleep 10
-  run_id=$(gh run list --workflow=docker_ockam.yml -b docker -u $GITHUB_USERNAME -L 1 -R $owner/artifacts --json databaseId | jq -r .[0].databaseId)
-  gh run watch $run_id --exit-status -R $owner/artifacts
+  run_id=$(gh run list --workflow=ockam-package.yml -b develop -u $GITHUB_USERNAME -L 1 -R $owner/ockam --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "ockam" $run_id &
+  gh run watch $run_id --exit-status -R $owner/ockam
 }
 
 function homebrew_repo_bump() {
-  gh workflow run create-release-pull-request.yml --ref main -F tag=$1 -R $owner/homebrew-ockam
+  set -e
+  tag=$1
+  file_and_sha=$2
+
+  gh workflow run create-release-pull-request.yml --ref main -F binaries="$file_and_sha" -F branch_name="$release_name" -F tag=$tag -R $owner/homebrew-ockam
   # Wait for workflow run
   sleep 10
   run_id=$(gh run list --workflow=create-release-pull-request.yml -b main -u $GITHUB_USERNAME -L 1 -R $owner/homebrew-ockam --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "homebrew-ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/homebrew-ockam
 
   # Create PR to kickstart workflow
@@ -70,10 +131,13 @@ function homebrew_repo_bump() {
 }
 
 function terraform_repo_bump() {
-  gh workflow run create-release-pull-request.yml --ref main -R $owner/terraform-provider-ockam -F tag=$1
+  set -e
+  gh workflow run create-release-pull-request.yml --ref main -R $owner/terraform-provider-ockam -F tag=$1 -F branch_name=$release_name
   # Wait for workflow run
   sleep 10
   run_id=$(gh run list --workflow=create-release-pull-request.yml -b main -u $GITHUB_USERNAME -L 1 -R $owner/terraform-provider-ockam  --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "terraform-provider-ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/terraform-provider-ockam
 
   # Create PR to kickstart workflow
@@ -82,11 +146,39 @@ function terraform_repo_bump() {
 }
 
 function terraform_binaries_release() {
+  set -e
   gh workflow run release.yml --ref main -R $owner/terraform-provider-ockam -F tag=$1
   # Wait for workflow run
   sleep 10
   run_id=$(gh run list --workflow=release.yml -b main -u $GITHUB_USERNAME -L 1 -R $owner/terraform-provider-ockam  --json databaseId | jq -r .[0].databaseId)
+
+  approve_deployment "terraform-provider-ockam" $run_id &
   gh run watch $run_id --exit-status -R $owner/terraform-provider-ockam
+}
+
+function delete_ockam_draft_package() {
+  set -e
+  versions=$(gh api -H "Accept: application/vnd.github+json" /orgs/build-trust/packages/container/ockam/versions)
+  version_length=$(echo "$versions" | jq '. | length')
+
+  for (( c=0; c<$version_length; c++ )); do
+    id=$(echo "$versions" | jq -r ".[$c].id")
+
+    tags=$(echo "$versions" | jq ".[$c].metadata.container.tags")
+    tags_length=$(echo "$tags" | jq ". | length")
+
+    for (( d=0; d<$tags_length; d++ )); do
+      tag_name=$(echo "$tags" | jq -r ".[$d]")
+
+      if [[ $tag_name == *"-draft"* ]]; then
+        echo -n | gh api \
+          --method DELETE \
+          -H "Accept: application/vnd.github+json" \
+          /orgs/$owner/packages/container/ockam/versions/$id --input -
+        break
+      fi
+    done
+  done
 }
 
 function dialog_info() {
@@ -102,47 +194,91 @@ function success_info() {
 
 if [[ -z $SKIP_OCKAM_BUMP || $SKIP_OCKAM_BUMP == false ]]; then
   ockam_bump
-  dialog_info "Crate bump pull request created.... Please merge pull request and press enter to start binaries release."
-fi
-
-if [[ -z $SKIP_CRATES_IO_PUBLISH || $SKIP_CRATES_IO_PUBLISH == false ]]; then
-  ockam_crate_release
-  success_info "Crates.io publish successful"
+  success_info "Crate bump pull request created.... Starting Ockam crates.io publish."
 fi
 
 if [[ -z $SKIP_OCKAM_BINARY_RELEASE || $SKIP_OCKAM_BINARY_RELEASE == false ]]; then
   release_ockam_binaries
-  dialog_info "Draft release has been created, please vet and publish release then press enter to start homebrew and terraform CI"
-  dialog_info "Script requires draft release to be published and tag created to accurately use latest tag.... Press enter if draft release has been published."
+  success_info "Draft release has been created.... Starting Homebrew release."
 fi
 
 # Get latest tag
 if [[ -z $LATEST_TAG_NAME ]]; then
-  latest_tag_name=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${owner}/ockam/releases/latest | jq -r .tag_name)
-  dialog_info "Latest tag is $latest_tag_name press enter if correct"
+  latest_tag_name=$(gh api -H "Accept: application/vnd.github+json" /repos/$owner/ockam/releases | jq -r .[0].tag_name)
+  if [[ $latest_tag_name != *"ockam_v"* ]]; then
+    echo "Invalid Git Tag gotten"
+  fi
+
+  success_info "Latest tag is $latest_tag_name press enter if correct"
 else
   latest_tag_name="$LATEST_TAG_NAME"
 fi
 
-if [[ -z $SKIP_OCKAM_PACKAGE_RELEASE || $SKIP_OCKAM_PACKAGE_RELEASE  == false ]]; then
-  release_ockam_package $latest_tag_name
-  success_info "Ockam package release successful."
+# Get File hash from draft release
+file_and_sha=""
+
+temp_dir=$(mktemp -d)
+pushd $temp_dir
+gh release download $latest_tag_name -R $owner/ockam
+
+# TODO Ensure that SHA are cosign verified
+while read -r line; do
+  file=($line)
+  if [[ ${file[1]} == *".so"* || ${file[1]} == *".sig"* ]]; then
+    continue
+  fi
+
+  file_and_sha="$file_and_sha ${file[1]}:${file[0]}"
+done < sha256sums.txt
+popd
+rm -rf /tmp/$release_name
+
+echo "File and hash are $file_and_sha"
+
+if [[ -z $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE || $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE  == false ]]; then
+  release_ockam_package $latest_tag_name "$file_and_sha" false
+  success_info "Ockam package draft release successful.... Starting Homebrew release"
 fi
 
 # Homebrew Release
 if [[ -z $SKIP_HOMEBREW_BUMP || $SKIP_HOMEBREW_BUMP == false ]]; then
-  homebrew_repo_bump $latest_tag_name
-  success_info "Homebrew bump successful."
+  homebrew_repo_bump $latest_tag_name "$file_and_sha"
+  success_info "Homebrew release successful.... Starting Terraform Release"
 fi
 
 if [[ -z $SKIP_TERRAFORM_BUMP || $SKIP_TERRAFORM_BUMP == false ]]; then
   terraform_repo_bump $latest_tag_name
 fi
 
-dialog_info "Terraform pull request created, please vet and merge pull request then press enter to start Terraform binary release"
-
 if [[ -z $SKIP_TERRAFORM_BINARY_RELEASE || $SKIP_TERRAFORM_BINARY_RELEASE == false ]]; then
   terraform_binaries_release $latest_tag_name
 fi
 
+dialog_info "Please vet ockam, docker, homebrew and terraform release... Press Enter to merge all changes."
+
+# Release Ockam Github release
+if [[ -z $SKIP_OCKAM_DRAFT_RELEASE || $SKIP_OCKAM_DRAFT_RELEASE == false ]]; then
+  gh release edit $latest_tag_name --draft=false -R $owner/ockam
+fi
+
+# Release Terraform Github release
+if [[ -z $SKIP_TERRAFORM_DRAFT_RELEASE || $SKIP_TERRAFORM_DRAFT_RELEASE == false ]]; then
+  terraform_tag=${latest_tag_name:6}
+  gh release edit $terraform_tag --draft=false -R $owner/terraform-provider-ockam
+fi
+
+# Release Ockam package
+if [[ -z $SKIP_OCKAM_PACKAGE_RELEASE || $SKIP_OCKAM_PACKAGE_RELEASE  == false ]]; then
+  release_ockam_package $latest_tag_name "$file_and_sha" true
+  success_info "Ockam package release successful."
+fi
+
+delete_ockam_draft_package
+
+if [[ -z $SKIP_CRATES_IO_PUBLISH || $SKIP_CRATES_IO_PUBLISH == false ]]; then
+  ockam_crate_release
+  success_info "Crates.io publish successful.... Starting Ockam binary release."
+fi
+
 success_info "Release Done 🚀🚀🚀"
+exit 0

--- a/tools/templates/ockam.dockerfile
+++ b/tools/templates/ockam.dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/build-trust/ockam-builder:latest as builder
+
+COPY assets .
+
+RUN \
+    set -xe; \
+    ls; \
+    case "$(uname -m)" in \
+        aarch64*) \
+            echo "ockam.aarch64-unknown-linux-gnu_sha256_value  ockam.aarch64-unknown-linux-gnu" | sha256sum -c; \
+            mv ockam.aarch64-unknown-linux-gnu /ockam; \
+            ;; \
+        x86_64*) \
+            echo "ockam.x86_64-unknown-linux-gnu_sha256_value  ockam.x86_64-unknown-linux-gnu" | sha256sum -c; \
+            mv ockam.x86_64-unknown-linux-gnu /ockam; \
+            ;; \
+        *) \
+            echo "unknown arch:" \
+            uname -a; \
+            exit 1; \
+        ;; \
+    esac; \
+    chmod u+x /ockam;
+
+FROM gcr.io/distroless/cc@sha256:1dc7ae628f0308f77dac8538b4b246453ac3636aa5ba22084e3d22d59a7f3cca
+COPY --from=builder /ockam /
+ENTRYPOINT ["/ockam"]


### PR DESCRIPTION
Add draft release support. To use this workflow [Github CLI](https://cli.github.com/manual/gh_auth_login) must have scope `package:delete` this is so that we can [delete package versions](https://docs.github.com/en/rest/packages#delete-package-version-for-an-organization)