### PR TITLE
fix(rust): make command message send less fragile

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -26,12 +26,25 @@ async fn send_message(mut ctx: Context, cmd: SendCommand) -> anyhow::Result<()> 
         addr if addr.contains("/-") => {
             let mut buffer = String::new();
             io::stdin().read_line(&mut buffer)?;
-            addr.replace("/-", buffer.trim())
+            let args_from_stdin = buffer
+                .trim()
+                .split('/')
+                .filter(|&s| !s.is_empty())
+                .fold("".to_owned(), |acc, s| format!("{acc}/{s}"));
+
+            addr.replace("/-", &args_from_stdin)
         }
         addr if addr.contains("-/") => {
             let mut buffer = String::new();
             io::stdin().read_line(&mut buffer)?;
-            addr.replace("-/", buffer.trim())
+
+            let args_from_stdin = buffer
+                .trim()
+                .split('/')
+                .filter(|&s| !s.is_empty())
+                .fold("/".to_owned(), |acc, s| format!("{acc}{s}/"));
+
+            addr.replace("-/", &args_from_stdin)
         }
         _ => cmd.addr,
     };


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
Currently these commands will fail ([#3068](https://github.com/build-trust/ockam/issues/3068#issuecomment-1206085030)):
```
» echo "/ip4/127.0.0.1/tcp/49344" | ockam message send -- -/ockam/uppercase "hello"
Error invalid digit found in string
```
```
» echo "ip4/127.0.0.1/tcp/49344/" | ockam message send -- -/ockam/uppercase "hello"
Error invalid prefix in protocol string "ip4/127.0.0.1/tcp/49344/ockam/uppercase"
```
```
» echo "ip4/127.0.0.1/tcp/49344" | ockam message send -- -/ockam/uppercase "hello"
Error invalid prefix in protocol string "ip4/127.0.0.1/tcp/49344ockam/uppercase"
```

```
» echo "/ockam/uppercase/" | ockam message send /ip4/127.0.0.1/tcp/49344/- "hello"
Error invalid prefix in protocol string "/"
```
```
» echo "ockam/uppercase" | ockam message send /ip4/127.0.0.1/tcp/49344/- "hello"
Error invalid digit found in string
```
## Proposed Changes
Make command read from piped input STDIN less fragile and let commands like above pass. 
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->




