### PR TITLE
chore(rust): add missing `cfg` directives to fix `no_std` build

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -1,4 +1,19 @@
 //! Attribute Based Access Control
+#![warn(
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate core;
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub mod error;
 

--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -3,6 +3,8 @@ use crate::{Action, Key, Resource, Subject, Value};
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use serde::{Deserialize, Serialize};
 
+use alloc::vec;
+
 /// Pimitive conditional operators used to construct ABAC policies.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Conditional {

--- a/implementations/rust/ockam/ockam_abac/src/types.rs
+++ b/implementations/rust/ockam/ockam_abac/src/types.rs
@@ -1,10 +1,13 @@
-use core::fmt;
 use ockam_core::compat::{
     collections::BTreeMap,
     string::{String, ToString},
 };
 use ockam_identity::IdentityIdentifier;
+
 use serde::{Deserialize, Serialize};
+
+use alloc::format;
+use core::fmt;
 
 /// TODO ockam_identity::IdentityIdentifier ?
 pub type Identity = String;


### PR DESCRIPTION
This PR fixes `ockam_abac` crate `no_std` build failure.