### PR TITLE
fix(rust): make path in error optional

### DIFF
--- a/implementations/rust/ockam/schema.cddl
+++ b/implementations/rust/ockam/schema.cddl
@@ -44,7 +44,7 @@ status = 200 ;; OK
 
 error = {
     ?0: 5359172,
-     1: path,
+    ?1: path,
     ?2: method,
     ?3: message
 }


### PR DESCRIPTION
This was missing in PR #3280