### PR TITLE
feat(rust): add node protocol to multiaddr

### DIFF
--- a/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
@@ -1,6 +1,6 @@
 use super::{Code, Codec, Protocol};
 use crate::codec::StdCodec;
-use crate::proto::{DnsAddr, Service, Tcp};
+use crate::proto::{DnsAddr, Node, Service, Tcp};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
 use core::fmt;
@@ -29,6 +29,8 @@ impl Default for Registry {
         r.register(DnsAddr::CODE, DnsAddr::PREFIX, std_codec.clone());
         #[allow(clippy::redundant_clone)]
         r.register(Service::CODE, Service::PREFIX, std_codec.clone());
+        #[allow(clippy::redundant_clone)]
+        r.register(Node::CODE, Node::PREFIX, std_codec.clone());
         #[cfg(feature = "std")]
         r.register(
             crate::proto::Ip4::CODE,


### PR DESCRIPTION
This adds another protocol type `node` but nb. that we do not support mapping between multi-addresses which contain a `node` and `ockam_core::{Route, Address}`. It is assumed that multi-addresses with `node` protocols are processed and replace `node` with other protocols, e.g. `ip4` etc.