### PR TITLE
feat(rust): add launch configuration to start services

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context, Result};
+use ockam::identity::IdentityIdentifier;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -15,6 +16,18 @@ pub struct VaultConfig {
 pub struct IdentityConfig {
     #[serde(default = "identity_default_addr")]
     pub(crate) address: String,
+
+    #[serde(default)]
+    pub(crate) disabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecureChannelListenerConfig {
+    #[serde(default = "sec_listener_default_addr")]
+    pub(crate) address: String,
+
+    #[serde(default)]
+    pub(crate) authorized_identifiers: Vec<IdentityIdentifier>,
 
     #[serde(default)]
     pub(crate) disabled: bool,
@@ -46,6 +59,7 @@ pub struct AuthenticatorConfig {
 pub struct ServiceConfigs {
     pub(crate) vault: Option<VaultConfig>,
     pub(crate) identity: Option<IdentityConfig>,
+    pub(crate) secure_channel_listener: Option<SecureChannelListenerConfig>,
     pub(crate) verifier: Option<VerifierConfig>,
     pub(crate) authenticator: Option<AuthenticatorConfig>,
 }
@@ -69,6 +83,10 @@ fn vault_default_addr() -> String {
 
 fn identity_default_addr() -> String {
     "identity_service".to_string()
+}
+
+fn sec_listener_default_addr() -> String {
+    "api".to_string()
 }
 
 fn verifier_default_addr() -> String {

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -1,0 +1,80 @@
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VaultConfig {
+    #[serde(default = "vault_default_addr")]
+    pub(crate) address: String,
+
+    #[serde(default)]
+    pub(crate) disabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityConfig {
+    #[serde(default = "identity_default_addr")]
+    pub(crate) address: String,
+
+    #[serde(default)]
+    pub(crate) disabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifierConfig {
+    #[serde(default = "verifier_default_addr")]
+    pub(crate) address: String,
+
+    #[serde(default)]
+    pub(crate) disabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthenticatorConfig {
+    #[serde(default = "authenticator_default_addr")]
+    pub(crate) address: String,
+
+    pub(crate) enrollers: PathBuf,
+
+    pub(crate) project: String,
+
+    #[serde(default)]
+    pub(crate) disabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceConfigs {
+    pub(crate) vault: Option<VaultConfig>,
+    pub(crate) identity: Option<IdentityConfig>,
+    pub(crate) verifier: Option<VerifierConfig>,
+    pub(crate) authenticator: Option<AuthenticatorConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub(crate) startup_services: Option<ServiceConfigs>,
+}
+
+impl Config {
+    pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let s = std::fs::read_to_string(path.as_ref())
+            .with_context(|| anyhow!("failed to read {:?}", path.as_ref()))?;
+        serde_json::from_str(&s).with_context(|| anyhow!("invalid config {:?}", path.as_ref()))
+    }
+}
+
+fn vault_default_addr() -> String {
+    "vault_service".to_string()
+}
+
+fn identity_default_addr() -> String {
+    "identity_service".to_string()
+}
+
+fn verifier_default_addr() -> String {
+    "verifier".to_string()
+}
+
+fn authenticator_default_addr() -> String {
+    "authenticator".to_string()
+}

--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod config;
 pub(crate) mod start;
 
 pub(crate) use start::StartCommand;

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,22 +1,22 @@
-use std::path::PathBuf;
-
 use crate::node::NodeOpts;
 use crate::util::{api, connect_to, exitcode, stop_node};
 use crate::CommandGlobalOpts;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context as _, Result};
 use clap::{Args, Subcommand};
 use minicbor::Decoder;
+use ockam::Context;
 use ockam_api::error::ApiError;
 use ockam_api::nodes::models::services::{StartAuthenticatorRequest, StartVerifierService};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Error, Method, Request, Response, Status};
 use ockam_core::Route;
+use std::path::PathBuf;
 use tracing::debug;
 
 #[derive(Clone, Debug, Args)]
 pub struct StartCommand {
     #[clap(flatten)]
-    node_opts: NodeOpts,
+    pub node_opts: NodeOpts,
 
     #[clap(subcommand)]
     pub create_subcommand: StartSubCommand,
@@ -25,13 +25,16 @@ pub struct StartCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum StartSubCommand {
     Vault {
-        addr: Option<String>,
+        #[clap(default_value = "vault_service")]
+        addr: String,
     },
     Identity {
-        addr: Option<String>,
+        #[clap(default_value = "identity_service")]
+        addr: String,
     },
     Authenticated {
-        addr: Option<String>,
+        #[clap(default_value = "authenticated")]
+        addr: String,
     },
     Verifier {
         #[clap(long, default_value = "verifier")]
@@ -50,7 +53,7 @@ pub enum StartSubCommand {
 }
 
 impl StartCommand {
-    pub fn run(opts: CommandGlobalOpts, command: StartCommand) -> anyhow::Result<()> {
+    pub fn run(opts: CommandGlobalOpts, command: StartCommand) -> Result<()> {
         let cfg = opts.config;
         let port = match cfg.select_node(&command.node_opts.api_node) {
             Some(cfg) => cfg.port,
@@ -61,14 +64,38 @@ impl StartCommand {
         };
 
         match command.create_subcommand {
-            StartSubCommand::Vault { .. } => connect_to(port, command, start_vault_service),
-            StartSubCommand::Identity { .. } => connect_to(port, command, start_identity_service),
-            StartSubCommand::Authenticated { .. } => {
-                connect_to(port, command, start_authenticated_service)
+            StartSubCommand::Vault { .. } => connect_to(port, command, |mut ctx, cmd, rte| async {
+                let a = start_vault_service(&mut ctx, cmd, rte).await;
+                let b = stop_node(ctx).await;
+                a.and(b)
+            }),
+            StartSubCommand::Identity { .. } => {
+                connect_to(port, command, |mut ctx, cmd, rte| async {
+                    let a = start_identity_service(&mut ctx, cmd, rte).await;
+                    let b = stop_node(ctx).await;
+                    a.and(b)
+                })
             }
-            StartSubCommand::Verifier { .. } => connect_to(port, command, start_verifier_service),
+            StartSubCommand::Authenticated { .. } => {
+                connect_to(port, command, |mut ctx, cmd, rte| async {
+                    let a = start_authenticated_service(&mut ctx, cmd, rte).await;
+                    let b = stop_node(ctx).await;
+                    a.and(b)
+                })
+            }
+            StartSubCommand::Verifier { .. } => {
+                connect_to(port, command, |mut ctx, cmd, rte| async {
+                    let a = start_verifier_service(&mut ctx, cmd, rte).await;
+                    let b = stop_node(ctx).await;
+                    a.and(b)
+                })
+            }
             StartSubCommand::Authenticator { .. } => {
-                connect_to(port, command, start_authenticator_service)
+                connect_to(port, command, |mut ctx, cmd, rte| async {
+                    let a = start_authenticator_service(&mut ctx, cmd, rte).await;
+                    let b = stop_node(ctx).await;
+                    a.and(b)
+                })
             }
         }
 
@@ -77,16 +104,14 @@ impl StartCommand {
 }
 
 pub async fn start_vault_service(
-    ctx: ockam::Context,
+    ctx: &mut Context,
     cmd: StartCommand,
     mut base_route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let addr = match cmd.create_subcommand {
         StartSubCommand::Vault { addr, .. } => addr,
         _ => return Err(ApiError::generic("Internal logic error").into()),
     };
-
-    let addr = addr.unwrap_or_else(|| "vault_service".to_string());
 
     let response: Vec<u8> = ctx
         .send_and_receive(
@@ -116,27 +141,26 @@ pub async fn start_vault_service(
         _ => Err(anyhow!("Unexpected response received from node")),
     };
     match res {
-        Ok(o) => println!("{o}"),
+        Ok(o) => {
+            println!("{o}");
+            Ok(())
+        }
         Err(err) => {
             eprintln!("{err}");
             std::process::exit(exitcode::IOERR);
         }
-    };
-
-    stop_node(ctx).await
+    }
 }
 
 pub async fn start_identity_service(
-    ctx: ockam::Context,
+    ctx: &mut Context,
     cmd: StartCommand,
     mut base_route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let addr = match cmd.create_subcommand {
         StartSubCommand::Identity { addr, .. } => addr,
         _ => return Err(ApiError::generic("Internal logic error").into()),
     };
-
-    let addr = addr.unwrap_or_else(|| "identity_service".to_string());
 
     let response: Vec<u8> = ctx
         .send_and_receive(
@@ -166,27 +190,26 @@ pub async fn start_identity_service(
         _ => Err(anyhow!("Unexpected response received from node")),
     };
     match res {
-        Ok(o) => println!("{o}"),
+        Ok(o) => {
+            println!("{o}");
+            Ok(())
+        }
         Err(err) => {
             eprintln!("{err}");
             std::process::exit(exitcode::IOERR);
         }
-    };
-
-    stop_node(ctx).await
+    }
 }
 
 pub async fn start_authenticated_service(
-    ctx: ockam::Context,
+    ctx: &mut Context,
     cmd: StartCommand,
     mut base_route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let addr = match cmd.create_subcommand {
         StartSubCommand::Authenticated { addr, .. } => addr,
         _ => return Err(ApiError::generic("Internal logic error").into()),
     };
-
-    let addr = addr.unwrap_or_else(|| "authenticated".to_string());
 
     let response: Vec<u8> = ctx
         .send_and_receive(
@@ -216,21 +239,22 @@ pub async fn start_authenticated_service(
         _ => Err(anyhow!("Unexpected response received from node")),
     };
     match res {
-        Ok(o) => println!("{o}"),
+        Ok(o) => {
+            println!("{o}");
+            Ok(())
+        }
         Err(err) => {
             eprintln!("{err}");
             std::process::exit(exitcode::IOERR);
         }
-    };
-
-    stop_node(ctx).await
+    }
 }
 
 pub async fn start_verifier_service(
-    ctx: ockam::Context,
+    ctx: &mut Context,
     cmd: StartCommand,
     mut route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let addr = match cmd.create_subcommand {
         StartSubCommand::Verifier { addr } => addr,
         _ => unreachable!(),
@@ -249,27 +273,25 @@ pub async fn start_verifier_service(
 
     if let Some(Status::Ok) = hdr.status() {
         println!("Verifier service started at address: {addr}");
-        return stop_node(ctx).await;
+        return Ok(());
     }
 
     if hdr.has_body() {
         if let Ok(err) = dec.decode::<Error>() {
             if let Some(msg) = err.message() {
-                eprintln!("Failed to start verifier service: {}", msg);
-                return stop_node(ctx).await;
+                return Err(anyhow!("Failed to start verifier service: {}", msg));
             }
         }
     }
 
-    eprintln!("Failed to start verifier service");
-    stop_node(ctx).await
+    Err(anyhow!("Failed to start verifier service"))
 }
 
 pub async fn start_authenticator_service(
-    ctx: ockam::Context,
+    ctx: &mut Context,
     cmd: StartCommand,
     mut route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let (addr, enrollers, project) = match cmd.create_subcommand {
         StartSubCommand::Authenticator {
             addr: a,
@@ -296,18 +318,16 @@ pub async fn start_authenticator_service(
 
     if let Some(Status::Ok) = hdr.status() {
         println!("Authenticator service started at address: {addr}");
-        return stop_node(ctx).await;
+        return Ok(());
     }
 
     if hdr.has_body() {
         if let Ok(err) = dec.decode::<Error>() {
             if let Some(msg) = err.message() {
-                eprintln!("Failed to start authenticator service: {}", msg);
-                return stop_node(ctx).await;
+                return Err(anyhow!("Failed to start authenticator service: {}", msg));
             }
         }
     }
 
-    eprintln!("Failed to start authenticator service");
-    stop_node(ctx).await
+    Err(anyhow!("Failed to start authenticator service"))
 }


### PR DESCRIPTION
Example:

```json
{
  "startup_services": {
    "vault": {},
    "identity": {
      "address": "identity_service"
    },
    "verifier": {
      "address": "verify"
      "disabled": true
    },
    "authenticator": {
      "enrollers": "/tmp/enrollers.json",
      "project": "p42"
    }
  }
}
```
Opening as a draft PR as it currently abuses the existing `launch_config` parameter and needs better integration with the rest of the system.