### PR TITLE
feat(rust): make `IdentityIdentifier` encodable

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
@@ -106,7 +106,7 @@ impl<V: IdentityVault> IdentityService<V> {
             Post => match req.path_segments::<2>().as_slice() {
                 [""] => {
                     let identity = Identity::create(&self.ctx, &self.vault).await?;
-                    let identifier = identity.identifier()?;
+                    let identifier = identity.identifier();
 
                     let body =
                         CreateResponse::new(identity.export().await?, String::from(identifier));
@@ -123,7 +123,7 @@ impl<V: IdentityVault> IdentityService<V> {
                         Identity::import(&self.ctx, args.identity(), &self.vault).await?;
 
                     let body = ValidateIdentityChangeHistoryResponse::new(String::from(
-                        identity.identifier()?,
+                        identity.identifier(),
                     ));
 
                     Self::ok_response(req, Some(body), enc)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -197,13 +197,11 @@ impl NodeManager {
         self.start_echoer_service_impl(ctx, "echo".into()).await?;
 
         let authorized_identifiers = if self.config.readlock_inner().identity_was_overridden {
-            if let Some(identity) = &self.identity {
+            self.identity.as_ref().map(|i| {
                 // If we had overridden Identity - we should trust only this identity,
                 // otherwise - trust all
-                Some(vec![identity.identifier()?])
-            } else {
-                None
-            }
+                vec![i.identifier().clone()]
+            })
         } else {
             None
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
@@ -25,7 +25,7 @@ impl NodeManager {
         if let Some(identity) = &self.identity {
             return if reuse_if_exists {
                 debug!("Using existing identity");
-                identity.identifier()
+                Ok(identity.identifier().clone())
             } else {
                 Err(ockam_core::Error::new(
                     Origin::Application,
@@ -38,7 +38,7 @@ impl NodeManager {
         let vault = self.vault()?;
 
         let identity = Identity::create(ctx, vault).await?;
-        let identifier = identity.identifier()?;
+        let identifier = identity.identifier().clone();
         let exported_identity = identity.export().await?;
 
         self.config.inner().write().unwrap().identity = Some(exported_identity);
@@ -77,7 +77,7 @@ impl NodeManager {
         req: &Request<'_>,
     ) -> Result<ResponseBuilder<ShortIdentityResponse<'_>>> {
         let identity = self.identity()?;
-        let identifier = identity.identifier()?;
+        let identifier = identity.identifier();
 
         let response =
             Response::ok(req.id()).body(ShortIdentityResponse::new(identifier.to_string()));

--- a/implementations/rust/ockam/ockam_api/src/old/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/old/identity.rs
@@ -34,7 +34,7 @@ pub async fn create_identity(
     }
 
     let identity = Identity::create(ctx, vault).await?;
-    let identifier = identity.identifier()?;
+    let identifier = identity.identifier();
     tracing::debug!("Saving new identity: {:?}", identifier.key_id());
     save_identity(ockam_dir, &identity).await?;
     tracing::info!(
@@ -61,7 +61,7 @@ pub async fn load_identity(
         ));
     }
     let identity = Identity::import(ctx, &stored_ident.identity, vault).await?;
-    tracing::info!("Loaded identity {:?}", identity.identifier()?,);
+    tracing::info!("Loaded identity {:?}", identity.identifier());
     Ok(identity)
 }
 

--- a/implementations/rust/ockam/ockam_api/src/signer.rs
+++ b/implementations/rust/ockam/ockam_api/src/signer.rs
@@ -24,7 +24,7 @@ pub struct Server<V: IdentityVault, S> {
 impl<V: IdentityVault, S> fmt::Debug for Server<V, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Server")
-            .field("id", &self.id.identifier())
+            .field("id", self.id.identifier())
             .finish()
     }
 }
@@ -64,7 +64,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Server<V, S> {
                     let pos = dec.position();
                     dec.decode::<Attributes>()?; // typecheck
                     let att = &dec.input()[pos..];
-                    let iid = self.id.identifier()?;
+                    let iid = self.id.identifier();
                     let sig = self.id.create_signature(att).await?;
                     let bdy = {
                         let a = CowBytes::from(att);
@@ -125,7 +125,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Server<V, S> {
     }
 
     async fn verify(&self, data: &[u8], sig: &Signature<'_>) -> Result<bool> {
-        let ours = self.id.identifier()?;
+        let ours = self.id.identifier();
         let theirs = sig.identity().as_str();
 
         let sig = vault::Signature::new(sig.data().to_vec());

--- a/implementations/rust/ockam/ockam_api/tests/auth.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth.rs
@@ -37,7 +37,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         let e_store = InMemoryStorage::new();
         let m_store = InMemoryStorage::new();
         let mut auth = direct::Server::new(m_store, e_store, mk_signer(ctx).await?);
-        auth.set_admin(&admin.identifier()?);
+        auth.set_admin(admin.identifier());
         ctx.start_worker("auth", auth).await?;
     }
 
@@ -49,7 +49,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
             .create_secure_channel("api", TrustEveryonePolicy, &InMemoryStorage::new())
             .await?;
         let mut c = direct::Client::new(route![a2a, "auth"], ctx).await?;
-        c.add_enroller(IdentityId::new(e.identifier()?.key_id()))
+        c.add_enroller(IdentityId::new(e.identifier().key_id()))
             .await?;
         e
     };
@@ -69,7 +69,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
 
     // Add the member via the enroller's connection:
     let mut c = direct::Client::new(route![e2a, "auth"], ctx).await?;
-    c.add_member(IdentityId::new(m.identifier()?.key_id()))
+    c.add_member(IdentityId::new(m.identifier().key_id()))
         .await?;
 
     // Open a secure channel from member to authenticator:

--- a/implementations/rust/ockam/ockam_api/tests/signer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/signer.rs
@@ -16,7 +16,7 @@ async fn signer(ctx: &mut Context) -> Result<()> {
 
     let mut c = signer::Client::new("signer".into(), ctx).await?;
 
-    let bid = b.identifier()?;
+    let bid = b.identifier();
     let mut attrs = Attributes::new();
     attrs.put("id", bid.key_id().as_bytes());
     let cred = c.sign(&attrs).await?.to_owned();

--- a/implementations/rust/ockam/ockam_command/src/old/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/identity.rs
@@ -46,7 +46,7 @@ pub async fn create_identity(
     let vault = OckamVault::new(Some(Arc::new(vault_storage)));
     let identity = Identity::create(ctx, &vault).await?;
     let exported = IdentityData {
-        id: identity.identifier()?,
+        id: identity.identifier().clone(),
         data: identity.changes().await?,
     };
 

--- a/implementations/rust/ockam/ockam_command/src/old/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/mod.rs
@@ -35,7 +35,7 @@ pub async fn print_identity(_arg: (), mut ctx: ockam::Context) -> anyhow::Result
     ensure_identity_exists(false)?;
     let dir = get_ockam_dir()?;
     let identity = load_identity(&ctx, &dir).await?;
-    let identifier = identity.identifier()?;
+    let identifier = identity.identifier();
     println!("{}", identifier.key_id());
     ctx.stop().await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -99,8 +99,8 @@ mod test {
         let alice = Identity::create(ctx, &alice_vault).await?;
         let bob = Identity::create(ctx, &bob_vault).await?;
 
-        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier()?);
-        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier()?);
+        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
+        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
 
         bob.create_secure_channel_listener("bob_listener", bob_trust_policy, &bob_storage)
             .await?;
@@ -118,7 +118,7 @@ mod test {
         let msg = ctx.receive::<String>().await?.take();
 
         let local_info = IdentitySecureChannelLocalInfo::find_info(msg.local_message())?;
-        assert_eq!(local_info.their_identity_id(), &alice.identifier()?);
+        assert_eq!(local_info.their_identity_id(), alice.identifier());
 
         let return_route = msg.return_route();
         assert_eq!("Hello, Bob!", msg.body());
@@ -128,7 +128,7 @@ mod test {
         let msg = ctx.receive::<String>().await?.take();
 
         let local_info = IdentitySecureChannelLocalInfo::find_info(msg.local_message())?;
-        assert_eq!(local_info.their_identity_id(), &bob.identifier()?);
+        assert_eq!(local_info.their_identity_id(), bob.identifier());
 
         assert_eq!("Hello, Alice!", msg.body());
 
@@ -145,8 +145,8 @@ mod test {
         let alice = Identity::create(ctx, &vault).await?;
         let bob = Identity::create(ctx, &vault).await?;
 
-        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier()?);
-        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier()?);
+        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
+        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
 
         bob.create_secure_channel_listener("bob_listener", bob_trust_policy.clone(), &bob_storage)
             .await?;
@@ -198,8 +198,8 @@ mod test {
         let alice = Identity::create(ctx, &vault).await?;
         let bob = Identity::create(ctx, &vault).await?;
 
-        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier()?);
-        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier()?);
+        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
+        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
 
         bob.create_secure_channel_listener("bob_listener", bob_trust_policy.clone(), &bob_storage)
             .await?;
@@ -270,8 +270,8 @@ mod test {
         let alice = Identity::create(ctx, &vault).await?;
         let bob = Identity::create(ctx, &vault).await?;
 
-        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier()?);
-        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier()?);
+        let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
+        let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
 
         let n = rand::random::<u8>() % 5 + 4;
         let mut channels = vec![];
@@ -349,7 +349,7 @@ mod test {
         let alice = Identity::create(ctx, &vault).await?;
         let bob = Identity::create(ctx, &vault).await?;
 
-        let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier()?);
+        let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().clone());
         WorkerBuilder::with_access_control(access_control, "receiver", receiver)
             .start(ctx)
             .await?;
@@ -389,7 +389,7 @@ mod test {
         let alice = Identity::create(ctx, &vault).await?;
         let bob = Identity::create(ctx, &vault).await?;
 
-        let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier()?);
+        let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().clone());
         WorkerBuilder::with_access_control(access_control, "receiver", receiver)
             .start(ctx)
             .await?;

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -1,6 +1,7 @@
 use crate::{IdentityError, IdentityStateConst};
 use core::fmt::{Display, Formatter};
 use core::str::FromStr;
+use minicbor::{Decode, Encode};
 use ockam_core::compat::string::String;
 use ockam_core::vault::{Hasher, KeyId};
 use ockam_core::{Error, Result};
@@ -8,8 +9,9 @@ use serde::{Deserialize, Serialize};
 
 /// An identifier of an Identity.
 #[allow(clippy::derive_hash_xor_eq)] // we manually implement a constant time Eq
-#[derive(Clone, Debug, Hash, Serialize, Deserialize, Default, PartialOrd, Ord)]
-pub struct IdentityIdentifier(KeyId);
+#[derive(Clone, Debug, Hash, Encode, Decode, Serialize, Deserialize, Default, PartialOrd, Ord)]
+#[cbor(transparent)]
+pub struct IdentityIdentifier(#[n(0)] KeyId);
 
 /// Unique [`crate::Identity`] identifier, computed as SHA256 of root public key
 impl IdentityIdentifier {
@@ -45,6 +47,12 @@ impl Display for IdentityIdentifier {
 
 impl From<IdentityIdentifier> for String {
     fn from(id: IdentityIdentifier) -> Self {
+        Self::from(&id)
+    }
+}
+
+impl From<&IdentityIdentifier> for String {
+    fn from(id: &IdentityIdentifier) -> Self {
         format!("{}{}", IdentityIdentifier::PREFIX, &id.0)
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -164,8 +164,8 @@ impl<V: IdentityVault> Identity<V> {
 }
 
 impl<V: IdentityVault> Identity<V> {
-    pub fn identifier(&self) -> Result<IdentityIdentifier> {
-        Ok(self.id.clone())
+    pub fn identifier(&self) -> &IdentityIdentifier {
+        &self.id
     }
 
     pub async fn create_key(&self, label: String) -> Result<()> {

--- a/implementations/rust/ockam/ockam_identity/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/tests.rs
@@ -24,10 +24,10 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
     let bob = Identity::create(ctx, &bob_vault).await?;
 
     alice
-        .update_known_identity(&bob.identifier()?, &bob.changes().await?, &alice_storage)
+        .update_known_identity(bob.identifier(), &bob.changes().await?, &alice_storage)
         .await?;
 
-    bob.update_known_identity(&alice.identifier()?, &alice.changes().await?, &bob_storage)
+    bob.update_known_identity(alice.identifier(), &alice.changes().await?, &bob_storage)
         .await?;
 
     // Some state known to both parties. In Noise this would be a computed hash, for example.
@@ -42,14 +42,14 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
     let bob_proof = bob.create_signature(&state).await?;
 
     if !alice
-        .verify_signature(&bob_proof, &bob.identifier()?, &state, &alice_storage)
+        .verify_signature(&bob_proof, bob.identifier(), &state, &alice_storage)
         .await?
     {
         return test_error("bob's proof was invalid");
     }
 
     if !bob
-        .verify_signature(&alice_proof, &alice.identifier()?, &state, &bob_storage)
+        .verify_signature(&alice_proof, alice.identifier(), &state, &bob_storage)
         .await?
     {
         return test_error("alice's proof was invalid");
@@ -77,10 +77,10 @@ async fn test_key_rotation(ctx: &mut Context) -> Result<()> {
     bob.rotate_root_secret_key().await?;
 
     alice
-        .update_known_identity(&bob.identifier()?, &bob.changes().await?, &alice_storage)
+        .update_known_identity(bob.identifier(), &bob.changes().await?, &alice_storage)
         .await?;
 
-    bob.update_known_identity(&alice.identifier()?, &alice.changes().await?, &bob_storage)
+    bob.update_known_identity(alice.identifier(), &alice.changes().await?, &bob_storage)
         .await?;
 
     ctx.stop().await?;
@@ -101,20 +101,20 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
     let bob = Identity::create(ctx, &bob_vault).await?;
 
     alice
-        .update_known_identity(&bob.identifier()?, &bob.changes().await?, &alice_storage)
+        .update_known_identity(bob.identifier(), &bob.changes().await?, &alice_storage)
         .await?;
 
-    bob.update_known_identity(&alice.identifier()?, &alice.changes().await?, &bob_storage)
+    bob.update_known_identity(alice.identifier(), &alice.changes().await?, &bob_storage)
         .await?;
 
     alice.rotate_root_secret_key().await?;
     bob.rotate_root_secret_key().await?;
 
     alice
-        .update_known_identity(&bob.identifier()?, &bob.changes().await?, &alice_storage)
+        .update_known_identity(bob.identifier(), &bob.changes().await?, &alice_storage)
         .await?;
 
-    bob.update_known_identity(&alice.identifier()?, &alice.changes().await?, &bob_storage)
+    bob.update_known_identity(alice.identifier(), &alice.changes().await?, &bob_storage)
         .await?;
 
     // Re-Prove
@@ -129,14 +129,14 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
     let bob_proof = bob.create_signature(&state).await?;
 
     if !alice
-        .verify_signature(&bob_proof, &bob.identifier()?, &state, &alice_storage)
+        .verify_signature(&bob_proof, bob.identifier(), &state, &alice_storage)
         .await?
     {
         return test_error("bob's proof was invalid");
     }
 
     if !bob
-        .verify_signature(&alice_proof, &alice.identifier()?, &state, &bob_storage)
+        .verify_signature(&alice_proof, alice.identifier(), &state, &bob_storage)
         .await?
     {
         return test_error("alice's proof was invalid");


### PR DESCRIPTION
Derive `minicbor::{Encode, Decode}` for `IdentityIdentifier` to enable direct use of the type in API requests and responses.

Also changes `Identiy::identifier` to return `&IdentityIdentifier` instead of `Result<IdentityIdentifier>` as the method never fails and to better support callers that do not need to get a clone of the value.