### PR TITLE
fix(rust): cloud and node arguments set as global

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -57,6 +57,6 @@ impl NodeCommand {
 #[derive(Clone, Debug, Args)]
 pub struct NodeOpts {
     /// Override the default API node
-    #[clap(short, long, default_value = "default")]
+    #[clap(global = true, short, long, default_value = "default")]
     pub api_node: String,
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -24,7 +24,7 @@ pub struct CreateCommand {
     pub project_name: String,
 
     /// Services enabled for this project.
-    #[clap(display_order = 1003)]
+    #[clap(display_order = 1003, last = true)]
     pub services: Vec<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -357,7 +357,7 @@ pub(crate) fn parse_portal_status(resp: &[u8]) -> Result<(Response, PortalStatus
 #[derive(Clone, Debug, Args)]
 pub struct CloudOpts {
     /// Ockam cloud node's address
-    #[clap(default_value = "listener")]
+    #[clap(global = true, default_value = "listener")]
     pub addr: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
@@ -3,19 +3,15 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = [
-        "--test-argument-parser",
-        "invitation",
-        "/dnsaddr/localhost/tcp/4000",
-        "-a",
-        "node-name",
-    ];
+    let prefix_args = ["--test-argument-parser", "invitation"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-id")
-        .arg("invitee@test.com");
+        .arg("invitee@test.com")
+        .args(common_args);
     cmd.assert().success();
 
     // With custom cloud address
@@ -23,19 +19,26 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-id")
-        .arg("invitee@test.com");
+        .arg("invitee@test.com")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list");
+    cmd.args(&prefix_args).arg("list").args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("accept").arg("invitation-id");
+    cmd.args(&prefix_args)
+        .arg("accept")
+        .arg("invitation-id")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("reject").arg("invitation-id");
+    cmd.args(&prefix_args)
+        .arg("reject")
+        .arg("invitation-id")
+        .args(common_args);
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -3,38 +3,40 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = [
-        "--test-argument-parser",
-        "project",
-        "/dnsaddr/localhost/tcp/4000",
-        "-a",
-        "node-name",
-    ];
+    let prefix_args = ["--test-argument-parser", "project"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-id")
         .arg("project-name")
-        .arg("service-a service-b");
+        .arg("--")
+        .arg("service-a")
+        .arg("service-b");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list").arg("space-id");
+    cmd.args(&prefix_args)
+        .arg("list")
+        .arg("space-id")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("show")
         .arg("space-id")
-        .arg("project-id");
+        .arg("project-id")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("delete")
         .arg("space-id")
-        .arg("project-id");
+        .arg("project-id")
+        .args(common_args);
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -3,28 +3,32 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = [
-        "--test-argument-parser",
-        "space",
-        "/dnsaddr/localhost/tcp/4000",
-        "-a",
-        "node-name",
-    ];
+    let prefix_args = ["--test-argument-parser", "space"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("create").arg("space-name");
+    cmd.args(&prefix_args)
+        .arg("create")
+        .arg("space-name")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list");
+    cmd.args(&prefix_args).arg("list").args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("show").arg("space-id");
+    cmd.args(&prefix_args)
+        .arg("show")
+        .arg("space-id")
+        .args(common_args);
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("delete").arg("space-id");
+    cmd.args(&prefix_args)
+        .arg("delete")
+        .arg("space-id")
+        .args(common_args);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
Common arguments of cloud commands (basically `NodeOpts` and `CloudOpts`) were not set as global,
and the user had to write those arguments before the subcommand:
`ockam space <ADDRESS> list ...`

Now, `NodeOpts` and `CloudOpts` have the `global` attribute so that subcommands can use them
as their own arguments:
`ockam space list <ADDRESS> ...`

This is a workaround until https://github.com/build-trust/ockam/issues/2994 is done