### PR TITLE
refactor(rust): split `transport` api::service into `tcp connection/listener`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -286,13 +286,26 @@ impl NodeManager {
                 ))
                 .to_vec()?,
 
-            // ==*== Transports ==*==
-            // TODO: Get all transports
-            (Get, ["node", "transport"]) => Response::ok(req.id())
+            // ==*== Tcp Connection ==*==
+            // TODO: Get all tcp connections
+            (Get, ["node", "tcp", "connection"]) => Response::ok(req.id())
                 .body(TransportList::new(self.get_transports()))
                 .to_vec()?,
-            (Post, ["node", "transport"]) => self.add_transport(req, dec).await?.to_vec()?,
-            (Delete, ["node", "transport"]) => self.delete_transport(req, dec).await?.to_vec()?,
+            (Post, ["node", "tcp", "connection"]) => {
+                self.add_transport(req, dec).await?.to_vec()?
+            }
+            (Delete, ["node", "tcp", "connection"]) => {
+                self.delete_transport(req, dec).await?.to_vec()?
+            }
+
+            // ==*== Tcp Listeners ==*==
+            (Get, ["node", "tcp", "listener"]) => Response::ok(req.id())
+                .body(TransportList::new(self.get_transports()))
+                .to_vec()?,
+            (Post, ["node", "tcp", "listener"]) => self.add_transport(req, dec).await?.to_vec()?,
+            (Delete, ["node", "tcp", "listener"]) => {
+                self.delete_transport(req, dec).await?.to_vec()?
+            }
 
             // ==*== Vault ==*==
             (Post, ["node", "vault"]) => self.create_vault(req, dec).await?.to_vec()?,

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -40,8 +40,7 @@ pub(crate) fn create_tcp_connection(
     let payload =
         models::transport::CreateTransport::new(models::transport::TransportType::Tcp, tt, addr);
     let mut buf = vec![];
-    // TODO: change path to /node/tcp_connection in api::service <======================================
-    Request::builder(Method::Post, "/node/transport")
+    Request::builder(Method::Post, "/node/tcp/connection")
         .body(payload)
         .encode(&mut buf)?;
     Ok(buf)
@@ -54,8 +53,7 @@ pub(crate) fn create_tcp_listener(cmd: &crate::tcp::listener::CreateCommand) -> 
     let payload =
         models::transport::CreateTransport::new(models::transport::TransportType::Tcp, tt, addr);
     let mut buf = vec![];
-    // TODO: change path to /node/tcp_listener in api::service <======================================
-    Request::builder(Method::Post, "/node/transport")
+    Request::builder(Method::Post, "/node/tcp/listener")
         .body(payload)
         .encode(&mut buf)?;
     Ok(buf)
@@ -66,8 +64,7 @@ pub(crate) fn delete_tcp_connection(
     cmd: &crate::tcp::connection::DeleteCommand,
 ) -> Result<Vec<u8>> {
     let mut buf = vec![];
-    // TODO: change path to /node/tcp_connection in api::service <=====================================
-    Request::builder(Method::Delete, "/node/transport")
+    Request::builder(Method::Delete, "/node/tcp/connection")
         .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force))
         .encode(&mut buf)?;
 
@@ -77,8 +74,7 @@ pub(crate) fn delete_tcp_connection(
 /// Construct a request to delete node tcp connection
 pub(crate) fn delete_tcp_listener(cmd: &crate::tcp::listener::DeleteCommand) -> Result<Vec<u8>> {
     let mut buf = vec![];
-    // TODO: change path to /node/tcp_connection in api::service <=====================================
-    Request::builder(Method::Delete, "/node/transport")
+    Request::builder(Method::Delete, "/node/tcp/listener")
         .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force))
         .encode(&mut buf)?;
 


### PR DESCRIPTION
Follow up to #3140.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

