### PR TITLE
feat(rust): added bind check before using a user supplied port

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::util::exitcode;
+use crate::util::{bind_to_port_check, exitcode};
 use crate::{
     node::show::query_status,
     util::{
@@ -151,6 +151,12 @@ impl CreateCommand {
         // development) re-executing the current binary is a more
         // deterministic way of starting a node.
         let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
+
+        // Check if the port is used by some other services or process
+        if !bind_to_port_check(addr) {
+            eprintln!("Another process is listening on the provided port!");
+            std::process::exit(exitcode::IOERR);
+        }
 
         // FIXME: not really clear why this is causing issues
         if cfg.port_is_used(addr.port()) {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, get_final_element, stop_node};
+use crate::util::{bind_to_port_check, connect_to, exitcode, get_final_element, stop_node};
 use crate::util::{ComposableSnippet, Operation, PortalMode, Protocol};
 use crate::CommandGlobalOpts;
 use clap::Args;
@@ -68,6 +68,12 @@ impl CreateCommand {
                 std::process::exit(-1);
             }
         };
+
+        // Check if the port is used by some other services or process
+        if !bind_to_port_check(&command.from) {
+            eprintln!("Another process is listening on the provided port!");
+            std::process::exit(exitcode::IOERR);
+        }
 
         let composite = (&command).into();
         let node = node.to_string();

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,5 +1,9 @@
 use core::time::Duration;
-use std::{env, net::TcpListener, path::Path};
+use std::{
+    env,
+    net::{SocketAddr, TcpListener},
+    path::Path,
+};
 
 use anyhow::{anyhow, Context};
 use minicbor::{Decode, Decoder, Encode};
@@ -406,4 +410,10 @@ pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
 
     #[allow(unstable_name_collisions)]
     data.iter().map(AsRef::as_ref).intersperse(", ").collect()
+}
+
+pub fn bind_to_port_check(address: &SocketAddr) -> bool {
+    let port = address.port();
+    let ip = address.ip();
+    std::net::TcpListener::bind((ip, port)).is_ok()
 }


### PR DESCRIPTION
## Added

Bind check before using the user supplied port in `node create`, `tcp-listener create` and `tcp-inlet create`

Helper function is placed under utils

## Ouput

![image](https://user-images.githubusercontent.com/38526063/185959229-ed800986-3181-4599-bf27-2e9a49b4daf5.png)

ran the following commands

![image](https://user-images.githubusercontent.com/38526063/185959859-8258de4e-08b3-4bc3-8425-eed92e753577.png)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
