### PR TITLE
feat(rust): do not create default vault and identity if they exist

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -162,23 +162,8 @@ impl NodeManager {
 
     async fn create_defaults(&mut self, ctx: &Context) -> Result<()> {
         // Create default vault and identity, if they don't exists already
-        self.create_vault_impl(None).await.or_else(|e| {
-            if e.code().kind == Kind::AlreadyExists {
-                debug!("Using existing vault");
-                Ok(())
-            } else {
-                Err(e)
-            }
-        })?;
-        self.create_identity_impl(ctx).await.or_else(|e| {
-            if e.code().kind == Kind::AlreadyExists {
-                let identity = self.identity()?;
-                debug!("Using existing identity");
-                identity.identifier()
-            } else {
-                Err(e)
-            }
-        })?;
+        self.create_vault_impl(None, true).await?;
+        self.create_identity_impl(ctx, true).await?;
 
         Ok(())
     }
@@ -473,8 +458,8 @@ pub(crate) mod tests {
             .await?;
 
             // Initialize identity
-            node_man.create_vault_impl(None).await?;
-            node_man.create_identity_impl(ctx).await?;
+            node_man.create_vault_impl(None, false).await?;
+            node_man.create_identity_impl(ctx, false).await?;
 
             // Initialize node_man worker and return its route
             ctx.start_worker(node_manager, node_man).await?;
@@ -504,8 +489,8 @@ pub(crate) mod tests {
             )
             .await?;
 
-            node_man.create_vault_impl(None).await?;
-            node_man.create_identity_impl(ctx).await?;
+            node_man.create_vault_impl(None, false).await?;
+            node_man.create_identity_impl(ctx, false).await?;
 
             // Initialize secure channel listener on the mock cloud worker
             node_man

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
@@ -8,6 +8,7 @@ use crate::{Request, Response, ResponseBuilder};
 use ockam::identity::{Identity, IdentityIdentifier};
 use ockam::vault::Vault;
 use ockam::{Context, Result};
+use ockam_core::errcode::{Kind, Origin};
 
 impl NodeManager {
     pub(crate) fn identity(&self) -> Result<&Identity<Vault>> {
@@ -21,7 +22,11 @@ impl NodeManager {
         ctx: &Context,
     ) -> Result<IdentityIdentifier> {
         if self.identity.is_some() {
-            return Err(ApiError::generic("Identity already exists"))?;
+            return Err(ockam_core::Error::new(
+                Origin::Application,
+                Kind::AlreadyExists,
+                "Identity already exists",
+            ))?;
         }
 
         let vault = self.vault()?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
@@ -7,6 +7,7 @@ use minicbor::Decoder;
 use ockam::vault::storage::FileStorage;
 use ockam::vault::Vault;
 use ockam::Result;
+use ockam_core::errcode::{Kind, Origin};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -19,7 +20,11 @@ impl NodeManager {
 
     pub(super) async fn create_vault_impl(&mut self, path: Option<PathBuf>) -> Result<()> {
         if self.vault.is_some() {
-            return Err(ApiError::generic("Vault already exists"))?;
+            return Err(ockam_core::Error::new(
+                Origin::Application,
+                Kind::AlreadyExists,
+                "Vault already exists",
+            ))?;
         }
 
         let path = path.unwrap_or_else(|| self.node_dir.join("vault.json"));


### PR DESCRIPTION
if the node is started pointing to an existing vault / identity, reuse the existing ones instead of failing or creating new ones.
Default services are started as usual.

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
