### PR TITLE
feat(rust): add support /node/name and /service/name to commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, stop_node};
+use crate::util::{connect_to, exitcode, get_final_element, stop_node};
 use crate::CommandGlobalOpts;
 use crate::{node::NodeOpts, util::api};
 use clap::Args;
@@ -17,7 +17,8 @@ pub struct ShowCommand {
 impl ShowCommand {
     pub fn run(opts: CommandGlobalOpts, command: Self) -> anyhow::Result<()> {
         let cfg = opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
+        let node = get_final_element(&command.node_opts.api_node);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -11,7 +11,7 @@ use ockam_core::api::{Response, Status};
 use ockam_core::Route;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::{api, connect_to, embedded_node, exitcode, stop_node};
+use crate::util::{api, connect_to, embedded_node, exitcode, get_final_element, stop_node};
 
 #[derive(Clone, Debug, Args)]
 pub struct SendCommand {
@@ -42,7 +42,8 @@ impl SendCommand {
         };
 
         if let Some(node) = &cmd.from {
-            let port = opts.config.get_node_port(node);
+            let name = get_final_element(node);
+            let port = opts.config.get_node_port(name);
             connect_to(port, (opts, cmd), send_message_via_connection_to_a_node);
         } else {
             embedded_node(send_message_from_embedded_node, cmd)

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,4 +1,4 @@
-use crate::util::get_node_name_from_path;
+use crate::util::get_final_element;
 use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
 use anyhow::{anyhow, Context};
@@ -44,8 +44,8 @@ pub struct SecureChannelNodeOpts {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
         let cfg = opts.config;
-        let input_value = get_node_name_from_path(&command.node_opts.from);
-        let port = match cfg.select_node(input_value) {
+        let node = get_final_element(&command.node_opts.from);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
@@ -62,7 +62,7 @@ impl CreateCommand {
                 }
             },
             node_opts: SecureChannelNodeOpts {
-                from: input_value.to_string(),
+                from: node.to_string(),
             },
             ..command
         };

--- a/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel_listener/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{api, connect_to, exitcode, stop_node};
+use crate::util::{api, connect_to, exitcode, get_final_element, stop_node};
 use crate::CommandGlobalOpts;
 
 use clap::Args;
@@ -32,7 +32,8 @@ pub struct SecureChannelListenerNodeOpts {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) -> anyhow::Result<()> {
         let cfg = opts.config;
-        let port = match cfg.select_node(&command.node_opts.at) {
+        let node = get_final_element(&command.node_opts.at);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,3 +1,4 @@
+use crate::util::get_final_element;
 use crate::{
     util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
@@ -60,7 +61,8 @@ impl From<&'_ CreateCommand> for ComposableSnippet {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.from) {
+        let node = get_final_element(&command.node_opts.from);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
@@ -71,7 +73,7 @@ impl CreateCommand {
         connect_to(port, command.clone(), create_connection);
 
         let composite = (&command).into();
-        let node = command.node_opts.from;
+        let node = node.to_string();
 
         let startup_config = match cfg.get_startup_cfg(&node) {
             Ok(cfg) => cfg,

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -3,6 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
+use crate::util::get_final_element;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode, stop_node},
@@ -25,7 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
+        let node = get_final_element(&command.node_opts.api_node);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
+use crate::util::{api, connect_to, exitcode, get_final_element, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -18,7 +18,8 @@ pub struct ListCommand {
 impl ListCommand {
     pub fn run(opts: CommandGlobalOpts, command: ListCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
+        let node = get_final_element(&command.node_opts.api_node);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,3 +1,4 @@
+use crate::util::get_final_element;
 use crate::{
     util::{api, connect_to, exitcode, stop_node},
     CommandGlobalOpts,
@@ -53,7 +54,8 @@ impl From<&'_ CreateCommand> for ComposableSnippet {
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, command: CreateCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.at) {
+        let node = get_final_element(&command.node_opts.at);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
@@ -64,7 +66,7 @@ impl CreateCommand {
         connect_to(port, command.clone(), create_listener);
 
         let composite = (&command).into();
-        let node = command.node_opts.at;
+        let node = node.to_string();
 
         let startup_config = match cfg.get_startup_cfg(&node) {
             Ok(cfg) => cfg,

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -3,6 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
+use crate::util::get_final_element;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode, stop_node},
@@ -25,7 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(opts: CommandGlobalOpts, command: DeleteCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
+        let node = get_final_element(&command.node_opts.api_node);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
+use crate::util::{api, connect_to, exitcode, get_final_element, stop_node};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -18,7 +18,8 @@ pub struct ListCommand {
 impl ListCommand {
     pub fn run(opts: CommandGlobalOpts, command: ListCommand) {
         let cfg = &opts.config;
-        let port = match cfg.select_node(&command.node_opts.api_node) {
+        let node = get_final_element(&command.node_opts.api_node);
+        let port = match cfg.select_node(node) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available. Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -148,7 +148,7 @@ pub fn print_path(p: &Path) -> String {
     p.to_str().unwrap_or("<unprintable>").to_string()
 }
 
-pub fn get_node_name_from_path(input_path: &str) -> &str {
+pub fn get_final_element(input_path: &str) -> &str {
     //  Get Node name from Node Path
     //  if Input path has "/", we split the path and return the final element
     //  if the final element is empty string, we return None
@@ -156,7 +156,7 @@ pub fn get_node_name_from_path(input_path: &str) -> &str {
         let split_path: Vec<&str> = input_path.split('/').collect();
         match split_path.last() {
             Some(last_value) if last_value.is_empty() => {
-                eprintln!("Invalid Node Format");
+                eprintln!("Invalid Format: {}", input_path);
                 std::process::exit(exitcode::IOERR);
             }
             Some(last_value) => last_value,


### PR DESCRIPTION
This works:

```bash
> ockam node create middle
```

```bash
> python3 -m http.server --bind 127.0.0.1 5000
```

```bash
> ockam node create blue
> ockam tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
> ockam forwarder create --at /node/middle --from /service/forwarder_to_blue --for /node/blue
```

```bash
> ockam node create green
> ockam secure-channel create --from /node/green --to /node/middle/service/forwarder_to_blue/service/api \
    | ockam tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/outlet
```

```bash
> curl 127.0.0.1:7000 
```

