### PR TITLE
fix(rust): fix ockam node start and error info

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -105,7 +105,7 @@ impl CreateCommand {
                     verbose,
                 ) {
                     eprintln!(
-                        "failed to update node configuration for '{}': {:?}",
+                        "failed to update node configuration for '{}': {}",
                         command.node_name, e
                     );
                     std::process::exit(-1);
@@ -141,7 +141,7 @@ impl CreateCommand {
                 verbose,
             ) {
                 eprintln!(
-                    "failed to update node configuration for '{}': {:?}",
+                    "failed to update node configuration for '{}': {}",
                     command.node_name, e
                 );
                 std::process::exit(-1);

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,6 +1,6 @@
 use crate::{util::startup, CommandGlobalOpts};
 use clap::Args;
-use nix::{sys::signal::Signal, unistd::Pid};
+use nix::unistd::Pid;
 use rand::prelude::random;
 
 #[derive(Clone, Debug, Args)]
@@ -14,11 +14,9 @@ impl StartCommand {
     pub fn run(opts: CommandGlobalOpts, command: Self) {
         let cfg = opts.config;
 
-        // First we check whether a PID was registered and if it is
-        // still alive.  In case a node is actually running (we test
-        // with SIGUSR1) we abort the operation
+        // First we check whether a PID was registered and if it is still alive.
         if let Ok(Some(pid)) = cfg.get_node_pid(&command.node_name) {
-            let res = nix::sys::signal::kill(Pid::from_raw(pid), Signal::SIGUSR1);
+            let res = nix::sys::signal::kill(Pid::from_raw(pid), None);
 
             if res.is_ok() {
                 eprintln!(

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -33,11 +33,11 @@ impl Deref for OckamConfig {
 /// message.
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
-    #[error("node with name {} already exists", 0)]
+    #[error("node with name {0} already exists")]
     Exists(String),
-    #[error("node with name {} does not exist", 0)]
+    #[error("node with name {0} does not exist")]
     NotFound(String),
-    #[error("node with name {} is not local", 0)]
+    #[error("node with name {0} is not local")]
     NotLocal(String),
 }
 


### PR DESCRIPTION
fix issue (#3184) and some error message output.

## Current Behavior
 If n1 already exists it will print out debug format error message.
```
» ockam create node n1

failed to update node configuration for 'n1': Exists("n1")
```

If starting a non-existing node, error message will be printed out as below.
```
» ockam node start n2

failed to load startup configuration for node 'n2' because: node with name 0 does not exist
```

## Proposed Changes
```
» ockam create node n1

failed to update node configuration for 'n1': node with name n1 already exists

» ockam node start n2

failed to load startup configuration for node 'n2' because: node with name n2 does not exist
```



