### PR TITLE
fix(rust): mutliaddr support for projects

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -11,8 +11,10 @@ use std::{
 #[derive(Debug, Default)]
 pub struct LookupMeta {
     /// Append any project name that is encountered during look-up
-    pub project: VecDeque<String>,
+    pub project: VecDeque<Name>,
 }
+
+pub type Name = String;
 
 /// A generic lookup mechanism for configuration values
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -52,13 +54,13 @@ impl ConfigLookup {
     /// Store a project route and identifier as lookup
     pub fn set_project(
         &mut self,
-        prj_name: String,
+        name: String,
         node_route: String,
         id: String,
         identity_id: String,
     ) {
         self.map.insert(
-            format!("/project/{}", prj_name),
+            format!("/project/{}", name),
             LookupValue::Project(ProjectLookup {
                 node_route,
                 id,
@@ -67,9 +69,9 @@ impl ConfigLookup {
         );
     }
 
-    pub fn get_project(&self, project_name: &str) -> Option<&ProjectLookup> {
+    pub fn get_project(&self, name: &str) -> Option<&ProjectLookup> {
         self.map
-            .get(&format!("/project/{}", project_name))
+            .get(&format!("/project/{}", name))
             .and_then(|value| match value {
                 LookupValue::Project(project) => Some(project),
                 _ => None,
@@ -170,7 +172,7 @@ pub struct ProjectLookup {
 impl ProjectLookup {
     pub fn node_route(&self) -> MultiAddr {
         MultiAddr::from_str(&self.node_route).expect(
-            "tried retrieving a MultiAddr from PrjoectLookup where no MultiAddr had been stored",
+            "tried retrieving a MultiAddr from ProjectLookup where no MultiAddr had been stored",
         )
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -34,17 +34,13 @@ pub fn clean_multiaddr(
                 new_ma.push_back(Tcp(addr.port())).ok()?;
             }
             Project::CODE => {
+                // Parse project name from the MultiAddr.
                 let alias = p.cast::<Project>()?;
+                // Store it in the lookup meta, so we can later
+                // retrieve it from either the config or the cloud.
                 lookup_meta.project.push_back(alias.to_string());
-                let project = lookup
-                    .get_project(&*alias)
-                    .expect("provided invalid substitution route");
-
-                let project_node = project.node_route();
-                let project_node_iter = project_node.iter().peekable();
-                for project_node_segment in project_node_iter {
-                    new_ma.push_back_value(&project_node_segment).ok()?;
-                }
+                // No substitution done here. It will be done later by `clean_projects_multiaddr`.
+                new_ma.push_back_value(&p).ok()?
             }
             Space::CODE => panic!("/space/ substitutions are not supported yet!"),
             _ => new_ma.push_back_value(&p).ok()?,

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -140,7 +140,7 @@ pub struct GlobalArgs {
     test_argument_parser: bool,
 }
 
-#[derive(Debug, Clone, ArgEnum, PartialEq)]
+#[derive(Debug, Clone, ArgEnum, PartialEq, Eq)]
 pub enum OutputFormat {
     Plain,
     Json,

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -283,7 +283,7 @@ async fn setup(
     let bind = c.tcp_listener_address;
     tcp.listen(&bind).await?;
 
-    let node_dir = cfg.get_node_dir(&c.node_name).unwrap(); // can't fail because we already checked it
+    let node_dir = cfg.get_node_dir(&c.node_name)?;
     let node_man = NodeManager::create(
         &ctx,
         c.node_name.clone(),

--- a/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
@@ -1,5 +1,5 @@
 use super::{Buffer, Checked, Code, Codec, Protocol};
-use crate::proto::{DnsAddr, Node, Service, Tcp};
+use crate::proto::{DnsAddr, Node, Project, Service, Tcp};
 use crate::{Error, ProtoValue};
 use core::fmt;
 use unsigned_varint::decode;
@@ -49,7 +49,7 @@ impl Codec for StdCodec {
                 let (x, y) = input.split_at(2);
                 Ok((Checked(x), y))
             }
-            c @ DnsAddr::CODE | c @ Service::CODE | c @ Node::CODE => {
+            c @ DnsAddr::CODE | c @ Service::CODE | c @ Node::CODE | c @ Project::CODE => {
                 let (len, input) = decode::usize(input)?;
                 if input.len() < len {
                     return Err(Error::required_bytes(c, len));
@@ -71,6 +71,7 @@ impl Codec for StdCodec {
             DnsAddr::CODE => DnsAddr::read_bytes(input).is_ok(),
             Service::CODE => Service::read_bytes(input).is_ok(),
             Node::CODE => Node::read_bytes(input).is_ok(),
+            Project::CODE => Project::read_bytes(input).is_ok(),
             _ => false,
         }
     }
@@ -85,6 +86,7 @@ impl Codec for StdCodec {
             DnsAddr::CODE => DnsAddr::read_bytes(val.data())?.write_bytes(buf),
             Service::CODE => Service::read_bytes(val.data())?.write_bytes(buf),
             Node::CODE => Node::read_bytes(val.data())?.write_bytes(buf),
+            Project::CODE => Project::read_bytes(val.data())?.write_bytes(buf),
             code => return Err(Error::unregistered(code)),
         }
         Ok(())
@@ -123,6 +125,10 @@ impl Codec for StdCodec {
                 Node::read_str(value)?.write_bytes(buf);
                 Ok(())
             }
+            Project::PREFIX => {
+                Project::read_str(value)?.write_bytes(buf);
+                Ok(())
+            }
             _ => Err(Error::unregistered_prefix(prefix)),
         }
     }
@@ -158,6 +164,10 @@ impl Codec for StdCodec {
             }
             Node::CODE => {
                 Node::read_bytes(value)?.write_str(f)?;
+                Ok(())
+            }
+            Project::CODE => {
+                Project::read_bytes(value)?.write_str(f)?;
                 Ok(())
             }
             _ => Err(Error::unregistered(code)),

--- a/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
@@ -1,6 +1,6 @@
 use super::{Code, Codec, Protocol};
 use crate::codec::StdCodec;
-use crate::proto::{DnsAddr, Node, Service, Tcp};
+use crate::proto::{DnsAddr, Node, Project, Service, Tcp};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
 use core::fmt;
@@ -31,6 +31,8 @@ impl Default for Registry {
         r.register(Service::CODE, Service::PREFIX, std_codec.clone());
         #[allow(clippy::redundant_clone)]
         r.register(Node::CODE, Node::PREFIX, std_codec.clone());
+        #[allow(clippy::redundant_clone)]
+        r.register(Project::CODE, Project::PREFIX, std_codec.clone());
         #[cfg(feature = "std")]
         r.register(
             crate::proto::Ip4::CODE,


### PR DESCRIPTION
Needed for https://github.com/build-trust/ockam/pull/3306

* Fixes support for `project` prefix on MultiAddr.
* Add missing config updates