### PR TITLE
Allow project metadata lookups and route substitution

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -72,6 +72,7 @@ async fn create(
                 OutputFormat::Plain => body.id.to_string(),
                 OutputFormat::Json => serde_json::to_string(&body)?,
             };
+
             Ok(output)
         }
         Some(Status::InternalServerError) => {

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use rand::prelude::random;
 
 use ockam::Context;
 use ockam_api::cloud::space::Space;
@@ -11,7 +12,7 @@ use crate::{stop_node, CommandGlobalOpts};
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the space.
-    #[clap(display_order = 1001)]
+    #[clap(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()))]
     pub name: String,
 
     #[clap(flatten)]

--- a/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
@@ -206,3 +206,5 @@ macro_rules! gen_str_proto {
 gen_str_proto!(DnsAddr, 56, "dnsaddr");
 gen_str_proto!(Service, 62526, "service");
 gen_str_proto!(Node, 72526, "node");
+gen_str_proto!(Project, 82526, "project");
+gen_str_proto!(Space, 92526, "space");


### PR DESCRIPTION
This PR adds a mechanism to the ockam CLI connfiguration to store project lookups, as well as retrieving them in the `MultiAddr` clean/ substitution function.  Additional metadata fields are also accessible for constructing message payloads to the target project controller.

[ @adrianbenavides ]