### PR TITLE
chore: Show default identity on node show|list|create

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -8,6 +8,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     str::FromStr,
 };
+use ockam_api::Status;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -52,6 +53,21 @@ pub async fn query_status(
         ..
     } = api::parse_status(&resp)?;
 
+    // Getting short id for the node
+    let resp: Vec<u8> = ctx
+        .send_and_receive(
+            base_route.modify().append(NODEMANAGER_ADDR),
+            api::short_identity()?
+        )
+        .await
+        .context("Failed to process request for short id")?;
+
+    let (response, result) = api::parse_short_identity_response(&resp)?;
+    let default_id = match response.status() {
+        Some(Status::Ok) => { format!("{}", result.identity_id) }
+        _ => { String::from("NOT FOUND") }
+    };
+
     let node_cfg = cfg.get_node(&node_name).unwrap();
     let api_address = SocketAddr::new(IpAddr::from_str("127.0.0.1").unwrap(), node_cfg.port);
     let (mlog, _) = cfg.log_paths_for_node(&node_name.to_string()).unwrap();
@@ -63,12 +79,13 @@ Node:
   Name: {}
   Status: {}
   API Address: {}
+  Default Identity: {}
   Pid: {}
   Worker count: {}
   Transport count: {}
   Log Path: {}
 "#,
-        node_name, status, api_address, pid, workers, transports, log_path
+        node_name, status, api_address, default_id, pid, workers, transports, log_path
     );
     util::stop_node(ctx).await
 }


### PR DESCRIPTION
Adds a node's default identity to be shown when printed using `ockam
node show|list|create`.

See issue [#3100](https://github.com/build-trust/ockam/issues/3100)

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently the summary printed by `node create | list | show` does not include the default id information.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

This change adds the short id to the print out as suggested in the referenced issue.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
