### PR TITLE
fix(rust): `addr` argument for cloud commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -73,14 +73,14 @@ mod node {
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<Attributes> = dec.decode()?;
-            let cloud_address = req_wrapper.cloud_address;
+            let cloud_address = req_wrapper.route;
             let req_body: Attributes = req_wrapper.req;
             let req_body = RequestEnrollmentToken::new(req_body);
 
             let label = "enrollment_token_generator";
             trace!(target: TARGET, "generating tokens");
 
-            let route = self.api_service_route(&cloud_address, "enrollment_token_authenticator");
+            let route = self.api_service_route(&cloud_address, "enrollment_token_authenticator")?;
             let req_builder = Request::post("v0/").body(req_body);
             match request(ctx, label, "request_enrollment_token", route, req_builder).await {
                 Ok(r) => Ok(r),
@@ -115,7 +115,7 @@ mod node {
             body: AuthenticateToken<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_address = req_wrapper.cloud_address;
+            let cloud_address = req_wrapper.route;
 
             // TODO: add AuthenticateAuth0Token to schema.cddl and use it here
             let schema = None;
@@ -123,13 +123,13 @@ mod node {
             let r = match body {
                 AuthenticateToken::Auth0(body) => {
                     label = "auth0_authenticator";
-                    let route = self.api_service_route(&cloud_address, label);
+                    let route = self.api_service_route(&cloud_address, label)?;
                     let req_builder = Request::post("v0/enroll").body(body);
                     request(ctx, label, schema, route, req_builder).await
                 }
                 AuthenticateToken::EnrollmentToken(body) => {
                     label = "enrollment_token_authenticator";
-                    let route = self.api_service_route(&cloud_address, label);
+                    let route = self.api_service_route(&cloud_address, label)?;
                     let req_builder = Request::post("v0/enroll").body(body);
                     request(ctx, label, schema, route, req_builder).await
                 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -1,5 +1,5 @@
 use minicbor::{Decode, Encode};
-use ockam_core::{self, Address};
+use ockam_core::Route;
 
 use crate::CowStr;
 #[cfg(feature = "tag")]
@@ -19,16 +19,16 @@ pub struct CloudRequestWrapper<'a, T> {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<8956240>,
     #[b(1)] pub req: T,
-    #[b(2)] pub cloud_address: CowStr<'a>,
+    #[b(2)] pub route: CowStr<'a>,
 }
 
 impl<'a, T> CloudRequestWrapper<'a, T> {
-    pub fn new(req: T, cloud_node_address: &Address) -> Self {
+    pub fn new(req: T, route: &Route) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             req,
-            cloud_address: cloud_node_address.to_string().into(),
+            route: route.to_string().into(),
         }
     }
 }
@@ -37,7 +37,7 @@ impl<'a, T> CloudRequestWrapper<'a, T> {
 pub type BareCloudRequestWrapper<'a> = CloudRequestWrapper<'a, ()>;
 
 impl<'a> BareCloudRequestWrapper<'a> {
-    pub fn bare(cloud_node_address: &Address) -> Self {
-        Self::new((), cloud_node_address)
+    pub fn bare(route: &Route) -> Self {
+        Self::new((), route)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -14,15 +14,15 @@ use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct GenerateEnrollmentTokenCommand {
-    /// Attributes (use '=' to separate key from value)
-    #[clap(value_delimiter('='), last = true, required = true)]
-    pub attrs: Vec<String>,
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
 
     #[clap(flatten)]
     node_opts: NodeOpts,
 
-    #[clap(flatten)]
-    pub cloud_opts: CloudOpts,
+    /// Attributes (use '=' to separate key from value)
+    #[clap(value_delimiter('='), last = true, required = true)]
+    pub attrs: Vec<String>,
 }
 
 impl GenerateEnrollmentTokenCommand {

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -17,6 +17,12 @@ mod enrollment_token_generate;
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+
     /// Authenticates an enrollment token
     #[clap(display_order = 1003, long, group = "enroll_params")]
     pub token: Option<String>,
@@ -24,12 +30,6 @@ pub struct EnrollCommand {
     /// Enroll using the Auth0 flow
     #[clap(display_order = 1004, long, group = "enroll_params")]
     auth0: bool,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    #[clap(flatten)]
-    pub cloud_opts: CloudOpts,
 }
 
 impl EnrollCommand {

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -15,6 +15,9 @@ use crate::{CommandGlobalOpts, MessageFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
     /// Ockam's cloud address.
     #[clap(default_value = DEFAULT_CLOUD_ADDRESS)]
     addr: MultiAddr,
@@ -23,9 +26,6 @@ pub struct CreateCommand {
     /// If set, a static forwarder named after the passed alias will be created{n}
     /// Otherwise, it will create an ephemeral forwarder (default)
     alias: Option<String>,
-
-    #[clap(flatten)]
-    node_opts: NodeOpts,
 }
 
 impl CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/mod.rs
@@ -16,14 +16,14 @@ mod reject;
 
 #[derive(Clone, Debug, Args)]
 pub struct InvitationCommand {
-    #[clap(subcommand)]
-    subcommand: InvitationSubcommand,
-
     #[clap(flatten)]
     node_opts: NodeOpts,
 
     #[clap(flatten)]
     cloud_opts: CloudOpts,
+
+    #[clap(subcommand)]
+    subcommand: InvitationSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -16,14 +16,14 @@ mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct ProjectCommand {
-    #[clap(subcommand)]
-    subcommand: ProjectSubcommand,
-
     #[clap(flatten)]
     node_opts: NodeOpts,
 
     #[clap(flatten)]
     cloud_opts: CloudOpts,
+
+    #[clap(subcommand)]
+    subcommand: ProjectSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -16,14 +16,14 @@ mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct SpaceCommand {
-    #[clap(subcommand)]
-    subcommand: SpaceSubcommand,
-
     #[clap(flatten)]
     node_opts: NodeOpts,
 
     #[clap(flatten)]
     cloud_opts: CloudOpts,
+
+    #[clap(subcommand)]
+    subcommand: SpaceSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -6,8 +6,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = [
         "--test-argument-parser",
         "enroll",
-        "--addr",
-        "/dnsaddr/localhost/tcp/4000",
+        "secure-channel-address",
         "-a",
         "node-name",
     ];

--- a/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
@@ -6,7 +6,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = [
         "--test-argument-parser",
         "invitation",
-        "--addr",
         "/dnsaddr/localhost/tcp/4000",
         "-a",
         "node-name",

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -6,7 +6,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = [
         "--test-argument-parser",
         "project",
-        "--addr",
         "/dnsaddr/localhost/tcp/4000",
         "-a",
         "node-name",

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -6,7 +6,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = [
         "--test-argument-parser",
         "space",
-        "--addr",
         "/dnsaddr/localhost/tcp/4000",
         "-a",
         "node-name",

--- a/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
@@ -6,7 +6,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.arg("--test-argument-parser")
         .arg("token")
-        .arg("--addr")
         .arg("/ip4/127.0.0.1/tcp/8080")
         .arg("-a")
         .arg("node-name")


### PR DESCRIPTION
Removes name flag from `addr` argument so it can be used as in the rest of commands that makes
 use of this attribute: `command /dnsaddr/...` instead of `command --addr /dnsaddr/...`.

Makes the `addr` argument able to accept either a MultiAddr or an Address to make it easier to
test against local secure channels and remote nodes.