### PR TITLE
fix(rust): add default value for `nodes` and remove `api_node` config

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -34,7 +34,7 @@ pub struct OckamConfig {
     /// persist this data to the configuration
     #[serde(skip)]
     pub directories: Option<ProjectDirs>,
-    pub api_node: String,
+    #[serde(default = "default_nodes")]
     pub nodes: BTreeMap<String, NodeConfig>,
 
     #[serde(default = "default_lookup")]
@@ -42,7 +42,12 @@ pub struct OckamConfig {
 
     pub default_identity: Option<Vec<u8>>,
     pub default_vault_path: Option<PathBuf>,
+    /// Default node
     pub default: Option<String>,
+}
+
+fn default_nodes() -> BTreeMap<String, NodeConfig> {
+    BTreeMap::new()
 }
 
 fn default_lookup() -> ConfigLookup {
@@ -53,9 +58,8 @@ impl ConfigValues for OckamConfig {
     fn default_values(_node_dir: &Path) -> Self {
         Self {
             directories: Some(Self::directories()),
-            api_node: "default".into(),
             nodes: BTreeMap::new(),
-            lookup: ConfigLookup::new(),
+            lookup: default_lookup(),
             default_identity: None,
             default_vault_path: None,
             default: None,

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -88,17 +88,6 @@ impl OckamConfig {
         Ok(())
     }
 
-    /// Get available global configuration values
-    // TODO: make this consider node scope options
-    pub fn values() -> Vec<&'static str> {
-        vec!["api-node"]
-    }
-
-    /// Get the current API node configuration setting
-    pub fn get_api_node(&self) -> String {
-        self.inner.readlock_inner().api_node.clone()
-    }
-
     pub fn get_default_vault_path(&self) -> Option<PathBuf> {
         self.inner.readlock_inner().default_vault_path.clone()
     }
@@ -291,12 +280,6 @@ impl OckamConfig {
 
         inner.nodes.get_mut(name).unwrap().pid = pid.into();
         Ok(())
-    }
-
-    /// Update the api node name on record
-    pub fn set_api_node(&self, node_name: &str) {
-        let mut inner = self.inner.writelock_inner();
-        inner.api_node = node_name.into();
     }
 
     pub fn set_node_alias(&self, alias: String, addr: InternetAddress) {


### PR DESCRIPTION
This will help support config files without `nodes` and/or `api_node` fields when upgrading from older versions.