### PR TITLE
feat(rust): derive background node's verbosity from input arguments, defaults to debug

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -86,9 +86,16 @@ impl CreateCommand {
                 .open(elog)
                 .expect("failed to open stderr log path");
 
+            let verbose = match opts.global_args.verbose {
+                // Enable logs at DEBUG level by default
+                0 => "-vv".to_string(),
+                // Pass the provided verbosity level to the background node
+                v => format!("-{}", "v".repeat(v as usize)),
+            };
+
             let child = Command::new(ockam)
                 .args([
-                    "-vv", // Enable logs at DEBUG level
+                    &verbose,
                     "node",
                     "create",
                     "--port",


### PR DESCRIPTION
I wanted to record `trace` logs, which are widely used in `ockam_api` but I couldn't set a custom verbosity level to background nodes. With these changes, the default behavior is unchanged, but if you want to modify it, you can just pass the desired level when calling the `create` command:

`ockam create node -vvv` -> will spawn a background node with `trace` verbosity.