### PR TITLE
Commands output format consistent

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -277,7 +277,7 @@ impl NodeManager {
             (Get, ["node"]) => Response::ok(req.id())
                 .body(NodeStatus::new(
                     self.node_name.as_str(),
-                    "[✓]",
+                    "Running",
                     ctx.list_workers().await?.len() as u32,
                     std::process::id() as i32,
                     self.transports.len() as u32,

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -166,8 +166,9 @@ impl CreateCommand {
             // Wait a bit
             std::thread::sleep(Duration::from_millis(500));
 
+            println!("\nNode Created!");
             // Then query the node manager for the status
-            connect_to(address.port(), (), query_status);
+            connect_to(address.port(), cfg.clone(), query_status);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use crate::util::{self, api, connect_to};
 use crate::{node::show::query_status, CommandGlobalOpts, OckamConfig};
 use clap::Args;
-use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use crossbeam_channel::{bounded, Sender};
 use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::util::{self, api, connect_to};
-use crate::{CommandGlobalOpts, OckamConfig};
+use crate::{node::show::query_status, CommandGlobalOpts, OckamConfig};
 use clap::Args;
 use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
 use crossbeam_channel::{bounded, Sender};
@@ -33,38 +33,10 @@ impl ListCommand {
         };
         verify_pids(cfg, node_names);
 
-        let table = cfg
-            .get_inner()
+        cfg.get_inner()
             .nodes
             .iter()
-            .fold(vec![], |mut acc, (name, node_cfg)| {
-                let (mlog, _) = cfg.log_paths_for_node(name).unwrap();
-
-                let row = vec![
-                    name.cell(),
-                    node_cfg.port.cell().justify(Justify::Right),
-                    match node_cfg.pid {
-                        Some(pid) => format!("Yes (pid: {})", pid),
-                        None => "No".into(),
-                    }
-                    .cell()
-                    .justify(Justify::Left),
-                    util::print_path(&mlog).cell(),
-                ];
-                acc.push(row);
-                acc
-            })
-            .table()
-            .title(vec![
-                "Node name".cell().bold(true),
-                "API port".cell().bold(true),
-                "Running".cell().bold(true),
-                "Log path".cell().bold(true),
-            ]);
-
-        if let Err(e) = print_stdout(table) {
-            eprintln!("failed to print node status: {}", e);
-        }
+            .for_each(|(_, node_cfg)| connect_to(node_cfg.port, cfg.clone(), query_status));
     }
 }
 
@@ -74,7 +46,7 @@ fn verify_pids(cfg: &OckamConfig, nodes: Vec<String>) {
         let node_cfg = cfg.get_node(&node_name).unwrap();
 
         let (tx, rx) = bounded(1);
-        println!("Checking state for node '{}'", node_name);
+
         connect_to(node_cfg.port, tx, query_pid);
         let verified_pid = rx.recv().unwrap();
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -58,8 +58,17 @@ pub async fn query_status(
     let log_path = util::print_path(&mlog);
 
     println!(
-        "\nNode:\n\x20\x20Name: {}\n\x20\x20Status: {}\n\x20\x20API Address: {}\n\x20\x20Pid: {}\n\x20\x20Worker count: {}\n\x20\x20Transport count: {}\n\x20\x20Log Path: {}",
-        node_name, status, api_address, pid, workers,transports , log_path
+        r#"
+Node:
+  Name: {}
+  Status: {}
+  API Address: {}
+  Pid: {}
+  Worker count: {}
+  Transport count: {}
+  Log Path: {}
+"#,
+        node_name, status, api_address, pid, workers, transports, log_path
     );
     util::stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,9 +1,13 @@
-use crate::util::{self, api, connect_to};
+use crate::util::{self, api, connect_to, OckamConfig};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
 use clap::Args;
 use ockam::Route;
 use ockam_api::nodes::{models::base::NodeStatus, NODEMANAGER_ADDR};
+use std::{
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -22,11 +26,15 @@ impl ShowCommand {
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (), query_status);
+        connect_to(port, cfg.clone(), query_status);
     }
 }
 
-pub async fn query_status(ctx: ockam::Context, _: (), mut base_route: Route) -> anyhow::Result<()> {
+pub async fn query_status(
+    ctx: ockam::Context,
+    cfg: OckamConfig,
+    mut base_route: Route,
+) -> anyhow::Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
             base_route.modify().append(NODEMANAGER_ADDR),
@@ -44,10 +52,14 @@ pub async fn query_status(ctx: ockam::Context, _: (), mut base_route: Route) -> 
         ..
     } = api::parse_status(&resp)?;
 
-    println!(
-        "Node: {}, Status: {}, Worker count: {}, Pid: {}, Transport count: {}",
-        node_name, status, workers, pid, transports,
-    );
+    let node_cfg = cfg.get_node(&node_name).unwrap();
+    let api_address = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), node_cfg.port);
+    let (mlog, _) = cfg.log_paths_for_node(&node_name.to_string()).unwrap();
+    let log_path = util::print_path(&mlog);
 
+    println!(
+        "\nNode:\n\x20\x20Name: {}\n\x20\x20Status: {}\n\x20\x20API Address: {}\n\x20\x20Pid: {}\n\x20\x20Worker count: {}\n\x20\x20Transport count: {}\n\x20\x20Log Path: {}",
+        node_name, status, api_address, pid, workers,transports , log_path
+    );
     util::stop_node(ctx).await
 }


### PR DESCRIPTION
A PR to make output node information format consistent across `ockam node create | show | list` commands. (#3042) 
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
