### PR TITLE
feat(rust): project node identity

### DIFF
--- a/implementations/rust/ockam/ockam_api/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/schema.cddl
@@ -97,10 +97,14 @@ project = {
     2: project_name,
     3: space_name,
     4: [+ service_name],
-    5: access_route,
+    5: access_route,  ; could be an empty string if the cloud node hasn't started yet (TODO: make it an optional field instead)
     6: [+ user],
     7: space_id,
+    ?8: project_node_identity ; optional, it can be missing if the cloud node hasn't started yet
 }
+
+project_node_identity = identity_id
+
 
 projects = [* project]
 


### PR DESCRIPTION
@adrianbenavides  I updated the project' schema to reflect the identity_id field that is already available.   You can take over from here to update the rust code.

Also, all invitation related schema and code should be removed (but could be a separate issue on separate PR),  as that invitation workflow was removed.