### PR TITLE
ci(rust): make cargo-target cache also dependent on rustc version

### DIFF
--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -3,10 +3,12 @@ description: CARGO_TARGET_DIR Cache
 runs:
   using: "composite"
   steps:
+    - run: rustc --version > rustc_version.txt && cat rustc_version.txt
+      shell: bash
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc-${{ hashFiles('**/Cargo.lock') }}
+        key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('./rustc_version.txt') }}
         restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -187,11 +187,11 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           ref: ${{ github.event.inputs.commit_sha }}
+      - run: rustup default nightly
+      - run: rustup update nightly
       - uses: ./.github/actions/gradle_cache
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
-      - run: rustup default nightly
-      - run: rustup update nightly
       - run: RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
@@ -204,11 +204,11 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           ref: ${{ github.event.inputs.commit_sha }}
+      - run: rustup default nightly
+      - run: rustup update nightly
       - uses: ./.github/actions/gradle_cache
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
-      - run: rustup default nightly
-      - run: rustup update nightly
       - run: cd implementations/rust && ../../gradlew build
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
@@ -221,11 +221,11 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           ref: ${{ github.event.inputs.commit_sha }}
+      - run: rustup default nightly
+      - run: rustup update nightly
       - uses: ./.github/actions/gradle_cache
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
-      - run: rustup default nightly
-      - run: rustup update nightly
       - run: cd implementations/rust && ../../gradlew test
         env:
           NIGHTLY_CI: 1


### PR DESCRIPTION
## Current Behavior

* The `cargo-target` cache aims to allow previously compiled Rust components to be reused and reduce compilation time. 
* The cache key is such that caches are not updated when `rustc` is updated.
* This is okay for jobs that use rust stable, but for jobs that use rust nightly, it appears, the regular update of the compiler causes those jobs to often re-compile Ockam's dependencies.

* See #3180.

## Proposed Changes

* Make cache key for `cargo-target` also dependent on  version of `rustc`.

* To do this, `rustup` commands need to be executed before the cache key is calculated by `./.github/actions/cargo_target_dir_cache`.

* Below are new example keys for jobs `Rust - Test` and `Rust - Nightly Test` of the `Rust` workflow. 

> cache-cargo-target-`Rust`-`test`-ghcr.io/build-trust/ockam-builder@sha256:`e43dd`94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc-`bb4d9`732ca9adc221394c6a3dd81bf9e1b1a5f02f5295601616bbe8566835a8e-`507d5`52b127d9150cea6d7bdfd3217277f5a9df97b8e3b311d2c229d381e03c3

> cache-cargo-target-`Rust`-`test_nightly`-ghcr.io/build-trust/ockam-builder@sha256:`e43dd`94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc-`bb4d9`732ca9adc221394c6a3dd81bf9e1b1a5f02f5295601616bbe8566835a8e-`e7a1f`9fced36bc53c690f650f8ce2e378fd7c650cab8ad2e7ac1278325ed7a6f

Now `cargo-target` caches are now unique for each...
* Workflow (here `Rust`)
* Job (here `test` and `test_nightly`)
* `ockam-builder` docker image (here `e43dd...`)
* Hash of `Cargo.lock` files (here `bb4d9...`)
* Hash of `rustc --version` output (here `507d5...` and `e7a1f...`)

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
