### PR TITLE
fix(rust): always run credentials commands through background nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
@@ -3,12 +3,15 @@ use clap::Args;
 use ockam::Context;
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::util::delete_embedded_node;
+use crate::node::NodeOpts;
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct GetCredentialCommand {
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
     #[clap(long, short)]
     pub from: MultiAddr,
 
@@ -34,9 +37,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: GetCredentialCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::embedded(ctx, &opts).await?;
+    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::credentials::get_credential(&cmd.from, cmd.overwrite))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/present_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present_credential.rs
@@ -3,13 +3,16 @@ use clap::Args;
 use ockam::Context;
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::util::delete_embedded_node;
+use crate::node::NodeOpts;
 use crate::util::api::{self};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct PresentCredentialCommand {
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
     #[clap(long, display_order = 900, name = "ROUTE")]
     pub to: MultiAddr,
 
@@ -35,9 +38,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: PresentCredentialCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::embedded(ctx, &opts).await?;
+    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::credentials::present_credential(&cmd.to, cmd.oneway))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/set_authority.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/set_authority.rs
@@ -2,13 +2,16 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::util::delete_embedded_node;
+use crate::node::NodeOpts;
 use crate::util::api::{self};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct SetAuthorityCommand {
+    #[clap(flatten)]
+    pub node_opts: NodeOpts,
+
     #[clap(value_name = "AUTHORITY")]
     pub authority: Vec<String>,
 }
@@ -31,9 +34,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: SetAuthorityCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::embedded(ctx, &opts).await?;
+    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::credentials::set_authority(&cmd.authority))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }


### PR DESCRIPTION
Since credentials commands store state in the node, we have to run these commands through background nodes.

This PR adds the `NodeOpts` argument back to these commands and stop using embedded nodes. 