### PR TITLE
refactor(rust): move project readiness logic into ockam_api

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -103,26 +103,24 @@ pub fn multiaddr_to_route(ma: &MultiAddr) -> Option<Route> {
 /// Try to convert a multiaddr to an Ockam Address
 pub fn multiaddr_to_addr(ma: &MultiAddr) -> Option<Address> {
     let mut it = ma.iter().peekable();
-
-    let proto = it.next()?;
-    match proto.code() {
+    let p = it.next()?;
+    match p.code() {
         DnsAddr::CODE => {
-            let host = proto.cast::<DnsAddr>()?;
+            let host = p.cast::<DnsAddr>()?;
             if let Some(p) = it.peek() {
                 if p.code() == Tcp::CODE {
-                    let tcp = proto.cast::<Tcp>()?;
+                    let tcp = p.cast::<Tcp>()?;
                     return Some(Address::new(TCP, format!("{}:{}", &*host, *tcp)));
                 }
             }
+            None
         }
         Service::CODE => {
-            let local = proto.cast::<Service>()?;
-            return Some(Address::new(LOCAL, &*local));
+            let local = p.cast::<Service>()?;
+            Some(Address::new(LOCAL, &*local))
         }
-        _ => {}
-    };
-
-    None
+        _ => None,
+    }
 }
 
 /// Try to convert an Ockam Route into a MultiAddr.


### PR DESCRIPTION
Refactors https://github.com/build-trust/ockam/pull/3359, moving the "awaiting for project" logic inside the `Project` struct. It also adds a new function in the project/util.rs to run the readiness check, so we can remove the duplicate code in the `project create` and `enroll` commands.

Tested again creating a project from scratch.

Other changes:
- Update config on `clean_projects_multiaddr` after retrieving new projects
- Fix `multiaddr_to_addr`, where it was using the wrong `ProtoValue` to cast the TCP port

