### PR TITLE
fix(elixir): minor credential exchange fixes

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_set.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_set.ex
@@ -3,11 +3,25 @@ defmodule Ockam.Credential.AttributeSet do
   Data struvture representing attribute set:
   group of attributes with common expiration metadata
   """
+
   use TypedStruct
+
+  defmodule Attributes do
+    @moduledoc """
+    Attributes are returned by verifier as an embedded struct,
+    with a single field (a string() -> binary() map)
+    """
+    use TypedStruct
+
+    typedstruct do
+      plugin(Ockam.TypedCBOR.Plugin)
+      field(:attributes, %{String.t() => binary()}, minicbor: [key: 1])
+    end
+  end
 
   typedstruct do
     plugin(Ockam.TypedCBOR.Plugin)
-    field(:attributes, %{String.t() => binary()}, minicbor: [key: 1])
+    field(:attributes, Attributes.t(), minicbor: [key: 1, schema: Attributes.minicbor_schema()])
     field(:expiration, integer(), minicbor: [key: 2])
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_storage.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_storage.ex
@@ -52,7 +52,7 @@ defmodule Ockam.Credential.AttributeStorageETS do
   @spec get_attributes(identity_id()) :: %{String.t() => binary()}
   def get_attributes(id) do
     case get_attribute_set(id) do
-      {:ok, %{attributes: attributes}} -> attributes
+      {:ok, %{attributes: %{attributes: attributes}}} -> attributes
       {:error, _reason} -> %{}
     end
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/verifier/sidecar.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/verifier/sidecar.ex
@@ -27,7 +27,7 @@ defmodule Ockam.Credential.Verifier.Sidecar do
     path = "verify"
 
     request =
-      VerifyRequest.encode!(%{
+      VerifyRequest.encode!(%VerifyRequest{
         credential: credential,
         subject_id: subject_id,
         authorities: authorities

--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/verifier/stub.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/verifier/stub.ex
@@ -3,11 +3,13 @@ defmodule Ockam.Credential.Verifier.Stub do
   Stub implementation for credential verifier
   """
   alias Ockam.Credential.AttributeSet
+  alias Ockam.Credential.AttributeSet.Attributes
 
   def verify(credential, subject_id, authorities)
       when is_binary(credential) and is_binary(subject_id) and is_map(authorities) do
     with {:ok, %{attributes: attributes, expiration: expiration}} <- parse_credential(credential) do
-      {:ok, %AttributeSet{attributes: attributes, expiration: expiration}}
+      {:ok,
+       %AttributeSet{attributes: %Attributes{attributes: attributes}, expiration: expiration}}
     end
   end
 

--- a/implementations/elixir/ockam/ockam_services/lib/services/api/credential_exchange_api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/credential_exchange_api.ex
@@ -72,7 +72,7 @@ defmodule Ockam.Services.API.CredentialExchange do
     Enum.map(authorities_config, fn identity_data ->
       with {:ok, identity} <- Identity.make_identity(identity_data),
            {:ok, identity_id} <- Identity.validate_identity_change_history(identity) do
-        {identity_id, identity}
+        {identity_id, Identity.get_data(identity)}
       end
     end)
     |> Map.new()

--- a/implementations/elixir/ockam/ockam_services/test/attribute_storage_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/attribute_storage_test.exs
@@ -4,6 +4,7 @@ defmodule Test.Services.AttributeSrotageTest do
   alias Ockam.Credential.AttributeStorageETS, as: AttributeStorage
 
   alias Ockam.Credential.AttributeSet
+  alias Ockam.Credential.AttributeSet.Attributes
 
   test "stored attributes" do
     AttributeStorage.init()
@@ -11,13 +12,13 @@ defmodule Test.Services.AttributeSrotageTest do
     id = "foo"
 
     attribute_set = %AttributeSet{
-      attributes: %{"project" => "123", "role" => "member"},
+      attributes: %Attributes{attributes: %{"project" => "123", "role" => "member"}},
       expiration: System.os_time(:second) + 100
     }
 
     AttributeStorage.put_attribute_set(id, attribute_set)
 
-    assert attribute_set.attributes == AttributeStorage.get_attributes(id)
+    assert attribute_set.attributes.attributes == AttributeStorage.get_attributes(id)
   end
 
   test "expired attributes" do


### PR DESCRIPTION
Two small fixes to make the elixir'  credential exchange and authorization works with the rust implementation:


1) The result returned by the verifier component contains the attribute map inside a nested struct, essentially:
```
  {1 => {1 =>  attribute_map}, 2=> expiration}
```
  instead of
```
  {1 => attribute_map, 2=> expiration}
```
  this PR adapt the elixir side to match.

2)  Pass to the verifier the raw authority' identity bytes,  instead of the data as wrapped by Elixir'  `Ockam.Identity`  module.
