### PR TITLE
refactor(rust): added serde default value

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -35,7 +35,12 @@ pub struct OckamConfig {
     pub lookup: ConfigLookup,
     pub default_identity: Option<Vec<u8>>,
     pub default_vault_path: Option<PathBuf>,
+    #[serde(default = "default_node")]
     pub default: Option<String>,
+}
+
+fn default_node() -> Option<String> {
+    None
 }
 
 impl ConfigValues for OckamConfig {


### PR DESCRIPTION
## Added

default serde value for newly added config field `default`

OUTPUT:

![default parsing](https://user-images.githubusercontent.com/38526063/186948906-991f3790-5ebd-4c00-b1d8-4201c7416c30.gif)


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
