### PR TITLE
refactor(rust): add `NodeManagerWorker` which handles the requests

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -37,14 +37,14 @@ mod node {
         AuthenticateEnrollmentToken, EnrollmentToken, RequestEnrollmentToken,
     };
     use crate::cloud::CloudRequestWrapper;
-    use crate::nodes::NodeManager;
+    use crate::nodes::NodeManagerWorker;
     use ockam_identity::credential::Attributes;
 
     use super::*;
 
     const TARGET: &str = "ockam_api::cloud::enroll";
 
-    impl NodeManager {
+    impl NodeManagerWorker {
         /// Executes an enrollment process to generate a new set of access tokens using the auth0 flow.
         pub(crate) async fn enroll_auth0(
             &mut self,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -195,13 +195,13 @@ mod node {
     use ockam_node::Context;
 
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
-    use crate::nodes::NodeManager;
+    use crate::nodes::NodeManagerWorker;
 
     use super::*;
 
     const TARGET: &str = "ockam_api::cloud::project";
 
-    impl NodeManager {
+    impl NodeManagerWorker {
         pub(crate) async fn create_project(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -67,11 +67,11 @@ mod node {
 
     use crate::cloud::space::CreateSpace;
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
-    use crate::nodes::NodeManager;
+    use crate::nodes::NodeManagerWorker;
 
     const TARGET: &str = "ockam_api::cloud::space";
 
-    impl NodeManager {
+    impl NodeManagerWorker {
         pub(crate) async fn create_space(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -94,14 +94,96 @@ mod node {
     use ockam_node::Context;
 
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
-    use crate::nodes::NodeManager;
+    use crate::nodes::NodeManagerWorker;
 
     use super::*;
 
     const TARGET: &str = "ockam_api::cloud::subscription";
     const API_SERVICE: &str = "subscriptions";
 
-    impl NodeManager {
+    impl NodeManagerWorker {
+        pub(crate) async fn unsubscribe(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "unsubscribe";
+            trace!(target: TARGET, subscription = %id, "unsubscribing");
+
+            let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn update_subscription_space(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "list_sbuscriptions";
+            trace!(target: TARGET, subscription = %id, "updating subscription space");
+
+            let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+        pub(crate) async fn update_subscription_contact_info(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "update_subscription_contact_info";
+            trace!(target: TARGET, subscription = %id, "updating subscription contact info");
+
+            let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+        pub(crate) async fn list_subscriptions(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "list_subscriptions";
+            trace!(target: TARGET, "listing subscriptions");
+
+            let req_builder = Request::get("/v0/");
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+        pub(crate) async fn get_subscription(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "get_subscription";
+            trace!(target: TARGET, subscription = %id, "getting subscription");
+
+            let req_builder = Request::get(format!("/v0/{}", id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
         pub(crate) async fn activate_subscription(
             &mut self,
             ctx: &mut Context,
@@ -124,92 +206,6 @@ mod node {
                 req_builder,
             )
             .await
-        }
-
-        pub(crate) async fn get_subscription(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-            id: &str,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-
-            let label = "get_subscription";
-            trace!(target: TARGET, subscription = %id, "getting subscription");
-
-            let req_builder = Request::get(format!("/v0/{}", id));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
-        }
-
-        pub(crate) async fn list_subscriptions(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-
-            let label = "list_subscriptions";
-            trace!(target: TARGET, "listing subscriptions");
-
-            let req_builder = Request::get("/v0/");
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
-        }
-
-        pub(crate) async fn update_subscription_contact_info(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-            id: &str,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-            let req_body = req_wrapper.req;
-
-            let label = "update_subscription_contact_info";
-            trace!(target: TARGET, subscription = %id, "updating subscription contact info");
-
-            let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
-        }
-
-        pub(crate) async fn update_subscription_space(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-            id: &str,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-            let req_body = req_wrapper.req;
-
-            let label = "list_sbuscriptions";
-            trace!(target: TARGET, subscription = %id, "updating subscription space");
-
-            let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
-        }
-
-        pub(crate) async fn unsubscribe(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-            id: &str,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-
-            let label = "unsubscribe";
-            trace!(target: TARGET, subscription = %id, "unsubscribing");
-
-            let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -9,4 +9,4 @@ pub mod models;
 pub const NODEMANAGER_ADDR: &str = "_internal.nodemanager";
 
 /// The main node-manager service running on remote nodes
-pub use service::{IdentityOverride, NodeManager};
+pub use service::{IdentityOverride, NodeManager, NodeManagerWorker};

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -47,11 +47,11 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::nodes::NodeManager;
+    use crate::nodes::NodeManagerWorker;
 
     const TARGET: &str = "ockam_api::message";
 
-    impl NodeManager {
+    impl NodeManagerWorker {
         pub(crate) async fn send_message(
             &mut self,
             ctx: &mut Context,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
-use super::map_multiaddr_err;
+use super::{map_multiaddr_err, NodeManagerWorker};
 use crate::error::ApiError;
 use crate::nodes::models::secure_channel::{
     CreateSecureChannelListenerRequest, CreateSecureChannelRequest, CreateSecureChannelResponse,
     CredentialExchangeMode, DeleteSecureChannelRequest, DeleteSecureChannelResponse,
     ShowSecureChannelRequest, ShowSecureChannelResponse,
 };
+use crate::nodes::registry::Registry;
 use crate::nodes::NodeManager;
 use crate::DefaultAddress;
 use minicbor::Decoder;
@@ -133,115 +134,6 @@ impl NodeManager {
         Ok(sc_addr)
     }
 
-    pub(super) async fn create_secure_channel<'a>(
-        &mut self,
-        req: &Request<'_>,
-        dec: &mut Decoder<'_>,
-    ) -> Result<ResponseBuilder<CreateSecureChannelResponse<'a>>> {
-        let CreateSecureChannelRequest {
-            addr,
-            authorized_identifiers,
-            credential_exchange_mode,
-            timeout,
-            ..
-        } = dec.decode()?;
-
-        info!("Handling request to create a new secure channel: {}", addr);
-
-        let authorized_identifiers = match authorized_identifiers {
-            Some(ids) => {
-                let ids = ids
-                    .into_iter()
-                    .map(|x| IdentityIdentifier::try_from(x.0.as_ref()))
-                    .collect::<Result<Vec<IdentityIdentifier>>>()?;
-
-                Some(ids)
-            }
-            None => None,
-        };
-
-        // TODO: Improve error handling + move logic into CreateSecureChannelRequest
-        let addr = MultiAddr::try_from(addr.as_ref()).map_err(map_multiaddr_err)?;
-        let route = crate::multiaddr_to_route(&addr)
-            .ok_or_else(|| ApiError::generic("Invalid Multiaddr"))?;
-
-        let channel = self
-            .create_secure_channel_impl(
-                route,
-                authorized_identifiers,
-                credential_exchange_mode,
-                timeout,
-            )
-            .await?;
-
-        let response = Response::ok(req.id()).body(CreateSecureChannelResponse::new(&channel));
-
-        Ok(response)
-    }
-
-    pub(super) async fn delete_secure_channel<'a>(
-        &mut self,
-        req: &Request<'_>,
-        dec: &mut Decoder<'_>,
-    ) -> Result<ResponseBuilder<DeleteSecureChannelResponse<'a>>> {
-        let body: DeleteSecureChannelRequest = dec.decode()?;
-
-        info!(
-            "Handling request to delete secure channel: {}",
-            body.channel
-        );
-
-        let identity = self.identity()?;
-
-        let sc_address = Address::from(body.channel.as_ref());
-
-        debug!(%sc_address, "Deleting secure channel");
-
-        let res = match identity.stop_secure_channel(&sc_address).await {
-            Ok(()) => {
-                trace!(%sc_address, "Removed secure channel");
-                self.registry.secure_channels.remove_by_addr(&sc_address);
-                Some(sc_address)
-            }
-            Err(err) => {
-                trace!(%sc_address, "Error removing secure channel: {err}");
-                None
-            }
-        };
-
-        Ok(Response::ok(req.id()).body(DeleteSecureChannelResponse::new(res)))
-    }
-
-    pub(super) fn list_secure_channels(
-        &mut self,
-        req: &Request<'_>,
-    ) -> ResponseBuilder<Vec<String>> {
-        Response::ok(req.id()).body(
-            self.registry
-                .secure_channels
-                .list()
-                .iter()
-                .map(|v| v.addr().to_string())
-                .collect(),
-        )
-    }
-
-    pub(super) async fn show_secure_channel<'a>(
-        &mut self,
-        req: &Request<'_>,
-        dec: &mut Decoder<'_>,
-    ) -> Result<ResponseBuilder<ShowSecureChannelResponse<'a>>> {
-        let body: ShowSecureChannelRequest = dec.decode()?;
-
-        let sc_address = Address::from(body.channel.as_ref());
-
-        debug!(%sc_address, "On show secure channel");
-
-        let info = self.registry.secure_channels.get_by_addr(&sc_address);
-
-        Ok(Response::ok(req.id()).body(ShowSecureChannelResponse::new(info)))
-    }
-
     pub(super) async fn create_secure_channel_listener_impl(
         &mut self,
         addr: Address,
@@ -281,12 +173,146 @@ impl NodeManager {
 
         Ok(())
     }
+}
+
+impl NodeManagerWorker {
+    pub(super) fn list_secure_channels(
+        &self,
+        req: &Request<'_>,
+        registry: &Registry,
+    ) -> ResponseBuilder<Vec<String>> {
+        Response::ok(req.id()).body(
+            registry
+                .secure_channels
+                .list()
+                .iter()
+                .map(|v| v.addr().to_string())
+                .collect(),
+        )
+    }
+
+    pub(super) fn list_secure_channel_listener(
+        &self,
+        req: &Request<'_>,
+        registry: &Registry,
+    ) -> ResponseBuilder<Vec<String>> {
+        Response::ok(req.id()).body(
+            registry
+                .secure_channel_listeners
+                .iter()
+                .map(|(addr, _)| addr.to_string())
+                .collect(),
+        )
+    }
+
+    pub(super) async fn create_secure_channel<'a>(
+        &mut self,
+        req: &Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<ResponseBuilder<CreateSecureChannelResponse<'a>>> {
+        let mut node_manager = self.node_manager.write().await;
+        let CreateSecureChannelRequest {
+            addr,
+            authorized_identifiers,
+            credential_exchange_mode,
+            timeout,
+            ..
+        } = dec.decode()?;
+
+        info!("Handling request to create a new secure channel: {}", addr);
+
+        let authorized_identifiers = match authorized_identifiers {
+            Some(ids) => {
+                let ids = ids
+                    .into_iter()
+                    .map(|x| IdentityIdentifier::try_from(x.0.as_ref()))
+                    .collect::<Result<Vec<IdentityIdentifier>>>()?;
+
+                Some(ids)
+            }
+            None => None,
+        };
+
+        // TODO: Improve error handling + move logic into CreateSecureChannelRequest
+        let addr = MultiAddr::try_from(addr.as_ref()).map_err(map_multiaddr_err)?;
+        let route = crate::multiaddr_to_route(&addr)
+            .ok_or_else(|| ApiError::generic("Invalid Multiaddr"))?;
+
+        let channel = node_manager
+            .create_secure_channel_impl(
+                route,
+                authorized_identifiers,
+                credential_exchange_mode,
+                timeout,
+            )
+            .await?;
+
+        let response = Response::ok(req.id()).body(CreateSecureChannelResponse::new(&channel));
+
+        Ok(response)
+    }
+
+    pub(super) async fn delete_secure_channel<'a>(
+        &mut self,
+        req: &Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<ResponseBuilder<DeleteSecureChannelResponse<'a>>> {
+        let body: DeleteSecureChannelRequest = dec.decode()?;
+
+        info!(
+            "Handling request to delete secure channel: {}",
+            body.channel
+        );
+        let mut node_manager = self.node_manager.write().await;
+        let identity = node_manager.identity()?;
+
+        let sc_address = Address::from(body.channel.as_ref());
+
+        debug!(%sc_address, "Deleting secure channel");
+
+        let res = match identity.stop_secure_channel(&sc_address).await {
+            Ok(()) => {
+                trace!(%sc_address, "Removed secure channel");
+                node_manager
+                    .registry
+                    .secure_channels
+                    .remove_by_addr(&sc_address);
+                Some(sc_address)
+            }
+            Err(err) => {
+                trace!(%sc_address, "Error removing secure channel: {err}");
+                None
+            }
+        };
+
+        Ok(Response::ok(req.id()).body(DeleteSecureChannelResponse::new(res)))
+    }
+    pub(super) async fn show_secure_channel<'a>(
+        &mut self,
+        req: &Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<ResponseBuilder<ShowSecureChannelResponse<'a>>> {
+        let node_manager = self.node_manager.read().await;
+        let body: ShowSecureChannelRequest = dec.decode()?;
+
+        let sc_address = Address::from(body.channel.as_ref());
+
+        debug!(%sc_address, "On show secure channel");
+
+        let info = node_manager
+            .registry
+            .secure_channels
+            .get_by_addr(&sc_address);
+
+        Ok(Response::ok(req.id()).body(ShowSecureChannelResponse::new(info)))
+    }
 
     pub(super) async fn create_secure_channel_listener(
         &mut self,
         req: &Request<'_>,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder<()>> {
+        let mut node_manager = self.node_manager.write().await;
         let CreateSecureChannelListenerRequest {
             addr,
             authorized_identifiers,
@@ -310,24 +336,12 @@ impl NodeManager {
             return Ok(Response::bad_request(req.id()));
         }
 
-        self.create_secure_channel_listener_impl(addr, authorized_identifiers)
+        node_manager
+            .create_secure_channel_listener_impl(addr, authorized_identifiers)
             .await?;
 
         let response = Response::ok(req.id());
 
         Ok(response)
-    }
-
-    pub(super) fn list_secure_channel_listener(
-        &mut self,
-        req: &Request<'_>,
-    ) -> ResponseBuilder<Vec<String>> {
-        Response::ok(req.id()).body(
-            self.registry
-                .secure_channel_listeners
-                .iter()
-                .map(|(addr, _)| addr.to_string())
-                .collect(),
-        )
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
@@ -1,4 +1,4 @@
-use super::map_anyhow_err;
+use super::{map_anyhow_err, NodeManagerWorker};
 use crate::nodes::models::vault::CreateVaultRequest;
 use crate::nodes::NodeManager;
 use minicbor::Decoder;
@@ -47,17 +47,20 @@ impl NodeManager {
 
         Ok(())
     }
+}
 
+impl NodeManagerWorker {
     pub(super) async fn create_vault(
         &mut self,
         req: &Request<'_>,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder> {
+        let mut node_manager = self.node_manager.write().await;
         let req_body: CreateVaultRequest = dec.decode()?;
 
         let path = req_body.path.map(|p| PathBuf::from(p.0.as_ref()));
 
-        self.create_vault_impl(path, false).await?;
+        node_manager.create_vault_impl(path, false).await?;
 
         let response = Response::ok(req.id());
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -2,12 +2,10 @@ use clap::Args;
 use rand::prelude::random;
 
 use anyhow::{Context as _, Result};
-use ockam::compat::asynchronous::RwLock;
 use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Arc,
 };
 
 use crate::node::util::{
@@ -306,9 +304,7 @@ async fn run_background_node_impl(
         tcp.async_try_clone().await?,
     )
     .await?;
-    let node_manager_worker = NodeManagerWorker {
-        node_manager: Arc::new(RwLock::new(node_man)),
-    };
+    let node_manager_worker = NodeManagerWorker::new(node_man);
 
     ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context as _, Result};
 
-use ockam::compat::asynchronous::RwLock;
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
 use ockam_api::config::cli;
@@ -69,9 +68,7 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
     )
     .await?;
 
-    let node_manager_worker = NodeManagerWorker {
-        node_manager: Arc::new(RwLock::new(node_man)),
-    };
+    let node_manager_worker = NodeManagerWorker::new(node_man);
 
     ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
         .await?;


### PR DESCRIPTION
Test version of suggested solutions in https://github.com/build-trust/ockam/issues/3524

1. Rename NodeManager to NodeManagerWorker and let it only handle requests
2. Move all state to a separate structure (name NodeManager is still good here)

I have added the `NodeManagerWorker` which will handle the requests, i wasnt sure about which states to keep in the `NodeManager`, @SanjoDeundiak please take a look a these changes and let me know what else should be added Thankyou.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
