### PR TITLE
chore(rust): secure listener from config, no authorized identities

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -349,7 +349,7 @@ async fn start_services(
     if let Some(cfg) = config.secure_channel_listener {
         if !cfg.disabled {
             let adr = Address::from((LOCAL, cfg.address));
-            let ids = cfg.authorized_identifiers.into();
+            let ids = cfg.authorized_identifiers;
             let rte = addr.clone().into();
             println!("starting secure-channel listener ...");
             secure_channel_listener::create_listener(ctx, adr, ids, rte).await?;

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -27,7 +27,7 @@ pub struct SecureChannelListenerConfig {
     pub(crate) address: String,
 
     #[serde(default)]
-    pub(crate) authorized_identifiers: Vec<IdentityIdentifier>,
+    pub(crate) authorized_identifiers: Option<Vec<IdentityIdentifier>>,
 
     #[serde(default)]
     pub(crate) disabled: bool,


### PR DESCRIPTION
Make the `authorized_identifiers`  field on json' config optional, so it's read as `None` if field is not specified (and the trust policy in that case is trustall).
Otherwise right now not putting the `authorized_identifiers` field is interpreted as an empty list,  and there is no way to specify trustall.

