### PR TITLE
Rename `--api-node` and provide `-a` option to `delete` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -10,7 +10,7 @@ pub struct DeleteCommand {
     node_opts: NodeOpts,
 
     /// Terminate all nodes
-    #[clap(long)]
+    #[clap(long, short)]
     all: bool,
 
     /// Should the node be terminated with SIGKILL instead of SIGTERM

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -50,6 +50,6 @@ impl NodeCommand {
 #[derive(Clone, Debug, Args)]
 pub struct NodeOpts {
     /// Override the default API node
-    #[clap(global = true, short, long, default_value = "default")]
+    #[clap(global = true, name = "node", short, long, default_value = "default")]
     pub api_node: String,
 }

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -7,7 +7,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         "--test-argument-parser",
         "enroll",
         "/dnsaddr/cloud.ockam.io/tcp/62526",
-        "-a",
+        "-n",
         "node-name",
     ];
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
@@ -9,7 +9,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("create")
         .arg("/ip4/127.0.0.1/tcp/8080")
         .arg("forwarder_alias")
-        .arg("-a")
+        .arg("-n")
         .arg("node-name");
     cmd.assert().success();
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_invitation.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "invitation"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-n", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "project"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-n", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "space"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000", "-a", "node-name"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000", "-n", "node-name"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)

--- a/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_token.rs
@@ -7,7 +7,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("token")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("-a")
+        .arg("-n")
         .arg("node-name")
         .arg("--")
         .arg("k1=v1")


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

- Currently, commands that use `NodeOpts` has it assigned via `-a, --api-node`. 
- Deleting all nodes gets issued via the command `node delete --all`.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
- Provide the `name = "node"` for the `api_node` field in the `NodeOpts` struct. 
- Add `short` to the `all` field in the `delete` subcommand to expose the `-a` option.
 
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Fixes #3037 
Fixes #3038 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
