### PR TITLE
fix(rust): check if project node can establish a secure channel before marking it as ready

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -87,10 +87,7 @@ impl Project<'_> {
     }
 
     pub fn is_ready(&self) -> bool {
-        !(self.access_route.is_empty()
-            || self.authority_access_route.is_none()
-            || self.identity.is_none()
-            || self.authority_identity.is_none())
+        !(self.access_route.is_empty() || self.identity.is_none())
     }
 
     pub async fn is_reachable(&self) -> Result<bool> {


### PR DESCRIPTION
* `is_ready` stops checking authority fields, since it seems that we now always receive `None` on the `authority access route`
* when creating a project on the `enroll` command, it now waits until a secure channel can be established. In my tests, I've found that after a project is TCP-ready, sometimes it establishes the secure channel right away, and sometimes it takes 4-8 seconds until it can do it (I could only reproduce this case one time out of 10-15 runs)