### PR TITLE
`ockam node show` and `ockam node delete` should take target node as last argument

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,4 +1,3 @@
-use crate::node::NodeOpts;
 use crate::CommandGlobalOpts;
 use clap::Args;
 use nix::sys::signal::{self, Signal};
@@ -6,8 +5,9 @@ use nix::unistd::Pid;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
+    /// Name of the node.
+    #[clap(default_value = "default")]
+    node_name: String,
 
     /// Should the node be terminated with SIGKILL instead of SIGTERM
     #[clap(display_order = 900, long, short)]
@@ -16,7 +16,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
-        delete_node(&opts, &command.node_opts.api_node, command.sigkill);
+        delete_node(&opts, &command.node_name, command.sigkill);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,4 +1,3 @@
-use crate::node::NodeOpts;
 use crate::util::{self, api, connect_to};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
@@ -8,14 +7,15 @@ use ockam_api::nodes::{types::NodeStatus, NODEMAN_ADDR};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
+    /// Name of the node.
+    #[clap(default_value = "default")]
+    node_name: String,
 }
 
 impl ShowCommand {
     pub fn run(opts: CommandGlobalOpts, command: ShowCommand) {
         let cfg = &opts.config;
-        let port = match cfg.get_inner().nodes.get(&command.node_opts.api_node) {
+        let port = match cfg.get_inner().nodes.get(&command.node_name) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/tests/cmd_node.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_node.rs
@@ -1,0 +1,40 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+
+#[test]
+fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
+    // show node success
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("node")
+        .arg("show")
+        .arg("node-name");
+    cmd.assert().success();
+
+    // show node failure
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("node")
+        .arg("show")
+        .arg("--api-node")
+        .arg("node-name");
+    cmd.assert().failure();
+
+    // delete node success
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("node")
+        .arg("delete")
+        .arg("node-name");
+    cmd.assert().success();
+
+    // delete node failure
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.arg("--test-argument-parser")
+        .arg("node")
+        .arg("delete")
+        .arg("--api-node")
+        .arg("node-name");
+    cmd.assert().failure();
+    Ok(())
+}


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behaviour

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
Currently, the node commands `show` and `delete` require that the last argument be `--api-node some-node`. 

Example:
`ockam node show --api-node green`
and
`ockam node delete --api-node green`

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
Switching out the `NodeOpts` sruct, which creates the `--api-node` argument during flattening, for a simple field `node_name` on the respective command structs will result in being able to pass `node-name` as the last argument for these commands.

<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Fixes #2988
Fixes #2989

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://www.ockam.io/learn/how-to-guides/contributing/CONTRIBUTING#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://www.ockam.io/learn/how-to-guides/high-performance-team/conduct/).
- [x] I have accepted the Ockam [Contributor License Agreement](https://www.ockam.io/learn/how-to-guides/contributing/cla/) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/contributors](https://github.com/build-trust/contributors) repository.

<!-- Looking forward to merging your contribution!! -->
