### PR TITLE
fix(rust): Called atomic_update after setting new default node

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
@@ -16,6 +16,11 @@ impl SetDefaultNodeCommand {
         match opts.config.select_node(name) {
             Some(_) => {
                 opts.config.set_default_node(&name.to_string());
+                // Save the config update
+                if let Err(e) = opts.config.atomic_update().run() {
+                    eprintln!("failed to update configuration: {}", e);
+                    std::process::exit(exitcode::IOERR);
+                }
             }
             None => {
                 eprintln!("Node ({}) is not registered yet", command.name);


### PR DESCRIPTION
## FIx:

Previously when i updated the default_node, i didnt call atomic_update (this updates the value to local config file), that was the reason why get-default-node outputed n1 (as it was the first created node and it got saved to local config file)

## Current:

```rust
 opts.config.set_default_node(&name.to_string());
  // Save the config update
  if let Err(e) = opts.config.atomic_update().run() {
      eprintln!("failed to update configuration: {}", e);
      std::process::exit(exitcode::IOERR);
  }
```

## output

![set default](https://user-images.githubusercontent.com/38526063/186673086-03c56bb9-fecc-4228-87d3-a6c146e0fceb.gif)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
