### PR TITLE
Remove homebrew from CI

### DIFF
--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -51,7 +51,7 @@ jobs:
           os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-gnu
-          container: "ghcr.io/build-trust/ockam-builder@sha256:61a48fb34a97b9de981f1a9a72885a6e1a0df1d486c131add220fdb26a1bd38b"
+          container: "ghcr.io/build-trust/ockam-builder@sha256:35ca467816e36a5bd16fcaa31141d0fd9507df94b8672fb02bc86b939746c889"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -25,13 +25,12 @@
 # ORCHESTRATOR_TESTS=1 LONG_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/commands.bats
 
 # bats_lib=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
-# bats_lib=$(brew --prefix)/lib # macos
 
 # Ockam binary to use
 OCKAM=ockam
+
 if [[ -z $BATS_LIB ]]; then
-  echo "Please set path to bats-support and bat-assert lib"
-  exit 1
+  bats_lib=$(brew --prefix)/lib # macos
 fi
 
 setup_file() {

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -25,10 +25,14 @@
 # ORCHESTRATOR_TESTS=1 LONG_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/commands.bats
 
 # bats_lib=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
-bats_lib=$(brew --prefix)/lib # macos
+# bats_lib=$(brew --prefix)/lib # macos
 
 # Ockam binary to use
 OCKAM=ockam
+if [[ -z $BATS_LIB ]]; then
+  echo "Please set path to bats-support and bat-assert lib"
+  exit 1
+fi
 
 setup_file() {
   pushd $(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir') &>/dev/null
@@ -45,8 +49,8 @@ teardown_file() {
 }
 
 setup() {
-  load "$bats_lib/bats-support/load.bash"
-  load "$bats_lib/bats-assert/load.bash"
+  load "$BATS_LIB/bats-support/load.bash"
+  load "$BATS_LIB/bats-assert/load.bash"
   $OCKAM node delete --all || true
 }
 

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -17,9 +17,6 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
     MOLD_HOME=/opt/mold
 
 RUN set -xe; \
-    # Setup base tools
-    apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends ca-certificates curl locales xz-utils clang; \
     case $(dpkg --print-architecture) in \
       "amd64") \
         echo "Using AMD64"; \
@@ -31,15 +28,6 @@ RUN set -xe; \
         JQ_SHA256="af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44" && JQ_OS="linux64"; \
         MOLD_SHA256="3893f89e5e0dcddcecc9f2ee17f14ad94fbf8b324eca45974b965353a50dac37" && MOLD_OS="x86_64-linux"; \
         OS="x86_64-unknown-linux-gnu"; \
-
-        # Setup brew
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; \
-        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /root/.profile; \
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"; \
-        brew tap kaos/shell; \
-        brew install bats-assert; \
-        brew install python3; \
-        pip3 install selenium; \
       ;; \
       "arm64") \
         export CARGO_NET_GIT_FETCH_WITH_CLI=true; \
@@ -59,18 +47,21 @@ RUN set -xe; \
         exit 1; \
       ;; \
     esac; \
+# Setup base tools
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends ca-certificates curl locales xz-utils clang; \
 # Setup locale
     LANG=en_US.UTF-8; \
     echo $LANG UTF-8 > /etc/locale.gen; \
     locale-gen; \
     update-locale LANG=$LANG; \
-# Install firefox and geckodriver
-    apt-get install firefox-esr --assume-yes; \
-    wget https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-linux64.tar.gz -O /tmp/geckodriver.tar.gz \
-      && tar -C /opt -xzf /tmp/geckodriver.tar.gz \
-      && chmod 755 /opt/geckodriver \
-      && ln -fs /opt/geckodriver /usr/bin/geckodriver \
-      && ln -fs /opt/geckodriver /usr/local/bin/geckodriver; \
+# Setup Bats
+    mkdir /usr/lib/bats && cd /usr/lib/bats && git init; \
+    git submodule add https://github.com/bats-core/bats-core.git; \
+    cd bats-core && ./install.sh /usr; \
+    cd - && rm -rf bats-core; \
+    git submodule add https://github.com/bats-core/bats-support.git; \
+    git submodule add https://github.com/bats-core/bats-assert.git; \
 # Setup nodejs
     NODEJS_PACKAGE="node-v${NODEJS_VERSION}-${NODEJS_OS}.tar.xz"; \
     curl --proto '=https' --tlsv1.2 -sSOL \
@@ -157,12 +148,13 @@ RUN set -xe; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
-ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${JAVA_HOME}/bin:${RUSTUP_HOME}/bin:${CARGO_HOME}/bin:${CMAKE_HOME}/bin:${NODEJS_HOME}/bin:${MOLD_HOME}/bin:$PATH" \
+ENV PATH="${CARGO_HOME}/bin:${CMAKE_HOME}/bin:${NODEJS_HOME}/bin:${MOLD_HOME}/bin:$PATH" \
     AR=/usr/bin/ar \
     AS=/usr/bin/as \
     CC=/usr/local/bin/gcc \
     CPP=/usr/local/bin/cpp \
     CXX=/usr/local/bin/g++ \
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    BATS_LIB=/usr/lib/bats
 
 WORKDIR /work


### PR DESCRIPTION
This PR removes brew installation from ockam-builder docker image and  installs bats from source. Now users have to indicate bats-assert and bats-support path to run `bats commands.bat` instead of the script assuming brew to be the source of bats installation.