### PR TITLE
fix(rust): remove `block_future`

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -69,29 +69,7 @@ pub use node::{NodeBuilder, NullWorker};
 #[cfg(feature = "std")]
 use core::future::Future;
 #[cfg(feature = "std")]
-use tokio::{runtime::Runtime, task};
-
-/// Execute a future without blocking the executor
-///
-/// This is a wrapper around two simple tokio functions to allow
-/// ockam_node to wait for a task to be completed in a non-async
-/// environment.
-///
-/// This function is not meant to be part of the ockam public API, but
-/// as an implementation utility for other ockam utilities that use
-/// tokio.
-#[doc(hidden)]
-#[cfg(feature = "std")]
-pub fn block_future<F>(rt: &Runtime, f: F) -> <F as Future>::Output
-where
-    F: Future + Send,
-    F::Output: Send,
-{
-    task::block_in_place(move || {
-        let local = task::LocalSet::new();
-        local.block_on(rt, f)
-    })
-}
+use tokio::task;
 
 #[doc(hidden)]
 #[cfg(feature = "std")]


### PR DESCRIPTION
`block_future` is only used by `Executor::execute` which is itself a blocking method and not invoked from an async context (nor should it), hence it seems unnecessary to use tokio's task::block_in_place.

