### PR TITLE
feat(rust): add global command to disable ansi colors on tracing messages

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -100,6 +100,10 @@ pub struct GlobalArgs {
     )]
     verbose: u8,
 
+    /// Disable ANSI terminal colors for trace messages.
+    #[clap(global = true, long, action)]
+    no_color: bool,
+
     #[clap(global = true, long = "format", value_enum, default_value = "plain")]
     output_format: OutputFormat,
 
@@ -242,7 +246,10 @@ pub fn run() {
     let cfg = OckamConfig::load();
 
     if !ockam_command.global_args.quiet {
-        setup_logging(ockam_command.global_args.verbose);
+        setup_logging(
+            ockam_command.global_args.verbose,
+            ockam_command.global_args.no_color,
+        );
         tracing::debug!("Parsed {:?}", &ockam_command);
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -130,6 +130,7 @@ impl CreateCommand {
 
             let mut args = vec![
                 verbose,
+                "--no-color".to_string(),
                 "node".to_string(),
                 "create".to_string(),
                 "--api-address".to_string(),

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -96,7 +96,7 @@ pub fn find_available_port() -> anyhow::Result<u16> {
     Ok(address.port())
 }
 
-pub fn setup_logging(verbose: u8) {
+pub fn setup_logging(verbose: u8, no_color: bool) {
     let ockam_crates = [
         "ockam",
         "ockam_node",
@@ -127,10 +127,11 @@ pub fn setup_logging(verbose: u8) {
             .with_default_directive(LevelFilter::TRACE.into())
             .parse_lossy(ockam_crates.map(|c| format!("{c}=trace")).join(",")),
     };
+    let fmt = fmt::Layer::default().with_ansi(!no_color);
     let result = tracing_subscriber::registry()
         .with(filter)
         .with(tracing_error::ErrorLayer::default())
-        .with(fmt::layer())
+        .with(fmt)
         .try_init();
     if result.is_err() {
         eprintln!("Failed to initialise tracing logging.");


### PR DESCRIPTION
By default, logs will have ansi colors enabled and background nodes, which write logs to a file,
will have colors disabled so they are readable.

So, for example, when creating a node with logs enabled, you will see colored logs in the terminal like:

![image](https://user-images.githubusercontent.com/12375782/182389286-407eeb15-e333-447a-b2f8-347abc157343.png)

But, the created background node will write its logs without ansi colors like:

```
2022-08-02T13:34:05.072993Z DEBUG ockam_command: Parsed OckamCommand { subcommand: Node(NodeCommand { subcommand: Create(CreateCommand { node_name: "3f264a35", foreground: true, skip_defaults: false, api_address: "127.0.0.1:46077", no_watchdog: false }) }), global_args: GlobalArgs { quiet: false, verbose: 3, no_color: true, output_format: Plain, test_argument_parser: false } }
2022-08-02T13:34:05.073072Z  INFO ockam_node::node: Initializing ockam node with access control: AllowAll
2022-08-02T13:34:05.074033Z TRACE ockam_node::executor: Initializing node executor
2022-08-02T13:34:05.074286Z DEBUG ockam_transport_tcp::router::tcp_router: Initialising new TcpRouter with address 0#aab4e4033286e54e6a4069d85925cc20
```

instead of:

```
[2m2022-08-02T13:43:13.759691Z[0m [34mDEBUG[0m [2mockam_command[0m[2m:[0m Parsed OckamCommand { subcommand: Node(NodeCommand { subcommand: Create(CreateCommand { node_name: "4714609d", foreground: true, skip_defaults: false, api_address: "127.0.0.1:33021", no_watchdog: false }) }), global_args: GlobalArgs { quiet: false, verbose: 3, no_color: false, output_format: Plain, test_argument_parser: false } }
[2m2022-08-02T13:43:13.759766Z[0m [32m INFO[0m [2mockam_node::node[0m[2m:[0m Initializing ockam node with access control: AllowAll
[2m2022-08-02T13:43:13.760893Z[0m [35mTRACE[0m [2mockam_node::executor[0m[2m:[0m Initializing node executor
```