### PR TITLE
feat(rust): extend the declarative config support

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -92,6 +92,7 @@ impl NodeManagerWorker {
         let alias = alias.map(|a| a.0.into()).unwrap_or_else(random_alias);
 
         info!("Handling request to create inlet portal");
+        debug!(%bind_addr, %alias, ?outlet_route, "Creating inlet portal");
 
         let outlet_route = MultiAddr::from_str(&outlet_route).map_err(map_multiaddr_err)?;
         let outlet_route = match multiaddr_to_route(&outlet_route) {

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -145,7 +145,6 @@ impl CreateCommand {
 
             let cmd = self.overwrite_addr().unwrap();
             let addr = SocketAddr::from_str(&cmd.tcp_listener_address).unwrap();
-
             embedded_node(
                 Self::create_background_node,
                 (options.clone(), cmd.clone(), addr),
@@ -156,9 +155,12 @@ impl CreateCommand {
                 (cfg.clone(), cmd.node_name, true),
                 print_query_status,
             );
-            if let Some(config) = self.config {
-                crate::node::util::run::CommandsRunner::run(&config)
-                    .context("Failed to run commands from config")
+            if let Some(config_path) = &self.config {
+                crate::node::util::run::CommandsRunner::run_node_init(config_path)
+                    .context("Failed to run init commands")
+                    .unwrap();
+                crate::node::util::run::CommandsRunner::run_node_startup(config_path)
+                    .context("Failed to startup commands")
                     .unwrap();
             }
         }

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -1,20 +1,23 @@
-mod create;
-mod delete;
-mod list;
-mod show;
-mod start;
-mod stop;
-pub mod util;
+use clap::{Args, Subcommand};
 
 pub(crate) use create::CreateCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
+use run::RunCommand;
 use show::ShowCommand;
 use start::StartCommand;
 use stop::StopCommand;
 
 use crate::{help, CommandGlobalOpts};
-use clap::{Args, Subcommand};
+
+mod create;
+mod delete;
+mod list;
+mod run;
+mod show;
+mod start;
+mod stop;
+pub mod util;
 
 const HELP_DETAIL: &str = "\
 About:
@@ -136,6 +139,8 @@ pub enum NodeSubcommand {
     #[command(display_order = 800)]
     Show(ShowCommand),
     #[command(display_order = 800)]
+    Run(RunCommand),
+    #[command(display_order = 800)]
     Start(StartCommand),
     #[command(display_order = 800)]
     Stop(StopCommand),
@@ -147,6 +152,7 @@ impl NodeCommand {
             NodeSubcommand::Create(c) => c.run(options),
             NodeSubcommand::Delete(c) => c.run(options),
             NodeSubcommand::List(c) => c.run(options),
+            NodeSubcommand::Run(c) => c.run(options),
             NodeSubcommand::Show(c) => c.run(options),
             NodeSubcommand::Start(c) => c.run(options),
             NodeSubcommand::Stop(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/node/run.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/run.rs
@@ -1,0 +1,31 @@
+use anyhow::Context;
+use clap::Args;
+use std::path::PathBuf;
+use tracing::error;
+
+use crate::{help, CommandGlobalOpts};
+
+const HELP_DETAIL: &str = "";
+
+/// Run a node given a configuration file
+#[derive(Clone, Debug, Args)]
+#[command(help_template = help::template(HELP_DETAIL))]
+pub struct RunCommand {
+    pub config: PathBuf,
+}
+
+impl RunCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        if let Err(e) = self.run_impl(options) {
+            error!(%e);
+            eprintln!("{e:?}");
+            std::process::exit(e.code());
+        }
+    }
+
+    fn run_impl(self, _opts: CommandGlobalOpts) -> crate::Result<()> {
+        crate::node::util::run::CommandsRunner::run(self.config)
+            .context("Failed to run commands from config")?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context as _, Result};
+use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
+use tracing::trace;
 
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
@@ -11,8 +13,6 @@ use ockam_api::nodes::{IdentityOverride, NodeManager, NodeManagerWorker, NODEMAN
 use ockam_multiaddr::MultiAddr;
 use ockam_vault::storage::FileStorage;
 use ockam_vault::Vault;
-use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
-use tracing::trace;
 
 use crate::node::CreateCommand;
 use crate::project::ProjectInfo;
@@ -254,27 +254,196 @@ fn delete_node_config(opts: &CommandGlobalOpts, node_name: &str) {
 }
 
 pub mod run {
-    use std::collections::VecDeque;
     use std::env::current_exe;
+    #[cfg(test)]
+    use std::fmt::{Display, Formatter};
+    use std::io::Write;
+    use std::iter::Peekable;
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
+    use std::slice::Iter;
+    use std::str::FromStr;
 
+    use clap::Parser;
     use tracing::trace;
 
-    use ockam_core::compat::collections::HashMap;
+    use ockam_multiaddr::proto::Node;
+
+    use crate::OckamCommand;
 
     use super::*;
 
     pub struct CommandsRunner {
+        exe: PathBuf,
         path: PathBuf,
-        commands: HashMap<String, Command>,
+        commands: Commands,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, Default)]
+    #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+    struct Commands {
+        /// Run when executing the `node run` command.
+        run: Option<RunNode>,
+        /// Run when the node is created.
+        #[serde(default)]
+        on_node_init: Vec<Command>,
+        /// Run after initialization is done. Will rerun on every node restart.
+        #[serde(default)]
+        on_node_startup: Vec<Command>,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, Default)]
+    #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+    struct RunNode {
+        name: String,
+        args: Option<CommandArgs>,
+    }
+
+    impl RunNode {
+        /// Return the `args` field as a Vec of strings.
+        fn args<P: AsRef<Path>>(&self, path: P, exe: &str) -> Vec<String> {
+            let mut args: Vec<String> = format!("{} node create {}", exe, self.name)
+                .split_whitespace()
+                .map(|x| x.to_string())
+                .collect();
+            if let Some(a) = &self.args {
+                args.extend(a.args());
+            }
+            args.extend([
+                "--config".to_string(),
+                path.as_ref().to_str().expect("Invalid path").to_string(),
+            ]);
+            args
+        }
+    }
+
+    impl From<RunNode> for Command {
+        fn from(r: RunNode) -> Self {
+            let args = match r.args {
+                Some(args) => match args {
+                    CommandArgs::String(s) => s,
+                    CommandArgs::Vec(v) => v.join(" "),
+                },
+                None => String::new(),
+            };
+            Command::String(format!("node create {} {}", r.name, args))
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(untagged)]
+    #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+    enum Command {
+        String(String),
+        Obj(CommandObj),
+    }
+
+    impl Command {
+        fn new(command: String, pipe: Option<bool>) -> Self {
+            if pipe.is_none() {
+                Command::String(command)
+            } else {
+                Command::Obj(CommandObj {
+                    command: Some(command),
+                    args: None,
+                    pipe,
+                })
+            }
+        }
+
+        /// Return the `args` field as a Vec of strings.
+        fn args(&self) -> Vec<String> {
+            match self {
+                Command::String(s) => s.split_whitespace().map(|s| s.to_string()).collect(),
+                Command::Obj(o) => o.args(),
+            }
+        }
+
+        fn pipe_output(&self) -> bool {
+            match self {
+                Command::String(_) => false,
+                Command::Obj(o) => o.pipe_output(),
+            }
+        }
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
-    struct Command {
-        args: Vec<String>,
-        depends_on: Option<String>,
+    struct CommandObj {
+        command: Option<String>,
+        args: Option<CommandArgs>,
+        /// Pipes output to the next command.
+        pipe: Option<bool>,
+    }
+
+    impl CommandObj {
+        /// Return the `args` field as a Vec of strings.
+        fn args(&self) -> Vec<String> {
+            let mut args = Vec::new();
+            // Collect args from `command` and `args`
+            if let Some(command) = &self.command {
+                args.extend(command.split_whitespace().map(|s| s.to_string()));
+            }
+            if let Some(a) = &self.args {
+                args.extend(a.args());
+            }
+            // Add `--pipe` if needed. This can be used by commands to output a different message based on this flag.
+            if self.pipe_output() {
+                args.push("--pipe".to_string());
+            }
+            args
+        }
+
+        fn pipe_output(&self) -> bool {
+            self.pipe.unwrap_or(false)
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(untagged)]
+    #[cfg_attr(test, derive(Clone, Debug, PartialEq))]
+    enum CommandArgs {
+        String(String),
+        Vec(Vec<String>),
+    }
+
+    impl CommandArgs {
+        fn args(&self) -> Vec<String> {
+            match self {
+                CommandArgs::String(s) => s.split_whitespace().map(|s| s.to_string()).collect(),
+                // `join` and `split` to convert to single-value entries.
+                // E.g. ["--flag", "--arg value"] -> ["--flag", "--arg", "value"]
+                CommandArgs::Vec(v) => v
+                    .join(" ")
+                    .split(' ')
+                    .map(|s| s.to_string())
+                    .filter(|x| !x.is_empty())
+                    .collect(),
+            }
+        }
+    }
+
+    #[derive(clap::ValueEnum, Clone, Debug)]
+    pub enum CommandSection {
+        OnNodeInit,
+        OnNodeStartup,
+    }
+
+    impl Default for CommandSection {
+        fn default() -> Self {
+            Self::OnNodeInit
+        }
+    }
+
+    #[cfg(test)]
+    impl Display for CommandSection {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            let s = match self {
+                CommandSection::OnNodeInit => "node-init",
+                CommandSection::OnNodeStartup => "node-startup",
+            };
+            write!(f, "{}", s)
+        }
     }
 
     impl CommandsRunner {
@@ -284,9 +453,10 @@ pub mod run {
                 let s = std::fs::read_to_string(path)?;
                 serde_json::from_str(&s)?
             } else {
-                HashMap::new()
+                Commands::default()
             };
             Ok(Self {
+                exe: current_exe().unwrap_or_else(|_| "ockam".into()),
                 path: path.into(),
                 commands,
             })
@@ -294,33 +464,43 @@ pub mod run {
 
         pub fn export<P: AsRef<Path>>(
             path: P,
-            export_as: String,
-            depends_on: Option<String>,
+            section: CommandSection,
             args: Vec<String>,
+            pipe: Option<bool>,
         ) -> Result<()> {
             let path = path.as_ref();
-            let mut c = Self::new(path)?;
-            c.add(export_as, depends_on, args);
-            c.update()?;
+            let mut cr = Self::new(path)?;
+            cr.add(section, args, pipe);
+            cr.persist()?;
             Ok(())
         }
 
-        fn add(&mut self, name: String, depends_on: Option<String>, args: Vec<String>) {
-            let args = Self::cleanup_args(args);
-            self.commands.insert(name, Command { args, depends_on });
+        fn add(&mut self, section: CommandSection, args: Vec<String>, pipe: Option<bool>) {
+            let command = Command::new(Self::cleanup_export_args(args).join(" "), pipe);
+            match section {
+                CommandSection::OnNodeInit => self.commands.on_node_init.push(command),
+                CommandSection::OnNodeStartup => self.commands.on_node_startup.push(command),
+            };
         }
 
-        fn cleanup_args(mut args: Vec<String>) -> Vec<String> {
+        /// Remove all "export" related arguments.
+        fn cleanup_export_args(mut args: Vec<String>) -> Vec<String> {
             let mut cleaned = vec![];
             // Remove the command executable path
             args.remove(0);
             // Remove export arguments
-            let export_args = ["--export", "--export-as", "--depends-on"];
+            let export_args = ["--export", "--export-section", "--pipe"];
             let mut it = args.into_iter();
             while let Some(arg) = it.next() {
                 if export_args.contains(&&*arg) {
-                    // Skip argument value
-                    it.next();
+                    // Continue to next argument if it's a `flag` argument
+                    if ["--pipe"].contains(&&*arg) {
+                        continue;
+                    }
+                    // Skip next item (argument value) if it's a `key=value` argument
+                    else {
+                        it.next();
+                    }
                 } else {
                     cleaned.push(arg);
                 }
@@ -328,106 +508,190 @@ pub mod run {
             cleaned
         }
 
-        fn update(self) -> Result<()> {
+        /// Persist commands to file.
+        fn persist(self) -> Result<()> {
             let s = serde_json::to_string_pretty(&self.commands)
                 .context("Failed to convert commands to json format")?;
             std::fs::write(&self.path, &s).context("Failed to write commands to file")?;
             Ok(())
         }
 
-        /// Run all commands sorted based on their dependencies
+        /// Create a node given the arguments from the "run" section
         pub fn run<P: AsRef<Path>>(path: P) -> Result<()> {
-            let c = Self::new(path)?;
-            let ockam = current_exe().unwrap_or_else(|_| "ockam".into());
-            for cmd in c.sort_commands()? {
-                std::thread::sleep(std::time::Duration::from_millis(250));
-                trace!("Running command with args {:?}", cmd.args);
-                println!("Running command with args '{}'", cmd.args.join(" "));
-                std::process::Command::new(&ockam)
-                    .args(cmd.args)
-                    .stdout(Stdio::inherit())
+            let cr = Self::new(path)?;
+            match cr.commands.run {
+                None => Err(anyhow!("Couldn't create node: `run` section not defined")),
+                Some(r) => {
+                    let args = r.args(&cr.path, cr.exe.to_str().expect("Invalid executable path"));
+                    let cmd: OckamCommand = OckamCommand::parse_from(args);
+                    cmd.run();
+                    Ok(())
+                }
+            }
+        }
+
+        /// Run "on_node_init" commands section
+        pub fn run_node_init<P: AsRef<Path>>(path: P) -> Result<()> {
+            let cr = Self::new(path)?;
+            let cmds = cr.commands.on_node_init;
+            let mut it = cmds.iter().peekable();
+            // Node was just created, prompt user before executing the first command
+            CommandsRunner::wait_for_prompt(it.peek())?;
+            CommandsRunner::go(&cr.exe, it)
+        }
+
+        /// Run "on_node_startup" commands section
+        pub fn run_node_startup<P: AsRef<Path>>(path: P) -> Result<()> {
+            let cr = Self::new(path)?;
+            let cmds = cr.commands.on_node_startup;
+            let it = cmds.iter().peekable();
+            CommandsRunner::go(&cr.exe, it)
+        }
+
+        /// Execute the list of commands
+        fn go(exe: &PathBuf, mut it: Peekable<Iter<Command>>) -> Result<()> {
+            let mut prev_output: Option<Vec<u8>> = None;
+            let mut stdin = Stdio::null();
+            while let Some(cmd) = it.next() {
+                CommandsRunner::command_preprocessing(exe, cmd)?;
+                let args = cmd.args();
+                trace!("Running command `{:?}`", &args);
+                println!("\nRunning command '{}'", &args.join(" "));
+
+                // We have different scenarios based on the `pipe` field
+                //  1. Pipe output to next command
+                //  2. Pipe input from previous command
+                //  3. Both 1 and 2
+                let mut child = std::process::Command::new(&exe)
+                    .args(&args)
+                    .stdout(Stdio::piped())
+                    .stdin(stdin)
                     .stderr(Stdio::inherit())
-                    .output()?;
+                    .spawn()?;
+
+                // Write previous output to stdin
+                if let Some(input) = prev_output.take() {
+                    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+                    std::thread::spawn(move || {
+                        stdin.write_all(&input).expect("Failed to write to stdin");
+                    });
+                }
+
+                let output = child.wait_with_output()?;
+
+                // Stdout is piped to the child process, so we print it here in the current process.
+                print!("\n{}", String::from_utf8_lossy(&output.stdout));
+
+                // Stop processing any further commands if the current command failed
+                if !output.status.success() {
+                    return Err(anyhow!("Command returned non-zero exit code"));
+                }
+
+                // Save output for next command
+                if cmd.pipe_output() {
+                    stdin = Stdio::piped();
+                    prev_output = Some(output.stdout);
+                } else {
+                    stdin = Stdio::null();
+                }
+
+                // If command was `node create`, then prompt the user before continuing to the next command.
+                let args = cmd.args();
+                if args.len() >= 2 && &args[0] == "node" && &args[1] == "create" {
+                    CommandsRunner::wait_for_prompt(it.peek())?;
+                }
+
+                std::thread::sleep(std::time::Duration::from_millis(250));
             }
             Ok(())
         }
 
-        /// Sort list of commands based on their dependencies
-        fn sort_commands(self) -> Result<Vec<Command>> {
-            // Check that `depend_on` reference to existing commands
-            for (name, cmd) in &self.commands {
-                if let Some(depends_on) = &cmd.depends_on {
-                    if !self.commands.contains_key(depends_on) {
-                        return Err(anyhow!(
-                            "Command '{}' depends on non-existing command '{}'",
-                            name,
-                            depends_on
-                        ));
+        /// Parse current command to find the necessary steps to be run before it.
+        ///
+        /// E.g. a command that has a `/node/blue` argument will trigger the creation of a node named `blue`.
+        fn command_preprocessing(exe: &PathBuf, cmd: &Command) -> Result<()> {
+            // The config file can be updated by other commands that are run on different threads,
+            // so we load the config file each time we run a command so we always have an updated version.
+            let lookup = OckamConfig::load();
+            for arg in &cmd.args() {
+                // Parse arguments to find a `/node/<name>/...` instance and create a node with that name if it doesn't exist.
+                if arg.starts_with("/node/") {
+                    let node_name = {
+                        let maddr = MultiAddr::from_str(arg)?;
+                        let mut it = maddr.iter().peekable();
+                        let p = it.next().context("Should have a first value")?;
+                        let name = p
+                            .cast::<Node>()
+                            .context("Failed to parse node name from address")?;
+                        if lookup.get_node(&name).is_ok() {
+                            // Node already exists, continue to next iteration.
+                            continue;
+                        }
+                        name.to_string()
+                    };
+                    println!("Creating node '{node_name}'");
+                    let mut args = vec!["node".into(), "create".into(), node_name];
+                    let mut optional_args = CommandsRunner::ask_for_node_args()?;
+                    args.append(&mut optional_args);
+                    trace!("Running command {:?}", args);
+                    let status = std::process::Command::new(&exe)
+                        .args(args)
+                        .stdout(Stdio::inherit())
+                        .stderr(Stdio::inherit())
+                        .status()?;
+                    if !status.success() {
+                        return Err(anyhow!("Failed to create node"));
                     }
+                    CommandsRunner::wait_for_prompt(Some(&cmd))?;
+                    std::thread::sleep(std::time::Duration::from_millis(250));
                 }
             }
-            // Convert hashmap to a ring buffer so we can cycle through the commands multiple times.
-            let mut commands: VecDeque<(String, Command)> =
-                self.commands.into_iter().map(|(k, v)| (k, v)).collect();
-            // We will store how many times we cycle through each command.
-            let mut cycles: HashMap<String, usize> = HashMap::new();
-            let max_cycles = commands.len();
-            // We will store the commands with unresolved dependencies (using `name` and `depends_on`).
-            let mut unresolved = HashMap::new();
-            // Other variables to store the sorting state.
-            let mut names = vec![];
-            let mut sorted = vec![];
-            // Process commands until we have them all sorted and there are none left on the list.
-            while let Some((name, cmd)) = commands.pop_front() {
-                // Process command dependencies.
-                if let Some(depends_on) = &cmd.depends_on {
-                    // Dependency is in a previous position of the list. We can push the current command to the sorted list.
-                    if names.contains(depends_on) {
-                        names.push(name);
-                        sorted.push(cmd);
-                    }
-                    // Dependency is in a further position of the list.
-                    else {
-                        // In the worst-case scenario, we will sort one element on each cycle, so we will sort the complete list
-                        // in `max_cycles` cycles. Otherwise, we have a circular dependency.
-                        if let Some(c) = cycles.get_mut(&name) {
-                            let curr = *c;
-                            *c = curr + 1;
-                            if *c > max_cycles {
-                                let msg = unresolved
-                                    .into_iter()
-                                    .map(|(k, v)| format!("command {k} -> depends_on {v}"))
-                                    .collect::<Vec<_>>();
-                                return Err(anyhow!("Circular dependency detected for {msg:?}"));
-                            }
-                        } else {
-                            // Initialize cycle counter for the current command.
-                            cycles.insert(name.clone(), 1);
-                        }
+            Ok(())
+        }
 
-                        // If the `depends_on` is on the unresolved hashmap and the command name matches the item's value, then
-                        // we have a circular dependency. Example:
-                        // 1. name=A, depends_on=B -> we store (A,B) in the dependencies hashmap
-                        // 2. name=B, depends_on=A -> we find "A" key with "B" value -> circular dependency
-                        if let Some(n) = unresolved.get(depends_on) {
-                            if name.eq(n) {
-                                return Err(anyhow!(
-                                        "Circular dependency detected for commands {name} <-> {depends_on}",
-                                    ));
-                            }
-                        }
-                        // We requeue the command at the end of the list and we also store it in the unresolved hashmap.
-                        unresolved.insert(name.clone(), depends_on.clone());
-                        commands.push_back((name, cmd));
-                    }
-                }
-                // Command has no dependencies. We can add it right away to the sorted list.
-                else {
-                    sorted.push(cmd);
-                    names.push(name);
-                }
+        /// Waits for the user to press `Enter` before proceeding with the next command.
+        /// If there is no next command, the prompt will be skipped.
+        fn wait_for_prompt(next_cmd: Option<&&Command>) -> Result<()> {
+            if let Some(next_cmd) = next_cmd {
+                print!(
+                    "Press `Enter` to continue to the next command: `{}`",
+                    next_cmd.args().join(" ")
+                );
+                let mut input = String::new();
+                std::io::stdout().flush()?;
+                std::io::stdin().read_line(&mut input)?;
             }
-            Ok(sorted)
+            Ok(())
+        }
+
+        /// Prompt the user for the optional arguments to be passed to the `node create` command.
+        fn ask_for_node_args() -> Result<Vec<String>> {
+            let mut args = vec![];
+            println!("Enter optional arguments for the node (e.g. `--project project.json`):");
+            let mut input = String::new();
+            std::io::stdout().flush()?;
+            std::io::stdin().read_line(&mut input)?;
+            if input.trim().is_empty() {
+                println!("No optional arguments provided");
+            } else {
+                args.push(input.trim().to_string());
+                println!("The optional arguments are: `{}`", args.join(" "));
+            }
+            print!("Proceed? [Y/n] ");
+            std::io::stdout().flush()?;
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            if input.trim().to_lowercase() == "y" || input.trim().is_empty() {
+                // Convert to single-value entries. E.g. ["--flag", "--arg value"] -> ["--flag", "--arg", "value"]
+                Ok(args
+                    .join(" ")
+                    .split(' ')
+                    .map(|s| s.to_string())
+                    .filter(|x| !x.is_empty())
+                    .collect())
+            } else {
+                CommandsRunner::ask_for_node_args()
+            }
         }
     }
 
@@ -443,39 +707,151 @@ pub mod run {
             let file_path = dir.path().join("cmds.json");
             let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
             assert_eq!(cr.path, file_path);
-            assert!(cr.commands.is_empty());
+            assert!(cr.commands.on_node_init.is_empty());
+            assert!(cr.commands.on_node_startup.is_empty());
         }
 
         #[test]
         fn create_from_existing_file() {
             let contents = r#"{
-                "command1": {
-                    "args": ["arg1", "arg2"],
-                    "depends_on": null
+                "run": {
+                    "name": "my_node",
+                    "args": "--project project.json"
                 },
-                "command2": {
-                    "args": ["arg3", "arg4"],
-                    "depends_on": "command1"
-                }
+                "on_node_init": [
+                    {
+                        "args": ["init", "1"],
+                        "pipe": true
+                    },
+                    {
+                        "command": "init",
+                        "args": ["2"]
+                    }
+                ],
+                "on_node_startup": [
+                    "startup 3",
+                    {
+                        "command": "startup 4"
+                    }
+                ]
             }"#;
             let dir = tempdir().expect("Failed to create temp dir");
             let file_path = dir.path().join("cmds.json");
             std::fs::write(&file_path, contents).expect("Failed to write contents to file");
             let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
             assert_eq!(cr.path, file_path);
-            assert_eq!(cr.commands.len(), 2);
 
-            let cmd1 = cr.commands.get("command1").expect("Failed to get command1");
-            assert_eq!(cmd1.args, vec!["arg1", "arg2"]);
-            assert!(cmd1.depends_on.is_none());
+            // Run section
+            let run = cr.commands.run.expect("Failed to parse run section");
+            assert_eq!(run.name, "my_node");
+            assert_eq!(
+                run.args.unwrap(),
+                CommandArgs::String("--project project.json".into())
+            );
 
-            let cmd2 = cr.commands.get("command2").expect("Failed to get command2");
-            assert_eq!(cmd2.args, vec!["arg3", "arg4"]);
-            assert_eq!(cmd2.depends_on, Some("command1".to_string()));
+            // Node init section
+            assert_eq!(cr.commands.on_node_init.len(), 2);
+
+            let cmd1 = cr.commands.on_node_init.get(0).expect("Failed to get cmd1");
+            assert_eq!(cmd1.args(), vec!["init", "1", "--pipe"]);
+            assert!(cmd1.pipe_output());
+
+            let cmd2 = cr.commands.on_node_init.get(1).expect("Failed to get cmd2");
+            assert_eq!(cmd2.args(), vec!["init", "2"]);
+            assert!(!cmd2.pipe_output());
+
+            // Node startup section
+            assert_eq!(cr.commands.on_node_startup.len(), 2);
+
+            let cmd3 = cr
+                .commands
+                .on_node_startup
+                .get(0)
+                .expect("Failed to get cm3");
+            assert_eq!(cmd3.args(), vec!["startup", "3"]);
+            assert!(!cmd3.pipe_output());
+
+            let cmd4 = cr
+                .commands
+                .on_node_startup
+                .get(1)
+                .expect("Failed to get cmd4");
+            assert_eq!(cmd4.args(), vec!["startup", "4"]);
+            assert!(!cmd4.pipe_output());
         }
 
         #[test]
-        fn cleanup_args() {
+        fn create_from_existing_file_with_single_section() {
+            let contents = r#"{
+                "on_node_init": [
+                    "init 1",
+                    "init 2"
+                ]
+            }"#;
+            let dir = tempdir().expect("Failed to create temp dir");
+            let file_path = dir.path().join("cmds.json");
+            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
+            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
+            assert_eq!(cr.path, file_path);
+
+            // Node init section
+            assert_eq!(cr.commands.on_node_init.len(), 2);
+
+            let cmd1 = cr.commands.on_node_init.get(0).expect("Failed to get cmd1");
+            assert_eq!(cmd1.args(), vec!["init", "1"]);
+            assert!(!cmd1.pipe_output());
+
+            let cmd2 = cr.commands.on_node_init.get(1).expect("Failed to get cmd2");
+            assert_eq!(cmd2.args(), vec!["init", "2"]);
+            assert!(!cmd2.pipe_output());
+        }
+
+        #[test]
+        fn parse_command_args() {
+            let expected_args = vec!["startup", "--arg", "value"];
+            let assert = |contents: &str| {
+                let cmd: Command = serde_json::from_str(contents).expect("Failed to parse command");
+                assert_eq!(&cmd.args(), &expected_args);
+            };
+
+            // Plain string
+            let contents = r#""startup --arg value""#;
+            assert(contents);
+
+            // Args list with single-entry values
+            let contents = r#"{
+                "args": ["startup", "--arg", "value"]
+            }"#;
+            assert(contents);
+
+            // Args list with multi-entry values
+            let contents = r#"{
+                "args": ["startup", "--arg value"]
+            }"#;
+            assert(contents);
+
+            // One-liner args
+            let contents = r#"{
+                "args": "startup --arg value"
+            }"#;
+            assert(contents);
+
+            // With command field + args list
+            let contents = r#"{
+                "command": "startup",
+                "args": "--arg value"
+            }"#;
+            assert(contents);
+
+            // One-liner command
+            let contents = r#"{
+                "command": "startup --arg value"
+            }"#;
+            assert(contents);
+        }
+
+        #[test]
+        fn cleanup_export_args() {
             let dir = tempdir().expect("Failed to create temp dir");
             let file_path = dir.path().join("cmds.json");
             let args = vec![
@@ -485,12 +861,9 @@ pub mod run {
                 "blue".to_string(),
                 "--export".to_string(),
                 file_path.to_str().unwrap().to_string(),
-                "--export-as".to_string(),
-                "ndblue".to_string(),
-                "--depends-on".to_string(),
-                "enroll".to_string(),
+                "--pipe".to_string(),
             ];
-            let cleaned = CommandsRunner::cleanup_args(args);
+            let cleaned = CommandsRunner::cleanup_export_args(args);
             assert_eq!(cleaned, vec!["node", "create", "blue"]);
         }
 
@@ -500,8 +873,7 @@ pub mod run {
             let file_path = dir.path().join("cmds.json");
             let mut cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
 
-            let export_as = "ndblue".to_string();
-            let depends_on = "enroll".to_string();
+            let section = CommandSection::OnNodeStartup;
             let args = vec![
                 "ockam".to_string(),
                 "node".to_string(),
@@ -509,26 +881,28 @@ pub mod run {
                 "blue".to_string(),
                 "--export".to_string(),
                 file_path.to_str().unwrap().to_string(),
-                "--export-as".to_string(),
-                export_as.clone(),
-                "--depends-on".to_string(),
-                depends_on.clone(),
+                "--export-section".to_string(),
+                section.to_string(),
             ];
             let cleaned_args = vec!["node", "create", "blue"];
 
-            cr.add(export_as.clone(), Some(depends_on.clone()), args);
-            assert_eq!(cr.commands.len(), 1);
-            let cmd = cr.commands.get(&export_as).expect("Failed to get command");
-            assert_eq!(cmd.args, cleaned_args);
-            assert_eq!(cmd.depends_on, Some(depends_on));
+            cr.add(CommandSection::OnNodeStartup, args, None);
+            assert_eq!(cr.commands.on_node_startup.len(), 1);
+            let cmd = cr
+                .commands
+                .on_node_startup
+                .get(0)
+                .expect("Failed to get command");
+            assert_eq!(cmd.args(), cleaned_args);
+            assert!(!cmd.pipe_output());
         }
 
         #[test]
         fn export() {
             let dir = tempdir().expect("Failed to create temp dir");
             let file_path = dir.path().join("cmds.json");
-            let export_as = "ndblue".to_string();
-            let depends_on = None;
+            let section = CommandSection::OnNodeInit;
+            let pipe = Some(true);
             let args = vec![
                 "ockam".to_string(),
                 "node".to_string(),
@@ -536,127 +910,22 @@ pub mod run {
                 "blue".to_string(),
                 "--export".to_string(),
                 file_path.to_str().unwrap().to_string(),
-                "--export-as".to_string(),
-                export_as.clone(),
+                "--export-section".to_string(),
+                section.to_string(),
+                "--pipe".to_string(),
             ];
-            let cleaned_args = vec!["node", "create", "blue"];
-            CommandsRunner::export(file_path.clone(), export_as.clone(), depends_on, args)
+            CommandsRunner::export(file_path.clone(), section, args, pipe)
                 .expect("Failed to export");
 
             let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
-            assert_eq!(cr.commands.len(), 1);
+            assert_eq!(cr.commands.on_node_init.len(), 1);
             let cmd = cr
                 .commands
-                .get(&export_as)
+                .on_node_init
+                .get(0)
                 .expect("Failed to retrieve command from file");
-            assert_eq!(cmd.args, cleaned_args);
-            assert!(cmd.depends_on.is_none());
-        }
-
-        #[test]
-        fn sort_commands() {
-            let contents = r#"{
-                "c": {
-                    "args": ["c", "arg"],
-                    "depends_on": "a"
-                },
-                "b": {
-                    "args": ["b", "arg"],
-                    "depends_on": "c"
-                },
-                "a": {
-                    "args": ["a", "arg"],
-                    "depends_on": null
-                }
-            }"#;
-            let dir = tempdir().expect("Failed to create temp dir");
-            let file_path = dir.path().join("cmds.json");
-            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
-            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
-            let res = cr.sort_commands().expect("Failed to sort commands");
-            let expected = vec![
-                Command {
-                    args: vec!["a".to_string(), "arg".to_string()],
-                    depends_on: None,
-                },
-                Command {
-                    args: vec!["c".to_string(), "arg".to_string()],
-                    depends_on: Some("a".to_string()),
-                },
-                Command {
-                    args: vec!["b".to_string(), "arg".to_string()],
-                    depends_on: Some("c".to_string()),
-                },
-            ];
-            assert_eq!(res, expected);
-        }
-
-        #[test]
-        fn sort_depends_on_points_to_invalid_command() {
-            let contents = r#"{
-                "b": {
-                    "args": ["b", "arg"],
-                    "depends_on": "c"
-                },
-                "a": {
-                    "args": ["a", "arg"],
-                    "depends_on": null
-                }
-            }"#;
-            let dir = tempdir().expect("Failed to create temp dir");
-            let file_path = dir.path().join("cmds.json");
-            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
-            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
-            let res = cr.sort_commands();
-            assert!(res.is_err());
-        }
-
-        #[test]
-        fn sort_commands_circular_dependency_direct() {
-            let contents = r#"{
-                "a": {
-                    "args": ["a", "arg"],
-                    "depends_on": "b"
-                },
-                "b": {
-                    "args": ["b", "arg"],
-                    "depends_on": "a"
-                }
-            }"#;
-            let dir = tempdir().expect("Failed to create temp dir");
-            let file_path = dir.path().join("cmds.json");
-            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
-            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
-            let res = cr.sort_commands();
-            assert!(res.is_err());
-        }
-
-        #[test]
-        fn sort_commands_circular_dependency_indirect() {
-            let contents = r#"{
-                "a": {
-                    "args": ["a", "arg"],
-                    "depends_on": "d"
-                },
-                "b": {
-                    "args": ["b", "arg"],
-                    "depends_on": "a"
-                },
-                "c": {
-                    "args": ["c", "arg"],
-                    "depends_on": null
-                },
-                "d": {
-                    "args": ["d", "arg"],
-                    "depends_on": "b"
-                }
-            }"#;
-            let dir = tempdir().expect("Failed to create temp dir");
-            let file_path = dir.path().join("cmds.json");
-            std::fs::write(&file_path, contents).expect("Failed to write contents to file");
-            let cr = CommandsRunner::new(&file_path).expect("Failed to create CommandsRunner");
-            let res = cr.sort_commands();
-            assert!(res.is_err());
+            assert_eq!(cmd.args(), vec!["node", "create", "blue", "--pipe"]);
+            assert!(cmd.pipe_output());
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -91,7 +91,10 @@ impl CreateCommand {
             Some(multiaddr) => {
                 // if stdout is not interactive/tty write the secure channel address to it
                 // in case some other program is trying to read it as piped input
-                if !atty::is(Stream::Stdout) {
+                if !atty::is(Stream::Stdout)
+                // or if the `--pipe` flag is set
+                || options.global_args.export.pipe()
+                {
                     println!("{}", multiaddr)
                 }
 


### PR DESCRIPTION
## Scope

Being able to execute a set of commands after a node is created.

This PR contains the work described in `Implement commands parser` of the [design issue](https://github.com/build-trust/codebase/issues/400), specifically:
- Support piping
- After a node is created, wait for user input before running next command
- Section to define arguments to be used when creating the node
- Sections to define commands to be run after node creation/restart

## How to test

Create a json file with the following contents:

```json
{
  "run": {
    "name": "green"
  },
  "on_node_init": [
    {
      "command": "secure-channel create --from /node/green --to /node/blue/service/api",
      "pipe": true
    },
    "tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/echo"
  ]
}
```

Execute the command `ockam node run <path-to-file>.json`.

This command will create the `green` node without the default arguments and then it will execute the commands defined in the `on_node_init` section. Note that the `secure-channel` command needs a node called `blue`. If it doesn't exist, it will be created automatically.

## Next up

- Use this feature on the `ockam node start` command
