### PR TITLE
docs(rust): add examples section to ockam help commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -11,10 +11,27 @@ use ockam_multiaddr::MultiAddr;
 use crate::util::api::CloudOpts;
 use crate::util::output::Output;
 use crate::util::{get_final_element, node_rpc, RpcBuilder, DEFAULT_ORCHESTRATOR_ADDRESS};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
+
+const EXAMPLES: &str = "\
+EXAMPLES
+
+    # Create two nodes
+    $ ockam node create n1
+    $ ockam node create n2
+
+    # Create a forwarder to node n2 at node n1
+    $ ockam forwarder create --from forwarder_to_n2 --for /node/n2 --at /node/n1
+
+    # Send message via the forwarder
+    $ ockam message send hello --to /node/n1/service/forwarder_to_n2/service/uppercase
+
+LEARN MORE
+";
 
 #[derive(Clone, Debug, Args)]
+#[clap(help_template = const_str::replace!(HELP_TEMPLATE, "LEARN MORE", EXAMPLES))]
 pub struct CreateCommand {
     /// Name of the forwarder (Optional).
     #[clap(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,6 +1,6 @@
 use crate::util::{bind_to_port_check, connect_to, exitcode, get_final_element};
 use crate::util::{ComposableSnippet, Operation, PortalMode, Protocol};
-use crate::CommandGlobalOpts;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::Args;
 use minicbor::Decoder;
 use ockam::{Context, Route};
@@ -11,8 +11,31 @@ use ockam_core::api::{Request, Response, Status};
 use ockam_multiaddr::MultiAddr;
 use std::net::SocketAddr;
 
+const EXAMPLES: &str = "\
+EXAMPLES
+
+    # Create a target service, we'll use a simple http server for this example
+    $ python3 -m http.server --bind 127.0.0.1 5000
+
+    # Create two nodes
+    $ ockam node create n1
+    $ ockam node create n2
+
+    # Create a TCP outlet from n1 to the target server
+    $ ockam tcp-outlet create --at /node/n1 --from /service/outlet --to 127.0.0.1:5000
+
+    # Create a TCP inlet from n2 to the outlet on n1
+    $ ockam tcp-inlet create --at /node/n2 --from 127.0.0.1:6000 --to /node/n1/service/outlet
+
+    # Access the service via the inlet/outlet pair
+    $ curl 127.0.0.1:6000
+
+LEARN MORE
+";
+
 /// Create TCP Inlets
 #[derive(Clone, Debug, Args)]
+#[clap(help_template = const_str::replace!(HELP_TEMPLATE, "LEARN MORE", EXAMPLES))]
 pub struct CreateCommand {
     /// Node on which to start the tcp inlet.
     #[clap(long, display_order = 900, name = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,6 +1,6 @@
 use crate::util::{connect_to, exitcode, get_final_element};
 use crate::util::{ComposableSnippet, Operation, PortalMode, Protocol};
-use crate::CommandGlobalOpts;
+use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 use clap::Args;
 use minicbor::Decoder;
 use ockam::{Context, Route};
@@ -14,8 +14,31 @@ use ockam_core::api::{Request, Response, Status};
 use ockam_core::route;
 use std::net::SocketAddr;
 
+const EXAMPLES: &str = "\
+EXAMPLES
+
+    # Create a target service, we'll use a simple http server for this example
+    $ python3 -m http.server --bind 127.0.0.1 5000
+
+    # Create two nodes
+    $ ockam node create n1
+    $ ockam node create n2
+
+    # Create a TCP outlet from n1 to the target server
+    $ ockam tcp-outlet create --at /node/n1 --from /service/outlet --to 127.0.0.1:5000
+
+    # Create a TCP inlet from n2 to the outlet on n1
+    $ ockam tcp-inlet create --at /node/n2 --from 127.0.0.1:6000 --to /node/n1/service/outlet
+
+    # Access the service via the inlet/outlet pair
+    $ curl 127.0.0.1:6000
+
+LEARN MORE
+";
+
 /// Create TCP Outlets
 #[derive(Clone, Debug, Args)]
+#[clap(help_template = const_str::replace!(HELP_TEMPLATE, "LEARN MORE", EXAMPLES))]
 pub struct CreateCommand {
     /// Node on which to start the tcp outlet.
     #[clap(long, display_order = 900, name = "NODE")]


### PR DESCRIPTION
This PR addresses issues #3317, #3318 and #3319.

Currently, using the --help flag on each of the commands doesn't show the required examples section. This PR adds the respective examples section.