### PR TITLE
refactor(rust): removed node name default value

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -6,7 +6,6 @@ use tracing::{debug, trace};
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Name of the node.
-    #[clap(default_value = "default")]
     node_name: String,
 
     /// Terminate all nodes


### PR DESCRIPTION
## fix

Removed default value for `node_name` in delete command

## output 

![image](https://user-images.githubusercontent.com/38526063/187029514-0eb4c87d-0884-4448-b42f-18342d1e5444.png)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
