### PR TITLE
feat(rust): add `list` subcommand for `secure-channel`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -1,8 +1,8 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
 use ockam_core::Address;
-
 use ockam_core::CowStr;
+
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 use ockam_identity::IdentityIdentifier;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
@@ -144,7 +144,7 @@ impl<'a> TransportStatus<'a> {
     }
 }
 
-/// Respons body when interacting with a transport
+/// Response body when interacting with a transport
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -336,6 +336,8 @@ impl NodeManager {
             }
 
             // ==*== Secure channels ==*==
+            // TODO: Change to RequestBuilder format
+            (Get, ["node", "secure_channel"]) => self.list_secure_channels(req).to_vec()?,
             (Get, ["node", "secure_channel_listener"]) => {
                 self.list_secure_channel_listener(req).to_vec()?
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -117,6 +117,20 @@ impl NodeManager {
         Ok(Response::ok(req.id()).body(response))
     }
 
+    pub(super) fn list_secure_channels(
+        &mut self,
+        req: &Request<'_>,
+    ) -> ResponseBuilder<Vec<String>> {
+        println!("HERE1");
+        Response::ok(req.id()).body(
+            self.registry
+                .secure_channels
+                .iter()
+                .map(|(addr, _)| addr.to_string())
+                .collect(),
+        )
+    }
+
     pub(super) async fn create_secure_channel_listener_impl(
         &mut self,
         addr: Address,

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -1,0 +1,48 @@
+use clap::Args;
+use ockam::Context;
+
+use crate::{
+    node::NodeOpts,
+    util::{api, node_rpc, stop_node, Rpc},
+    CommandGlobalOpts,
+};
+
+#[derive(Args, Clone, Debug)]
+pub struct ListCommand {
+    /// Node of which secure channels shall be listed
+    #[clap(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ListCommand {
+    pub fn run(opts: CommandGlobalOpts, cmd: Self) {
+        node_rpc(secure_channel_list_rpc, (opts, cmd));
+    }
+}
+
+async fn secure_channel_list_rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let res = secure_channel_list_rpc_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
+
+async fn secure_channel_list_rpc_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::list_secure_channels()).await?;
+    let res = rpc.parse_response::<Vec<String>>()?;
+
+    println!("Secure channels for node `{}`:", &cmd.node_opts.api_node);
+
+    for addr in res {
+        println!("  {}", addr);
+    }
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -1,8 +1,10 @@
 pub(crate) mod create;
 pub(crate) mod delete;
+pub(crate) mod list;
 
 pub(crate) use create::CreateCommand;
 pub(crate) use delete::DeleteCommand;
+pub(crate) use list::ListCommand;
 
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::{Args, Subcommand};
@@ -18,8 +20,14 @@ pub enum SecureChannelSubcommand {
     /// Create Secure Channel Connector
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Create(CreateCommand),
+
+    /// Delete Secure Channel Connector
     #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
     Delete(DeleteCommand),
+
+    /// List Secure Channel Connector
+    #[clap(display_order = 900, help_template = HELP_TEMPLATE)]
+    List(ListCommand),
 }
 
 impl SecureChannelCommand {
@@ -27,6 +35,7 @@ impl SecureChannelCommand {
         match command.subcommand {
             SecureChannelSubcommand::Create(sub_cmd) => sub_cmd.run(opts),
             SecureChannelSubcommand::Delete(sub_cmd) => sub_cmd.run(opts),
+            SecureChannelSubcommand::List(command) => ListCommand::run(opts, command),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -125,6 +125,11 @@ pub(crate) fn short_identity() -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Construct a request builder to list all secure channels on the given node
+pub(crate) fn list_secure_channels() -> RequestBuilder<'static, ()> {
+    Request::builder(Method::Get, "/node/secure_channel")
+}
+
 /// Construct a request to create Secure Channels
 pub(crate) fn create_secure_channel(
     addr: MultiAddr,


### PR DESCRIPTION
Fix #3188 

~~Currently, this doesn't work, `RESP` is (). Possible issues.
- Only using `Address` from `registry.secure_channels` as `SecureChannelInfo` only impls Default.
- `SecureChannelList` and `SecureChannelRespone` model struct is the issue. As they are heavily derived from `TransportList`.
- `service::get_secure_channels` ~~

Sorry, I wasn't able to figure it out on my own. Some help would be appreciated, thanks.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.


