### PR TITLE
ci: 'ockam command test' workflow to run when tests changed

### DIFF
--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -14,10 +14,7 @@ on:
       - "**.rs"
       - "**.toml"
       - "**/Cargo.lock"
-      - "**.gradle"
-      - "tools/gradle/**"
-      - "gradlew"
-      - "gradlew.bat"
+      - "implementations/rust/ockam/ockam_command/tests/commands.bats"
       - ".github/actions/**"
 
   push:
@@ -26,10 +23,7 @@ on:
       - "**.rs"
       - "**.toml"
       - "**/Cargo.lock"
-      - "**.gradle"
-      - "tools/gradle/**"
-      - "gradlew"
-      - "gradlew.bat"
+      - "implementations/rust/ockam/ockam_command/tests/commands.bats"
       - ".github/actions/**"
   schedule:
     - cron: "0 1 * * *"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

The 'Ockam Command Test' GitHub CI workflow runs when Rust code is changed, Gradle files are changed or GitHub Action files are changed. 

This meant the workflow was not run when the test script it executes is changed (`implementations/rust/ockam/ockam_command/tests/commands.bats`).

https://github.com/build-trust/ockam/blob/4725c3efe5066dc1203b712982b34a3b5eb90320/.github/workflows/ockam_command.yml#L6-L35

## Proposed Changes

Modify the workflow's `on` section...
* Remove Gradle files.
* Add test script file.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
