### PR TITLE
feat(rust): improve the node's secure-channel registry

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -101,7 +101,7 @@ pub struct DeleteSecureChannelResponse<'a> {
 }
 
 impl<'a> DeleteSecureChannelResponse<'a> {
-    pub fn new(channel: Option<&Address>) -> Self {
+    pub fn new(channel: Option<Address>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -4,6 +4,7 @@ use crate::nodes::models::secure_channel::{
     CreateSecureChannelListenerRequest, CreateSecureChannelRequest, CreateSecureChannelResponse,
     DeleteSecureChannelRequest, DeleteSecureChannelResponse,
 };
+use crate::nodes::registry::{IdentityRouteKey, SecureChannelInfo};
 use crate::nodes::NodeManager;
 use minicbor::Decoder;
 use ockam::identity::TrustEveryonePolicy;
@@ -11,23 +12,34 @@ use ockam::{Address, Result, Route};
 use ockam_core::api::{Request, Response, ResponseBuilder};
 use ockam_identity::{IdentityIdentifier, TrustMultiIdentifiersPolicy};
 use ockam_multiaddr::MultiAddr;
+use std::sync::Arc;
 
 impl NodeManager {
     pub(super) async fn create_secure_channel_impl<'a>(
         &mut self,
-        route: Route,
+        sc_route: Route,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
     ) -> Result<Address> {
         let identity = self
             .identity
             .as_ref()
             .ok_or_else(|| ApiError::generic("Identity doesn't exist"))?;
+        let key_route = IdentityRouteKey::new(identity, &sc_route).await?;
 
-        let channel = match authorized_identifiers {
+        // If channel was already created, do nothing.
+        if let Some(channel) = self.registry.secure_channels.get(&key_route) {
+            let addr = channel.addr();
+            trace!(%addr, "Using cached secure channel");
+            return Ok(addr.clone());
+        }
+
+        // Else, create it.
+        trace!(%sc_route, "Creating secure channel");
+        let sc_addr = match authorized_identifiers {
             Some(ids) => {
                 identity
                     .create_secure_channel(
-                        route,
+                        sc_route.clone(),
                         TrustMultiIdentifiersPolicy::new(ids),
                         &self.authenticated_storage,
                     )
@@ -35,16 +47,28 @@ impl NodeManager {
             }
             None => {
                 identity
-                    .create_secure_channel(route, TrustEveryonePolicy, &self.authenticated_storage)
+                    .create_secure_channel(
+                        sc_route.clone(),
+                        TrustEveryonePolicy,
+                        &self.authenticated_storage,
+                    )
                     .await
             }
         }?;
 
-        self.registry
-            .secure_channels
-            .insert(channel.clone(), Default::default());
+        trace!(%sc_route, %sc_addr, "Created secure channel");
+        // Store the channel using the target route as a key
+        let key_route = IdentityRouteKey::new(identity, &sc_route).await?;
+        let v = Arc::new(SecureChannelInfo::new(sc_route, sc_addr.clone()));
+        self.registry.secure_channels.insert(key_route, v.clone());
 
-        Ok(channel)
+        // Store the channel using its address as a key
+        let scr: Route = sc_addr.clone().into();
+        let key_addr = IdentityRouteKey::new(identity, &scr).await?;
+        self.registry.secure_channels.insert(key_addr, v);
+
+        // Return secure channel address
+        Ok(sc_addr)
     }
 
     pub(super) async fn create_secure_channel<'a>(
@@ -98,35 +122,44 @@ impl NodeManager {
             body.channel
         );
 
-        let channel_addr = &(*body.channel).into();
-        let response = DeleteSecureChannelResponse::new(
-            self.registry
-                .secure_channels
-                .remove_entry(channel_addr)
-                .map(|(_, _)| channel_addr),
-        );
+        let identity = self
+            .identity
+            .as_ref()
+            .ok_or_else(|| ApiError::generic("Identity doesn't exist"))?;
 
-        if response.channel.is_some() {
-            self.identity
-                .as_ref()
-                .ok_or_else(|| ApiError::generic("Identity doesn't exist"))?
-                .stop_secure_channel(channel_addr)
-                .await?;
-        }
+        let sc_address = Address::from(body.channel.as_ref());
 
-        Ok(Response::ok(req.id()).body(response))
+        debug!(%sc_address, "Deleting secure channel");
+
+        // Best effort to tear down the channel.
+        let _ = identity.stop_secure_channel(&sc_address).await;
+
+        // Remove both the Address and Route entries from the registry.
+        let sc_addr = sc_address.clone().into();
+        let key_addr = IdentityRouteKey::new(identity, &sc_addr).await?;
+        let res = if let Some(v) = self.registry.secure_channels.remove(&key_addr) {
+            trace!(%sc_addr, "Removed secure channel");
+            let sc_route = v.route();
+            let key_route = IdentityRouteKey::new(identity, sc_route).await?;
+            self.registry.secure_channels.remove(&key_route);
+            trace!(%sc_route, "Removed secure channel");
+            Some(sc_address)
+        } else {
+            trace!(%sc_addr, "No secure channels found for the passed address");
+            None
+        };
+        Ok(Response::ok(req.id()).body(DeleteSecureChannelResponse::new(res)))
     }
 
     pub(super) fn list_secure_channels(
         &mut self,
         req: &Request<'_>,
     ) -> ResponseBuilder<Vec<String>> {
-        println!("HERE1");
         Response::ok(req.id()).body(
             self.registry
                 .secure_channels
                 .iter()
-                .map(|(addr, _)| addr.to_string())
+                .map(|(_, v)| v.addr().to_string())
                 .collect(),
         )
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -1,8 +1,10 @@
-use crate::util::{api, node_rpc, stop_node, Rpc};
+use crate::util::{api, node_rpc, stop_node, ConfigError, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
+use ockam_api::multiaddr_to_addr;
 use ockam_api::nodes::models::secure_channel::DeleteSecureChannelResponse;
+use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Args)]
 pub struct SecureChannelNodeOpts {
@@ -21,8 +23,7 @@ pub struct DeleteCommand {
     #[clap(flatten)]
     node_opts: SecureChannelNodeOpts,
 
-    #[clap(default_value = "default")]
-    channel: String,
+    channel: MultiAddr,
 }
 
 impl DeleteCommand {
@@ -30,21 +31,17 @@ impl DeleteCommand {
         node_rpc(rpc, (opts, self));
     }
 
-    async fn rpc_callback(
-        self,
-        ctx: &ockam::Context,
-        opts: CommandGlobalOpts,
-    ) -> crate::Result<()> {
-        let ch = self.channel.clone();
+    async fn rpc_callback(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        // We apply the inverse transformation done in the `create` command.
+        let addr = multiaddr_to_addr(&self.channel)
+            .ok_or_else(|| ConfigError::InvalidSecureChannelAddress(self.channel.to_string()))?;
 
         let mut rpc = Rpc::new(ctx, &opts, &self.node_opts.at)?;
-        rpc.request(api::delete_secure_channel(self.channel.into()))
-            .await?;
+        rpc.request(api::delete_secure_channel(&addr)).await?;
         let res = rpc.parse_response::<DeleteSecureChannelResponse>()?;
-
         match res.channel {
-            Some(_) => println!("deleted {}", ch),
-            None => println!("channel with address {} not found", ch),
+            Some(_) => println!("Deleted {}", self.channel),
+            None => println!("Channel with address {} not found", self.channel),
         }
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -24,7 +24,6 @@ pub(crate) mod node {
         Request::builder(Method::Get, "/node")
     }
 }
-
 /// Construct a request to query node status
 pub(crate) fn query_status() -> Result<Vec<u8>> {
     let mut buf = vec![];
@@ -146,15 +145,13 @@ pub(crate) fn create_secure_channel(
 ) -> RequestBuilder<'static, models::secure_channel::CreateSecureChannelRequest<'static>> {
     let payload =
         models::secure_channel::CreateSecureChannelRequest::new(&addr, authorized_identifiers);
-
     Request::builder(Method::Post, "/node/secure_channel").body(payload)
 }
 
 pub(crate) fn delete_secure_channel(
-    addr: Address,
+    addr: &Address,
 ) -> RequestBuilder<'static, models::secure_channel::DeleteSecureChannelRequest<'static>> {
-    let payload = models::secure_channel::DeleteSecureChannelRequest::new(&addr);
-
+    let payload = models::secure_channel::DeleteSecureChannelRequest::new(addr);
     Request::builder(Method::Delete, "/node/secure_channel").body(payload)
 }
 


### PR DESCRIPTION
So that we can retrieve them by both target route (to avoid creating duplicated secure channels) and secure channel address (to remove them).