### PR TITLE
Fix names of executables in End-to-Encryption through Kafka guide

### DIFF
--- a/documentation/use-cases/end-to-end-encryption-through-kafka/README.md
+++ b/documentation/use-cases/end-to-end-encryption-through-kafka/README.md
@@ -111,7 +111,7 @@ To make it easy to try, we've created a Docker image that contains both Alice an
 1. Run Bob’s program:
 
     ```
-    docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka ockam_kafka_bob
+    docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka bob
     ```
 
     The Bob program creates a Secure Channel Listener to accept requests to begin an Authenticated Key
@@ -130,7 +130,7 @@ To make it easy to try, we've created a Docker image that contains both Alice an
 3. In a separate terminal window, run the Alice program:
 
     ```
-    docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka ockam_kafka_alice
+    docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka alice
     ```
 
 4. The Alice program will stop to ask for the stream addresses that were printed in step 2. Enter them.


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Please refer to Run section in the guide [End to End Encryption through Kafka](https://github.com/build-trust/ockam/tree/develop/documentation/use-cases/end-to-end-encryption-through-kafka). The docker commands threw following errors 

`error: exec: "ockam_kafka_bob": executable file not found in $PATH`
`error: exec: "ockam_kafka_alice": executable file not found in $PATH`

## Proposed Changes
Following changes to the docker commands worked for me:
`docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka bob`
`docker run --rm --interactive --tty ghcr.io/build-trust/examples/kafka alice`


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
