### PR TITLE
Rename export/print functions to long/short 

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -297,11 +297,11 @@ impl NodeManager {
 
             // ==*== Identity ==*==
             (Post, ["node", "identity"]) => self.create_identity(ctx, req).await?.to_vec()?,
-            (Post, ["node", "identity", "actions", "export"]) => {
-                self.export_identity(req).await?.to_vec()?
+            (Post, ["node", "identity", "actions", "show", "short"]) => {
+                self.short_identity(req).await?.to_vec()?
             }
-            (Post, ["node", "identity", "actions", "print"]) => {
-                self.print_identity(req).await?.to_vec()?
+            (Post, ["node", "identity", "actions", "show", "long"]) => {
+                self.long_identity(req).await?.to_vec()?
             }
 
             // ==*== Secure channels ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
@@ -50,7 +50,7 @@ impl NodeManager {
         Ok(response)
     }
 
-    pub(super) async fn export_identity(
+    pub(super) async fn long_identity(
         &mut self,
         req: &Request<'_>,
     ) -> Result<ResponseBuilder<LongIdentityResponse<'_>>> {
@@ -61,7 +61,7 @@ impl NodeManager {
         Ok(response)
     }
 
-    pub(super) async fn print_identity(
+    pub(super) async fn short_identity(
         &mut self,
         req: &Request<'_>,
     ) -> Result<ResponseBuilder<ShortIdentityResponse<'_>>> {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -91,14 +91,14 @@ pub(crate) fn create_identity() -> Result<Vec<u8>> {
 /// Construct a request to export Identity
 pub(crate) fn long_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];
-    Request::builder(Method::Post, "/node/identity/actions/export").encode(&mut buf)?;
+    Request::builder(Method::Post, "/node/identity/actions/show/long").encode(&mut buf)?;
     Ok(buf)
 }
 
 /// Construct a request to print Identity Id
 pub(crate) fn short_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];
-    Request::builder(Method::Post, "/node/identity/actions/print").encode(&mut buf)?;
+    Request::builder(Method::Post, "/node/identity/actions/show/short").encode(&mut buf)?;
     Ok(buf)
 }
 


### PR DESCRIPTION
Follow-up to #3083, renames export/print to long/short for consistency.

## Question:
- Why can't API's `Request::builder` distinguish between `/node/identity/actions/show/full` and `/node/identity/actions/show/` paths? 
- As `ockam identity show --full ...` worked fine, but got error with `ockam identity show ...`


## Checks
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
