### PR TITLE
fix(rust): resolve projects locally

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -124,6 +124,17 @@ impl ConfigLookup {
         m.push_back(Tcp(addr.port())).ok()?;
         Some(m)
     }
+
+    pub fn projects(&self) -> impl Iterator<Item = (String, ProjectLookup)> + '_ {
+        self.map.iter().filter_map(|(k, v)| {
+            if let LookupValue::Project(p) = v {
+                let name = k.strip_prefix("/project/").unwrap_or(k).to_string();
+                Some((name, p.clone()))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -21,24 +21,20 @@ pub struct CreateForwarder<'a> {
     #[b(2)] alias: Option<CowStr<'a>>,
     /// Forwarding service is at rust node.
     #[n(3)] at_rust_node: bool,
-    /// The orchestrator address used to resolve the project address
-    /// and authorised identity.
-    #[n(4)] cloud_addr: Option<MultiAddr>,
     /// An authorised identity for secure channels.
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
-    #[n(5)] authorized: Option<IdentityIdentifier>
+    #[n(4)] authorized: Option<IdentityIdentifier>
 }
 
 impl<'a> CreateForwarder<'a> {
-    pub fn at_project(address: MultiAddr, alias: Option<String>, cloud: MultiAddr) -> Self {
+    pub fn at_project(address: MultiAddr, alias: Option<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: Default::default(),
             address,
             alias: alias.map(|s| s.into()),
             at_rust_node: false,
-            cloud_addr: Some(cloud),
             authorized: None,
         }
     }
@@ -55,7 +51,6 @@ impl<'a> CreateForwarder<'a> {
             address,
             alias: alias.map(|s| s.into()),
             at_rust_node,
-            cloud_addr: None,
             authorized: auth,
         }
     }
@@ -74,10 +69,6 @@ impl<'a> CreateForwarder<'a> {
 
     pub fn authorized(&self) -> Option<IdentityIdentifier> {
         self.authorized.clone()
-    }
-
-    pub fn cloud_addr(&self) -> Option<&MultiAddr> {
-        self.cloud_addr.as_ref()
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -23,6 +23,7 @@ use ockam_vault::storage::FileStorage;
 use ockam_vault::Vault;
 
 use super::registry::Registry;
+use crate::config::lookup::ProjectLookup;
 use crate::config::{cli::AuthoritiesConfig, Config};
 use crate::error::ApiError;
 use crate::lmdb::LmdbStorage;
@@ -104,6 +105,7 @@ pub struct NodeManager {
     vault: Option<Vault>,
     identity: Option<Identity<Vault>>,
     project_id: Option<Vec<u8>>,
+    projects: Arc<BTreeMap<String, ProjectLookup>>,
     authorities: Option<Authorities>,
     pub(crate) authenticated_storage: LmdbStorage,
     pub(crate) registry: Registry,
@@ -156,6 +158,7 @@ impl NodeManager {
         enable_credential_checks: bool,
         ac: Option<&AuthoritiesConfig>,
         project_id: Option<Vec<u8>>,
+        projects: BTreeMap<String, ProjectLookup>,
         api_transport: (TransportType, TransportMode, String),
         tcp_transport: TcpTransport,
     ) -> Result<Self> {
@@ -246,6 +249,7 @@ impl NodeManager {
             enable_credential_checks,
             vault,
             identity,
+            projects: Arc::new(projects),
             project_id,
             authorities: None,
             authenticated_storage,
@@ -605,6 +609,7 @@ pub(crate) mod tests {
                 false,
                 None,
                 None,
+                Default::default(),
                 (
                     TransportType::Tcp,
                     TransportMode::Listen,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -13,8 +14,7 @@ use ockam_multiaddr::{Match, MultiAddr, Protocol};
 use ockam_node::tokio::time::timeout;
 use ockam_node::Context;
 
-use crate::cloud::project::Project as ProjectData;
-use crate::cloud::CloudRequestWrapper;
+use crate::config::lookup::ProjectLookup;
 use crate::error::ApiError;
 use crate::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
 use crate::nodes::models::secure_channel::{
@@ -40,7 +40,7 @@ impl NodeManager {
 
         debug!(addr = %req.address(), alias = ?req.alias(), "Handling CreateForwarder request");
 
-        let addr = self.connect(ctx, &req).await?;
+        let addr = self.connect(&req).await?;
         let route = multiaddr_to_route(&addr)
             .ok_or_else(|| ApiError::message("invalid address: {addr}"))?;
 
@@ -70,8 +70,8 @@ impl NodeManager {
                     this,
                     c,
                     req.address().clone(),
-                    req.cloud_addr().cloned(),
                     req.alias().map(|a| a.to_string()),
+                    self.projects.clone(),
                 );
                 self.sessions.lock().unwrap().add(s);
             }
@@ -98,16 +98,13 @@ impl NodeManager {
     }
 
     /// Resolve project ID (if any) and create secure channel if necessary.
-    async fn connect(&mut self, ctx: &mut Context, req: &CreateForwarder<'_>) -> Result<MultiAddr> {
+    async fn connect(&mut self, req: &CreateForwarder<'_>) -> Result<MultiAddr> {
         if let Some(p) = req.address().first() {
             if p.code() == Project::CODE {
                 let p = p
                     .cast::<Project>()
                     .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
-                let m = req
-                    .cloud_addr()
-                    .ok_or_else(|| ApiError::generic("request has no cloud address"))?;
-                let (mut a, i) = self.resolve_project(ctx, &p, m).await?;
+                let (mut a, i) = resolve_project(&self.projects, &p)?;
                 a.try_extend(req.address().iter().skip(1))?;
                 debug!(addr = %a, "creating secure channel");
                 let r =
@@ -136,58 +133,17 @@ impl NodeManager {
         }
         Ok(req.address().clone())
     }
-
-    /// Resolve the project name to an address and authorised identity.
-    async fn resolve_project(
-        &mut self,
-        ctx: &mut Context,
-        project: &str,
-        cloud: &MultiAddr,
-    ) -> Result<(MultiAddr, IdentityIdentifier)> {
-        debug!(%project, %cloud, "resolving project");
-        let req = minicbor::to_vec(&CloudRequestWrapper::bare(cloud))?;
-        let vec = self
-            .get_project(ctx, &mut Decoder::new(&req), project)
-            .await?;
-        let (addr, auth) = project_data(&vec)?;
-        debug!(%project, %addr, "resolved project");
-        Ok((addr, auth))
-    }
 }
 
-/// Resolve the project name to an address and authorised identity.
-///
-/// Uses message passing since callers of this fuunction do not posses a
-/// unique reference to `NodeManager`.
-async fn resolve_project(
-    manager: Address,
-    ctx: &Context,
-    project: &str,
-    cloud: &MultiAddr,
+fn resolve_project(
+    set: &BTreeMap<String, ProjectLookup>,
+    name: &str,
 ) -> Result<(MultiAddr, IdentityIdentifier)> {
-    debug!(%project, %cloud, "resolving project");
-    let req = Request::get(format!("/v0/projects/{project}"))
-        .body(CloudRequestWrapper::bare(cloud))
-        .to_vec()?;
-    let vec: Vec<u8> = ctx.send_and_receive(manager, req).await?;
-    let (addr, auth) = project_data(&vec)?;
-    debug!(%project, %addr, "resolved project");
-    Ok((addr, auth))
-}
-
-/// Extract the project address and identity from response bytes.
-fn project_data(bytes: &[u8]) -> Result<(MultiAddr, IdentityIdentifier)> {
-    let mut dec = Decoder::new(bytes);
-    let res: Response = dec.decode()?;
-    if res.status() != Some(Status::Ok) {
-        return Err(ApiError::generic("failed to get project info"));
+    if let Some(info) = set.get(name) {
+        Ok((info.node_route.clone(), info.identity_id.clone()))
+    } else {
+        Err(ApiError::message(format!("project {name} not found")))
     }
-    let res: ProjectData = dec.decode()?;
-    let addr = res.access_route()?;
-    let auth = res
-        .identity
-        .ok_or_else(|| ApiError::generic("project has no identity"))?;
-    Ok((addr, auth))
 }
 
 /// Configure the session for automatic recovery.
@@ -196,17 +152,17 @@ fn enable_recovery(
     manager: Address,
     ctx: Arc<Context>,
     addr: MultiAddr,
-    cloud: Option<MultiAddr>,
     alias: Option<String>,
+    projects: Arc<BTreeMap<String, ProjectLookup>>,
 ) {
     let auth = session.get::<IdentityIdentifier>(IDENTITY).cloned();
     session.set_replacement(move |prev| {
         let ctx = ctx.clone();
         let addr = addr.clone();
-        let cloud = cloud.clone();
         let alias = alias.clone();
         let auth = auth.clone();
         let manager = manager.clone();
+        let projects = projects.clone();
         Box::pin(async move {
             debug!(%prev, %addr, "creating new remote forwarder");
             let f = async {
@@ -215,8 +171,7 @@ fn enable_recovery(
                         let p = p
                             .cast::<Project>()
                             .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
-                        let c = cloud.ok_or_else(|| ApiError::message("missing cloud address"))?;
-                        let (mut a, i) = resolve_project(manager.clone(), &ctx, &p, &c).await?;
+                        let (mut a, i) = resolve_project(&projects, &p)?;
                         a.try_extend(addr.iter().skip(1))?;
                         replace_sec_chan(&ctx, &manager, &prev, &a, Some(i)).await?
                     } else if addr.matches(

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -289,6 +289,7 @@ async fn run_background_node_impl(
     tcp.listen(&bind).await?;
 
     let node_dir = cfg.get_node_dir(&c.node_name)?;
+    let projects = cfg.inner().lookup().projects().collect();
     let node_man = NodeManager::create(
         ctx,
         c.node_name.clone(),
@@ -298,6 +299,7 @@ async fn run_background_node_impl(
         c.enable_credential_checks,
         Some(&cfg.authorities(&c.node_name)?.snapshot()),
         project_id,
+        projects,
         (TransportType::Tcp, TransportMode::Listen, bind),
         tcp.async_try_clone().await?,
     )

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -52,6 +52,7 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
     let bind = cmd.tcp_listener_address;
     tcp.listen(&bind).await?;
     let node_dir = cfg.get_node_dir_raw(&cmd.node_name)?;
+    let projects = cfg.inner().lookup().projects().collect();
     let node_man = NodeManager::create(
         ctx,
         cmd.node_name.clone(),
@@ -61,6 +62,7 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
         cmd.enable_credential_checks,
         Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
         project_id,
+        projects,
         (TransportType::Tcp, TransportMode::Listen, bind),
         tcp,
     )


### PR DESCRIPTION
A node may not always have access to the controller to resolve project names to routes, so instead use the locally available project information to resolve project references.