### PR TITLE
feat(rust): refactor rpc struct so it allows working with embedded nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -61,7 +61,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
         )
         .await?;
         let at = crate::project::util::clean_projects_multiaddr(at, projects_sc)?;
-        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(&tcp).build()?;
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(&tcp)?.build();
         let cmd = CreateCommand { at, ..cmd };
         rpc.request(req(&cmd, at_rust_node)?).await?;
         rpc.parse_and_print_response::<ForwarderInfo>()?;

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -92,7 +92,7 @@ async fn send_message_via_connection_to_a_node(
         .await?;
         let to = crate::project::util::clean_projects_multiaddr(to, projects_sc)?;
 
-        let mut rpc = RpcBuilder::new(ctx, opts, &api_node).tcp(&tcp).build()?;
+        let mut rpc = RpcBuilder::new(ctx, opts, &api_node).tcp(&tcp)?.build();
         rpc.request(req(&to, &cmd.message)).await?;
         let res = rpc.parse_response::<Vec<u8>>()?;
         println!(

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -99,6 +99,21 @@ impl From<&'_ CreateCommand> for ComposableSnippet {
     }
 }
 
+impl Default for CreateCommand {
+    fn default() -> Self {
+        Self {
+            node_name: hex::encode(&random::<[u8; 4]>()),
+            foreground: false,
+            tcp_listener_address: "127.0.0.1:0".to_string(),
+            skip_defaults: false,
+            child_process: false,
+            launch_config: None,
+            no_watchdog: false,
+            project: None,
+        }
+    }
+}
+
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let verbose = options.global_args.verbose;
@@ -193,7 +208,7 @@ impl CreateCommand {
             std::process::exit(exitcode::IOERR);
         }
 
-        create_default_identity_if_needed(&ctx, cfg.clone()).await?;
+        create_default_identity_if_needed(&ctx, cfg).await?;
 
         // Construct the arguments list and re-execute the ockam
         // CLI in foreground mode to start the newly created node
@@ -239,7 +254,7 @@ impl CreateCommand {
     }
 }
 
-async fn create_default_identity_if_needed(ctx: &Context, cfg: OckamConfig) -> Result<()> {
+async fn create_default_identity_if_needed(ctx: &Context, cfg: &OckamConfig) -> Result<()> {
     // Get default root vault (create if needed)
     let default_vault_path = cfg.get_default_vault_path().unwrap_or_else(|| {
         let default_vault_path = cli::OckamConfig::directories()
@@ -314,7 +329,7 @@ async fn run_background_node_impl(
 ) -> Result<()> {
     // This node was initially created as a foreground node
     if !c.child_process {
-        create_default_identity_if_needed(ctx, cfg.clone()).await?;
+        create_default_identity_if_needed(ctx, &cfg).await?;
     }
 
     let identity_override = if c.skip_defaults {
@@ -359,6 +374,52 @@ async fn run_background_node_impl(
     Ok(())
 }
 
+pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<String> {
+    let cmd = CreateCommand::default();
+
+    // Create node directory if it doesn't exist
+    fs::create_dir_all(&cfg.get_node_dir_raw(&cmd.node_name)?).await?;
+
+    // This node was initially created as a foreground node
+    if !cmd.child_process {
+        create_default_identity_if_needed(ctx, cfg).await?;
+    }
+
+    let identity_override = if cmd.skip_defaults {
+        None
+    } else {
+        Some(get_identity_override(ctx, cfg).await?)
+    };
+
+    if let Some(path) = &cmd.project {
+        add_project_authority(path, &cmd.node_name, cfg).await?
+    }
+
+    let tcp = TcpTransport::create(ctx).await?;
+    let bind = cmd.tcp_listener_address;
+    tcp.listen(&bind).await?;
+
+    let node_dir = cfg.get_node_dir_raw(&cmd.node_name)?;
+    let mut node_man = NodeManager::create(
+        ctx,
+        cmd.node_name.clone(),
+        node_dir,
+        identity_override,
+        cmd.skip_defaults || cmd.launch_config.is_some(),
+        (TransportType::Tcp, TransportMode::Listen, bind),
+        tcp,
+    )
+    .await?;
+
+    node_man
+        .configure_authorities(&cfg.authorities(&cmd.node_name)?.snapshot())
+        .await?;
+
+    ctx.start_worker(NODEMANAGER_ADDR, node_man).await?;
+
+    Ok(cmd.node_name.clone())
+}
+
 async fn add_project_authority<P>(path: P, node: &str, cfg: &OckamConfig) -> Result<()>
 where
     P: AsRef<Path>,
@@ -385,7 +446,7 @@ where
 }
 
 async fn start_services(
-    ctx: &mut Context,
+    ctx: &Context,
     tcp: &TcpTransport,
     cfg: &Path,
     addr: SocketAddr,

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -1,4 +1,4 @@
-mod create;
+pub mod create;
 mod delete;
 mod list;
 mod show;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -55,8 +55,8 @@ async fn run_impl(
         .context(format!("Space '{}' does not exist", cmd.space_name))?;
     let tcp = TcpTransport::create(ctx).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
-        .tcp(&tcp)
-        .build()?;
+        .tcp(&tcp)?
+        .build();
     rpc.request(api::project::create(
         &cmd.project_name,
         &space_id,

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -75,8 +75,8 @@ async fn run_impl(
 
     // Send request
     let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
-        .tcp(&tcp)
-        .build()?;
+        .tcp(&tcp)?
+        .build();
     rpc.request(api::project::delete(
         &space_id,
         &project_id,

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -53,9 +53,9 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, EnrollCommand)) 
 
         let req = Request::post("/members").body(AddMember::new(cmd.member));
         let mut rpc = RpcBuilder::new(ctx, opts, &cmd.node_opts.api_node)
-            .tcp(&tcp)
+            .tcp(&tcp)?
             .to(&to)?
-            .build()?;
+            .build();
         rpc.request(req).await?;
         rpc.is_ok()?;
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -86,8 +86,8 @@ async fn run_impl(
 
     // Send request
     let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
-        .tcp(&tcp)
-        .build()?;
+        .tcp(&tcp)?
+        .build();
     rpc.request(api::project::show(&id, controller_route))
         .await?;
     let info: ProjectInfo = rpc.parse_response::<Project>()?.into();

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -3,10 +3,11 @@ use ockam::Context;
 
 use ockam_api::cloud::project::Project;
 
+use crate::node::create::start_embedded_node;
 use crate::node::NodeOpts;
 use crate::project::util::config;
 use crate::util::api::CloudOpts;
-use crate::util::{api, node_rpc, Rpc};
+use crate::util::{api, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 /// List projects
@@ -34,7 +35,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = start_embedded_node(ctx, &opts.config).await?;
+    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::list(cmd.cloud_opts.route()))
         .await?;
     let projects = rpc.parse_and_print_response::<Vec<Project>>()?;

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -61,8 +61,8 @@ async fn run_impl(
 
     // Send request
     let mut rpc = RpcBuilder::new(ctx, &opts, &cmd.node_opts.api_node)
-        .tcp(&tcp)
-        .build()?;
+        .tcp(&tcp)?
+        .build();
     rpc.request(api::project::show(&id, controller_route))
         .await?;
     let project = rpc.parse_and_print_response::<Project>()?;

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -101,7 +101,7 @@ async fn create_secure_channel_to_project<'a>(
     project_identity: &str,
 ) -> crate::Result<MultiAddr> {
     let authorized_identifier = vec![IdentityIdentifier::from_str(project_identity)?];
-    let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+    let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
     rpc.request(api::create_secure_channel(
         project_access_route,
         Some(authorized_identifier),
@@ -118,7 +118,7 @@ async fn delete_secure_channel<'a>(
     api_node: &str,
     sc_addr: &MultiAddr,
 ) -> crate::Result<()> {
-    let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+    let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
     let addr = multiaddr_to_addr(sc_addr).context("Failed to convert MultiAddr to addr")?;
     rpc.request(api::delete_secure_channel(&addr)).await?;
     rpc.is_ok()?;
@@ -141,8 +141,8 @@ pub async fn check_project_readiness<'a>(
             std::io::stdout().flush()?;
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             let mut rpc = RpcBuilder::new(ctx, opts, &node_opts.api_node)
-                .tcp(tcp)
-                .build()?;
+                .tcp(tcp)?
+                .build();
             rpc.request(api::project::show(&project.id, cloud_route))
                 .await?;
             let p = rpc.parse_response::<Project>()?;
@@ -282,7 +282,7 @@ pub mod config {
         api_node: &str,
         controller_route: &MultiAddr,
     ) -> Result<()> {
-        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
         rpc.request(api::project::list(controller_route)).await?;
         let projects = rpc.parse_response::<Vec<Project>>()?;
         set_projects(&opts.config, &projects)?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -162,7 +162,7 @@ async fn rpc(ctx: Context, (options, command): (CommandGlobalOpts, CreateCommand
     let authorized_identifiers = command.authorized.clone();
 
     // Delegate the request to create a secure channel to the from node.
-    let mut rpc = RpcBuilder::new(&ctx, &options, from).tcp(&tcp).build()?;
+    let mut rpc = RpcBuilder::new(&ctx, &options, from).tcp(&tcp)?.build();
     let request = api::create_secure_channel(to, authorized_identifiers);
     rpc.request(request).await?;
     let response = rpc.parse_response::<CreateSecureChannelResponse>()?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -44,8 +44,8 @@ impl CreateCommand {
             }
         };
 
-        connect_to(port, self, |mut ctx, cmd, rte| async {
-            create_listener(&mut ctx, cmd.address, cmd.authorized_identifier, rte).await?;
+        connect_to(port, self, |ctx, cmd, rte| async {
+            create_listener(&ctx, cmd.address, cmd.authorized_identifier, rte).await?;
             drop(ctx);
             Ok(())
         });
@@ -53,7 +53,7 @@ impl CreateCommand {
 }
 
 pub async fn create_listener(
-    ctx: &mut ockam::Context,
+    ctx: &ockam::Context,
     addr: Address,
     authorized_identifiers: Option<Vec<IdentityIdentifier>>,
     mut base_route: Route,

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -73,13 +73,13 @@ impl StartCommand {
         };
 
         match self.create_subcommand {
-            StartSubCommand::Vault { .. } => connect_to(port, self, |mut ctx, cmd, rte| async {
-                start_vault_service(&mut ctx, cmd, rte).await?;
+            StartSubCommand::Vault { .. } => connect_to(port, self, |ctx, cmd, rte| async {
+                start_vault_service(&ctx, cmd, rte).await?;
                 drop(ctx);
                 Ok(())
             }),
-            StartSubCommand::Identity { .. } => connect_to(port, self, |mut ctx, cmd, rte| async {
-                start_identity_service(&mut ctx, cmd, rte).await?;
+            StartSubCommand::Identity { .. } => connect_to(port, self, |ctx, cmd, rte| async {
+                start_identity_service(&ctx, cmd, rte).await?;
                 drop(ctx);
                 Ok(())
             }),
@@ -90,8 +90,8 @@ impl StartCommand {
                     Ok(())
                 })
             }
-            StartSubCommand::Verifier { .. } => connect_to(port, self, |mut ctx, cmd, rte| async {
-                start_verifier_service(&mut ctx, cmd, rte).await?;
+            StartSubCommand::Verifier { .. } => connect_to(port, self, |ctx, cmd, rte| async {
+                start_verifier_service(&ctx, cmd, rte).await?;
                 drop(ctx);
                 Ok(())
             }),
@@ -103,8 +103,8 @@ impl StartCommand {
                 })
             }
             StartSubCommand::Authenticator { .. } => {
-                connect_to(port, self, |mut ctx, cmd, rte| async {
-                    start_authenticator_service(&mut ctx, cmd, rte).await?;
+                connect_to(port, self, |ctx, cmd, rte| async {
+                    start_authenticator_service(&ctx, cmd, rte).await?;
                     drop(ctx);
                     Ok(())
                 })
@@ -116,7 +116,7 @@ impl StartCommand {
 }
 
 pub async fn start_vault_service(
-    ctx: &mut Context,
+    ctx: &Context,
     cmd: StartCommand,
     mut base_route: Route,
 ) -> Result<()> {
@@ -165,7 +165,7 @@ pub async fn start_vault_service(
 }
 
 pub async fn start_identity_service(
-    ctx: &mut Context,
+    ctx: &Context,
     cmd: StartCommand,
     mut base_route: Route,
 ) -> Result<()> {
@@ -263,7 +263,7 @@ pub async fn start_authenticated_service(
 }
 
 pub async fn start_verifier_service(
-    ctx: &mut Context,
+    ctx: &Context,
     cmd: StartCommand,
     mut route: Route,
 ) -> Result<()> {
@@ -337,7 +337,7 @@ pub async fn start_credentials_service(
 }
 
 pub async fn start_authenticator_service(
-    ctx: &mut Context,
+    ctx: &Context,
     cmd: StartCommand,
     mut route: Route,
 ) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -3,17 +3,14 @@ use clap::Args;
 use ockam::Context;
 use ockam_api::cloud::space::Space;
 
-use crate::node::NodeOpts;
+use crate::node::create::start_embedded_node;
 use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, Rpc};
+use crate::util::{node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    #[clap(flatten)]
-    pub node_opts: NodeOpts,
-
     #[clap(flatten)]
     pub cloud_opts: CloudOpts,
 }
@@ -33,7 +30,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::new(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = start_embedded_node(ctx, &opts.config).await?;
+    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::space::list(cmd.cloud_opts.route()))
         .await?;
     let spaces = rpc.parse_and_print_response::<Vec<Space>>()?;

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -6,7 +6,6 @@ use ockam_api::cloud::space::Space;
 pub mod config {
     use crate::util::{api, RpcBuilder};
     use crate::{CommandGlobalOpts, OckamConfig};
-    use ockam::TcpTransport;
     use ockam_multiaddr::MultiAddr;
 
     use super::*;
@@ -40,11 +39,10 @@ pub mod config {
     pub async fn refresh_spaces(
         ctx: &Context,
         opts: &CommandGlobalOpts,
-        tcp: &TcpTransport,
         api_node: &str,
         controller_route: &MultiAddr,
     ) -> Result<()> {
-        let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp).build()?;
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
         rpc.request(api::space::list(controller_route)).await?;
         let spaces = rpc.parse_response::<Vec<Space>>()?;
         set_spaces(&opts.config, &spaces)?;

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -121,6 +121,18 @@ impl OckamConfig {
         Ok(PathBuf::new().join(node_path))
     }
 
+    /// Get the node state directory
+    pub fn get_node_dir_raw(&self, name: &str) -> Result<PathBuf> {
+        let inner = self.inner.readlock_inner();
+        let node_path = inner
+            .directories
+            .as_ref()
+            .context("configuration is in an invalid state")?
+            .data_local_dir()
+            .join(slugify(&format!("node-{}", name)));
+        Ok(node_path)
+    }
+
     /// Get the API port used by a node
     pub fn get_node_port(&self, name: &str) -> u16 {
         let inner = self.inner.readlock_inner();
@@ -203,7 +215,7 @@ impl OckamConfig {
     }
 
     pub fn authorities(&self, node: &str) -> Result<AuthoritiesConfig> {
-        let path = self.get_node_dir(node)?;
+        let path = self.get_node_dir_raw(node)?;
         Ok(AuthoritiesConfig::load(path))
     }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -34,22 +34,30 @@ pub(crate) mod output;
 pub const DEFAULT_ORCHESTRATOR_ADDRESS: &str =
     "/dnsaddr/orchestrator.ockam.io/tcp/6252/service/api";
 
-pub struct RpcBuilder<'a, 'b> {
-    ctx: &'a Context,
-    opts: &'a CommandGlobalOpts,
-    node: &'b str,
-    to: Route,
-    tcp: Option<&'a TcpTransport>,
+pub enum RpcMode<'a> {
+    Embedded,
+    Background {
+        cfg: NodeConfig,
+        tcp: Option<&'a TcpTransport>,
+    },
 }
 
-impl<'a, 'b> RpcBuilder<'a, 'b> {
-    pub fn new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node: &'b str) -> Self {
+pub struct RpcBuilder<'a> {
+    ctx: &'a Context,
+    opts: &'a CommandGlobalOpts,
+    node_name: String,
+    to: Route,
+    mode: RpcMode<'a>,
+}
+
+impl<'a> RpcBuilder<'a> {
+    pub fn new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node_name: &str) -> Self {
         RpcBuilder {
             ctx,
             opts,
-            node,
+            node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
-            tcp: None,
+            mode: RpcMode::Embedded,
         }
     }
 
@@ -59,16 +67,20 @@ impl<'a, 'b> RpcBuilder<'a, 'b> {
         Ok(self)
     }
 
-    pub fn tcp(mut self, tcp: &'a TcpTransport) -> Self {
-        self.tcp = Some(tcp);
-        self
+    pub fn tcp(mut self, tcp: &'a TcpTransport) -> Result<Self> {
+        let cfg = self.opts.config.get_node(&self.node_name)?;
+        self.mode = RpcMode::Background {
+            cfg,
+            tcp: Some(tcp),
+        };
+        Ok(self)
     }
 
-    pub fn build(self) -> Result<Rpc<'a>> {
-        let mut rpc = Rpc::new(self.ctx, self.opts, self.node)?;
+    pub fn build(self) -> Rpc<'a> {
+        let mut rpc = Rpc::_new(self.ctx, self.opts, &self.node_name);
         rpc.to = self.to;
-        rpc.tcp = self.tcp;
-        Ok(rpc)
+        rpc.mode = self.mode;
+        rpc
     }
 }
 
@@ -76,22 +88,45 @@ pub struct Rpc<'a> {
     ctx: &'a Context,
     buf: Vec<u8>,
     opts: &'a CommandGlobalOpts,
-    cfg: NodeConfig,
+    node_name: String,
     to: Route,
-    /// Needed for when we want to call multiple Rpc's from a single command.
-    tcp: Option<&'a TcpTransport>,
+    mode: RpcMode<'a>,
+}
+
+impl<'a> Drop for Rpc<'a> {
+    fn drop(&mut self) {
+        if let RpcMode::Embedded = self.mode {
+            // Try removing the node's directory
+            let _ = self
+                .opts
+                .config
+                .get_node_dir_raw(&self.node_name)
+                .map(std::fs::remove_dir_all);
+        }
+    }
 }
 
 impl<'a> Rpc<'a> {
-    pub fn new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node: &str) -> Result<Rpc<'a>> {
-        let cfg = opts.config.get_node(node)?;
+    fn _new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node_name: &str) -> Rpc<'a> {
+        Rpc {
+            ctx,
+            buf: Vec::new(),
+            opts,
+            node_name: node_name.to_string(),
+            to: NODEMANAGER_ADDR.into(),
+            mode: RpcMode::Embedded,
+        }
+    }
+
+    pub fn new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node_name: &str) -> Result<Rpc<'a>> {
+        let cfg = opts.config.get_node(node_name)?;
         Ok(Rpc {
             ctx,
             buf: Vec::new(),
             opts,
-            cfg,
+            node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
-            tcp: None,
+            mode: RpcMode::Background { cfg, tcp: None },
         })
     }
 
@@ -129,21 +164,24 @@ impl<'a> Rpc<'a> {
     }
 
     async fn route_impl(&mut self, ctx: &Context) -> Result<Route> {
-        let addr = node_addr(&self.cfg);
-        let addr_str = addr.address();
-
-        match self.tcp {
-            None => {
-                let tcp = TcpTransport::create(ctx).await?;
-                tcp.connect(addr_str).await?;
+        let route = match self.mode {
+            RpcMode::Embedded => self.to.clone(),
+            RpcMode::Background { ref cfg, ref tcp } => {
+                let addr = Address::from((TCP, format!("localhost:{}", cfg.port)));
+                let addr_str = addr.address();
+                match tcp {
+                    None => {
+                        let tcp = TcpTransport::create(ctx).await?;
+                        tcp.connect(addr_str).await?;
+                    }
+                    Some(tcp) => {
+                        // Ignore "already connected" error.
+                        let _ = tcp.connect(addr_str).await;
+                    }
+                }
+                self.to.modify().prepend_route(addr.into()).into()
             }
-            Some(tcp) => {
-                // Ignore "already connected" error.
-                let _ = tcp.connect(addr_str).await;
-            }
-        }
-
-        let route = self.to.modify().prepend_route(addr.into()).into();
+        };
         debug!(%route, "Sending request");
         Ok(route)
     }
@@ -285,10 +323,6 @@ where
     if let Err(e) = res {
         eprintln!("Ockam node failed: {:?}", e,);
     }
-}
-
-fn node_addr(cfg: &NodeConfig) -> Address {
-    Address::from((TCP, format!("localhost:{}", cfg.port)))
 }
 
 pub fn node_rpc<A, F, Fut>(f: F, a: A)

--- a/implementations/rust/ockam/ockam_command/src/util/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/node.rs
@@ -44,7 +44,7 @@ pub async fn default_node(
         for node_name in node_names.iter() {
             trace!(%node_name, "Checking node");
             let nc = opts.config.get_node(node_name)?;
-            let mut rpc = RpcBuilder::new(ctx, opts, node_name).tcp(tcp).build()?;
+            let mut rpc = RpcBuilder::new(ctx, opts, node_name).tcp(tcp)?.build();
             if rpc
                 .request_with_timeout(
                     api::node::query_status(),

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -58,6 +58,9 @@ impl Output for Space<'_> {
 
 impl Output for Vec<Space<'_>> {
     fn output(&self) -> anyhow::Result<String> {
+        if self.is_empty() {
+            return Ok("No spaces found".to_string());
+        }
         let mut rows = vec![];
         for Space {
             id, name, users, ..
@@ -130,6 +133,9 @@ impl Output for ProjectInfo<'_> {
 
 impl Output for Vec<Project<'_>> {
     fn output(&self) -> anyhow::Result<String> {
+        if self.is_empty() {
+            return Ok("No projects found".to_string());
+        }
         let mut rows = vec![];
         for Project {
             id,
@@ -152,7 +158,7 @@ impl Output for Vec<Project<'_>> {
                 "Id".cell().bold(true),
                 "Name".cell().bold(true),
                 "Users".cell().bold(true),
-                "Space".cell().bold(true),
+                "Space Name".cell().bold(true),
             ])
             .display()?
             .to_string();
@@ -181,6 +187,9 @@ impl Output for Enroller<'_> {
 
 impl Output for Vec<Enroller<'_>> {
     fn output(&self) -> anyhow::Result<String> {
+        if self.is_empty() {
+            return Ok("No enrollers found".to_string());
+        }
         let mut rows = vec![];
         for Enroller {
             identity_id,

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "space"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000", "-n", "node-name"];
+    let common_args = ["/dnsaddr/localhost/tcp/4000"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -1,11 +1,19 @@
 
 # Install
+# =======
+# MacOS:
 #   brew tap kaos/shell
 #   brew install bats-assert
+#
+# Linux:
+#   npm install -g bats bats-support bats-assert
 #
 # https://bats-core.readthedocs.io/en/stable/
 # https://github.com/ztombol/bats-docs#installation
 # https://github.com/ztombol/bats-assert
+
+# bats_lib=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
+bats_lib=$(brew --prefix)/lib # macos
 
 setup_file() {
   pushd $(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir') &>/dev/null
@@ -22,8 +30,8 @@ teardown_file() {
 }
 
 setup() {
-  load "$(brew --prefix)/lib/bats-support/load.bash"
-  load "$(brew --prefix)/lib/bats-assert/load.bash"
+  load "$bats_lib/bats-support/load.bash"
+  load "$bats_lib/bats-assert/load.bash"
   ockam node delete --all || true
 }
 


### PR DESCRIPTION
Same PR as https://github.com/build-trust/ockam/pull/3390 adding the fix to the `node delete` command, which was reported to hang when running `commands.bats`.

I could reproduce the hang when running `commands.bats` on macos, and it now works on the same setup with the changes of this branch.