### PR TITLE
feat(rust): support STDIN in command message send

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -26,12 +26,12 @@ async fn send_message(mut ctx: Context, cmd: SendCommand) -> anyhow::Result<()> 
         addr if addr.contains("/-") => {
             let mut buffer = String::new();
             io::stdin().read_line(&mut buffer)?;
-            addr.replace("/-", &buffer.trim())
+            addr.replace("/-", buffer.trim())
         }
         addr if addr.contains("-/") => {
             let mut buffer = String::new();
             io::stdin().read_line(&mut buffer)?;
-            addr.replace("-/", &buffer.trim())
+            addr.replace("-/", buffer.trim())
         }
         _ => cmd.addr,
     };


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->
## Issue
[#3068](https://github.com/build-trust/ockam/issues/3068)
## Current Behavior
Current  message send command:
```
» ockam message send /ip4/127.0.0.1/tcp/53552/ockam/uppercase "hello"
HELLO
```
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Support piped input read from STDIN, examples:
```
» echo "/ockam/uppercase" | ockam message send /ip4/127.0.0.1/tcp/53552/- "hello"
HELLO
```
and
```
» echo "/ip4/127.0.0.1/tcp/53552/" | ockam message send -- -/ockam/uppercase "hello"
HELLO
```
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

