### PR TITLE
feat(rust): add identity override

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -28,6 +28,8 @@ pub struct OckamConfig {
     pub directories: Option<ProjectDirs>,
     pub api_node: String,
     pub nodes: BTreeMap<String, NodeConfig>,
+    pub default_identity: Option<Vec<u8>>,
+    pub default_vault_path: Option<PathBuf>,
 }
 
 impl ConfigValues for OckamConfig {
@@ -36,6 +38,8 @@ impl ConfigValues for OckamConfig {
             directories: Some(Self::directories()),
             api_node: "default".into(),
             nodes: BTreeMap::new(),
+            default_identity: None,
+            default_vault_path: None,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/config.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/config.rs
@@ -10,6 +10,8 @@ pub struct NodeManConfig {
     pub vault_path: Option<PathBuf>,
     /// Exported identity value
     pub identity: Option<Vec<u8>>,
+    /// Identity was overridden
+    pub identity_was_overridden: bool,
 }
 
 impl ConfigValues for NodeManConfig {

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -9,4 +9,4 @@ pub mod models;
 pub const NODEMANAGER_ADDR: &str = "_internal.nodemanager";
 
 /// The main node-manager service running on remote nodes
-pub use service::NodeManager;
+pub use service::{IdentityOverride, NodeManager};

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -89,7 +89,7 @@ impl NodeManager {
         let mut transports = BTreeMap::new();
         transports.insert(api_transport_id.clone(), api_transport);
 
-        let config = Config::<NodeManConfig>::load(node_dir.join("config.json"));
+        let config = Config::<NodeManConfig>::load(&node_dir, "config");
 
         // Check if we had existing AuthenticatedStorage, create with default location otherwise
         let authenticated_storage_path = config

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -194,7 +194,20 @@ impl NodeManager {
         self.start_uppercase_service_impl(ctx, "uppercase".into())
             .await?;
         self.start_echoer_service_impl(ctx, "echo".into()).await?;
-        self.create_secure_channel_listener_impl("api".into(), None)
+
+        let authorized_identifiers = if self.config.readlock_inner().identity_was_overridden {
+            if let Some(identity) = &self.identity {
+                // If we had overridden Identity - we should trust only this identity,
+                // otherwise - trust all
+                Some(vec![identity.identifier()?])
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        self.create_secure_channel_listener_impl("api".into(), authorized_identifiers)
             .await?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
@@ -8,7 +8,7 @@ use ockam::vault::storage::FileStorage;
 use ockam::vault::Vault;
 use ockam::Result;
 use ockam_core::errcode::{Kind, Origin};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 impl NodeManager {
@@ -16,6 +16,10 @@ impl NodeManager {
         self.vault
             .as_ref()
             .ok_or_else(|| ApiError::generic("Vault doesn't exist"))
+    }
+
+    pub fn default_vault_path(node_dir: &Path) -> PathBuf {
+        node_dir.join("vault.json")
     }
 
     pub(super) async fn create_vault_impl(
@@ -36,7 +40,7 @@ impl NodeManager {
             };
         }
 
-        let path = path.unwrap_or_else(|| self.node_dir.join("vault.json"));
+        let path = path.unwrap_or_else(|| Self::default_vault_path(&self.node_dir));
 
         let vault_storage = FileStorage::create(path.clone()).await?;
         let vault = Vault::new(Some(Arc::new(vault_storage)));

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -32,7 +32,6 @@ impl DeleteCommand {
 
                 if inner.nodes.is_empty() {
                     eprintln!("No nodes registered on this system!");
-                    std::process::exit(0);
                 }
 
                 inner.nodes.iter().map(|(name, _)| name.clone()).collect()

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -58,6 +58,14 @@ impl OckamConfig {
         self.inner.readlock_inner().api_node.clone()
     }
 
+    pub fn get_default_vault_path(&self) -> Option<PathBuf> {
+        self.inner.readlock_inner().default_vault_path.clone()
+    }
+
+    pub fn get_default_identity(&self) -> Option<Vec<u8>> {
+        self.inner.readlock_inner().default_identity.clone()
+    }
+
     /// Get the node state directory
     pub fn get_node_dir(&self, name: &str) -> Result<PathBuf, ConfigError> {
         let inner = self.inner.readlock_inner();
@@ -144,6 +152,14 @@ impl OckamConfig {
     }
 
     ///////////////////// WRITE ACCESSORS //////////////////////////////
+
+    pub fn set_default_vault_path(&self, default_vault_path: Option<PathBuf>) {
+        self.inner.writelock_inner().default_vault_path = default_vault_path
+    }
+
+    pub fn set_default_identity(&self, default_identity: Option<Vec<u8>>) {
+        self.inner.writelock_inner().default_identity = default_identity;
+    }
 
     /// Add a new node to the configuration for future lookup
     pub fn create_node(&self, name: &str, port: u16) -> Result<(), ConfigError> {

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -41,8 +41,8 @@ pub enum ConfigError {
 impl OckamConfig {
     pub fn load() -> Self {
         let directories = cli::OckamConfig::directories();
-        let config_path = directories.config_dir().join("config.json");
-        let inner = Config::<cli::OckamConfig>::load(config_path);
+        let config_dir = directories.config_dir();
+        let inner = Config::<cli::OckamConfig>::load(config_dir, "config");
         inner.writelock_inner().directories = Some(directories);
         Self { inner }
     }
@@ -221,8 +221,7 @@ impl Deref for StartupConfig {
 
 impl StartupConfig {
     pub fn load(node_dir: PathBuf) -> Self {
-        let config_path = node_dir.join("startup.json");
-        let inner = Config::<cli::StartupConfig>::load(config_path);
+        let inner = Config::<cli::StartupConfig>::load(&node_dir, "startup");
         Self { inner }
     }
 


### PR DESCRIPTION
If node is created with skip-defaults=false, it will be given default shared identity, and its default secure channel listener (on `/service/api`) will trust only that identity