### PR TITLE
fix(rust): node delete won't fail when trying to stop a process that no longer exists

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -53,6 +53,10 @@ impl ConfigLookup {
             })
     }
 
+    pub fn remove_node(&mut self, name: &str) -> Option<LookupValue> {
+        self.map.remove(&format!("/node/{}", name))
+    }
+
     pub fn set_space(&mut self, id: &str, name: &str) {
         self.map.insert(
             format!("/space/{}", name),

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -274,9 +274,10 @@ impl OckamConfig {
             Some(default_node_name) if default_node_name == name => inner.default = None,
             _ => {}
         }
+        inner.lookup.remove_node(name);
         match inner.nodes.remove(name) {
             Some(_) => Ok(()),
-            None => Err(ConfigError::Exists(name.to_string()).into()),
+            None => Err(ConfigError::NotFound(name.to_string()).into()),
         }
     }
 


### PR DESCRIPTION
A bug was found where the `node delete <node-name>` command failed if the passed node was stored in the config.file but its process didn't exist anymore. Deleting a node now also deletes it from the lookup table.

This can happen after restarting the machine or if the user manually stops the `ockam` process without updating the config file.

This PR modifies the node deletion logic so it won't fail when trying to stop the node's process.

This is the series of commands that was causing the issue:
```bash
ockam node create n1
# manually kill the process associated to n1 node
ockam node delete n1
```