### PR TITLE
feat(rust): add `dyn_info` for dynamic output with `ockam node create…

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -2,7 +2,6 @@ use crate::util::{self, api, connect_to, exitcode, OckamConfig};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
 use clap::Args;
-use colorful::Colorful;
 use ockam::Route;
 use ockam_api::config::cli::NodeConfig;
 use ockam_api::nodes::{models::base::NodeStatus, NODEMANAGER_ADDR};
@@ -35,41 +34,62 @@ impl ShowCommand {
 // clippy to stop complainaing about it.
 #[allow(clippy::too_many_arguments)]
 fn print_node_info(node_cfg: &NodeConfig, node_name: &str, status: &str, default_id: &str) {
-    println!(
-        r#"
-Node:
-  Name: {}
-  Status: {}
-  Services:
-    Service:
-      Type: TCP Listener
-      Address: /ip4/127.0.0.1/tcp/{}
-    Service:
-      Type: Secure Channel Listener
-      Address: /service/api
-      Route: /ip4/127.0.0.1/tcp/{}/service/api
-      Identity: {}
-      Authorized Identities:
-        - {}
-    Service:
-      Type: Uppercase
-      Address: /service/uppercase
-    Service:
-      Type: Echo
-      Address: /service/echo
-  Secure Channel Listener Address: /service/api
-"#,
-        node_name,
-        match status {
-            "UP" => status.light_green(),
-            "DOWN" => status.light_red(),
-            _ => status.white(),
-        },
-        node_cfg.port,
-        node_cfg.port,
-        default_id,
-        default_id,
-    );
+    let node_out = util::dyn_info::DynInfo::new_node()
+        .name(node_name)
+        .status(status)
+        .services()
+        .service(
+            "TCP Listener",
+            &format!("/ip4/127.0.0.1/tcp/{}", node_cfg.port),
+        )
+        .service_detailed(
+            "Secure Channel Listener",
+            "/service/api",
+            &format!("/ip4/127.0.0.1/tcp/{}/service/api", node_cfg.port),
+            default_id,
+            default_id,
+        )
+        .service("Uppercase", "/service/uppercase")
+        .service("Echo", "/service/echo")
+        .scl()
+        .build();
+
+    println!("{}", node_out);
+    //     println!(
+    //         r#"
+    // Node:
+    //   Name: {}
+    //   Status: {}
+    //   Services:
+    //     Service:
+    //       Type: TCP Listener
+    //       Address: /ip4/127.0.0.1/tcp/{}
+    //     Service:
+    //       Type: Secure Channel Listener
+    //       Address: /service/api
+    //       Route: /ip4/127.0.0.1/tcp/{}/service/api
+    //       Identity: {}
+    //       Authorized Identities:
+    //         - {}
+    //     Service:
+    //       Type: Uppercase
+    //       Address: /service/uppercase
+    //     Service:
+    //       Type: Echo
+    //       Address: /service/echo
+    //   Secure Channel Listener Address: /service/api
+    // "#,
+    //         node_name,
+    //         match status {
+    //             "UP" => status.light_green(),
+    //             "DOWN" => status.light_red(),
+    //             _ => status.white(),
+    //         },
+    //         node_cfg.port,
+    //         node_cfg.port,
+    //         default_id,
+    //         default_id,
+    //     );
 }
 
 pub async fn query_status(

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -35,37 +35,39 @@ impl ShowCommand {
 #[allow(clippy::too_many_arguments)]
 fn print_node_info(node_cfg: &NodeConfig, node_name: &str, status: &str, default_id: &str) {
     use util::dyn_info::{NodeService, ServiceType};
-    let node_out = util::dyn_info::DynNodeInfo::new(node_name.to_string())
-        .status(status.to_string())
+    let tcp_addr = format!("/ip4/127.0.0.1/tcp/{}", node_cfg.port);
+    let sec_chanl_list = format!("/ip4/127.0.0.1/tcp/{}/service/api", node_cfg.port);
+    let node_out = util::dyn_info::DynNodeInfo::new(node_name)
+        .status(status)
         .service(NodeService::new(
             ServiceType::TCPListener,
-            format!("/ip4/127.0.0.1/tcp/{}", node_cfg.port),
+            &tcp_addr,
             None,
             None,
             None,
         ))
         .service(NodeService::new(
             ServiceType::SecureChannelListener,
-            format!("/service/api"),
-            Some(format!("/ip4/127.0.0.1/tcp/{}/service/api", node_cfg.port)),
-            Some(default_id.to_string()),
-            Some(vec![format!("{}", default_id)]),
+            "/service/api",
+            Some(&sec_chanl_list),
+            Some(default_id),
+            Some(vec![default_id]),
         ))
         .service(NodeService::new(
             ServiceType::Uppercase,
-            "/service/uppercase".to_string(),
+            "/service/uppercase",
             None,
             None,
             None,
         ))
         .service(NodeService::new(
             ServiceType::Echo,
-            "/service/echo".to_string(),
+            "/service/echo",
             None,
             None,
             None,
         ))
-        .secure_channel_addr_listener("/service/api".to_string());
+        .secure_channel_addr_listener("/service/api");
 
     println!("{}", node_out);
 }

--- a/implementations/rust/ockam/ockam_command/src/util/dyn_info.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/dyn_info.rs
@@ -1,0 +1,68 @@
+pub struct DynInfo(String);
+
+impl DynInfo {
+    pub fn new_node() -> Self {
+        DynInfo(String::from("Node:\n"))
+    }
+
+    pub fn name(mut self, name: &str) -> Self {
+        let name = format!("  Name: {}\n", name);
+        self.0.push_str(&name);
+        self
+    }
+
+    pub fn status(mut self, status: &str) -> Self {
+        let status = format!("  Status: {}\n", status);
+        self.0.push_str(&status);
+        self
+    }
+
+    pub fn services(mut self) -> Self {
+        self.0.push_str("  Services:");
+        self
+    }
+
+    pub fn service(mut self, r#type: &str, address: &str) -> Self {
+        let service = format!(
+            r#"
+    Service: 
+      Type: {}
+      Address: {}"#,
+            r#type, address
+        );
+        self.0.push_str(&service);
+        self
+    }
+
+    pub fn service_detailed(
+        mut self,
+        r#type: &str,
+        address: &str,
+        route: &str,
+        identity: &str,
+        auth_identity: &str,
+    ) -> Self {
+        let service_detailed = format!(
+            r#"
+    Service:
+      Type: {}
+      Address: {}
+      Route: {}
+      Identity: {}
+      Authorized Identities:
+        - {}"#,
+            r#type, address, route, identity, auth_identity
+        );
+        self.0.push_str(&service_detailed);
+        self
+    }
+
+    pub fn scl(mut self) -> Self {
+        self.0
+            .push_str("\n  Secure Channel Listener Address: /service/api");
+        self
+    }
+    pub fn build(self) -> String {
+        self.0
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/dyn_info.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/dyn_info.rs
@@ -1,68 +1,147 @@
-pub struct DynInfo(String);
+use colorful::Colorful;
+use std::fmt;
+#[derive(Debug, Clone)]
+pub struct DynNodeInfo {
+    name: String,
+    status: String,
+    services: Vec<NodeService>,
+    secure_channel_addr_listener: String,
+}
 
-impl DynInfo {
-    pub fn new_node() -> Self {
-        DynInfo(String::from("Node:\n"))
+#[derive(Debug, Clone)]
+pub struct NodeService {
+    service_type: ServiceType,
+    address: String,
+    route: Option<String>,
+    identity: Option<String>,
+    auth_identity: Option<Vec<String>>,
+}
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum ServiceType {
+    TCPConnection,
+    TCPListener,
+    SecureChannelConnection,
+    SecureChannelListener,
+    Uppercase,
+    Echo,
+}
+
+// Can't accept arbitrary status
+// #[derive(Debug)]
+// pub enum Status {
+//     UP,
+//     DOWN,
+//     NONE,
+// }
+
+impl DynNodeInfo {
+    /// Name of the Node
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            status: String::new(),
+            services: Vec::new(),
+            secure_channel_addr_listener: String::new(),
+        }
     }
-
-    pub fn name(mut self, name: &str) -> Self {
-        let name = format!("  Name: {}\n", name);
-        self.0.push_str(&name);
+    /// Status can either be UP, DOWN, TODO
+    pub fn status(mut self, status: String) -> Self {
+        self.status = status;
         self
     }
 
-    pub fn status(mut self, status: &str) -> Self {
-        let status = format!("  Status: {}\n", status);
-        self.0.push_str(&status);
+    /// Use NodeService::new()
+    pub fn service(mut self, service: NodeService) -> Self {
+        self.services.push(service);
         self
     }
 
-    pub fn services(mut self) -> Self {
-        self.0.push_str("  Services:");
+    pub fn secure_channel_addr_listener(mut self, addr: String) -> Self {
+        self.secure_channel_addr_listener = addr;
         self
     }
+}
 
-    pub fn service(mut self, r#type: &str, address: &str) -> Self {
-        let service = format!(
-            r#"
-    Service: 
-      Type: {}
-      Address: {}"#,
-            r#type, address
-        );
-        self.0.push_str(&service);
-        self
-    }
-
-    pub fn service_detailed(
-        mut self,
-        r#type: &str,
-        address: &str,
-        route: &str,
-        identity: &str,
-        auth_identity: &str,
+impl NodeService {
+    pub fn new(
+        service_type: ServiceType,
+        address: String,
+        route: Option<String>,
+        identity: Option<String>,
+        auth_identity: Option<Vec<String>>,
     ) -> Self {
-        let service_detailed = format!(
-            r#"
-    Service:
-      Type: {}
-      Address: {}
-      Route: {}
-      Identity: {}
-      Authorized Identities:
-        - {}"#,
-            r#type, address, route, identity, auth_identity
-        );
-        self.0.push_str(&service_detailed);
-        self
+        Self {
+            service_type,
+            address,
+            route,
+            identity,
+            auth_identity,
+        }
     }
+}
 
-    pub fn scl(mut self) -> Self {
-        self.0
-            .push_str("\n  Secure Channel Listener Address: /service/api");
-        self
+impl fmt::Display for DynNodeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut format_services = String::new();
+        for service in &self.services {
+            format_services = format_services + &format!("{}", service);
+        }
+
+        write!(
+            f,
+            "{}",
+            format!(
+                "Node:\n\tName: {}\n\tStatus: {}\n\tServices:\n{}\tSecure Channel Listener Address:{}",
+                self.name,
+                match self.status.as_str() {
+                    "UP" => self.status.clone().light_green(),
+                    "DOWN" => self.status.clone().light_red(),
+                    _ => self.status.clone().white(),
+                },
+                format_services,
+                self.secure_channel_addr_listener,
+            )
+        )
     }
-    pub fn build(self) -> String {
-        self.0
+}
+
+impl fmt::Display for NodeService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut out = format!(
+            "\t\tService:\n\t\t\tType: {}\n\t\t\tAddress: {}\n",
+            self.service_type, self.address
+        );
+        match (
+            self.route.clone(),
+            self.identity.clone(),
+            self.auth_identity.clone(),
+        ) {
+            (Some(route), Some(identity), Some(auth_identity)) => {
+                let mut format_auth_identity = String::new();
+                for iden in auth_identity {
+                    format_auth_identity = format_auth_identity + &format!("\t\t\t\t- {}\n", iden);
+                }
+                out.push_str(&format!(
+                    "\t\t\tRoute: {}\n\t\t\tIdentity: {}\n\t\t\tAuthorized Identities: \n{}",
+                    route, identity, format_auth_identity
+                ));
+            }
+            (_, _, _) => (),
+        }
+        write!(f, "{}", out)
+    }
+}
+
+impl fmt::Display for ServiceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServiceType::TCPConnection => write!(f, "TCP Connection"),
+            ServiceType::TCPListener => write!(f, "TCP Listener"),
+            ServiceType::SecureChannelConnection => write!(f, "Secure Channel Connection"),
+            ServiceType::SecureChannelListener => write!(f, "Secure Channel Listener"),
+            ServiceType::Uppercase => write!(f, "Uppercase"),
+            ServiceType::Echo => write!(f, "Echo"),
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,7 +1,7 @@
 pub mod api;
+pub mod dyn_info;
 pub mod exitcode;
 pub mod startup;
-pub mod dyn_info;
 
 mod addon;
 pub use addon::AddonCommand;

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod exitcode;
 pub mod startup;
+pub mod dyn_info;
 
 mod addon;
 pub use addon::AddonCommand;


### PR DESCRIPTION
WIP Fix #3177 

~~This is really rough, improvements I can think of:~~
~~- have enums for `Type` and `Address` being dependent on it.~~
~~- use `String::with_capacity()` to reduce reallocations.~~
~~- add more options (if any)~~

- Is the current approach alright, or is it too manual?
- Is there a better way to format without using `\t` and `\n`?
- Should I separate `serivce` into `service_brief` and `service_verbose`, to reduce `None` usage?

I'm sure there are many more improvements that can be made, please provide your recommendations.
