### PR TITLE
Ockam configuration module refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,6 +2132,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "cddl-cat",
+ "directories",
  "fake",
  "lmdb-rkv",
  "minicbor",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -36,6 +36,7 @@ tinyvec         = { version = "1.6.0", features = ["rustc_1_57"] }
 tracing         = { version = "0.1.34", default-features = false }
 lmdb-rkv        = { version = "0.14.0", optional = true }
 anyhow          = "1"
+directories     = "4"
 
 [dependencies.ockam_core]
 version          = "0.61.0"

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -1,0 +1,89 @@
+//! Configuration files used by the ockam CLI
+
+use crate::config::{snippet::ComposableSnippet, ConfigValues};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, VecDeque};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+/// The main ockam CLI configuration
+///
+/// Used to determine CLI runtime behaviour and index existing nodes
+/// on a system.
+///
+/// ## Updates
+///
+/// This configuration is read and updated by the user-facing `ockam`
+/// CLI.  Furthermore the data is only relevant for user-facing
+/// `ockam` CLI instances.  As such writes to this config don't have
+/// to be synchronised to detached consumers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OckamConfig {
+    /// We keep track of the project directories at runtime but don't
+    /// persist this data to the configuration
+    #[serde(skip)]
+    pub directories: Option<ProjectDirs>,
+    pub api_node: String,
+    pub nodes: BTreeMap<String, NodeConfig>,
+}
+
+impl ConfigValues for OckamConfig {
+    fn default_values(_node_dir: &Path) -> Self {
+        Self {
+            directories: Some(Self::directories()),
+            api_node: "default".into(),
+            nodes: BTreeMap::new(),
+        }
+    }
+}
+
+impl OckamConfig {
+    /// Determine the default storage location for the ockam config
+    pub fn directories() -> ProjectDirs {
+        match env::var("OCKAM_PROJECT_PATH") {
+            Ok(dir) => {
+                let dir = PathBuf::from(&dir);
+                ProjectDirs::from_path(dir).expect(
+                    "failed to determine configuration storage location.
+Verify that your OCKAM_PROJECT_PATH environment variable is valid.",
+                )
+            }
+            Err(_) => ProjectDirs::from("io", "ockam", "ockam-cli").expect(
+                "failed to determine configuration storage location.
+Verify that your XDG_CONFIG_HOME and XDG_DATA_HOME environment variables are correctly set.
+Otherwise your OS or OS configuration may not be supported!",
+            ),
+        }
+    }
+}
+
+/// Per-node runtime configuration
+///
+/// ## Updates
+///
+/// This configuration is used to keep track of individual nodes by
+/// the CLI.  The config is updated periodically but writes to it
+/// don't have to be synced to consumers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeConfig {
+    pub port: u16,
+    pub pid: Option<i32>,
+    pub state_dir: PathBuf,
+}
+
+/// Node launch configuration
+///
+///
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StartupConfig {
+    pub commands: VecDeque<ComposableSnippet>,
+}
+
+impl ConfigValues for StartupConfig {
+    fn default_values(_node_dir: &Path) -> Self {
+        Self::default()
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/config/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/mod.rs
@@ -1,12 +1,16 @@
 use crate::config::atomic::AtomicUpdater;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use std::fs::{create_dir_all, File};
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::{
+    fs::{create_dir_all, File},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+};
 
 pub mod atomic;
+pub mod cli;
+pub mod snippet;
 
 pub trait ConfigValues: Serialize + DeserializeOwned {
     fn default_values(config_dir: &Path) -> Self;
@@ -14,27 +18,40 @@ pub trait ConfigValues: Serialize + DeserializeOwned {
 
 #[derive(Clone)]
 pub struct Config<V: ConfigValues> {
-    dir: PathBuf,
+    path: PathBuf,
     inner: Arc<RwLock<V>>,
 }
 
 impl<V: ConfigValues> Config<V> {
     pub fn dir(&self) -> &Path {
-        &self.dir
+        self.path.parent().unwrap()
     }
 
     pub fn inner(&self) -> &Arc<RwLock<V>> {
         &self.inner
     }
 
+    /// Read lock the inner collection and return a guard to it
+    pub fn readlock_inner(&self) -> RwLockReadGuard<'_, V> {
+        self.inner.read().unwrap()
+    }
+
+    /// Write lock the inner collection and return a guard to it
+    pub fn writelock_inner(&self) -> RwLockWriteGuard<'_, V> {
+        self.inner.write().unwrap()
+    }
+
     /// Attempt to load a config.  If none exists, one is created and then returned.
-    pub fn load(dir: PathBuf) -> Self {
+    pub fn load(config_path: PathBuf) -> Self {
+        let dir = config_path
+            .parent()
+            .expect("Configuration path has no parent directory");
+
         if let Err(e) = create_dir_all(&dir) {
             eprintln!("failed to create configuration directory {:?}: {}", &dir, e);
             std::process::exit(-1);
         }
 
-        let config_path = dir.join("config.json");
         let inner = match File::open(&config_path) {
             Ok(ref mut f) => {
                 let mut buf = String::new();
@@ -47,11 +64,11 @@ impl<V: ConfigValues> Config<V> {
                 })
             }
             Err(_) => {
-                let new_inner = V::default_values(&dir);
+                let new_inner = V::default_values(dir);
                 let json: String =
                     serde_json::to_string_pretty(&new_inner).expect("failed to serialise config");
                 let mut f =
-                    File::create(config_path).expect("failed to create default config file");
+                    File::create(&config_path).expect("failed to create default config file");
                 f.write_all(json.as_bytes())
                     .expect("failed to write config");
                 new_inner
@@ -59,13 +76,17 @@ impl<V: ConfigValues> Config<V> {
         };
 
         Self {
-            dir,
+            path: config_path,
             inner: Arc::new(RwLock::new(inner)),
         }
     }
 
     /// Atomically update the configuration
     pub fn atomic_update(&self) -> AtomicUpdater<V> {
-        AtomicUpdater::new(self.dir.clone(), "config".to_string(), self.inner.clone())
+        AtomicUpdater::new(
+            self.dir().to_path_buf(),
+            "config".to_string(),
+            self.inner.clone(),
+        )
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/config/snippet.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/snippet.rs
@@ -1,21 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, fmt, fs::File, io::Read, path::Path};
-
-/// A stand-alone configuration file to setup a foreground node
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct LaunchConfig {
-    pub vec: VecDeque<ComposableSnippet>,
-}
-
-impl LaunchConfig {
-    pub fn load(p: &Path) -> anyhow::Result<Self> {
-        let mut buf = String::new();
-        let mut f = File::open(p)?;
-        f.read_to_string(&mut buf)?;
-        let this = serde_json::from_str(&buf)?;
-        Ok(this)
-    }
-}
+use std::fmt;
 
 /// A composable snippet run against an existing node
 ///
@@ -84,15 +68,11 @@ pub enum RemoteMode {
 
 impl fmt::Display for RemoteMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Connector => "connector",
-                Self::Receiver => "receiver",
-                Self::Listener => "listener",
-            }
-        )
+        f.write_str(match self {
+            Self::Connector => "connector",
+            Self::Receiver => "receiver",
+            Self::Listener => "listener",
+        })
     }
 }
 
@@ -105,14 +85,10 @@ pub enum PortalMode {
 
 impl fmt::Display for PortalMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Inlet => "inlet",
-                Self::Outlet => "outlet",
-            }
-        )
+        f.write_str(match self {
+            Self::Inlet => "inlet",
+            Self::Outlet => "outlet",
+        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -88,7 +88,7 @@ impl NodeManager {
         let mut transports = BTreeMap::new();
         transports.insert(api_transport_id.clone(), api_transport);
 
-        let config = Config::<NodeManConfig>::load(node_dir.clone());
+        let config = Config::<NodeManConfig>::load(node_dir.join("config.json"));
 
         // Check if we had existing AuthenticatedStorage, create with default location otherwise
         let authenticated_storage_path = config

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -33,8 +33,8 @@ pub(crate) fn query_transports() -> Result<Vec<u8>> {
 pub(crate) fn create_transport(cmd: &crate::transport::CreateCommand) -> Result<Vec<u8>> {
     // FIXME: this should not rely on CreateCommand internals!
     let (tt, addr) = match &cmd.create_subcommand {
-        transport::CreateTypeCommand::TcpConnector { addr } => {
-            (models::transport::TransportMode::Connect, addr)
+        transport::CreateTypeCommand::TcpConnector { address } => {
+            (models::transport::TransportMode::Connect, address)
         }
         transport::CreateTypeCommand::TcpListener { bind } => {
             (models::transport::TransportMode::Listen, bind)

--- a/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
@@ -32,7 +32,18 @@ pub enum Operation {
         protocol: Protocol,
         address: String,
     },
-    Portal,
+    Portal {
+        mode: PortalMode,
+        protocol: Protocol,
+        /// Socket or address to bind to.  For the inlet this is a
+        /// `$Protocol` socket.  For the outlet this is an Ockam
+        /// MultiAddr.
+        bind: String,
+        /// The peer of this portal endpoint.  For an outlet this is
+        /// the target remote.  For the inlet this is the outlet
+        /// route.
+        peer: String,
+    },
     SecureChannel,
     Forwarder,
 }
@@ -63,6 +74,26 @@ impl fmt::Display for RemoteMode {
                 Self::Connector => "connector",
                 Self::Receiver => "receiver",
                 Self::Listener => "listener",
+            }
+        )
+    }
+}
+
+/// Mode of a particular portal structure
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PortalMode {
+    Inlet,
+    Outlet,
+}
+
+impl fmt::Display for PortalMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Inlet => "inlet",
+                Self::Outlet => "outlet",
             }
         )
     }

--- a/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// A composable snippet run against an existing node
 ///
@@ -23,15 +24,51 @@ pub struct ComposableSnippet {
 pub enum Operation {
     /// The node was created with a
     Node {
-        port: u16,
+        api_addr: String,
         node_name: String,
     },
     Transport {
-        listen: bool,
-        tcp: bool,
-        addr: String,
+        mode: RemoteMode,
+        protocol: Protocol,
+        address: String,
     },
     Portal,
     SecureChannel,
     Forwarder,
+}
+
+/// The mode a remote operation is using
+///
+/// * A `Connector` is a connection initiator.  It can either contact a
+/// `Socket` or a `Listener`
+///
+/// * A `Receiver` is a fully fledged, static responder, meaning it only
+/// handles a connection from a single `Connector`
+///
+/// * A `Listener` spawns `Receiver`s for any incoming `Connector`
+/// handshake
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum RemoteMode {
+    Connector,
+    Receiver,
+    Listener,
+}
+
+impl fmt::Display for RemoteMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Connector => "connector",
+                Self::Receiver => "receiver",
+                Self::Listener => "listener",
+            }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Protocol {
+    Tcp,
 }

--- a/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{collections::VecDeque, fmt};
 
 /// A composable snippet run against an existing node
 ///
@@ -21,6 +21,7 @@ pub struct ComposableSnippet {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
 pub enum Operation {
     /// The node was created with a
     Node {
@@ -102,4 +103,9 @@ impl fmt::Display for PortalMode {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Protocol {
     Tcp,
+}
+
+/// Take a JSON encoded configuration and decode it into a series of composable snippets
+pub fn decode(s: &str) -> anyhow::Result<VecDeque<ComposableSnippet>> {
+    Ok(serde_json::from_str(s)?)
 }

--- a/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config/snippets.rs
@@ -1,5 +1,21 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, fmt};
+use std::{collections::VecDeque, fmt, fs::File, io::Read, path::Path};
+
+/// A stand-alone configuration file to setup a foreground node
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LaunchConfig {
+    pub vec: VecDeque<ComposableSnippet>,
+}
+
+impl LaunchConfig {
+    pub fn load(p: &Path) -> anyhow::Result<Self> {
+        let mut buf = String::new();
+        let mut f = File::open(p)?;
+        f.read_to_string(&mut buf)?;
+        let this = serde_json::from_str(&buf)?;
+        Ok(this)
+    }
+}
 
 /// A composable snippet run against an existing node
 ///
@@ -103,9 +119,4 @@ impl fmt::Display for PortalMode {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Protocol {
     Tcp,
-}
-
-/// Take a JSON encoded configuration and decode it into a series of composable snippets
-pub fn decode(s: &str) -> anyhow::Result<VecDeque<ComposableSnippet>> {
-    Ok(serde_json::from_str(s)?)
 }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod setup;
 
 mod addon;
 pub use addon::AddonCommand;

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -5,8 +5,7 @@ mod addon;
 pub use addon::AddonCommand;
 
 mod config;
-pub use config::snippets;
-pub use config::{ConfigError, NodeConfig, OckamConfig};
+pub use config::*;
 
 use anyhow::Context;
 use ockam::{route, NodeBuilder, Route, TcpTransport, TCP};

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -4,6 +4,7 @@ mod addon;
 pub use addon::AddonCommand;
 
 mod config;
+pub use config::snippets;
 pub use config::{ConfigError, NodeConfig, OckamConfig};
 
 use anyhow::Context;

--- a/implementations/rust/ockam/ockam_command/src/util/setup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/setup.rs
@@ -2,11 +2,9 @@
 
 #![allow(unused)]
 
-use crate::util::snippets::{ComposableSnippet, Operation};
+use crate::util::{ComposableSnippet, Operation, RemoteMode};
 use std::collections::VecDeque;
 use std::{env::current_exe, path::PathBuf, process::Command};
-
-use super::snippets::RemoteMode;
 
 pub fn run(node: &str, vec: &VecDeque<ComposableSnippet>) {
     let ockam = current_exe().unwrap_or_else(|_| "ockam".into());

--- a/implementations/rust/ockam/ockam_command/src/util/setup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/setup.rs
@@ -1,0 +1,82 @@
+//! An automatic setup mechanism for composition snippets
+
+#![allow(unused)]
+
+use crate::util::snippets::{ComposableSnippet, Operation};
+use std::collections::VecDeque;
+use std::{env::current_exe, path::PathBuf, process::Command};
+
+use super::snippets::RemoteMode;
+
+pub fn run(node: &str, vec: &VecDeque<ComposableSnippet>) {
+    let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
+
+    for snippet in vec {
+        run_snippet(&ockam, node, snippet);
+    }
+}
+
+pub fn run_foreground(node: &str, vec: &VecDeque<ComposableSnippet>) {
+    let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
+
+    for snippet in vec {
+        // When we run in foreground mode we skip the Node creation
+        // step because it already exists and is waiting for us
+        // (hopefully).
+        if let Operation::Node { .. } = snippet.op {
+            continue;
+        }
+
+        run_snippet(&ockam, node, snippet);
+    }
+}
+
+fn run_snippet(
+    ockam: &PathBuf,
+    node_name: &str,
+    snippet @ ComposableSnippet { id, op, params }: &ComposableSnippet,
+) {
+    let args = match op {
+        Operation::Node {
+            api_addr,
+            node_name: _,
+        } => vec!["node", "create", node_name, "--api-address", api_addr],
+        Operation::Transport {
+            mode,
+            address,
+            protocol: _,
+        } => vec![
+            "transport",
+            "create",
+            "--node",
+            node_name,
+            match mode {
+                RemoteMode::Connector => "tcp-connector",
+                RemoteMode::Listener => "tcp-listener",
+                RemoteMode::Receiver => unimplemented!(),
+            },
+            address,
+        ],
+        Operation::Portal {
+            mode,
+            protocol,
+            bind,
+            peer,
+        } => {
+            todo!()
+        }
+        Operation::SecureChannel => {
+            todo!()
+        }
+
+        Operation::Forwarder => {
+            todo!()
+        }
+    };
+
+    if let Err(e) = Command::new(ockam).args(args).output() {
+        eprintln!("failed to execute snippet '{:?}': {}", snippet, e);
+    }
+
+    println!("ok");
+}


### PR DESCRIPTION
Currently `ockam_command` and `ockam_api` have two separate configuration modules. This PR moves all config structs to `ockam_api` while keeping command-specific utility functions separate.

This PR also adds a separate `startup.json` config which is updated with every command run, in order to populate a restart script.