### PR TITLE
fix(rust): use explicit workspace member list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,34 @@
 [workspace]
 resolver = "2"
 members = [
-    # This trick (where we glob workspace members with `*/src/..` or
-    # `*/examples/..` — the latter being used because not all of our examples
-    # have `src` directories, but they all have `examples` directories) helps
-    # avoid including some obvious non-code folders. For example: folders
-    # containing only gitignored contents which are leftover from a branch
-    # change are typical (note that this was the motivation).
-    #
-    # In an ideal world, we'd have a better way to identify all rust crates, but
-    # I'm not sure how — the only item that's guaranteed to be present in Rust
-    # crates is `Cargo.toml`, and `cargo` is unwilling to fall for something
-    # like `members = ["**/Cargo.toml/.."]`.
-    "implementations/rust/ockam/*/src/..",
-    "examples/rust/*/examples/..",
-
-    "tools/docs/example_test_helper",
+    "examples/rust/file_transfer",
+    "examples/rust/get_started",
+    "examples/rust/ockam_kafka",
+    "examples/rust/tcp_inlet_and_outlet",
+    "implementations/rust/ockam/ockam",
+    "implementations/rust/ockam/ockam_abac",
+    "implementations/rust/ockam/ockam_api",
+    "implementations/rust/ockam/ockam_channel",
+    "implementations/rust/ockam/ockam_command",
+    "implementations/rust/ockam/ockam_core",
+    "implementations/rust/ockam/ockam_examples",
+    "implementations/rust/ockam/ockam_executor",
+    "implementations/rust/ockam/ockam_ffi",
+    "implementations/rust/ockam/ockam_identity",
+    "implementations/rust/ockam/ockam_key_exchange_core",
+    "implementations/rust/ockam/ockam_key_exchange_x3dh",
+    "implementations/rust/ockam/ockam_key_exchange_xx",
+    "implementations/rust/ockam/ockam_macros",
+    "implementations/rust/ockam/ockam_multiaddr",
+    "implementations/rust/ockam/ockam_node",
+    "implementations/rust/ockam/ockam_transport_ble",
+    "implementations/rust/ockam/ockam_transport_core",
+    "implementations/rust/ockam/ockam_transport_tcp",
+    "implementations/rust/ockam/ockam_transport_udp",
+    "implementations/rust/ockam/ockam_transport_websocket",
+    "implementations/rust/ockam/ockam_vault",
     "tools/docs/example_blocks",
+    "tools/docs/example_test_helper"
 ]
 
 exclude = ["implementations/rust/ockam/ockam_examples/example_projects"]

--- a/implementations/rust/ockam/ockam_examples/example_projects/access_control/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/access_control/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0"
 publish = false
 rust-version = "1.56.0"
 
+[workspace]
+
 [features]
 default = ["std"]
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 autobins = false
 publish = false
 
+[workspace]
+
 [dependencies]
 ockam = { path = "../../../ockam" }
 ockam_node = { path = "../../../ockam_node" }

--- a/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0"
 homepage = "https://github.com/build-trust/ockam"
 publish = false
 
+[workspace]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
@@ -7,6 +7,8 @@ name = "hello_ockam_no_std"
 version = "0.1.0"
 publish = false
 
+[workspace]
+
 [features]
 default = ["std"]
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/node/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 publish = false
 autobins = false
 
+[workspace]
+
 [dependencies]
 ockam = { path = "../../../ockam" }
 ockam_node = { path = "../../../ockam_node" }

--- a/implementations/rust/ockam/ockam_examples/example_projects/ports/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ports/Cargo.toml
@@ -8,6 +8,8 @@ homepage = "https://github.com/build-trust/ockam"
 publish = false
 autobins = false
 
+[workspace]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
@@ -9,6 +9,8 @@ description = """
 An example of issuing, holding, and verifying a credential
 """
 
+[workspace]
+
 [[bin]]
 name = "alice"
 path = "src/bin/alice.rs"

--- a/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tcp/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ockam Developers"]
 edition = "2021"
 publish = false
 
+[workspace]
+
 [dependencies]
 ockam = { path = "../../../ockam" }
 ockam_node = { path = "../../../ockam_node" }

--- a/implementations/rust/ockam/ockam_examples/example_projects/tunnel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tunnel/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ockam Developers"]
 edition = "2021"
 publish = false
 
+[workspace]
+
 [dependencies]
 ockam = { path = "../../../ockam" }
 rand = "0.8"

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Ockam Developers"]
 edition = "2021"
 publish = false
 
+[workspace]
+
 [dependencies]
 ockam = { path = "../../../ockam" }
 ockam_node = { path = "../../../ockam_node" }


### PR DESCRIPTION
While this requires updating the member list when projects are added or removed it may help tools such as dependabot processing it.
