### PR TITLE
feat(rust): use names instead of ids on spaces and projects commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -51,6 +51,30 @@ impl ConfigLookup {
             })
     }
 
+    pub fn set_space(&mut self, id: &str, name: &str) {
+        self.map.insert(
+            format!("/space/{}", name),
+            LookupValue::Space(SpaceLookup { id: id.to_string() }),
+        );
+    }
+
+    pub fn get_space(&self, name: &str) -> Option<&SpaceLookup> {
+        self.map
+            .get(&format!("/space/{}", name))
+            .and_then(|value| match value {
+                LookupValue::Space(space) => Some(space),
+                _ => None,
+            })
+    }
+
+    pub fn remove_space(&mut self, name: &str) -> Option<LookupValue> {
+        self.map.remove(&format!("/space/{}", name))
+    }
+
+    pub fn remove_spaces(&mut self) {
+        self.map.retain(|k, _| !k.starts_with("/space/"));
+    }
+
     /// Store a project route and identifier as lookup
     pub fn set_project(
         &mut self,
@@ -77,11 +101,20 @@ impl ConfigLookup {
                 _ => None,
             })
     }
+
+    pub fn remove_project(&mut self, name: &str) -> Option<LookupValue> {
+        self.map.remove(&format!("/project/{}", name))
+    }
+
+    pub fn remove_projects(&mut self) {
+        self.map.retain(|k, _| !k.starts_with("/project/"));
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LookupValue {
     Address(InternetAddress),
+    Space(SpaceLookup),
     Project(ProjectLookup),
 }
 
@@ -159,6 +192,13 @@ impl From<SocketAddr> for InternetAddress {
             SocketAddr::V6(v6) => Self::V6(v6),
         }
     }
+}
+
+/// Represents a remote Ockam space lookup
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SpaceLookup {
+    /// Identifier of this space
+    pub id: String,
 }
 
 /// Represents a remote Ockam project lookup

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -49,7 +49,7 @@ impl AuthenticatedCommand {
     }
 }
 
-async fn run_impl(ctx: Context, cmd: AuthenticatedSubcommand) -> anyhow::Result<()> {
+async fn run_impl(ctx: Context, cmd: AuthenticatedSubcommand) -> crate::Result<()> {
     TcpTransport::create(&ctx).await?;
     match &cmd {
         AuthenticatedSubcommand::Get { addr, id, key } => {

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -62,7 +62,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
         let api_node = get_final_element(&cmd.to);
         let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
         let (at, meta) = clean_multiaddr(&cmd.at, &opts.config.get_lookup()).unwrap();
-        let projects_sc = crate::project::util::lookup_projects(
+        let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
             ctx,
             opts,
             &tcp,
@@ -75,7 +75,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
         let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(&tcp).build()?;
         let cmd = CreateCommand { at, ..cmd };
         rpc.request(req(&cmd, at_rust_node)?).await?;
-        rpc.print_response::<ForwarderInfo>()?;
+        rpc.parse_and_print_response::<ForwarderInfo>()?;
         Ok(())
     }
     go(&mut ctx, &opts, cmd).await

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -161,7 +161,7 @@ impl CreateCommand {
     pub async fn create_background_node(
         ctx: Context,
         (opts, cmd, addr): (CommandGlobalOpts, CreateCommand, SocketAddr),
-    ) -> Result<()> {
+    ) -> crate::Result<()> {
         let verbose = opts.global_args.verbose;
         let cfg = &opts.config;
 

--- a/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
@@ -54,6 +54,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::add_enroller(&cmd)).await?;
-    rpc.print_response::<Enroller>()?;
+    rpc.parse_and_print_response::<Enroller>()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/add_member.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_member.rs
@@ -38,7 +38,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, AddMemberCommand
     async fn go(ctx: &mut Context, opts: &CommandGlobalOpts, cmd: AddMemberCommand) -> Result<()> {
         let tcp = TcpTransport::create(ctx).await?;
         let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
-        let projects_sc = crate::project::util::lookup_projects(
+        let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
             ctx,
             opts,
             &tcp,

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,20 +1,20 @@
+use anyhow::Context as _;
 use clap::Args;
 use ockam::{Context, TcpTransport};
 
 use ockam_api::cloud::project::Project;
 
 use crate::node::NodeOpts;
-use crate::project::util::check_project_readiness;
+use crate::project::util::{check_project_readiness, config};
 use crate::util::api::CloudOpts;
-use crate::util::output::Output;
 use crate::util::{api, node_rpc, RpcBuilder};
-use crate::CommandGlobalOpts;
+use crate::{space, CommandGlobalOpts};
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Id of the space the project belongs to.
+    /// Name of the space the project belongs to.
     #[clap(display_order = 1001)]
-    pub space_id: String,
+    pub space_name: String,
 
     /// Name of the project.
     #[clap(display_order = 1002)]
@@ -50,14 +50,22 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
 ) -> crate::Result<()> {
+    let space_id = space::config::get_space(&opts.config, &cmd.space_name)
+        .context(format!("Space '{}' does not exist", cmd.space_name))?;
     let tcp = TcpTransport::create(ctx).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
         .tcp(&tcp)
         .build()?;
-    rpc.request(api::project::create(&cmd)).await?;
+    rpc.request(api::project::create(
+        &cmd.project_name,
+        &space_id,
+        cmd.cloud_opts.route(),
+    ))
+    .await?;
     let project = rpc.parse_response::<Project>()?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.node_opts, &cmd.cloud_opts, &tcp, project).await?;
-    println!("{}", project.output()?);
+    config::set_project(&opts.config, &project)?;
+    rpc.print_response(project)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,17 +1,13 @@
-use anyhow::{anyhow, Context};
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
+use ockam::Context;
 
 use ockam_api::cloud::project::Project;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
+use crate::project::util::config;
 use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::util::{api, node_rpc, Rpc};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
@@ -24,60 +20,23 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ListCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), list);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn list(
-    ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+    run_impl(&mut ctx, opts, cmd).await
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::list(&cmd).to_vec()?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
-
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let body = dec.decode::<Vec<Project>>()?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => format!("{body:#?}"),
-                OutputFormat::Json => serde_json::to_string(&body)?,
-            };
-            Ok(output)
-        }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListCommand,
+) -> crate::Result<()> {
+    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    rpc.request(api::project::list(cmd.cloud_opts.route()))
+        .await?;
+    let projects = rpc.parse_and_print_response::<Vec<Project>>()?;
+    config::set_projects(&opts.config, &projects)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
@@ -46,6 +46,6 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::project::list_enrollers(&cmd)).await?;
-    rpc.print_response::<Vec<Enroller>>()?;
+    rpc.parse_and_print_response::<Vec<Enroller>>()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -8,6 +8,8 @@ mod list_enrollers;
 mod show;
 pub mod util;
 
+pub use util::config;
+
 use clap::{Args, Subcommand};
 
 pub use crate::credentials::get_credential::GetCredentialCommand;

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -1,33 +1,21 @@
-use anyhow::{anyhow, Context};
+use anyhow::Context as _;
 use clap::Args;
-use minicbor::Decoder;
-use tracing::debug;
 
+use ockam::{Context, TcpTransport};
 use ockam_api::cloud::project::Project;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-use ockam_core::Route;
 
 use crate::node::NodeOpts;
-use crate::util::api::CloudOpts;
-use crate::util::{api, connect_to, exitcode};
-use crate::{CommandGlobalOpts, OutputFormat};
+use crate::project::util::config;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, RpcBuilder};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
-    /// Id of the space.
-    /// TODO: this is not used at all?
+    /// Name of the project.
     #[clap(display_order = 1001)]
-    pub space_id: String,
+    pub name: String,
 
-    /// Id of the project.
-    #[clap(display_order = 1002)]
-    pub project_id: String,
-    // TODO: add project_name arg that conflicts with project_id
-    //  so we can call the get_project_by_name api method
-    // /// Name of the project.
-    // #[clap(display_order = 1002)]
-    // pub project_name: String,
     #[clap(flatten)]
     pub node_opts: NodeOpts,
 
@@ -37,60 +25,46 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(opts: CommandGlobalOpts, cmd: ShowCommand) {
-        let cfg = &opts.config;
-        let port = match cfg.select_node(&cmd.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
-        connect_to(port, (opts, cmd), show);
+        node_rpc(rpc, (opts, cmd));
     }
 }
 
-async fn show(
-    ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, ShowCommand),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let route: Route = base_route.modify().append(NODEMANAGER_ADDR).into();
-    debug!(?cmd, %route, "Sending request");
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> crate::Result<()> {
+    run_impl(&mut ctx, opts, cmd).await
+}
 
-    let response: Vec<u8> = ctx
-        .send_and_receive(route, api::project::show(&cmd).to_vec()?)
-        .await
-        .context("Failed to process request")?;
-    let mut dec = Decoder::new(&response);
-    let header = dec.decode::<Response>()?;
-    debug!(?header, "Received response");
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ShowCommand,
+) -> crate::Result<()> {
+    let controller_route = cmd.cloud_opts.route();
+    let tcp = TcpTransport::create(ctx).await?;
 
-    let res = match header.status() {
-        Some(Status::Ok) => {
-            let body = dec.decode::<Project>()?;
-            let output = match opts.global_args.output_format {
-                OutputFormat::Plain => format!("{body:#?}"),
-                OutputFormat::Json => serde_json::to_string(&body)?,
-            };
-            Ok(output)
-        }
-        Some(Status::InternalServerError) => {
-            let err = dec
-                .decode::<String>()
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(anyhow!(
-                "An error occurred while processing the request: {err}"
-            ))
-        }
-        _ => Err(anyhow!("Unexpected response received from node")),
-    };
-    match res {
-        Ok(o) => println!("{o}"),
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(exitcode::IOERR);
+    // Lookup project
+    let id = match config::get_project(&opts.config, &cmd.name) {
+        Some(id) => id,
+        None => {
+            config::refresh_projects(
+                ctx,
+                &opts,
+                &tcp,
+                &cmd.node_opts.api_node,
+                cmd.cloud_opts.route(),
+            )
+            .await?;
+            config::get_project(&opts.config, &cmd.name)
+                .context(format!("Project '{}' does not exist", cmd.name))?
         }
     };
 
+    // Send request
+    let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+        .tcp(&tcp)
+        .build()?;
+    rpc.request(api::project::show(&id, controller_route))
+        .await?;
+    let project = rpc.parse_and_print_response::<Project>()?;
+    config::set_project(&opts.config, &project)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -63,9 +63,10 @@ impl CreateCommand {
             eprintln!("Could not convert {} into route", &self.to);
             std::process::exit(exitcode::USAGE);
         });
-        let projects_sc =
-            crate::project::util::lookup_projects(ctx, opts, tcp, &meta, cloud_addr, api_node)
-                .await?;
+        let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
+            ctx, opts, tcp, &meta, cloud_addr, api_node,
+        )
+        .await?;
         crate::project::util::clean_projects_multiaddr(to, projects_sc)
     }
 

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -5,6 +5,7 @@ use ockam::Context;
 use ockam_api::cloud::space::Space;
 
 use crate::node::NodeOpts;
+use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -46,6 +47,7 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::space::create(&cmd)).await?;
-    rpc.print_response::<Space>()?;
+    let space = rpc.parse_and_print_response::<Space>()?;
+    config::set_space(&opts.config, &space)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,17 +1,18 @@
 use clap::Args;
 
-use ockam::Context;
+use ockam::{Context, TcpTransport};
 
 use crate::node::NodeOpts;
+use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, Rpc};
+use crate::util::{node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    /// Id of the space.
+    /// Name of the space.
     #[clap(display_order = 1001)]
-    pub id: String,
+    pub name: String,
 
     #[clap(flatten)]
     pub node_opts: NodeOpts,
@@ -38,8 +39,41 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
-    rpc.request(api::space::delete(&cmd)).await?;
+    let tcp = TcpTransport::create(ctx).await?;
+    let controller_route = cmd.cloud_opts.route();
+
+    // Try to remove from config, in case the space was removed from the cloud but not from the config file.
+    let _ = config::remove_space(&opts.config, &cmd.name);
+
+    // Lookup space
+    let id = match config::get_space(&opts.config, &cmd.name) {
+        Some(id) => id,
+        None => {
+            // The space is not in the config file.
+            // Fetch all available spaces from the cloud.
+            config::refresh_spaces(ctx, &opts, &tcp, &cmd.node_opts.api_node, controller_route)
+                .await?;
+
+            // If the space is not found in the lookup, then it must not exist in the cloud, so we exit the command.
+            match config::get_space(&opts.config, &cmd.name) {
+                Some(id) => id,
+                None => {
+                    return Ok(());
+                }
+            }
+        }
+    };
+
+    // Send request
+    let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+        .tcp(&tcp)
+        .build()?;
+    rpc.request(api::space::delete(&id, controller_route))
+        .await?;
     rpc.is_ok()?;
+
+    // Try to remove from config again, in case it was re-added after the refresh.
+    let _ = config::remove_space(&opts.config, &cmd.name);
+
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -4,6 +4,7 @@ use ockam::Context;
 use ockam_api::cloud::space::Space;
 
 use crate::node::NodeOpts;
+use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -33,7 +34,9 @@ async fn run_impl(
     cmd: ListCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
-    rpc.request(api::space::list(&cmd)).await?;
-    rpc.print_response::<Vec<Space>>()?;
+    rpc.request(api::space::list(cmd.cloud_opts.route()))
+        .await?;
+    let spaces = rpc.parse_and_print_response::<Vec<Space>>()?;
+    config::set_spaces(&opts.config, &spaces)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -4,6 +4,7 @@ pub use create::CreateCommand;
 pub use delete::DeleteCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
+pub use util::config;
 
 use crate::{CommandGlobalOpts, HELP_TEMPLATE};
 
@@ -11,6 +12,7 @@ mod create;
 mod delete;
 mod list;
 mod show;
+pub mod util;
 
 #[derive(Clone, Debug, Args)]
 pub struct SpaceCommand {

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,18 +1,20 @@
+use anyhow::Context as _;
 use clap::Args;
 
-use ockam::Context;
+use ockam::{Context, TcpTransport};
 use ockam_api::cloud::space::Space;
 
 use crate::node::NodeOpts;
+use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, Rpc};
+use crate::util::{node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
-    /// Id of the space.
+    /// Name of the space.
     #[clap(display_order = 1001)]
-    pub id: String,
+    pub name: String,
 
     #[clap(flatten)]
     pub node_opts: NodeOpts,
@@ -36,8 +38,32 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ShowCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
-    rpc.request(api::space::show(&cmd)).await?;
-    rpc.print_response::<Space>()?;
+    let controller_route = cmd.cloud_opts.route();
+    let tcp = TcpTransport::create(ctx).await?;
+
+    // Lookup space
+    let id = match config::get_space(&opts.config, &cmd.name) {
+        Some(id) => id,
+        None => {
+            config::refresh_spaces(
+                ctx,
+                &opts,
+                &tcp,
+                &cmd.node_opts.api_node,
+                cmd.cloud_opts.route(),
+            )
+            .await?;
+            config::get_space(&opts.config, &cmd.name)
+                .context(format!("Space '{}' does not exist", cmd.name))?
+        }
+    };
+
+    // Send request
+    let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+        .tcp(&tcp)
+        .build()?;
+    rpc.request(api::space::show(&id, controller_route)).await?;
+    let space = rpc.parse_and_print_response::<Space>()?;
+    config::set_space(&opts.config, &space)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+
+use ockam::Context;
+use ockam_api::cloud::space::Space;
+
+pub mod config {
+    use crate::util::{api, RpcBuilder};
+    use crate::{CommandGlobalOpts, OckamConfig};
+    use ockam::TcpTransport;
+    use ockam_multiaddr::MultiAddr;
+
+    use super::*;
+
+    pub fn set_space(config: &OckamConfig, space: &Space) -> Result<()> {
+        config.set_space_alias(&space.id, &space.name);
+        config.atomic_update().run()?;
+        Ok(())
+    }
+
+    pub fn set_spaces(config: &OckamConfig, spaces: &[Space]) -> Result<()> {
+        config.remove_spaces_alias();
+        for space in spaces.iter() {
+            config.set_space_alias(&space.id, &space.name);
+        }
+        config.atomic_update().run()?;
+        Ok(())
+    }
+
+    pub fn remove_space(config: &OckamConfig, name: &str) -> Result<()> {
+        config.remove_space_alias(name)?;
+        config.atomic_update().run()?;
+        Ok(())
+    }
+
+    pub fn get_space(config: &OckamConfig, name: &str) -> Option<String> {
+        let inner = config.writelock_inner();
+        inner.lookup.get_space(name).map(|s| s.id.clone())
+    }
+
+    pub async fn refresh_spaces(
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
+        tcp: &TcpTransport,
+        api_node: &str,
+        controller_route: &MultiAddr,
+    ) -> Result<()> {
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+        rpc.request(api::space::list(controller_route)).await?;
+        let spaces = rpc.parse_response::<Vec<Space>>()?;
+        set_spaces(&opts.config, &spaces)?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -272,18 +272,22 @@ pub(crate) mod space {
         Request::post("v0/spaces").body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
     }
 
-    pub(crate) fn list(cmd: &ListCommand) -> RequestBuilder<BareCloudRequestWrapper> {
-        Request::get("v0/spaces").body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
+        Request::get("v0/spaces").body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn show(cmd: &ShowCommand) -> RequestBuilder<BareCloudRequestWrapper> {
-        Request::get(format!("v0/spaces/{}", cmd.id))
-            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    pub(crate) fn show<'a>(
+        id: &str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        Request::get(format!("v0/spaces/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn delete(cmd: &DeleteCommand) -> RequestBuilder<BareCloudRequestWrapper> {
-        Request::delete(format!("v0/spaces/{}", cmd.id))
-            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    pub(crate) fn delete<'a>(
+        id: &str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        Request::delete(format!("v0/spaces/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
     }
 }
 
@@ -294,29 +298,34 @@ pub(crate) mod project {
 
     use super::*;
 
-    pub(crate) fn create(
-        cmd: &CreateCommand,
-    ) -> RequestBuilder<CloudRequestWrapper<CreateProject>> {
-        let b = CreateProject::new(cmd.project_name.as_str(), &[], &cmd.services);
-        Request::post(format!("v0/projects/{}", cmd.space_id))
-            .body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
+    pub(crate) fn create<'a>(
+        project_name: &'a str,
+        space_id: &'a str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
+        let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
+        Request::post(format!("v0/projects/{}", space_id))
+            .body(CloudRequestWrapper::new(b, cloud_route))
     }
 
-    pub(crate) fn list(cmd: &ListCommand) -> RequestBuilder<BareCloudRequestWrapper> {
-        Request::get("v0/projects").body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
+        Request::get("v0/projects").body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn show(cmd: &ShowCommand) -> RequestBuilder<BareCloudRequestWrapper> {
-        Request::get(format!("v0/projects/{}", cmd.project_id))
-            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+    pub(crate) fn show<'a>(
+        id: &str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        Request::get(format!("v0/projects/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn delete(cmd: DeleteCommand) -> anyhow::Result<Vec<u8>> {
-        let mut buf = vec![];
-        Request::delete(format!("v0/projects/{}/{}", cmd.space_id, cmd.project_id))
-            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
-            .encode(&mut buf)?;
-        Ok(buf)
+    pub(crate) fn delete<'a>(
+        space_id: &'a str,
+        project_id: &'a str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        Request::delete(format!("v0/projects/{}/{}", space_id, project_id))
+            .body(CloudRequestWrapper::bare(cloud_route))
     }
 
     pub(crate) fn add_enroller(

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -102,6 +102,38 @@ impl Output for Project<'_> {
     }
 }
 
+impl Output for Vec<Project<'_>> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut rows = vec![];
+        for Project {
+            id,
+            name,
+            users,
+            space_name,
+            ..
+        } in self
+        {
+            rows.push([
+                id.cell(),
+                name.cell(),
+                comma_separated(users).cell(),
+                space_name.cell(),
+            ]);
+        }
+        let table = rows
+            .table()
+            .title([
+                "Id".cell().bold(true),
+                "Name".cell().bold(true),
+                "Users".cell().bold(true),
+                "Space".cell().bold(true),
+            ])
+            .display()?
+            .to_string();
+        Ok(table)
+    }
+}
+
 impl Output for CreateSecureChannelResponse<'_> {
     fn output(&self) -> anyhow::Result<String> {
         let addr = route_to_multiaddr(&route![self.addr.to_string()])

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -9,7 +9,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
-        .arg("space-id")
+        .arg("space-name")
         .arg("project-name")
         .args(common_args)
         .arg("--")
@@ -24,7 +24,6 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("show")
-        .arg("space-id")
         .arg("project-id")
         .args(common_args);
     cmd.assert().success();
@@ -32,7 +31,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("delete")
-        .arg("space-id")
+        .arg("space-name")
         .arg("project-id")
         .args(common_args);
     cmd.assert().success();


### PR DESCRIPTION
Adds functionality to use names instead of ids on spaces and projects commands.

* Extends the `lookup` section of the config file to add spaces information (for now, a space -> id relationship)
* Updates (sets/removes) the lookup data when running the `space|project create|delete|show|list` commands
* When the given space|project name is not found, we fetch all available spaces|projects and update the config file
* On project commands, if the given space is not found in the config, exits with an error (**should we force a "fetch all" here as well?**, note that spaces lookup data will be refreshed everytime the user runs a space command)