### PR TITLE
feat(rust):  crud operation for project enrollers

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -244,7 +244,6 @@ pub mod enrollment_token {
     #[cbor(map)]
     pub struct EnrollmentToken<'a> {
         #[cfg(feature = "tag")]
-        #[serde(skip_serializing)]
         #[n(0)] pub tag: TypeTag<8932763>,
         #[n(1)] pub token: Token<'a>,
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -11,7 +11,6 @@ use ockam_core::TypeTag;
 #[cbor(map)]
 pub struct Invitation<'a> {
     #[cfg(feature = "tag")]
-    #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<7088378>,
     #[b(1)] pub id: CowStr<'a>,
     #[b(2)] pub inviter: CowStr<'a>,

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -11,7 +11,6 @@ use ockam_core::TypeTag;
 #[cbor(map)]
 pub struct Space<'a> {
     #[cfg(feature = "tag")]
-    #[serde(skip_serializing)]
     #[n(0)] pub tag: TypeTag<7574645>,
     #[b(1)] pub id: CowStr<'a>,
     #[b(2)] pub name: CowStr<'a>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -385,6 +385,18 @@ impl NodeManager {
             }
             (Delete, ["v0", "spaces", id]) => self.delete_space(ctx, dec, id).await?,
 
+            // ==*== Project' enrollers ==*==
+            (Post, ["v0", "project-enrollers", project_id]) => {
+                self.add_project_enroller(ctx, dec, project_id).await?
+            }
+            (Get, ["v0", "project-enrollers", project_id]) => {
+                self.list_project_enrollers(ctx, dec, project_id).await?
+            }
+            (Delete, ["v0", "project-enrollers", project_id, identity_id]) => {
+                self.delete_project_enroller(ctx, dec, project_id, identity_id)
+                    .await?
+            }
+
             // ==*== Projects ==*==
             (Post, ["v0", "projects", space_id]) => self.create_project(ctx, dec, space_id).await?,
             (Get, ["v0", "projects"]) => self.list_projects(ctx, dec).await?,

--- a/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
@@ -1,0 +1,60 @@
+use clap::Args;
+
+use ockam::Context;
+use ockam_api::cloud::project::Enroller;
+
+use crate::node::NodeOpts;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
+
+#[derive(Clone, Debug, Args)]
+pub struct AddEnrollerCommand {
+    /// Id of the project.
+    #[clap(display_order = 1001)]
+    pub project_id: String,
+
+    /// Identity id to add as an authorized enroller.
+    #[clap(display_order = 1002)]
+    pub enroller_identity_id: String,
+
+    /// Description of this enroller, optional.
+    #[clap(display_order = 1003)]
+    pub description: Option<String>,
+
+    // TODO: add project_name arg that conflicts with project_id
+    //  so we can call the get_project_by_name api method
+    // /// Name of the project.
+    // #[clap(display_order = 1002)]
+    // pub project_name: String,
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+impl AddEnrollerCommand {
+    pub fn run(opts: CommandGlobalOpts, cmd: AddEnrollerCommand) {
+        node_rpc(rpc, (opts, cmd));
+    }
+}
+
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, AddEnrollerCommand),
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
+
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: AddEnrollerCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::project::add_enroller(&cmd)).await?;
+    rpc.print_response::<Enroller>()
+}

--- a/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
@@ -1,0 +1,54 @@
+use clap::Args;
+
+use ockam::Context;
+
+use crate::node::NodeOpts;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
+
+#[derive(Clone, Debug, Args)]
+pub struct DeleteEnrollerCommand {
+    /// Id of the project.
+    #[clap(display_order = 1001)]
+    pub project_id: String,
+
+    #[clap(display_order = 1002)]
+    pub enroller_identity_id: String,
+
+    // TODO: add project_name arg that conflicts with project_id
+    //  so we can call the get_project_by_name api method
+    // /// Name of the project.
+    // #[clap(display_order = 1002)]
+    // pub project_name: String,
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+impl DeleteEnrollerCommand {
+    pub fn run(opts: CommandGlobalOpts, cmd: DeleteEnrollerCommand) {
+        node_rpc(rpc, (opts, cmd));
+    }
+}
+
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteEnrollerCommand),
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
+
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: DeleteEnrollerCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::project::delete_enroller(&cmd)).await?;
+    rpc.check_response()
+}

--- a/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
@@ -1,0 +1,52 @@
+use clap::Args;
+
+use ockam::Context;
+use ockam_api::cloud::project::Enroller;
+
+use crate::node::NodeOpts;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, Rpc};
+use crate::{stop_node, CommandGlobalOpts};
+
+#[derive(Clone, Debug, Args)]
+pub struct ListEnrollersCommand {
+    /// Id of the project.
+    #[clap(display_order = 1001)]
+    pub project_id: String,
+
+    // TODO: add project_name arg that conflicts with project_id
+    //  so we can call the get_project_by_name api method
+    // /// Name of the project.
+    // #[clap(display_order = 1002)]
+    // pub project_name: String,
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+impl ListEnrollersCommand {
+    pub fn run(opts: CommandGlobalOpts, cmd: ListEnrollersCommand) {
+        node_rpc(rpc, (opts, cmd));
+    }
+}
+
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListEnrollersCommand),
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
+
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListEnrollersCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::project::list_enrollers(&cmd)).await?;
+    rpc.print_response::<Vec<Enroller>>()
+}

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,15 +1,21 @@
 use clap::{Args, Subcommand};
 
+pub use add_enroller::AddEnrollerCommand;
 pub use create::CreateCommand;
 pub use delete::DeleteCommand;
+pub use delete_enroller::DeleteEnrollerCommand;
 pub use list::ListCommand;
+pub use list_enrollers::ListEnrollersCommand;
 pub use show::ShowCommand;
 
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
+mod add_enroller;
 mod create;
 mod delete;
+mod delete_enroller;
 mod list;
+mod list_enrollers;
 mod show;
 
 #[derive(Clone, Debug, Args)]
@@ -35,6 +41,18 @@ pub enum ProjectSubcommand {
     /// Show projects
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Show(ShowCommand),
+
+    /// Adds an authorized enroller to the project' authority
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    AddEnroller(AddEnrollerCommand),
+
+    /// List a project' authority authorized enrollers
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    ListEnrollers(ListEnrollersCommand),
+
+    /// Remove an identity as authorized enroller from the project' authority
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    DeleteEnroller(DeleteEnrollerCommand),
 }
 
 impl ProjectCommand {
@@ -44,6 +62,9 @@ impl ProjectCommand {
             ProjectSubcommand::Delete(scmd) => DeleteCommand::run(opts, scmd),
             ProjectSubcommand::List(scmd) => ListCommand::run(opts, scmd),
             ProjectSubcommand::Show(scmd) => ShowCommand::run(opts, scmd),
+            ProjectSubcommand::AddEnroller(scmd) => AddEnrollerCommand::run(opts, scmd),
+            ProjectSubcommand::ListEnrollers(scmd) => ListEnrollersCommand::run(opts, scmd),
+            ProjectSubcommand::DeleteEnroller(scmd) => DeleteEnrollerCommand::run(opts, scmd),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -16,6 +16,7 @@ use crate::{CommandGlobalOpts, OutputFormat};
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Id of the space.
+    /// TODO: this is not used at all?
     #[clap(display_order = 1001)]
     pub space_id: String,
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -7,8 +7,9 @@ use minicbor::Decoder;
 use clap::Args;
 use ockam::identity::IdentityIdentifier;
 use ockam::Result;
-use ockam_api::cloud::CloudRequestWrapper;
+use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
 use ockam_api::nodes::*;
+use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Method, Request, Response};
 use ockam_core::Address;
 use ockam_multiaddr::MultiAddr;
@@ -247,8 +248,7 @@ pub(crate) mod enroll {
 /// Helpers to create spaces API requests
 pub(crate) mod space {
     use crate::space::*;
-    use ockam_api::cloud::{space::*, BareCloudRequestWrapper};
-    use ockam_core::api::RequestBuilder;
+    use ockam_api::cloud::space::*;
 
     use super::*;
 
@@ -315,6 +315,43 @@ pub(crate) mod project {
         .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
         .encode(&mut buf)?;
         Ok(buf)
+    }
+
+    pub(crate) fn add_enroller(
+        cmd: &AddEnrollerCommand,
+    ) -> RequestBuilder<CloudRequestWrapper<AddEnroller>> {
+        let b = AddEnroller::new(
+            cmd.enroller_identity_id.as_str(),
+            cmd.description.as_deref(),
+        );
+        Request::builder(
+            Method::Post,
+            format!("v0/project-enrollers/{}", cmd.project_id),
+        )
+        .body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
+    }
+
+    pub(crate) fn list_enrollers(
+        cmd: &ListEnrollersCommand,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
+        Request::builder(
+            Method::Get,
+            format!("v0/project-enrollers/{}", cmd.project_id),
+        )
+        .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    }
+
+    pub(crate) fn delete_enroller(
+        cmd: &DeleteEnrollerCommand,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
+        Request::builder(
+            Method::Delete,
+            format!(
+                "v0/project-enrollers/{}/{}",
+                cmd.project_id, cmd.enroller_identity_id
+            ),
+        )
+        .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -1,5 +1,6 @@
 use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
+use ockam_api::cloud::project::Enroller;
 
 use crate::util::comma_separated;
 use ockam_api::cloud::space::Space;
@@ -57,6 +58,38 @@ impl Output for Vec<Space<'_>> {
                 "ID".cell().bold(true),
                 "Name".cell().bold(true),
                 "Users".cell().bold(true),
+            ])
+            .display()?
+            .to_string();
+        Ok(table)
+    }
+}
+
+impl Output for Enroller<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut w = String::new();
+        write!(w, "identity_id: {}", self.identity_id)?;
+        write!(w, "\nadded_by: {}", self.added_by)?;
+        Ok(w)
+    }
+}
+
+impl Output for Vec<Enroller<'_>> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut rows = vec![];
+        for Enroller {
+            identity_id,
+            added_by,
+            ..
+        } in self
+        {
+            rows.push([identity_id.cell(), added_by.cell()]);
+        }
+        let table = rows
+            .table()
+            .title([
+                "Identity ID".cell().bold(true),
+                "Added By".cell().bold(true),
             ])
             .display()?
             .to_string();

--- a/implementations/rust/ockam/ockam_core/src/type_tag.rs
+++ b/implementations/rust/ockam/ockam_core/src/type_tag.rs
@@ -8,7 +8,7 @@ use minicbor::{Decode, Encode};
 /// This zero-sized type is meant to help catching type errors in cases where
 /// CBOR items structurally match various nominal types. It will end up as an
 /// unsigned integer in CBOR and decoding checks that the value is expected.
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct TypeTag<const N: usize>;
 
 // Custom `Debug` impl to include the tag number.


### PR DESCRIPTION
add/list/delete project enrollers from the (internal) project authority.

@adrianbenavides  I think you can take over from here and reorganize the code or cli interface if needed.
 