### PR TITLE
feat(rust): resolve forwarder project name in manager

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -1,7 +1,10 @@
 use bytes::Bytes;
 use ockam_core::compat::collections::VecDeque;
 use ockam_identity::IdentityIdentifier;
-use ockam_multiaddr::MultiAddr;
+use ockam_multiaddr::{
+    proto::{self, DnsAddr, Ip4, Ip6, Tcp},
+    MultiAddr,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -108,6 +111,18 @@ impl ConfigLookup {
         meta.project
             .iter()
             .any(|name| self.get_project(name).is_none())
+    }
+
+    pub fn node_address(&self, node: &proto::Node) -> Option<MultiAddr> {
+        let addr = self.get_node(node)?;
+        let mut m = MultiAddr::default();
+        match addr {
+            InternetAddress::Dns(dns, _) => m.push_back(DnsAddr::new(dns)).ok()?,
+            InternetAddress::V4(v4) => m.push_back(Ip4(*v4.ip())).ok()?,
+            InternetAddress::V6(v6) => m.push_back(Ip6(*v6.ip())).ok()?,
+        }
+        m.push_back(Tcp(addr.port())).ok()?;
+        Some(m)
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/error.rs
@@ -11,6 +11,17 @@ impl ApiError {
     pub fn generic(cause: &str) -> ockam_core::Error {
         ockam_core::Error::new(Origin::Application, Kind::Unknown, cause)
     }
+
+    pub fn message<T: fmt::Display>(m: T) -> ockam_core::Error {
+        ockam_core::Error::new(Origin::Application, Kind::Unknown, m.to_string())
+    }
+
+    pub fn wrap<E>(e: E) -> ockam_core::Error
+    where
+        E: ockam_core::compat::error::Error + Send + Sync + 'static,
+    {
+        ockam_core::Error::new(Origin::Application, Kind::Unknown, e)
+    }
 }
 
 #[derive(Debug)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -16,13 +16,18 @@ pub struct CreateForwarder<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3386455>,
     /// Address to create forwarder at.
-    #[n(1)] pub(crate) address: MultiAddr,
+    #[n(1)] address: MultiAddr,
     /// Forwarder alias.
-    #[b(2)] pub(crate) alias: Option<CowStr<'a>>,
+    #[b(2)] alias: Option<CowStr<'a>>,
     /// Forwarding service is at rust node.
-    #[n(3)] pub(crate) at_rust_node: bool,
-    #[n(4)] pub(crate) cloud_addr: Option<MultiAddr>,
-    #[n(5)] pub(crate) authorized: Option<IdentityIdentifier>
+    #[n(3)] at_rust_node: bool,
+    /// The orchestrator address used to resolve the project address
+    /// and authorised identity.
+    #[n(4)] cloud_addr: Option<MultiAddr>,
+    /// An authorised identity for secure channels.
+    /// Only set for non-project addresses as for projects the project's
+    /// authorised identity will be used.
+    #[n(5)] authorized: Option<IdentityIdentifier>
 }
 
 impl<'a> CreateForwarder<'a> {
@@ -53,6 +58,26 @@ impl<'a> CreateForwarder<'a> {
             cloud_addr: None,
             authorized: auth,
         }
+    }
+
+    pub fn address(&self) -> &MultiAddr {
+        &self.address
+    }
+
+    pub fn alias(&self) -> Option<&str> {
+        self.alias.as_deref()
+    }
+
+    pub fn at_rust_node(&self) -> bool {
+        self.at_rust_node
+    }
+
+    pub fn authorized(&self) -> Option<IdentityIdentifier> {
+        self.authorized.clone()
+    }
+
+    pub fn cloud_addr(&self) -> Option<&MultiAddr> {
+        self.cloud_addr.as_ref()
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -5,7 +5,7 @@ use core::str::FromStr;
 use ockam::{Address, Error, TCP};
 use ockam_core::{Route, LOCAL};
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Node, Project, Secure, Service, Space, Tcp};
-use ockam_multiaddr::{Match, MultiAddr, Protocol};
+use ockam_multiaddr::{MultiAddr, Protocol};
 use std::net::{SocketAddrV4, SocketAddrV6};
 
 /// Go through a multiaddr and remove all instances of
@@ -165,14 +165,6 @@ pub fn try_address_to_multiaddr(a: &Address) -> Result<MultiAddr, Error> {
         }
     }
     Ok(ma)
-}
-
-pub fn is_secure_channel_addr(a: &MultiAddr) -> bool {
-    a.matches(&[
-        Match::any([DnsAddr::CODE, Ip4::CODE, Ip6::CODE]),
-        Tcp::CODE.into(),
-        Secure::CODE.into(),
-    ])
 }
 
 /// Tells whether the input MultiAddr references a local node or a remote node.

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -5,7 +5,7 @@ use core::str::FromStr;
 use ockam::{Address, Error, TCP};
 use ockam_core::{Route, LOCAL};
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Node, Project, Secure, Service, Space, Tcp};
-use ockam_multiaddr::{MultiAddr, Protocol};
+use ockam_multiaddr::{Match, MultiAddr, Protocol};
 use std::net::{SocketAddrV4, SocketAddrV6};
 
 /// Go through a multiaddr and remove all instances of
@@ -165,6 +165,14 @@ pub fn try_address_to_multiaddr(a: &Address) -> Result<MultiAddr, Error> {
         }
     }
     Ok(ma)
+}
+
+pub fn is_secure_channel_addr(a: &MultiAddr) -> bool {
+    a.matches(&[
+        Match::any([DnsAddr::CODE, Ip4::CODE, Ip6::CODE]),
+        Tcp::CODE.into(),
+        Secure::CODE.into(),
+    ])
 }
 
 /// Tells whether the input MultiAddr references a local node or a remote node.

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -91,6 +91,9 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
             cmd.forwarder_name.clone()
         };
         let body = if Some(Project::CODE) == cmd.at.first().map(|p| p.code()) {
+            if cmd.authorized.is_some() {
+                return Err(anyhow!("--authorized can not be used with project addresses").into());
+            }
             CreateForwarder::at_project(ma, Some(alias), cmd.cloud_opts.route())
         } else {
             CreateForwarder::at_node(ma, Some(alias), at_rust_node, cmd.authorized)

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -1,20 +1,16 @@
-use std::collections::HashMap;
-
 use anyhow::{anyhow, Context as _};
 use clap::Args;
-use ockam_api::config::lookup::InternetAddress;
-use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Project, Tcp};
+use ockam::identity::IdentityIdentifier;
+use ockam_multiaddr::proto::Project;
 use rand::prelude::random;
 
 use ockam::{Context, TcpTransport};
 use ockam_api::is_local_node;
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
-use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
 use ockam_core::api::Request;
 use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
 
 use crate::forwarder::HELP_DETAIL;
-use crate::project::util;
 use crate::util::api::CloudOpts;
 use crate::util::output::Output;
 use crate::util::{get_final_element, node_rpc, RpcBuilder};
@@ -40,6 +36,10 @@ pub struct CreateCommand {
     #[arg(long, id = "ROUTE", display_order = 900)]
     at: MultiAddr,
 
+    /// Authorized identity for secure channel connection (optional)
+    #[arg(long, name = "AUTHORIZED", display_order = 900)]
+    authorized: Option<IdentityIdentifier>,
+
     /// Orchestrator address to resolve projects present in the `at` argument
     #[command(flatten)]
     cloud_opts: CloudOpts,
@@ -59,7 +59,6 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     let lookup = opts.config.lookup();
 
     let mut ma = MultiAddr::default();
-    let mut pa = HashMap::new();
 
     for proto in cmd.at.iter() {
         match proto.code() {
@@ -68,35 +67,18 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
                     .cast::<Node>()
                     .ok_or_else(|| anyhow!("invalid node address protocol"))?;
                 let addr = lookup
-                    .get_node(&alias)
-                    .ok_or_else(|| anyhow!("unknown node {}", &*alias))?;
-                match addr {
-                    InternetAddress::Dns(dns, _) => ma.push_back(DnsAddr::new(dns))?,
-                    InternetAddress::V4(v4) => ma.push_back(Ip4(*v4.ip()))?,
-                    InternetAddress::V6(v6) => ma.push_back(Ip6(*v6.ip()))?,
-                }
-                ma.push_back(Tcp(addr.port()))?
+                    .node_address(&alias)
+                    .ok_or_else(|| anyhow!("no address for node {}", &*alias))?;
+                ma.try_extend(&addr)?
             }
             Project::CODE => {
-                let alias = proto
+                let name = proto
                     .cast::<Project>()
                     .ok_or_else(|| anyhow!("invalid project address protocol"))?;
-                if lookup.get_project(&alias).is_none() {
-                    util::config::refresh_projects(
-                        &ctx,
-                        &opts,
-                        api_node,
-                        &cmd.cloud_opts.route(),
-                        Some(&tcp),
-                    )
-                    .await?
-                }
-                if let Some(p) = lookup.get_project(&alias) {
-                    ma.try_extend(&p.node_route)?;
-                    pa.insert(p.node_route.clone(), p.identity_id.clone());
-                } else {
-                    return Err(anyhow!("unknown project name {}", &*alias).into());
-                }
+                let proj = lookup
+                    .get_project(&name)
+                    .ok_or_else(|| anyhow!("no project found with name {}", &*name))?;
+                ma.push_back(Project::new(&proj.id))?
             }
             _ => ma.push_back_value(&proto)?,
         }
@@ -108,13 +90,11 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
         } else {
             cmd.forwarder_name.clone()
         };
-        let body = CreateForwarder::new(
-            ma,
-            Some(alias),
-            at_rust_node,
-            pa,
-            CredentialExchangeMode::Oneway,
-        );
+        let body = if Some(Project::CODE) == cmd.at.first().map(|p| p.code()) {
+            CreateForwarder::at_project(ma, Some(alias), cmd.cloud_opts.route())
+        } else {
+            CreateForwarder::at_node(ma, Some(alias), at_rust_node, cmd.authorized)
+        };
         Request::post("/node/forwarder").body(body)
     };
 

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -524,14 +524,14 @@ impl MultiAddr {
     }
 
     /// Check if the protocol codes match the given sequence.
-    pub fn matches<'a, I>(&self, codes: I) -> bool
+    pub fn matches<'a, I>(&self, start: usize, codes: I) -> bool
     where
         I: IntoIterator<Item = &'a Match>,
         I::IntoIter: ExactSizeIterator,
     {
         let codes = codes.into_iter();
         let mut n = codes.len();
-        for (p, c) in self.iter().zip(codes) {
+        for (p, c) in self.iter().skip(start).zip(codes) {
             n -= 1;
             match c {
                 Match::Val(c) => {

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -150,7 +150,7 @@ impl<T> Deref for Checked<T> {
 }
 
 /// A numeric protocol code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Code(u32);
 
 impl fmt::Display for Code {
@@ -521,6 +521,54 @@ impl MultiAddr {
     {
         self.try_extend(iter)?;
         Ok(self)
+    }
+
+    /// Check if the protocol codes match the given sequence.
+    pub fn matches<'a, I>(&self, codes: I) -> bool
+    where
+        I: IntoIterator<Item = &'a Match>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let codes = codes.into_iter();
+        let mut n = codes.len();
+        for (p, c) in self.iter().zip(codes) {
+            n -= 1;
+            match c {
+                Match::Val(c) => {
+                    if p.code() != *c {
+                        return false;
+                    }
+                }
+                Match::Any(cs) => {
+                    if !cs.contains(&p.code()) {
+                        return false;
+                    }
+                }
+            }
+        }
+        n == 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Match {
+    Val(Code),
+    Any(TinyVec<[Code; 4]>),
+}
+
+impl Match {
+    pub fn code(c: Code) -> Self {
+        Self::Val(c)
+    }
+
+    pub fn any<I: IntoIterator<Item = Code>>(cs: I) -> Self {
+        Self::Any(cs.into_iter().collect())
+    }
+}
+
+impl From<Code> for Match {
+    fn from(c: Code) -> Self {
+        Match::code(c)
     }
 }
 

--- a/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Node, Project, Secure, Service, Space, Tcp};
-use ockam_multiaddr::{Code, MultiAddr, Protocol};
+use ockam_multiaddr::{Code, Match, MultiAddr, Protocol};
 use quickcheck::{quickcheck, Arbitrary, Gen};
 use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::*;
@@ -43,6 +43,11 @@ quickcheck! {
         let byts = minicbor::to_vec(&a.0).unwrap();
         let addr = minicbor::decode(&byts).unwrap();
         a.0 == addr
+    }
+
+    fn match_test(a: Addr) -> bool {
+        let codes = a.0.iter().map(|p| Match::code(p.code())).collect::<Vec<_>>();
+        a.0.matches(&codes)
     }
 
     fn push_back_value(a: Addr) -> bool {

--- a/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/tests/id.rs
@@ -47,7 +47,7 @@ quickcheck! {
 
     fn match_test(a: Addr) -> bool {
         let codes = a.0.iter().map(|p| Match::code(p.code())).collect::<Vec<_>>();
-        a.0.matches(&codes)
+        a.0.matches(0, &codes)
     }
 
     fn push_back_value(a: Addr) -> bool {


### PR DESCRIPTION
Since project routes are not guaranteed to be stable this commit moves the resolution of project references to routes when creating a remote forwarder to the node manager. The command-line layer merely maps a project name to a project ID but leaves everything else to the node manager.

On top of https://github.com/build-trust/ockam/pull/3497.