### PR TITLE
feat(rust): add `--config` argument to `node create` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -87,3 +87,4 @@ ockam_core = { path = "../ockam_core", version = "^0.70.0" }
 
 [dev-dependencies]
 assert_cmd = "2"
+tempfile = "3"

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -83,6 +83,9 @@ pub struct CreateCommand {
 
     #[clap(long, hide = true)]
     pub project: Option<PathBuf>,
+
+    #[clap(long, hide = true)]
+    pub config: Option<PathBuf>,
 }
 
 impl From<&'_ CreateCommand> for ComposableSnippet {
@@ -110,6 +113,7 @@ impl Default for CreateCommand {
             launch_config: None,
             no_watchdog: false,
             project: None,
+            config: None,
         }
     }
 }
@@ -164,6 +168,11 @@ impl CreateCommand {
                 (cfg.clone(), cmd.node_name, true),
                 print_query_status,
             );
+            if let Some(config) = self.config {
+                crate::node::util::run::CommandsRunner::run(&config)
+                    .context("Failed to run commands from config")
+                    .unwrap();
+            }
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Context as _, Result};
 use std::sync::Arc;
 
-use crate::{util::startup, CommandGlobalOpts};
+use anyhow::{anyhow, Context as _, Result};
+
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
 use ockam_api::config::cli;
@@ -17,6 +17,7 @@ use tracing::trace;
 use crate::node::CreateCommand;
 use crate::project::ProjectInfo;
 use crate::{project, OckamConfig};
+use crate::{util::startup, CommandGlobalOpts};
 
 pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<String> {
     let cmd = CreateCommand::default();
@@ -242,4 +243,412 @@ fn delete_node_config(opts: &CommandGlobalOpts, node_name: &str) {
 
     // Try removing the node's info from the config file.
     opts.config.remove_node(node_name);
+}
+
+pub mod run {
+    use std::collections::VecDeque;
+    use std::env::current_exe;
+    use std::path::{Path, PathBuf};
+    use std::process::Stdio;
+
+    use tracing::trace;
+
+    use ockam_core::compat::collections::HashMap;
+
+    use super::*;
+
+    pub struct CommandsRunner {
+        path: PathBuf,
+        commands: HashMap<String, Command>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+    struct Command {
+        args: Vec<String>,
+        depends_on: Option<String>,
+    }
+
+    impl CommandsRunner {
+        fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+            let path = path.as_ref();
+            let commands = if path.exists() {
+                let s = std::fs::read_to_string(path)?;
+                serde_json::from_str(&s)?
+            } else {
+                HashMap::new()
+            };
+            Ok(Self {
+                path: path.into(),
+                commands,
+            })
+        }
+
+        pub fn export<P: AsRef<Path>>(
+            path: P,
+            export_as: String,
+            depends_on: Option<String>,
+            args: Vec<String>,
+        ) -> Result<()> {
+            let path = path.as_ref();
+            let mut c = Self::new(path)?;
+            c.add(export_as, depends_on, args);
+            c.update()?;
+            Ok(())
+        }
+
+        fn add(&mut self, name: String, depends_on: Option<String>, args: Vec<String>) {
+            let args = Self::cleanup_args(args);
+            self.commands.insert(name, Command { args, depends_on });
+        }
+
+        fn cleanup_args(mut args: Vec<String>) -> Vec<String> {
+            let mut cleaned = vec![];
+            // Remove the command executable path
+            args.remove(0);
+            // Remove export arguments
+            let export_args = ["--export", "--export-as", "--depends-on"];
+            let mut it = args.into_iter();
+            while let Some(arg) = it.next() {
+                if export_args.contains(&&*arg) {
+                    // Skip argument value
+                    it.next();
+                } else {
+                    cleaned.push(arg);
+                }
+            }
+            cleaned
+        }
+
+        fn update(self) -> Result<()> {
+            let s = serde_json::to_string_pretty(&self.commands)
+                .context("Failed to convert commands to json format")?;
+            std::fs::write(&self.path, &s).context("Failed to write commands to file")?;
+            Ok(())
+        }
+
+        /// Run all commands sorted based on their dependencies
+        pub fn run<P: AsRef<Path>>(path: P) -> Result<()> {
+            let c = Self::new(path)?;
+            let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
+            for cmd in c.sort_commands()? {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                trace!("Running command with args {:?}", cmd.args);
+                println!("Running command with args '{}'", cmd.args.join(" "));
+                std::process::Command::new(&ockam)
+                    .args(cmd.args)
+                    .stdout(Stdio::inherit())
+                    .stderr(Stdio::inherit())
+                    .output()?;
+            }
+            Ok(())
+        }
+
+        /// Sort list of commands based on their dependencies
+        fn sort_commands(self) -> Result<Vec<Command>> {
+            // Check that `depend_on` reference to existing commands
+            for (name, cmd) in &self.commands {
+                if let Some(depends_on) = &cmd.depends_on {
+                    if !self.commands.contains_key(depends_on) {
+                        return Err(anyhow!(
+                            "Command '{}' depends on non-existing command '{}'",
+                            name,
+                            depends_on
+                        ));
+                    }
+                }
+            }
+            // Convert hashmap to a ring buffer so we can cycle through the commands multiple times.
+            let mut commands: VecDeque<(String, Command)> =
+                self.commands.into_iter().map(|(k, v)| (k, v)).collect();
+            // We will store how many times we cycle through each command.
+            let mut cycles: HashMap<String, usize> = HashMap::new();
+            let max_cycles = commands.len();
+            // We will store the commands with unresolved dependencies (using `name` and `depends_on`).
+            let mut unresolved = HashMap::new();
+            // Other variables to store the sorting state.
+            let mut names = vec![];
+            let mut sorted = vec![];
+            // Process commands until we have them all sorted and there are none left on the list.
+            while let Some((name, cmd)) = commands.pop_front() {
+                // Process command dependencies.
+                if let Some(depends_on) = &cmd.depends_on {
+                    // Dependency is in a previous position of the list. We can push the current command to the sorted list.
+                    if names.contains(depends_on) {
+                        names.push(name);
+                        sorted.push(cmd);
+                    }
+                    // Dependency is in a further position of the list.
+                    else {
+                        // In the worst-case scenario, we will sort one element on each cycle, so we will sort the complete list
+                        // in `max_cycles` cycles. Otherwise, we have a circular dependency.
+                        if let Some(c) = cycles.get_mut(&name) {
+                            let curr = *c;
+                            *c = curr + 1;
+                            if *c > max_cycles {
+                                let msg = unresolved
+                                    .into_iter()
+                                    .map(|(k, v)| format!("command {k} -> depends_on {v}"))
+                                    .collect::<Vec<_>>();
+                                return Err(anyhow!("Circular dependency detected for {msg:?}"));
+                            }
+                        } else {
+                            // Initialize cycle counter for the current command.
+                            cycles.insert(name.clone(), 1);
+                        }
+
+                        // If the `depends_on` is on the unresolved hashmap and the command name matches the item's value, then
+                        // we have a circular dependency. Example:
+                        // 1. name=A, depends_on=B -> we store (A,B) in the dependencies hashmap
+                        // 2. name=B, depends_on=A -> we find "A" key with "B" value -> circular dependency
+                        if let Some(n) = unresolved.get(depends_on) {
+                            if name.eq(n) {
+                                return Err(anyhow!(
+                                        "Circular dependency detected for commands {name} <-> {depends_on}",
+                                    ));
+                            }
+                        }
+                        // We requeue the command at the end of the list and we also store it in the unresolved hashmap.
+                        unresolved.insert(name.clone(), depends_on.clone());
+                        commands.push_back((name, cmd));
+                    }
+                }
+                // Command has no dependencies. We can add it right away to the sorted list.
+                else {
+                    sorted.push(cmd);
+                    names.push(name);
+                }
+            }
+            Ok(sorted)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use tempfile::tempdir;
+
+        use super::*;
+
+        #[test]
+        fn create_from_empty_file() {
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            assert_eq!(cr.path, file_path);
+            assert!(cr.commands.is_empty());
+        }
+
+        #[test]
+        fn create_from_existing_file() {
+            let contents = r#"{
+                "command1": {
+                    "args": ["arg1", "arg2"],
+                    "depends_on": null
+                },
+                "command2": {
+                    "args": ["arg3", "arg4"],
+                    "depends_on": "command1"
+                }
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            assert_eq!(cr.path, file_path);
+            assert_eq!(cr.commands.len(), 2);
+
+            let cmd1 = cr.commands.get("command1").expect("Failed to get command1");
+            assert_eq!(cmd1.args, vec!["arg1", "arg2"]);
+            assert!(cmd1.depends_on.is_none());
+
+            let cmd2 = cr.commands.get("command2").expect("Failed to get command2");
+            assert_eq!(cmd2.args, vec!["arg3", "arg4"]);
+            assert_eq!(cmd2.depends_on, Some("command1".to_string()));
+        }
+
+        #[test]
+        fn cleanup_args() {
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            let args = vec![
+                "ockam".to_string(),
+                "node".to_string(),
+                "create".to_string(),
+                "blue".to_string(),
+                "--export".to_string(),
+                file_path.to_str().unwrap().to_string(),
+                "--export-as".to_string(),
+                "ndblue".to_string(),
+                "--depends-on".to_string(),
+                "enroll".to_string(),
+            ];
+            let cleaned = CommandsRunner::cleanup_args(args);
+            assert_eq!(cleaned, vec!["node", "create", "blue"]);
+        }
+
+        #[test]
+        fn add() {
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            let mut cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+
+            let export_as = "ndblue".to_string();
+            let depends_on = "enroll".to_string();
+            let args = vec![
+                "ockam".to_string(),
+                "node".to_string(),
+                "create".to_string(),
+                "blue".to_string(),
+                "--export".to_string(),
+                file_path.to_str().unwrap().to_string(),
+                "--export-as".to_string(),
+                export_as.clone(),
+                "--depends-on".to_string(),
+                depends_on.clone(),
+            ];
+            let cleaned_args = vec!["node", "create", "blue"];
+
+            cr.add(export_as.clone(), Some(depends_on.clone()), args);
+            assert_eq!(cr.commands.len(), 1);
+            let cmd = cr.commands.get(&export_as).expect("Failed to get command");
+            assert_eq!(cmd.args, cleaned_args);
+            assert_eq!(cmd.depends_on, Some(depends_on));
+        }
+
+        #[test]
+        fn export() {
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            let export_as = "ndblue".to_string();
+            let depends_on = None;
+            let args = vec![
+                "ockam".to_string(),
+                "node".to_string(),
+                "create".to_string(),
+                "blue".to_string(),
+                "--export".to_string(),
+                file_path.to_str().unwrap().to_string(),
+                "--export-as".to_string(),
+                export_as.clone(),
+            ];
+            let cleaned_args = vec!["node", "create", "blue"];
+            CommandsRunner::export(file_path.clone(), export_as.clone(), depends_on, args)
+                .expect("Failed to export");
+
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            assert_eq!(cr.commands.len(), 1);
+            let cmd = cr
+                .commands
+                .get(&export_as)
+                .expect("Failed to retrieve command from file");
+            assert_eq!(cmd.args, cleaned_args);
+            assert!(cmd.depends_on.is_none());
+        }
+
+        #[test]
+        fn sort_commands() {
+            let contents = r#"{
+                "c": {
+                    "args": ["c", "arg"],
+                    "depends_on": "a"
+                },
+                "b": {
+                    "args": ["b", "arg"],
+                    "depends_on": "c"
+                },
+                "a": {
+                    "args": ["a", "arg"],
+                    "depends_on": null
+                }
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            let res = cr.sort_commands().expect("Failed to sort commands");
+            let expected = vec![
+                Command {
+                    args: vec!["a".to_string(), "arg".to_string()],
+                    depends_on: None,
+                },
+                Command {
+                    args: vec!["c".to_string(), "arg".to_string()],
+                    depends_on: Some("a".to_string()),
+                },
+                Command {
+                    args: vec!["b".to_string(), "arg".to_string()],
+                    depends_on: Some("c".to_string()),
+                },
+            ];
+            assert_eq!(res, expected);
+        }
+
+        #[test]
+        fn sort_depends_on_points_to_invalid_command() {
+            let contents = r#"{
+                "b": {
+                    "args": ["b", "arg"],
+                    "depends_on": "c"
+                },
+                "a": {
+                    "args": ["a", "arg"],
+                    "depends_on": null
+                }
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            let res = cr.sort_commands();
+            assert!(res.is_err());
+        }
+
+        #[test]
+        fn sort_commands_circular_dependency_direct() {
+            let contents = r#"{
+                "a": {
+                    "args": ["a", "arg"],
+                    "depends_on": "b"
+                },
+                "b": {
+                    "args": ["b", "arg"],
+                    "depends_on": "a"
+                }
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            let res = cr.sort_commands();
+            assert!(res.is_err());
+        }
+
+        #[test]
+        fn sort_commands_circular_dependency_indirect() {
+            let contents = r#"{
+                "a": {
+                    "args": ["a", "arg"],
+                    "depends_on": "d"
+                },
+                "b": {
+                    "args": ["b", "arg"],
+                    "depends_on": "a"
+                },
+                "c": {
+                    "args": ["c", "arg"],
+                    "depends_on": null
+                },
+                "d": {
+                    "args": ["d", "arg"],
+                    "depends_on": "b"
+                }
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            let res = cr.sort_commands();
+            assert!(res.is_err());
+        }
+    }
 }


### PR DESCRIPTION
It loads a json file containing a list of commands that will be executed after creating a node. To generate this json file, the user can use the global `--export`, `--export-as`, and `--depends-on` arguments on any command, that will copy the command input to the desired file.

## How to test

```bash
ockam node list --export commands.json
ockam node create blue --config commands.json
```

## Options to export commands to a json file

```bash
# Will generate random name for the command
$ ockam node list --export commands.json

# Set name for command 
$ ockam node list --export commands.json --export-as node-list

# Depend on other command
$ ockam node list --export commands.json --depends-on node-create
```

## Structure of the config file 

```json
{
  "node-list": {
    "args": [
      "node",
      "list"
    ],
    "depends_on": null
  }
}
```



