### PR TITLE
feat(rust): add api endpoint to send messages

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -1,7 +1,7 @@
 mod config;
 mod registry;
 
-pub(crate) mod service;
+pub mod service;
 
 pub mod models;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -26,6 +26,7 @@ use crate::nodes::models::transport::{TransportList, TransportMode, TransportTyp
 use crate::{Method, Request, Response, Status};
 
 mod identity;
+pub mod message;
 mod portals;
 mod secure_channel;
 mod services;
@@ -385,6 +386,9 @@ impl NodeManager {
             (Put, ["v0", "enroll", "token"]) => {
                 self.authenticate_enrollment_token(ctx, req, dec).await?
             }
+
+            // ==*== Messages ==*==
+            (Post, ["v0", "message"]) => self.send_message(ctx, req, dec).await?,
 
             // ==*== Catch-all for Unimplemented APIs ==*==
             _ => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -1,0 +1,78 @@
+use minicbor::{Decode, Encode};
+use ockam_core::{Result, Route};
+use ockam_multiaddr::MultiAddr;
+use std::str::FromStr;
+
+use crate::error::ApiError;
+#[cfg(feature = "tag")]
+use crate::TypeTag;
+use crate::{CowBytes, CowStr};
+
+#[derive(Encode, Decode, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct SendMessage<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] pub tag: TypeTag<8400702>,
+    #[b(1)] pub route: CowStr<'a>,
+    #[b(2)] pub message: CowBytes<'a>,
+}
+
+impl<'a> SendMessage<'a> {
+    pub fn new<S: Into<CowBytes<'a>>>(route: &MultiAddr, message: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            route: route.to_string().into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn route(&self) -> Result<Route> {
+        let maddr = MultiAddr::from_str(self.route.as_ref())
+            .map_err(|_err| ApiError::generic(&format!("Invalid route: {}", self.route)))?;
+        crate::multiaddr_to_route(&maddr)
+            .ok_or_else(|| ApiError::generic(&format!("Invalid MultiAddr: {}", maddr)))
+    }
+}
+
+mod node {
+    use minicbor::Decoder;
+    use tracing::trace;
+
+    use ockam_core::{self, Result};
+    use ockam_node::Context;
+
+    use crate::nodes::NodeManager;
+    use crate::{Request, Response, Status};
+
+    const TARGET: &str = "ockam_api::message";
+
+    impl NodeManager {
+        pub(crate) async fn send_message(
+            &mut self,
+            ctx: &mut Context,
+            req: &Request<'_>,
+            dec: &mut Decoder<'_>,
+        ) -> Result<Vec<u8>> {
+            let req_body: super::SendMessage = dec.decode()?;
+            let route = req_body.route()?;
+            let msg = req_body.message.to_vec();
+            let msg_length = msg.len();
+
+            trace!(target: TARGET, route = %req_body.route, msg_l = %msg_length, "sending message");
+
+            let res: Result<Vec<u8>> = ctx.send_and_receive(route, msg).await;
+            match res {
+                Ok(r) => Ok(Response::builder(req.id(), Status::Ok).body(r).to_vec()?),
+                Err(err) => {
+                    error!(target: TARGET, ?err, "Failed to send message");
+                    Ok(Response::builder(req.id(), Status::InternalServerError)
+                        .body(err.to_string())
+                        .to_vec()?)
+                }
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -310,7 +310,7 @@ pub fn run() {
             GenerateEnrollmentTokenCommand::run(opts, command)
         }
         OckamSubcommand::Forwarder(command) => ForwarderCommand::run(opts, command),
-        OckamSubcommand::Message(command) => MessageCommand::run(command),
+        OckamSubcommand::Message(command) => MessageCommand::run(opts, command),
         OckamSubcommand::Node(command) => NodeCommand::run(opts, command),
         OckamSubcommand::Project(command) => ProjectCommand::run(opts, command),
         OckamSubcommand::Space(command) => SpaceCommand::run(opts, command),

--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -1,6 +1,6 @@
-use crate::HELP_TEMPLATE;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
-use send::SendCommand;
+pub use send::SendCommand;
 
 mod send;
 
@@ -18,9 +18,9 @@ pub enum MessageSubcommand {
 }
 
 impl MessageCommand {
-    pub fn run(cmd: MessageCommand) {
+    pub fn run(opts: CommandGlobalOpts, cmd: MessageCommand) {
         match cmd.subcommand {
-            MessageSubcommand::Send(cmd) => SendCommand::run(cmd),
+            MessageSubcommand::Send(cmd) => SendCommand::run(opts, cmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -1,34 +1,80 @@
+use anyhow::{anyhow, Context};
 use clap::Args;
+use minicbor::Decoder;
+use std::str::FromStr;
+use tracing::debug;
 
-use ockam::{Context, TcpTransport};
+use crate::CommandGlobalOpts;
+use ockam_api::nodes::NODEMANAGER_ADDR;
+use ockam_api::{Response, Status};
+use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::embedded_node;
+use crate::util::{api, connect_to, stop_node};
 
 #[derive(Clone, Debug, Args)]
 pub struct SendCommand {
-    /// The route to send the message to (required)
+    /// The node to send messages from
+    #[clap(short, long, value_name = "NODE")]
+    from: String,
+
+    /// The route to send the message to
     #[clap(short, long, value_name = "ROUTE")]
-    to: MultiAddr,
-    message: String,
+    pub to: String,
+
+    pub message: String,
 }
 
 impl SendCommand {
-    pub fn run(cmd: SendCommand) {
-        embedded_node(send_message, cmd)
+    pub fn run(opts: CommandGlobalOpts, cmd: SendCommand) {
+        let port = opts.config.get_node_port(&cmd.from);
+        connect_to(port, (opts, cmd), send_message);
+    }
+
+    pub fn to(&self) -> anyhow::Result<MultiAddr> {
+        MultiAddr::from_str(&self.to).context("Invalid route")
     }
 }
 
-async fn send_message(mut ctx: Context, cmd: SendCommand) -> anyhow::Result<()> {
-    let _tcp = TcpTransport::create(&ctx).await?;
+async fn send_message(
+    ctx: ockam::Context,
+    (_opts, cmd): (CommandGlobalOpts, SendCommand),
+    mut base_route: Route,
+) -> anyhow::Result<()> {
+    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
+    debug!(?cmd, %route, "Sending request");
 
-    if let Some(route) = ockam_api::multiaddr_to_route(&cmd.to) {
-        ctx.send(route, cmd.message).await?;
-        let message = ctx.receive::<String>().await?;
-        println!("{}", message);
-    }
+    let response: Vec<u8> = ctx
+        .send_and_receive(route, api::message::send(cmd)?)
+        .await
+        .context("Failed to process request")?;
+    let mut dec = Decoder::new(&response);
+    let header = dec
+        .decode::<Response>()
+        .context("Failed to decode Response")?;
+    debug!(?header, "Received response");
 
-    ctx.stop().await?;
+    let res = match (header.status(), header.has_body()) {
+        (Some(Status::Ok), true) => {
+            let body = dec
+                .decode::<Vec<u8>>()
+                .context("Failed to decode response body")?;
+            Ok(String::from_utf8(body)?)
+        }
+        (Some(status), true) => {
+            let err = dec
+                .decode::<String>()
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(anyhow!(
+                "An error occurred while processing the request with status code {status:?}: {err}"
+            ))
+        }
+        _ => Err(anyhow!("Unexpected response received from node")),
+    };
+    match res {
+        Ok(o) => println!("{o}"),
+        Err(err) => eprintln!("{err}"),
+    };
 
-    Ok(())
+    stop_node(ctx).await
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -20,6 +20,7 @@ pub struct CreateCommand {
     /// Route to a secure channel listener (required)
     #[clap(name = "to", short, long, value_name = "ROUTE")]
     addr: MultiAddr,
+
     /// Pre-known Identifiers of the other side
     #[clap(short, long)]
     authorized_identifier: Option<Vec<IdentityIdentifier>>,

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -359,6 +359,21 @@ pub(crate) mod project {
     }
 }
 
+pub(crate) mod message {
+    use crate::message::*;
+    use ockam_api::nodes::service::message::*;
+
+    use super::*;
+
+    pub(crate) fn send(cmd: SendCommand) -> anyhow::Result<Vec<u8>> {
+        let mut buf = vec![];
+        Request::builder(Method::Post, "v0/message")
+            .body(SendMessage::new(&cmd.to()?, cmd.message.as_bytes()))
+            .encode(&mut buf)?;
+        Ok(buf)
+    }
+}
+
 ////////////// !== parsers
 
 /// Parse the base response without the inner payload

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -69,13 +69,16 @@ impl OckamConfig {
     }
 
     /// Get the API port used by a node
-    pub fn get_node_port(&self, name: &str) -> Result<u16, ConfigError> {
+    pub fn get_node_port(&self, name: &str) -> u16 {
         let inner = self.inner.readlock_inner();
-        Ok(inner
+        inner
             .nodes
             .get(name)
-            .ok_or_else(|| ConfigError::NodeNotFound(name.to_string()))?
-            .port)
+            .unwrap_or_else(|| {
+                eprintln!("No such node available. Run `ockam node list` to list available nodes");
+                std::process::exit(-1);
+            })
+            .port
     }
 
     /// In the future this will actually refer to the watchdog pid or


### PR DESCRIPTION
Add functionality to support https://github.com/build-trust/ockam/issues/3053.

Example of use:

```bash
$ ockam node create n1 --api-address 127.0.0.1:6001
$ ockam node create n2 --api-address 127.0.0.1:6002
$ ockam node create n3 --api-address 127.0.0.1:6003
$ ockam message send --from n1 --to /ip4/127.0.0.1/tcp/6002/ip4/127.0.0.1/tcp/6003/service/uppercase hello
> HELLO
```