### PR TITLE
refactor(rust): minor refactors to command's config

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -86,13 +86,11 @@ Otherwise your OS or OS configuration may not be supported!",
         }
     }
 
-    // UTILITY FUNCTIONS NEEDED IN OCKAM_API
-
     /// This function could be zero-copy if we kept the lock on the
     /// backing store for as long as we needed it.  Because this may
     /// have unwanted side-effects, instead we eagerly copy data here.
     /// This may be optimised in the future!
-    pub fn get_lookup(&self) -> &ConfigLookup {
+    pub fn lookup(&self) -> &ConfigLookup {
         &self.lookup
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/config/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/mod.rs
@@ -91,7 +91,7 @@ impl<V: ConfigValues> Config<V> {
     }
 
     /// Atomically update the configuration
-    pub fn atomic_update(&self) -> AtomicUpdater<V> {
-        AtomicUpdater::new(self.config_dir.join(&self.config_name), self.inner.clone())
+    pub fn persist_config_updates(&self) -> anyhow::Result<()> {
+        AtomicUpdater::new(self.config_dir.join(&self.config_name), self.inner.clone()).run()
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -127,7 +127,7 @@ impl NodeManager {
 
                     config.writelock_inner().authenticated_storage_path =
                         Some(default_location.clone());
-                    config.atomic_update().run().map_err(map_anyhow_err)?;
+                    config.persist_config_updates().map_err(map_anyhow_err)?;
 
                     default_location
                 }
@@ -145,7 +145,7 @@ impl NodeManager {
             config.writelock_inner().identity = Some(identity_override.identity);
             config.writelock_inner().identity_was_overridden = true;
 
-            config.atomic_update().run().map_err(map_anyhow_err)?;
+            config.persist_config_updates().map_err(map_anyhow_err)?;
         }
 
         // Check if we had existing Vault

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
@@ -34,7 +34,9 @@ impl NodeManager {
         let exported_identity = identity.export().await?;
 
         self.config.inner().write().unwrap().identity = Some(exported_identity);
-        self.config.atomic_update().run().map_err(map_anyhow_err)?;
+        self.config
+            .persist_config_updates()
+            .map_err(map_anyhow_err)?;
 
         self.identity = Some(identity);
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
@@ -39,7 +39,9 @@ impl NodeManager {
         let vault = Vault::new(Some(Arc::new(vault_storage)));
 
         self.config.inner().write().unwrap().vault_path = Some(path);
-        self.config.atomic_update().run().map_err(map_anyhow_err)?;
+        self.config
+            .persist_config_updates()
+            .map_err(map_anyhow_err)?;
 
         self.vault = Some(vault);
 

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -9,7 +9,7 @@ pub struct GetCommand {
 
 impl GetCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        let lookup = options.config.get_lookup();
+        let lookup = options.config.lookup();
         match lookup.get_node(&self.alias) {
             Some(addr) => {
                 println!("Node: {}\nAddress: {}", self.alias, addr);

--- a/implementations/rust/ockam/ockam_command/src/configuration/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/list.rs
@@ -7,7 +7,7 @@ pub struct ListCommand {}
 
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        let lookup = options.config.get_lookup();
+        let lookup = options.config.lookup();
 
         for (alias, value) in &lookup.map {
             // Currently we only have this one type of lookup but we

--- a/implementations/rust/ockam/ockam_command/src/configuration/set.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set.rs
@@ -24,7 +24,7 @@ impl SetCommand {
         };
 
         options.config.set_node_alias(self.name, target_addr);
-        if let Err(e) = options.config.atomic_update().run() {
+        if let Err(e) = options.config.persist_config_updates() {
             eprintln!("{}", e);
             std::process::exit(exitcode::IOERR);
         }

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -50,7 +50,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
         let tcp = TcpTransport::create(ctx).await?;
         let api_node = get_final_element(&cmd.to);
         let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
-        let (at, meta) = clean_multiaddr(&cmd.at, &opts.config.get_lookup()).unwrap();
+        let (at, meta) = clean_multiaddr(&cmd.at, &opts.config.lookup()).unwrap();
         let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
             ctx,
             opts,

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -18,13 +18,7 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = options.config;
-        let port = match cfg.select_node(&self.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(&self.node_opts.api_node);
 
         connect_to(port, self, create_identity);
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -18,13 +18,7 @@ impl ShowCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = options.config;
         let node = get_final_element(&self.node_opts.api_node);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
 
         connect_to(port, self, show_identity);
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -44,7 +44,7 @@ impl SendCommand {
 async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> Result<()> {
     async fn go(ctx: &mut Context, opts: &CommandGlobalOpts, cmd: SendCommand) -> Result<()> {
         // Process `--to` Multiaddr
-        let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup())
+        let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.lookup())
             .context("Argument '--to' is invalid")?;
 
         // Setup environment depending on whether we are sending the message from an embedded node or a background node

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -129,7 +129,7 @@ impl CreateCommand {
                 }
 
                 // Save the config update
-                if let Err(e) = cfg.atomic_update().run() {
+                if let Err(e) = cfg.persist_config_updates() {
                     eprintln!("failed to update configuration: {}", e);
                     std::process::exit(exitcode::IOERR);
                 }
@@ -196,7 +196,7 @@ impl CreateCommand {
         }
 
         // Save the config update
-        if let Err(e) = cfg.atomic_update().run() {
+        if let Err(e) = cfg.persist_config_updates() {
             eprintln!("failed to update configuration: {}", e);
             std::process::exit(exitcode::IOERR);
         }
@@ -216,11 +216,11 @@ impl CreateCommand {
         );
 
         let composite = (&cmd).into();
-        let startup_cfg = cfg.get_startup_cfg(&cmd.node_name).unwrap();
+        let startup_cfg = cfg.startup_cfg(&cmd.node_name).unwrap();
         startup_cfg.writelock_inner().commands = vec![composite].into();
 
         // Save the config update
-        if let Err(e) = startup_cfg.atomic_update().run() {
+        if let Err(e) = startup_cfg.persist_config_updates() {
             eprintln!("failed to update configuration: {}", e);
             std::process::exit(exitcode::IOERR);
         }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -11,7 +11,7 @@ impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node_names = {
-            let inner = cfg.get_inner();
+            let inner = cfg.inner();
 
             if inner.nodes.is_empty() {
                 println!("No nodes registered on this system!");
@@ -29,15 +29,12 @@ impl ListCommand {
         };
         verify_pids(cfg, node_names);
 
-        cfg.get_inner()
-            .nodes
-            .iter()
-            .for_each(|(node_name, node_cfg)| {
-                connect_to(
-                    node_cfg.port,
-                    (cfg.clone(), node_name.clone(), false),
-                    print_query_status,
-                )
-            });
+        cfg.inner().nodes.iter().for_each(|(node_name, node_cfg)| {
+            connect_to(
+                node_cfg.port,
+                (cfg.clone(), node_name.clone(), false),
+                print_query_status,
+            )
+        });
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -21,7 +21,7 @@ pub struct ShowCommand {
 impl ShowCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let port = match cfg.get_inner().nodes.get(&self.node_name) {
+        let port = match cfg.inner().nodes.get(&self.node_name) {
             Some(cfg) => cfg.port,
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -35,7 +35,7 @@ impl StartCommand {
         }
 
         // Load the node's launch configuration
-        let start_cfg = match cfg.get_startup_cfg(&self.node_name) {
+        let start_cfg = match cfg.startup_cfg(&self.node_name) {
             Ok(cfg) => cfg,
             Err(e) => {
                 eprintln!(

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -85,7 +85,7 @@ pub(super) async fn create_default_identity_if_needed(
         cfg.set_default_identity(Some(exported_data));
     };
 
-    cfg.atomic_update().run()?;
+    cfg.persist_config_updates()?;
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -55,7 +55,7 @@ impl Runner {
 
     async fn run(self) -> Result<()> {
         let tcp = TcpTransport::create(&self.ctx).await?;
-        let map = self.opts.config.get_lookup();
+        let map = self.opts.config.lookup();
         let to = if let Some(a) = project_authority(&self.cmd.to, &map)? {
             let mut addr = self.secure_channel(&tcp, a).await?;
             for proto in self.cmd.to.iter().skip(1) {

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -50,7 +50,7 @@ pub async fn get_projects_secure_channels_from_config_lookup(
     api_node: &str,
     tcp: Option<&TcpTransport>,
 ) -> Result<Vec<MultiAddr>> {
-    let cfg_lookup = opts.config.get_lookup();
+    let cfg_lookup = opts.config.lookup();
     let mut sc = Vec::with_capacity(meta.project.len());
 
     // In case a project is missing from the config file, we fetch them all from the cloud.
@@ -260,7 +260,7 @@ pub mod config {
 
     pub async fn set_project(config: &OckamConfig, project: &Project<'_>) -> Result<()> {
         set(config, project).await?;
-        config.atomic_update().run()?;
+        config.persist_config_updates()?;
         Ok(())
     }
 
@@ -269,13 +269,13 @@ pub mod config {
         for project in projects.iter() {
             set(config, project).await?;
         }
-        config.atomic_update().run()?;
+        config.persist_config_updates()?;
         Ok(())
     }
 
     pub fn remove_project(config: &OckamConfig, name: &str) -> Result<()> {
-        config.remove_project_alias(name)?;
-        config.atomic_update().run()?;
+        config.remove_project_alias(name);
+        config.persist_config_updates()?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -56,7 +56,7 @@ impl CreateCommand {
         api_node: &str,
         tcp: &TcpTransport,
     ) -> anyhow::Result<MultiAddr> {
-        let config = &opts.config.get_lookup();
+        let config = &opts.config.lookup();
         let (to, meta) = clean_multiaddr(&self.to, config)
             .context(format!("Could not convert {} into route", &self.to))?;
         let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
@@ -151,7 +151,7 @@ impl CreateCommand {
 async fn rpc(ctx: Context, (options, command): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
-    let config = &options.config.get_lookup();
+    let config = &options.config.lookup();
     let from = &command.parse_from_node(config);
     let to = &command
         .parse_to_route(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -36,13 +36,7 @@ impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = options.config;
         let node = get_final_element(&self.node_opts.at);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
 
         connect_to(port, self, |ctx, cmd, rte| async {
             create_listener(&ctx, cmd.address, cmd.authorized_identifier, rte).await?;

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -64,13 +64,7 @@ pub enum StartSubCommand {
 impl StartCommand {
     pub fn run(self, options: CommandGlobalOpts) -> Result<()> {
         let cfg = options.config;
-        let port = match cfg.select_node(&self.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(&self.node_opts.api_node);
 
         match self.create_subcommand {
             StartSubCommand::Vault { .. } => connect_to(port, self, |ctx, cmd, rte| async {

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -12,7 +12,7 @@ pub mod config {
 
     pub fn set_space(config: &OckamConfig, space: &Space) -> Result<()> {
         config.set_space_alias(&space.id, &space.name);
-        config.atomic_update().run()?;
+        config.persist_config_updates()?;
         Ok(())
     }
 
@@ -21,13 +21,13 @@ pub mod config {
         for space in spaces.iter() {
             config.set_space_alias(&space.id, &space.name);
         }
-        config.atomic_update().run()?;
+        config.persist_config_updates()?;
         Ok(())
     }
 
     pub fn remove_space(config: &OckamConfig, name: &str) -> Result<()> {
-        config.remove_space_alias(name)?;
-        config.atomic_update().run()?;
+        config.remove_space_alias(name);
+        config.persist_config_updates()?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -27,13 +27,7 @@ impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node = get_final_element(&self.node_opts.api_node);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
         connect_to(port, self, delete_connection);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -19,13 +19,7 @@ impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node = get_final_element(&self.node_opts.api_node);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
 
         connect_to(port, (), list_connections);
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -56,13 +56,7 @@ impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node = get_final_element(&self.node_opts.at);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
 
         let input_addr = match std::net::SocketAddr::from_str(&self.address) {
             Ok(value) => value,
@@ -83,7 +77,7 @@ impl CreateCommand {
         let composite = (&self).into();
         let node = node.to_string();
 
-        let startup_config = match cfg.get_startup_cfg(&node) {
+        let startup_config = match cfg.startup_cfg(&node) {
             Ok(cfg) => cfg,
             Err(e) => {
                 eprintln!("failed to load startup configuration: {}", e);
@@ -91,7 +85,7 @@ impl CreateCommand {
             }
         };
         startup_config.add_composite(composite);
-        if let Err(e) = startup_config.atomic_update().run() {
+        if let Err(e) = startup_config.persist_config_updates() {
             eprintln!("failed to update configuration: {}", e);
             std::process::exit(exitcode::IOERR);
         }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -27,13 +27,7 @@ impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node = get_final_element(&self.node_opts.api_node);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
         connect_to(port, self, delete_listener);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -19,13 +19,7 @@ impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let node = get_final_element(&self.node_opts.api_node);
-        let port = match cfg.select_node(node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(node);
 
         connect_to(port, (), list_listeners);
     }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -481,14 +481,14 @@ pub fn verify_pids(cfg: &OckamConfig, nodes: Vec<String>) {
         let verified_pid = rx.recv().unwrap();
 
         if node_cfg.pid != verified_pid {
-            if let Err(e) = cfg.update_pid(&node_name, verified_pid) {
+            if let Err(e) = cfg.set_node_pid(&node_name, verified_pid) {
                 eprintln!("failed to update pid for node {}: {}", node_name, e);
                 std::process::exit(exitcode::IOERR);
             }
         }
     }
 
-    if cfg.atomic_update().run().is_err() {
+    if cfg.persist_config_updates().is_err() {
         eprintln!("failed to update PID information in config!");
         std::process::exit(exitcode::IOERR);
     }

--- a/implementations/rust/ockam/ockam_command/src/util/startup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/startup.rs
@@ -54,7 +54,7 @@ pub fn spawn_node(
     address: &str,
     project: Option<&Path>,
 ) {
-    let (mlog, elog) = cfg.log_paths_for_node(name).unwrap();
+    let (mlog, elog) = cfg.node_log_paths(name).unwrap();
 
     let main_log_file = OpenOptions::new()
         .create(true)
@@ -104,11 +104,11 @@ pub fn spawn_node(
         .expect("could not spawn node");
 
     // Update the pid in the config (should we remove this?)
-    cfg.update_pid(name, child.id() as i32)
+    cfg.set_node_pid(name, child.id() as i32)
         .expect("should never panic");
 
     // Save the config update
-    if let Err(e) = cfg.atomic_update().run() {
+    if let Err(e) = cfg.persist_config_updates() {
         eprintln!("failed to update configuration: {}", e);
         std::process::exit(exitcode::IOERR);
     }

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -20,13 +20,7 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = options.config;
-        let port = match cfg.select_node(&self.node_opts.api_node) {
-            Some(cfg) => cfg.port,
-            None => {
-                eprintln!("No such node available.  Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            }
-        };
+        let port = cfg.get_node_port(&self.node_opts.api_node);
 
         connect_to(port, self, create_vault);
 


### PR DESCRIPTION
- `atomic_update` is now executed in one single call, instead of returning an instance of `AtomicUpdater` and call the `run` function afterward
- simplify some method names
- use `get_node_port` instead of `select_node` wherever possible
- removing items from the lookup table will never fail now. This will make the system more stable in the event that the same delete operation is run from different nodes at the same time