### PR TITLE
fix(rust): align serialisations of `IdentityIdentifier`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "ockam_node",
  "ockam_transport_tcp",
  "ockam_vault",
+ "quickcheck",
  "rand 0.8.5",
  "rand_xorshift",
  "serde",

--- a/implementations/rust/ockam/ockam_command/src/old/identity.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/identity.rs
@@ -106,7 +106,7 @@ pub fn parse_identities(idents: &str) -> anyhow::Result<Vec<IdentityIdentifier>>
                     "Failed to parse identifier (should be 64 hexadecimal ASCII characters): {s:?}"
                 ))
             } else {
-                Ok(IdentityIdentifier::from_key_id(s.into()))
+                Ok(IdentityIdentifier::from_key_id(s))
             }
         })
         .collect()
@@ -139,7 +139,7 @@ pub fn read_trusted_idents_from_file(
                 Expected 64 ascii hex chars, but got: {line:?}",
             );
         }
-        let ident = IdentityIdentifier::from_key_id(line.into());
+        let ident = IdentityIdentifier::from_key_id(line);
         idents.push(ident);
     }
     Ok(idents)

--- a/implementations/rust/ockam/ockam_command/src/old/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/old/mod.rs
@@ -125,7 +125,7 @@ pub fn add_trusted(arg: AddTrustedIdentityOpts) -> anyhow::Result<()> {
     }
     let strings_to_write = idents_to_write
         .into_iter()
-        .map(|s| s.key_id().clone())
+        .map(|s| s.key_id().to_string())
         .collect::<Vec<String>>();
     let new_contents = strings_to_write.join("\n");
 

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -88,5 +88,6 @@ hex = { version = "0.4", default-features = false }
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }
 ockam_vault = { path = "../ockam_vault", version = "^0.60.0" }
+quickcheck = "1.0.3"
 rand_xorshift = "0"
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/src/change_history.rs
+++ b/implementations/rust/ockam/ockam_identity/src/change_history.rs
@@ -99,7 +99,7 @@ impl IdentityChangeHistory {
             .compute_key_id_for_public_key(&root_public_key)
             .await?;
 
-        Ok(IdentityIdentifier::from_key_id(key_id))
+        Ok(IdentityIdentifier::from_key_id(&key_id))
     }
 
     pub fn get_public_key(&self, label: &str) -> Result<PublicKey> {

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -422,7 +422,7 @@ mod test {
         };
 
         let access_control = IdentityAccessControlBuilder::new_with_id(
-            "I79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
+            "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
         WorkerBuilder::with_access_control(access_control, "receiver", receiver)
             .start(ctx)

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -422,7 +422,7 @@ mod test {
         };
 
         let access_control = IdentityAccessControlBuilder::new_with_id(
-            "P79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
+            "I79b26ba2ea5ad9b54abe5bebbcce7c446beda8c948afc0de293250090e5270b6".try_into()?,
         );
         WorkerBuilder::with_access_control(access_control, "receiver", receiver)
             .start(ctx)

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -17,7 +17,7 @@ pub struct IdentityIdentifier(#[n(0)] KeyId);
 
 /// Unique [`crate::Identity`] identifier, computed as SHA256 of root public key
 impl IdentityIdentifier {
-    const PREFIX: &'static str = "I";
+    const PREFIX: &'static str = "P";
 
     /// Create an IdentityIdentifier from a KeyId
     pub fn from_key_id(key_id: &str) -> Self {

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -17,7 +17,7 @@ pub struct IdentityIdentifier(#[n(0)] KeyId);
 
 /// Unique [`crate::Identity`] identifier, computed as SHA256 of root public key
 impl IdentityIdentifier {
-    const PREFIX: &'static str = "P";
+    const PREFIX: &'static str = "I";
 
     /// Create an IdentityIdentifier from a KeyId
     pub fn from_key_id(key_id: &str) -> Self {


### PR DESCRIPTION
Currently `IdentityIdentifier`s are serialized differently, depending on the method:

- `IdentityIdentifier::to_string` yields a string with a leading 'P'.
- Serializing via serde or minicbor will not prepend the 'P' prefix.

When deserializing from a string via `TryFrom`, the 'P' must be present and is removed. Deserializing via serde and minicbor accepts any string. In practice this can cause problems if the `to_string` representation is read via serde, as the key ID itself would contain the 'P' character.

This commit suggests the following approach:

The 'P' is present in all serialisations and all deserialisations expect it to be there or error otherwise.
