### PR TITLE
fix(rust): set project data into the lookup table when creating a node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -14,7 +14,7 @@ use ockam_node::tokio;
 use crate::error::ApiError;
 use crate::multiaddr_to_addr;
 
-#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Default)]
 #[cbor(map)]
 pub struct Project<'a> {
     #[cfg(feature = "tag")]
@@ -40,7 +40,7 @@ pub struct Project<'a> {
 
     #[cbor(b(5))]
     #[serde(borrow)]
-    pub access_route: CowStr<'a>, //TODO: should be optional, waiting for changes on the elixir side
+    pub access_route: CowStr<'a>,
 
     #[cbor(b(6))]
     #[serde(borrow)]

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -28,7 +28,11 @@ pub struct InfoCommand {
 pub struct ProjectInfo<'a> {
     #[serde(borrow)]
     pub id: CowStr<'a>,
+    #[serde(borrow)]
+    pub name: CowStr<'a>,
     pub identity: Option<IdentityIdentifier>,
+    #[serde(borrow)]
+    pub access_route: CowStr<'a>,
     #[serde(borrow)]
     pub authority_access_route: Option<CowStr<'a>>,
     #[serde(borrow)]
@@ -39,9 +43,25 @@ impl<'a> From<Project<'a>> for ProjectInfo<'a> {
     fn from(p: Project<'a>) -> Self {
         Self {
             id: p.id,
+            name: p.name,
             identity: p.identity,
+            access_route: p.access_route,
             authority_access_route: p.authority_access_route,
             authority_identity: p.authority_identity,
+        }
+    }
+}
+
+impl<'a> From<&ProjectInfo<'a>> for Project<'a> {
+    fn from(p: &ProjectInfo<'a>) -> Self {
+        Project {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            identity: p.identity.clone(),
+            access_route: p.access_route.clone(),
+            authority_access_route: p.authority_access_route.clone(),
+            authority_identity: p.authority_identity.clone(),
+            ..Default::default()
         }
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
+++ b/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 /// Contrary to `Cow<_, str>` the `Decode` impl for this type will always borrow
 /// from input so using it in types like `Option`, `Vec<_>` etc will not produce
 /// owned element values.
-#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, Encode, Decode, Serialize, Deserialize, Eq, PartialOrd, Ord, Hash, Default,
+)]
 #[cbor(transparent)]
 #[serde(transparent)]
 pub struct CowStr<'a>(


### PR DESCRIPTION
When creating a node with the `--project` argument, a json file was loaded and parsed as an instance of `ProjectInfo` to set up the project authority. This object is now also used to add the project data to the node's config lookup table, so the user can later use `/project/<name>` routes. Additionally, `ProjectInfo` now includes the project's `name` and `access_route`.