### PR TITLE
refactor(rust): make it easier to write commands' api req/res handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "directories",
  "dirs",
  "hex",
+ "itertools",
  "minicbor",
  "nix",
  "ockam",

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -3,10 +3,9 @@ use std::borrow::Cow;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use ockam_core::{self, async_trait};
-
 #[cfg(feature = "tag")]
-use ockam_core::api::TypeTag;
+use ockam_core::TypeTag;
+use ockam_core::{self, async_trait};
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
@@ -222,8 +221,9 @@ pub mod auth0 {
 }
 
 pub mod enrollment_token {
-    use crate::auth::types::Attributes;
     use serde::Serialize;
+
+    use crate::auth::types::Attributes;
 
     use super::*;
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -1,12 +1,13 @@
-use minicbor::{Decode, Encode};
-use ockam_core::{CowStr, Result, Route};
-use ockam_multiaddr::MultiAddr;
 use std::str::FromStr;
 
-use crate::error::ApiError;
+use minicbor::{Decode, Encode};
 
 #[cfg(feature = "tag")]
-use crate::TypeTag;
+use ockam_core::TypeTag;
+use ockam_core::{CowStr, Result, Route};
+use ockam_multiaddr::MultiAddr;
+
+use crate::error::ApiError;
 
 pub mod enroll;
 pub mod project;

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,9 +1,9 @@
 use minicbor::{Decode, Encode};
-use ockam_core::CowStr;
 use serde::Serialize;
 
+use ockam_core::CowStr;
 #[cfg(feature = "tag")]
-use crate::TypeTag;
+use ockam_core::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Debug)]
 #[cfg_attr(test, derive(Clone))]
@@ -346,11 +346,12 @@ mod tests {
     }
 
     mod node_api {
+        use ockam_core::api::Status;
+        use ockam_core::route;
+
         use crate::cloud::CloudRequestWrapper;
         use crate::nodes::NodeManager;
         use crate::route_to_multiaddr;
-        use ockam_core::api::Status;
-        use ockam_core::route;
 
         use super::*;
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -2,9 +2,8 @@ use minicbor::{Decode, Encode};
 use serde::Serialize;
 
 use ockam_core::CowStr;
-
 #[cfg(feature = "tag")]
-use crate::TypeTag;
+use ockam_core::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Debug)]
 #[cfg_attr(test, derive(Clone))]
@@ -326,11 +325,12 @@ pub mod tests {
     }
 
     mod node_api {
+        use ockam_core::api::Status;
+        use ockam_core::route;
+
         use crate::cloud::CloudRequestWrapper;
         use crate::nodes::NodeManager;
         use crate::route_to_multiaddr;
-        use ockam_core::api::Status;
-        use ockam_core::route;
 
         use super::*;
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -56,6 +56,7 @@ dialoguer = "0.10"
 directories = "4"
 dirs = "4.0.0"
 hex = "0.4"
+itertools = "0.10"
 minicbor = { version = "0.18.0", features = ["derive"] }
 nix = "0.24"
 open = "2"

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -43,7 +43,9 @@ pub enum AuthenticatedSubcommand {
 
 impl AuthenticatedCommand {
     pub fn run(c: AuthenticatedCommand) {
-        embedded_node(run_impl, c.subcommand)
+        if let Err(e) = embedded_node(run_impl, c.subcommand) {
+            eprintln!("Ockam node failed: {:?}", e,);
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/email.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/email.rs
@@ -20,7 +20,9 @@ impl EnrollEmailCommand {
         println!("\nThank you for trying Ockam. We are working towards a developer release of Ockam Orchestrator in September.
 Please tell us your email and we'll let you know when we're ready to enroll new users to Ockam Orchestrator.\n");
         let email = read_user_input().expect("couldn't read user input");
-        embedded_node(enroll, (cmd, email));
+        if let Err(e) = embedded_node(enroll, (cmd, email)) {
+            eprintln!("Ockam node failed: {:?}", e,);
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -1,0 +1,32 @@
+use crate::util::ConfigError;
+use crate::{exitcode, ExitCode};
+use tracing::error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub struct Error(ExitCode);
+
+impl Error {
+    pub fn new(code: ExitCode) -> Self {
+        assert!(code > 0, "Exit code can't be OK");
+        Self(code)
+    }
+
+    pub fn code(&self) -> ExitCode {
+        self.0
+    }
+}
+
+impl From<ConfigError> for Error {
+    fn from(e: ConfigError) -> Self {
+        error!("{e}");
+        Error::new(exitcode::CONFIG)
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        error!("{e}");
+        Error::new(exitcode::SOFTWARE)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -32,6 +32,7 @@ use tcp::listener::TcpListenerCommand;
 use tcp::outlet::TcpOutletCommand;
 
 // to be removed
+pub mod error;
 mod old;
 
 use old::cmd::identity::IdentityOpts;
@@ -43,10 +44,13 @@ use old::{add_trusted, exit_with_result, node_subcommand, print_identity, print_
 use crate::enroll::GenerateEnrollmentTokenCommand;
 use crate::identity::IdentityCommand;
 use crate::service::ServiceCommand;
-use crate::util::OckamConfig;
+use crate::util::exitcode::ExitCode;
+use crate::util::{exitcode, stop_node, OckamConfig};
 use crate::vault::VaultCommand;
 use clap::{crate_version, ArgEnum, Args, ColorChoice, Parser, Subcommand};
-use util::setup_logging;
+use util::{embedded_node, setup_logging};
+
+pub use error::{Error, Result};
 
 const HELP_TEMPLATE: &str = "\
 {before-help}

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use minicbor::Decoder;
 use tracing::debug;
 
-use crate::CommandGlobalOpts;
+use crate::{embedded_node, CommandGlobalOpts};
 use ockam::TcpTransport;
 use ockam_api::clean_multiaddr;
 use ockam_api::nodes::NODEMANAGER_ADDR;
@@ -11,7 +11,7 @@ use ockam_core::api::{Response, Status};
 use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::{api, connect_to, embedded_node, exitcode, get_final_element, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 
 #[derive(Clone, Debug, Args)]
 pub struct SendCommand {
@@ -42,11 +42,10 @@ impl SendCommand {
         };
 
         if let Some(node) = &cmd.from {
-            let name = get_final_element(node);
-            let port = opts.config.get_node_port(name);
+            let port = opts.config.get_node_port(node);
             connect_to(port, (opts, cmd), send_message_via_connection_to_a_node);
-        } else {
-            embedded_node(send_message_from_embedded_node, cmd)
+        } else if let Err(e) = embedded_node(send_message_from_embedded_node, cmd) {
+            eprintln!("Ockam node failed: {:?}", e,);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -140,7 +140,9 @@ impl CreateCommand {
                 }
             }
 
-            embedded_node(setup, (command, cfg.clone()));
+            if let Err(e) = embedded_node(setup, (command, cfg.clone())) {
+                eprintln!("Ockam node failed: {:?}", e,);
+            }
         } else {
             // On systems with non-obvious path setups (or during
             // development) re-executing the current binary is a more

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,17 +1,12 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
 
+use ockam::Context;
 use ockam_api::cloud::space::Space;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -32,65 +27,25 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), create);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn create(
-    ctx: ockam::Context,
+async fn rpc(
+    mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::create(cmd)?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec
-        .decode::<Response>()
-        .context("Failed to decode Response")?;
-    debug!(?header, "Received response");
-
-    let res = match (header.status(), header.has_body()) {
-        (Some(Status::Ok), true) => {
-            let body = dec
-                .decode::<Space>()
-                .context("Failed to decode response body")?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => body.id.to_string(),
-                OutputFormat::Json => serde_json::to_string(&body)
-                    .context("Failed to serialize command output as json")?,
-            };
-            Ok(output)
-        }
-        (Some(status), true) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request with status code {status:?}: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
-    stop_node(ctx).await
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: CreateCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::space::create(&cmd)).await?;
+    rpc.print_response::<Space>()
 }

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,17 +1,11 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use serde_json::json;
-use tracing::debug;
 
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
+use ockam::Context;
 
 use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -28,63 +22,25 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), delete);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn delete(
-    ctx: ockam::Context,
+async fn rpc(
+    mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
-    let space_id = cmd.id.clone();
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::delete(cmd)?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
-
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => "Space deleted".to_string(),
-                OutputFormat::Json => json!({
-                    "id": space_id,
-                })
-                .to_string(),
-            };
-            Ok(output)
-        }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
-    stop_node(ctx).await
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: DeleteCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::space::delete(&cmd)).await?;
+    rpc.check_response()
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -1,17 +1,12 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
 
+use ockam::Context;
 use ockam_api::cloud::space::Space;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
@@ -24,60 +19,22 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), list);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn list(
-    ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::list(cmd)?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
-
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let body = dec.decode::<Vec<Space>>()?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => format!("{body:#?}"),
-                OutputFormat::Json => serde_json::to_string(&body)?,
-            };
-            Ok(output)
-        }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
-    stop_node(ctx).await
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::space::list(&cmd)).await?;
+    rpc.print_response::<Vec<Space>>()
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,17 +1,12 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
 
+use ockam::Context;
 use ockam_api::cloud::space::Space;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -28,60 +23,22 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ShowCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), show);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn show(
-    ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ShowCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::space::show(cmd)?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
-
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let body = dec.decode::<Space>()?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => format!("{body:#?}"),
-                OutputFormat::Json => serde_json::to_string(&body)?,
-            };
-            Ok(output)
-        }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
-    stop_node(ctx).await
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ShowCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::space::show(&cmd)).await?;
+    rpc.print_response::<Space>()
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -247,41 +247,30 @@ pub(crate) mod enroll {
 /// Helpers to create spaces API requests
 pub(crate) mod space {
     use crate::space::*;
-    use ockam_api::cloud::space::*;
+    use ockam_api::cloud::{space::*, BareCloudRequestWrapper};
+    use ockam_core::api::RequestBuilder;
 
     use super::*;
 
-    pub(crate) fn create(cmd: CreateCommand) -> anyhow::Result<Vec<u8>> {
+    pub(crate) fn create(cmd: &CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
         let b = CreateSpace::new(cmd.name.as_str(), &cmd.admins);
-        let mut buf = vec![];
         Request::builder(Method::Post, "v0/spaces")
             .body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
-            .encode(&mut buf)?;
-        Ok(buf)
     }
 
-    pub(crate) fn list(cmd: ListCommand) -> anyhow::Result<Vec<u8>> {
-        let mut buf = vec![];
+    pub(crate) fn list(cmd: &ListCommand) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::builder(Method::Get, "v0/spaces")
             .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
-            .encode(&mut buf)?;
-        Ok(buf)
     }
 
-    pub(crate) fn show(cmd: ShowCommand) -> anyhow::Result<Vec<u8>> {
-        let mut buf = vec![];
+    pub(crate) fn show(cmd: &ShowCommand) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::builder(Method::Get, format!("v0/spaces/{}", cmd.id))
             .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
-            .encode(&mut buf)?;
-        Ok(buf)
     }
 
-    pub(crate) fn delete(cmd: DeleteCommand) -> anyhow::Result<Vec<u8>> {
-        let mut buf = vec![];
+    pub(crate) fn delete(cmd: &DeleteCommand) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::builder(Method::Delete, format!("v0/spaces/{}", cmd.id))
             .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
-            .encode(&mut buf)?;
-        Ok(buf)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -1,0 +1,65 @@
+use cli_table::{Cell, Style, Table};
+use core::fmt::Write;
+
+use crate::util::comma_separated;
+use ockam_api::cloud::space::Space;
+
+/// Trait to control how a given type will be printed as a CLI output.
+///
+/// The `Output` allows us to reuse the same formatting logic across different commands
+/// and extract the formatting logic out of the commands logic.
+///
+/// Note that we can't just implement the `Display` trait because most of the types we want
+/// to output in the commands are defined in other crates. We can still reuse the `Display`
+/// implementation if it's available and already formats the type as we want. For example:
+///
+/// ```ignore
+/// struct MyType;
+///
+/// impl std::fmt::Display for MyType {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         write!(f, "MyType")
+///     }
+/// }
+///
+/// impl Output for MyType {
+///     fn output(&self) -> anyhow::Result<String> {
+///         Ok(self.to_string())
+///     }
+/// }
+/// ```
+pub trait Output {
+    fn output(&self) -> anyhow::Result<String>;
+}
+
+impl Output for Space<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut w = String::new();
+        write!(w, "id: {}", self.id)?;
+        write!(w, "\nname: {}", self.name)?;
+        write!(w, "\nusers: {}", comma_separated(&self.users))?;
+        Ok(w)
+    }
+}
+
+impl Output for Vec<Space<'_>> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut rows = vec![];
+        for Space {
+            id, name, users, ..
+        } in self
+        {
+            rows.push([id.cell(), name.cell(), comma_separated(users).cell()]);
+        }
+        let table = rows
+            .table()
+            .title([
+                "ID".cell().bold(true),
+                "Name".cell().bold(true),
+                "Users".cell().bold(true),
+            ])
+            .display()?
+            .to_string();
+        Ok(table)
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -150,6 +150,22 @@ pub enum Status {
     #[n(501)] NotImplemented
 }
 
+impl Display for Status {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(match self {
+            Status::Ok => "200 Ok",
+            Status::BadRequest => "400 BadRequest",
+            Status::Unauthorized => "401 Unauthorized",
+            Status::Forbidden => "403 Forbidden",
+            Status::NotFound => "404 NotFound",
+            Status::Conflict => "409 Conflict",
+            Status::MethodNotAllowed => "405 MethodNotAllowed",
+            Status::InternalServerError => "500 InternalServerError",
+            Status::NotImplemented => "501 NotImplemented",
+        })
+    }
+}
+
 impl Id {
     pub fn fresh() -> Self {
         Id(rand::random())

--- a/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
+++ b/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
@@ -12,9 +12,7 @@ use serde::{Deserialize, Serialize};
 /// Contrary to `Cow<_, str>` the `Decode` impl for this type will always borrow
 /// from input so using it in types like `Option`, `Vec<_>` etc will not produce
 /// owned element values.
-#[derive(
-    Debug, Clone, Encode, Decode, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
-)]
+#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize, Eq, PartialOrd, Ord, Hash)]
 #[cbor(transparent)]
 #[serde(transparent)]
 pub struct CowStr<'a>(
@@ -75,5 +73,11 @@ impl<'a> Display for CowStr<'a> {
 impl<'a, S: ?Sized + AsRef<str>> PartialEq<S> for CowStr<'a> {
     fn eq(&self, other: &S) -> bool {
         self.0 == other.as_ref()
+    }
+}
+
+impl<'a> AsRef<str> for CowStr<'a> {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }


### PR DESCRIPTION
Add an abstraction layer on top of `connect_to` to make it easier to write commands' api req/res handlers. It removes a lot of boilerplate around calling the background node and especially, around handling errors. This can prove especially helpful for new contributors.

## Scope, limitations and future changes

The scope of this PR is to apply the new abstraction layer ONLY on `space` commands. For every command group we want to refactor to use this new layer, we have to implement a new trait (`Output`) that defines how the objects that we receive from the nodes are printed in the console. Note that with that trait implemented for `Space` and `Vec<Space>`, we have all we need to properly handle the output of `show`, `get`, and `list` commands.

The ideal situation would be to have an async runtime at the top level (at lib.rs or even at bin/ockam.rs) and pass down the `Context`. If I were to do this on this PR, I'd have to refactor every command which is way out of the scope, so that's why I have those `node_rpc` + `rpc` functions inside the commands. 

We should gradually refactor all the commands in small PR's, and once we have that ready, we can create the async runtime at the top level and then remove the `node_rpc` + `rpc` functions from all commands and just call the `run_impl` method.

## Commands with custom/partial outputs

We have some commands where we don't want to print the whole response or where we want to show a simple message at the end of the command.

To print a message after we receive a response (without body) from the node we can do the following:

```rust
let mut rpc = Rpc::new(...)?;
rpc.request(...).await?;
rpc.check_response()?;
println!("Success");
Ok(())
```

To manually decide what fields of the response body are printed we can do the following:

```rust
let mut rpc = Rpc::new(...)?;
rpc.request(...).await?;
let b = rpc.parse_response::<Space>()?;
println!("The space id is {}", b.id);
Ok(())
```

## Output for `space` commands

```bash
> space create ...
id: id-9joim12kmd
name: name-ajsndono2
users: u1, u2

> space show $ID
id: id-9joim12kmd
name: name-ajsndono2
users: u1, u2

> space list
+-----+-------+--------------+
| ID  | Name  | Users        |
+-----+-------+--------------+
| id1 | name1 | user1, user2 |
+-----+-------+--------------+
| id2 | name2 | user3, user2 |
+-----+-------+--------------+

> space delete $ID 

