### PR TITLE
WIP - fix(rust): do not skip starting services when node starts

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -91,7 +91,6 @@ pub struct NodeManager {
     transports: BTreeMap<Alias, (TransportType, TransportMode, String)>,
     tcp_transport: TcpTransport,
     pub(crate) controller_identity_id: IdentityIdentifier,
-    skip_defaults: bool,
     vault: Option<Vault>,
     identity: Option<Identity<Vault>>,
     authorities: Option<Authorities>,
@@ -208,7 +207,6 @@ impl NodeManager {
             transports,
             tcp_transport,
             controller_identity_id: Self::load_controller_identity_id()?,
-            skip_defaults,
             vault,
             identity,
             authorities: None,
@@ -490,11 +488,7 @@ impl Worker for NodeManager {
     type Context = Context;
 
     async fn initialize(&mut self, ctx: &mut Context) -> Result<()> {
-        if !self.skip_defaults {
-            self.initialize_defaults(ctx).await?;
-        }
-
-        Ok(())
+        self.initialize_defaults(ctx).await
     }
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Vec<u8>>) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -23,6 +23,8 @@ impl StartCommand {
 
         // First we check whether a PID was registered and if it is still alive.
         if let Ok(Some(pid)) = cfg.get_node_pid(&self.node_name) {
+            // Note: On CI where <defunct> processes can occur,
+            // the below `kill 0 pid` can imply a killed process is okay.
             let res = nix::sys::signal::kill(Pid::from_raw(pid), None);
 
             if res.is_ok() {

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -77,6 +77,21 @@ teardown() {
   assert_output "HELLO"
 }
 
+@test "create a node with a name, stop it, start it and send it a message" {
+  run $OCKAM node create n1
+  assert_success
+
+  run $OCKAM node stop n1
+  assert_success
+
+  run $OCKAM node start n1
+  assert_success
+
+  run $OCKAM message send "hello" --to /node/n1/service/uppercase
+  assert_success
+  assert_output "HELLO"
+}
+
 @test "create two nodes and send message from one to the other" {
   $OCKAM node create n1
   $OCKAM node create n2


### PR DESCRIPTION
## Current Behavior

- Issue #3234 found that when the `ockam` CLI is used to create, stop and then start a node, that node no longer responds to messages sent to its `uppercase` service.
- `ockam_api::NodeManager` only starts a node's default services if `skip_defaults` is `false`. When starting a node that has been stopped, `skip_defaults` is `true` (added in PR #3024).

[https://github.com/build-trust/ockam/blob/cbf0573a5bbaa1eb7a89486c235f877e49568891/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L492-L498](https://github.com/build-trust/ockam/blob/cbf0573a5bbaa1eb7a89486c235f877e49568891/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L492-L498)

[https://github.com/build-trust/ockam/blob/cbf0573a5bbaa1eb7a89486c235f877e49568891/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L255-L294](https://github.com/build-trust/ockam/blob/cbf0573a5bbaa1eb7a89486c235f877e49568891/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L255-L294)

## Proposed Changes

This assumes it is okay for `skip_defaults` to be ignored in this case. 
Is it okay? (@SanjoDeundiak, @mrinalwadhwa)

- Remove `skip_defaults` check, so `NodeManager` always starts a node's default services.
- Create test case in `ockam_command/tests/commands.bats` that fails without this PR.
- Because on CI machines killed processes sometimes do not disappear but are marked `<defunct>`, modify the `StopCommand` handler so that a stopped node's `pid` is removed from the config file, and hence the `StartCommand` handler does not have to rely on `kill 0 pid` to test if a process is alive. This was causing [https://github.com/build-trust/ockam/issues/3234#issuecomment-1217868771](https://github.com/build-trust/ockam/issues/3234#issuecomment-1217868771).
- Fixes #3234.

## Checks

- [x]  All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x]  All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x]  I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x]  I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.