### PR TITLE
Replaced --port argument with new --api-address argument

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -2,10 +2,11 @@ use clap::Args;
 use rand::prelude::random;
 
 use std::{env::current_exe, fs::OpenOptions, process::Command, time::Duration};
+use std::net::SocketAddr;
 
 use crate::{
     node::show::query_status,
-    util::{connect_to, embedded_node, OckamConfig, DEFAULT_TCP_PORT},
+    util::{connect_to, embedded_node, OckamConfig, DEFAULT_API_ADDRESS},
     CommandGlobalOpts,
 };
 use ockam::{Context, TcpTransport};
@@ -28,9 +29,9 @@ pub struct CreateCommand {
     #[clap(display_order = 901, long, short)]
     skip_defaults: bool,
 
-    /// Specify the API port
-    #[clap(default_value_t = DEFAULT_TCP_PORT, long, short)]
-    port: u16,
+    /// Specify the API address
+    #[clap(default_value = DEFAULT_API_ADDRESS, long, short)]
+    api_address: String,
 
     #[clap(long, hide = true)]
     no_watchdog: bool,
@@ -38,13 +39,16 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
         let cfg = &opts.config;
+        let address: SocketAddr = command.api_address.parse()
+            .expect("failed to parse api address");
+
         if command.foreground {
             // HACK: try to get the current node dir.  If it doesn't
             // exist the user PROBABLY started a non-detached node.
             // Thus we need to create the node dir so that subsequent
             // calls to it don't fail
             if cfg.get_node_dir(&command.node_name).is_err() {
-                if let Err(e) = cfg.create_node(&command.node_name, command.port, 0) {
+                if let Err(e) = cfg.create_node(&command.node_name, address.port(), 0) {
                     eprintln!(
                         "failed to update node configuration for '{}': {:?}",
                         command.node_name, e
@@ -61,7 +65,7 @@ impl CreateCommand {
             let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
 
             // FIXME: not really clear why this is causing issues
-            if cfg.port_is_used(command.port) {
+            if cfg.port_is_used(address.port()) {
                 eprintln!("Another node is listening on the provided port!");
                 std::process::exit(-1);
             }
@@ -69,7 +73,7 @@ impl CreateCommand {
             // First we create a new node in the configuration so that
             // we can ask it for the correct log path, as well as
             // making sure the watchdog can do its job later on.
-            if let Err(e) = cfg.create_node(&command.node_name, command.port, 0) {
+            if let Err(e) = cfg.create_node(&command.node_name, address.port(), 0) {
                 eprintln!(
                     "failed to update node configuration for '{}': {:?}",
                     command.node_name, e
@@ -102,8 +106,8 @@ impl CreateCommand {
                 verbose,
                 "node".to_string(),
                 "create".to_string(),
-                "--port".to_string(),
-                command.port.to_string(),
+                "--api-address".to_string(),
+                command.api_address,
                 "--foreground".to_string(),
             ];
 
@@ -137,14 +141,14 @@ impl CreateCommand {
             std::thread::sleep(Duration::from_millis(500));
 
             // Then query the node manager for the status
-            connect_to(command.port, (), query_status);
+            connect_to(address.port(), (), query_status);
         }
     }
 }
 
 async fn setup(ctx: Context, (c, cfg): (CreateCommand, OckamConfig)) -> anyhow::Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
-    let bind = format!("0.0.0.0:{}", c.port);
+    let bind = c.api_address;
     tcp.listen(&bind).await?;
 
     let node_dir = cfg.get_node_dir(&c.node_name).unwrap(); // can't fail because we already checked it

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 pub const DEFAULT_CLOUD_ADDRESS: &str = "/dnsaddr/cloud.ockam.io/tcp/62526";
-pub const DEFAULT_TCP_PORT: u16 = 62526;
+pub const DEFAULT_API_ADDRESS: &str = "127.0.0.1:62526";
 
 /// A simple wrapper for shutting down the local embedded node (for
 /// the client side of the CLI).  Swallows errors and turns them into


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
Currently there is a --port argument in the ´node create´ command which determines the port the node should listen on.
The default and hardcoded IP-Address is 0.0.0.0
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Issue: #3039
Replacing the --port argument with a --api-address argument where you can set the IP address and the port number.
 
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
