### PR TITLE
feat(rust): add method to create projects' secure channels given an input multiaddr

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,9 +1,11 @@
 use minicbor::{Decode, Encode};
 use serde::Serialize;
+use std::str::FromStr;
 
 use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use ockam_multiaddr::MultiAddr;
 
 #[derive(Encode, Decode, Serialize, Debug)]
 #[rustfmt::skip]
@@ -46,6 +48,10 @@ impl Project<'_> {
 
     pub fn is_ready(&self) -> bool {
         !self.access_route.is_empty() & self.identity.is_some()
+    }
+
+    pub fn access_route(&self) -> MultiAddr {
+        MultiAddr::from_str(&self.access_route).expect("Invalid access route")
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -35,11 +35,12 @@ impl<'a> CreateForwarder<'a> {
 }
 
 /// Response body when creating a forwarder
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Decode, Encode, serde::Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct ForwarderInfo<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip)]
     #[n(0)] tag: TypeTag<2757430>,
     #[b(1)] forwarding_route: CowStr<'a>,
     #[b(2)] remote_address: CowStr<'a>,

--- a/implementations/rust/ockam/ockam_command/src/configuration/set.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set.rs
@@ -24,5 +24,9 @@ impl SetCommand {
         };
 
         opts.config.set_node_alias(command.name, target_addr);
+        if let Err(e) = opts.config.atomic_update().run() {
+            eprintln!("{}", e);
+            std::process::exit(exitcode::IOERR);
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -1,46 +1,55 @@
+use std::fmt::{Debug, Display, Formatter};
+
 use crate::util::ConfigError;
 use crate::{exitcode, ExitCode};
-use tracing::error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub struct Error(ExitCode);
+#[derive(Debug)]
+pub struct Error {
+    code: ExitCode,
+    inner: anyhow::Error,
+}
 
 impl Error {
-    pub fn new(code: ExitCode) -> Self {
+    pub fn new(code: ExitCode, err: anyhow::Error) -> Self {
         assert_ne!(code, 0, "Error's exit code can't be OK");
-        Self(code)
+        Self { code, inner: err }
     }
 
     pub fn code(&self) -> ExitCode {
-        self.0
+        self.code
     }
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl std::error::Error for Error {}
+
 impl From<ConfigError> for Error {
     fn from(e: ConfigError) -> Self {
-        error!("{e}");
-        Error::new(exitcode::CONFIG)
+        Error::new(exitcode::CONFIG, e.into())
     }
 }
 
 impl From<ockam::Error> for Error {
     fn from(e: ockam::Error) -> Self {
-        error!("{e}");
-        Error::new(exitcode::SOFTWARE)
+        Error::new(exitcode::SOFTWARE, e.into())
     }
 }
 
 impl From<anyhow::Error> for Error {
     fn from(e: anyhow::Error) -> Self {
-        error!("{e}");
-        Error::new(exitcode::SOFTWARE)
+        Error::new(exitcode::SOFTWARE, e)
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        error!("{e}");
-        Error::new(exitcode::IOERR)
+        Error::new(exitcode::IOERR, e.into())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -39,7 +39,7 @@ use crate::util::exitcode::ExitCode;
 use crate::util::{exitcode, stop_node, OckamConfig};
 use crate::vault::VaultCommand;
 use clap::{crate_version, ArgEnum, Args, ColorChoice, Parser, Subcommand};
-use util::{embedded_node, setup_logging};
+use util::setup_logging;
 
 pub use error::{Error, Result};
 

--- a/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
@@ -56,5 +56,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::add_enroller(&cmd)).await?;
-    rpc.print_response::<Enroller>()
+    rpc.print_response::<Enroller>()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/add_member.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_member.rs
@@ -1,18 +1,23 @@
 use clap::Args;
 
 use ockam::identity::IdentityIdentifier;
-use ockam::Context;
+use ockam::{Context, TcpTransport};
 use ockam_api::authenticator::direct::types::AddMember;
 use ockam_api::clean_multiaddr;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{stop_node, CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
 pub struct AddMemberCommand {
+    /// Orchestrator address to resolve projects present in the `at` argument
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
+
     #[clap(flatten)]
     node_opts: NodeOpts,
 
@@ -31,13 +36,27 @@ impl AddMemberCommand {
 
 async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, AddMemberCommand)) -> Result<()> {
     async fn go(ctx: &mut Context, opts: &CommandGlobalOpts, cmd: AddMemberCommand) -> Result<()> {
-        let (to, _meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
+        let tcp = TcpTransport::create(ctx).await?;
+        let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
+        let projects_sc = crate::project::util::lookup_projects(
+            ctx,
+            opts,
+            &tcp,
+            &meta,
+            &cmd.cloud_opts.addr,
+            &cmd.node_opts.api_node,
+        )
+        .await?;
+        let to = crate::project::util::clean_projects_multiaddr(to, projects_sc)?;
+
         let req = Request::post("/members").body(AddMember::new(cmd.member));
         let mut rpc = RpcBuilder::new(ctx, opts, &cmd.node_opts.api_node)
+            .tcp(&tcp)
             .to(&to)?
             .build()?;
         rpc.request(req).await?;
-        rpc.is_ok()
+        rpc.is_ok()?;
+        Ok(())
     }
     let result = go(&mut ctx, &opts, cmd).await;
     stop_node(ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,17 +1,14 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
+use ockam::{Context, TcpTransport};
+use std::io::Write;
 
 use ockam_api::cloud::project::Project;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode, stop_node};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::output::Output;
+use crate::util::{api, node_rpc, stop_node, RpcBuilder};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -37,61 +34,64 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: CreateCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), create);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn create(
-    ctx: ockam::Context,
+async fn rpc(
+    mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+) -> crate::Result<()> {
+    let res = run_impl(&mut ctx, opts, cmd).await;
+    stop_node(ctx).await?;
+    res
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::create(&cmd).to_vec()?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: CreateCommand,
+) -> crate::Result<()> {
+    let tcp = TcpTransport::create(ctx).await?;
+    let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+        .tcp(&tcp)
+        .build()?;
+    rpc.request(api::project::create(&cmd)).await?;
+    let mut project = rpc.parse_response::<Project>()?;
 
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let body = dec.decode::<Project>()?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => body.id.to_string(),
-                OutputFormat::Json => serde_json::to_string(&body)?,
-            };
-
-            Ok(output)
+    if project.access_route.is_empty() {
+        print!("\nProject created. Waiting until it's operative...");
+        let cmd = crate::project::ShowCommand {
+            space_id: project.space_id.to_string(),
+            project_id: project.id.to_string(),
+            node_opts: cmd.node_opts.clone(),
+            cloud_opts: cmd.cloud_opts.clone(),
+        };
+        loop {
+            print!(".");
+            std::io::stdout().flush()?;
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+                .tcp(&tcp)
+                .build()?;
+            rpc.request(api::project::show(&cmd)).await?;
+            let p = rpc.parse_response::<Project>()?;
+            if p.is_ready() {
+                project = p.to_owned();
+                break;
+            }
         }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
-    stop_node(ctx).await
+    }
+    opts.config.set_project_alias(
+        project.name.to_string(),
+        project.access_route.to_string(),
+        project.id.to_string(),
+        project
+            .identity
+            .as_ref()
+            .expect("Project should have identity set")
+            .to_string(),
+    )?;
+    println!("{}", project.output()?);
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
@@ -50,5 +50,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::delete_enroller(&cmd)).await?;
-    rpc.is_ok()
+    rpc.is_ok()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -1,17 +1,22 @@
 use clap::Args;
 
 use ockam::identity::credential::Credential;
-use ockam::Context;
+use ockam::{Context, TcpTransport};
 use ockam_api::clean_multiaddr;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::NodeOpts;
+use crate::util::api::CloudOpts;
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{stop_node, CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
 pub struct GetCredentialCommand {
+    /// Orchestrator address to resolve projects present in the `at` argument
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
+
     #[clap(flatten)]
     node_opts: NodeOpts,
 
@@ -34,12 +39,26 @@ async fn rpc(
         opts: &CommandGlobalOpts,
         cmd: &GetCredentialCommand,
     ) -> Result<()> {
-        let (to, _meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
+        let tcp = TcpTransport::create(ctx).await?;
+        let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
+        let projects_sc = crate::project::util::lookup_projects(
+            ctx,
+            opts,
+            &tcp,
+            &meta,
+            &cmd.cloud_opts.addr,
+            &cmd.node_opts.api_node,
+        )
+        .await?;
+        let to = crate::project::util::clean_projects_multiaddr(to, projects_sc)?;
+
         let mut rpc = RpcBuilder::new(ctx, opts, &cmd.node_opts.api_node)
+            .tcp(&tcp)
             .to(&to)?
             .build()?;
         rpc.request(Request::post("/credential")).await?;
-        rpc.print_response::<Credential<'_>>()
+        rpc.print_response::<Credential<'_>>()?;
+        Ok(())
     }
     let result = go(&mut ctx, &opts, &cmd).await;
     stop_node(ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
@@ -48,5 +48,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::list_enrollers(&cmd)).await?;
-    rpc.print_response::<Vec<Enroller>>()
+    rpc.print_response::<Vec<Enroller>>()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -7,6 +7,7 @@ mod get_credential;
 mod list;
 mod list_enrollers;
 mod show;
+pub mod util;
 
 use clap::{Args, Subcommand};
 

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -1,0 +1,126 @@
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context, Result};
+use tracing::{debug, trace};
+
+use ockam::identity::IdentityIdentifier;
+use ockam::TcpTransport;
+use ockam_api::cloud::project::Project;
+use ockam_api::cloud::CloudRequestWrapper;
+use ockam_api::config::lookup::LookupMeta;
+use ockam_api::nodes::models;
+use ockam_api::nodes::models::secure_channel::CreateSecureChannelResponse;
+use ockam_core::api::{Method, Request};
+use ockam_multiaddr::{MultiAddr, Protocol};
+
+use crate::util::RpcBuilder;
+use crate::CommandGlobalOpts;
+
+pub fn clean_projects_multiaddr(
+    input: MultiAddr,
+    projects_secure_channels: Vec<MultiAddr>,
+) -> Result<MultiAddr> {
+    let mut new_ma = MultiAddr::default();
+    let mut sc_iter = projects_secure_channels.iter().peekable();
+    for p in input.iter().peekable() {
+        match p.code() {
+            ockam_multiaddr::proto::Project::CODE => {
+                let alias = p
+                    .cast::<ockam_multiaddr::proto::Project>()
+                    .ok_or_else(|| anyhow!("Invalid project value"))?;
+                let sc = sc_iter
+                    .next()
+                    .ok_or_else(|| anyhow!("Missing secure channel for project {}", &*alias))?;
+                for v in sc.iter().peekable() {
+                    new_ma.push_back_value(&v)?;
+                }
+            }
+            _ => new_ma.push_back_value(&p)?,
+        }
+    }
+    debug!(%input, %new_ma, "Projects names replaced with secure channels");
+    Ok(new_ma)
+}
+
+pub async fn lookup_projects(
+    ctx: &ockam::Context,
+    opts: &CommandGlobalOpts,
+    tcp: &TcpTransport,
+    meta: &LookupMeta,
+    cloud_addr: &MultiAddr,
+    api_node: &str,
+) -> Result<Vec<MultiAddr>> {
+    let cfg_lookup = opts.config.get_lookup();
+    let mut sc = Vec::with_capacity(meta.project.len());
+    for name in meta.project.iter() {
+        // Try to get the project node's access route + identity id from the config
+        let (project_access_route, project_identity_id) = match cfg_lookup.get_project(name) {
+            Some(p) => (p.node_route(), p.identity_id.to_string()),
+            None => {
+                trace!(%name, "Project not found in config, retrieving from cloud");
+                // If it's not in the config, retrieve it from the API
+                let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+                rpc.request(
+                    Request::builder(Method::Get, format!("v0/projects/name/{}", name))
+                        .body(CloudRequestWrapper::bare(cloud_addr)),
+                )
+                .await?;
+                let project = rpc
+                    .parse_response::<Project>()
+                    .context("Failed to parse Project response")?;
+                let identity_id = project
+                    .identity
+                    .as_ref()
+                    .expect("Project should have identity set")
+                    .to_string();
+                // Store the project in the config lookup table
+                opts.config.set_project_alias(
+                    project.name.to_string(),
+                    project.access_route.to_string(),
+                    project.id.to_string(),
+                    identity_id.to_string(),
+                )?;
+                // Return the project data needed to create the secure channel
+                (project.access_route(), identity_id)
+            }
+        };
+        // Now we can create the secure channel to the project's node
+        sc.push(
+            create_secure_channel_to_project(
+                ctx,
+                opts,
+                tcp,
+                api_node,
+                &project_access_route,
+                &project_identity_id,
+            )
+            .await?,
+        );
+    }
+    // There should be the same number of project occurrences in the
+    // input MultiAddr than there are in the secure channels vector.
+    assert_eq!(meta.project.len(), sc.len());
+    Ok(sc)
+}
+
+async fn create_secure_channel_to_project<'a>(
+    ctx: &ockam::Context,
+    opts: &CommandGlobalOpts,
+    tcp: &TcpTransport,
+    api_node: &str,
+    project_access_route: &MultiAddr,
+    project_identity: &str,
+) -> crate::Result<MultiAddr> {
+    let authorized_identifier = vec![IdentityIdentifier::from_str(project_identity)?];
+    let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+    let req = {
+        let payload = models::secure_channel::CreateSecureChannelRequest::new(
+            project_access_route,
+            Some(authorized_identifier),
+        );
+        Request::builder(Method::Post, "/node/secure_channel").body(payload)
+    };
+    rpc.request(req).await?;
+    let sc = rpc.parse_response::<CreateSecureChannelResponse>()?;
+    Ok(sc.addr()?)
+}

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -48,5 +48,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::create(&cmd)).await?;
-    rpc.print_response::<Space>()
+    rpc.print_response::<Space>()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -42,5 +42,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::delete(&cmd)).await?;
-    rpc.is_ok()
+    rpc.is_ok()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -36,5 +36,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::list(&cmd)).await?;
-    rpc.print_response::<Vec<Space>>()
+    rpc.print_response::<Vec<Space>>()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -40,5 +40,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::show(&cmd)).await?;
-    rpc.print_response::<Space>()
+    rpc.print_response::<Space>()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -210,22 +210,6 @@ pub(crate) fn start_authenticated_service(addr: &str) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-pub(crate) mod secure_channel {
-    use super::*;
-    use crate::secure_channel;
-
-    /// Construct a request to create Secure Channels
-    pub(crate) fn create(
-        cmd: &secure_channel::CreateCommand,
-    ) -> RequestBuilder<models::secure_channel::CreateSecureChannelRequest> {
-        let payload = models::secure_channel::CreateSecureChannelRequest::new(
-            &cmd.to,
-            cmd.authorized.clone(),
-        );
-        Request::builder(Method::Post, "/node/secure_channel").body(payload)
-    }
-}
-
 /// Helpers to create enroll API requests
 pub(crate) mod enroll {
     use crate::enroll::*;
@@ -343,21 +327,6 @@ pub(crate) mod project {
             ),
         )
         .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
-    }
-}
-
-pub(crate) mod message {
-    use crate::message::*;
-    use ockam_api::nodes::service::message::*;
-
-    use super::*;
-
-    pub(crate) fn send(cmd: SendCommand) -> anyhow::Result<Vec<u8>> {
-        let mut buf = vec![];
-        Request::builder(Method::Post, "v0/message")
-            .body(SendMessage::new(&cmd.to, cmd.message.as_bytes()))
-            .encode(&mut buf)?;
-        Ok(buf)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -1,6 +1,6 @@
 //! Handle local node configuration
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use ockam_api::config::{cli, lookup::ConfigLookup, lookup::InternetAddress, Config};
 use ockam_multiaddr::MultiAddr;
 use slug::slugify;
@@ -59,6 +59,16 @@ impl OckamConfig {
         let inner = Config::<cli::OckamConfig>::load(config_dir, "config");
         inner.writelock_inner().directories = Some(directories);
         Self { inner }
+    }
+
+    pub fn remove(self) -> Result<()> {
+        let inner = self.inner.writelock_inner();
+        let config_dir = inner
+            .directories
+            .as_ref()
+            .expect("configuration is in an invalid state")
+            .config_dir();
+        std::fs::remove_dir_all(config_dir).context("Failed to delete config directory")
     }
 
     /// Get available global configuration values


### PR DESCRIPTION
Built on top of https://github.com/build-trust/ockam/pull/3312. We have to merge that first.

Project lookup added to:
- `forwarder create`
- `message send`
- `secure-channel create`
- `project add-member`
- `project get-credential`

Other changes:
- `enroll` now does not create the secure channel, as it will be created when doing the project lookup
- `project create` command now updates the config file with the project info, so it can be used by the lookup method
- Refactor `Error` struct to simplify its use. It can now be built passing an `anyhow` error so that we can output the error message, instead of just the exit code

## :warning: Important note :warning:

Currently, these changes will only work if the projects' info is stored in the config file, which is done when creating projects with the `enroll` command and the `project create` command.

When a project name from the input MultiAddr doesn't exist in the config file it will try to fetch it from the cloud to create the secure channel. This logic won't work until we have an API method that enables us to retrieve projects by name. We should add this endpoint on the elixir side.