### PR TITLE
Secure channel message flow authorization configuration

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -38,10 +38,11 @@ defmodule Ockam.Worker do
   end
 
   def update_authorization_state(state, address, authorization) do
-    update_authorization_state(state, %{address => authorization})
+    update_authorization_state(state, %{address => Authorization.expand_config(authorization)})
   end
 
   def update_authorization_state(state, update) when is_map(update) do
+    update = Authorization.expand_config(update)
     current_authorization = Map.get(state, :authorization, [])
 
     new_authorization =
@@ -58,7 +59,7 @@ defmodule Ockam.Worker do
   end
 
   def update_authorization_state(state, update) when is_list(update) do
-    Map.put(state, :authorization, update)
+    Map.put(state, :authorization, Authorization.expand_config(update))
   end
 
   defmacro __using__(_options) do

--- a/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/identity/secure_channel_test.exs
@@ -191,4 +191,25 @@ defmodule Ockam.Identity.SecureChannel.Tests do
       payload: "PING!"
     }
   end
+
+  test "dynamic identity" do
+    {:ok, listener} = SecureChannel.create_listener(identity: :dynamic)
+
+    {:ok, channel} =
+      SecureChannel.create_channel(
+        identity: :dynamic,
+        route: [listener]
+      )
+
+    {:ok, me} = Ockam.Node.register_random_address()
+    Logger.info("Channel: #{inspect(channel)} me: #{inspect(me)}")
+    Ockam.Router.route("PING!", [channel, me], [me])
+
+    assert_receive %Ockam.Message{
+      onward_route: [^me],
+      payload: "PING!",
+      return_route: return_route,
+      local_metadata: %{identity_id: id, identity: _identity, channel: :identity_secure_channel}
+    }
+  end
 end

--- a/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_cloud_node/config/runtime.exs
@@ -118,7 +118,7 @@ identity_module =
       exit(:invalid_config)
   end
 
-config :ockam_services, identity_module: identity_module
+config :ockam, identity_module: identity_module
 
 ## Services config
 

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
@@ -53,7 +53,7 @@ defmodule Ockam.Services.Provider.SecureChannel do
 
   def service_options(:identity_secure_channel, args) do
     ## TODO: make it possible to read service identity from some storage
-    identity_module = Keyword.get(args, :identity_module, default_identity_module())
+    identity_module = Keyword.get(args, :identity_module, Ockam.Identity.default_implementation())
 
     extra_services =
       case identity_module do
@@ -92,10 +92,5 @@ defmodule Ockam.Services.Provider.SecureChannel do
       error ->
         raise "error starting service options for identity secure channel: #{inspect(error)}"
     end
-  end
-
-  defp default_identity_module() do
-    ## TODO: WARNING: These defaults are not for production use
-    Application.get_env(:ockam_services, :identity_module, Ockam.Identity.Stub)
   end
 end


### PR DESCRIPTION
Initiator authorization now can be configured with :authorization key

For listener:
Listener authorization now can be configured with :authorization key
Responder authorization now can be configured with :responder_authorization key

**BREAKING** this change requires update to default identity_module configuration, it was moved from `ockam_services` application to `ockam`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
