### PR TITLE
feat(rust): long_version should display git hash and compile timestamp

### DIFF
--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+fn hash() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}
+
+fn main() {
+    hash();
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -44,7 +44,7 @@ use crate::identity::IdentityCommand;
 use crate::service::ServiceCommand;
 use crate::util::OckamConfig;
 use crate::vault::VaultCommand;
-use clap::{ArgEnum, Args, ColorChoice, Parser, Subcommand};
+use clap::{crate_version, ArgEnum, Args, ColorChoice, Parser, Subcommand};
 use util::setup_logging;
 
 const HELP_TEMPLATE: &str = "\
@@ -65,11 +65,23 @@ FEEDBACK
     on Github https://github.com/build-trust/ockam/discussions/new
 ";
 
+fn long_version() -> &'static str {
+    let crate_version = crate_version!();
+    let git_hash = env!("GIT_HASH");
+    let message = format!(
+        "{}\n\nCompiled from (git hash): {}",
+        crate_version, git_hash
+    );
+
+    Box::leak(message.into_boxed_str())
+}
+
 /// Work seamlessly with Ockam from the command line.
 #[derive(Debug, Parser)]
 #[clap(
     name = "ockam",
     version,
+    long_version = long_version(),
     propagate_version(true),
     color(ColorChoice::Never),
     help_template = HELP_TEMPLATE,


### PR DESCRIPTION
https://github.com/build-trust/ockam/issues/3160

This is example output of `ockam --version`

```
ockam 0.68.0

Compiled from (git hash): 9ba3e4e7ea179f182e029620d8e6b27f802207cb
Compiled at: Sun, 07 Aug 2022 17:17:25 -0700
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
