### PR TITLE
refactor(rust): make node delete command more robust when "force" argument is present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,6 +2250,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slug",
+ "sysinfo",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3533,6 +3543,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71eb43e528fdc239f08717ec2a378fdb017dddbc3412de15fff527554591a66c"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -66,6 +66,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json", "def
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 slug = "0.1"
+sysinfo = { version = "0.25", default-features = false }
 tempfile = "3.3"
 thiserror = "1"
 tokio = { version="1", features = ["full"] }

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -19,7 +19,12 @@ impl StopCommand {
     pub fn run(opts: CommandGlobalOpts, command: Self) {
         let cfg = opts.config;
         match cfg.get_node_pid(&command.node_name) {
-            Ok(Some(pid)) => startup::stop(pid, command.kill),
+            Ok(Some(pid)) => {
+                if let Err(e) = startup::stop(pid, command.kill) {
+                    eprintln!("{e:?}");
+                    std::process::exit(exitcode::OSERR);
+                }
+            }
             Ok(_) => {
                 eprintln!("Node {} is not running!", &command.node_name);
                 std::process::exit(exitcode::IOERR);

--- a/implementations/rust/ockam/ockam_command/src/util/startup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/startup.rs
@@ -4,6 +4,7 @@
 
 use crate::exitcode;
 use crate::util::{ComposableSnippet, OckamConfig, Operation, RemoteMode, StartupConfig};
+use anyhow::Context;
 use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 use std::collections::VecDeque;
@@ -12,15 +13,17 @@ use std::process::Stdio;
 use std::{env::current_exe, fs::OpenOptions, path::PathBuf, process::Command};
 
 /// Stop a node without deleting its state directory
-pub fn stop(pid: i32, sigkill: bool) {
-    let _ = signal::kill(
+pub fn stop(pid: i32, sigkill: bool) -> anyhow::Result<()> {
+    signal::kill(
         Pid::from_raw(pid),
         if sigkill {
             Signal::SIGKILL
         } else {
             Signal::SIGTERM
         },
-    );
+    )
+    .context(format!("Failed to kill process with PID {pid}"))?;
+    Ok(())
 }
 
 /// Execute a series of commands to setup a node


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/3322

It largely improves error handling, using less `std::process::exit` and propagating errors
more contextually.

When using the `--force` argument, it will try to delete all the nodes present in the
config file, but won't propagate any error if it fails to delete a given node or if there are
no nodes in the config file. Also, it will always try to delete the node's PID and its
content from the config file, regardless of whether one of the two operations fails.

Additionally, when the `--all` argument is also passed, it will remove both the config
directory and the nodes directory, and any orphan ockam process.