### PR TITLE
feat(rust): add syntax highlighting to shell script examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1228,16 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1762,6 +1781,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "lmdb-rkv"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2293,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slug",
+ "syntect",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -2539,6 +2583,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,6 +2783,20 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time",
+ "xml-rs",
+]
 
 [[package]]
 name = "polyval"
@@ -3115,6 +3195,12 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -3546,6 +3632,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3760,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa 1.0.2",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -4307,6 +4427,15 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "zeroize"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 slug = "0.1"
 sysinfo = { version = "0.25", default-features = false }
+syntect = "5"
 tempfile = "3.3"
 thiserror = "1"
 tokio = { version="1", features = ["full"] }

--- a/implementations/rust/ockam/ockam_command/src/highlight.rs
+++ b/implementations/rust/ockam/ockam_command/src/highlight.rs
@@ -1,0 +1,56 @@
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{Style, ThemeSet},
+    parsing::SyntaxSet,
+    util::{as_24_bit_terminal_escaped, LinesWithEndings},
+};
+
+const HELP_TEMPLATE_TOP: &str = "\
+{before-help}
+{name} {version} {author-with-newline}
+{about-with-newline}
+{usage-heading}
+    {usage}
+
+{all-args}
+
+EXAMPLES
+";
+
+const HELP_TEMPLATE_BOTTOM: &str = "
+LEARN MORE
+    Use 'ockam <SUBCOMMAND> --help' for more information about a subcommand.
+    Learn more at https://docs.ockam.io/get-started#command
+
+FEEDBACK
+    If you have any questions or feedback, please start a discussion
+    on Github https://github.com/build-trust/ockam/discussions/new
+";
+
+pub(crate) fn shell_scripts(script: &str) -> &'static str {
+    let mut highlighted: Vec<String> = Vec::new();
+
+    for line in LinesWithEndings::from(HELP_TEMPLATE_TOP) {
+        highlighted.push(line.to_string());
+    }
+
+    let ps = SyntaxSet::load_defaults_newlines();
+    let ts = ThemeSet::load_defaults();
+
+    let syntax = ps.find_syntax_by_extension("sh").unwrap();
+    let mut h = HighlightLines::new(syntax, &ts.themes["base16-mocha.dark"]);
+
+    for line in LinesWithEndings::from(script) {
+        let ranges: Vec<(Style, &str)> = h.highlight_line(line, &ps).unwrap_or_default();
+        highlighted.push(as_24_bit_terminal_escaped(&ranges[..], false));
+    }
+
+    // Push a reset to clear the coloring.
+    highlighted.push("\x1b[0m".to_string());
+
+    for line in LinesWithEndings::from(HELP_TEMPLATE_BOTTOM) {
+        highlighted.push(line.to_string());
+    }
+
+    Box::leak(highlighted.join("").into_boxed_str())
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -6,6 +6,7 @@ mod configuration;
 mod credentials;
 mod enroll;
 mod forwarder;
+mod highlight;
 mod identity;
 mod message;
 mod node;
@@ -105,7 +106,7 @@ fn long_version() -> &'static str {
     propagate_version(true),
     color(ColorChoice::Never),
     term_width = 100,
-    help_template = const_str::replace!(HELP_TEMPLATE, "LEARN MORE", EXAMPLES),
+    help_template = highlight::shell_scripts(EXAMPLES),
 )]
 pub struct OckamCommand {
     #[clap(subcommand)]


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

Shell script examples in help messages are plain text and not styled at all.
Ref: #3311 

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Makes use of [the `syntect` crate](https://crates.io/crates/syntect) to run a syntax highlighting pass over [the example shell scripts for the `ockam` command](https://user-images.githubusercontent.com/460028/186890649-3b6f5603-d59e-4056-acf1-63ceba076f67.png).

Setting this PR as a draft for this first pass as it only affects the base command and not any sub-commands yet, to see whether or not the implementation is a good fit for this project.

### Details

I split `const HELP_TEMPLATE: &str` in half to make things a bit simpler in the newly-added `highlight` module and its `shell_scripts` function. Let me know if this looks OK and I can apply the same pattern across the other sub-commands.

### Colour samples

These are the different themes available in the crate.
Each has the `bg: bool` flag toggled on and off for background highlighting.
Click for bigger images.

InspiredGitHub: <img width="100" alt="sample of InspiredGitHub style" src="https://user-images.githubusercontent.com/460028/187027562-d78c5a59-1b12-4055-86b5-bc3ebca96e63.png">

Solarized (dark): <img width="100" alt="sample of Solarized (dark) style" src="https://user-images.githubusercontent.com/460028/187027578-6e8dd912-2ba5-43cb-833c-0bc467589082.png">

Solarized (light): <img width="100" alt="sample of Solarized (light) style" src="https://user-images.githubusercontent.com/460028/187027590-fc76a9b5-30e9-48c2-b3e6-ceb5b8c8e96a.png">

base16-eighties.dark: <img width="100" alt="sample of base16-eighties.dark style" src="https://user-images.githubusercontent.com/460028/187027605-07975d0f-9886-437d-82fb-3b2220880bfb.png">

base16-mocha.dark: <img width="100" alt="sample of base16-mocha.dark style" src="https://user-images.githubusercontent.com/460028/187027623-53eb7a44-2462-430c-9958-0c09669927d1.png">

base16-ocean.dark: <img width="100" alt="sample of base16-ocean.dark style" src="https://user-images.githubusercontent.com/460028/187027636-81013ba9-7cc1-4a1e-af92-e697327b2669.png">

base16-ocean.light: <img width="100" alt="sample of base16-ocean.light style" src="https://user-images.githubusercontent.com/460028/187027642-148ed140-5808-400c-a96e-b39c5e359616.png">

Let me know which theme suits best.
For my 2p it's `base16-mocha.dark` with `bg` false.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
