### PR TITLE
Show default identity in ockam identity show

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -120,17 +120,18 @@ impl OckamConfig {
         Ok(node_path)
     }
 
+    /// Try to get the API port used by a node
+    pub fn try_get_node_port(&self, name: &str) -> Option<u16> {
+        let inner = self.inner.readlock_inner();
+        inner.nodes.get(name).map(|node| node.port)
+    }
+
     /// Get the API port used by a node
     pub fn get_node_port(&self, name: &str) -> u16 {
-        let inner = self.inner.readlock_inner();
-        inner
-            .nodes
-            .get(name)
-            .unwrap_or_else(|| {
-                eprintln!("No such node available. Run `ockam node list` to list available nodes");
-                std::process::exit(exitcode::IOERR);
-            })
-            .port
+        self.try_get_node_port(name).unwrap_or_else(|| {
+            eprintln!("No such node available. Run `ockam node list` to list available nodes");
+            std::process::exit(exitcode::IOERR);
+        })
     }
 
     /// In the future this will actually refer to the watchdog pid or


### PR DESCRIPTION
fix(rust): Fix issue 3461, Make ockam identity show command work without creating nodes

## Current Behavior

```
> ockam enroll
...
> ockam identity show
No such node available. Run `ockam node list` to list available nodes
```

## Proposed Changes

Check for a failure to find a port number for an identity and show information
about the default identity instead.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
