### PR TITLE
fix(elixir): don't reuse metadata in `Message.reply`

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/message.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/message.ex
@@ -15,7 +15,13 @@ defmodule Ockam.Message do
   return_route is `[my_address]`
   """
   def reply(message, my_address, payload) do
-    %{message | onward_route: return_route(message), return_route: [my_address], payload: payload}
+    reply_route = return_route(message)
+
+    %Ockam.Message{
+      onward_route: reply_route,
+      return_route: [my_address],
+      payload: payload
+    }
   end
 
   @doc """


### PR DESCRIPTION

## Current Behavior

Currently `Message.reply` using the same logic as `Message.forward` preserving message metadata
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Generate a new message.
`Message.reply` source is the replying worker it should not inherit metadata from request message

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
