### PR TITLE
refactor(rust): move embedded node deletion to last step to preserve logs on error

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -151,6 +151,7 @@ impl<'a> ShowSecureChannelRequest<'a> {
 #[cbor(map)]
 pub struct ShowSecureChannelResponse<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip)]
     #[n(0)] tag: TypeTag<4566220>,
     #[b(1)] pub channel: Option<Cow<'a, str>>,
     #[b(2)] pub route: Option<Cow<'a, str>>,

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -74,13 +74,13 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             .tcp(tcp.as_ref())?
             .build();
         rpc.request(req(&to, &cmd.message)).await?;
-        delete_embedded_node(&opts.config, rpc.node_name()).await;
         let res = rpc.parse_response::<Vec<u8>>()?;
         println!(
             "{}",
             String::from_utf8(res).context("Received content is not a valid utf8 string")?
         );
 
+        delete_embedded_node(&opts.config, rpc.node_name()).await;
         Ok(())
     }
     go(&mut ctx, &opts, cmd).await

--- a/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
@@ -49,7 +49,7 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::project::add_enroller(&cmd)).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     rpc.parse_and_print_response::<Enroller>()?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -61,8 +61,8 @@ async fn run_impl(
     let project = rpc.parse_response::<Project>()?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     config::set_project(&opts.config, &project).await?;
     rpc.print_response(project)?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -77,11 +77,11 @@ async fn run_impl(
         controller_route,
     ))
     .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     rpc.is_ok()?;
 
     // Try to remove from config again, in case it was re-added after the refresh.
     let _ = config::remove_project(&opts.config, &cmd.project_name);
 
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
@@ -43,7 +43,7 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::project::delete_enroller(&cmd)).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     rpc.is_ok()?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -78,8 +78,8 @@ async fn run_impl(
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::show(&id, controller_route))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let info: ProjectInfo = rpc.parse_response::<Project>()?.into();
     rpc.print_response(&info)?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -34,8 +34,8 @@ async fn run_impl(
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::project::list(cmd.cloud_opts.route()))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let projects = rpc.parse_and_print_response::<Vec<Project>>()?;
     config::set_projects(&opts.config, &projects).await?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
@@ -41,7 +41,7 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::project::list_enrollers(&cmd)).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     rpc.parse_and_print_response::<Vec<Enroller>>()?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -53,8 +53,8 @@ async fn run_impl(
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::show(&id, controller_route))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let project = rpc.parse_and_print_response::<Project>()?;
     config::set_project(&opts.config, &project).await?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -44,8 +44,8 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::space::create(&cmd)).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let space = rpc.parse_and_print_response::<Space>()?;
     config::set_space(&opts.config, &space)?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -64,11 +64,11 @@ async fn run_impl(
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::space::delete(&id, controller_route))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     rpc.is_ok()?;
 
     // Try to remove from config again, in case it was re-added after the refresh.
     let _ = config::remove_space(&opts.config, &cmd.name);
 
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -33,8 +33,8 @@ async fn run_impl(
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::space::list(cmd.cloud_opts.route()))
         .await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let spaces = rpc.parse_and_print_response::<Vec<Space>>()?;
     config::set_spaces(&opts.config, &spaces)?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -51,8 +51,8 @@ async fn run_impl(
     // Send request
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::space::show(&id, controller_route)).await?;
-    delete_embedded_node(&opts.config, rpc.node_name()).await;
     let space = rpc.parse_and_print_response::<Space>()?;
     config::set_space(&opts.config, &space)?;
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }


### PR DESCRIPTION
If a command fails, we want to preserve the node directory. Moving the deletion to be executed right before exiting the command will guarantee that.