### PR TITLE
fix(elixir): encode api error messages as cbor strings

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api.ex
@@ -49,7 +49,7 @@ defmodule Ockam.Services.API do
   """
   def reply_error(request, reason, address) do
     status = status_code(reason)
-    body = error_message(reason)
+    body = CBOR.encode(error_message(reason))
     reply(request, status, body, address)
   end
 
@@ -94,11 +94,15 @@ defmodule Ockam.Services.API do
 
   ## TODO: better standard error messages
   def error_message({:bad_request, data}) do
-    inspect(data)
+    error_message(data)
   end
 
   def error_message({:resource_exists, data}) do
-    inspect(data)
+    error_message(data)
+  end
+
+  def error_message(message) when is_binary(message) do
+    message
   end
 
   def error_message(message) do


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->



<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
