### PR TITLE
fix(elixir): make elixir tcp client heartbeats work the samy way as rust client

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -87,10 +87,16 @@ defmodule Ockam.Transport.TCP.Client do
     {:stop, :normal, state}
   end
 
-  def handle_info(:heartbeat, %{socket: socket} = state) do
+  def handle_info(:heartbeat, state) do
     case heartbeat_enabled?(state) do
       true ->
-        :gen_tcp.send(socket, "")
+        empty_message = %Message{
+          onward_route: [state.address],
+          return_route: [],
+          payload: ""
+        }
+
+        encode_and_send_over_tcp(empty_message, state)
         schedule_heartbeat(state)
 
       false ->


### PR DESCRIPTION
Ideally we'd want to enable [TCP keepalive](https://github.com/build-trust/ockam/issues/3450) on both, but Rust is currently sending empty messages, so making it identical for Elixir for now.


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
