### PR TITLE
refactor(rust): remove default value from help text

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -12,8 +12,8 @@ use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    /// Name of the space.
-    #[clap(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()))]
+    /// Name of the space
+    #[clap(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
     pub name: String,
 
     #[clap(flatten)]


### PR DESCRIPTION
`ockam space create` currently outputs helptext that includes the default value
for the space name which is a randomly generated hex. This PR removes that default
value from help text.

closes #3414 
