### PR TITLE
fix(rust): creation of static forwarder without heartbeats

### DIFF
--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -187,7 +187,7 @@ impl RemoteForwarder {
         let registration_route = hub_route
             .into()
             .modify()
-            .append("forwarding_service")
+            .append("static_forwarding_service")
             .into();
 
         // let remote_address = Address::random_local().without_type().to_string();
@@ -201,7 +201,7 @@ impl RemoteForwarder {
         );
 
         debug!(
-            "Starting ephemeral RemoteForwarder at {}",
+            "Starting static RemoteForwarder without heartbeats at {}",
             &addresses.main_address
         );
         ctx.start_worker(addresses.main_address, forwarder).await?;

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -174,6 +174,9 @@ impl RemoteForwarder {
     }
 
     /// Create and start new static RemoteForwarder without heart beats
+    // This is a temporary kind of RemoteForwarder that will only run on
+    // rust nodes (hence the `forwarding_service` addr to create static forwarders).
+    // We will use it while we don't have heartbeats implemented on rust nodes.
     pub async fn create_static_without_heartbeats(
         ctx: &Context,
         hub_route: impl Into<Route>,
@@ -187,7 +190,7 @@ impl RemoteForwarder {
         let registration_route = hub_route
             .into()
             .modify()
-            .append("static_forwarding_service")
+            .append("forwarding_service")
             .into();
 
         // let remote_address = Address::random_local().without_type().to_string();

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -1,0 +1,62 @@
+use minicbor::Decoder;
+
+use ockam::remote::RemoteForwarder;
+use ockam::Result;
+use ockam_core::api::{Request, Response, Status};
+use ockam_multiaddr::MultiAddr;
+use ockam_node::Context;
+
+use crate::error::ApiError;
+use crate::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
+use crate::nodes::service::map_multiaddr_err;
+use crate::nodes::NodeManager;
+
+impl NodeManager {
+    pub(super) async fn create_forwarder(
+        &mut self,
+        ctx: &mut Context,
+        req: &Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<Vec<u8>> {
+        let CreateForwarder {
+            address,
+            alias,
+            at_rust_node,
+            ..
+        } = dec.decode()?;
+        let addr = MultiAddr::try_from(address.0.as_ref()).map_err(map_multiaddr_err)?;
+        let route = crate::multiaddr_to_route(&addr)
+            .ok_or_else(|| ApiError::generic("Invalid Multiaddr"))?;
+        debug!(%addr, ?alias, "Handling CreateForwarder request");
+
+        let forwarder = match alias {
+            Some(alias) => {
+                if at_rust_node {
+                    RemoteForwarder::create_static_without_heartbeats(ctx, route, alias.to_string())
+                        .await
+                } else {
+                    RemoteForwarder::create_static(ctx, route, alias.to_string()).await
+                }
+            }
+            None => RemoteForwarder::create(ctx, route).await,
+        };
+
+        match forwarder {
+            Ok(info) => {
+                let b = ForwarderInfo::from(info);
+                debug!(
+                    forwarding_route = %b.forwarding_route(),
+                    remote_address = %b.remote_address(),
+                    "CreateForwarder request processed, sending back response"
+                );
+                Ok(Response::ok(req.id()).body(b).to_vec()?)
+            }
+            Err(err) => {
+                error!(?err, "Failed to create forwarder");
+                Ok(Response::builder(req.id(), Status::InternalServerError)
+                    .body(err.to_string())
+                    .to_vec()?)
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -24,7 +24,7 @@ impl Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.inner, f)
+        std::fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -27,10 +27,6 @@ pub struct CreateCommand {
     #[clap(long = "from", display_order = 900)]
     from: Option<String>,
 
-    /// Forwarding address.
-    #[clap(hide = true)]
-    address: Option<String>,
-
     /// Orchestrator address to resolve projects present in the `at` argument
     #[clap(flatten)]
     cloud_opts: CloudOpts,
@@ -77,13 +73,13 @@ async fn rpc(
 
 /// Construct a request to create a forwarder
 fn req(cmd: &CreateCommand) -> RequestBuilder<CreateForwarder> {
-    let (at_rust_node, address) = match &cmd.from {
+    let (at_rust_node, alias) = match &cmd.from {
         Some(s) => (true, Some(get_final_element(s))),
-        None => (false, cmd.address.as_deref()),
+        None => (false, None),
     };
     Request::builder(Method::Post, "/node/forwarder").body(CreateForwarder::new(
         &cmd.at,
-        address,
+        alias,
         at_rust_node,
     ))
 }

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -1,9 +1,9 @@
+use anyhow::Context as _;
 use clap::Args;
 
-use crate::CommandGlobalOpts;
 use ockam::{Context, TcpTransport};
-use ockam_api::clean_multiaddr;
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
+use ockam_api::{clean_multiaddr, is_local_node};
 use ockam_core::api::{Method, Request, RequestBuilder};
 use ockam_multiaddr::MultiAddr;
 
@@ -12,19 +12,21 @@ use crate::util::output::Output;
 use crate::util::{
     get_final_element, node_rpc, stop_node, RpcBuilder, DEFAULT_ORCHESTRATOR_ADDRESS,
 };
+use crate::CommandGlobalOpts;
+use crate::Result;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Node for which to create the forwarder.
-    #[clap(long = "for", name = "NODE", display_order = 900)]
-    for_node: String,
+    #[clap(long, name = "NODE", display_order = 900)]
+    to: String,
 
     /// Route to the node on which to create the forwarder.
     #[clap(long, name = "ROUTE", default_value = DEFAULT_ORCHESTRATOR_ADDRESS, display_order = 900)]
     at: MultiAddr,
 
     /// Forwarding address.
-    #[clap(long = "from", display_order = 900)]
+    #[clap(long, display_order = 900)]
     from: Option<String>,
 
     /// Orchestrator address to resolve projects present in the `at` argument
@@ -38,17 +40,11 @@ impl CreateCommand {
     }
 }
 
-async fn rpc(
-    mut ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
-    async fn go(
-        ctx: &mut Context,
-        opts: &CommandGlobalOpts,
-        cmd: CreateCommand,
-    ) -> crate::Result<()> {
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+    async fn go(ctx: &mut Context, opts: &CommandGlobalOpts, cmd: CreateCommand) -> Result<()> {
         let tcp = TcpTransport::create(ctx).await?;
-        let api_node = get_final_element(&cmd.for_node);
+        let api_node = get_final_element(&cmd.to);
+        let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
         let (at, meta) = clean_multiaddr(&cmd.at, &opts.config.get_lookup()).unwrap();
         let projects_sc = crate::project::util::lookup_projects(
             ctx,
@@ -62,7 +58,7 @@ async fn rpc(
         let at = crate::project::util::clean_projects_multiaddr(at, projects_sc)?;
         let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(&tcp).build()?;
         let cmd = CreateCommand { at, ..cmd };
-        rpc.request(req(&cmd)).await?;
+        rpc.request(req(&cmd, at_rust_node)?).await?;
         rpc.print_response::<ForwarderInfo>()?;
         Ok(())
     }
@@ -72,16 +68,15 @@ async fn rpc(
 }
 
 /// Construct a request to create a forwarder
-fn req(cmd: &CreateCommand) -> RequestBuilder<CreateForwarder> {
-    let (at_rust_node, alias) = match &cmd.from {
-        Some(s) => (true, Some(get_final_element(s))),
-        None => (false, None),
-    };
-    Request::builder(Method::Post, "/node/forwarder").body(CreateForwarder::new(
-        &cmd.at,
-        alias,
-        at_rust_node,
-    ))
+fn req(cmd: &CreateCommand, at_rust_node: bool) -> anyhow::Result<RequestBuilder<CreateForwarder>> {
+    let alias = cmd.from.as_ref().map(|s| get_final_element(s));
+    Ok(
+        Request::builder(Method::Post, "/node/forwarder").body(CreateForwarder::new(
+            &cmd.at,
+            alias,
+            at_rust_node,
+        )),
+    )
 }
 
 impl Output for ForwarderInfo<'_> {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -296,7 +296,7 @@ where
         |ctx, a| async {
             let res = f(ctx, a).await;
             if let Err(e) = res {
-                error!("{e}");
+                error!("{e:?}");
                 eprintln!("{e}");
                 std::process::exit(e.code());
             }
@@ -305,7 +305,7 @@ where
         a,
     );
     if let Err(e) = res {
-        eprintln!("Ockam node failed: {:?}", e);
+        eprintln!("Ockam node failed: {e}");
         std::process::exit(exitcode::SOFTWARE);
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
@@ -7,11 +7,12 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("forwarder")
         .arg("create")
-        .arg("--at")
-        .arg("/ip4/127.0.0.1/tcp/8080")
-        .arg("--for")
+        .arg("--from")
+        .arg("forwarder_for_node_blue")
+        .arg("--to")
         .arg("node_blue")
-        .arg("forwarder_for_node_blue");
+        .arg("--at")
+        .arg("/ip4/127.0.0.1/tcp/8080");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
Adds a more elaborate logic to derive from the `--at` argument if it references a local node or a remote node. Still a hacky approach until rust forwarder service supports the heartbeat protocol.

Also, the `address` argument has been removed because it was not being used and the `for_node` argument has been renamed to `to`.

Finally, the forwarder service has been moved to its own module (no logic changes done, just moved the `create_forwarder` function).

```bash
$ ockam forwarder create --from forwarder_to_n2 --to /node/n2 --at /node/n1
/service/forwarder_to_n2

$ ockam forwarder create --to /node/n2 --at /node/n1
/service/register # !!! this is not what we want

$ ockam forwarder create --from /service/forwarder_to_d --to /node/default --at /project/default
/service/forward_to_forwarder_to_d

$ ockam forwarder create --at /project/default --to /node/default
/service/FWD_9a311b2755e4c6c0
```

## Note

When executing the command the way we agreed to, it doesn't return a consistent address for the forwarder:

```bash
$ ockam forwarder create --at /project/default --from /service/forwarder_to_d --for /node/default
/service/forward_to_forwarder_to_d
```

Should we stop prepending `forwarder_to` to the forwarder name? If not, it doesn't make too much sense to pass the alias argument as `/service/<alias>`.