### PR TITLE
fix(rust): print node status will wait only when creating new nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -154,7 +154,7 @@ impl CreateCommand {
             .unwrap();
             connect_to(
                 addr.port(),
-                (cfg.clone(), cmd.node_name),
+                (cfg.clone(), cmd.node_name, true),
                 print_query_status,
             );
         }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -35,7 +35,7 @@ impl ListCommand {
             .for_each(|(node_name, node_cfg)| {
                 connect_to(
                     node_cfg.port,
-                    (cfg.clone(), node_name.clone()),
+                    (cfg.clone(), node_name.clone(), false),
                     print_query_status,
                 )
             });


### PR DESCRIPTION
The `node create|list|show` commands run a method that retrieves the node status. In a previous PR,
this method was modified to block until the node was ready. This introduced a deadlock issue when
running the `list` and `show` commands. This commit changes that behavior so that the `create`
command is the only one waiting until the node is up.
