### PR TITLE
fix(rust): `project create` command when services + node + cloud args are passed

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -23,40 +23,42 @@ pub struct CreateCommand {
     #[clap(display_order = 1002)]
     pub project_name: String,
 
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+
     /// Services enabled for this project.
-    #[clap(display_order = 1003, last = true)]
+    #[clap(display_order = 1100, last = true)]
     pub services: Vec<String>,
     //TODO:  list of admins
 }
 
 impl CreateCommand {
-    pub fn run(
-        opts: CommandGlobalOpts,
-        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
-        cmd: CreateCommand,
-    ) {
+    pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&node_opts.api_node) {
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cloud_opts, cmd), create);
+        connect_to(port, (opts, cmd), create);
     }
 }
 
 async fn create(
     ctx: ockam::Context,
-    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, CreateCommand),
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::create(cmd, cloud_opts)?)
+        .send_and_receive(route, api::project::create(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -22,29 +22,31 @@ pub struct DeleteCommand {
     /// Id of the project.
     #[clap(display_order = 1002)]
     pub project_id: String,
+
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
 }
 
 impl DeleteCommand {
-    pub fn run(
-        opts: CommandGlobalOpts,
-        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
-        cmd: DeleteCommand,
-    ) {
+    pub fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&node_opts.api_node) {
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cloud_opts, cmd), delete);
+        connect_to(port, (opts, cmd), delete);
     }
 }
 
 async fn delete(
     ctx: ockam::Context,
-    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, DeleteCommand),
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
@@ -52,7 +54,7 @@ async fn delete(
     let project_id = cmd.project_id.clone();
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::delete(cmd, cloud_opts)?)
+        .send_and_receive(route, api::project::delete(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -14,36 +14,38 @@ use crate::util::{api, connect_to, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
-pub struct ListCommand;
+pub struct ListCommand {
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
 
 impl ListCommand {
-    pub fn run(
-        opts: CommandGlobalOpts,
-        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
-        cmd: ListCommand,
-    ) {
+    pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&node_opts.api_node) {
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cloud_opts, cmd), list);
+        connect_to(port, (opts, cmd), list);
     }
 }
 
 async fn list(
     ctx: ockam::Context,
-    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, ListCommand),
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::list(cmd, cloud_opts)?)
+        .send_and_receive(route, api::project::list(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -5,8 +5,6 @@ pub use delete::DeleteCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 
-use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
 mod create;
@@ -16,12 +14,6 @@ mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct ProjectCommand {
-    #[clap(flatten)]
-    node_opts: NodeOpts,
-
-    #[clap(flatten)]
-    cloud_opts: CloudOpts,
-
     #[clap(subcommand)]
     subcommand: ProjectSubcommand,
 }
@@ -48,18 +40,10 @@ pub enum ProjectSubcommand {
 impl ProjectCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ProjectCommand) {
         match cmd.subcommand {
-            ProjectSubcommand::Create(scmd) => {
-                CreateCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
-            }
-            ProjectSubcommand::Delete(scmd) => {
-                DeleteCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
-            }
-            ProjectSubcommand::List(scmd) => {
-                ListCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
-            }
-            ProjectSubcommand::Show(scmd) => {
-                ShowCommand::run(opts, (cmd.cloud_opts, cmd.node_opts), scmd)
-            }
+            ProjectSubcommand::Create(scmd) => CreateCommand::run(opts, scmd),
+            ProjectSubcommand::Delete(scmd) => DeleteCommand::run(opts, scmd),
+            ProjectSubcommand::List(scmd) => ListCommand::run(opts, scmd),
+            ProjectSubcommand::Show(scmd) => ShowCommand::run(opts, scmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -27,36 +27,37 @@ pub struct ShowCommand {
     // /// Name of the project.
     // #[clap(display_order = 1002)]
     // pub project_name: String,
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
 }
 
 impl ShowCommand {
-    pub fn run(
-        opts: CommandGlobalOpts,
-        (cloud_opts, node_opts): (CloudOpts, NodeOpts),
-        cmd: ShowCommand,
-    ) {
+    pub fn run(opts: CommandGlobalOpts, cmd: ShowCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&node_opts.api_node) {
+        let port = match cfg.select_node(&cmd.node_opts.api_node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(-1);
             }
         };
-        connect_to(port, (opts, cloud_opts, cmd), show);
+        connect_to(port, (opts, cmd), show);
     }
 }
 
 async fn show(
     ctx: ockam::Context,
-    (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, ShowCommand),
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
     let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::show(cmd, cloud_opts)?)
+        .send_and_receive(route, api::project::show(cmd)?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -301,38 +301,38 @@ pub(crate) mod project {
 
     use super::*;
 
-    pub(crate) fn create(cmd: CreateCommand, cloud_opts: CloudOpts) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn create(cmd: CreateCommand) -> anyhow::Result<Vec<u8>> {
         let b = CreateProject::new(cmd.project_name.as_str(), &[], &cmd.services);
         let mut buf = vec![];
         Request::builder(Method::Post, format!("v0/projects/{}", cmd.space_id))
-            .body(CloudRequestWrapper::new(b, cloud_opts.route()))
+            .body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
             .encode(&mut buf)?;
         Ok(buf)
     }
 
-    pub(crate) fn list(_cmd: ListCommand, cloud_opts: CloudOpts) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn list(cmd: ListCommand) -> anyhow::Result<Vec<u8>> {
         let mut buf = vec![];
         Request::builder(Method::Get, "v0/projects")
-            .body(CloudRequestWrapper::bare(cloud_opts.route()))
+            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
             .encode(&mut buf)?;
         Ok(buf)
     }
 
-    pub(crate) fn show(cmd: ShowCommand, cloud_opts: CloudOpts) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn show(cmd: ShowCommand) -> anyhow::Result<Vec<u8>> {
         let mut buf = vec![];
         Request::builder(Method::Get, format!("v0/projects/{}", cmd.project_id))
-            .body(CloudRequestWrapper::bare(cloud_opts.route()))
+            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
             .encode(&mut buf)?;
         Ok(buf)
     }
 
-    pub(crate) fn delete(cmd: DeleteCommand, cloud_opts: CloudOpts) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn delete(cmd: DeleteCommand) -> anyhow::Result<Vec<u8>> {
         let mut buf = vec![];
         Request::builder(
             Method::Delete,
             format!("v0/projects/{}/{}", cmd.space_id, cmd.project_id),
         )
-        .body(CloudRequestWrapper::bare(cloud_opts.route()))
+        .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
         .encode(&mut buf)?;
         Ok(buf)
     }

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -11,7 +11,10 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("create")
         .arg("space-id")
         .arg("project-name")
-        .args(common_args);
+        .args(common_args)
+        .arg("--")
+        .arg("service-a")
+        .arg("service-b");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/2994

When using `node_opts` and `cloud_opts` at the command level (project/mod.rs), it was
causing some weird behaviors when we tried to use those arguments mixed with Vec<T>
arguments. More specifically, clap is not able to parse the arguments in the expected order
making it impossible to pass both a Vec<T> argument and any of the global arguments defined
at `node_opts` and `cloud_opts`.

In this commit, the global arguments have been moved at the subcommand level so we can put
them *before* the Vec<T> arguments, and now clap is able to parse all arguments properly.