### PR TITLE
feat(rust): find available port when running `node create`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -6,14 +6,14 @@ pub use addon::AddonCommand;
 mod config;
 pub use config::{ConfigError, NodeConfig, OckamConfig};
 
+use anyhow::Context;
 use ockam::{route, NodeBuilder, Route, TcpTransport, TCP};
-use std::{env, path::Path};
+use std::{env, net::TcpListener, path::Path};
 use tracing::error;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 pub const DEFAULT_CLOUD_ADDRESS: &str = "/dnsaddr/cloud.ockam.io/tcp/62526";
-pub const DEFAULT_API_ADDRESS: &str = "127.0.0.1:62526";
 
 /// A simple wrapper for shutting down the local embedded node (for
 /// the client side of the CLI).  Swallows errors and turns them into
@@ -86,6 +86,14 @@ where
     if let Err(e) = res {
         eprintln!("Ockam node failed: {:?}", e,);
     }
+}
+
+pub fn find_available_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("Unable to bind to an open port")?;
+    let address = listener
+        .local_addr()
+        .context("Unable to get local address")?;
+    Ok(address.port())
 }
 
 pub fn setup_logging(verbose: u8) {


### PR DESCRIPTION
find an available port when creating a node when no `api_address` is provided,
so that `ockam node create` can be run multiple times in a row without trying to bind to an existing port

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
`ockam create node` defaults to an address of `127.0.0.1:62526`.  This prevents repeat runs of `ockam create node` from succeeding as it will try to bind to the already in use port of `62526`
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Per #3063, find an available port that can be used each time `ockam create node` is run
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
