### PR TITLE
feat(rust): upgrade to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,42 +516,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "04d5891a0b7bbd946e91a79c350b5475764d7d7eda9c71141059a9d2ab0853e5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "terminal_size 0.2.1",
- "textwrap 0.15.1",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "f00c7ed9ef8826baf070d8f477714b0d9219f8d15744d1b5267cc8a89a1f0286"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.0-rc.2",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "51eef4d62724bf369e9ca7458cfde0c55263708b4552020058fba384864e8c23"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -562,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2312,7 +2310,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "atty",
- "clap 3.2.22",
+ "clap 4.0.0-rc.2",
  "clap_complete",
  "cli-table",
  "colorful",
@@ -3824,15 +3822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-dependencies = [
- "terminal_size 0.2.1",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = "1"
 async-recursion = { version = "1.0.0" }
 async-trait = "0.1"
 atty = "0.2"
-clap = { version = "3.2.17", features = ["derive", "cargo", "wrap_help"] }
+clap = { version = "4.0.0-rc.2", features = ["derive", "cargo", "wrap_help"] }
 cli-table = "0.4"
 const-str = "0.4.3"
 crossbeam-channel = "0.5"
@@ -77,7 +77,7 @@ tracing-error = "0.2"
 tracing-subscriber = "0.3.9"
 validator = "0.15"
 colorful = "0.2"
-clap_complete = "3.2.4"
+clap_complete = "4.0.0-rc.1"
 
 ockam = { path = "../ockam", version = "^0.76.0", features = ["software_vault"] }
 ockam_api = { path = "../ockam_api", version = "0.19.0", features = ["std", "authenticators"] }

--- a/implementations/rust/ockam/ockam_command/src/admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/mod.rs
@@ -8,18 +8,18 @@ mod subscription;
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
 pub struct AdminCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub subcommand: AdminSubCommand,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum AdminSubCommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Subscription(subscription::SubscriptionCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 use std::path::PathBuf;
 
+use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 
 use ockam::Context;
@@ -17,12 +18,12 @@ use crate::{help, CommandGlobalOpts};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
 pub struct SubscriptionCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SubscriptionSubcommand,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 }
 
@@ -34,11 +35,11 @@ pub enum SubscriptionSubcommand {
         json: PathBuf,
 
         /// Space ID to attach the subscription to
-        #[clap(
-            name = "space",
+        #[arg(
+            id = "space",
             value_name = "SPACE_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         space_id: String,
     },
@@ -50,16 +51,16 @@ pub enum SubscriptionSubcommand {
     /// You can use either the subscription ID or the space ID.
     Unsubscribe {
         /// Subscription ID
-        #[clap(group = "id")]
+        #[arg(group = "id")]
         subscription_id: Option<String>,
 
         /// Space ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "space",
+            id = "space",
             value_name = "SPACE_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         space_id: Option<String>,
     },
@@ -70,7 +71,7 @@ pub enum SubscriptionSubcommand {
 
 #[derive(Clone, Debug, Args)]
 pub struct SubscriptionUpdate {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SubscriptionUpdateSubcommand,
 }
 
@@ -83,22 +84,22 @@ enum SubscriptionUpdateSubcommand {
         json: PathBuf,
 
         /// Subscription ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "subscription",
+            id = "subscription",
             value_name = "SUBSCRIPTION_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         subscription_id: Option<String>,
 
         /// Space ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "space",
+            id = "space",
             value_name = "SPACE_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         space_id: Option<String>,
     },
@@ -107,22 +108,22 @@ enum SubscriptionUpdateSubcommand {
     /// You can use either the subscription ID or the space ID.
     Space {
         /// Subscription ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "subscription",
+            id = "subscription",
             value_name = "SUBSCRIPTION_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         subscription_id: Option<String>,
 
         /// Space ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "current_space",
+            id = "current_space",
             value_name = "SPACE_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         space_id: Option<String>,
 

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -1,6 +1,7 @@
 use crate::help;
 use crate::util::embedded_node;
 use anyhow::{anyhow, Result};
+use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use ockam::{Context, TcpTransport};
 use ockam_api::auth;
@@ -9,9 +10,9 @@ use ockam_multiaddr::MultiAddr;
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
 pub struct AuthenticatedCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: AuthenticatedSubcommand,
 }
 
@@ -23,11 +24,11 @@ pub enum AuthenticatedSubcommand {
         addr: MultiAddr,
 
         /// Subject identifier
-        #[clap(long, forbid_empty_values = true)]
+        #[arg(long, value_parser(NonEmptyStringValueParser::new()))]
         id: String,
 
         /// Attribute key.
-        #[clap(forbid_empty_values = true)]
+        #[arg(value_parser(NonEmptyStringValueParser::new()))]
         key: String,
     },
     /// Delete attribute
@@ -36,11 +37,11 @@ pub enum AuthenticatedSubcommand {
         addr: MultiAddr,
 
         /// Subject identifier
-        #[clap(long, forbid_empty_values = true)]
+        #[arg(long, value_parser(NonEmptyStringValueParser::new()))]
         id: String,
 
         /// Attribute key.
-        #[clap(forbid_empty_values = true)]
+        #[arg(value_parser(NonEmptyStringValueParser::new()))]
         key: String,
     },
 }

--- a/implementations/rust/ockam/ockam_command/src/completion/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/completion/mod.rs
@@ -4,7 +4,7 @@ use clap_complete::{generate, Shell};
 use std::io;
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     Generate shell completion scripts for Ockam commands.
 
     If you’ve installed `ockam` command using a package manager, you likely
@@ -28,10 +28,10 @@ ABOUT:
 
 /// Generate shell completion scripts
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct CompletionCommand {
     /// The type of shell (bash, zsh, fish)
-    #[clap(display_order = 900, long, short)]
+    #[arg(display_order = 900, long, short)]
     shell: Shell,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
@@ -17,9 +17,9 @@ use clap::{Args, Subcommand};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
 pub struct ConfigurationCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: ConfigurationSubcommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
@@ -8,10 +8,10 @@ use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct GetCredentialCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub node_opts: NodeOpts,
 
-    #[clap(long)]
+    #[arg(long)]
     pub overwrite: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -9,14 +9,14 @@ use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     hide = help::hide(),
     help_template = help::template(""),
     arg_required_else_help = true,
     subcommand_required = true
 )]
 pub struct CredentialCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: CredentialSubcommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/credential/present_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present_credential.rs
@@ -10,13 +10,13 @@ use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct PresentCredentialCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub node_opts: NodeOpts,
 
-    #[clap(long, display_order = 900, name = "ROUTE")]
+    #[arg(long, display_order = 900, id = "ROUTE")]
     pub to: MultiAddr,
 
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub oneway: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -29,9 +29,9 @@ const HELP_DETAIL: &str = "";
 
 /// Enroll with Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[clap(help_template = help::template(HELP_DETAIL))]
+#[command(help_template = help::template(HELP_DETAIL))]
 pub struct EnrollCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -18,25 +18,25 @@ use crate::{help, CommandGlobalOpts};
 
 /// Create Forwarders
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     help_template = help::template(HELP_DETAIL)
 )]
 pub struct CreateCommand {
     /// Name of the forwarder (optional)
-    #[clap(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     pub forwarder_name: String,
 
     /// Node for which to create the forwarder
-    #[clap(long, name = "NODE", display_order = 900)]
+    #[arg(long, id = "NODE", display_order = 900)]
     to: String,
 
     /// Route to the node at which to create the forwarder (optional)
-    #[clap(long, name = "ROUTE", display_order = 900)]
+    #[arg(long, id = "ROUTE", display_order = 900)]
     at: MultiAddr,
 
     /// Orchestrator address to resolve projects present in the `at` argument
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
@@ -7,7 +7,7 @@ use crate::{help, CommandGlobalOpts};
 mod create;
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     Forwarders enable an ockam node to register a forwarding address on another node.
     Any message that arrives at this forwarding address is immediately dispatched
     to the node that registered the forwarding address.
@@ -49,13 +49,13 @@ ABOUT:
 
 /// Manage Forwarders
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     subcommand_required = true,
     help_template = help::template(HELP_DETAIL)
 )]
 pub struct ForwarderCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: ForwarderSubCommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/help.rs
+++ b/implementations/rust/ockam/ockam_command/src/help.rs
@@ -17,11 +17,11 @@ const TEMPLATE_TOP: &str = "
 ";
 
 const TEMPLATE_BOTTOM: &str = "
-LEARN MORE:
+Learn more:
     Use 'ockam <SUBCOMMAND> --help' for more information about a subcommand.
     Learn more at https://docs.ockam.io/get-started#command
 
-FEEDBACK:
+Feedback:
     If you have any questions or feedback, please start a discussion
     on Github https://github.com/build-trust/ockam/discussions/new
 ";

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -9,9 +9,9 @@ use ockam_core::api::Status;
 use ockam_core::Route;
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct CreateCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -10,7 +10,7 @@ use clap::{Args, Subcommand};
 /// Manage Identities
 #[derive(Clone, Debug, Args)]
 pub struct IdentityCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: IdentitySubcommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -8,9 +8,9 @@ use ockam_core::api::Status;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
-    #[clap(short, long, action)]
+    #[arg(short, long)]
     full: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -54,7 +54,7 @@ use version::Version;
 
 use crate::admin::AdminCommand;
 use crate::subscription::SubscriptionCommand;
-use clap::{ArgEnum, Args, Parser, Subcommand};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use upgrade::check_if_an_upgrade_is_available;
 
 const ABOUT: &str = "\
@@ -63,7 +63,7 @@ credential management, and authorization policy enforcement — at scale.
 ";
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     Orchestrate end-to-end encryption, mutual authentication, key management,
     credential management, and authorization policy enforcement — at scale.
 
@@ -72,7 +72,7 @@ ABOUT:
     to build secure by-design applications that have granular control over every
     trust and access decision.
 
-EXAMPLES:
+Examples:
 
     Let's walk through a simple example to create an end-to-end encrypted,
     mutually authenticated, secure and private cloud relay – for any application.
@@ -142,7 +142,7 @@ EXAMPLES:
 ";
 
 #[derive(Debug, Parser)]
-#[clap(
+#[command(
     name = "ockam",
     term_width = 100,
     about = ABOUT,
@@ -150,40 +150,49 @@ EXAMPLES:
     help_template = help::template(HELP_DETAIL),
     version,
     long_version = Version::long(),
-    next_help_heading = "GLOBAL OPTIONS",
-    mut_arg("help", |a| a.help_heading("GLOBAL OPTIONS")),
-    mut_subcommand("help", |c| c.about("Print help information"))
+    next_help_heading = "Global options",
+    disable_help_flag = true
 )]
 pub struct OckamCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: OckamSubcommand,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     global_args: GlobalArgs,
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct GlobalArgs {
+    #[arg(
+        global = true,
+        long,
+        short,
+        help("Print help information"),
+        help_heading("Global options"),
+        action = ArgAction::Help
+    )]
+    help: Option<bool>,
+
     /// Do not print any trace messages
-    #[clap(global = true, long, short, conflicts_with("verbose"))]
+    #[arg(global = true, long, short, conflicts_with("verbose"))]
     quiet: bool,
 
     /// Increase verbosity of trace messages
-    #[clap(
+    #[arg(
         global = true,
         long,
         short,
         conflicts_with("quiet"),
-        parse(from_occurrences)
+        action = ArgAction::Count
     )]
     verbose: u8,
 
     /// Output without any colors
-    #[clap(hide = help::hide(), global = true, long, action)]
+    #[arg(hide = help::hide(), global = true, long)]
     no_color: bool,
 
     /// Output format
-    #[clap(
+    #[arg(
         hide = help::hide(),
         global = true,
         long = "output",
@@ -194,14 +203,14 @@ pub struct GlobalArgs {
 
     // if test_argument_parser is true, command arguments are checked
     // but the command is not executed.
-    #[clap(global = true, long, hide = true)]
+    #[arg(global = true, long, hide = true)]
     test_argument_parser: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     export: ExportCommandArgs,
 }
 
-#[derive(Debug, Clone, ArgEnum, PartialEq, Eq)]
+#[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
 pub enum OutputFormat {
     Plain,
     Json,
@@ -211,15 +220,15 @@ pub enum OutputFormat {
 pub struct ExportCommandArgs {
     /// Export the command input to a file.
     /// Used to run a set of commands after creating a node with `ockam node create --run commands.json`
-    #[clap(global = true, long = "export")]
+    #[arg(global = true, long = "export")]
     export_path: Option<PathBuf>,
 
     /// Unique name for the exported command.
-    #[clap(global = true, long, hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(global = true, long, hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     export_as: String,
 
     /// Reference to a previously exported command that must be run before the current command.
-    #[clap(global = true, long)]
+    #[arg(global = true, long)]
     depends_on: Option<String>,
 }
 
@@ -240,37 +249,37 @@ impl CommandGlobalOpts {
 
 #[derive(Debug, Subcommand)]
 pub enum OckamSubcommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Enroll(EnrollCommand),
-    #[clap(display_order = 801)]
+    #[command(display_order = 801)]
     Space(SpaceCommand),
-    #[clap(display_order = 802)]
+    #[command(display_order = 802)]
     Project(ProjectCommand),
-    #[clap(display_order = 803)]
+    #[command(display_order = 803)]
     Reset(ResetCommand),
 
-    #[clap(display_order = 811)]
+    #[command(display_order = 811)]
     Node(NodeCommand),
-    #[clap(display_order = 812)]
+    #[command(display_order = 812)]
     Identity(IdentityCommand),
-    #[clap(display_order = 813)]
+    #[command(display_order = 813)]
     TcpListener(TcpListenerCommand),
-    #[clap(display_order = 814)]
+    #[command(display_order = 814)]
     TcpConnection(TcpConnectionCommand),
-    #[clap(display_order = 815)]
+    #[command(display_order = 815)]
     TcpOutlet(TcpOutletCommand),
-    #[clap(display_order = 816)]
+    #[command(display_order = 816)]
     TcpInlet(TcpInletCommand),
-    #[clap(display_order = 817)]
+    #[command(display_order = 817)]
     SecureChannelListener(SecureChannelListenerCommand),
-    #[clap(display_order = 818)]
+    #[command(display_order = 818)]
     SecureChannel(SecureChannelCommand),
-    #[clap(display_order = 819)]
+    #[command(display_order = 819)]
     Forwarder(ForwarderCommand),
-    #[clap(display_order = 820)]
+    #[command(display_order = 820)]
     Message(MessageCommand),
 
-    #[clap(display_order = 900)]
+    #[command(display_order = 900)]
     Completion(CompletionCommand),
 
     Authenticated(AuthenticatedCommand),

--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -5,7 +5,7 @@ pub use send::SendCommand;
 mod send;
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     An Ockam node is any running application that can communicate with other applications
     using various Ockam protocols like Routing, Secure Channels, Forwarding etc.
 
@@ -52,7 +52,7 @@ ABOUT:
         - A secure channel listener at /service/api
         - A tcp listener listening at some TCP port
 
-EXAMPLES:
+Examples:
 
 ```sh
     # Create two nodes
@@ -83,20 +83,19 @@ EXAMPLES:
 
 /// Send and Receive Messages
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL),
-    mut_subcommand("help", |c| c.about("Print help information"))
+    help_template = help::template(HELP_DETAIL)
 )]
 pub struct MessageCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: MessageSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum MessageSubcommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Send(SendCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -16,23 +16,23 @@ use crate::{help, message::HELP_DETAIL, CommandGlobalOpts};
 
 /// Send messages
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct SendCommand {
     /// The node to send messages from
-    #[clap(short, long, value_name = "NODE")]
+    #[arg(short, long, value_name = "NODE")]
     from: Option<String>,
 
     /// The route to send the message to
-    #[clap(short, long, value_name = "ROUTE")]
+    #[arg(short, long, value_name = "ROUTE")]
     pub to: MultiAddr,
 
     /// Override Default Timeout
-    #[clap(long, value_name = "TIMEOUT")]
+    #[arg(long, value_name = "TIMEOUT")]
     pub timeout: Option<u64>,
 
     pub message: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -38,36 +38,36 @@ use ockam_core::LOCAL;
 
 /// Create Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(help_template = help::template(HELP_DETAIL))]
+#[command(help_template = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Name of the node (Optional).
-    #[clap(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     pub node_name: String,
 
     /// Run the node in foreground.
-    #[clap(display_order = 900, long, short)]
+    #[arg(display_order = 900, long, short)]
     pub foreground: bool,
 
     /// TCP listener address
-    #[clap(
+    #[arg(
         display_order = 900,
         long,
         short,
-        name = "SOCKET_ADDRESS",
+        id = "SOCKET_ADDRESS",
         default_value = "127.0.0.1:0"
     )]
     pub tcp_listener_address: String,
 
     /// Skip creation of default Vault and Identity
-    #[clap(long, short, hide = true)]
+    #[arg(long, short, hide = true)]
     pub skip_defaults: bool,
 
     /// Skip credential checks
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     pub enable_credential_checks: bool,
 
     /// ockam_command started a child process to run this node in foreground.
-    #[clap(display_order = 900, long, hide = true)]
+    #[arg(display_order = 900, long, hide = true)]
     pub child_process: bool,
 
     /// JSON config to setup a foreground node
@@ -75,16 +75,16 @@ pub struct CreateCommand {
     /// This argument is currently ignored on background nodes.  Node
     /// configuration is run asynchronously and may take several
     /// seconds to complete.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     pub launch_config: Option<PathBuf>,
 
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     pub no_watchdog: bool,
 
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     pub project: Option<PathBuf>,
 
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     pub config: Option<PathBuf>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -4,18 +4,18 @@ use clap::Args;
 
 /// Delete Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Name of the node.
-    #[clap(default_value = "default", hide_default_value = true, group = "nodes")]
+    #[arg(default_value = "default", hide_default_value = true, group = "nodes")]
     node_name: String,
 
     /// Terminate all nodes
-    #[clap(long, short, group = "nodes")]
+    #[arg(long, short, group = "nodes")]
     all: bool,
 
     /// Clean up config directories and all nodes state directories
-    #[clap(display_order = 901, long, short)]
+    #[arg(display_order = 901, long, short)]
     force: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -4,7 +4,7 @@ use clap::Args;
 
 /// List Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(help_template = help::template(HELP_DETAIL))]
+#[command(help_template = help::template(HELP_DETAIL))]
 pub struct ListCommand {}
 
 impl ListCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -17,7 +17,7 @@ use crate::{help, CommandGlobalOpts};
 use clap::{Args, Subcommand};
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     An Ockam node is any running application that can communicate with other applications
     using various Ockam protocols like Routing, Secure Channels, Forwarding etc.
 
@@ -64,7 +64,7 @@ ABOUT:
         - A secure channel listener at /service/api
         - A tcp listener listening at some TCP port
 
-EXAMPLES:
+Examples:
 ```sh
     # Create two nodes
     $ ockam node create n1
@@ -115,30 +115,29 @@ EXAMPLES:
 
 /// Manage Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL),
-    mut_subcommand("help", |c| c.about("Print help information"))
+    help_template = help::template(HELP_DETAIL)
 )]
 pub struct NodeCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: NodeSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum NodeSubcommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Create(CreateCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Delete(DeleteCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     List(ListCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Show(ShowCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Start(StartCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Stop(StopCommand),
 }
 
@@ -158,6 +157,6 @@ impl NodeCommand {
 #[derive(Clone, Debug, Args)]
 pub struct NodeOpts {
     /// Override the default API node
-    #[clap(global = true, name = "node", short, long, default_value = "default")]
+    #[arg(global = true, id = "node", short, long, default_value = "default")]
     pub api_node: String,
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -11,10 +11,10 @@ use std::time::Duration;
 
 /// Show Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Name of the node.
-    #[clap(default_value = "default")]
+    #[arg(default_value = "default")]
     node_name: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -10,10 +10,10 @@ use rand::prelude::random;
 
 /// Start Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct StartCommand {
     /// Name of the node.
-    #[clap(default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(default_value_t = hex::encode(&random::<[u8;4]>()))]
     node_name: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -9,13 +9,13 @@ use rand::prelude::random;
 
 /// Stop Nodes
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct StopCommand {
     /// Name of the node.
-    #[clap(default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(default_value_t = hex::encode(&random::<[u8;4]>()))]
     node_name: String,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
-    #[clap(long)]
+    #[arg(long)]
     force: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/add_enroller.rs
@@ -11,21 +11,21 @@ use crate::CommandGlobalOpts;
 
 /// Adds an authorized enroller to the project' authority
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct AddEnrollerCommand {
     /// Id of the project.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub project_id: String,
 
     /// Identity id to add as an authorized enroller.
-    #[clap(display_order = 1002)]
+    #[arg(display_order = 1002)]
     pub enroller_identity_id: String,
 
     /// Description of this enroller, optional.
-    #[clap(display_order = 1003)]
+    #[arg(display_order = 1003)]
     pub description: Option<String>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -15,22 +15,22 @@ use crate::{space, CommandGlobalOpts};
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the space the project belongs to.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub space_name: String,
 
     /// Name of the project.
-    #[clap(display_order = 1002, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
+    #[arg(display_order = 1002, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
     pub project_name: String,
 
     // Enforce credentials for member access to the project node
-    #[clap(long, display_order = 1003)]
+    #[arg(long, display_order = 1003)]
     pub enforce_credentials: Option<bool>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 
     /// Services enabled for this project.
-    #[clap(display_order = 1100, last = true)]
+    #[arg(display_order = 1100, last = true)]
     pub services: Vec<String>,
     //TODO:  list of admins
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -13,14 +13,14 @@ use crate::{space, CommandGlobalOpts};
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Name of the space.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub space_name: String,
 
     /// Name of the project.
-    #[clap(display_order = 1002)]
+    #[arg(display_order = 1002)]
     pub project_name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete_enroller.rs
@@ -10,16 +10,16 @@ use crate::CommandGlobalOpts;
 
 /// Remove an identity as authorized enroller from the project' authority
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct DeleteEnrollerCommand {
     /// Id of the project.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub project_id: String,
 
-    #[clap(display_order = 1002)]
+    #[arg(display_order = 1002)]
     pub enroller_identity_id: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -20,19 +20,19 @@ use crate::{help, CommandGlobalOpts, Result};
 
 /// An authorised enroller can add members to a project.
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct EnrollCommand {
     /// Orchestrator address to resolve projects present in the `at` argument
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 
-    #[clap(long, short)]
+    #[arg(long, short)]
     member: IdentityIdentifier,
 
-    #[clap(long, short)]
+    #[arg(long, short)]
     to: MultiAddr,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -14,13 +14,13 @@ use crate::{stop_node, CommandGlobalOpts, Result};
 #[derive(Clone, Debug, Args)]
 pub struct GetCredentialCommand {
     /// Orchestrator address to resolve projects present in the `at` argument
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 
-    #[clap(long, short)]
+    #[arg(long, short)]
     to: MultiAddr,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -16,10 +16,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Args)]
 pub struct InfoCommand {
     /// Name of the project.
-    #[clap(long)]
+    #[arg(long)]
     pub name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -12,7 +12,7 @@ use crate::CommandGlobalOpts;
 /// List projects
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list_enrollers.rs
@@ -11,13 +11,13 @@ use crate::CommandGlobalOpts;
 
 /// List a project' authority authorized enrollers
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct ListEnrollersCommand {
     /// Id of the project.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub project_id: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -29,9 +29,9 @@ use crate::CommandGlobalOpts;
 
 /// Manage Projects in Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, subcommand_required = true)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
 pub struct ProjectCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: ProjectSubcommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -14,10 +14,10 @@ use crate::CommandGlobalOpts;
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Name of the project.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -5,7 +5,7 @@ use std::io::{self, BufReader, Read, Write};
 
 #[derive(Clone, Debug, Args)]
 pub struct ResetCommand {
-    #[clap(display_order = 901, long, short)]
+    #[arg(display_order = 901, long, short)]
     yes: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -23,22 +23,22 @@ use ockam_multiaddr::MultiAddr;
 
 /// Create Secure Channels
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node from which to initiate the secure channel (required)
-    #[clap(value_name = "NODE", long, display_order = 800)]
+    #[arg(value_name = "NODE", long, display_order = 800)]
     pub from: String,
 
     /// Route to a secure channel listener (required)
-    #[clap(value_name = "ROUTE", long, display_order = 800)]
+    #[arg(value_name = "ROUTE", long, display_order = 800)]
     pub to: MultiAddr,
 
     /// Identifiers authorized to be presented by the listener
-    #[clap(value_name = "IDENTIFIER", long, short, display_order = 801)]
+    #[arg(value_name = "IDENTIFIER", long, short, display_order = 801)]
     pub authorized: Option<Vec<IdentityIdentifier>>,
 
     /// Orchestrator address to resolve projects present in the `at` argument
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -17,14 +17,14 @@ use ockam_core::{Address, AddressParseError};
 
 /// Delete Secure Channels
 #[derive(Clone, Debug, Parser)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Node from which to initiate the secure channel (required)
-    #[clap(value_name = "NODE", long, display_order = 800)]
+    #[arg(value_name = "NODE", long, display_order = 800)]
     at: String,
 
     /// Address at which the channel to be deleted is running (required)
-    #[clap(parse(try_from_str = parse_address), display_order = 800)]
+    #[arg(value_parser(parse_address), display_order = 800)]
     address: Address,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -19,10 +19,10 @@ use crate::{
 
 /// List Secure Channels
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct ListCommand {
     /// Node at which the returned secure channels were initiated (required)
-    #[clap(value_name = "NODE", long, display_order = 800)]
+    #[arg(value_name = "NODE", long, display_order = 800)]
     at: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -12,23 +12,23 @@ use ockam_core::{Address, Route};
 
 /// Create Secure Channel Listeners
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: SecureChannelListenerNodeOpts,
 
     /// Address for this listener
     address: Address,
 
     /// Authorized Identifiers of secure channel initiators
-    #[clap(short, long, value_name = "IDENTIFIER")]
+    #[arg(short, long, value_name = "IDENTIFIER")]
     authorized_identifier: Option<Vec<IdentityIdentifier>>,
 }
 
 #[derive(Clone, Debug, Args)]
 pub struct SecureChannelListenerNodeOpts {
     /// Node at which to create the listener
-    #[clap(global = true, long, value_name = "NODE", default_value = "default")]
+    #[arg(global = true, long, value_name = "NODE", default_value = "default")]
     pub at: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -10,10 +10,10 @@ use crate::{help, CommandGlobalOpts};
 
 /// List Secure Channel Listeners
 #[derive(Args, Clone, Debug)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct ListCommand {
     /// Node of which secure listeners shall be listed
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
@@ -10,22 +10,21 @@ use clap::{Args, Subcommand};
 
 /// Manage Secure Channel Listeners
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL),
-    mut_subcommand("help", |c| c.about("Print help information"))
+    help_template = help::template(HELP_DETAIL)
 )]
 pub struct SecureChannelListenerCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SecureChannelListenerSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum SecureChannelListenerSubcommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Create(CreateCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     List(ListCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -14,7 +14,7 @@ use crate::{help, CommandGlobalOpts};
 use clap::{Args, Subcommand};
 
 const HELP_DETAIL: &str = "\
-ABOUT:
+About:
     Secure Channels provide end-to-end encrypted and mutually authenticated communication
     that is safe against eavesdropping, tampering, and forgery of messages en-route.
 
@@ -138,26 +138,25 @@ ABOUT:
 
 /// Manage Secure Channels.
 #[derive(Clone, Debug, Args)]
-#[clap(
+#[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL),
-    mut_subcommand("help", |c| c.about("Print help information"))
+    help_template = help::template(HELP_DETAIL)
 )]
 pub struct SecureChannelCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SecureChannelSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 enum SecureChannelSubcommand {
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Create(CreateCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Delete(DeleteCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     List(ListCommand),
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Show(ShowCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -12,14 +12,14 @@ use ockam_core::Address;
 
 /// Show Secure Channels
 #[derive(Clone, Debug, Args)]
-#[clap(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Node
-    #[clap(value_name = "NODE", long, display_order = 800)]
+    #[arg(value_name = "NODE", long, display_order = 800)]
     at: String,
 
     /// Channel address
-    #[clap(display_order = 800)]
+    #[arg(display_order = 800)]
     address: Address,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -8,15 +8,15 @@ use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct ServiceCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: ServiceSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum ServiceSubcommand {
-    #[clap(display_order = 900)]
+    #[command(display_order = 900)]
     Start(StartCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -18,46 +18,46 @@ use tracing::debug;
 
 #[derive(Clone, Debug, Args)]
 pub struct StartCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub node_opts: NodeOpts,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub create_subcommand: StartSubCommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum StartSubCommand {
     Vault {
-        #[clap(default_value_t = vault_default_addr())]
+        #[arg(default_value_t = vault_default_addr())]
         addr: String,
     },
     Identity {
-        #[clap(default_value_t = identity_default_addr())]
+        #[arg(default_value_t = identity_default_addr())]
         addr: String,
     },
     Authenticated {
-        #[clap(default_value_t = authenticated_default_addr())]
+        #[arg(default_value_t = authenticated_default_addr())]
         addr: String,
     },
     Verifier {
-        #[clap(long, default_value_t = verifier_default_addr())]
+        #[arg(long, default_value_t = verifier_default_addr())]
         addr: String,
     },
     Credentials {
-        #[clap(long, default_value_t = credentials_default_addr())]
+        #[arg(long, default_value_t = credentials_default_addr())]
         addr: String,
 
-        #[clap(long)]
+        #[arg(long)]
         oneway: bool,
     },
     Authenticator {
-        #[clap(long, default_value_t = authenticator_default_addr())]
+        #[arg(long, default_value_t = authenticator_default_addr())]
         addr: String,
 
-        #[clap(long)]
+        #[arg(long)]
         enrollers: PathBuf,
 
-        #[clap(long)]
+        #[arg(long)]
         project: String,
     },
 }

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -14,14 +14,14 @@ use colorful::Colorful;
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Name of the space.
-    #[clap(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
+    #[arg(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true)]
     pub name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 
     /// Administrators for this space
-    #[clap(display_order = 1100, last = true)]
+    #[arg(display_order = 1100, last = true)]
     pub admins: Vec<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -11,10 +11,10 @@ use crate::CommandGlobalOpts;
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     /// Name of the space.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -11,7 +11,7 @@ use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -16,32 +16,28 @@ pub mod util;
 
 /// Manage Spaces in Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[clap(
-    arg_required_else_help = true,
-    subcommand_required = true,
-    mut_subcommand("help", |c| c.about("Print help information")),
-)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
 pub struct SpaceCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SpaceSubcommand,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum SpaceSubcommand {
     /// Create spaces
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Create(CreateCommand),
 
     /// Delete spaces
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Delete(DeleteCommand),
 
     /// List spaces
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     List(ListCommand),
 
     /// Show spaces
-    #[clap(display_order = 800)]
+    #[command(display_order = 800)]
     Show(ShowCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -12,10 +12,10 @@ use crate::CommandGlobalOpts;
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
     /// Name of the space.
-    #[clap(display_order = 1001)]
+    #[arg(display_order = 1001)]
     pub name: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub cloud_opts: CloudOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -1,5 +1,6 @@
 use core::fmt::Write;
 
+use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 
 use ockam::Context;
@@ -17,12 +18,12 @@ use crate::{help, CommandGlobalOpts};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
 pub struct SubscriptionCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: SubscriptionSubcommand,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     cloud_opts: CloudOpts,
 }
 
@@ -32,16 +33,16 @@ pub enum SubscriptionSubcommand {
     /// You can use either the subscription ID or the space ID.
     Show {
         /// Subscription ID
-        #[clap(group = "id")]
+        #[arg(group = "id")]
         subscription_id: Option<String>,
 
         /// Space ID
-        #[clap(
+        #[arg(
             group = "id",
-            name = "space",
+            id = "space",
             value_name = "SPACE_ID",
             long,
-            forbid_empty_values = true
+            value_parser(NonEmptyStringValueParser::new())
         )]
         space_id: Option<String>,
     },

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddrV4;
 #[derive(Clone, Debug, Args)]
 pub struct TcpConnectionNodeOpts {
     /// Node that will initiate the connection
-    #[clap(
+    #[arg(
         global = true,
         short,
         long,
@@ -29,11 +29,11 @@ pub struct TcpConnectionNodeOpts {
 
 #[derive(Args, Clone, Debug)]
 pub struct CreateCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: TcpConnectionNodeOpts,
 
     /// The address to connect to (required)
-    #[clap(name = "to", short, long, value_name = "ADDRESS")]
+    #[arg(id = "to", short, long, value_name = "ADDRESS")]
     pub address: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -12,14 +12,14 @@ use crate::{
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 
     /// Tcp Connection ID
     pub id: String,
 
     /// Force this operation: delete the API transport if requested
-    #[clap(long)]
+    #[arg(long)]
     pub force: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -11,7 +11,7 @@ use ockam_api::nodes::{
 
 #[derive(Args, Clone, Debug)]
 pub struct ListCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
@@ -12,7 +12,7 @@ use clap::{Args, Subcommand};
 /// Manage TCP Connections
 #[derive(Args, Clone, Debug)]
 pub struct TcpConnectionCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: TcpConnectionSubCommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -12,7 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use std::net::SocketAddr;
 
 const HELP_DETAIL: &str = "\
-EXAMPLES:
+Examples:
 
 ```sh
     # Create a target service, we'll use a simple http server for this example
@@ -35,22 +35,22 @@ EXAMPLES:
 
 /// Create TCP Inlets
 #[derive(Clone, Debug, Args)]
-#[clap(help_template = help::template(HELP_DETAIL))]
+#[command(help_template = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node on which to start the tcp inlet.
-    #[clap(long, display_order = 900, name = "NODE")]
+    #[arg(long, display_order = 900, id = "NODE")]
     at: String,
 
     /// Address on which to accept tcp connections.
-    #[clap(long, display_order = 900, name = "SOCKET_ADDRESS")]
+    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS")]
     from: SocketAddr,
 
     /// Route to a tcp outlet.
-    #[clap(long, display_order = 900, name = "ROUTE")]
+    #[arg(long, display_order = 900, id = "ROUTE")]
     to: MultiAddr,
 
     /// Enable credentials authorization
-    #[clap(long, short, display_order = 802)]
+    #[arg(long, short, display_order = 802)]
     pub check_credential: bool,
 }
 
@@ -171,8 +171,8 @@ fn make_api_request(
 }
 
 /// Parse the returned status response
-fn parse_inlet_status(resp: &[u8]) -> ockam::Result<(Response, models::portal::InletStatus<'_>)> {
+fn parse_inlet_status(resp: &[u8]) -> ockam::Result<(Response, InletStatus<'_>)> {
     let mut dec = Decoder::new(resp);
     let response = dec.decode::<Response>()?;
-    Ok((response, dec.decode::<models::portal::InletStatus>()?))
+    Ok((response, dec.decode::<InletStatus>()?))
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
@@ -7,7 +7,7 @@ use create::CreateCommand;
 /// Manage TCP Inlets
 #[derive(Clone, Debug, Args)]
 pub struct TcpInletCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: TcpInletSubCommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 
 #[derive(Args, Clone, Debug)]
 pub struct CreateCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: TCPListenerNodeOpts,
 
     /// Address for this listener (eg. 127.0.0.1:7000)
@@ -25,7 +25,7 @@ pub struct CreateCommand {
 #[derive(Clone, Debug, Args)]
 pub struct TCPListenerNodeOpts {
     /// Node at which to create the listener
-    #[clap(global = true, long, value_name = "NODE", default_value = "default")]
+    #[arg(global = true, long, value_name = "NODE", default_value = "default")]
     pub at: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -12,14 +12,14 @@ use crate::{
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 
     /// Tcp Listener ID
     pub id: String,
 
     /// Force this operation: delete the API transport if requested
-    #[clap(long)]
+    #[arg(long)]
     pub force: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -11,7 +11,7 @@ use ockam_api::nodes::{
 
 #[derive(Args, Clone, Debug)]
 pub struct ListCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/mod.rs
@@ -12,7 +12,7 @@ use clap::{Args, Subcommand};
 /// Manage TCP Listeners
 #[derive(Args, Clone, Debug)]
 pub struct TcpListenerCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: TcpListenerSubCommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -15,7 +15,7 @@ use ockam_core::route;
 use std::net::SocketAddr;
 
 const HELP_DETAIL: &str = "\
-EXAMPLES:
+Examples:
 
 ```sh
     # Create a target service, we'll use a simple http server for this example
@@ -38,22 +38,22 @@ EXAMPLES:
 
 /// Create TCP Outlets
 #[derive(Clone, Debug, Args)]
-#[clap(help_template = help::template(HELP_DETAIL))]
+#[command(help_template = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node on which to start the tcp outlet.
-    #[clap(long, display_order = 900, name = "NODE")]
+    #[arg(long, display_order = 900, id = "NODE")]
     at: String,
 
     /// Address of the tcp outlet.
-    #[clap(long, display_order = 901, name = "OUTLET_ADDRESS")]
+    #[arg(long, display_order = 901, id = "OUTLET_ADDRESS")]
     from: String,
 
     /// TCP address to send raw tcp traffic.
-    #[clap(long, display_order = 902, name = "SOCKET_ADDRESS")]
+    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS")]
     to: SocketAddr,
 
     /// Enable credentials authorization
-    #[clap(long, short, display_order = 802)]
+    #[arg(long, short, display_order = 802)]
     pub check_credential: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -7,7 +7,7 @@ use create::CreateCommand;
 /// Manage TCP Outlets
 #[derive(Clone, Debug, Args)]
 pub struct TcpOutletCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: TcpOutletSubCommand,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/addon.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 #[derive(Clone, Debug, Args)]
 pub struct AddonCommand {
     /// Operation to perform
-    #[clap(possible_values = vec!["create", "delete", "show", "list"])]
+    #[arg(value_parser(["create", "delete", "show", "list"]))]
     operation: String,
     /// Add-on subcommand to call
     // Its full name must be `ockam-<scope>-<name>`, so for example:

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -9,11 +9,11 @@ use ockam_core::Route;
 /// Create vaults
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     node_opts: NodeOpts,
 
     /// Path to the Vault storage file
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub path: Option<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -7,9 +7,9 @@ use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 
 #[derive(Clone, Debug, Args)]
-#[clap(hide = help::hide())]
+#[command(hide = help::hide())]
 pub struct VaultCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: VaultSubcommand,
 }
 


### PR DESCRIPTION


<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

clap & clap_complete v3 are used

## Proposed Changes

- upgrade clap to v4.0.0.0-rc.2 & clap_complete to v4.0.0-rc.1
- address v3 & v4 deprecation warnings
- transition derives to command/arg
- deactivate mut_subcommand for "help" (causes runtime error) disable_help_flag and add global help arg
- unify help templates with new default help styling (lower-/uppercase)

## Notes
Changing the `about` text for the `help` for subcommands was removed as this is not possible with the new version utilizing `mut_subcommand`.
Formatting and styling the help is no longer possible the same way as in v3. [`clap::Command::help_template`](https://docs.rs/clap/4.0.0-rc.2/clap/struct.Command.html#method.help_template) formats the variables (e.g. `{usage}`) now with the new style (bold/underlined) but within the template there is no support for bold/underline in custom strings.

## Checks

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
