### PR TITLE
feat(rust): add exitcodes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -63,6 +63,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | event-listener                | Apache-2.0 OR MIT                                    | https://github.com/stjepang/event-listener                                |
 | executor                      | Apache-2.0 OR MIT                                    | https://www.github.com/richardanaya/executor                              |
 | executor-macros               | Apache-2.0 OR MIT                                    | https://crates.io/crates/executor-macros                                  |
+| exitcode                      | Apache-2.0                                           | https://github.com/benwilber/exitcode                                     |
 | fastrand                      | Apache-2.0 OR MIT                                    | https://github.com/smol-rs/fastrand                                       |
 | ff                            | Apache-2.0 OR MIT                                    | https://github.com/zkcrypto/ff                                            |
 | flume                         | Apache-2.0 OR MIT                                    | https://github.com/zesterer/flume                                         |

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -1,4 +1,4 @@
-use crate::CommandGlobalOpts;
+use crate::{util::exitcode, CommandGlobalOpts};
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -19,6 +19,7 @@ impl GetCommand {
                     "Alias {} not known.  Add it first with `ockam alias set`!",
                     command.alias
                 );
+                std::process::exit(exitcode::DATAERR);
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/configuration/set.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set.rs
@@ -1,4 +1,4 @@
-use crate::CommandGlobalOpts;
+use crate::{util::exitcode, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::config::lookup::InternetAddress;
 
@@ -19,7 +19,7 @@ impl SetCommand {
                     "Invalid alias address!  Please provide an address in the following schema: <address>:<port>. \
                      IPv6, IPv4, and DNS addresses are supported!"
                 );
-                std::process::exit(-1);
+                std::process::exit(exitcode::USAGE);
             }
         };
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
@@ -12,7 +12,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
 
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
@@ -25,7 +25,7 @@ impl EnrollAuth0Command {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), enroll);
@@ -68,7 +68,10 @@ async fn enroll(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_authenticate.rs
@@ -7,7 +7,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_api::{Response, Status};
 use ockam_core::Route;
 
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
@@ -20,7 +20,7 @@ impl AuthenticateEnrollmentTokenCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), authenticate);
@@ -60,7 +60,10 @@ async fn authenticate(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/enrollment_token_generate.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -33,7 +33,7 @@ impl GenerateEnrollmentTokenCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), generate);
@@ -77,7 +77,10 @@ async fn generate(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -11,7 +11,7 @@ use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node, DEFAULT_CLOUD_ADDRESS};
+use crate::util::{api, connect_to, exitcode, stop_node, DEFAULT_CLOUD_ADDRESS};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -36,7 +36,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), create);
@@ -94,7 +94,10 @@ async fn create(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
@@ -20,7 +20,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -49,7 +49,8 @@ pub async fn create_identity(
             println!("Identity {} created!", result.identity_id)
         }
         _ => {
-            eprintln!("An error occurred while creating Identity",)
+            eprintln!("An error occurred while creating Identity",);
+            std::process::exit(exitcode::CANTCREAT);
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, stop_node};
+use crate::util::{connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use crate::{node::NodeOpts, util::api};
 use clap::Args;
@@ -21,7 +21,7 @@ impl ShowCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -51,7 +51,8 @@ pub async fn show_identity(
                 println!("{}", hex::encode(result.identity.0.as_ref()))
             }
             _ => {
-                eprintln!("An error occurred while exporting Identity",)
+                eprintln!("An error occurred while exporting Identity",);
+                std::process::exit(exitcode::IOERR);
             }
         }
 
@@ -71,7 +72,8 @@ pub async fn show_identity(
                 println!("{}", result.identity_id)
             }
             _ => {
-                eprintln!("An error occurred while getting Identity",)
+                eprintln!("An error occurred while getting Identity",);
+                std::process::exit(exitcode::IOERR);
             }
         }
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -10,7 +10,7 @@ use ockam_api::{clean_multiaddr, Response, Status};
 use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::{api, connect_to, embedded_node, stop_node};
+use crate::util::{api, connect_to, embedded_node, exitcode, stop_node};
 
 #[derive(Clone, Debug, Args)]
 pub struct SendCommand {
@@ -33,8 +33,8 @@ impl SendCommand {
             to: match clean_multiaddr(&cmd.to, &opts.config.get_lookup()) {
                 Some(to) => to,
                 None => {
-                    eprintln!("failed to normalise MultiAddr route");
-                    std::process::exit(-1);
+                    eprintln!("failed to normalize MultiAddr route");
+                    std::process::exit(exitcode::USAGE);
                 }
             },
             ..cmd
@@ -103,7 +103,10 @@ async fn send_message_via_connection_to_a_node(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use crate::util::exitcode;
 use crate::{
     node::show::query_status,
     util::{
@@ -103,13 +104,13 @@ impl CreateCommand {
                         "failed to update node configuration for '{}': {}",
                         command.node_name, e
                     );
-                    std::process::exit(-1);
+                    std::process::exit(exitcode::CANTCREAT);
                 }
 
                 // Save the config update
                 if let Err(e) = cfg.atomic_update().run() {
                     eprintln!("failed to update configuration: {}", e);
-                    std::process::exit(-1);
+                    std::process::exit(exitcode::IOERR);
                 }
             }
 
@@ -123,7 +124,7 @@ impl CreateCommand {
             // FIXME: not really clear why this is causing issues
             if cfg.port_is_used(address.port()) {
                 eprintln!("Another node is listening on the provided port!");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
 
             // First we create a new node in the configuration so that
@@ -134,7 +135,7 @@ impl CreateCommand {
                     "failed to update node configuration for '{}': {}",
                     command.node_name, e
                 );
-                std::process::exit(-1);
+                std::process::exit(exitcode::CANTCREAT);
             }
 
             // Construct the arguments list and re-execute the ockam
@@ -155,7 +156,7 @@ impl CreateCommand {
             // Save the config update
             if let Err(e) = startup_cfg.atomic_update().run() {
                 eprintln!("failed to update configuration: {}", e);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
 
             // Unless this CLI was called from another watchdog we
@@ -165,6 +166,7 @@ impl CreateCommand {
             // Save the config update
             if let Err(e) = cfg.atomic_update().run() {
                 eprintln!("failed to update configuration: {}", e);
+                std::process::exit(exitcode::IOERR);
             }
 
             // Wait a bit

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::util::{self, api, connect_to};
+use crate::util::{self, api, connect_to, exitcode};
 use crate::{node::show::query_status, CommandGlobalOpts, OckamConfig};
 use clap::Args;
 use crossbeam_channel::{bounded, Sender};
@@ -18,7 +18,7 @@ impl ListCommand {
 
             if inner.nodes.is_empty() {
                 println!("No nodes registered on this system!");
-                std::process::exit(0);
+                std::process::exit(exitcode::IOERR);
             }
 
             // Before printing node state we have to verify it.  This
@@ -58,12 +58,14 @@ fn verify_pids(cfg: &OckamConfig, nodes: Vec<String>) {
         if node_cfg.pid != verified_pid {
             if let Err(e) = cfg.update_pid(&node_name, verified_pid) {
                 eprintln!("failed to update pid for node {}: {}", node_name, e);
+                std::process::exit(exitcode::IOERR);
             }
         }
     }
 
     if cfg.atomic_update().run().is_err() {
         eprintln!("failed to update PID information in config!");
+        std::process::exit(exitcode::IOERR);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,4 +1,4 @@
-use crate::util::{self, api, connect_to, OckamConfig};
+use crate::util::{self, api, connect_to, exitcode, OckamConfig};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
 use clap::Args;
@@ -23,7 +23,7 @@ impl ShowCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (cfg.clone(), command.node_name), query_status);

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,4 +1,7 @@
-use crate::{util::startup, CommandGlobalOpts};
+use crate::{
+    util::{exitcode, startup},
+    CommandGlobalOpts,
+};
 use clap::Args;
 use nix::unistd::Pid;
 use rand::prelude::random;
@@ -23,7 +26,7 @@ impl StartCommand {
                     "Node '{}' already appears to be running as PID {}",
                     command.node_name, pid
                 );
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         }
 
@@ -35,7 +38,7 @@ impl StartCommand {
                     "failed to load startup configuration for node '{}' because: {}",
                     command.node_name, e
                 );
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,7 @@
-use crate::{util::startup, CommandGlobalOpts};
+use crate::{
+    util::{exitcode, startup},
+    CommandGlobalOpts,
+};
 use clap::Args;
 use rand::prelude::random;
 
@@ -19,11 +22,11 @@ impl StopCommand {
             Ok(Some(pid)) => startup::stop(pid, command.kill),
             Ok(_) => {
                 eprintln!("Node {} is not running!", &command.node_name);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
             Err(_) => {
                 eprintln!("Node {} does not exist!", &command.node_name);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
     }

--- a/implementations/rust/ockam/ockam_command/src/old/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/mod.rs
@@ -8,6 +8,8 @@ use identity::load_identity;
 use ockam::{identity::IdentityIdentifier, NodeBuilder};
 use storage::{ensure_identity_exists, get_ockam_dir};
 
+use crate::util::exitcode;
+
 pub mod identity;
 pub mod storage;
 
@@ -168,7 +170,7 @@ pub fn print_error_and_exit(v: bool, e: anyhow::Error) -> ! {
     for cause in e.chain().skip(1) {
         eprintln!("- caused by: {}", message(v, cause));
     }
-    std::process::exit(1);
+    std::process::exit(exitcode::IOERR);
 }
 
 pub fn exit_with_result(verbose: bool, result: Result<()>) -> ! {

--- a/implementations/rust/ockam/ockam_command/src/portal/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/portal/create.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::util::{ComposableSnippet, Operation, PortalMode, Protocol};
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
@@ -94,7 +94,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -111,14 +111,14 @@ impl CreateCommand {
             Ok(cfg) => cfg,
             Err(e) => {
                 eprintln!("failed to load startup configuration: {}", e);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
         startup_cfg.add_composite(composite);
         if let Err(e) = startup_cfg.atomic_update().run() {
             eprintln!("failed to update configuration: {}", e);
-            std::process::exit(-1);
+            std::process::exit(exitcode::IOERR);
         }
     }
 }
@@ -157,7 +157,10 @@ pub async fn create_inlet(
             )
         }
 
-        _ => eprintln!("An unknown error occurred while creating an inlet..."),
+        _ => {
+            eprintln!("An unknown error occurred while creating an inlet...");
+            std::process::exit(exitcode::UNAVAILABLE)
+        }
     }
 
     stop_node(ctx).await
@@ -201,7 +204,10 @@ pub async fn create_outlet(
             );
         }
 
-        _ => eprintln!("An unknown error occurred while creating an outlet..."),
+        _ => {
+            eprintln!("An unknown error occurred while creating an outlet...");
+            std::process::exit(exitcode::UNAVAILABLE);
+        }
     }
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -42,7 +42,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), create);
@@ -86,7 +86,10 @@ async fn create(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -37,7 +37,7 @@ impl DeleteCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), delete);
@@ -84,7 +84,10 @@ async fn delete(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -29,7 +29,7 @@ impl ListCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), list);
@@ -73,7 +73,10 @@ async fn list(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -41,7 +41,7 @@ impl ShowCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), show);
@@ -85,7 +85,10 @@ async fn show(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use anyhow::{anyhow, Context};
 use clap::Args;
@@ -46,7 +46,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -54,8 +54,8 @@ impl CreateCommand {
             addr: match clean_multiaddr(&command.addr, &cfg.get_lookup()) {
                 Some(addr) => addr,
                 None => {
-                    eprintln!("failed to normalise MultiAddr route");
-                    std::process::exit(-1);
+                    eprintln!("failed to normalize MultiAddr route");
+                    std::process::exit(exitcode::USAGE);
                 }
             },
             ..command
@@ -108,7 +108,10 @@ pub async fn create_connector(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 
 use clap::Args;
@@ -36,7 +36,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -71,7 +71,8 @@ pub async fn create_listener(
             println!("Secure Channel Listener created at {}!", addr)
         }
         _ => {
-            eprintln!("An error occurred while creating secure channel listener",)
+            eprintln!("An error occurred while creating secure channel listener",);
+            std::process::exit(exitcode::CANTCREAT)
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use anyhow::{anyhow, Context};
 use clap::{Args, Subcommand};
@@ -33,7 +33,7 @@ impl StartCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -90,7 +90,10 @@ pub async fn start_vault_service(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await
@@ -137,7 +140,10 @@ pub async fn start_identity_service(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await
@@ -184,7 +190,10 @@ pub async fn start_authenticated_service(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -37,7 +37,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), create);
@@ -86,7 +86,10 @@ async fn create(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -33,7 +33,7 @@ impl DeleteCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), delete);
@@ -80,7 +80,10 @@ async fn delete(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -29,7 +29,7 @@ impl ListCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), list);
@@ -73,7 +73,10 @@ async fn list(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -10,7 +10,7 @@ use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::{CommandGlobalOpts, OutputFormat};
 
 #[derive(Clone, Debug, Args)]
@@ -33,7 +33,7 @@ impl ShowCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, (opts, cmd), show);
@@ -77,7 +77,10 @@ async fn show(
     };
     match res {
         Ok(o) => println!("{o}"),
-        Err(err) => eprintln!("{err}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(exitcode::IOERR);
+        }
     };
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    util::{api, connect_to, stop_node},
+    util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
 };
 use clap::Args;
@@ -63,7 +63,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -76,13 +76,13 @@ impl CreateCommand {
             Ok(cfg) => cfg,
             Err(e) => {
                 eprintln!("failed to load startup configuration: {}", e);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         startup_config.add_composite(composite);
         if let Err(e) = startup_config.atomic_update().run() {
             eprintln!("failed to update configuration: {}", e);
-            std::process::exit(-1);
+            std::process::exit(exitcode::IOERR);
         }
     }
 }
@@ -102,7 +102,7 @@ pub async fn create_connection(
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
 
@@ -119,7 +119,7 @@ pub async fn create_connection(
                 Some(addr) => addr,
                 None => {
                     eprintln!("Couldn't convert given address into `MultiAddr`");
-                    std::process::exit(-1)
+                    std::process::exit(exitcode::SOFTWARE);
                 }
             };
 
@@ -132,7 +132,8 @@ pub async fn create_connection(
             eprintln!(
                 "An error occurred while creating the tcp connection: {}",
                 payload
-            )
+            );
+            std::process::exit(exitcode::CANTCREAT);
         }
     }
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -4,7 +4,7 @@ use ockam_api::{nodes::NODEMANAGER_ADDR, Response, Status};
 
 use crate::{
     node::NodeOpts,
-    util::{api, connect_to, stop_node},
+    util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
 };
 
@@ -28,7 +28,7 @@ impl DeleteCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, command, delete_connection);
@@ -50,7 +50,7 @@ pub async fn delete_connection(
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
     let r: Response = api::parse_response(&resp)?;
@@ -61,6 +61,7 @@ pub async fn delete_connection(
             eprintln!("Failed to delete tcp connection");
             if !cmd.force {
                 eprintln!("You may have to provide --force to delete the API transport");
+                std::process::exit(exitcode::UNAVAILABLE);
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -22,7 +22,7 @@ impl ListCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -41,7 +41,7 @@ pub async fn list_connections(ctx: Context, _: (), mut base_route: Route) -> any
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
 
@@ -74,6 +74,7 @@ pub async fn list_connections(ctx: Context, _: (), mut base_route: Route) -> any
 
     if let Err(e) = print_stdout(table) {
         eprintln!("failed to print node status: {}", e);
+        std::process::exit(exitcode::IOERR);
     }
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    util::{api, connect_to, stop_node},
+    util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
 };
 use clap::Args;
@@ -56,7 +56,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -69,13 +69,13 @@ impl CreateCommand {
             Ok(cfg) => cfg,
             Err(e) => {
                 eprintln!("failed to load startup configuration: {}", e);
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         startup_config.add_composite(composite);
         if let Err(e) = startup_config.atomic_update().run() {
             eprintln!("failed to update configuration: {}", e);
-            std::process::exit(-1);
+            std::process::exit(exitcode::IOERR);
         }
     }
 }
@@ -95,7 +95,7 @@ pub async fn create_listener(
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
 
@@ -112,7 +112,7 @@ pub async fn create_listener(
                 Some(addr) => addr,
                 None => {
                     eprintln!("Couldn't convert given address into `MultiAddr`");
-                    std::process::exit(-1)
+                    std::process::exit(exitcode::SOFTWARE);
                 }
             };
 
@@ -125,7 +125,8 @@ pub async fn create_listener(
             eprintln!(
                 "An error occurred while creating the tcp listener: {}",
                 payload
-            )
+            );
+            std::process::exit(exitcode::CANTCREAT);
         }
     }
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -4,7 +4,7 @@ use ockam_api::{nodes::NODEMANAGER_ADDR, Response, Status};
 
 use crate::{
     node::NodeOpts,
-    util::{api, connect_to, stop_node},
+    util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
 };
 
@@ -28,7 +28,7 @@ impl DeleteCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
         connect_to(port, command, delete_listener);
@@ -50,7 +50,7 @@ pub async fn delete_listener(
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
     let r: Response = api::parse_response(&resp)?;
@@ -61,6 +61,7 @@ pub async fn delete_listener(
             eprintln!("Failed to delete tcp listener");
             if !cmd.force {
                 eprintln!("You may have to provide --force to delete the API transport");
+                std::process::exit(exitcode::UNAVAILABLE);
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -22,7 +22,7 @@ impl ListCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -41,7 +41,7 @@ pub async fn list_listeners(ctx: Context, _: (), mut base_route: Route) -> anyho
         Ok(sr_msg) => sr_msg,
         Err(e) => {
             eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(-1)
+            std::process::exit(exitcode::IOERR);
         }
     };
 
@@ -74,6 +74,7 @@ pub async fn list_listeners(ctx: Context, _: (), mut base_route: Route) -> anyho
 
     if let Err(e) = print_stdout(table) {
         eprintln!("failed to print node status: {}", e);
+        std::process::exit(exitcode::IOERR);
     }
 
     stop_node(ctx).await

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -12,6 +12,8 @@ pub use ockam_api::config::snippet::{
     ComposableSnippet, Operation, PortalMode, Protocol, RemoteMode,
 };
 
+use crate::util::exitcode;
+
 /// A simple wrapper around the main configuration structure to add
 /// local config utility/ query functions
 #[derive(Clone)]
@@ -93,7 +95,7 @@ impl OckamConfig {
             .get(name)
             .unwrap_or_else(|| {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             })
             .port
     }
@@ -199,7 +201,7 @@ impl OckamConfig {
 
         if let Err(e) = create_dir_all(&state_dir) {
             eprintln!("failed to create new node state directory: {}", e);
-            std::process::exit(-1);
+            std::process::exit(exitcode::CANTCREAT);
         }
 
         // Add this node to the config lookup table

--- a/implementations/rust/ockam/ockam_command/src/util/exitcode.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/exitcode.rs
@@ -1,0 +1,78 @@
+#![allow(dead_code)]
+/// Alias for the numeric type that holds system exit codes.
+pub type ExitCode = i32;
+
+/// Successful exit
+pub const OK: ExitCode = 0;
+
+/// The command was used incorrectly, e.g., with the
+/// wrong number of arguments, a bad flag, a bad syntax
+/// in a parameter, etc.
+pub const USAGE: ExitCode = 64;
+
+/// The input data was incorrect in some way.  This
+/// should only be used for user's data and not system
+/// files.
+pub const DATAERR: ExitCode = 65;
+
+/// An input file (not a system file) did not exist or
+/// was not readable.  This could also include errors
+/// like "No message" to a mailer (if it cared to
+/// catch it).
+pub const NOINPUT: ExitCode = 66;
+
+/// The user specified did not exist.  This might be
+/// used for mail addresses or remote logins.
+pub const NOUSER: ExitCode = 67;
+
+/// The host specified did not exist.  This is used in
+/// mail addresses or network requests.
+pub const NOHOST: ExitCode = 68;
+
+/// A service is unavailable.  This can occur if a
+/// support program or file does not exist. This can also
+/// be used as a catchall message when something you
+/// wanted to do doesn't work, but you don't know why.
+pub const UNAVAILABLE: ExitCode = 69;
+
+/// An internal software error has been detected.  This
+/// should be limited to non-operating system related
+/// errors as possible.
+pub const SOFTWARE: ExitCode = 70;
+
+/// An operating system error has been detected.  This
+/// is intended to be used for such things as "cannot
+/// fork", "cannot create pipe", or the like.  It
+/// includes things like getuid returning a user that
+/// does not exist in the passwd file.
+pub const OSERR: ExitCode = 71;
+
+/// Some system file (e.g., /etc/passwd, /var/run/utmp,
+/// etc.) does not exist, cannot be opened, or has some
+/// sort of error (e.g., syntax error).
+pub const OSFILE: ExitCode = 72;
+
+/// A (user specified) output file cannot be created.
+pub const CANTCREAT: ExitCode = 73;
+
+/// An error occurred while doing I/O on some file.
+pub const IOERR: ExitCode = 74;
+
+/// Temporary failure, indicating something that is not
+/// really an error.  In sendmail, this means that a
+/// mailer (e.g.) could not create a connection, and
+/// the request should be reattempted later.
+pub const TEMPFAIL: ExitCode = 75;
+
+/// The remote system returned something that was
+/// "not possible" during a protocol exchange.
+pub const PROTOCOL: ExitCode = 76;
+
+/// You did not have sufficient permission to perform
+/// the operation.  This is not intended for file system
+/// problems, which should use `NOINPUT` or `CANTCREAT`,
+/// but rather for higher level permissions.
+pub const NOPERM: ExitCode = 77;
+
+/// Something was found in an unconfigured or misconfigured state.
+pub const CONFIG: ExitCode = 78;

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, stop_node};
+use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
@@ -23,7 +23,7 @@ impl CreateCommand {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(-1);
+                std::process::exit(exitcode::IOERR);
             }
         };
 
@@ -52,7 +52,8 @@ pub async fn create_vault(
             println!("Vault created!")
         }
         _ => {
-            eprintln!("An error occurred while creating Vault",)
+            eprintln!("An error occurred while creating Vault",);
+            std::process::exit(exitcode::CANTCREAT);
         }
     }
 


### PR DESCRIPTION
Fix #3199 

- Vast majority of errors were `IOERR`.
- Unused errors in `util/exitcode.rs` were ignored using `_` rather than removing.
- Didn't use `OK` exitcode as it implied by default.
- Didn't add comment describing exitcode usage, as they are self-explanatory and would be redundant.

Clarification required:
1. `message::send.rs`, etcetera have "failed to normalize MultiAddr route" 
    - Is this a `USAGE` error or `SOFTWARE` error?
2. Can error in `create.rs`(`forwarder/create.rs#L99` etcetera) be considered as `CANTCREAT` error?
3. `tcp/connection/delete.rs#L64` "You may have to provide --force to delete the API transport"
    - Can this be `USAGE` error?
4. `util/mod.rs#L68` "encountered an error in command handler code"
    - Is this `USAGE`, `IOERR` or `SOFTWARE` error?
    
Unrelated: Shouldn't `/transport` dir be removed?
