### PR TITLE
ci: use `cargo add` in crate install instructions

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -131,10 +131,10 @@ jobs:
 
           # Rust Crates
 
-          To use Ockam as a Rust library, add the following line to your Cargo.toml file:
+          To use Ockam as a Rust library, run the following command within your project directory:
 
-          \`\`\`
-          ockam = \"$ockam_version\"
+          \`\`\`bash
+          cargo add ockam@$ockam_version
           \`\`\`
 
           The following crates were published as part of this release:


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

When CI runs, the generated install instructions for adding `ockam` as a library to a project instructs the user to add `ockam = "latest-and-greatest"` to the `Cargo.toml` file.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Since cargo has the subcommand `cargo add` to add in library dependencies "nicely", we change the install instructions to direct the user to issue the command `cargo add ockam@latest-and-greatest` within their project directory to have `cargo` manipulate the `Cargo.toml` file for the user.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Fixes #3058

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
