### PR TITLE
ci: run doctests after cargo nextest

### DIFF
--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -14,7 +14,7 @@ ext {
   // See...
   //  https://github.com/build-trust/ockam/issues/2822
   //  https://github.com/build-trust/ockam/issues/2342
-  environmentCI = { ->
+  environmentVars = { ->
     env = [
       RUSTFLAGS: "--cfg tokio_unstable -Cdebuginfo=0 -Dwarnings -C link-arg=-fuse-ld=/opt/mold/bin/mold",
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: "clang",
@@ -41,7 +41,7 @@ ext {
 task lint_cargo_fmt_check {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('fmt', '--all', '--', '--check')
     }
   }
@@ -50,7 +50,7 @@ task lint_cargo_fmt_check {
 task lint_cargo_clippy {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('clippy', '--no-deps', '--', '-D', 'warnings')
     }
   }
@@ -59,7 +59,7 @@ task lint_cargo_clippy {
 task lint_cargo_deny {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('deny', '--all-features', '--manifest-path=../../Cargo.toml', 'check', 'licenses', 'advisories')
     }
   }
@@ -75,7 +75,7 @@ task lint {
 task build_docs {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('doc', '--no-deps')
     }
   }
@@ -84,7 +84,7 @@ task build_docs {
 task build {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('--locked', 'build')
     }
   }
@@ -93,7 +93,7 @@ task build {
 task build_examples {
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('--locked', 'build', '--examples')
     }
   }
@@ -104,13 +104,24 @@ task test {
   description 'Test the project.'
 
   doLast {
-    exec {
-      environment environmentCI()
-
-      if (ci) {
-        // Use cargo nextest in CI
+    if (ci) {
+      // Use 'cargo nextest' in CI
+      exec {
+        environment environmentVars()
         commandLine cargo('--locked', 'nextest', 'run')
-      } else {
+      }
+      // Nextest does not currently support doctests,
+      // so run doctests using cargo
+      // See https://github.com/nextest-rs/nextest/issues/16
+      exec {
+        environment environmentVars()
+        commandLine cargo('--locked', 'test', '--doc')
+      }
+    }
+    else {
+      // Use 'cargo test' when not in CI
+      exec {
+        environment environmentVars()
         commandLine cargo('--locked', 'test')
       }
     }
@@ -123,7 +134,7 @@ task clean {
 
   doLast {
     exec {
-      environment environmentCI()
+      environment environmentVars()
       commandLine cargo('clean')
     }
   }


### PR DESCRIPTION
## Current Behavior

Issue #3033 identified that Rust doctests are not being run by the GitHub CI. This is because...

- #2949 updated CI to use `cargo nextest` instead of `cargo test`. 
- However, `nextest` [does not currently support doctests](https://github.com/nextest-rs/nextest/issues/16).
- So, doctests have been silently not running. 

## Proposed Changes

- Modify CI so `cargo test --doc` is run after `cargo nextest`.
- In gradle script, rename `environmentCI()` to `environmentVars()` so it makes more sense.

Fixes #3033. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
