### PR TITLE
feat(rust): add `secure` protocol to multi-addr

### DIFF
--- a/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
@@ -1,5 +1,5 @@
 use super::{Buffer, Checked, Code, Codec, Protocol};
-use crate::proto::{DnsAddr, Node, Project, Service, Tcp};
+use crate::proto::{DnsAddr, Node, Project, Secure, Service, Space, Tcp};
 use crate::{Error, ProtoValue};
 use core::fmt;
 use unsigned_varint::decode;
@@ -9,9 +9,12 @@ pub struct StdCodec;
 impl Codec for StdCodec {
     fn split_str<'a>(
         &self,
-        _prefix: &str,
+        prefix: &str,
         input: &'a str,
     ) -> Result<(Checked<&'a str>, &'a str), Error> {
+        if prefix == Secure::PREFIX {
+            return Ok((Checked(""), input));
+        }
         if let Some(p) = input.find('/') {
             let (x, y) = input.split_at(p);
             Ok((Checked(x), y))
@@ -49,7 +52,12 @@ impl Codec for StdCodec {
                 let (x, y) = input.split_at(2);
                 Ok((Checked(x), y))
             }
-            c @ DnsAddr::CODE | c @ Service::CODE | c @ Node::CODE | c @ Project::CODE => {
+            Secure::CODE => Ok((Checked(&[]), input)),
+            c @ DnsAddr::CODE
+            | c @ Service::CODE
+            | c @ Node::CODE
+            | c @ Project::CODE
+            | c @ Space::CODE => {
                 let (len, input) = decode::usize(input)?;
                 if input.len() < len {
                     return Err(Error::required_bytes(c, len));
@@ -72,6 +80,8 @@ impl Codec for StdCodec {
             Service::CODE => Service::read_bytes(input).is_ok(),
             Node::CODE => Node::read_bytes(input).is_ok(),
             Project::CODE => Project::read_bytes(input).is_ok(),
+            Space::CODE => Space::read_bytes(input).is_ok(),
+            Secure::CODE => Secure::read_bytes(input).is_ok(),
             _ => false,
         }
     }
@@ -87,6 +97,8 @@ impl Codec for StdCodec {
             Service::CODE => Service::read_bytes(val.data())?.write_bytes(buf),
             Node::CODE => Node::read_bytes(val.data())?.write_bytes(buf),
             Project::CODE => Project::read_bytes(val.data())?.write_bytes(buf),
+            Space::CODE => Space::read_bytes(val.data())?.write_bytes(buf),
+            Secure::CODE => Secure::read_bytes(val.data())?.write_bytes(buf),
             code => return Err(Error::unregistered(code)),
         }
         Ok(())
@@ -129,6 +141,14 @@ impl Codec for StdCodec {
                 Project::read_str(value)?.write_bytes(buf);
                 Ok(())
             }
+            Space::PREFIX => {
+                Space::read_str(value)?.write_bytes(buf);
+                Ok(())
+            }
+            Secure::PREFIX => {
+                Secure::read_str(value)?.write_bytes(buf);
+                Ok(())
+            }
             _ => Err(Error::unregistered_prefix(prefix)),
         }
     }
@@ -168,6 +188,14 @@ impl Codec for StdCodec {
             }
             Project::CODE => {
                 Project::read_bytes(value)?.write_str(f)?;
+                Ok(())
+            }
+            Space::CODE => {
+                Space::read_bytes(value)?.write_str(f)?;
+                Ok(())
+            }
+            Secure::CODE => {
+                Secure::read_bytes(value)?.write_str(f)?;
                 Ok(())
             }
             _ => Err(Error::unregistered(code)),

--- a/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/codec.rs
@@ -9,12 +9,9 @@ pub struct StdCodec;
 impl Codec for StdCodec {
     fn split_str<'a>(
         &self,
-        prefix: &str,
+        _prefix: &str,
         input: &'a str,
     ) -> Result<(Checked<&'a str>, &'a str), Error> {
-        if prefix == Secure::PREFIX {
-            return Ok((Checked(""), input));
-        }
         if let Some(p) = input.find('/') {
             let (x, y) = input.split_at(p);
             Ok((Checked(x), y))
@@ -52,12 +49,12 @@ impl Codec for StdCodec {
                 let (x, y) = input.split_at(2);
                 Ok((Checked(x), y))
             }
-            Secure::CODE => Ok((Checked(&[]), input)),
             c @ DnsAddr::CODE
             | c @ Service::CODE
             | c @ Node::CODE
             | c @ Project::CODE
-            | c @ Space::CODE => {
+            | c @ Space::CODE
+            | c @ Secure::CODE => {
                 let (len, input) = decode::usize(input)?;
                 if input.len() < len {
                     return Err(Error::required_bytes(c, len));

--- a/implementations/rust/ockam/ockam_multiaddr/src/error.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/error.rs
@@ -31,10 +31,6 @@ impl Error {
         Error(ErrorImpl::InvalidProto(c))
     }
 
-    pub(crate) fn invalid_prefix<S: Into<String>>(s: S) -> Self {
-        Error(ErrorImpl::InvalidPrefix(s.into()))
-    }
-
     pub(crate) fn into_impl(self) -> ErrorImpl {
         self.0
     }
@@ -44,7 +40,6 @@ impl Error {
 pub(crate) enum ErrorImpl {
     Unregistered(Code),
     InvalidProto(Code),
-    InvalidPrefix(String),
     UnregisteredPrefix(String),
     InvalidVarint(unsigned_varint::decode::Error),
     Message(String),
@@ -59,7 +54,6 @@ impl fmt::Display for Error {
         match &self.0 {
             ErrorImpl::Unregistered(c) => write!(f, "unregistered protocol (code {c})"),
             ErrorImpl::InvalidProto(c) => write!(f, "invalid protocol value (code {c})"),
-            ErrorImpl::InvalidPrefix(s) => write!(f, "invalid prefix in protocol string {s:?}"),
             ErrorImpl::UnregisteredPrefix(s) => write!(f, "unregistered protocol prefix {s:?}"),
             ErrorImpl::Message(m) => write!(f, "{m}"),
             ErrorImpl::InvalidVarint(e) => e.fmt(f),
@@ -82,8 +76,7 @@ impl std::error::Error for Error {
             | ErrorImpl::RequiredBytes(..)
             | ErrorImpl::Unregistered(_)
             | ErrorImpl::UnregisteredPrefix(_)
-            | ErrorImpl::Message(_)
-            | ErrorImpl::InvalidPrefix(_) => None,
+            | ErrorImpl::Message(_) => None,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -295,6 +295,11 @@ impl MultiAddr {
         }
     }
 
+    /// Access the registry of this `MultiAddr`.
+    pub fn registry(&self) -> &Registry {
+        &self.reg
+    }
+
     /// Try to parse the given string as a multi-address.
     ///
     /// Alternative to the corresponding `TryFrom` impl, accepting an explicit

--- a/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
@@ -153,6 +153,42 @@ impl Protocol<'_> for Tcp {
     }
 }
 
+/// A security marker.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Secure;
+
+impl Secure {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Protocol<'_> for Secure {
+    const CODE: Code = Code::new(99526);
+    const PREFIX: &'static str = "secure";
+
+    fn read_str(_input: Checked<&str>) -> Result<Self, Error> {
+        debug_assert!(_input.is_empty(), "unexpected text input: {}", *_input);
+        Ok(Self)
+    }
+
+    fn read_bytes(_input: Checked<&[u8]>) -> Result<Self, Error> {
+        debug_assert!(_input.is_empty(), "unexpected binary input: {:x?}", *_input);
+        Ok(Self)
+    }
+
+    fn write_str(&self, f: &mut fmt::Formatter) -> Result<(), Error> {
+        f.write_str("/secure")?;
+        Ok(())
+    }
+
+    fn write_bytes(&self, buf: &mut dyn Buffer) {
+        let mut b = encode::u32_buffer();
+        let uvi = encode::u32(Self::CODE.into(), &mut b);
+        buf.extend_with(uvi)
+    }
+}
+
 macro_rules! gen_str_proto {
     ($t:ident, $c:literal, $p:literal) => {
         #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/proto.rs
@@ -153,42 +153,6 @@ impl Protocol<'_> for Tcp {
     }
 }
 
-/// A security marker.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Secure;
-
-impl Secure {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Protocol<'_> for Secure {
-    const CODE: Code = Code::new(99526);
-    const PREFIX: &'static str = "secure";
-
-    fn read_str(_input: Checked<&str>) -> Result<Self, Error> {
-        debug_assert!(_input.is_empty(), "unexpected text input: {}", *_input);
-        Ok(Self)
-    }
-
-    fn read_bytes(_input: Checked<&[u8]>) -> Result<Self, Error> {
-        debug_assert!(_input.is_empty(), "unexpected binary input: {:x?}", *_input);
-        Ok(Self)
-    }
-
-    fn write_str(&self, f: &mut fmt::Formatter) -> Result<(), Error> {
-        f.write_str("/secure")?;
-        Ok(())
-    }
-
-    fn write_bytes(&self, buf: &mut dyn Buffer) {
-        let mut b = encode::u32_buffer();
-        let uvi = encode::u32(Self::CODE.into(), &mut b);
-        buf.extend_with(uvi)
-    }
-}
-
 macro_rules! gen_str_proto {
     ($t:ident, $c:literal, $p:literal) => {
         #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -244,3 +208,4 @@ gen_str_proto!(Service, 62526, "service");
 gen_str_proto!(Node, 72526, "node");
 gen_str_proto!(Project, 82526, "project");
 gen_str_proto!(Space, 92526, "space");
+gen_str_proto!(Secure, 99526, "secure");

--- a/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/registry.rs
@@ -1,6 +1,6 @@
 use super::{Code, Codec, Protocol};
 use crate::codec::StdCodec;
-use crate::proto::{DnsAddr, Node, Project, Service, Tcp};
+use crate::proto::{DnsAddr, Node, Project, Secure, Service, Space, Tcp};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;
 use core::fmt;
@@ -33,6 +33,10 @@ impl Default for Registry {
         r.register(Node::CODE, Node::PREFIX, std_codec.clone());
         #[allow(clippy::redundant_clone)]
         r.register(Project::CODE, Project::PREFIX, std_codec.clone());
+        #[allow(clippy::redundant_clone)]
+        r.register(Space::CODE, Space::PREFIX, std_codec.clone());
+        #[allow(clippy::redundant_clone)]
+        r.register(Secure::CODE, Secure::PREFIX, std_codec.clone());
         #[cfg(feature = "std")]
         r.register(
             crate::proto::Ip4::CODE,

--- a/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
@@ -108,7 +108,7 @@ quickcheck! {
                         prot.push_back(Ip6::CODE)
                     }
                     Secure::CODE => {
-                        addr.push_back(Secure::new()).unwrap();
+                        addr.push_back(Secure::new("secure")).unwrap();
                         prot.push_back(Secure::CODE)
                     }
                     Service::CODE => {
@@ -159,7 +159,7 @@ impl Arbitrary for Addr {
                 DnsAddr::CODE => a.push_back(DnsAddr::new(gen_hostname())).unwrap(),
                 Ip4::CODE => a.push_back(Ip4::new(Ipv4Addr::arbitrary(g))).unwrap(),
                 Ip6::CODE => a.push_back(Ip6::new(Ipv6Addr::arbitrary(g))).unwrap(),
-                Secure::CODE => a.push_back(Secure::new()).unwrap(),
+                Secure::CODE => a.push_back(Secure::new(gen_string())).unwrap(),
                 Service::CODE => a.push_back(Service::new(gen_string())).unwrap(),
                 Project::CODE => a.push_back(Project::new(gen_string())).unwrap(),
                 Space::CODE => a.push_back(Space::new(gen_string())).unwrap(),

--- a/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
@@ -1,14 +1,22 @@
-use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Tcp};
+use core::fmt;
+use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Node, Project, Secure, Service, Space, Tcp};
 use ockam_multiaddr::{Code, MultiAddr, Protocol};
 use quickcheck::{quickcheck, Arbitrary, Gen};
+use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::*;
 use std::collections::VecDeque;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
 /// Newtype to implement `Arbitrary` for.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct Addr(MultiAddr);
+
+impl fmt::Debug for Addr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Addr").field(&self.0.to_string()).finish()
+    }
+}
 
 quickcheck! {
     fn to_str_from_str(a: Addr) -> bool {
@@ -99,6 +107,26 @@ quickcheck! {
                         addr.push_back(Ip6::new(Ipv6Addr::from_str("::1").unwrap())).unwrap();
                         prot.push_back(Ip6::CODE)
                     }
+                    Secure::CODE => {
+                        addr.push_back(Secure::new()).unwrap();
+                        prot.push_back(Secure::CODE)
+                    }
+                    Service::CODE => {
+                        addr.push_back(Service::new("service")).unwrap();
+                        prot.push_back(Service::CODE);
+                    }
+                    Node::CODE => {
+                        addr.push_back(Node::new("node")).unwrap();
+                        prot.push_back(Node::CODE);
+                    }
+                    Project::CODE => {
+                        addr.push_back(Project::new("project")).unwrap();
+                        prot.push_back(Project::CODE);
+                    }
+                    Space::CODE => {
+                        addr.push_back(Space::new("space")).unwrap();
+                        prot.push_back(Space::CODE);
+                    }
                     _ => unreachable!()
                 }
             }
@@ -110,7 +138,17 @@ quickcheck! {
     }
 }
 
-const PROTOS: &[Code] = &[Tcp::CODE, DnsAddr::CODE, Ip4::CODE, Ip6::CODE];
+const PROTOS: &[Code] = &[
+    Tcp::CODE,
+    DnsAddr::CODE,
+    Ip4::CODE,
+    Ip6::CODE,
+    Secure::CODE,
+    Service::CODE,
+    Node::CODE,
+    Project::CODE,
+    Space::CODE,
+];
 
 impl Arbitrary for Addr {
     fn arbitrary(g: &mut Gen) -> Self {
@@ -121,6 +159,11 @@ impl Arbitrary for Addr {
                 DnsAddr::CODE => a.push_back(DnsAddr::new(gen_hostname())).unwrap(),
                 Ip4::CODE => a.push_back(Ip4::new(Ipv4Addr::arbitrary(g))).unwrap(),
                 Ip6::CODE => a.push_back(Ip6::new(Ipv6Addr::arbitrary(g))).unwrap(),
+                Secure::CODE => a.push_back(Secure::new()).unwrap(),
+                Service::CODE => a.push_back(Service::new(gen_string())).unwrap(),
+                Project::CODE => a.push_back(Project::new(gen_string())).unwrap(),
+                Space::CODE => a.push_back(Space::new(gen_string())).unwrap(),
+                Node::CODE => a.push_back(Node::new(gen_string())).unwrap(),
                 _ => unreachable!(),
             }
         }
@@ -165,4 +208,10 @@ fn gen_hostname() -> String {
         v.push(gen_label(&mut g))
     }
     v.join(".")
+}
+
+fn gen_string() -> String {
+    let mut s = Alphanumeric.sample_string(&mut rand::thread_rng(), 23);
+    s.retain(|c| c != '/');
+    s
 }


### PR DESCRIPTION
As an empty protocol `secure` can denote a secure channel in a multi-addr, e.g. `/ip4/127.0.0.1/tcp/8000/secure`

