### PR TITLE
feat(rust): add project info command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -10,6 +10,7 @@ use std::{
     str::FromStr,
 };
 
+use crate::project::ProjectInfo;
 use crate::secure_channel::listener::create as secure_channel_listener;
 use crate::service::config::Config;
 use crate::service::start::{self, StartCommand, StartSubCommand};
@@ -31,7 +32,6 @@ use ockam_api::config::cli;
 use ockam_api::error::ApiError;
 use ockam_api::nodes::IdentityOverride;
 use ockam_api::{
-    cloud::project::Project,
     nodes::models::transport::{TransportMode, TransportType},
     nodes::{NodeManager, NODEMANAGER_ADDR},
 };
@@ -360,7 +360,7 @@ where
     P: AsRef<Path>,
 {
     let s = fs::read_to_string(path.as_ref()).await?;
-    let p: Project = serde_json::from_str(&s)?;
+    let p: ProjectInfo = serde_json::from_str(&s)?;
     let m = p
         .authority_access_route
         .map(|a| MultiAddr::try_from(&*a))

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -1,0 +1,96 @@
+use anyhow::Context as _;
+use clap::Args;
+
+use ockam::identity::IdentityIdentifier;
+use ockam::{Context, TcpTransport};
+use ockam_api::cloud::project::Project;
+use ockam_core::CowStr;
+
+use crate::node::NodeOpts;
+use crate::project::util::config;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, RpcBuilder};
+use crate::CommandGlobalOpts;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Args)]
+pub struct InfoCommand {
+    /// Name of the project.
+    #[clap(long)]
+    pub name: String,
+
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ProjectInfo<'a> {
+    #[serde(borrow)]
+    pub id: CowStr<'a>,
+    pub identity: Option<IdentityIdentifier>,
+    #[serde(borrow)]
+    pub authority_access_route: Option<CowStr<'a>>,
+    #[serde(borrow)]
+    pub authority_identity: Option<CowStr<'a>>,
+}
+
+impl<'a> From<Project<'a>> for ProjectInfo<'a> {
+    fn from(p: Project<'a>) -> Self {
+        Self {
+            id: p.id,
+            identity: p.identity,
+            authority_access_route: p.authority_access_route,
+            authority_identity: p.authority_identity,
+        }
+    }
+}
+
+impl InfoCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, (options, self));
+    }
+}
+
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, InfoCommand)) -> crate::Result<()> {
+    run_impl(&mut ctx, opts, cmd).await
+}
+
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: InfoCommand,
+) -> crate::Result<()> {
+    let controller_route = cmd.cloud_opts.route();
+    let tcp = TcpTransport::create(ctx).await?;
+
+    // Lookup project
+    let id = match config::get_project(&opts.config, &cmd.name) {
+        Some(id) => id,
+        None => {
+            config::refresh_projects(
+                ctx,
+                &opts,
+                &tcp,
+                &cmd.node_opts.api_node,
+                cmd.cloud_opts.route(),
+            )
+            .await?;
+            config::get_project(&opts.config, &cmd.name)
+                .context(format!("Project '{}' does not exist", cmd.name))?
+        }
+    };
+
+    // Send request
+    let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
+        .tcp(&tcp)
+        .build()?;
+    rpc.request(api::project::show(&id, controller_route))
+        .await?;
+    let info: ProjectInfo = rpc.parse_response::<Project>()?.into();
+    rpc.print_response(&info)?;
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -3,11 +3,13 @@ mod create;
 mod delete;
 mod delete_enroller;
 mod enroll;
+mod info;
 mod list;
 mod list_enrollers;
 mod show;
 pub mod util;
 
+pub use info::ProjectInfo;
 pub use util::config;
 
 use clap::{Args, Subcommand};
@@ -18,6 +20,7 @@ pub use create::CreateCommand;
 pub use delete::DeleteCommand;
 pub use delete_enroller::DeleteEnrollerCommand;
 pub use enroll::EnrollCommand;
+pub use info::InfoCommand;
 pub use list::ListCommand;
 pub use list_enrollers::ListEnrollersCommand;
 pub use show::ShowCommand;
@@ -38,6 +41,7 @@ pub enum ProjectSubcommand {
     Delete(DeleteCommand),
     List(ListCommand),
     Show(ShowCommand),
+    Info(InfoCommand),
     AddEnroller(AddEnrollerCommand),
     ListEnrollers(ListEnrollersCommand),
     DeleteEnroller(DeleteEnrollerCommand),
@@ -55,6 +59,7 @@ impl ProjectCommand {
             ProjectSubcommand::ListEnrollers(c) => c.run(options),
             ProjectSubcommand::DeleteEnroller(c) => c.run(options),
             ProjectSubcommand::Enroll(c) => c.run(options),
+            ProjectSubcommand::Info(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
Previously the output of project show was given to new members that enroll, however it contained private information (e.g. the users list) which are of no concern to an individual new member. This PR adds a project info structure that contains only the relevant information for the enrolling member.