### PR TITLE
feat(elixir): improvements in authorization configs

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx.ex
@@ -18,6 +18,14 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX do
     end
   end
 
+  def handle_internal(event, {:key_establishment, role, _role_state} = state, data)
+      when role in [:initiator, :responder] do
+    case role do
+      :initiator -> Initiator.handle_internal(event, state, data)
+      :responder -> Responder.handle_internal(event, state, data)
+    end
+  end
+
   ## TODO: batter name to not collide with Ockam.Worker.handle_message
   def handle_message(message, {:key_establishment, role, _role_state} = state, data)
       when role in [:initiator, :responder] do

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/initiator.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/initiator.ex
@@ -8,10 +8,10 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Initiator do
   @role :initiator
 
   def setup(_options, data) do
-    {:ok, {:key_establishment, @role, :ready}, data, [{:next_event, :info, :enter}]}
+    {:ok, {:key_establishment, @role, :ready}, data, [{:next_event, :internal, :enter}]}
   end
 
-  def handle_message(:enter, {:key_establishment, @role, :ready}, data) do
+  def handle_internal(:enter, {:key_establishment, @role, :ready}, data) do
     message1_onward_route = data.peer.route
     message1_return_route = [data.ciphertext_address]
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/responder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/responder.ex
@@ -10,11 +10,19 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Responder do
   def setup(_options, data) do
     actions =
       case Map.get(data, :initiating_message) do
-        nil -> []
-        message -> [{:next_event, :info, message}]
+        nil ->
+          []
+
+        message ->
+          ciphertext_address = Map.fetch!(data, :ciphertext_address)
+          [{:next_event, :info, Message.set_onward_route(message, [ciphertext_address])}]
       end
 
     {:ok, {:key_establishment, @role, :awaiting_message1}, data, actions}
+  end
+
+  def handle_internal(event, _state, _data) do
+    {:error, {:event_not_supported, event}}
   end
 
   def handle_message(message, {:key_establishment, @role, :awaiting_message1}, data) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/listener.ex
@@ -27,11 +27,13 @@ if Code.ensure_loaded?(:ranch) do
       ip = Keyword.get_lazy(options, :ip, &default_ip/0)
       port = Keyword.get_lazy(options, :port, &default_port/0)
 
+      handler_options = Keyword.get(options, :handler_options, [])
+
       ref = make_ref()
       transport = :ranch_tcp
       transport_options = [port: port, ip: ip]
       protocol = Ockam.Transport.TCP.Handler
-      protocol_options = [packet: 2, nodelay: true]
+      protocol_options = [packet: 2, nodelay: true, handler_options: handler_options]
 
       with {:ok, _apps} <- Application.ensure_all_started(:ranch),
            {:ok, ranch_listener} <-

--- a/implementations/elixir/ockam/ockam_services/lib/services.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services.ex
@@ -38,7 +38,7 @@ defmodule Ockam.Services do
           Ockam.Services.Provider
         ]
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+    Supervisor.start_link(children, strategy: :one_for_all, intensity: 0, name: __MODULE__)
   end
 
   def start_service(name, options \\ []) do

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider.ex
@@ -23,7 +23,8 @@ defmodule Ockam.Services.Provider do
   def child_spec(args) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, args}
+      start: {__MODULE__, :start_link, args},
+      type: :supervisor
     }
   end
 


### PR DESCRIPTION
Make to_my_address rule implicit unless worker re-define is_authorized/2
Implement authorization check for TCP handlers
Pass TCP handler options via listen options of transport
Example:
```
config :ockam_services,
  tcp_transport: [listen: [port: tcp_port, handler_options: [authorization: [:is_local]]]]
```

Implement authorization for encryption secure channels
Make internal encryption channel accept messages only from patent identity channels

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
