### PR TITLE
feat(rust): clear node's pid in config file on stopcommand

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -23,6 +23,8 @@ impl StartCommand {
 
         // First we check whether a PID was registered and if it is still alive.
         if let Ok(Some(pid)) = cfg.get_node_pid(&self.node_name) {
+            // Note: On CI machines where <defunct> processes can occur,
+            // the below `kill 0 pid` can imply a killed process is okay.
             let res = nix::sys::signal::kill(Pid::from_raw(pid), None);
 
             if res.is_ok() {

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -27,6 +27,19 @@ impl StopCommand {
                 if let Err(e) = startup::stop(pid, self.force) {
                     eprintln!("{e:?}");
                     std::process::exit(exitcode::OSERR);
+                } else {
+                    // Clear pid in config, so StartCommand does not have to rely on
+                    // `kill 0 pid` to detect if a node is running.
+                    if let Err(e) = cfg.set_node_pid(&self.node_name, None) {
+                        eprintln!("Failed to update pid for node {}: {}", &self.node_name, e);
+                        std::process::exit(exitcode::IOERR);
+                    }
+
+                    // Save the config update
+                    if let Err(e) = cfg.persist_config_updates() {
+                        eprintln!("Failed to update configuration: {}", e);
+                        std::process::exit(exitcode::IOERR);
+                    }
                 }
             }
             Ok(_) => {


### PR DESCRIPTION
## Current Behavior

* On CI machines, when a node's process is sent `SIGTERM` or `SIGINT` the process does not disappear but can remain as `<defunct>`.
* This caused `StartCommand` to erroneously think a node was running because `kill(pid, None)` returned `Ok()`. 

https://github.com/build-trust/ockam/blob/ca41fd401736abde52bf349709349866a8b1d665/implementations/rust/ockam/ockam_command/src/node/start.rs#L20-L35

* See #3234 and #3456.
* Also see [What is a `<defunct>` process, and why doesn't it get killed?](https://askubuntu.com/questions/201303/what-is-a-defunct-process-and-why-doesnt-it-get-killed).

## Proposed Changes

* On running `StopCommand` and after a node is sent a `SIGTERM` or `SIGINT`, remove the node's pid from the config file.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
