### PR TITLE
doc fix

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,6 +53,14 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
 
       - name: Check that example source and guide code blocks match
-        run: OCKAM_HOME=$PWD tools/docs/check_documentation.sh
+        id: cache
+        run: |
+          OCKAM_HOME=$PWD bash -ex tools/docs/check_documentation.sh
+
+          # Only cache rust build if example blocks code was built
+          if [[ ls target ]]; then
+            echo "::set-output name=is_cached::true"
+          fi
 
       - uses: ./.github/actions/cargo_target_dir_pre_cache
+        if: steps.cache.outputs.is_cached


### PR DESCRIPTION
[We are caching cargo binaries](https://github.com/build-trust/ockam/blob/c64c1cafdf4e203d20db9c588557a828ebfb0b39/.github/actions/cargo_home_cache/action.yml#L9) for all rust builds, [check documentation checks if example_block binary exist](https://github.com/build-trust/ockam/blob/c64c1cafdf4e203d20db9c588557a828ebfb0b39/tools/docs/check_documentation.sh#L29) (which is always true for every successful cache download), [and doesn't build example_blocks binary](https://github.com/build-trust/ockam/blob/c64c1cafdf4e203d20db9c588557a828ebfb0b39/tools/docs/check_documentation.sh#L29) if cache download is successful, leading to `target` directory not being created and cache failing as there's no target directory to upload. We now only perform caching only if Rust code is built.