### PR TITLE
feat(rust): add static forwarding service

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -18,15 +18,18 @@ pub struct CreateForwarder<'a> {
     #[b(1)] pub(crate) address: CowStr<'a>,
     /// Forwarder alias
     #[n(2)] pub(crate) alias: Option<CowStr<'a>>,
+    /// Forwarding service is at rust node
+    #[n(3)] pub(crate) at_rust_node: bool,
 }
 
 impl<'a> CreateForwarder<'a> {
-    pub fn new(address: &MultiAddr, alias: Option<&'a str>) -> Self {
+    pub fn new(address: &MultiAddr, alias: Option<&'a str>, at_rust_node: bool) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: Default::default(),
             address: address.to_string().into(),
             alias: alias.map(|s| s.into()),
+            at_rust_node,
         }
     }
 }
@@ -103,6 +106,7 @@ mod tests {
                 .body(CreateForwarder::new(
                     &route_to_multiaddr(&route).unwrap(),
                     None,
+                    false,
                 ))
                 .encode(&mut buf)?;
             buf

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -25,6 +25,11 @@ pub struct CreateCommand {
     at: MultiAddr,
 
     /// Forwarding address.
+    #[clap(long = "from", display_order = 900)]
+    from: Option<String>,
+
+    /// Forwarding address.
+    #[clap(hide = true)]
     address: Option<String>,
 }
 
@@ -91,9 +96,18 @@ async fn create(
 
 /// Construct a request to create a forwarder
 pub(crate) fn make_api_request(cmd: CreateCommand) -> ockam::Result<Vec<u8>> {
+    let (at_rust_node, address) = match &cmd.from {
+        Some(_s) => (true, &cmd.from),
+        None => (false, &cmd.address),
+    };
+
     let mut buf = vec![];
     Request::builder(Method::Post, "/node/forwarder")
-        .body(CreateForwarder::new(&cmd.at, cmd.address.as_deref()))
+        .body(CreateForwarder::new(
+            &cmd.at,
+            address.as_deref(),
+            at_rust_node,
+        ))
         .encode(&mut buf)?;
     Ok(buf)
 }


### PR DESCRIPTION
This works:

```
> ockam node create n1 --tcp-listener-address 127.0.0.1:6001
> ockam node create n2 --tcp-listener-address 127.0.0.1:6002
> ockam forwarder create --from forwarder_for_n2 --for n2 --at /ip4/127.0.0.1/tcp/6001
> ockam message send --to /node/n1/service/forwarder_for_n2/service/uppercase hello
HELLO
```