### PR TITLE
feat(rust): add reset command implementation

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -13,6 +13,7 @@ mod identity;
 mod message;
 mod node;
 mod project;
+mod reset;
 mod secure_channel;
 mod service;
 mod space;
@@ -29,12 +30,13 @@ use completion::CompletionCommand;
 use configuration::ConfigurationCommand;
 use credential::CredentialCommand;
 use enroll::EnrollCommand;
-use error::{Error, Result};
+use error::Result;
 use forwarder::ForwarderCommand;
 use identity::IdentityCommand;
 use message::MessageCommand;
 use node::NodeCommand;
 use project::ProjectCommand;
+use reset::ResetCommand;
 use secure_channel::{listener::SecureChannelListenerCommand, SecureChannelCommand};
 use service::ServiceCommand;
 use space::SpaceCommand;
@@ -220,6 +222,8 @@ pub enum OckamSubcommand {
     Space(SpaceCommand),
     #[clap(display_order = 802)]
     Project(ProjectCommand),
+    #[clap(display_order = 803)]
+    Reset(ResetCommand),
 
     #[clap(display_order = 811)]
     Node(NodeCommand),
@@ -302,6 +306,7 @@ pub fn run() {
         OckamSubcommand::Completion(c) => c.run(),
         OckamSubcommand::Credential(c) => c.run(options),
         OckamSubcommand::Subscription(c) => c.run(options),
+        OckamSubcommand::Reset(c) => c.run(options),
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,8 +1,6 @@
-use crate::{help, node::HELP_DETAIL, util::startup, CommandGlobalOpts};
+use crate::node::util::{delete_all_nodes, delete_node};
+use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
-use ockam_api::config::cli::OckamConfig;
-use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
-use tracing::trace;
 
 /// Delete Nodes
 #[derive(Clone, Debug, Args)]
@@ -32,95 +30,11 @@ impl DeleteCommand {
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
     if cmd.all {
-        // Try to delete all nodes found in the config file + their associated processes
-        let nn: Vec<String> = {
-            let inner = &opts.config.inner();
-            inner.nodes.iter().map(|(name, _)| name.clone()).collect()
-        };
-        for node_name in nn.iter() {
-            delete_node(&opts, node_name, cmd.force)
-        }
-
-        // Try to delete dangling embedded nodes directories
-        let dirs = OckamConfig::directories();
-        let nodes_dir = dirs.data_local_dir();
-        if nodes_dir.exists() {
-            for entry in nodes_dir.read_dir()? {
-                let dir = entry?;
-                if !dir.file_type()?.is_dir() {
-                    continue;
-                }
-                if let Some(dir_name) = dir.file_name().to_str() {
-                    if !nn.contains(&dir_name.to_string()) {
-                        let _ = std::fs::remove_dir_all(dir.path());
-                    }
-                }
-            }
-        }
-
-        // If force is enabled
-        if cmd.force {
-            // delete the config and nodes directories
-            opts.config.remove()?;
-            // and all dangling/orphan ockam processes
-            if let Ok(cpid) = get_current_pid() {
-                let s = System::new_all();
-                for (pid, process) in s.processes() {
-                    if pid != &cpid && process.name() == "ockam" {
-                        process.kill();
-                    }
-                }
-            }
-        }
-        // If not, persist updates to the config file
-        else if let Err(e) = opts.config.persist_config_updates() {
-            eprintln!("Failed to update config file. You might need to run the command with --force to delete all config directories");
-            return Err(crate::Error::new(crate::exitcode::IOERR, e));
-        }
+        delete_all_nodes(opts, cmd.force)?;
     } else {
         delete_node(&opts, &cmd.node_name, cmd.force);
         opts.config.persist_config_updates()?;
         println!("Deleted node '{}'", &cmd.node_name);
     }
     Ok(())
-}
-
-fn delete_node(opts: &CommandGlobalOpts, node_name: &str, sigkill: bool) {
-    trace!(%node_name, "Deleting node");
-
-    // We ignore the result of killing the node process as it could be not
-    // found (after a restart or if the user manually deleted it, for example).
-    let _ = delete_node_pid(opts, node_name, sigkill);
-
-    delete_node_config(opts, node_name);
-}
-
-fn delete_node_pid(opts: &CommandGlobalOpts, node_name: &str, sigkill: bool) -> anyhow::Result<()> {
-    trace!(%node_name, "Deleting node pid");
-    // Stop the process PID if it has one assigned in the config file
-    if let Some(pid) = opts.config.get_node_pid(node_name)? {
-        startup::stop(pid, sigkill)?;
-        // Give some room for the process to stop
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        // If it fails to bind, the port is still in use, so we try again to stop the process
-        let addr = format!("127.0.0.1:{}", opts.config.get_node_port(node_name));
-        if std::net::TcpListener::bind(&addr).is_err() {
-            startup::stop(pid, sigkill)?;
-        }
-    }
-    Ok(())
-}
-
-fn delete_node_config(opts: &CommandGlobalOpts, node_name: &str) {
-    trace!(%node_name, "Deleting node config");
-
-    // Try removing the node's directory.
-    // If the directory is not found, we ignore the result and continue.
-    let _ = opts
-        .config
-        .get_node_dir_raw(node_name)
-        .map(std::fs::remove_dir_all);
-
-    // Try removing the node's info from the config file.
-    opts.config.remove_node(node_name);
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,14 +1,18 @@
 use anyhow::{anyhow, Context as _, Result};
 use std::sync::Arc;
 
+use crate::{util::startup, CommandGlobalOpts};
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
 use ockam_api::config::cli;
+use ockam_api::config::cli::OckamConfig as OckamConfigApi;
 use ockam_api::nodes::models::transport::{TransportMode, TransportType};
 use ockam_api::nodes::{IdentityOverride, NodeManager, NODEMANAGER_ADDR};
 use ockam_multiaddr::MultiAddr;
 use ockam_vault::storage::FileStorage;
 use ockam_vault::Vault;
+use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
+use tracing::trace;
 
 use crate::node::CreateCommand;
 use crate::project::ProjectInfo;
@@ -150,4 +154,91 @@ pub async fn delete_embedded_node(cfg: &OckamConfig, name: &str) {
     if let Ok(dir) = cfg.get_node_dir_raw(name) {
         let _ = tokio::fs::remove_dir_all(dir).await;
     }
+}
+
+pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> anyhow::Result<()> {
+    // Try to delete all nodes found in the config file + their associated processes
+    let nn: Vec<String> = {
+        let inner = &opts.config.inner();
+        inner.nodes.iter().map(|(name, _)| name.clone()).collect()
+    };
+    for node_name in nn.iter() {
+        delete_node(&opts, node_name, force)
+    }
+
+    // Try to delete dangling embedded nodes directories
+    let dirs = OckamConfigApi::directories();
+    let nodes_dir = dirs.data_local_dir();
+    if nodes_dir.exists() {
+        for entry in nodes_dir.read_dir()? {
+            let dir = entry?;
+            if !dir.file_type()?.is_dir() {
+                continue;
+            }
+            if let Some(dir_name) = dir.file_name().to_str() {
+                if !nn.contains(&dir_name.to_string()) {
+                    let _ = std::fs::remove_dir_all(dir.path());
+                }
+            }
+        }
+    }
+
+    // If force is enabled
+    if force {
+        // delete the config and nodes directories
+        opts.config.remove()?;
+        // and all dangling/orphan ockam processes
+        if let Ok(cpid) = get_current_pid() {
+            let s = System::new_all();
+            for (pid, process) in s.processes() {
+                if pid != &cpid && process.name() == "ockam" {
+                    process.kill();
+                }
+            }
+        }
+    } else if let Err(e) = opts.config.persist_config_updates() {
+        eprintln!("Failed to update config file. You might need to run the command with --force to delete all config directories");
+        return Err(e);
+    }
+    Ok(())
+}
+
+pub fn delete_node(opts: &CommandGlobalOpts, node_name: &str, sigkill: bool) {
+    trace!(%node_name, "Deleting node");
+
+    // We ignore the result of killing the node process as it could be not
+    // found (after a restart or if the user manually deleted it, for example).
+    let _ = delete_node_pid(opts, node_name, sigkill);
+
+    delete_node_config(opts, node_name);
+}
+
+fn delete_node_pid(opts: &CommandGlobalOpts, node_name: &str, sigkill: bool) -> anyhow::Result<()> {
+    trace!(%node_name, "Deleting node pid");
+    // Stop the process PID if it has one assigned in the config file
+    if let Some(pid) = opts.config.get_node_pid(node_name)? {
+        startup::stop(pid, sigkill)?;
+        // Give some room for the process to stop
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        // If it fails to bind, the port is still in use, so we try again to stop the process
+        let addr = format!("127.0.0.1:{}", opts.config.get_node_port(node_name));
+        if std::net::TcpListener::bind(&addr).is_err() {
+            startup::stop(pid, sigkill)?;
+        }
+    }
+    Ok(())
+}
+
+fn delete_node_config(opts: &CommandGlobalOpts, node_name: &str) {
+    trace!(%node_name, "Deleting node config");
+
+    // Try removing the node's directory.
+    // If the directory is not found, we ignore the result and continue.
+    let _ = opts
+        .config
+        .get_node_dir_raw(node_name)
+        .map(std::fs::remove_dir_all);
+
+    // Try removing the node's info from the config file.
+    opts.config.remove_node(node_name);
 }

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -1,0 +1,43 @@
+use crate::node::util::delete_all_nodes;
+use crate::CommandGlobalOpts;
+use clap::Args;
+use std::io::{self, BufReader, Read, Write};
+
+#[derive(Clone, Debug, Args)]
+pub struct ResetCommand {
+    #[clap(display_order = 901, long, short)]
+    yes: bool,
+}
+
+impl ResetCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        let _ = run_impl(options, self);
+    }
+}
+
+fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> crate::Result<()> {
+    if cmd.yes || get_user_confirmation() {
+        if let Err(e) = delete_all_nodes(opts, true) {
+            eprintln!("{}", e);
+            std::process::exit(crate::util::exitcode::IOERR);
+        }
+    }
+    Ok(())
+}
+
+fn get_user_confirmation() -> bool {
+    let prompt = "Please confirm the you really want a full reset (y/N) ";
+    print!("{}", prompt);
+    if io::stdout().flush().is_err() {
+        // If stdout wasn't flushed properly, fallback to println
+        println!("{}", prompt);
+    }
+    let stdin = BufReader::new(io::stdin());
+    stdin
+        .bytes()
+        .next()
+        .and_then(|c| c.ok())
+        .map(|c| c as char)
+        .map(|c| (c == 'y' || c == 'Y'))
+        .unwrap_or(false)
+}


### PR DESCRIPTION
# Added

new reset command that does the same `node delete --force --all`

# Output

![reset-impl](https://user-images.githubusercontent.com/38526063/189470806-161e04a4-e619-44f7-9997-c4b8289df666.gif)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
