### PR TITLE
feat(rust): flag when creating project to enforce credentials true|false

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -128,11 +128,13 @@ pub struct CreateProject<'a> {
     #[b(1)] pub name: CowStr<'a>,
     #[b(2)] pub services: Vec<CowStr<'a>>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
+    #[b(4)] pub enforce_credentials: Option<bool>
 }
 
 impl<'a> CreateProject<'a> {
     pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(
         name: S,
+        enforce_credentials: Option<bool>,
         users: &'a [T],
         services: &'a [T],
     ) -> Self {
@@ -140,6 +142,7 @@ impl<'a> CreateProject<'a> {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             name: name.into(),
+            enforce_credentials,
             services: services.iter().map(|x| CowStr::from(x.as_ref())).collect(),
             users: users.iter().map(|x| CowStr::from(x.as_ref())).collect(),
         }
@@ -372,6 +375,7 @@ mod tests {
                 name: String::arbitrary(g).into(),
                 services: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
                 users: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
+                enforce_credentials: None,
             })
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -146,6 +146,7 @@ async fn default_project<'a>(
         rpc.request(api::project::create(
             "default",
             &space.id,
+            None,
             &cloud_opts.route(),
         ))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -22,6 +22,10 @@ pub struct CreateCommand {
     #[clap(display_order = 1002, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
     pub project_name: String,
 
+    // Enforce credentials for member access to the project node
+    #[clap(long, display_order = 1003)]
+    pub enforce_credentials: Option<bool>,
+
     #[clap(flatten)]
     pub cloud_opts: CloudOpts,
 
@@ -56,6 +60,7 @@ async fn run_impl(
     rpc.request(api::project::create(
         &cmd.project_name,
         &space_id,
+        cmd.enforce_credentials,
         &cmd.cloud_opts.route(),
     ))
     .await?;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -299,9 +299,10 @@ pub(crate) mod project {
     pub(crate) fn create<'a>(
         project_name: &'a str,
         space_id: &'a str,
+        enforce_credentials: Option<bool>,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
+        let b = CreateProject::new::<&str, &str>(project_name, enforce_credentials, &[], &[]);
         Request::post(format!("v0/projects/{}", space_id))
             .body(CloudRequestWrapper::new(b, cloud_route))
     }


### PR DESCRIPTION
A new option is added to `project create` 

`--enforce-credentials true|false`

If option is not given,  project will be created at what is the default value on cloud environment.  This is also true for default projects created on first enrollment,  as they don't pass this new option. 
