### PR TITLE
Metaclips/crate io release fix

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.release_branch }}
 
       - name: Publish Ockam Crates
         shell: bash


### PR DESCRIPTION
This PR release ockam crates to crates.io from the develop brach... this will be called after draft release is pushed to production