### PR TITLE
chore(rust): fix new lints for rust 1.63.0

### DIFF
--- a/implementations/rust/ockam/ockam/src/metadata.rs
+++ b/implementations/rust/ockam/ockam/src/metadata.rs
@@ -136,7 +136,7 @@ impl DerefMut for Metadata {
 /// attached with scope metadata to indicate the message index.
 #[test]
 fn nest_metadata() {
-    #[derive(Serialize, Deserialize, Message, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, Message, PartialEq, Eq, Debug, Clone)]
     struct FakePipeMsg {
         vec: Vec<u8>,
     }

--- a/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
+++ b/implementations/rust/ockam/ockam/src/pipe/behavior/mod.rs
@@ -70,7 +70,7 @@ impl Clone for PipeBehavior {
             hooks: self
                 .hooks
                 .iter()
-                .map(|b| *dyn_clone::clone_box(&*b))
+                .map(|b| *dyn_clone::clone_box(b))
                 .collect(),
         }
     }

--- a/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/requests.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The expected response to this request is
 /// [`InitResponse`](super::responses::InitResponse).
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct CreateStreamRequest {
     /// The stream name.
     pub stream_name: Option<String>,
@@ -34,7 +34,7 @@ impl CreateStreamRequest {
 ///
 /// The expected response to this request is
 /// [`PushConfirm`](super::responses::PushConfirm).
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct PushRequest {
     /// The request ID
     pub request_id: Uint,
@@ -60,7 +60,7 @@ impl PushRequest {
 /// Pull messages from the mailbox.
 ///
 /// The expected response to this request is [`super::responses::PullResponse`].
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct PullRequest {
     /// The request id
     pub request_id: Uint,
@@ -92,7 +92,7 @@ impl PullRequest {
 ///
 /// The expected response to this request is
 /// [`IndexResponse`](super::responses::IndexResponse).
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub enum IndexRequest {
     /// A request for an index
     Get {

--- a/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
+++ b/implementations/rust/ockam/ockam/src/protocols/stream/responses.rs
@@ -9,7 +9,7 @@ use ockam_core::{Decodable, Uint};
 use serde::{Deserialize, Serialize};
 
 /// Response to a [`CreateStreamRequest`](super::requests::CreateStreamRequest)
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct InitResponse {
     /// The name of the stream.
     pub stream_name: String,
@@ -32,7 +32,7 @@ impl InitResponse {
 }
 
 /// Confirm push operation on the mailbox
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct PushConfirm {
     /// The request id
     pub request_id: Uint,
@@ -60,7 +60,7 @@ impl PushConfirm {
 
 /// A simple status code.
 // TODO: replace with `Result<(), ()>`?
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Status {
     /// Indicates success.
     Ok,
@@ -85,7 +85,7 @@ impl From<Option<()>> for Status {
 }
 
 /// Response to a [`PullRequest`](super::requests::PullRequest)
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct PullResponse {
     /// The request id
     pub request_id: Uint,
@@ -110,7 +110,7 @@ impl PullResponse {
 }
 
 /// A stream message with a reference index
-#[derive(Debug, PartialEq, Serialize, Deserialize, Message)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Message)]
 pub struct StreamMessage {
     /// Index of the message in the stream
     pub index: Uint,
@@ -120,7 +120,7 @@ pub struct StreamMessage {
 
 /// The index return payload, to an
 /// [`IndexRequest`](super::requests::IndexRequest).
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IndexResponse {
     /// The client id
     pub client_id: String,

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 /// Information about a remotely forwarded worker.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Message)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Message)]
 pub struct RemoteForwarderInfo {
     forwarding_route: Route,
     remote_address: String,

--- a/implementations/rust/ockam/ockam/src/system/mod.rs
+++ b/implementations/rust/ockam/ockam/src/system/mod.rs
@@ -40,7 +40,7 @@ impl<C: Send + 'static, M: Message> Clone for WorkerSystem<C, M> {
             map: self
                 .map
                 .iter()
-                .map(|(addr, h)| (addr.clone(), *dyn_clone::clone_box(&*h)))
+                .map(|(addr, h)| (addr.clone(), *dyn_clone::clone_box(h)))
                 .collect(),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -9,7 +9,7 @@ use ockam_core::{self, async_trait};
 use crate::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
-#[cfg_attr(test, derive(PartialEq, Clone))]
+#[cfg_attr(test, derive(PartialEq, Eq, Clone))]
 #[cbor(transparent)]
 #[serde(transparent)]
 pub struct Token<'a>(#[n(0)] pub Cow<'a, str>);
@@ -165,7 +165,7 @@ pub mod auth0 {
 
     // Req/Res types
 
-    #[derive(serde::Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
     pub struct DeviceCode<'a> {
         pub device_code: Cow<'a, str>,
         pub user_code: Cow<'a, str>,
@@ -175,14 +175,14 @@ pub mod auth0 {
         pub interval: usize,
     }
 
-    #[derive(serde::Deserialize, Debug, PartialEq)]
+    #[derive(serde::Deserialize, Debug, PartialEq, Eq)]
     pub struct TokensError<'a> {
         pub error: Cow<'a, str>,
         pub error_description: Cow<'a, str>,
     }
 
     #[derive(serde::Deserialize, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Clone))]
+    #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
     pub struct Auth0Token<'a> {
         pub token_type: TokenType,
         pub access_token: Token<'a>,
@@ -213,7 +213,7 @@ pub mod auth0 {
     // Auxiliary types
 
     #[derive(serde::Deserialize, Encode, Decode, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Clone))]
+    #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
     #[rustfmt::skip]
     #[cbor(index_only)]
     pub enum TokenType {

--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -23,7 +23,7 @@ pub struct Invitation<'a> {
 }
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 #[rustfmt::skip]
 #[cbor(index_only)]
 pub enum Scope {
@@ -32,7 +32,7 @@ pub enum Scope {
 }
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
-#[cfg_attr(test, derive(Clone, PartialEq))]
+#[cfg_attr(test, derive(Clone, PartialEq, Eq))]
 #[rustfmt::skip]
 #[cbor(index_only)]
 pub enum State {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
@@ -86,7 +86,7 @@ impl Display for TransportType {
 }
 
 /// Encode which type of transport is being requested
-#[derive(Copy, Clone, Debug, Decode, Encode, PartialEq)]
+#[derive(Copy, Clone, Debug, Decode, Encode, PartialEq, Eq)]
 #[rustfmt::skip]
 pub enum TransportMode {
     /// Listen on a set address

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -114,10 +114,7 @@ impl NodeManager {
                     default_location
                 }
             };
-
-            let storage = LmdbStorage::new(&authenticated_storage_path).await?;
-
-            storage
+            LmdbStorage::new(&authenticated_storage_path).await?
         };
 
         if let Some(identity_override) = identity_override {

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -149,7 +149,7 @@ fn clean_multiaddr_simple() {
     let lookup = {
         let mut map = ConfigLookup::new();
         map.set_node(
-            "hub".into(),
+            "hub",
             SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 666)).into(),
         );
         map

--- a/implementations/rust/ockam/ockam_channel/src/common.rs
+++ b/implementations/rust/ockam/ockam_channel/src/common.rs
@@ -3,7 +3,7 @@ use ockam_core::{Address, Message};
 use serde::{Deserialize, Serialize};
 
 /// Key Exchange completed message
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Message)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Message)]
 pub struct KeyExchangeCompleted {
     address: Address,
     auth_hash: [u8; 32],

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info};
 /// SecureChannel info returned from start_initiator_channel
 /// Auth hash can be used for further authentication of the channel
 /// and tying it up cryptographically to some source of Trust. (e.g. Entities)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct SecureChannelInfo {
     worker_address: Address,
     auth_hash: [u8; 32],

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_listener.rs
@@ -27,7 +27,7 @@ impl<V: SecureChannelVault, N: SecureChannelNewKeyExchanger> SecureChannelListen
 }
 
 /// SecureChannelListener message wrapper.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug, Message)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Message)]
 pub struct CreateResponderChannelMessage {
     payload: Vec<u8>,
     custom_payload: Option<Vec<u8>>,

--- a/implementations/rust/ockam/ockam_command/src/old/session/msg.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/session/msg.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use ockam::Message;
 
-#[derive(Serialize, Deserialize, Message, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Message, Debug, Clone, PartialEq, Eq)]
 pub struct RequestId(pub String);
 
 impl RequestId {

--- a/implementations/rust/ockam/ockam_core/src/uint.rs
+++ b/implementations/rust/ockam/ockam_core/src/uint.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// This is to avoid cross-platform and cross-language compatibility
 /// inconsistencies that may be encountered by using Rust fixed-size
 /// integers.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Uint(serde_bare::Uint);
 
 impl Uint {

--- a/implementations/rust/ockam/ockam_executor/src/time.rs
+++ b/implementations/rust/ockam/ockam_executor/src/time.rs
@@ -55,7 +55,7 @@ pub mod error {
     use core::fmt;
     use ockam_core::compat::{error, io};
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Eq)]
     pub struct Elapsed(());
 
     impl Elapsed {

--- a/implementations/rust/ockam/ockam_ffi/src/error.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/error.rs
@@ -6,7 +6,7 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 
 #[repr(C)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 /// Error type relating to FFI specific failures.
 pub struct FfiOckamError {
     code: i32,

--- a/implementations/rust/ockam/ockam_identity/src/change_history.rs
+++ b/implementations/rust/ockam/ockam_identity/src/change_history.rs
@@ -11,7 +11,7 @@ use ockam_core::{allow, deny, Encodable, Result};
 use ockam_vault::PublicKey;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Encode, Decode, PartialEq)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 #[cbor(index_only)]
 pub enum IdentityHistoryComparison {
     #[n(1)]

--- a/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
@@ -34,7 +34,7 @@ quickcheck! {
         }
         let mut ma = MultiAddr::default();
         for proto in vec.iter().rev() {
-            ma.push_front_value(&proto).unwrap()
+            ma.push_front_value(proto).unwrap()
         }
         a.0 == ma
     }

--- a/implementations/rust/ockam/ockam_node/src/delayed.rs
+++ b/implementations/rust/ockam/ockam_node/src/delayed.rs
@@ -116,7 +116,7 @@ mod tests {
     ) -> Result<()> {
         let msgs_count = Arc::new(AtomicI8::new(0));
         let mut heartbeat =
-            DelayedEvent::create(&ctx, "counting_worker", "Hello".to_string()).await?;
+            DelayedEvent::create(ctx, "counting_worker", "Hello".to_string()).await?;
 
         let worker = CountingWorker {
             msgs_count: msgs_count.clone(),
@@ -140,7 +140,7 @@ mod tests {
     async fn rescheduling__counting_worker__aborts_existing(ctx: &mut Context) -> Result<()> {
         let msgs_count = Arc::new(AtomicI8::new(0));
         let mut heartbeat =
-            DelayedEvent::create(&ctx, "counting_worker", "Hello".to_string()).await?;
+            DelayedEvent::create(ctx, "counting_worker", "Hello".to_string()).await?;
 
         let worker = CountingWorker {
             msgs_count: msgs_count.clone(),
@@ -162,7 +162,7 @@ mod tests {
     async fn cancel__counting_worker__aborts_existing(ctx: &mut Context) -> Result<()> {
         let msgs_count = Arc::new(AtomicI8::new(0));
         let mut heartbeat =
-            DelayedEvent::create(&ctx, "counting_worker", "Hello".to_string()).await?;
+            DelayedEvent::create(ctx, "counting_worker", "Hello".to_string()).await?;
 
         let worker = CountingWorker {
             msgs_count: msgs_count.clone(),
@@ -186,7 +186,7 @@ mod tests {
     async fn drop__counting_worker__aborts_existing(ctx: &mut Context) -> Result<()> {
         let msgs_count = Arc::new(AtomicI8::new(0));
         let mut heartbeat =
-            DelayedEvent::create(&ctx, "counting_worker", "Hello".to_string()).await?;
+            DelayedEvent::create(ctx, "counting_worker", "Hello".to_string()).await?;
 
         let worker = CountingWorker {
             msgs_count: msgs_count.clone(),

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -245,7 +245,7 @@ impl AddressRecord {
 }
 
 /// Encode the run states a worker or processor can be in
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AddressState {
     /// The runner is looping in its main body (either handling messages or a manual run-loop)
     Running,

--- a/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/driver/bluetooth_hci/mod.rs
@@ -51,7 +51,7 @@ use crate::BleAddr;
 pub type Packet = bluetooth_hci::host::uart::Packet<BlueNRGEvent>;
 pub type Event = bluetooth_hci::event::Event<BlueNRGEvent>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 enum State {
     Disconnected,
     Advertising,

--- a/implementations/rust/ockam/ockam_transport_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/error.rs
@@ -5,7 +5,7 @@ use ockam_core::{
 };
 
 /// A Transport worker specific error type
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TransportError {
     /// Failed to send a malformed message
     SendBadMessage = 1,


### PR DESCRIPTION
Mostly deriving `Eq` on structs that already derived `PartialEq`.