### PR TITLE
Split `SecureChannel` into `Self` and `SecureChannelL…

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -11,6 +11,7 @@ mod node;
 mod portal;
 mod project;
 mod secure_channel;
+mod secure_channel_listener;
 mod service;
 mod space;
 mod transport;
@@ -27,6 +28,7 @@ use node::NodeCommand;
 use portal::PortalCommand;
 use project::ProjectCommand;
 use secure_channel::SecureChannelCommand;
+use secure_channel_listener::SecureChannelListenerCommand;
 use space::SpaceCommand;
 use transport::TransportCommand;
 
@@ -193,6 +195,10 @@ pub enum OckamSubcommand {
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     SecureChannel(SecureChannelCommand),
 
+    /// Manage Secure Channel Listeners
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    SecureChannelListener(SecureChannelListenerCommand),
+
     /// Manage Services
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Service(ServiceCommand),
@@ -269,6 +275,9 @@ pub fn run() {
         OckamSubcommand::Vault(command) => VaultCommand::run(opts, command),
         OckamSubcommand::Identity(command) => IdentityCommand::run(opts, command),
         OckamSubcommand::SecureChannel(command) => SecureChannelCommand::run(opts, command),
+        OckamSubcommand::SecureChannelListener(command) => {
+            SecureChannelListenerCommand::run(opts, command)
+        }
         OckamSubcommand::Service(command) => ServiceCommand::run(opts, command),
 
         // OLD

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -9,7 +9,7 @@ use ockam_api::error::ApiError;
 use ockam_api::nodes::models::secure_channel::CreateSecureChannelResponse;
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_api::{route_to_multiaddr, Response, Status};
-use ockam_core::{route, Address, Route};
+use ockam_core::{route, Route};
 use ockam_multiaddr::MultiAddr;
 use tracing::debug;
 
@@ -20,18 +20,6 @@ pub struct CreateCommand {
 
     /// What address to connect to
     addr: MultiAddr,
-    /// Pre-known Identifiers of the other side
-    #[clap(short, long)]
-    authorized_identifier: Option<Vec<IdentityIdentifier>>,
-}
-
-#[derive(Clone, Debug, Args)]
-pub struct CreateListenerCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    /// Specify an address for this listener
-    bind: Address,
     /// Pre-known Identifiers of the other side
     #[clap(short, long)]
     authorized_identifier: Option<Vec<IdentityIdentifier>>,
@@ -49,23 +37,6 @@ impl CreateCommand {
         };
 
         connect_to(port, command, create_connector);
-
-        Ok(())
-    }
-}
-
-impl CreateListenerCommand {
-    pub fn run(opts: CommandGlobalOpts, command: CreateListenerCommand) -> anyhow::Result<()> {
-        let cfg = opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
-            }
-        };
-
-        connect_to(port, command, create_listener);
 
         Ok(())
     }
@@ -117,38 +88,6 @@ pub async fn create_connector(
         Ok(o) => println!("{o}"),
         Err(err) => eprintln!("{err}"),
     };
-
-    stop_node(ctx).await
-}
-
-pub async fn create_listener(
-    ctx: ockam::Context,
-    cmd: CreateListenerCommand,
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let CreateListenerCommand {
-        bind: addr,
-        authorized_identifier: authorized_identifiers,
-        ..
-    } = cmd;
-
-    let resp: Vec<u8> = ctx
-        .send_and_receive(
-            base_route.modify().append(NODEMANAGER_ADDR),
-            api::create_secure_channel_listener(&addr, authorized_identifiers)?,
-        )
-        .await?;
-
-    let response = api::parse_create_secure_channel_listener_response(&resp)?;
-
-    match response.status() {
-        Some(Status::Ok) => {
-            eprintln!("Secure Channel Listener created at {}!", addr)
-        }
-        _ => {
-            eprintln!("An error occurred while creating secure channel listener",)
-        }
-    }
 
     stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -1,7 +1,6 @@
 pub(crate) mod create;
 
 pub(crate) use create::CreateCommand;
-pub(crate) use create::CreateListenerCommand;
 
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
@@ -17,19 +16,12 @@ pub enum SecureChannelSubcommand {
     /// Create Secure Channel Connector
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Create(CreateCommand),
-
-    /// Create Secure Channel Listener
-    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
-    CreateListener(CreateListenerCommand),
 }
 
 impl SecureChannelCommand {
     pub fn run(opts: CommandGlobalOpts, command: SecureChannelCommand) {
         match command.subcommand {
             SecureChannelSubcommand::Create(command) => CreateCommand::run(opts, command),
-            SecureChannelSubcommand::CreateListener(command) => {
-                CreateListenerCommand::run(opts, command)
-            }
         }
         .unwrap()
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
@@ -1,0 +1,73 @@
+use crate::node::NodeOpts;
+use crate::util::{api, connect_to, stop_node};
+use crate::CommandGlobalOpts;
+
+use clap::Args;
+
+use ockam::identity::IdentityIdentifier;
+
+use ockam_api::nodes::NODEMANAGER_ADDR;
+use ockam_api::Status;
+use ockam_core::{Address, Route};
+
+#[derive(Clone, Debug, Args)]
+
+pub struct CreateCommand {
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+
+    /// Specify an address for this listener
+    bind: Address,
+    /// Pre-known Identifiers of the other side
+    #[clap(short, long)]
+    authorized_identifier: Option<Vec<IdentityIdentifier>>,
+}
+
+impl CreateCommand {
+    pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
+        let cfg = opts.config;
+        let port = match cfg.select_node(&command.node_opts.api_node) {
+            Some(cfg) => cfg.port,
+            None => {
+                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            }
+        };
+
+        connect_to(port, command, create_listener);
+
+        Ok(())
+    }
+}
+
+pub async fn create_listener(
+    ctx: ockam::Context,
+    cmd: CreateCommand,
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let CreateCommand {
+        bind: addr,
+        authorized_identifier: authorized_identifiers,
+        ..
+    } = cmd;
+
+    let resp: Vec<u8> = ctx
+        .send_and_receive(
+            base_route.modify().append(NODEMANAGER_ADDR),
+            api::create_secure_channel_listener(&addr, authorized_identifiers)?,
+        )
+        .await?;
+
+    let response = api::parse_create_secure_channel_listener_response(&resp)?;
+
+    match response.status() {
+        Some(Status::Ok) => {
+            eprintln!("Secure Channel Listener created at {}!", addr)
+        }
+        _ => {
+            eprintln!("An error occurred while creating secure channel listener",)
+        }
+    }
+
+    stop_node(ctx).await
+}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel_listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel_listener/mod.rs
@@ -1,0 +1,28 @@
+pub mod create;
+
+pub(crate) use create::CreateCommand;
+
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
+use clap::{Args, Subcommand};
+
+#[derive(Clone, Debug, Args)]
+pub struct SecureChannelListenerCommand {
+    #[clap(subcommand)]
+    subcommand: SecureChannelListenerSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SecureChannelListenerSubcommand {
+    /// Create Secure Channel Listener
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    Create(CreateCommand),
+}
+
+impl SecureChannelListenerCommand {
+    pub fn run(opts: CommandGlobalOpts, command: SecureChannelListenerCommand) {
+        match command.subcommand {
+            SecureChannelListenerSubcommand::Create(command) => CreateCommand::run(opts, command),
+        }
+        .unwrap()
+    }
+}


### PR DESCRIPTION
Fix #3078 

Note: `secure_channel` has some `tracing::debug` code in it, is that intentional?(imo isn't)
## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

