### PR TITLE
fix: remove default identity_sidecar service from identity_secure_channel

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
@@ -55,19 +55,6 @@ defmodule Ockam.Services.Provider.SecureChannel do
     ## TODO: make it possible to read service identity from some storage
     identity_module = Keyword.get(args, :identity_module, Ockam.Identity.default_implementation())
 
-    extra_services =
-      case identity_module do
-        Ockam.Identity.Sidecar ->
-          [
-            Ockam.Services.Provider.Sidecar.child_spec(:identity_sidecar,
-              authorization: [:is_local]
-            )
-          ]
-
-        _other ->
-          []
-      end
-
     trust_policies =
       Keyword.get(args, :trust_policies, [
         {:cached_identity, [Ockam.Identity.TrustPolicy.KnownIdentitiesEts]}
@@ -83,8 +70,7 @@ defmodule Ockam.Services.Provider.SecureChannel do
           identity_module: identity_module,
           encryption_options: [vault: vault, identity_keypair: keypair],
           address: "identity_secure_channel",
-          trust_policies: trust_policies,
-          extra_services: extra_services
+          trust_policies: trust_policies
         ],
         other_args
       )


### PR DESCRIPTION

Identity sidecar service needs to be configurable and should not start by default in identity_secure_channel service.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
