### PR TITLE
feat(rust): change `--from` argument of forwarder create to `FORWARDER_NAME`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -23,7 +23,7 @@ pub struct CreateForwarder<'a> {
 }
 
 impl<'a> CreateForwarder<'a> {
-    pub fn new(address: &MultiAddr, alias: Option<&'a str>, at_rust_node: bool) -> Self {
+    pub fn new(address: &MultiAddr, alias: Option<String>, at_rust_node: bool) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: Default::default(),

--- a/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_forwarder.rs
@@ -7,12 +7,11 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("--test-argument-parser")
         .arg("forwarder")
         .arg("create")
-        .arg("--from")
-        .arg("forwarder_for_node_blue")
-        .arg("--to")
-        .arg("node_blue")
+        .arg("n1")
         .arg("--at")
-        .arg("/ip4/127.0.0.1/tcp/8080");
+        .arg("/ip4/127.0.0.1/tcp/8080")
+        .arg("--to")
+        .arg("node_blue");
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION

If name is provided:

```
ockam node create n1
ockam node create n2

ockam forwarder create n1 --at /node/n1 --to /node/n2
ockam message send hello --to /node/n1/service/forward_to_n1/service/uppercase
```

If no name is provided, a random name is generated before calling static forwarder

```
ockam node create n1
ockam node create n2

ockam forwarder create --at /node/n1 --to /node/n2 | \
  ockam message send hello --to /node/n1/-/service/uppercase
```