### PR TITLE
added Tcp keepalive & removed Tcp heartbeat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,7 @@ dependencies = [
  "ockam_transport_core",
  "rand 0.7.3",
  "serde",
+ "socket2",
  "tokio",
  "tracing",
  "trybuild",

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1.8", features = [
 rand = "0.7"
 hashbrown = { version = "0.12", default-features = false }
 tracing = { version = "0.1", default-features = false }
+socket2 = "0.4.7"
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
@@ -56,7 +56,7 @@ impl Processor for TcpListenProcessor {
         let handle_clone = self.router_handle.async_try_clone().await?;
         // And create a connection worker for it
         let (worker, pair) =
-            TcpSendWorker::new_pair(ctx, handle_clone, Some(stream), peer, Vec::new()).await?;
+            TcpSendWorker::new_pair(handle_clone, Some(stream), peer, Vec::new()).await?;
 
         // Register the connection with the local TcpRouter
         self.router_handle.register(&pair).await?;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Current implementations of TCP clients need to rely on ad-hoc heartbeats in order to keep the TCP connection open.

## Proposed Changes

Enable tcp_keepalive for the `TcpStream` through the `socket2` crate and remove usage of custom heartbeat.
This addresses: https://github.com/build-trust/ockam/issues/3450 and possibly https://github.com/build-trust/ockam/issues/3480

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
