### PR TITLE
ockam enroll - create default node/space/project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a20020e8e2d1881d8736f64011bb5ff99f1db9947ce3089706945c8915695cb"
 dependencies = [
+ "half",
  "minicbor-derive",
 ]
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -6,7 +6,6 @@ use ockam_core::CowStr;
 use ockam_core::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Debug)]
-#[cfg_attr(test, derive(Clone))]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct Project<'a> {
@@ -21,6 +20,29 @@ pub struct Project<'a> {
     #[b(6)] pub users: Vec<CowStr<'a>>,
     #[b(7)] pub space_id: CowStr<'a>,
     #[b(8)] pub identity: Option<CowStr<'a>>,
+}
+
+impl Clone for Project<'_> {
+    fn clone(&self) -> Self {
+        self.to_owned()
+    }
+}
+
+impl Project<'_> {
+    pub fn to_owned<'r>(&self) -> Project<'r> {
+        Project {
+            #[cfg(feature = "tag")]
+            tag: self.tag.to_owned(),
+            id: self.id.to_owned(),
+            name: self.name.to_owned(),
+            space_name: self.space_name.to_owned(),
+            services: self.services.iter().map(|x| x.to_owned()).collect(),
+            access_route: self.access_route.to_owned(),
+            users: self.users.iter().map(|x| x.to_owned()).collect(),
+            space_id: self.space_id.to_owned(),
+            identity: self.identity.as_ref().map(|x| x.to_owned()),
+        }
+    }
 }
 
 #[derive(Encode, Decode, Debug)]

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -6,7 +6,6 @@ use ockam_core::CowStr;
 use ockam_core::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Debug)]
-#[cfg_attr(test, derive(Clone))]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct Space<'a> {
@@ -16,6 +15,24 @@ pub struct Space<'a> {
     #[b(1)] pub id: CowStr<'a>,
     #[b(2)] pub name: CowStr<'a>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
+}
+
+impl Clone for Space<'_> {
+    fn clone(&self) -> Self {
+        self.to_owned()
+    }
+}
+
+impl Space<'_> {
+    pub fn to_owned<'r>(&self) -> Space<'r> {
+        Space {
+            #[cfg(feature = "tag")]
+            tag: self.tag.to_owned(),
+            id: self.id.to_owned(),
+            name: self.name.to_owned(),
+            users: self.users.iter().map(|x| x.to_owned()).collect(),
+        }
+    }
 }
 
 #[derive(Encode, Decode, Debug)]

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -89,6 +89,7 @@ Otherwise your OS or OS configuration may not be supported!",
 /// don't have to be synced to consumers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeConfig {
+    pub name: String,
     pub addr: InternetAddress,
     pub port: u16,
     pub verbose: u8,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
@@ -18,8 +18,7 @@ use ockam_core::TypeTag;
 #[cbor(map)]
 pub struct NodeStatus<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<6586555>,
+    #[n(0)] tag: TypeTag<6586555>,
     #[n(1)] pub node_name: Cow<'a, str>,
     #[n(2)] pub status: Cow<'a, str>,
     #[n(3)] pub workers: u32,

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -57,7 +57,7 @@ directories = "4"
 dirs = "4.0.0"
 hex = "0.4"
 itertools = "0.10"
-minicbor = { version = "0.18.0", features = ["derive"] }
+minicbor = { version = "0.18.0", features = ["derive", "alloc", "half"] }
 nix = "0.24"
 open = "2"
 rand = "0.8"

--- a/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/auth0.rs
@@ -1,82 +1,373 @@
-use anyhow::{anyhow, Context};
-use clap::Args;
-use colorful::Colorful;
-use minicbor::Decoder;
-use reqwest::StatusCode;
 use std::borrow::Borrow;
 use std::io::stdin;
+use std::str::FromStr;
+
+use clap::Args;
+use colorful::Colorful;
+use reqwest::StatusCode;
 use tokio_retry::{strategy::ExponentialBackoff, Retry};
-use tracing::debug;
+use tracing::{debug, info, trace};
 
+use ockam::identity::IdentityIdentifier;
+use ockam::{Context, TcpTransport};
 use ockam_api::cloud::enroll::auth0::*;
+use ockam_api::cloud::project::Project;
+use ockam_api::cloud::space::Space;
+use ockam_api::config::cli::NodeConfig;
 use ockam_api::error::ApiError;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
+use ockam_api::nodes::models::secure_channel::CreateSecureChannelResponse;
+use ockam_core::api::Status;
+use ockam_multiaddr::MultiAddr;
 
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, EnrollCommand};
+use crate::enroll::auth0::node::default_node;
+use crate::node::NodeOpts;
+use crate::secure_channel::create::SecureChannelNodeOpts;
+use crate::util::api::CloudOpts;
+use crate::util::output::Output;
+use crate::util::{api, node_rpc, stop_node, RpcBuilder};
+use crate::{exitcode, CommandGlobalOpts, EnrollCommand};
 
 #[derive(Clone, Debug, Args)]
 pub struct EnrollAuth0Command;
 
 impl EnrollAuth0Command {
     pub fn run(opts: CommandGlobalOpts, cmd: EnrollCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
+        node_rpc(rpc, (opts, cmd));
+    }
+}
+
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, EnrollCommand)) -> crate::Result<()> {
+    let res = run_impl(&ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
+
+async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: EnrollCommand) -> crate::Result<()> {
+    let tcp = TcpTransport::create(ctx).await?;
+    let nc = default_node(ctx, &opts, &tcp).await?;
+
+    enroll(ctx, &opts, &cmd, &tcp, &nc).await?;
+
+    let node_opts = NodeOpts {
+        api_node: nc.name.to_string(),
+    };
+    let cloud_opts = cmd.cloud_opts.clone();
+
+    let space = default_space(ctx, &opts, &tcp, &nc, &node_opts, &cloud_opts).await?;
+    let project = default_project(ctx, &opts, &tcp, &nc, &space, &node_opts, &cloud_opts).await?;
+    create_secure_channel_to_project(ctx, &opts, &tcp, &nc, &project, &node_opts).await?;
+
+    Ok(())
+}
+
+// TODO: move to util/node module
+mod node {
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    use anyhow::Context;
+    use tracing::{debug, trace};
+
+    use ockam::TcpTransport;
+    use ockam_api::config::cli::NodeConfig;
+    use ockam_api::nodes::models::base::NodeStatus;
+
+    use crate::node;
+    use crate::util::{api, RpcBuilder};
+    use crate::CommandGlobalOpts;
+
+    pub async fn default_node(
+        ctx: &ockam::Context,
+        opts: &CommandGlobalOpts,
+        tcp: &TcpTransport,
+    ) -> crate::Result<NodeConfig> {
+        let no_nodes = {
+            let cfg = opts.config.get_inner();
+            cfg.nodes.is_empty()
+        };
+
+        // If there are no spawned nodes, create one called "default" and return it.
+        let node = if no_nodes {
+            debug!("No nodes found in config, creating default node");
+            create_node(opts, "default").await?
+        }
+        // If there are spawned nodes, return the "default" node if exists and it's running
+        // or the first node we find that is running.
+        else {
+            let node_names = {
+                let cfg = opts.config.get_inner();
+                cfg.nodes
+                    .iter()
+                    .map(|(name, _)| name.to_string())
+                    .collect::<Vec<_>>()
+            };
+            // Find all running nodes, skip those that are stopped.
+            let mut ncs = vec![];
+            for node_name in node_names.iter() {
+                trace!(%node_name, "Checking node");
+                let nc = opts.config.get_node(node_name)?;
+                let mut rpc = RpcBuilder::new(ctx, opts, node_name).tcp(tcp).build()?;
+                if rpc
+                    .request_with_timeout(
+                        api::node::query_status(),
+                        core::time::Duration::from_millis(333),
+                    )
+                    .await
+                    .is_err()
+                {
+                    trace!(%node_name, "Node is not running");
+                    continue;
+                }
+                let ns = rpc.parse_response::<NodeStatus>()?;
+                // Update PID if changed
+                if nc.pid != Some(ns.pid) {
+                    opts.config.update_pid(&ns.node_name, ns.pid)?;
+                }
+                ncs.push(nc);
+            }
+            // Persist PID config changes
+            opts.config.atomic_update().run()?;
+            // No running nodes, create a new one
+            if ncs.is_empty() {
+                debug!("All existing nodes are stopped, creating a new one with a random name");
+                create_node(opts, None).await?
+            }
+            // Return the "default" node or the first one of the list
+            else {
+                match ncs.iter().find(|ns| ns.name == "default") {
+                    None => ncs
+                        .drain(..1)
+                        .next()
+                        .expect("already checked that is not empty"),
+                    Some(n) => n.clone(),
+                }
             }
         };
-        connect_to(port, (opts, cmd), enroll);
+        debug!("Using `{}` as the default node", node.name);
+        Ok(node)
+    }
+
+    async fn create_node(
+        opts: &CommandGlobalOpts,
+        name: impl Into<Option<&'static str>>,
+    ) -> crate::Result<NodeConfig> {
+        let node_name = name
+            .into()
+            .map(|name| name.to_string())
+            .unwrap_or_else(node::random_name);
+        match opts.config.select_node(&node_name) {
+            Some(node) => {
+                debug!(%node_name, "Returning existing node");
+                Ok(node)
+            }
+            None => {
+                debug!(%node_name, "Creating node");
+                let cmd = node::CreateCommand {
+                    node_name: node_name.clone(),
+                    foreground: false,
+                    tcp_listener_address: "127.0.0.1:0".to_string(),
+                    skip_defaults: false,
+                    launch_config: None,
+                    no_watchdog: false,
+                };
+                let cmd = cmd.overwrite_addr()?;
+                let addr = SocketAddr::from_str(&cmd.tcp_listener_address)
+                    .context("Failed to parse tcp listener address")?;
+                node::CreateCommand::create_background_node(opts, &cmd, &addr)?;
+                loop {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    if let Some(node) = opts.config.select_node(&node_name) {
+                        return Ok(node);
+                    }
+                }
+            }
+        }
     }
 }
 
 async fn enroll(
-    ctx: ockam::Context,
-    (_opts, cmd): (CommandGlobalOpts, EnrollCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    cmd: &EnrollCommand,
+    tcp: &TcpTransport,
+    nc: &NodeConfig,
+) -> crate::Result<()> {
     let auth0 = Auth0Service;
     let token = auth0.token().await?;
-
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
-
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::enroll::auth0(cmd, token)?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
-
-    let res = match header.status() {
+    let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+    rpc.request(api::enroll::auth0(cmd.clone(), token)).await?;
+    let (res, _) = rpc.check_response()?;
+    match res.status() {
         Some(Status::Ok) => {
-            let output = "Enrolled successfully".to_string();
-            Ok(output)
+            info!("Enrolled successfully");
+            return Ok(());
         }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
+        // If the same identity is enrolled more than once, we will receive a BadRequest error.
+        // From the client side, enrolling should be an idempotent operation, and therefore hide that error.
+        // TODO: Maybe we could store this in the config to avoid going through the process multiple times?
+        Some(Status::BadRequest) => {
+            info!("Already enrolled");
+            trace!(msg = %minicbor::display(rpc.buf()), "Received CBOR message");
+            return Ok(());
         }
-        _ => Err(anyhow!("Unexpected response received from node")),
+        Some(status) => {
+            eprintln!("An error occurred while processing the request. Status code: {status}");
+        }
+        None => {
+            eprintln!("No status code found in response");
+        }
+    }
+    trace!(msg = %minicbor::display(rpc.buf()), "Received CBOR message");
+    Err(crate::Error::new(exitcode::SOFTWARE))
+}
+
+async fn default_space<'a>(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    tcp: &TcpTransport,
+    nc: &NodeConfig,
+    node_opts: &NodeOpts,
+    cloud_opts: &CloudOpts,
+) -> crate::Result<Space<'a>> {
+    // Get available spaces for node's identity
+    let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+    let mut available_spaces = {
+        let cmd = crate::space::ListCommand {
+            node_opts: node_opts.clone(),
+            cloud_opts: cloud_opts.clone(),
+        };
+        rpc.request(api::space::list(&cmd)).await?;
+        rpc.parse_response::<Vec<Space>>()?
     };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
+    // If the identity has no spaces, create one
+    let default_space = if available_spaces.is_empty() {
+        let cmd = crate::space::CreateCommand {
+            node_opts: node_opts.clone(),
+            cloud_opts: cloud_opts.clone(),
+            name: crate::space::random_name(),
+            admins: vec![],
+        };
+        let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+        rpc.request(api::space::create(&cmd)).await?;
+        rpc.parse_response::<Space>()?.to_owned()
+    }
+    // If it has, return the first one on the list
+    else {
+        available_spaces
+            .drain(..1)
+            .next()
+            .expect("already checked that is not empty")
+            .to_owned()
+    };
+    println!("\n{}", default_space.output()?);
+    Ok(default_space)
+}
+
+async fn default_project<'a>(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    tcp: &TcpTransport,
+    nc: &NodeConfig,
+    space: &Space<'_>,
+    node_opts: &NodeOpts,
+    cloud_opts: &CloudOpts,
+) -> crate::Result<Project<'a>> {
+    // Get available project for the given space
+    let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+    let mut available_projects: Vec<Project> = {
+        let cmd = crate::project::ListCommand {
+            node_opts: node_opts.clone(),
+            cloud_opts: cloud_opts.clone(),
+        };
+        rpc.request(api::project::list(&cmd)).await?;
+        rpc.parse_response::<Vec<Project>>()?
+    };
+    // If the space has no projects, create one
+    let default_project = if available_projects.is_empty() {
+        let cmd = crate::project::CreateCommand {
+            space_id: space.id.to_string(),
+            project_name: "default".to_string(),
+            node_opts: node_opts.clone(),
+            cloud_opts: cloud_opts.clone(),
+            services: vec![], // TODO: define default services
+        };
+        let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+        rpc.request(api::project::create(&cmd)).await?;
+        rpc.parse_response::<Project>()?.to_owned()
+    }
+    // If it has, return the "default" project or first one on the list
+    else {
+        match available_projects.iter().find(|ns| ns.name == "default") {
+            None => available_projects
+                .drain(..1)
+                .next()
+                .expect("already checked that is not empty")
+                .to_owned(),
+            Some(p) => p.to_owned(),
         }
     };
 
-    stop_node(ctx).await
+    if default_project.access_route.is_empty() {
+        print!("\nProject created. Waiting until it's operative...");
+        let cmd = crate::project::ShowCommand {
+            space_id: space.id.to_string(),
+            project_id: default_project.id.to_string(),
+            node_opts: node_opts.clone(),
+            cloud_opts: cloud_opts.clone(),
+        };
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            print!(".");
+            let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+            rpc.request(api::project::show(&cmd)).await?;
+            let project = rpc.parse_response::<Project>()?;
+            if !project.access_route.is_empty() {
+                break;
+            }
+        }
+    }
+
+    // Store the default project in the config lookup table.
+    opts.config.set_project_alias(
+        default_project.name.to_string(),
+        default_project.access_route.to_string(),
+        default_project.id.to_string(),
+        default_project
+            .identity
+            .as_ref()
+            .expect("Project should have identity set")
+            .to_string(),
+    )?;
+    println!("\n{}", default_project.output()?);
+    Ok(default_project)
+}
+
+async fn create_secure_channel_to_project(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    tcp: &TcpTransport,
+    nc: &NodeConfig,
+    project: &Project<'_>,
+    node_opts: &NodeOpts,
+) -> crate::Result<()> {
+    // TODO: at node::service.rs, sec-channel registry should be the route, not the address
+    let authorized_identifier = project.identity.clone().map(|id| {
+        vec![IdentityIdentifier::from_str(id.as_ref())
+            .expect("Identity received from cloud should be valid")]
+    });
+    let cmd = crate::secure_channel::CreateCommand {
+        node_opts: SecureChannelNodeOpts {
+            from: node_opts.api_node.to_string(),
+        },
+        addr: MultiAddr::from_str(project.access_route.as_ref()).unwrap(),
+        authorized_identifier,
+    };
+    let mut rpc = RpcBuilder::new(ctx, opts, &nc.name).tcp(tcp).build()?;
+    rpc.request(api::secure_channel::create(&cmd)).await?;
+    let sc = rpc.parse_response::<CreateSecureChannelResponse>()?;
+    println!("\nSecure channel to project");
+    println!("  {}", sc.output()?);
+    Ok(())
 }
 
 pub struct Auth0Service;

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -8,7 +8,7 @@ pub struct Error(ExitCode);
 
 impl Error {
     pub fn new(code: ExitCode) -> Self {
-        assert!(code > 0, "Exit code can't be OK");
+        assert_ne!(code, 0, "Error's exit code can't be OK");
         Self(code)
     }
 
@@ -24,6 +24,13 @@ impl From<ConfigError> for Error {
     }
 }
 
+impl From<ockam::Error> for Error {
+    fn from(e: ockam::Error) -> Self {
+        error!("{e}");
+        Error::new(exitcode::SOFTWARE)
+    }
+}
+
 impl From<anyhow::Error> for Error {
     fn from(e: anyhow::Error) -> Self {
         error!("{e}");
@@ -34,6 +41,6 @@ impl From<anyhow::Error> for Error {
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         error!("{e}");
-        Error::new(exitcode::SOFTWARE)
+        Error::new(exitcode::IOERR)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -91,3 +91,7 @@ pub struct NodeOpts {
     #[clap(global = true, name = "node", short, long, default_value = "default")]
     pub api_node: String,
 }
+
+pub fn random_name() -> String {
+    hex::encode(&rand::random::<[u8; 4]>())
+}

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -77,6 +77,9 @@ pub async fn query_status(
     (cfg, node_name): (OckamConfig, String),
     mut base_route: Route,
 ) -> anyhow::Result<()> {
+    // Wait a little bit for the node to start up.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
     ctx.send(
         base_route.modify().append(NODEMANAGER_ADDR),
         api::query_status()?,

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -58,7 +58,7 @@ async fn create(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::create(cmd)?)
+        .send_and_receive(route, api::project::create(&cmd).to_vec()?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
@@ -50,5 +50,5 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::delete_enroller(&cmd)).await?;
-    rpc.check_response()
+    rpc.is_ok()
 }

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -7,7 +7,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
-use crate::util::{node_rpc, Rpc};
+use crate::util::{node_rpc, RpcBuilder};
 use crate::{stop_node, CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
@@ -35,8 +35,10 @@ async fn rpc(
         cmd: &GetCredentialCommand,
     ) -> Result<()> {
         let to = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
-        let mut rpc = Rpc::new(ctx, opts, &cmd.node_opts.api_node)?;
-        rpc.request_to(Request::post("/credential"), &to).await?;
+        let mut rpc = RpcBuilder::new(ctx, opts, &cmd.node_opts.api_node)
+            .to(&to)?
+            .build()?;
+        rpc.request(Request::post("/credential")).await?;
         rpc.print_response::<Credential<'_>>()
     }
     let result = go(&mut ctx, &opts, &cmd).await;

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -45,7 +45,7 @@ async fn list(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::list(cmd)?)
+        .send_and_receive(route, api::project::list(&cmd).to_vec()?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -58,7 +58,7 @@ async fn show(
     debug!(?cmd, %route, "Sending request");
 
     let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::show(cmd)?)
+        .send_and_receive(route, api::project::show(&cmd).to_vec()?)
         .await
         .context("Failed to process request")?;
     let mut dec = Decoder::new(&response);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -12,15 +12,15 @@ use ockam_multiaddr::MultiAddr;
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     #[clap(flatten)]
-    node_opts: SecureChannelNodeOpts,
+    pub node_opts: SecureChannelNodeOpts,
 
     /// Route to a secure channel listener (required)
     #[clap(name = "to", short, long, value_name = "ROUTE")]
-    addr: MultiAddr,
+    pub addr: MultiAddr,
 
     /// Pre-known Identifiers of the other side
     #[clap(short, long)]
-    authorized_identifier: Option<Vec<IdentityIdentifier>>,
+    pub authorized_identifier: Option<Vec<IdentityIdentifier>>,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -42,5 +42,5 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::delete(&cmd)).await?;
-    rpc.check_response()
+    rpc.is_ok()
 }

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -47,3 +47,7 @@ impl SpaceCommand {
         }
     }
 }
+
+pub fn random_name() -> String {
+    hex::encode(&rand::random::<[u8; 4]>())
+}

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -216,6 +216,7 @@ impl OckamConfig {
         inner.nodes.insert(
             name.to_string(),
             NodeConfig {
+                name: name.to_string(),
                 port: bind.port(),
                 addr: bind.into(),
                 verbose,

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -1,10 +1,14 @@
+use anyhow::Context;
 use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
 use ockam::credential::Credential;
-use ockam_api::cloud::project::Enroller;
+use ockam_api::cloud::project::{Enroller, Project};
 
 use crate::util::comma_separated;
 use ockam_api::cloud::space::Space;
+use ockam_api::nodes::models::secure_channel::CreateSecureChannelResponse;
+use ockam_api::route_to_multiaddr;
+use ockam_core::route;
 
 /// Trait to control how a given type will be printed as a CLI output.
 ///
@@ -37,9 +41,10 @@ pub trait Output {
 impl Output for Space<'_> {
     fn output(&self) -> anyhow::Result<String> {
         let mut w = String::new();
-        write!(w, "id: {}", self.id)?;
-        write!(w, "\nname: {}", self.name)?;
-        write!(w, "\nusers: {}", comma_separated(&self.users))?;
+        write!(w, "Space")?;
+        write!(w, "\n  Id: {}", self.id)?;
+        write!(w, "\n  Name: {}", self.name)?;
+        write!(w, "\n  Users: {}", comma_separated(&self.users))?;
         Ok(w)
     }
 }
@@ -56,7 +61,7 @@ impl Output for Vec<Space<'_>> {
         let table = rows
             .table()
             .title([
-                "ID".cell().bold(true),
+                "Id".cell().bold(true),
                 "Name".cell().bold(true),
                 "Users".cell().bold(true),
             ])
@@ -66,11 +71,35 @@ impl Output for Vec<Space<'_>> {
     }
 }
 
+impl Output for Project<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut w = String::new();
+        write!(w, "Project")?;
+        write!(w, "\n  Id: {}", self.id)?;
+        write!(w, "\n  Name: {}", self.name)?;
+        write!(w, "\n  Users: {}", comma_separated(&self.users))?;
+        write!(w, "\n  Services: {}", comma_separated(&self.services))?;
+        write!(w, "\n  Access route: {}", self.access_route)?;
+        write!(w, "\n  Identity: {:?}", self.identity)?;
+        Ok(w)
+    }
+}
+
+impl Output for CreateSecureChannelResponse<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let addr = route_to_multiaddr(&route![self.addr.to_string()])
+            .context("Invalid Secure Channel Address")?
+            .to_string();
+        Ok(addr)
+    }
+}
+
 impl Output for Enroller<'_> {
     fn output(&self) -> anyhow::Result<String> {
         let mut w = String::new();
-        write!(w, "identity_id: {}", self.identity_id)?;
-        write!(w, "\nadded_by: {}", self.added_by)?;
+        write!(w, "Enroller")?;
+        write!(w, "\n  Identity id: {}", self.identity_id)?;
+        write!(w, "\n  Added by: {}", self.added_by)?;
         Ok(w)
     }
 }


### PR DESCRIPTION
Modify the `enroll --auth0` command so it can work autonomously without running any previous command, creating the necessary node, space, project and secure channel in a single execution.

## How it works

1. Default node: check amongst the spawned nodes which ones are running. Select the node named "default" if it's available or the first one it finds. If no nodes are available (all down or no registered nodes), spawn a new background node called "default"
2. Execute the auth0 enroll process
3. After it enrolls, follow a similar approach to `1` to "get or create" the default space and project
4. Finally, it creates a secure channel between the background node and the project's node, using the project's identity id as the only authorized identity of the channel

## Others

- The `node/create.rs::CreateCommand` refactor: I've basically extracted part of the logic into a function so I can call it externally, but I haven't changed any logic.

## TODO's
- Define default services for new projects
- Agree on what key to use in the node's service registry to cache secure channels to support lookups by route and address (we could internally store routes and addresses as strings and provide a higher-level abstraction that works with the real types).
- There are a couple of minor TODO's with no real impact, just ideas of things we could improve on specific spots
