### PR TITLE
Changed the help text for -f, --foreground command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -18,7 +18,7 @@ pub struct CreateCommand {
     #[clap(default_value = "default")]
     node_name: String,
 
-    /// Spawn a node in the background.
+    /// Spawn a node in the foreground.
     #[clap(display_order = 900, long, short)]
     foreground: bool,
 


### PR DESCRIPTION
Fix #2991

The previous help text on the -f, --foreground command stated the opposite behavior of what the command does.

<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Simple change to `foreground` in the text.
Fixes [this issue](https://github.com/build-trust/ockam/issues/2991)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
