### PR TITLE
fix: typo

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/startup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/startup.rs
@@ -73,7 +73,7 @@ pub fn spawn_node(
         "--tcp-listener-address".to_string(),
         address.to_string(),
         "--foreground".to_string(),
-        "--child_process".to_string(),
+        "--child-process".to_string(),
     ];
 
     if skip_defaults {


### PR DESCRIPTION
ockam' cli commands fails to start due to typo on argument