### PR TITLE
feat(rust): add subscription command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -12,7 +12,13 @@ use crate::error::ApiError;
 pub mod enroll;
 pub mod project;
 pub mod space;
+pub mod subscription;
 
+/// If it's present, its contents will be used and will have priority over the contents
+/// from ./static/controller.id.
+///
+/// How to use: when running a command that spawns a background node or use an embedded node
+/// add the env variable. `OCKAM_CONTROLLER_IDENTITY_ID={identity.id-contents} ockam ...`
 pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY_ID";
 
 /// A wrapper around a cloud request with extra fields.

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -1,0 +1,215 @@
+use minicbor::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use ockam_core::CowStr;
+#[cfg(feature = "tag")]
+use ockam_core::TypeTag;
+
+#[derive(Encode, Decode, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct ActivateSubscription<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] pub tag: TypeTag<3888657>,
+    #[b(1)] pub space_id: Option<CowStr<'a>>,
+    #[b(2)] pub subscription_data: CowStr<'a>,
+    #[b(3)] pub space_name: Option<CowStr<'a>>,
+    #[b(4)] pub owner_emails: Option<Vec<CowStr<'a>>>,
+}
+
+impl<'a> ActivateSubscription<'a> {
+    /// Activates a subscription for an existing space
+    pub fn existing<S: Into<CowStr<'a>>>(space_id: S, subscription_data: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            space_id: Some(space_id.into()),
+            subscription_data: subscription_data.into(),
+            space_name: None,
+            owner_emails: None,
+        }
+    }
+
+    /// Activates a subscription for a space that will be newly created with the given space name
+    #[allow(unused)]
+    pub fn create<S: Into<CowStr<'a>>, T: AsRef<str>>(
+        space_name: S,
+        owner_emails: &'a [T],
+        subscription_data: S,
+    ) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            space_id: None,
+            subscription_data: subscription_data.into(),
+            space_name: Some(space_name.into()),
+            owner_emails: Some(
+                owner_emails
+                    .iter()
+                    .map(|x| CowStr::from(x.as_ref()))
+                    .collect(),
+            ),
+        }
+    }
+}
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[cbor(map)]
+pub struct Subscription<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)]
+    pub tag: TypeTag<3783606>,
+    #[b(1)]
+    #[serde(borrow)]
+    pub id: CowStr<'a>,
+    #[b(2)]
+    #[serde(borrow)]
+    marketplace: CowStr<'a>,
+    #[b(3)]
+    #[serde(borrow)]
+    pub status: CowStr<'a>,
+    #[b(4)]
+    #[serde(borrow)]
+    pub entitlements: CowStr<'a>,
+    #[b(5)]
+    #[serde(borrow)]
+    pub metadata: CowStr<'a>,
+    #[b(6)]
+    #[serde(borrow)]
+    pub contact_info: CowStr<'a>,
+    #[b(7)]
+    #[serde(borrow)]
+    pub space_id: Option<CowStr<'a>>,
+}
+
+mod node {
+    use minicbor::Decoder;
+    use tracing::trace;
+
+    use ockam_core::api::Request;
+    use ockam_core::{self, Result};
+    use ockam_node::Context;
+
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
+    use crate::nodes::NodeManager;
+
+    use super::*;
+
+    const TARGET: &str = "ockam_api::cloud::subscription";
+    const API_SERVICE: &str = "subscriptions";
+
+    impl NodeManager {
+        pub(crate) async fn activate_subscription(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<ActivateSubscription> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "activate_subscription";
+            trace!(target: TARGET, space_id = ?req_body.space_id, space_name = ?req_body.space_name, "activating subscription");
+
+            let req_builder = Request::post("/v0/activate").body(req_body);
+            self.request_controller(
+                ctx,
+                label,
+                "activate_request",
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+            )
+            .await
+        }
+
+        pub(crate) async fn get_subscription(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "get_subscription";
+            trace!(target: TARGET, subscription = %id, "getting subscription");
+
+            let req_builder = Request::get(format!("/v0/{}", id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn list_subscriptions(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "list_subscriptions";
+            trace!(target: TARGET, "listing subscriptions");
+
+            let req_builder = Request::get("/v0/");
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn update_subscription_contact_info(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "update_subscription_contact_info";
+            trace!(target: TARGET, subscription = %id, "updating subscription contact info");
+
+            let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn update_subscription_space(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "list_sbuscriptions";
+            trace!(target: TARGET, subscription = %id, "updating subscription space");
+
+            let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn unsubscribe(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "unsubscribe";
+            trace!(target: TARGET, subscription = %id, "unsubscribing");
+
+            let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -469,6 +469,18 @@ impl NodeManager {
                 self.authenticate_enrollment_token(ctx, dec).await?
             }
 
+            // ==*== Subscriptions ==*==
+            (Post, ["subscription"]) => self.activate_subscription(ctx, dec).await?,
+            (Get, ["subscription", id]) => self.get_subscription(ctx, dec, id).await?,
+            (Get, ["subscription"]) => self.list_subscriptions(ctx, dec).await?,
+            (Put, ["subscription", id, "contact_info"]) => {
+                self.update_subscription_contact_info(ctx, dec, id).await?
+            }
+            (Put, ["subscription", id, "space_id"]) => {
+                self.update_subscription_space(ctx, dec, id).await?
+            }
+            (Put, ["subscription", id, "unsubscribe"]) => self.unsubscribe(ctx, dec, id).await?,
+
             // ==*== Messages ==*==
             (Post, ["v0", "message"]) => self.send_message(ctx, req, dec).await?,
 

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -90,7 +90,7 @@ async fn default_space<'a>(
     // Get available spaces for node's identity
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
     let mut available_spaces = {
-        rpc.request(api::space::list(cloud_opts.route())).await?;
+        rpc.request(api::space::list(&cloud_opts.route())).await?;
         rpc.parse_response::<Vec<Space>>()?
     };
     // If the identity has no spaces, create one
@@ -137,7 +137,7 @@ async fn default_project<'a>(
     // Get available project for the given space
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
     let mut available_projects: Vec<Project> = {
-        rpc.request(api::project::list(cloud_opts.route())).await?;
+        rpc.request(api::project::list(&cloud_opts.route())).await?;
         rpc.parse_response::<Vec<Project>>()?
     };
     // If the space has no projects, create one
@@ -146,7 +146,7 @@ async fn default_project<'a>(
         rpc.request(api::project::create(
             "default",
             &space.id,
-            cloud_opts.route(),
+            &cloud_opts.route(),
         ))
         .await?;
         rpc.parse_response::<Project>()?.to_owned()

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -67,7 +67,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) 
             ctx,
             opts,
             &meta,
-            &cmd.cloud_opts.route_to_controller,
+            &cmd.cloud_opts.route(),
             api_node,
             Some(&tcp),
             credentials_exchange_mode,

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -63,7 +63,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             ctx,
             opts,
             &meta,
-            &cmd.cloud_opts.route_to_controller,
+            &cmd.cloud_opts.route(),
             &api_node,
             tcp.as_ref(),
             CredentialExchangeMode::None,

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -49,14 +49,14 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
 ) -> crate::Result<()> {
-    let space_id = space::config::get_space(&opts.config, &cmd.space_name)
+    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)
         .context(format!("Space '{}' does not exist", cmd.space_name))?;
     let node_name = start_embedded_node(ctx, &opts.config).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::create(
         &cmd.project_name,
         &space_id,
-        cmd.cloud_opts.route(),
+        &cmd.cloud_opts.route(),
     ))
     .await?;
     let project = rpc.parse_response::<Project>()?;

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -42,11 +42,11 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
 ) -> crate::Result<()> {
-    let space_id = space::config::get_space(&opts.config, &cmd.space_name)
+    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)
         .context(format!("Space '{}' does not exist", cmd.space_name))?;
 
     let node_name = start_embedded_node(ctx, &opts.config).await?;
-    let controller_route = cmd.cloud_opts.route();
+    let controller_route = &cmd.cloud_opts.route();
 
     // Try to remove from config, in case the project was removed from the cloud but not from the config file.
     let _ = config::remove_project(&opts.config, &cmd.project_name);

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -46,7 +46,7 @@ async fn rpc(
             opts,
             &tcp,
             &meta,
-            &cmd.cloud_opts.route_to_controller,
+            &cmd.cloud_opts.route(),
             &cmd.node_opts.api_node,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -61,14 +61,14 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: InfoCommand,
 ) -> crate::Result<()> {
-    let controller_route = cmd.cloud_opts.route();
+    let controller_route = &cmd.cloud_opts.route();
     let node_name = start_embedded_node(ctx, &opts.config).await?;
 
     // Lookup project
     let id = match config::get_project(&opts.config, &cmd.name) {
         Some(id) => id,
         None => {
-            config::refresh_projects(ctx, &opts, &node_name, cmd.cloud_opts.route(), None).await?;
+            config::refresh_projects(ctx, &opts, &node_name, &cmd.cloud_opts.route(), None).await?;
             config::get_project(&opts.config, &cmd.name)
                 .context(format!("Project '{}' does not exist", cmd.name))?
         }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -32,7 +32,7 @@ async fn run_impl(
     cmd: ListCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
-    rpc.request(api::project::list(cmd.cloud_opts.route()))
+    rpc.request(api::project::list(&cmd.cloud_opts.route()))
         .await?;
     let projects = rpc.parse_and_print_response::<Vec<Project>>()?;
     config::set_projects(&opts.config, &projects).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -36,14 +36,14 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ShowCommand,
 ) -> crate::Result<()> {
-    let controller_route = cmd.cloud_opts.route();
+    let controller_route = &cmd.cloud_opts.route();
     let node_name = start_embedded_node(ctx, &opts.config).await?;
 
     // Lookup project
     let id = match config::get_project(&opts.config, &cmd.name) {
         Some(id) => id,
         None => {
-            config::refresh_projects(ctx, &opts, &node_name, cmd.cloud_opts.route(), None).await?;
+            config::refresh_projects(ctx, &opts, &node_name, &cmd.cloud_opts.route(), None).await?;
             config::get_project(&opts.config, &cmd.name)
                 .context(format!("Project '{}' does not exist", cmd.name))?
         }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -138,7 +138,7 @@ pub async fn check_project_readiness<'a>(
 ) -> Result<Project<'a>> {
     if !project.is_ready() {
         print!("\nProject created. Waiting until it's operative...");
-        let cloud_route = cloud_opts.route();
+        let cloud_route = &cloud_opts.route();
         loop {
             print!(".");
             std::io::stdout().flush()?;
@@ -218,14 +218,17 @@ pub async fn check_project_readiness<'a>(
 }
 
 pub mod config {
+    use crate::util::output::Output;
     use ockam::{identity::PublicIdentity, Context};
     use ockam_api::config::lookup::ProjectAuthority;
     use ockam_vault::Vault;
+    use tracing::trace;
 
     use super::*;
 
     async fn set(config: &OckamConfig, project: &Project<'_>) -> Result<()> {
         if !project.is_ready() {
+            trace!("Project is not ready yet {}", project.output()?);
             return Err(anyhow!(
                 "Project is not ready yet, wait a few seconds and try again"
             ));

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -31,7 +31,7 @@ async fn run_impl(
     cmd: ListCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
-    rpc.request(api::space::list(cmd.cloud_opts.route()))
+    rpc.request(api::space::list(&cmd.cloud_opts.route()))
         .await?;
     let spaces = rpc.parse_and_print_response::<Vec<Space>>()?;
     config::set_spaces(&opts.config, &spaces)?;

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use clap::Args;
 
 use ockam::Context;
@@ -36,17 +35,10 @@ async fn run_impl(
     cmd: ShowCommand,
 ) -> crate::Result<()> {
     let node_name = start_embedded_node(ctx, &opts.config).await?;
-    let controller_route = cmd.cloud_opts.route();
+    let controller_route = &cmd.cloud_opts.route();
 
     // Lookup space
-    let id = match config::get_space(&opts.config, &cmd.name) {
-        Some(id) => id,
-        None => {
-            config::refresh_spaces(ctx, &opts, &node_name, cmd.cloud_opts.route()).await?;
-            config::get_space(&opts.config, &cmd.name)
-                .context(format!("Space '{}' does not exist", cmd.name))?
-        }
-    };
+    let id = config::get_space(ctx, &opts, &cmd.name, &node_name, &cmd.cloud_opts.route()).await?;
 
     // Send request
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -1,0 +1,347 @@
+use anyhow::{anyhow, Context as _};
+use core::fmt::Write;
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use ockam::Context;
+use ockam_api::cloud::subscription::{ActivateSubscription, Subscription};
+use ockam_api::cloud::CloudRequestWrapper;
+use ockam_core::api::Request;
+use ockam_core::CowStr;
+use ockam_multiaddr::MultiAddr;
+
+use crate::node::util::delete_embedded_node;
+use crate::util::api::CloudOpts;
+use crate::util::output::Output;
+use crate::util::{node_rpc, Rpc, RpcBuilder};
+use crate::{help, CommandGlobalOpts};
+
+const HELP_DETAIL: &str = "";
+
+#[derive(Clone, Debug, Args)]
+#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+pub struct SubscriptionCommand {
+    #[clap(subcommand)]
+    subcommand: SubscriptionSubcommand,
+
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SubscriptionSubcommand {
+    /// Attach a subscription to a space
+    Attach {
+        /// Path to the AWS json file with subscription details
+        json: PathBuf,
+
+        /// Space ID to attach the subscription to
+        #[clap(
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: String,
+    },
+
+    /// Show the details of a single subscription.
+    /// You can use either the subscription ID or the space ID.
+    Show {
+        /// Subscription ID
+        #[clap(group = "id")]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+    },
+
+    /// Show the details of all subscriptions
+    List,
+
+    /// Disable a subscription.
+    /// You can use either the subscription ID or the space ID.
+    Unsubscribe {
+        /// Subscription ID
+        #[clap(group = "id")]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+    },
+
+    Update(SubscriptionUpdate),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SubscriptionUpdate {
+    #[clap(subcommand)]
+    subcommand: SubscriptionUpdateSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum SubscriptionUpdateSubcommand {
+    /// Update the contact info of a subscription.
+    /// You can use either the subscription ID or the space ID.
+    ContactInfo {
+        /// Path to the AWS json file with contact info details
+        json: PathBuf,
+
+        /// Subscription ID
+        #[clap(
+            group = "id",
+            name = "subscription",
+            value_name = "SUBSCRIPTION_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+    },
+
+    /// Move the subscription to a different space.
+    /// You can use either the subscription ID or the space ID.
+    Space {
+        /// Subscription ID
+        #[clap(
+            group = "id",
+            name = "subscription",
+            value_name = "SUBSCRIPTION_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "current_space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+
+        /// Space ID to move subscription to
+        new_space_id: String,
+    },
+}
+
+impl SubscriptionCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
+) -> crate::Result<()> {
+    let controller_route = &cmd.cloud_opts.route();
+    let mut rpc = Rpc::embedded(&ctx, &opts).await?;
+    match cmd.subcommand {
+        SubscriptionSubcommand::Attach {
+            json,
+            space_id: space,
+        } => {
+            let json =
+                std::fs::read_to_string(&json).context(format!("failed to read {:?}", &json))?;
+            let b = ActivateSubscription::existing(space, json);
+            let req =
+                Request::post("subscription").body(CloudRequestWrapper::new(b, controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Subscription>()?;
+        }
+        SubscriptionSubcommand::Show {
+            subscription_id,
+            space_id,
+        } => {
+            let subscription_id = subscription_id_from_cmd_args(
+                &ctx,
+                &opts,
+                rpc.node_name(),
+                controller_route,
+                subscription_id,
+                space_id,
+            )
+            .await?;
+            let req = Request::get(format!("subscription/{}", subscription_id))
+                .body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Subscription>()?;
+        }
+        SubscriptionSubcommand::List => {
+            let req =
+                Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Vec<Subscription>>()?;
+        }
+        SubscriptionSubcommand::Unsubscribe {
+            subscription_id,
+            space_id,
+        } => {
+            let subscription_id = subscription_id_from_cmd_args(
+                &ctx,
+                &opts,
+                rpc.node_name(),
+                controller_route,
+                subscription_id,
+                space_id,
+            )
+            .await?;
+            let req = Request::put(format!("subscription/{}/unsubscribe", subscription_id))
+                .body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Subscription>()?;
+        }
+        SubscriptionSubcommand::Update(c) => {
+            let SubscriptionUpdate { subcommand: sc } = c;
+            match sc {
+                SubscriptionUpdateSubcommand::ContactInfo {
+                    json,
+                    space_id,
+                    subscription_id,
+                } => {
+                    let json = std::fs::read_to_string(&json)
+                        .context(format!("failed to read {:?}", &json))?;
+                    let subscription_id = subscription_id_from_cmd_args(
+                        &ctx,
+                        &opts,
+                        rpc.node_name(),
+                        controller_route,
+                        subscription_id,
+                        space_id,
+                    )
+                    .await?;
+                    let req =
+                        Request::put(format!("subscription/{}/contact_info", subscription_id))
+                            .body(CloudRequestWrapper::new(json, controller_route));
+                    rpc.request(req).await?;
+                    rpc.parse_and_print_response::<Subscription>()?;
+                }
+                SubscriptionUpdateSubcommand::Space {
+                    subscription_id,
+                    space_id,
+                    new_space_id,
+                } => {
+                    let subscription_id = subscription_id_from_cmd_args(
+                        &ctx,
+                        &opts,
+                        rpc.node_name(),
+                        controller_route,
+                        subscription_id,
+                        space_id,
+                    )
+                    .await?;
+                    let req = Request::put(format!("subscription/{}/space_id", subscription_id))
+                        .body(CloudRequestWrapper::new(new_space_id, controller_route));
+                    rpc.request(req).await?;
+                    rpc.parse_and_print_response::<Subscription>()?;
+                }
+            }
+        }
+    };
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
+    Ok(())
+}
+
+async fn subscription_id_from_cmd_args(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    api_node: &str,
+    controller_route: &MultiAddr,
+    subscription_id: Option<String>,
+    space_id: Option<String>,
+) -> crate::Result<String> {
+    match (subscription_id, space_id) {
+        (_, Some(space_id)) => {
+            subscription_id_from_space_id(ctx, opts, api_node, controller_route, &space_id).await
+        }
+        (Some(subscription_id), _) => Ok(subscription_id),
+        _ => unreachable!(),
+    }
+}
+
+async fn subscription_id_from_space_id(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    api_node: &str,
+    controller_route: &MultiAddr,
+    space_id: &str,
+) -> crate::Result<String> {
+    let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
+    let req = Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
+    rpc.request(req).await?;
+    let subscriptions = rpc.parse_response::<Vec<Subscription>>()?;
+    let subscription = subscriptions
+        .into_iter()
+        .find(|s| s.space_id == Some(CowStr::from(space_id)))
+        .ok_or_else(|| anyhow!("no subscription found for space {}", space_id))?;
+    Ok(subscription.id.to_string())
+}
+
+impl Output for Subscription<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut w = String::new();
+        write!(w, "Subscription")?;
+        write!(w, "\n  Id: {}", self.id)?;
+        write!(w, "\n  Status: {}", self.status)?;
+        write!(
+            w,
+            "\n  Space id: {}",
+            self.space_id.as_ref().unwrap_or(&CowStr::from("N/A"))
+        )?;
+        write!(w, "\n  Entitlements: {}", self.entitlements.as_ref())?;
+        write!(w, "\n  Metadata: {}", self.metadata.as_ref())?;
+        write!(w, "\n  Contact info: {}", self.contact_info.as_ref())?;
+        Ok(w)
+    }
+}
+
+impl<'a> Output for Vec<Subscription<'a>> {
+    fn output(&self) -> anyhow::Result<String> {
+        if self.is_empty() {
+            return Ok("No subscriptions found".to_string());
+        }
+        let mut w = String::new();
+        for (idx, s) in self.iter().enumerate() {
+            write!(w, "\n{idx}:")?;
+            write!(w, "\n  Id: {}", s.id)?;
+            write!(w, "\n  Status: {}", s.status)?;
+            write!(
+                w,
+                "\n  Space id: {}",
+                s.space_id.as_ref().unwrap_or(&CowStr::from("N/A"))
+            )?;
+            write!(w, "\n  Entitlements: {}", s.entitlements.as_ref())?;
+            write!(w, "\n  Metadata: {}", s.metadata.as_ref())?;
+            write!(w, "\n  Contact info: {}", s.contact_info.as_ref())?;
+            writeln!(w)?;
+        }
+        Ok(w)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -1,10 +1,13 @@
 //! API shim to make it nicer to interact with the ockam messaging API
 
-use crate::util::DEFAULT_ORCHESTRATOR_ADDRESS;
+use std::str::FromStr;
+
+use anyhow::Context;
+use clap::Args;
 // TODO: maybe we can remove this cross-dependency inside the CLI?
 use minicbor::Decoder;
+use tracing::trace;
 
-use clap::Args;
 use ockam::identity::IdentityIdentifier;
 use ockam::Result;
 use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
@@ -14,6 +17,8 @@ use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
 use ockam_core::Address;
 use ockam_multiaddr::MultiAddr;
+
+use crate::util::DEFAULT_CONTROLLER_ADDRESS;
 
 ////////////// !== generators
 
@@ -215,11 +220,13 @@ pub(crate) fn start_authenticated_service(addr: &str) -> Result<Vec<u8>> {
 }
 
 pub(crate) mod credentials {
-    use super::*;
     use hex::FromHexError;
+
     use ockam_api::nodes::models::credentials::{
         GetCredentialRequest, PresentCredentialRequest, SetAuthorityRequest,
     };
+
+    use super::*;
 
     pub(crate) fn present_credential(
         to: &MultiAddr,
@@ -249,8 +256,9 @@ pub(crate) mod credentials {
 
 /// Helpers to create enroll API requests
 pub(crate) mod enroll {
-    use crate::enroll::*;
     use ockam_api::cloud::enroll::auth0::{Auth0Token, AuthenticateAuth0Token};
+
+    use crate::enroll::*;
 
     use super::*;
 
@@ -260,20 +268,21 @@ pub(crate) mod enroll {
     ) -> RequestBuilder<CloudRequestWrapper<AuthenticateAuth0Token>> {
         let token = AuthenticateAuth0Token::new(token);
         Request::post("v0/enroll/auth0")
-            .body(CloudRequestWrapper::new(token, cmd.cloud_opts.route()))
+            .body(CloudRequestWrapper::new(token, &cmd.cloud_opts.route()))
     }
 }
 
 /// Helpers to create spaces API requests
 pub(crate) mod space {
-    use crate::space::*;
     use ockam_api::cloud::space::*;
+
+    use crate::space::*;
 
     use super::*;
 
     pub(crate) fn create(cmd: &CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
         let b = CreateSpace::new(cmd.name.as_str(), &cmd.admins);
-        Request::post("v0/spaces").body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
+        Request::post("v0/spaces").body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
     }
 
     pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
@@ -297,8 +306,9 @@ pub(crate) mod space {
 
 /// Helpers to create projects API requests
 pub(crate) mod project {
-    use crate::project::*;
     use ockam_api::cloud::project::*;
+
+    use crate::project::*;
 
     use super::*;
 
@@ -340,14 +350,14 @@ pub(crate) mod project {
             cmd.description.as_deref(),
         );
         Request::post(format!("v0/project-enrollers/{}", cmd.project_id))
-            .body(CloudRequestWrapper::new(b, cmd.cloud_opts.route()))
+            .body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
     }
 
     pub(crate) fn list_enrollers(
         cmd: &ListEnrollersCommand,
     ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::get(format!("v0/project-enrollers/{}", cmd.project_id))
-            .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+            .body(CloudRequestWrapper::bare(&cmd.cloud_opts.route()))
     }
 
     pub(crate) fn delete_enroller(
@@ -357,7 +367,7 @@ pub(crate) mod project {
             "v0/project-enrollers/{}/{}",
             cmd.project_id, cmd.enroller_identity_id
         ))
-        .body(CloudRequestWrapper::bare(cmd.cloud_opts.route()))
+        .body(CloudRequestWrapper::bare(&cmd.cloud_opts.route()))
     }
 }
 
@@ -442,15 +452,21 @@ pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Resu
 
 ////////////// !== share CLI args
 
+pub(crate) const OCKAM_CONTROLLER_ADDR: &str = "OCKAM_CONTROLLER_ADDR";
+
 #[derive(Clone, Debug, Args)]
-pub struct CloudOpts {
-    /// Ockam orchestrator address
-    #[clap(global = true, hide = true, default_value = DEFAULT_ORCHESTRATOR_ADDRESS)]
-    pub route_to_controller: MultiAddr,
-}
+pub struct CloudOpts;
 
 impl CloudOpts {
-    pub fn route(&self) -> &MultiAddr {
-        &self.route_to_controller
+    pub fn route(&self) -> MultiAddr {
+        let route = if let Ok(s) = std::env::var(OCKAM_CONTROLLER_ADDR) {
+            s
+        } else {
+            DEFAULT_CONTROLLER_ADDRESS.to_string()
+        };
+        trace!(%route, "Controller route");
+        MultiAddr::from_str(&route)
+            .context(format!("invalid Controller route: {route}"))
+            .unwrap()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -12,7 +12,13 @@ impl Version {
             "{}\n\nCompiled from (git hash): {}",
             crate_version, git_hash
         );
+        Box::leak(message.into_boxed_str())
+    }
 
+    pub(crate) fn short() -> &'static str {
+        let crate_version = crate_version!();
+        let git_hash = env!("GIT_HASH");
+        let message = format!("Version {crate_version}, hash: {git_hash}");
         Box::leak(message.into_boxed_str())
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -3,11 +3,7 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = [
-        "--test-argument-parser",
-        "enroll",
-        "/dnsaddr/cloud.ockam.io/tcp/62526",
-    ];
+    let prefix_args = ["--test-argument-parser", "enroll"];
 
     // auth0
     let mut cmd = Command::cargo_bin("ockam")?;

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -4,36 +4,30 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "project"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-name")
         .arg("project-name")
-        .args(common_args)
         .arg("--")
         .arg("service-a")
         .arg("service-b");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list").args(common_args);
+    cmd.args(&prefix_args).arg("list");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("show")
-        .arg("project-id")
-        .args(common_args);
+    cmd.args(&prefix_args).arg("show").arg("project-id");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("delete")
         .arg("space-name")
-        .arg("project-id")
-        .args(common_args);
+        .arg("project-id");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_space.rs
@@ -4,33 +4,25 @@ use std::process::Command;
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prefix_args = ["--test-argument-parser", "space"];
-    let common_args = ["/dnsaddr/localhost/tcp/4000"];
 
     let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(&prefix_args)
         .arg("create")
         .arg("space-name")
-        .args(common_args)
         .arg("--")
         .arg("extra-user");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args).arg("list").args(common_args);
+    cmd.args(&prefix_args).arg("list");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("show")
-        .arg("space-id")
-        .args(common_args);
+    cmd.args(&prefix_args).arg("show").arg("space-id");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(&prefix_args)
-        .arg("delete")
-        .arg("space-id")
-        .args(common_args);
+    cmd.args(&prefix_args).arg("delete").arg("space-id");
     cmd.assert().success();
 
     Ok(())

--- a/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_bytes.rs
+++ b/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_bytes.rs
@@ -3,15 +3,23 @@ use crate::compat::vec::Vec;
 
 use core::ops::Deref;
 use minicbor::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 /// A new type around `Cow<'_, [u8]>` that borrows from input.
 ///
 /// Contrary to `Cow<_, [u8]>` the `Decode` impl for this type will always borrow
 /// from input so using it in types like `Option`, `Vec<_>` etc will not produce
 /// owned element values.
-#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, Encode, Decode, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[cbor(transparent)]
-pub struct CowBytes<'a>(#[cbor(b(0), with = "minicbor::bytes")] pub Cow<'a, [u8]>);
+#[serde(transparent)]
+pub struct CowBytes<'a>(
+    #[cbor(b(0), with = "minicbor::bytes")]
+    #[serde(borrow)]
+    pub Cow<'a, [u8]>,
+);
 
 impl CowBytes<'_> {
     /// Returns true if the data is borrowed, i.e. if to_mut would require additional work.

--- a/implementations/rust/ockam/ockam_core/src/schema.cddl
+++ b/implementations/rust/ockam/ockam_core/src/schema.cddl
@@ -235,3 +235,13 @@ add_member = {
     ?0: 2820828,
      1: identity_id,
 }
+
+;;; Subscription ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+activate_request = {
+    ?0: 3888657,
+     1: text,       ;; space_id
+     2: text,       ;; subscription_data
+     3: text,       ;; space_name
+     4: [+ text]    ;; owner_emails
+}


### PR DESCRIPTION
https://github.com/build-trust/ockam-cloud/pull/206

Note: we may want to remove all commands/services except `activate subscription`. Show, list, update, unsubscribe won't be used directly by the end user.

* Accept either `subscription_id` `space_id`: `ockam subscription show $subscription_id` OR `ockam subscription show --space $space_id`. When a `space_id` is passed, the command fetches all available subscriptions to infer the `subscription_id`
* `CloudOpts` now reads the controller route from the `OCKAM_CONTROLLER_ADDR` env variable, and it defaults to `/dnsaddr/orchestrator.ockam.io/tcp/6252/service/api` as before

Examples of usage:

```bash
# Activate the subscription
$ ockam subscription attach $path-to-json-file --space $space-id
Subscription
  Id: something_blah
  Status: active
  Space id: 2fdfd4f6-5bf0-41f6-b1c8-fae39a87dd22
  Entitlements: {...}
  Metadata: {...}
  Contact info: {...}

# Show the subscription
$ ockam subscription show something_blah
... # same output as before

# List all subscriptions
$ ockam subscription list
0: 
  Id: ftcBt8bf6xK_9j88v7cw7hsnx3jwcacyzh5hn
  Status: pending
  Space id: N/A
  Entitlements: {...}
  Metadata: {...}
  Contact info: {...}

1: 
  Id: something_blah
  Status: active
  Space id: 2fdfd4f6-5bf0-41f6-b1c8-fae39a87dd22
  Entitlements: {...}
  Metadata: {...}
  Contact info: {...}
```