### PR TITLE
Restrict access control in proxy service with tcp connection

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/simple.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/simple.ex
@@ -43,15 +43,8 @@ defmodule Ockam.Messaging.PipeChannel.Simple do
   @doc false
   ## Inner message is forwarded with outer address in return route
   def forward_inner(message, state) do
-    [_me | onward_route] = Message.onward_route(message)
-    return_route = Message.return_route(message)
-    payload = Message.payload(message)
-
-    Router.route(%{
-      onward_route: onward_route,
-      return_route: [state.address | return_route],
-      payload: payload
-    })
+    message = Message.forward(message) |> Message.trace(state.address)
+    Router.route(message)
   end
 
   @doc false
@@ -61,15 +54,11 @@ defmodule Ockam.Messaging.PipeChannel.Simple do
     channel_route = Map.fetch!(state, :channel_route)
 
     [_me | onward_route] = Message.onward_route(message)
-    return_route = Message.return_route(message)
-    payload = Message.payload(message)
 
     sender = Map.fetch!(state, :sender)
 
-    Router.route(%{
-      onward_route: [sender | channel_route ++ onward_route],
-      return_route: return_route,
-      payload: payload
-    })
+    message = Message.set_onward_route(message, [sender | channel_route ++ onward_route])
+
+    Router.route(message)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/identity/identity_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/identity/identity_channel.ex
@@ -430,6 +430,12 @@ defmodule Ockam.Identity.SecureChannel.Data do
 
     inner_address = Map.fetch!(state, :inner_address)
 
+    state =
+      Ockam.Worker.update_authorization_state(state, inner_address, [
+        :from_secure_channel,
+        {:from_addresses, [:message, [encryption_channel]]}
+      ])
+
     {:ok,
      Map.merge(
        state,
@@ -439,13 +445,7 @@ defmodule Ockam.Identity.SecureChannel.Data do
          identity: identity,
          contact_id: contact_id,
          contact: contact,
-         additional_metadata: additional_metadata,
-         authorization: %{
-           inner_address => [
-             :from_secure_channel,
-             {:from_addresses, [:message, [encryption_channel]]}
-           ]
-         }
+         additional_metadata: additional_metadata
        }
      )}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
@@ -60,7 +60,7 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
     binary_message =
       Ockam.Protocol.encode_payload(Ockam.Protocol.Binary, :request, encoded_message)
 
-    ## TODO: should we forward metadta here?
+    ## TODO: should we forward metadata here?
     Ockam.Router.route(%{
       payload: binary_message,
       onward_route: [publisher_address],

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker/authorization.ex
@@ -229,8 +229,16 @@ defmodule Ockam.Worker.Authorization do
     end)
   end
 
-  def expand_config(config) do
+  def expand_config(config) when is_list(config) do
     expand_config(config, :message, :state)
+  end
+
+  def expand_config(config) when is_map(config) do
+    config
+    |> Enum.map(fn {k, v} when is_list(v) ->
+      {k, expand_config(v)}
+    end)
+    |> Map.new()
   end
 
   defp expand_config(config, message, state) do


### PR DESCRIPTION
## Current Behavior

Currently TCP connection created by the proxy service is accessible to all workers, which allows to circumvent the access control in the proxy worker
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Make tcp client only work with recoverable client messages.
Make recoverable client only accept messages from proxy worker and tcp client
Make proxy worker only accept messages from recoverable client on the inner address

### Caveat

Only addressing the proxies working with TCP address as the first address in the forwarding route.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
