### PR TITLE
feat(elixir): allow more generic proxy services for a sidecar

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/telemetry_logger.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/telemetry_logger.ex
@@ -14,7 +14,8 @@ if Code.ensure_loaded?(:telemetry) do
     def attach() do
       subscribe_events = [
         [:ockam, Ockam.Worker, :init, :start],
-        [:ockam, Ockam.Worker, :init, :stop]
+        [:ockam, Ockam.Worker, :init, :stop],
+        [:ockam, Ockam.Router, :route, :start]
       ]
 
       :telemetry.attach_many(

--- a/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
@@ -145,7 +145,9 @@ config :ockam_services,
     # discovery service
     Ockam.Services.Provider.Discovery,
     # proxies for remote services
-    Ockam.Services.Provider.Proxy
+    Ockam.Services.Provider.Proxy,
+    # proxies to services in other nodes
+    Ockam.Services.Provider.Sidecar
   ],
   services_config_source: services_config_source,
   # JSON version of the services definition

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/sidecar.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/sidecar.ex
@@ -15,34 +15,97 @@ defmodule Ockam.Services.Provider.Sidecar do
 
   **NOTE** service address is used by Ockam.Identity.Sidecar
   and will always be as defined in Ockam.Identity.Sidecar.api_route()
+
+  :ca_verifier_sidecar - sidecar service providing credential verifier for Ockam.Credential.Verifier.Sidecar
+
+  Options:
+
+  - sidecar_host - hostname for sidecar node, default is "localhost"
+  - sidecar_port - port for sidecar node, default is 4100
+  - sidecar_address - worker address on the sidecar node, default is "ca_verifier_service"
+
+  :sidecar_node - service forwarding to a sidecar node (essentialy a persistent TCP client)
+
+  Options:
+  - service_id - atom id of the service for the supervisor
+  - address - optional, address of the proxy worker, defaults to string service_id
+  - sidecar_host - hostname for sidecar node, default is "localhost"
+  - sidecar_port - port for sidecar node, default is 4100
+  - refresh_timeout - heartbeat timeout to check the connection
+
+  :sidecar_proxy - generic sidecar proxy service
+
+  Options:
+  - service_id - atom id of the service for the supervisor
+  - address - optional, address of the proxy worker, defaults to string service_id
+  - sidecar_host - hostname for sidecar node, default is "localhost"
+  - sidecar_port - port for sidecar node, default is 4100
+  - sidecar_address - worker address on the sidecar node
   """
   @behaviour Ockam.Services.Provider
 
+  alias Ockam.Transport.TCP.RecoverableClient
+  alias Ockam.Transport.TCPAddress
+
   @impl true
   def services() do
-    [:identity_sidecar]
+    [:identity_sidecar, :sidecar_proxy, :sidecar_node]
   end
 
   @impl true
-  def child_spec(:identity_sidecar, args) do
+  def child_spec(:identity_sidecar = service_id, args) do
+    sidecar_address = Keyword.get(args, :sidecar_address, "identity_service")
+    [address] = Ockam.Identity.Sidecar.api_route()
+
+    child_spec(
+      :sidecar_proxy,
+      args ++ [service_id: service_id, address: address, sidecar_address: sidecar_address]
+    )
+  end
+
+  def child_spec(:sidecar_proxy, args) do
+    service_id = Keyword.fetch!(args, :service_id)
+    address = Keyword.get(args, :address, to_string(service_id))
+
+    sidecar_address = Keyword.fetch!(args, :sidecar_address)
     sidecar_host = Keyword.get(args, :sidecar_host, "localhost")
     sidecar_port = Keyword.get(args, :sidecar_port, 4100)
-    sidecar_address = Keyword.get(args, :sidecar_address, "identity_service")
-    forward_route = [Ockam.Transport.TCPAddress.new(sidecar_host, sidecar_port), sidecar_address]
-
-    [api_address] = Ockam.Identity.Sidecar.api_route()
+    forward_route = [TCPAddress.new(sidecar_host, sidecar_port), sidecar_address]
 
     extra_options =
       Keyword.drop(
         args,
-        [:sidecar_port, :sidecar_host, :sidecar_address]
+        [:sidecar_port, :sidecar_host, :sidecar_address, :service_id]
       )
 
-    options = Keyword.merge(extra_options, forward_route: forward_route, address: api_address)
+    options = Keyword.merge(extra_options, forward_route: forward_route, address: address)
 
     %{
-      id: :identity_sidecar,
+      id: service_id,
       start: {Ockam.Services.Proxy, :start_link, [options]}
+    }
+  end
+
+  def child_spec(:sidecar_node, args) do
+    service_id = Keyword.fetch!(args, :service_id)
+    address = Keyword.get(args, :address, to_string(service_id))
+
+    sidecar_host = Keyword.get(args, :sidecar_host, "localhost")
+    sidecar_port = Keyword.get(args, :sidecar_port, 4100)
+
+    destination = TCPAddress.new(sidecar_host, sidecar_port)
+
+    extra_options =
+      Keyword.drop(
+        args,
+        [:sidecar_port, :sidecar_host, :service_id]
+      )
+
+    options = Keyword.merge(extra_options, destination: destination, address: address)
+
+    %{
+      id: service_id,
+      start: {RecoverableClient, :start_link, [options]}
     }
   end
 end


### PR DESCRIPTION
Add `sidecar_proxy` service to set up generic proxies to sidecar
Add `sidecar_node` service to set up TCP connection to sidecar node


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
