### PR TITLE
fix(rust): arguments used to create background node

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -94,7 +94,6 @@ impl CreateCommand {
                     "--port",
                     &command.port.to_string(),
                     "--foreground",
-                    "-a",
                     &command.node_name,
                 ])
                 .stdout(main_log_file)


### PR DESCRIPTION
Related PR: https://github.com/build-trust/ockam/pull/2977

I forgot to update the arguments passed when creating a background node.