### PR TITLE
fix(rust): `node create` command waits until node is up before returning response

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -17,7 +17,7 @@ use crate::service::start::{self, StartCommand, StartSubCommand};
 use crate::util::{bind_to_port_check, exitcode};
 use crate::{
     help,
-    node::show::query_status,
+    node::show::print_query_status,
     node::HELP_DETAIL,
     util::{
         connect_to, embedded_node, find_available_port, startup, ComposableSnippet, OckamConfig,
@@ -144,7 +144,11 @@ impl CreateCommand {
                 (options.clone(), cmd.clone(), addr),
             )
             .unwrap();
-            connect_to(addr.port(), (cfg.clone(), cmd.node_name), query_status);
+            connect_to(
+                addr.port(),
+                (cfg.clone(), cmd.node_name),
+                print_query_status,
+            );
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,5 +1,5 @@
 use crate::util::{connect_to, exitcode, verify_pids};
-use crate::{help, node::show::query_status, node::HELP_DETAIL, CommandGlobalOpts};
+use crate::{help, node::show::print_query_status, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
 /// List Nodes
@@ -36,7 +36,7 @@ impl ListCommand {
                 connect_to(
                     node_cfg.port,
                     (cfg.clone(), node_name.clone()),
-                    query_status,
+                    print_query_status,
                 )
             });
     }


### PR DESCRIPTION
I've tested this by artificially delaying the foreground node creation by 5 seconds.