### PR TITLE
refactor(rust): rename `CloudOpts` addr argument to route_to_controller

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -52,7 +52,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
             opts,
             &tcp,
             &meta,
-            &cmd.cloud_opts.addr,
+            &cmd.cloud_opts.route_to_controller,
             api_node,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -111,7 +111,7 @@ async fn send_message_via_connection_to_a_node(
             opts,
             &tcp,
             &meta,
-            &cmd.cloud_opts.addr,
+            &cmd.cloud_opts.route_to_controller,
             &api_node,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/add_member.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_member.rs
@@ -43,7 +43,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, AddMemberCommand
             opts,
             &tcp,
             &meta,
-            &cmd.cloud_opts.addr,
+            &cmd.cloud_opts.route_to_controller,
             &cmd.node_opts.api_node,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -46,7 +46,7 @@ async fn rpc(
             opts,
             &tcp,
             &meta,
-            &cmd.cloud_opts.addr,
+            &cmd.cloud_opts.route_to_controller,
             &cmd.node_opts.api_node,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -152,7 +152,13 @@ async fn rpc(ctx: Context, (options, command): (CommandGlobalOpts, CreateCommand
     let config = &options.config.get_lookup();
     let from = &command.parse_from_node(config);
     let to = &command
-        .parse_to_route(&ctx, &options, &tcp, &command.cloud_opts.addr, from)
+        .parse_to_route(
+            &ctx,
+            &options,
+            &tcp,
+            &command.cloud_opts.route_to_controller,
+            from,
+        )
         .await?;
 
     let authorized_identifiers = command.authorized.clone();

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -433,11 +433,11 @@ pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Resu
 pub struct CloudOpts {
     /// Ockam orchestrator address
     #[clap(global = true, hide = true, default_value = DEFAULT_ORCHESTRATOR_ADDRESS)]
-    pub addr: MultiAddr,
+    pub route_to_controller: MultiAddr,
 }
 
 impl CloudOpts {
     pub fn route(&self) -> &MultiAddr {
-        &self.addr
+        &self.route_to_controller
     }
 }


### PR DESCRIPTION
This argument is hidden and it's mainly used for development tasks (e.g. when we want to point
to the orchestrator of the local development environment).

Context: https://github.com/build-trust/ockam/pull/3306#issuecomment-1226249389