### PR TITLE
refactor(rust): auth0 command, extracting auth0 flow out of the node call

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -76,7 +76,6 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::enroll::auth0::Auth0TokenProvider;
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
     use crate::request;
@@ -86,10 +85,7 @@ mod node {
 
     const TARGET: &str = "ockam_api::cloud::invitation";
 
-    impl<A> NodeMan<A>
-    where
-        A: Auth0TokenProvider,
-    {
+    impl NodeMan {
         pub(crate) async fn create_invitation(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -55,7 +55,6 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::enroll::auth0::Auth0TokenProvider;
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
     use crate::request;
@@ -65,10 +64,7 @@ mod node {
 
     const TARGET: &str = "ockam_api::cloud::project";
 
-    impl<A> NodeMan<A>
-    where
-        A: Auth0TokenProvider,
-    {
+    impl NodeMan {
         pub(crate) async fn create_project(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -44,7 +44,6 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::enroll::auth0::Auth0TokenProvider;
     use crate::cloud::space::CreateSpace;
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeMan;
@@ -53,10 +52,7 @@ mod node {
 
     const TARGET: &str = "ockam_api::cloud::space";
 
-    impl<A> NodeMan<A>
-    where
-        A: Auth0TokenProvider,
-    {
+    impl NodeMan {
         pub(crate) async fn create_space(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,7 +1,6 @@
 use clap::Args;
 use std::{env::current_exe, fs::OpenOptions, process::Command, time::Duration};
 
-use crate::enroll::Auth0Service;
 use crate::{
     node::show::query_status,
     util::{connect_to, embedded_node, OckamConfig, DEFAULT_TCP_PORT},
@@ -142,7 +141,6 @@ async fn setup(ctx: Context, (c, cfg): (CreateCommand, OckamConfig)) -> anyhow::
         node_dir,
         (TransportType::Tcp, TransportMode::Listen, bind),
         tcp,
-        Auth0Service,
     )
     .await?;
     ctx.start_worker(NODEMAN_ADDR, node_man).await?;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -127,14 +127,16 @@ pub(crate) mod enroll {
     use crate::enroll::*;
     use anyhow::anyhow;
     use ockam_api::auth::types::Attributes;
+    use ockam_api::cloud::enroll::auth0::{Auth0Token, AuthenticateAuth0Token};
     use ockam_api::cloud::enroll::*;
 
     use super::*;
 
-    pub(crate) fn auth0(cmd: EnrollCommand) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn auth0(cmd: EnrollCommand, token: Auth0Token) -> anyhow::Result<Vec<u8>> {
+        let token = AuthenticateAuth0Token::new(token);
         let mut buf = vec![];
         Request::builder(Method::Post, "v0/enroll/auth0")
-            .body(CloudRequestWrapper::bare(&cmd.cloud_opts.route()?))
+            .body(CloudRequestWrapper::new(token, &cmd.cloud_opts.route()?))
             .encode(&mut buf)?;
         Ok(buf)
     }


### PR DESCRIPTION
This change is needed to avoid timing out while the user is still doing the auth0 flow. Now, once the user is done with the auth0 flow and we receive the token, we send it to the background node and the token is processed right away.

It's also needed to show the `println` calls to the user calling the command showing the information related to the flow (one-time code and status).