### PR TITLE
fix(rust): authority config keys must be strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,6 +1586,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -12,6 +12,7 @@ publish = true
 [features]
 std = [
     "either/use_std",
+    "hex/std",
     "minicbor/std",
     "ockam_core/std",
     "ockam_identity/std",
@@ -33,6 +34,7 @@ ockam           = { path = "../ockam", version = "^0.71.0", features = ["softwar
 either          = { version = "1.7.0", default-features = false }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.5.0", features = ["serde"] }
 cddl-cat        = { version = "0.6.1", optional = true }
+hex             = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 minicbor        = { version = "0.18.0", features = ["alloc", "derive"] }
 rust-embed      = "6"
 serde           = { version = "1.0.137", features = ["derive"] }

--- a/implementations/rust/ockam/ockam_api/src/config/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/mod.rs
@@ -17,7 +17,7 @@ pub trait ConfigValues: Serialize + DeserializeOwned {
     fn default_values(config_dir: &Path) -> Self;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config<V: ConfigValues> {
     config_dir: PathBuf,
     config_name: String,

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -19,6 +19,61 @@ pub mod lmdb;
 #[macro_use]
 extern crate tracing;
 
+use core::fmt;
+use minicbor::{Decode, Encode};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 #[derive(rust_embed::RustEmbed)]
 #[folder = "./static"]
 pub(crate) struct StaticFiles;
+
+/// Newtype around [`Vec<u8>`] that provides base-16 string encoding using serde.
+#[derive(Debug, Clone, Default, Encode, Decode)]
+#[cbor(transparent)]
+pub struct HexByteVec(#[b(0)] pub Vec<u8>);
+
+impl HexByteVec {
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for HexByteVec {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl From<HexByteVec> for Vec<u8> {
+    fn from(h: HexByteVec) -> Self {
+        h.0
+    }
+}
+
+impl Serialize for HexByteVec {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        if s.is_human_readable() {
+            hex::serde::serialize(&*self.0, s)
+        } else {
+            s.serialize_bytes(&*self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for HexByteVec {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        if d.is_human_readable() {
+            let v: Vec<u8> = hex::serde::deserialize(d)?;
+            Ok(Self(v))
+        } else {
+            let v = <Vec<u8>>::deserialize(d)?;
+            Ok(Self(v))
+        }
+    }
+}
+
+impl fmt::Display for HexByteVec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.serialize(f)
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -193,7 +193,7 @@ impl NodeManager {
         Ok(s)
     }
 
-    pub async fn configure_authorities(&mut self, ac: AuthoritiesConfig) -> Result<()> {
+    pub async fn configure_authorities(&mut self, ac: &AuthoritiesConfig) -> Result<()> {
         if let Some(v) = self.vault.as_ref() {
             self.authorities = Some(ac.to_public_identities(v).await?)
         } else {

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use slug::slugify;
 use tracing::{error, trace};
 
+use ockam::identity::IdentityIdentifier;
 pub use ockam_api::config::cli::NodeConfig;
 pub use ockam_api::config::snippet::{
     ComposableSnippet, Operation, PortalMode, Protocol, RemoteMode,
@@ -397,6 +398,7 @@ impl StartupConfig {
     }
 }
 
+#[derive(Debug)]
 pub struct AuthoritiesConfig {
     inner: Config<cli::AuthoritiesConfig>,
 }
@@ -407,9 +409,9 @@ impl AuthoritiesConfig {
         Self { inner }
     }
 
-    pub fn add_authority(&self, authority: Vec<u8>, addr: MultiAddr) -> Result<()> {
+    pub fn add_authority(&self, i: IdentityIdentifier, a: cli::Authority) -> Result<()> {
         let mut cfg = self.inner.writelock_inner();
-        cfg.add_authority(authority, addr);
+        cfg.add_authority(i, a);
         drop(cfg);
         self.inner.atomic_update().run()
     }


### PR DESCRIPTION
Change the authorities JSON format from `{ Vec<u8> -> MultiAddr }` to `{ IdentityIdentifier -> { identity : String, MultiAddr } }` with `identity` as the hex-encoded bytes.