### PR TITLE
feat(rust): move admin-only subscription commands under `ockam admin` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/mod.rs
@@ -1,0 +1,32 @@
+use clap::{Args, Subcommand};
+
+use crate::util::api::CloudOpts;
+use crate::{help, CommandGlobalOpts};
+
+mod subscription;
+
+const HELP_DETAIL: &str = "";
+
+#[derive(Clone, Debug, Args)]
+#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+pub struct AdminCommand {
+    #[clap(subcommand)]
+    pub subcommand: AdminSubCommand,
+
+    #[clap(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum AdminSubCommand {
+    #[clap(display_order = 800)]
+    Subscription(subscription::SubscriptionCommand),
+}
+
+impl AdminCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            AdminSubCommand::Subscription(c) => c.run(options),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -1,0 +1,232 @@
+use anyhow::Context as _;
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use ockam::Context;
+use ockam_api::cloud::subscription::{ActivateSubscription, Subscription};
+use ockam_api::cloud::CloudRequestWrapper;
+use ockam_core::api::Request;
+
+use crate::node::util::delete_embedded_node;
+use crate::subscription::utils;
+use crate::util::api::CloudOpts;
+use crate::util::{node_rpc, Rpc};
+use crate::{help, CommandGlobalOpts};
+
+const HELP_DETAIL: &str = "";
+
+#[derive(Clone, Debug, Args)]
+#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+pub struct SubscriptionCommand {
+    #[clap(subcommand)]
+    subcommand: SubscriptionSubcommand,
+
+    #[clap(flatten)]
+    cloud_opts: CloudOpts,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SubscriptionSubcommand {
+    /// Attach a subscription to a space
+    Attach {
+        /// Path to the AWS json file with subscription details
+        json: PathBuf,
+
+        /// Space ID to attach the subscription to
+        #[clap(
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: String,
+    },
+
+    /// Show the details of all subscriptions
+    List,
+
+    /// Disable a subscription.
+    /// You can use either the subscription ID or the space ID.
+    Unsubscribe {
+        /// Subscription ID
+        #[clap(group = "id")]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+    },
+
+    /// Update a subscription
+    Update(SubscriptionUpdate),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct SubscriptionUpdate {
+    #[clap(subcommand)]
+    subcommand: SubscriptionUpdateSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum SubscriptionUpdateSubcommand {
+    /// Update the contact info of a subscription.
+    /// You can use either the subscription ID or the space ID.
+    ContactInfo {
+        /// Path to the AWS json file with contact info details
+        json: PathBuf,
+
+        /// Subscription ID
+        #[clap(
+            group = "id",
+            name = "subscription",
+            value_name = "SUBSCRIPTION_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+    },
+
+    /// Move the subscription to a different space.
+    /// You can use either the subscription ID or the space ID.
+    Space {
+        /// Subscription ID
+        #[clap(
+            group = "id",
+            name = "subscription",
+            value_name = "SUBSCRIPTION_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        subscription_id: Option<String>,
+
+        /// Space ID
+        #[clap(
+            group = "id",
+            name = "current_space",
+            value_name = "SPACE_ID",
+            long,
+            forbid_empty_values = true
+        )]
+        space_id: Option<String>,
+
+        /// Space ID to move subscription to
+        new_space_id: String,
+    },
+}
+
+impl SubscriptionCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
+) -> crate::Result<()> {
+    let controller_route = &cmd.cloud_opts.route();
+    let mut rpc = Rpc::embedded(&ctx, &opts).await?;
+    match cmd.subcommand {
+        SubscriptionSubcommand::Attach {
+            json,
+            space_id: space,
+        } => {
+            let json =
+                std::fs::read_to_string(&json).context(format!("failed to read {:?}", &json))?;
+            let b = ActivateSubscription::existing(space, json);
+            let req =
+                Request::post("subscription").body(CloudRequestWrapper::new(b, controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Subscription>()?;
+        }
+        SubscriptionSubcommand::List => {
+            let req =
+                Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Vec<Subscription>>()?;
+        }
+        SubscriptionSubcommand::Unsubscribe {
+            subscription_id,
+            space_id,
+        } => {
+            let subscription_id = utils::subscription_id_from_cmd_args(
+                &ctx,
+                &opts,
+                rpc.node_name(),
+                controller_route,
+                subscription_id,
+                space_id,
+            )
+            .await?;
+            let req = Request::put(format!("subscription/{}/unsubscribe", subscription_id))
+                .body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Subscription>()?;
+        }
+        SubscriptionSubcommand::Update(c) => {
+            let SubscriptionUpdate { subcommand: sc } = c;
+            match sc {
+                SubscriptionUpdateSubcommand::ContactInfo {
+                    json,
+                    space_id,
+                    subscription_id,
+                } => {
+                    let json = std::fs::read_to_string(&json)
+                        .context(format!("failed to read {:?}", &json))?;
+                    let subscription_id = utils::subscription_id_from_cmd_args(
+                        &ctx,
+                        &opts,
+                        rpc.node_name(),
+                        controller_route,
+                        subscription_id,
+                        space_id,
+                    )
+                    .await?;
+                    let req =
+                        Request::put(format!("subscription/{}/contact_info", subscription_id))
+                            .body(CloudRequestWrapper::new(json, controller_route));
+                    rpc.request(req).await?;
+                    rpc.parse_and_print_response::<Subscription>()?;
+                }
+                SubscriptionUpdateSubcommand::Space {
+                    subscription_id,
+                    space_id,
+                    new_space_id,
+                } => {
+                    let subscription_id = utils::subscription_id_from_cmd_args(
+                        &ctx,
+                        &opts,
+                        rpc.node_name(),
+                        controller_route,
+                        subscription_id,
+                        space_id,
+                    )
+                    .await?;
+                    let req = Request::put(format!("subscription/{}/space_id", subscription_id))
+                        .body(CloudRequestWrapper::new(new_space_id, controller_route));
+                    rpc.request(req).await?;
+                    rpc.parse_and_print_response::<Subscription>()?;
+                }
+            }
+        }
+    };
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -1,6 +1,7 @@
 //! Orchestrate end-to-end encryption, mutual authentication, key management,
 //! credential management, and authorization policy enforcement — at scale.
 
+mod admin;
 mod authenticated;
 mod completion;
 mod configuration;
@@ -48,6 +49,7 @@ use util::{exitcode, exitcode::ExitCode, setup_logging, OckamConfig};
 use vault::VaultCommand;
 use version::Version;
 
+use crate::admin::AdminCommand;
 use crate::subscription::SubscriptionCommand;
 use clap::{ArgEnum, Args, Parser, Subcommand};
 use upgrade::check_if_an_upgrade_is_available;
@@ -255,6 +257,7 @@ pub enum OckamSubcommand {
     Service(ServiceCommand),
     Vault(VaultCommand),
     Subscription(SubscriptionCommand),
+    Admin(AdminCommand),
 }
 
 pub fn run() {
@@ -307,6 +310,7 @@ pub fn run() {
         OckamSubcommand::Credential(c) => c.run(options),
         OckamSubcommand::Subscription(c) => c.run(options),
         OckamSubcommand::Reset(c) => c.run(options),
+        OckamSubcommand::Admin(c) => c.run(options),
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -1,20 +1,17 @@
-use anyhow::{anyhow, Context as _};
 use core::fmt::Write;
-use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 
 use ockam::Context;
-use ockam_api::cloud::subscription::{ActivateSubscription, Subscription};
+use ockam_api::cloud::subscription::Subscription;
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
 use ockam_core::CowStr;
-use ockam_multiaddr::MultiAddr;
 
 use crate::node::util::delete_embedded_node;
 use crate::util::api::CloudOpts;
 use crate::util::output::Output;
-use crate::util::{node_rpc, Rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::{help, CommandGlobalOpts};
 
 const HELP_DETAIL: &str = "";
@@ -31,21 +28,6 @@ pub struct SubscriptionCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum SubscriptionSubcommand {
-    /// Attach a subscription to a space
-    Attach {
-        /// Path to the AWS json file with subscription details
-        json: PathBuf,
-
-        /// Space ID to attach the subscription to
-        #[clap(
-            name = "space",
-            value_name = "SPACE_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        space_id: String,
-    },
-
     /// Show the details of a single subscription.
     /// You can use either the subscription ID or the space ID.
     Show {
@@ -63,92 +45,6 @@ pub enum SubscriptionSubcommand {
         )]
         space_id: Option<String>,
     },
-
-    /// Show the details of all subscriptions
-    List,
-
-    /// Disable a subscription.
-    /// You can use either the subscription ID or the space ID.
-    Unsubscribe {
-        /// Subscription ID
-        #[clap(group = "id")]
-        subscription_id: Option<String>,
-
-        /// Space ID
-        #[clap(
-            group = "id",
-            name = "space",
-            value_name = "SPACE_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        space_id: Option<String>,
-    },
-
-    Update(SubscriptionUpdate),
-}
-
-#[derive(Clone, Debug, Args)]
-pub struct SubscriptionUpdate {
-    #[clap(subcommand)]
-    subcommand: SubscriptionUpdateSubcommand,
-}
-
-#[derive(Clone, Debug, Subcommand)]
-enum SubscriptionUpdateSubcommand {
-    /// Update the contact info of a subscription.
-    /// You can use either the subscription ID or the space ID.
-    ContactInfo {
-        /// Path to the AWS json file with contact info details
-        json: PathBuf,
-
-        /// Subscription ID
-        #[clap(
-            group = "id",
-            name = "subscription",
-            value_name = "SUBSCRIPTION_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        subscription_id: Option<String>,
-
-        /// Space ID
-        #[clap(
-            group = "id",
-            name = "space",
-            value_name = "SPACE_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        space_id: Option<String>,
-    },
-
-    /// Move the subscription to a different space.
-    /// You can use either the subscription ID or the space ID.
-    Space {
-        /// Subscription ID
-        #[clap(
-            group = "id",
-            name = "subscription",
-            value_name = "SUBSCRIPTION_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        subscription_id: Option<String>,
-
-        /// Space ID
-        #[clap(
-            group = "id",
-            name = "current_space",
-            value_name = "SPACE_ID",
-            long,
-            forbid_empty_values = true
-        )]
-        space_id: Option<String>,
-
-        /// Space ID to move subscription to
-        new_space_id: String,
-    },
 }
 
 impl SubscriptionCommand {
@@ -164,23 +60,11 @@ async fn run_impl(
     let controller_route = &cmd.cloud_opts.route();
     let mut rpc = Rpc::embedded(&ctx, &opts).await?;
     match cmd.subcommand {
-        SubscriptionSubcommand::Attach {
-            json,
-            space_id: space,
-        } => {
-            let json =
-                std::fs::read_to_string(&json).context(format!("failed to read {:?}", &json))?;
-            let b = ActivateSubscription::existing(space, json);
-            let req =
-                Request::post("subscription").body(CloudRequestWrapper::new(b, controller_route));
-            rpc.request(req).await?;
-            rpc.parse_and_print_response::<Subscription>()?;
-        }
         SubscriptionSubcommand::Show {
             subscription_id,
             space_id,
         } => {
-            let subscription_id = subscription_id_from_cmd_args(
+            let subscription_id = utils::subscription_id_from_cmd_args(
                 &ctx,
                 &opts,
                 rpc.node_name(),
@@ -194,114 +78,55 @@ async fn run_impl(
             rpc.request(req).await?;
             rpc.parse_and_print_response::<Subscription>()?;
         }
-        SubscriptionSubcommand::List => {
-            let req =
-                Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
-            rpc.request(req).await?;
-            rpc.parse_and_print_response::<Vec<Subscription>>()?;
-        }
-        SubscriptionSubcommand::Unsubscribe {
-            subscription_id,
-            space_id,
-        } => {
-            let subscription_id = subscription_id_from_cmd_args(
-                &ctx,
-                &opts,
-                rpc.node_name(),
-                controller_route,
-                subscription_id,
-                space_id,
-            )
-            .await?;
-            let req = Request::put(format!("subscription/{}/unsubscribe", subscription_id))
-                .body(CloudRequestWrapper::bare(controller_route));
-            rpc.request(req).await?;
-            rpc.parse_and_print_response::<Subscription>()?;
-        }
-        SubscriptionSubcommand::Update(c) => {
-            let SubscriptionUpdate { subcommand: sc } = c;
-            match sc {
-                SubscriptionUpdateSubcommand::ContactInfo {
-                    json,
-                    space_id,
-                    subscription_id,
-                } => {
-                    let json = std::fs::read_to_string(&json)
-                        .context(format!("failed to read {:?}", &json))?;
-                    let subscription_id = subscription_id_from_cmd_args(
-                        &ctx,
-                        &opts,
-                        rpc.node_name(),
-                        controller_route,
-                        subscription_id,
-                        space_id,
-                    )
-                    .await?;
-                    let req =
-                        Request::put(format!("subscription/{}/contact_info", subscription_id))
-                            .body(CloudRequestWrapper::new(json, controller_route));
-                    rpc.request(req).await?;
-                    rpc.parse_and_print_response::<Subscription>()?;
-                }
-                SubscriptionUpdateSubcommand::Space {
-                    subscription_id,
-                    space_id,
-                    new_space_id,
-                } => {
-                    let subscription_id = subscription_id_from_cmd_args(
-                        &ctx,
-                        &opts,
-                        rpc.node_name(),
-                        controller_route,
-                        subscription_id,
-                        space_id,
-                    )
-                    .await?;
-                    let req = Request::put(format!("subscription/{}/space_id", subscription_id))
-                        .body(CloudRequestWrapper::new(new_space_id, controller_route));
-                    rpc.request(req).await?;
-                    rpc.parse_and_print_response::<Subscription>()?;
-                }
-            }
-        }
     };
     delete_embedded_node(&opts.config, rpc.node_name()).await;
     Ok(())
 }
 
-async fn subscription_id_from_cmd_args(
-    ctx: &Context,
-    opts: &CommandGlobalOpts,
-    api_node: &str,
-    controller_route: &MultiAddr,
-    subscription_id: Option<String>,
-    space_id: Option<String>,
-) -> crate::Result<String> {
-    match (subscription_id, space_id) {
-        (_, Some(space_id)) => {
-            subscription_id_from_space_id(ctx, opts, api_node, controller_route, &space_id).await
-        }
-        (Some(subscription_id), _) => Ok(subscription_id),
-        _ => unreachable!(),
-    }
-}
+pub mod utils {
+    use anyhow::anyhow;
 
-async fn subscription_id_from_space_id(
-    ctx: &Context,
-    opts: &CommandGlobalOpts,
-    api_node: &str,
-    controller_route: &MultiAddr,
-    space_id: &str,
-) -> crate::Result<String> {
-    let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
-    let req = Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
-    rpc.request(req).await?;
-    let subscriptions = rpc.parse_response::<Vec<Subscription>>()?;
-    let subscription = subscriptions
-        .into_iter()
-        .find(|s| s.space_id == Some(CowStr::from(space_id)))
-        .ok_or_else(|| anyhow!("no subscription found for space {}", space_id))?;
-    Ok(subscription.id.to_string())
+    use ockam_multiaddr::MultiAddr;
+
+    use crate::util::RpcBuilder;
+
+    use super::*;
+
+    pub async fn subscription_id_from_cmd_args(
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
+        api_node: &str,
+        controller_route: &MultiAddr,
+        subscription_id: Option<String>,
+        space_id: Option<String>,
+    ) -> crate::Result<String> {
+        match (subscription_id, space_id) {
+            (_, Some(space_id)) => {
+                subscription_id_from_space_id(ctx, opts, api_node, controller_route, &space_id)
+                    .await
+            }
+            (Some(subscription_id), _) => Ok(subscription_id),
+            _ => unreachable!(),
+        }
+    }
+
+    async fn subscription_id_from_space_id(
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
+        api_node: &str,
+        controller_route: &MultiAddr,
+        space_id: &str,
+    ) -> crate::Result<String> {
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
+        let req = Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
+        rpc.request(req).await?;
+        let subscriptions = rpc.parse_response::<Vec<Subscription>>()?;
+        let subscription = subscriptions
+            .into_iter()
+            .find(|s| s.space_id == Some(CowStr::from(space_id)))
+            .ok_or_else(|| anyhow!("no subscription found for space {}", space_id))?;
+        Ok(subscription.id.to_string())
+    }
 }
 
 impl Output for Subscription<'_> {


### PR DESCRIPTION
```bash
$ ockam admin subscription
SUBCOMMANDS:
    attach         Attach a subscription to a space
    list           Show the details of all subscriptions
    unsubscribe    Disable a subscription. You can use either the subscription ID or the space
                       ID
    update         Update a subscription

$ ockam subscription
SUBCOMMANDS:
    show    Show the details of a single subscription. You can use either the subscription ID or
                the space ID
```