### PR TITLE
fix(elixir): fix return type in set_identity for `TrustPolicy.KnownIdentitiesEts`

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/trust_policy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/trust_policy.ex
@@ -194,7 +194,7 @@ defmodule Ockam.Identity.TrustPolicy.KnownIdentitiesEts do
   def set_identity(contact_id, contact, _arg) do
     ensure_table()
     true = :ets.insert(@table, {contact_id, contact})
-    {:ok, contact}
+    :ok
   end
 
   def ensure_table() do


### PR DESCRIPTION

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

`TrustPolicy.KnownIdentitiesEts` was returning `{:ok, identity}`

## Proposed Changes

Change return value to `:ok`

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
