### PR TITLE
feat(rust): `node create` default to a random 4 byte hex string

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,4 +1,6 @@
 use clap::Args;
+use rand::prelude::random;
+
 use std::{env::current_exe, fs::OpenOptions, process::Command, time::Duration};
 
 use crate::{
@@ -15,7 +17,7 @@ use ockam_api::{
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the node.
-    #[clap(default_value = "default")]
+    #[clap(default_value_t = hex::encode(&random::<[u8;4]>()))]
     node_name: String,
 
     /// Spawn a node in the foreground.


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
Currently issuing `ockam node create` results in the `node_name` defaulting to `default`.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
Instead of providing a default string for `node_name`, we generate a random 4 byte hex string as the default `node_name` 

<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Fixes #3036 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
