### PR TITLE
feat(rust): Rename Ockam Command MessageFormat to OutputFormat

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct GenerateEnrollmentTokenCommand {
@@ -59,9 +59,9 @@ async fn generate(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<EnrollmentToken>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("Token generated successfully: {:?}", body.token),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("Token generated successfully: {:?}", body.token),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -12,7 +12,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
 use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -70,12 +70,12 @@ async fn create(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<ForwarderInfo>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!(
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!(
                     "Forwarder created! You can send messages to it via this address:\n{}",
                     body.remote_address()
                 ),
-                MessageFormat::Json => json!({
+                OutputFormat::Json => json!({
                     "remote_address": body.remote_address(),
                 })
                 .to_string(),

--- a/implementations/rust/ockam/ockam_command/src/invitation/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/create.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -65,9 +65,9 @@ async fn create(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Invitation>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => "Invitation created".to_string(),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => "Invitation created".to_string(),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/invitation/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/invitation/list.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand;
@@ -53,9 +53,9 @@ async fn list(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Vec<Invitation>>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("{body:#?}"),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("{body:#?}"),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -98,8 +98,14 @@ pub struct GlobalArgs {
     )]
     verbose: u8,
 
-    #[clap(global = true, long, short, value_enum, default_value = "plain")]
-    message_format: MessageFormat,
+    #[clap(
+        global = true,
+        long = "format",
+        short = 'f',
+        value_enum,
+        default_value = "plain"
+    )]
+    output_format: OutputFormat,
 
     // if test_argument_parser is true, command arguments are checked
     // but the command is not executed.
@@ -108,7 +114,7 @@ pub struct GlobalArgs {
 }
 
 #[derive(Debug, Clone, ArgEnum)]
-pub enum MessageFormat {
+pub enum OutputFormat {
     Plain,
     Json,
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -66,9 +66,9 @@ async fn create(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Project>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => "Project created".to_string(),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => "Project created".to_string(),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -61,9 +61,9 @@ async fn delete(
 
     let res = match header.status() {
         Some(Status::Ok) => {
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => "Project deleted".to_string(),
-                MessageFormat::Json => json!({
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => "Project deleted".to_string(),
+                OutputFormat::Json => json!({
                     "id": project_id,
                 })
                 .to_string(),

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand;
@@ -53,9 +53,9 @@ async fn list(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Vec<Project>>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("{body:#?}"),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("{body:#?}"),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -66,9 +66,9 @@ async fn show(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Project>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("{body:#?}"),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("{body:#?}"),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -65,9 +65,9 @@ async fn create(
             let body = dec
                 .decode::<Space>()
                 .context("Failed to decode response body")?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => "Space created".to_string(),
-                MessageFormat::Json => serde_json::to_string(&body)
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => "Space created".to_string(),
+                OutputFormat::Json => serde_json::to_string(&body)
                     .context("Failed to serialize command output as json")?,
             };
             Ok(output)

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -57,9 +57,9 @@ async fn delete(
 
     let res = match header.status() {
         Some(Status::Ok) => {
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => "Space deleted".to_string(),
-                MessageFormat::Json => json!({
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => "Space deleted".to_string(),
+                OutputFormat::Json => json!({
                     "id": space_id,
                 })
                 .to_string(),

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand;
@@ -53,9 +53,9 @@ async fn list(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Vec<Space>>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("{body:#?}"),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("{body:#?}"),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
 use crate::util::{api, connect_to, stop_node};
-use crate::{CommandGlobalOpts, MessageFormat};
+use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -57,9 +57,9 @@ async fn show(
     let res = match header.status() {
         Some(Status::Ok) => {
             let body = dec.decode::<Space>()?;
-            let output = match opts.global_args.message_format {
-                MessageFormat::Plain => format!("{body:#?}"),
-                MessageFormat::Json => serde_json::to_string(&body)?,
+            let output = match opts.global_args.output_format {
+                OutputFormat::Plain => format!("{body:#?}"),
+                OutputFormat::Json => serde_json::to_string(&body)?,
             };
             Ok(output)
         }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

ockam command takes `-m` or `--message-format <MESSAGE_FORMAT>` options

## Proposed Changes

change options to `-f` or `--format <OUTPUT_FORMAT>`
change enum name to `OutputFormat`
change varialb ename to `output_format`
fixes #2990 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
