### PR TITLE
local forwarders

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use minicbor::Decoder;
 
 use ockam::remote::RemoteForwarder;
-use ockam::{Address, Context, Result, Route, Routed, TcpTransport, Worker};
+use ockam::{Address, Context, ForwardingService, Result, Route, Routed, TcpTransport, Worker};
 use ockam_core::compat::{boxed::Box, string::String};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::route;
@@ -195,6 +195,8 @@ impl NodeManager {
         self.start_uppercase_service_impl(ctx, "uppercase".into())
             .await?;
         self.start_echoer_service_impl(ctx, "echo".into()).await?;
+
+        ForwardingService::create(ctx).await?;
 
         let authorized_identifiers = if self.config.readlock_inner().identity_was_overridden {
             self.identity.as_ref().map(|i| {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -93,18 +93,6 @@ pub(crate) fn delete_tcp_listener(cmd: &crate::tcp::listener::DeleteCommand) -> 
     Ok(buf)
 }
 
-/// Construct a request to create a forwarder
-pub(crate) fn create_forwarder(cmd: &crate::forwarder::CreateCommand) -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::builder(Method::Post, "/node/forwarder")
-        .body(models::forwarder::CreateForwarder::new(
-            cmd.address(),
-            cmd.alias(),
-        ))
-        .encode(&mut buf)?;
-    Ok(buf)
-}
-
 /// Construct a request to create a Vault
 pub(crate) fn create_vault(path: Option<String>) -> Result<Vec<u8>> {
     let mut buf = vec![];

--- a/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
@@ -7,10 +7,11 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("forwarder")
         .arg("create")
+        .arg("--at")
         .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("forwarder_alias")
-        .arg("-n")
-        .arg("node-name");
+        .arg("--for")
+        .arg("node_blue")
+        .arg("forwarder_for_node_blue");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
This now works:

```
> ockam node create n1 --tcp-listener-address 127.0.0.1:6001
> ockam node create n2 --tcp-listener-address 127.0.0.1:6002
> ockam forwarder create --at /ip4/127.0.0.1/tcp/6001 --for n2
5e147f8ef52831216c8b002e56c1db3c

> ockam message send hello --to /ip4/127.0.0.1/tcp/6001/service/5e147f8ef52831216c8b002e56c1db3c/service/uppercase
HELLO
```

#3207 #3193 