### PR TITLE
refactor(rust): minor refactors to commands/api error handling

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -392,9 +392,6 @@ impl NodeManager {
             (Post, ["v0", "spaces"]) => self.create_space(ctx, dec).await?,
             (Get, ["v0", "spaces"]) => self.list_spaces(ctx, dec).await?,
             (Get, ["v0", "spaces", id]) => self.get_space(ctx, dec, id).await?,
-            (Get, ["v0", "spaces", "name", name]) => {
-                self.get_space_by_name(ctx, req, dec, name).await?
-            }
             (Delete, ["v0", "spaces", id]) => self.delete_space(ctx, dec, id).await?,
 
             // ==*== Project' enrollers ==*==
@@ -413,11 +410,6 @@ impl NodeManager {
             (Post, ["v0", "projects", space_id]) => self.create_project(ctx, dec, space_id).await?,
             (Get, ["v0", "projects"]) => self.list_projects(ctx, dec).await?,
             (Get, ["v0", "projects", project_id]) => self.get_project(ctx, dec, project_id).await?,
-            // TODO: ockam_command doesn't use this really yet
-            (Get, ["v0", "projects", space_id, project_name]) => {
-                self.get_project_by_name(ctx, req, dec, space_id, project_name)
-                    .await?
-            }
             (Delete, ["v0", "projects", space_id, project_id]) => {
                 self.delete_project(ctx, dec, space_id, project_id).await?
             }
@@ -462,7 +454,7 @@ impl Worker for NodeManager {
         let req: Request = match dec.decode() {
             Ok(r) => r,
             Err(e) => {
-                error!("failed to decode request: {:?}", e);
+                error!("Failed to decode request: {:?}", e);
                 return Ok(());
             }
         };
@@ -472,13 +464,13 @@ impl Worker for NodeManager {
             // If an error occurs, send a response with the error code so the listener can
             // fail fast instead of failing silently here and force the listener to timeout.
             Err(err) => {
-                error!(?err, "Failed to handle message");
+                error!(?err, "Failed to handle request");
                 Response::builder(req.id(), Status::InternalServerError)
-                    .body(err.to_string())
+                    .body(format!("Failed to handle request: {err}"))
                     .to_vec()?
             }
         };
-        warn!("** sending response");
+        trace!("** sending response");
         ctx.send(msg.return_route(), r).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -5,7 +5,6 @@ use crate::{exitcode, ExitCode};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
 pub struct Error {
     code: ExitCode,
     inner: anyhow::Error,
@@ -22,9 +21,15 @@ impl Error {
     }
 }
 
-impl Display for Error {
+impl Debug for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{code: {}, err: {}}}", self.code, self.inner)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -308,19 +308,19 @@ where
             let tcp = match TcpTransport::create(&ctx).await {
                 Ok(tcp) => tcp,
                 Err(e) => {
-                    eprintln!("failed to create TcpTransport");
+                    eprintln!("Failed to create TcpTransport. {e}");
                     error!(%e);
                     std::process::exit(exitcode::CANTCREAT);
                 }
             };
             if let Err(e) = tcp.connect(format!("localhost:{}", port)).await {
-                eprintln!("failed to connect to node");
+                eprintln!("Failed to connect to node. {e}");
                 error!(%e);
                 std::process::exit(exitcode::IOERR);
             }
             let route = route![(TCP, format!("localhost:{}", port))];
             if let Err(e) = lambda(ctx, a, route).await {
-                eprintln!("encountered an error in command handler code");
+                eprintln!("Encountered an error in command handler code. {e}");
                 error!(%e);
                 std::process::exit(exitcode::IOERR);
             }
@@ -343,8 +343,8 @@ where
         |ctx, a| async {
             let res = f(ctx, a).await;
             if let Err(e) = res {
-                error!("{e:?}");
-                eprintln!("{e}");
+                error!(%e);
+                eprintln!("{e:?}");
                 std::process::exit(e.code());
             }
             Ok(())
@@ -374,8 +374,8 @@ where
         stop_node(ctx).await.unwrap();
         match r {
             Err(e) => {
-                error!("{e:?}");
-                eprintln!("{e}");
+                error!(%e);
+                eprintln!("{e:?}");
                 std::process::exit(e.code());
             }
             Ok(v) => v,
@@ -482,14 +482,14 @@ pub fn verify_pids(cfg: &OckamConfig, nodes: Vec<String>) {
 
         if node_cfg.pid != verified_pid {
             if let Err(e) = cfg.set_node_pid(&node_name, verified_pid) {
-                eprintln!("failed to update pid for node {}: {}", node_name, e);
+                eprintln!("Failed to update pid for node {}: {}", node_name, e);
                 std::process::exit(exitcode::IOERR);
             }
         }
     }
 
     if cfg.persist_config_updates().is_err() {
-        eprintln!("failed to update PID information in config!");
+        eprintln!("Failed to update PID information in config!");
         std::process::exit(exitcode::IOERR);
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/error/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/mod.rs
@@ -87,7 +87,7 @@ impl Error {
         self.0.code
     }
 
-    /// Attach additional unstructured informaton to the error.
+    /// Attach additional unstructured information to the error.
     #[must_use]
     pub fn context(mut self, key: &str, val: impl core::fmt::Display) -> Self {
         self.0.add_context(key, &val);

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -55,7 +55,7 @@ impl NodeError {
 
     /// Create an ockam_core::Error from a tokio::Elapsed
     pub(crate) fn with_elapsed(self, err: Elapsed) -> Error {
-        Error::new(Origin::Node, Kind::Timeout, self).context("Elapsed", err)
+        Error::new(Origin::Node, Kind::Timeout, err).context("Type", self)
     }
 }
 


### PR DESCRIPTION
- `with_elapsed` now shows the `tokio::Elapsed` specific error instead of the generic `NodeError::Data` error

```bash
# previously
Failed to receive response from node

Caused by:
    0: failed to load data
    1: failed to load data

# now
Failed to receive response from node

Caused by:
    0: deadline has elapsed
    1: deadline has elapsed
```

- log display-mode error, eprint debug-mode error

```bash
# previously
2022-09-06T12:32:21.859300Z ERROR ockam_command::util: Error { code: 70, inner: Failed to receive response from node

Caused by:
    0: failed to load data
    1: failed to load data }
Failed to receive response from node

Caused by:
    0: failed to load data
    1: failed to load data

# now
2022-09-06T12:33:37.283110Z ERROR ockam_command::util: e={code: 70, err: Failed to receive response from node}
Failed to receive response from node

Caused by:
    0: deadline has elapsed
    1: deadline has elapsed
```

- remove unused `get_project|space_by_name` methods