### PR TITLE
fix(rust): project enroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,9 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -2218,6 +2221,7 @@ name = "ockam_api"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "bytes 1.2.1",
  "cddl-cat",
  "directories",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cast"
@@ -1477,7 +1477,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1616,7 +1616,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "fnv",
  "itoa 1.0.2",
 ]
@@ -1627,7 +1627,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "http",
  "pin-project-lite",
 ]
@@ -1650,7 +1650,7 @@ version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1674,7 +1674,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "hyper",
  "native-tls",
  "tokio",
@@ -2524,7 +2524,7 @@ dependencies = [
 name = "ockam_transport_udp"
 version = "0.14.0"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-util",
  "hashbrown 0.9.1",
  "ockam",
@@ -3069,7 +3069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3797,7 +3797,7 @@ version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "libc",
  "memchr",
  "mio",
@@ -3884,7 +3884,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -4009,7 +4009,7 @@ checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
 dependencies = [
  "base64",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.2.1",
  "http",
  "httparse",
  "log",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -30,6 +30,7 @@ direct-authenticator = ["lmdb", "std"]
 default              = ["lmdb"]
 
 [dependencies]
+bytes           = { version = "1.2.1", default-features = false, features = ["serde"] }
 ockam           = { path = "../ockam", version = "^0.72.0", features = ["software_vault"] }
 either          = { version = "1.7.0", default-features = false }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.6.0", features = ["serde"] }

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -87,7 +87,10 @@ impl Project<'_> {
     }
 
     pub fn is_ready(&self) -> bool {
-        !(self.access_route.is_empty() || self.identity.is_none())
+        !(self.access_route.is_empty()
+            || self.authority_access_route.is_none()
+            || self.identity.is_none()
+            || self.authority_identity.is_none())
     }
 
     pub async fn is_reachable(&self) -> Result<bool> {

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -1,4 +1,5 @@
 use ockam_core::compat::collections::VecDeque;
+use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -76,21 +77,9 @@ impl ConfigLookup {
     }
 
     /// Store a project route and identifier as lookup
-    pub fn set_project(
-        &mut self,
-        name: String,
-        node_route: String,
-        id: String,
-        identity_id: String,
-    ) {
-        self.map.insert(
-            format!("/project/{}", name),
-            LookupValue::Project(ProjectLookup {
-                node_route,
-                id,
-                identity_id,
-            }),
-        );
+    pub fn set_project(&mut self, name: String, proj: ProjectLookup) {
+        self.map
+            .insert(format!("/project/{}", name), LookupValue::Project(proj));
     }
 
     pub fn get_project(&self, name: &str) -> Option<&ProjectLookup> {
@@ -205,20 +194,11 @@ pub struct SpaceLookup {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectLookup {
     /// How to reach the node hosting this project
-    ///
-    /// This value MUST be a MultiAddr and is checked before storing
-    /// that it is.
-    node_route: String,
+    pub node_route: MultiAddr,
     /// Identifier of this project
     pub id: String,
     /// Identifier of the IDENTITY of the project (for secure-channel)
-    pub identity_id: String,
-}
-
-impl ProjectLookup {
-    pub fn node_route(&self) -> MultiAddr {
-        MultiAddr::from_str(&self.node_route).expect(
-            "tried retrieving a MultiAddr from ProjectLookup where no MultiAddr had been stored",
-        )
-    }
+    pub identity_id: IdentityIdentifier,
+    /// How to reach the project's authority node.
+    pub authority_access_route: Option<MultiAddr>,
 }

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use ockam_core::compat::collections::VecDeque;
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;
@@ -199,6 +200,35 @@ pub struct ProjectLookup {
     pub id: String,
     /// Identifier of the IDENTITY of the project (for secure-channel)
     pub identity_id: IdentityIdentifier,
-    /// How to reach the project's authority node.
-    pub authority_access_route: Option<MultiAddr>,
+    /// Project authority information.
+    pub authority: Option<ProjectAuthority>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProjectAuthority {
+    id: IdentityIdentifier,
+    address: MultiAddr,
+    identity: Bytes,
+}
+
+impl ProjectAuthority {
+    pub fn new(id: IdentityIdentifier, addr: MultiAddr, identity: Vec<u8>) -> Self {
+        Self {
+            id,
+            address: addr,
+            identity: identity.into(),
+        }
+    }
+
+    pub fn identity(&self) -> &[u8] {
+        &self.identity
+    }
+
+    pub fn identity_id(&self) -> &IdentityIdentifier {
+        &self.id
+    }
+
+    pub fn address(&self) -> &MultiAddr {
+        &self.address
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -158,7 +158,7 @@ async fn default_project<'a>(
     };
     let project =
         check_project_readiness(ctx, opts, cloud_opts, node_name, None, default_project).await?;
-    set_project(&opts.config, &project)?;
+    set_project(&opts.config, &project).await?;
     println!("{}", project.output()?);
     Ok(project)
 }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -28,7 +28,11 @@ impl Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.inner.as_ref())
+    }
+}
 
 impl From<ConfigError> for Error {
     fn from(e: ConfigError) -> Self {

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,7 +62,7 @@ async fn run_impl(
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
     delete_embedded_node(&opts.config, rpc.node_name()).await;
-    config::set_project(&opts.config, &project)?;
+    config::set_project(&opts.config, &project).await?;
     rpc.print_response(project)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -36,6 +36,6 @@ async fn run_impl(
         .await?;
     delete_embedded_node(&opts.config, rpc.node_name()).await;
     let projects = rpc.parse_and_print_response::<Vec<Project>>()?;
-    config::set_projects(&opts.config, &projects)?;
+    config::set_projects(&opts.config, &projects).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -55,6 +55,6 @@ async fn run_impl(
         .await?;
     delete_embedded_node(&opts.config, rpc.node_name()).await;
     let project = rpc.parse_and_print_response::<Project>()?;
-    config::set_project(&opts.config, &project)?;
+    config::set_project(&opts.config, &project).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -126,7 +126,7 @@ impl Output for ProjectInfo<'_> {
         writeln!(w, "{}: {}", "Project ID".bold(), self.id)?;
         writeln!(w, "{}: {}", "Project identity".bold(), pi)?;
         writeln!(w, "{}: {}", "Authority address".bold(), ar)?;
-        writeln!(w, "{}: {}", "Authority identity".bold(), ai)?;
+        write!(w, "{}: {}", "Authority identity".bold(), ai)?;
         Ok(w)
     }
 }


### PR DESCRIPTION
Currently `project enroll` establishes a secure channel to the project node instead of the project's authority. This commit extends the `ProjectLookup` data to include the authority access route. `project enroll` will attempt to map a `/project` protocol as given in the input multi-address to the corresponding authority address and establish a secure channel to the authority.

**Example**:

```
ockam project enroll \
    --member ... \
    --to /project/myproject/service/authenticator
```