### PR TITLE
feat(rust): `ockam node show` to use dynamic data from node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -91,6 +91,7 @@ pub struct InletStatus<'a> {
     #[b(3)] pub alias: Cow<'a, str>,
     /// An optional status payload
     #[b(4)] pub payload: Option<Cow<'a, str>>,
+    #[b(5)] pub outlet_route: Cow<'a, str>,
 }
 
 impl<'a> InletStatus<'a> {
@@ -102,6 +103,7 @@ impl<'a> InletStatus<'a> {
             worker_addr: "".into(),
             alias: "".into(),
             payload: Some(reason.into()),
+            outlet_route: "".into(),
         }
     }
 
@@ -110,6 +112,7 @@ impl<'a> InletStatus<'a> {
         worker_addr: impl Into<Cow<'a, str>>,
         alias: impl Into<Cow<'a, str>>,
         payload: impl Into<Option<Cow<'a, str>>>,
+        outlet_route: impl Into<Cow<'a, str>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -118,6 +121,7 @@ impl<'a> InletStatus<'a> {
             worker_addr: worker_addr.into(),
             alias: alias.into(),
             payload: payload.into(),
+            outlet_route: outlet_route.into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -192,3 +192,44 @@ impl<'a> StartCredentialsService<'a> {
         self.oneway
     }
 }
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct ServiceStatus<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<8542064>,
+    #[n(2)] pub addr: Cow<'a, str>,
+    #[n(3)] pub service_type: Cow<'a, str>,
+}
+
+impl<'a> ServiceStatus<'a> {
+    pub fn new(addr: impl Into<Cow<'a, str>>, service_type: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addr: addr.into(),
+            service_type: service_type.into(),
+        }
+    }
+}
+
+/// Response body for listing services
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct ServiceList<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<9587601>,
+    #[n(1)] pub list: Vec<ServiceStatus<'a>>
+}
+
+impl<'a> ServiceList<'a> {
+    pub fn new(list: Vec<ServiceStatus<'a>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            list,
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -101,10 +101,15 @@ pub(crate) struct AuthenticatorServiceInfo {}
 pub(crate) struct InletInfo {
     pub(crate) bind_addr: String,
     pub(crate) worker_addr: Address,
+    pub(crate) outlet_route: Route,
 }
 
 impl InletInfo {
-    pub(crate) fn new(bind_addr: &str, worker_addr: Option<&Address>) -> Self {
+    pub(crate) fn new(
+        bind_addr: &str,
+        worker_addr: Option<&Address>,
+        outlet_route: &Route,
+    ) -> Self {
         let worker_addr = match worker_addr {
             Some(addr) => addr.clone(),
             None => Address::from_string(""),
@@ -112,6 +117,7 @@ impl InletInfo {
         Self {
             bind_addr: bind_addr.to_owned(),
             worker_addr,
+            outlet_route: outlet_route.to_owned(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -492,6 +492,10 @@ impl NodeManagerWorker {
                 .start_credentials_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
+            (Get, ["node", "services"]) => {
+                let node_manager = self.node_manager.read().await;
+                self.list_services(req, &node_manager.registry).to_vec()?
+            }
 
             // ==*== Forwarder commands ==*==
             (Post, ["node", "forwarder"]) => self.create_forwarder(ctx, req.id(), dec).await?,

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -167,6 +167,12 @@ pub fn try_address_to_multiaddr(a: &Address) -> Result<MultiAddr, Error> {
     Ok(ma)
 }
 
+/// Try to convert an Ockam Address into a MultiAddr.
+pub fn addr_to_multiaddr<T: Into<Address>>(a: T) -> Option<MultiAddr> {
+    let r: Route = Route::from(a);
+    route_to_multiaddr(&r)
+}
+
 /// Tells whether the input MultiAddr references a local node or a remote node.
 ///
 /// This should be called before cleaning the MultiAddr.

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -56,7 +56,7 @@ pub async fn show_identity(
         let resp: Vec<u8> = ctx
             .send_and_receive(
                 base_route.modify().append(NODEMANAGER_ADDR),
-                api::short_identity()?,
+                api::short_identity().to_vec()?,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -3,11 +3,22 @@ use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use anyhow::Context;
 use clap::Args;
 use colorful::Colorful;
-use ockam::Route;
+use minicbor::Decoder;
 use ockam_api::config::cli::NodeConfig;
-use ockam_api::nodes::{models::base::NodeStatus, NODEMANAGER_ADDR};
-use ockam_core::api::Status;
+use ockam_api::nodes::models::portal::{InletList, OutletList};
+use ockam_api::nodes::models::services::ServiceList;
+use ockam_api::nodes::models::transport::TransportList;
+use ockam_api::nodes::NODEMANAGER_ADDR;
+use ockam_api::{addr_to_multiaddr, route_to_multiaddr};
+use ockam_core::api::{Response, Status};
+use ockam_core::{Result, Route};
+use ockam_multiaddr::proto::{DnsAddr, Node, Tcp};
+use ockam_multiaddr::MultiAddr;
 use std::time::Duration;
+
+const IS_NODE_UP_ATTEMPTS: usize = 10;
+const IS_NODE_UP_SLEEP_MILLIS: u64 = 250;
+const SEND_RECEIVE_TIMEOUT_SECS: u64 = 1;
 
 /// Show Nodes
 #[derive(Clone, Debug, Args)]
@@ -40,42 +51,94 @@ impl ShowCommand {
 // printing the node state in the future but for now we can just tell
 // clippy to stop complainaing about it.
 #[allow(clippy::too_many_arguments)]
-fn print_node_info(node_cfg: &NodeConfig, node_name: &str, status: &str, default_id: &str) {
+fn print_node_info(
+    node_cfg: &NodeConfig,
+    node_name: &str,
+    status: &str,
+    default_id: &str,
+    services: Option<&ServiceList>,
+    tcp_listeners: Option<&TransportList>,
+    secure_channel_listeners: Option<&Vec<String>>,
+    inlets_outlets: Option<(&InletList, &OutletList)>,
+) {
+    println!();
+    println!("Node:");
+    println!("  Name: {}", node_name);
     println!(
-        r#"
-Node:
-  Name: {}
-  Status: {}
-  Services:
-    Service:
-      Type: TCP Listener
-      Address: /ip4/127.0.0.1/tcp/{}
-    Service:
-      Type: Secure Channel Listener
-      Address: /service/api
-      Route: /ip4/127.0.0.1/tcp/{}/service/api
-      Identity: {}
-      Authorized Identities:
-        - {}
-    Service:
-      Type: Uppercase
-      Address: /service/uppercase
-    Service:
-      Type: Echo
-      Address: /service/echo
-  Secure Channel Listener Address: /service/api
-"#,
-        node_name,
+        "  Status: {}",
         match status {
             "UP" => status.light_green(),
             "DOWN" => status.light_red(),
             _ => status.white(),
-        },
-        node_cfg.port,
-        node_cfg.port,
-        default_id,
-        default_id,
+        }
     );
+
+    println!("  Route To Node:");
+    let mut m = MultiAddr::default();
+    if m.push_back(Node::new(node_name)).is_ok() {
+        println!("    Short: {}", m);
+    }
+
+    let mut m = MultiAddr::default();
+    if m.push_back(DnsAddr::new("localhost")).is_ok()
+        && m.push_back(Tcp::new(node_cfg.port)).is_ok()
+    {
+        println!("    Verbose: {}", m);
+    }
+    println!("  Identity: {}", default_id);
+
+    if let Some(list) = tcp_listeners {
+        println!("  Transports:");
+        for e in &list.list {
+            println!("    Transport:");
+            println!("      Type: {}", e.tt);
+            println!("      Mode: {}", e.tm);
+            println!("      Address: {}", e.payload);
+        }
+    }
+
+    if let Some(list) = secure_channel_listeners {
+        println!("  Secure Channel Listeners:");
+        for e in list {
+            println!("    Listener:");
+            if let Some(ma) = addr_to_multiaddr(e) {
+                println!("      Address: {}", ma);
+            }
+        }
+    }
+
+    if let Some((inlets, outlets)) = inlets_outlets {
+        println!("  Inlets:");
+        for e in &inlets.list {
+            println!("    Inlet:");
+            println!("      Listen Address: {}", e.bind_addr);
+            if let Some(r) = Route::parse(e.outlet_route.as_ref()) {
+                if let Some(ma) = route_to_multiaddr(&r) {
+                    println!("      Route To Outlet: {}", ma);
+                }
+            }
+        }
+        println!("  Outlets:");
+        for e in &outlets.list {
+            println!("    Outlet:");
+            println!("      Forward Address: {}", e.tcp_addr);
+
+            if let Some(ma) = addr_to_multiaddr(e.worker_addr.as_ref()) {
+                println!("      Address: {}", ma);
+            }
+        }
+    }
+
+    if let Some(list) = services {
+        println!("  Services:");
+        for e in &list.list {
+            println!("    Service:");
+            println!("      Type: {}", e.service_type);
+            if let Some(ma) = addr_to_multiaddr(e.addr.as_ref()) {
+                println!("      Address: {}", ma);
+            }
+        }
+    }
 }
 
 pub async fn print_query_status(
@@ -86,59 +149,136 @@ pub async fn print_query_status(
     let route = base_route.modify().append(NODEMANAGER_ADDR).into();
     let node_cfg = cfg.get_node(&node_name)?;
 
-    // Wait until node is up.
-    if query_status(&mut ctx, &route).await.is_err() {
-        if wait_until_ready {
-            let mut attempts = 10;
-            while attempts > 0 {
-                tokio::time::sleep(Duration::from_millis(250)).await;
-                if query_status(&mut ctx, &route).await.is_ok() {
-                    break;
-                }
-                attempts -= 1;
+    if !is_node_up(&mut ctx, &route, wait_until_ready).await? {
+        print_node_info(&node_cfg, &node_name, "DOWN", "N/A", None, None, None, None);
+    } else {
+        // Get short id for the node
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::short_identity().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get short identity from node")?;
+        let (response, result) = api::parse_short_identity_response(&resp)?;
+        let default_id = match response.status() {
+            Some(Status::Ok) => {
+                format!("{}", result.identity_id)
             }
-            if attempts <= 0 {
-                print_node_info(&node_cfg, &node_name, "DOWN", "N/A");
-                return Ok(());
-            }
-        } else {
-            print_node_info(&node_cfg, &node_name, "DOWN", "N/A");
-            return Ok(());
-        }
+            _ => String::from("NOT FOUND"),
+        };
+
+        // Get list of services for the node
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::list_services().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get list of services from node")?;
+        let services = api::parse_list_services_response(&resp)?;
+
+        // Get list of TCP listeners for node
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::list_tcp_listeners().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get list of tcp listeners from node")?;
+        let tcp_listeners = api::parse_tcp_list(&resp)?;
+
+        // Get list of Secure Channel Listeners
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::list_secure_channel_listener().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get list of secure channel listeners from node")?;
+        let mut dec = Decoder::new(&resp);
+        let _ = dec.decode::<Response>()?;
+        let secure_channel_listeners = dec.decode::<Vec<String>>()?;
+
+        // Get list of inlets
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::list_inlets().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get list of inlets from node")?;
+        let inlets = api::parse_list_inlets_response(&resp)?;
+
+        // Get list of outlets
+        let resp: Vec<u8> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::list_outlets().to_vec()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await
+            .context("Failed to get list of outlets from node")?;
+        let outlets = api::parse_list_outlets_response(&resp)?;
+
+        print_node_info(
+            &node_cfg,
+            &node_name,
+            "UP",
+            &default_id,
+            Some(&services),
+            Some(&tcp_listeners),
+            Some(&secure_channel_listeners),
+            Some((&inlets, &outlets)),
+        );
     }
 
-    // Get short id for the node
-    ctx.send(route.clone(), api::short_identity()?).await?;
-    let resp = ctx
-        .receive_duration_timeout::<Vec<u8>>(Duration::from_millis(250))
-        .await
-        .context("Failed to process request for short id")?;
-
-    let (response, result) = api::parse_short_identity_response(&resp)?;
-    let default_id = match response.status() {
-        Some(Status::Ok) => {
-            format!("{}", result.identity_id)
-        }
-        _ => String::from("NOT FOUND"),
-    };
-
-    print_node_info(&node_cfg, &node_name, "UP", &default_id);
     Ok(())
 }
 
-async fn query_status(ctx: &mut ockam::Context, route: &Route) -> anyhow::Result<()> {
-    ctx.send(route.clone(), api::query_status()?).await?;
+/// Send message(s) to a node to determine if it is 'up' and
+/// responding to requests.
+///
+/// If `wait_until_ready` is `true` and the node does not
+/// appear to be 'up', retry the test at time intervals up to
+/// a maximum number of retries. A use case for this is to
+/// allow a node time to start up and become ready.
+async fn is_node_up(
+    ctx: &mut ockam::Context,
+    route: &Route,
+    wait_until_ready: bool,
+) -> anyhow::Result<bool> {
+    let attempts = match wait_until_ready {
+        true => IS_NODE_UP_ATTEMPTS,
+        false => 1,
+    };
 
-    let resp = ctx
-        .receive_duration_timeout::<Vec<u8>>(Duration::from_millis(250))
-        .await
-        .context("Failed to process request");
-
-    match resp {
-        Ok(resp) => {
-            let NodeStatus { .. } = api::parse_status(&resp)?;
-            Ok(())
+    for att in 0..attempts {
+        // Sleep, if this not the first loop
+        if att > 0 {
+            tokio::time::sleep(Duration::from_millis(IS_NODE_UP_SLEEP_MILLIS)).await;
         }
-        Err(e) => Err(e),
+
+        // Test if node is up
+        let tx_result: Result<Vec<u8>> = ctx
+            .send_and_receive_with_timeout(
+                route.clone(),
+                api::query_status()?,
+                SEND_RECEIVE_TIMEOUT_SECS,
+            )
+            .await;
+        if let Ok(data) = tx_result {
+            if api::parse_status(&data).is_ok() {
+                // Node is up, return
+                return Ok(true);
+            }
+        }
     }
+
+    Ok(false)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -29,7 +29,7 @@ pub async fn list_listeners(ctx: Context, _: (), mut base_route: Route) -> anyho
     let resp: Vec<u8> = match ctx
         .send_and_receive(
             base_route.modify().append(NODEMANAGER_ADDR),
-            api::list_tcp_listeners()?,
+            api::list_tcp_listeners().to_vec()?,
         )
         .await
     {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -38,11 +38,8 @@ pub(crate) fn list_tcp_connections() -> Result<Vec<u8>> {
 }
 
 /// Construct a request to query node tcp listeners
-pub(crate) fn list_tcp_listeners() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    let builder = Request::get("/node/tcp/listener");
-    builder.encode(&mut buf)?;
-    Ok(buf)
+pub(crate) fn list_tcp_listeners() -> RequestBuilder<'static, ()> {
+    Request::get("/node/tcp/listener")
 }
 
 /// Construct a request to create node tcp connection
@@ -125,10 +122,23 @@ pub(crate) fn long_identity() -> Result<Vec<u8>> {
 }
 
 /// Construct a request to print Identity Id
-pub(crate) fn short_identity() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::post("/node/identity/actions/show/short").encode(&mut buf)?;
-    Ok(buf)
+pub(crate) fn short_identity() -> RequestBuilder<'static, ()> {
+    Request::post("/node/identity/actions/show/short")
+}
+
+/// Construct a request to print a list of services for the given node
+pub(crate) fn list_services() -> RequestBuilder<'static, ()> {
+    Request::get("/node/services")
+}
+
+/// Construct a request to print a list of inlets for the given node
+pub(crate) fn list_inlets() -> RequestBuilder<'static, ()> {
+    Request::get("/node/inlet")
+}
+
+/// Construct a request to print a list of outlets for the given node
+pub(crate) fn list_outlets() -> RequestBuilder<'static, ()> {
+    Request::get("/node/outlet")
 }
 
 /// Construct a request builder to list all secure channels on the given node
@@ -427,6 +437,24 @@ pub(crate) fn parse_short_identity_response(
         response,
         dec.decode::<models::identity::ShortIdentityResponse>()?,
     ))
+}
+
+pub(crate) fn parse_list_services_response(resp: &[u8]) -> Result<models::services::ServiceList> {
+    let mut dec = Decoder::new(resp);
+    let _ = dec.decode::<Response>()?;
+    Ok(dec.decode::<models::services::ServiceList>()?)
+}
+
+pub(crate) fn parse_list_inlets_response(resp: &[u8]) -> Result<models::portal::InletList> {
+    let mut dec = Decoder::new(resp);
+    let _ = dec.decode::<Response>()?;
+    Ok(dec.decode::<models::portal::InletList>()?)
+}
+
+pub(crate) fn parse_list_outlets_response(resp: &[u8]) -> Result<models::portal::OutletList> {
+    let mut dec = Decoder::new(resp);
+    let _ = dec.decode::<Response>()?;
+    Ok(dec.decode::<models::portal::OutletList>()?)
 }
 
 pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Result<Response> {

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -75,9 +75,15 @@ teardown() {
   assert_success
 }
 
-@test "create a node with a name" {
+@test "create a node with a name and do show on it" {
   run $OCKAM node create n1
   assert_success
+
+  run $OCKAM node show n1
+  assert_success
+  assert_output --partial "/dnsaddr/localhost/tcp/"
+  assert_output --partial "/service/api"
+  assert_output --partial "/service/uppercase"
 }
 
 @test "create a node with a name and send it a message" {


### PR DESCRIPTION
## Current Behavior

* `ockam node show` intends to show the status and details of a node (e.g. a list of its services). At the moment this feature uses static text and assumes things about the node (see below code).
* This code is also used by `ockam node list` and `ockam node create`.
* Related to #3177.

https://github.com/build-trust/ockam/blob/d4dd3529e09139dbebebbf8ba59db114353e8330/implementations/rust/ockam/ockam_command/src/node/show.rs#L43-L79

## Proposed Changes

* Modify `ockam node show` to ask the node for details about itself and display those details.
* Add a request/response `get` `/node/service` to allow the CLI to get a list of services from a node.
* Add a basic test to `ockam_command/tests/commands/bats` to test the new feature in CI.

## Queries

1. Is the output formatting of `ockam node show` okay? Instead of a verbose tree, could we output some of the information in a tabular style like `docker image ls`?

```shell
> docker image ls
REPOSITORY                                     TAG       IMAGE ID       CREATED        SIZE
ghcr.io/build-trust/ockam-builder              latest    b10ae04c8b6f   2 weeks ago    4.62GB
ghcr.io/build-trust/ockam-builder              <none>    9cfba9ba6e22   2 months ago   4.58GB
ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu   0.2.4     23b40ea6412a   3 months ago   1.03GB
hello-world                                    latest    46331d942d63   6 months ago   9.14kB
```

2. In the output, should the Transport field `Payload` be renamed?

3. The request/response `get` `/node/service` builds its response from `ockam_api::nodes::service::NodeManager.registry`. Is there a risk that this might leak private information from the registry to a user using the CLI?

4. Are there other details about a node that should be added to this feature (e.g. TCP inlets and outlets)?

## Example Output

```shell
> ockam node create n1
> ockam node create n2
> ockam secure-channel-listener create test --at /node/n1
> ockam tcp-listener create 127.0.0.1:7002 --at /node/n1
> ockam node list

Node:
  Name: n1
  Status: UP
  Route to node:
    Short: /node/n1
    Verbose: /dnsaddr/localhost/tcp/55754
  Identity: Pcf94e075af7c5885ab0eb84abb9a76223f7359f6c64bf753a136ae1b2bb3f02f
  Transports:
    Transport:
      Type: TCP
      Mode: Listening
      Payload: 127.0.0.1:55754
    Transport:
      Type: TCP
      Mode: Listening
      Payload: 127.0.0.1:7002
  Secure Channel Listeners:
    Listener:
      Address: /service/api
    Listener:
      Address: /service/test
  Services:
    Service:
      Type: vault
      Address: /service/vault_service
    Service:
      Type: identity
      Address: /service/identity_service
    Service:
      Type: authenticated
      Address: /service/authenticated
    Service:
      Type: uppercase
      Address: /service/uppercase
    Service:
      Type: echoer
      Address: /service/echo
    Service:
      Type: credentials
      Address: /service/credentials

Node:
  Name: n2
  Status: UP
  Route to node:
    Short: /node/n2
    Verbose: /dnsaddr/localhost/tcp/55761
  Identity: Pcf94e075af7c5885ab0eb84abb9a76223f7359f6c64bf753a136ae1b2bb3f02f
  Transports:
    Transport:
      Type: TCP
      Mode: Listening
      Payload: 127.0.0.1:55761
  Secure Channel Listeners:
    Listener:
      Address: /service/api
  Services:
    Service:
      Type: vault
      Address: /service/vault_service
    Service:
      Type: identity
      Address: /service/identity_service
    Service:
      Type: authenticated
      Address: /service/authenticated
    Service:
      Type: uppercase
      Address: /service/uppercase
    Service:
      Type: echoer
      Address: /service/echo
    Service:
      Type: credentials
      Address: /service/credentials
```

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

