### PR TITLE
refactor(rust): `NodeManager` constructor 

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -163,23 +163,54 @@ impl NodeManager {
 }
 
 pub struct NodeManagerGeneralOptions<'a> {
-    pub node_name: String,
-    pub node_dir: PathBuf,
-    pub skip_defaults: bool,
-    pub enable_credential_checks: bool,
-    pub ac: Option<&'a AuthoritiesConfig>,
+    node_name: String,
+    node_dir: PathBuf,
+    skip_defaults: bool,
+    enable_credential_checks: bool,
+    ac: Option<&'a AuthoritiesConfig>,
     // Should be passed only when creating fresh node and we want it to get default root Identity
-    pub identity_override: Option<IdentityOverride>,
+    identity_override: Option<IdentityOverride>,
+}
+
+impl <'a>NodeManagerGeneralOptions<'a> {
+   pub fn new(node_name: String, node_dir: PathBuf, skip_defaults: bool, enable_credential_checks: bool, ac: Option<&'a AuthoritiesConfig>, identity_override: Option<IdentityOverride>) -> Self {
+        Self {
+            node_name,
+            node_dir,
+            skip_defaults,
+            enable_credential_checks,
+            ac,
+            identity_override,
+        }
+    }
 }
 
 pub struct NodeManagerProjectsOptions {
-    pub project_id: Option<Vec<u8>>,
-    pub projects: BTreeMap<String, ProjectLookup>,
+    project_id: Option<Vec<u8>>,
+    projects: BTreeMap<String, ProjectLookup>,
+}
+
+impl NodeManagerProjectsOptions {
+    pub fn new(project_id: Option<Vec<u8>>, projects: BTreeMap<String, ProjectLookup>) -> Self {
+        Self {
+            project_id,
+            projects,
+        }
+    }
 }
 
 pub struct NodeManagerTransportOptions {
-    pub api_transport: (TransportType, TransportMode, String),
-    pub tcp_transport: TcpTransport,
+    api_transport: (TransportType, TransportMode, String),
+    tcp_transport: TcpTransport,
+}
+
+impl NodeManagerTransportOptions {
+    pub fn new(api_transport: (TransportType, TransportMode, String), tcp_transport: TcpTransport) -> Self {
+        Self {
+            api_transport,
+            tcp_transport
+        }
+   }
 }
 
 impl NodeManager {
@@ -659,26 +690,22 @@ pub(crate) mod tests {
             let node_address = transport.listen("127.0.0.1:0").await?;
             let mut node_man = NodeManager::create(
                 ctx,
-                NodeManagerGeneralOptions {
-                    node_name: "node".to_string(),
-                    node_dir: node_dir.into_path(),
-                    skip_defaults: true,
-                    enable_credential_checks: false,
-                    ac: None,
-                    identity_override: None
-                },
-                NodeManagerProjectsOptions {
-                    project_id: None,  
-                    projects: Default::default(),
-                },
-                NodeManagerTransportOptions {
-                    api_transport: (
-                        TransportType::Tcp,
-                        TransportMode::Listen,
-                        node_address.to_string(),
-                    ),
-                    tcp_transport: transport,
-                },
+                NodeManagerGeneralOptions::new(
+                    "node".to_string(),
+                    node_dir.into_path(),
+                    true,
+                    false,
+                    None,
+                    None
+                ),
+                NodeManagerProjectsOptions::new(
+                    None,
+                    Default::default()
+                ),
+                NodeManagerTransportOptions::new(
+                    (TransportType::Tcp, TransportMode::Listen, node_address.to_string()),
+                    transport
+                )
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -172,7 +172,13 @@ pub struct NodeManagerGeneralOptions {
 }
 
 impl NodeManagerGeneralOptions {
-   pub fn new(node_name: String, node_dir: PathBuf, skip_defaults: bool, enable_credential_checks: bool, identity_override: Option<IdentityOverride>) -> Self {
+    pub fn new(
+        node_name: String,
+        node_dir: PathBuf,
+        skip_defaults: bool,
+        enable_credential_checks: bool,
+        identity_override: Option<IdentityOverride>,
+    ) -> Self {
         Self {
             node_name,
             node_dir,
@@ -189,8 +195,12 @@ pub struct NodeManagerProjectsOptions<'a> {
     projects: BTreeMap<String, ProjectLookup>,
 }
 
-impl <'a>NodeManagerProjectsOptions<'a> {
-    pub fn new(ac: Option<&'a AuthoritiesConfig>, project_id: Option<Vec<u8>>, projects: BTreeMap<String, ProjectLookup>) -> Self {
+impl<'a> NodeManagerProjectsOptions<'a> {
+    pub fn new(
+        ac: Option<&'a AuthoritiesConfig>,
+        project_id: Option<Vec<u8>>,
+        projects: BTreeMap<String, ProjectLookup>,
+    ) -> Self {
         Self {
             ac,
             project_id,
@@ -205,12 +215,15 @@ pub struct NodeManagerTransportOptions {
 }
 
 impl NodeManagerTransportOptions {
-    pub fn new(api_transport: (TransportType, TransportMode, String), tcp_transport: TcpTransport) -> Self {
+    pub fn new(
+        api_transport: (TransportType, TransportMode, String),
+        tcp_transport: TcpTransport,
+    ) -> Self {
         Self {
             api_transport,
-            tcp_transport
+            tcp_transport,
         }
-   }
+    }
 }
 
 impl NodeManager {
@@ -233,7 +246,8 @@ impl NodeManager {
             let authenticated_storage_path = match authenticated_storage_path {
                 Some(p) => p,
                 None => {
-                    let default_location = general_options.node_dir.join("authenticated_storage.lmdb");
+                    let default_location =
+                        general_options.node_dir.join("authenticated_storage.lmdb");
 
                     config.writelock_inner().authenticated_storage_path =
                         Some(default_location.clone());
@@ -283,7 +297,9 @@ impl NodeManager {
             None => None,
         };
 
-        if general_options.enable_credential_checks && (projects_options.ac.is_none() || projects_options.project_id.is_none()) {
+        if general_options.enable_credential_checks
+            && (projects_options.ac.is_none() || projects_options.project_id.is_none())
+        {
             error!("Invalid NodeManager options: enable_credential_checks was provided, while not enough \
                 information was provided to enforce the checks");
             return Err(ockam_core::Error::new(
@@ -697,15 +713,15 @@ pub(crate) mod tests {
                     false,
                     None,
                 ),
-                NodeManagerProjectsOptions::new(
-                    None,
-                    None,
-                    Default::default()
-                ),
+                NodeManagerProjectsOptions::new(None, None, Default::default()),
                 NodeManagerTransportOptions::new(
-                    (TransportType::Tcp, TransportMode::Listen, node_address.to_string()),
-                    transport
-                )
+                    (
+                        TransportType::Tcp,
+                        TransportMode::Listen,
+                        node_address.to_string(),
+                    ),
+                    transport,
+                ),
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -184,7 +184,6 @@ pub struct NodeManagerTransportOptions {
 
 impl NodeManager {
     /// Create a new NodeManager with the node name from the ockam CLI
-    #[allow(clippy::too_many_arguments)]
     pub async fn create(
         ctx: &Context,
         general_options: NodeManagerGeneralOptions<'_>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -660,20 +660,26 @@ pub(crate) mod tests {
             let node_address = transport.listen("127.0.0.1:0").await?;
             let mut node_man = NodeManager::create(
                 ctx,
-                "node".to_string(),
-                node_dir.into_path(),
-                None,
-                true,
-                false,
-                None,
-                None,
-                Default::default(),
-                (
-                    TransportType::Tcp,
-                    TransportMode::Listen,
-                    node_address.to_string(),
-                ),
-                transport,
+                NodeManagerGeneralOptions {
+                    node_name: "node".to_string(),
+                    node_dir: node_dir.into_path(),
+                    skip_defaults: true,
+                    enable_credential_checks: false,
+                    ac: None,
+                    identity_override: None
+                },
+                NodeManagerProjectsOptions {
+                    project_id: None,  
+                    projects: Default::default(),
+                },
+                NodeManagerTransportOptions {
+                    api_transport: (
+                        TransportType::Tcp,
+                        TransportMode::Listen,
+                        node_address.to_string(),
+                    ),
+                    tcp_transport: transport,
+                },
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -305,10 +305,13 @@ async fn run_background_node_impl(
             node_dir,
             c.skip_defaults || c.launch_config.is_some(),
             c.enable_credential_checks,
-            Some(&cfg.authorities(&c.node_name)?.snapshot()),
             identity_override
         ),
-        NodeManagerProjectsOptions::new(project_id, projects),
+        NodeManagerProjectsOptions::new(
+            Some(&cfg.authorities(&c.node_name)?.snapshot()),
+            project_id,
+            projects
+        ),
         NodeManagerTransportOptions::new(
             (TransportType::Tcp, TransportMode::Listen, bind),
             tcp.async_try_clone().await?

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -28,7 +28,12 @@ use ockam::{Address, AsyncTryClone, NodeBuilder, TCP};
 use ockam::{Context, TcpTransport};
 use ockam_api::{
     nodes::models::transport::{TransportMode, TransportType},
-    nodes::{NodeManager, NODEMANAGER_ADDR, service::{NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions}, NodeManagerWorker},
+    nodes::{
+        service::{
+            NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
+        },
+        NodeManager, NodeManagerWorker, NODEMANAGER_ADDR,
+    },
 };
 use ockam_core::LOCAL;
 
@@ -305,17 +310,17 @@ async fn run_background_node_impl(
             node_dir,
             c.skip_defaults || c.launch_config.is_some(),
             c.enable_credential_checks,
-            identity_override
+            identity_override,
         ),
         NodeManagerProjectsOptions::new(
             Some(&cfg.authorities(&c.node_name)?.snapshot()),
             project_id,
-            projects
+            projects,
         ),
         NodeManagerTransportOptions::new(
             (TransportType::Tcp, TransportMode::Listen, bind),
-            tcp.async_try_clone().await?
-        )
+            tcp.async_try_clone().await?,
+        ),
     )
     .await?;
     let node_manager_worker = NodeManagerWorker::new(node_man);

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -300,22 +300,19 @@ async fn run_background_node_impl(
     let projects = cfg.inner().lookup().projects().collect();
     let node_man = NodeManager::create(
         ctx,
-        NodeManagerGeneralOptions {
-            node_name: c.node_name.clone(),
+        NodeManagerGeneralOptions::new(
+            c.node_name.clone(),
             node_dir,
-            skip_defaults: c.skip_defaults || c.launch_config.is_some(),
-            enable_credential_checks: c.enable_credential_checks,
-            ac: Some(&cfg.authorities(&c.node_name)?.snapshot()),
+            c.skip_defaults || c.launch_config.is_some(),
+            c.enable_credential_checks,
+            Some(&cfg.authorities(&c.node_name)?.snapshot()),
             identity_override
-        },
-        NodeManagerProjectsOptions {
-            project_id,  
-            projects
-        },
-        NodeManagerTransportOptions {
-            api_transport: (TransportType::Tcp, TransportMode::Listen, bind),
-            tcp_transport: tcp.async_try_clone().await?,
-        },
+        ),
+        NodeManagerProjectsOptions::new(project_id, projects),
+        NodeManagerTransportOptions::new(
+            (TransportType::Tcp, TransportMode::Listen, bind),
+            tcp.async_try_clone().await?
+        )
     )
     .await?;
     let node_manager_worker = NodeManagerWorker::new(node_man);

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -61,16 +61,16 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
             node_dir,
             cmd.skip_defaults || cmd.launch_config.is_some(),
             cmd.enable_credential_checks,
-            Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
             identity_override
         ),
         NodeManagerProjectsOptions::new(
+            Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
             project_id,  
             projects
         ),
         NodeManagerTransportOptions::new(
             (TransportType::Tcp, TransportMode::Listen, bind),
-            tcp,
+            tcp
         ),
     ) 
     .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -56,22 +56,22 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
     let projects = cfg.inner().lookup().projects().collect();
     let node_man = NodeManager::create(
         ctx,
-        NodeManagerGeneralOptions {
-            node_name: cmd.node_name.clone(),
+        NodeManagerGeneralOptions::new(
+            cmd.node_name.clone(),
             node_dir,
-            skip_defaults: cmd.skip_defaults || cmd.launch_config.is_some(),
-            enable_credential_checks: cmd.enable_credential_checks,
-            ac: Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
+            cmd.skip_defaults || cmd.launch_config.is_some(),
+            cmd.enable_credential_checks,
+            Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
             identity_override
-        },
-        NodeManagerProjectsOptions {
+        ),
+        NodeManagerProjectsOptions::new(
             project_id,  
             projects
-        },
-        NodeManagerTransportOptions {
-            api_transport: (TransportType::Tcp, TransportMode::Listen, bind),
-            tcp_transport: tcp,
-        },
+        ),
+        NodeManagerTransportOptions::new(
+            (TransportType::Tcp, TransportMode::Listen, bind),
+            tcp,
+        ),
     ) 
     .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -9,8 +9,10 @@ use ockam::{Context, TcpTransport};
 use ockam_api::config::cli;
 use ockam_api::config::cli::OckamConfig as OckamConfigApi;
 use ockam_api::nodes::models::transport::{TransportMode, TransportType};
+use ockam_api::nodes::service::{
+    NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
+};
 use ockam_api::nodes::{IdentityOverride, NodeManager, NodeManagerWorker, NODEMANAGER_ADDR};
-use ockam_api::nodes::service::{NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions};
 use ockam_multiaddr::MultiAddr;
 use ockam_vault::storage::FileStorage;
 use ockam_vault::Vault;
@@ -61,18 +63,15 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
             node_dir,
             cmd.skip_defaults || cmd.launch_config.is_some(),
             cmd.enable_credential_checks,
-            identity_override
+            identity_override,
         ),
         NodeManagerProjectsOptions::new(
             Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
-            project_id,  
-            projects
+            project_id,
+            projects,
         ),
-        NodeManagerTransportOptions::new(
-            (TransportType::Tcp, TransportMode::Listen, bind),
-            tcp
-        ),
-    ) 
+        NodeManagerTransportOptions::new((TransportType::Tcp, TransportMode::Listen, bind), tcp),
+    )
     .await?;
 
     let node_manager_worker = NodeManagerWorker::new(node_man);


### PR DESCRIPTION
## Current Behavior
Current version of `NodeManager::create` receives 11 arguments.
```rust
#[allow(clippy::too_many_arguments)]
pub async fn create(
        ctx: &Context,
        node_name: String,
        node_dir: PathBuf,
        // Should be passed only when creating fresh node and we want it to get default root Identity
        identity_override: Option<IdentityOverride>,
        skip_defaults: bool,
        enable_credential_checks: bool,
        ac: Option<&AuthoritiesConfig>,
        project_id: Option<Vec<u8>>,
        projects: BTreeMap<String, ProjectLookup>,
        api_transport: (TransportType, TransportMode, String),
        tcp_transport: TcpTransport,
) -> Result<Self>
```

## Proposed Changes
This PR is meant to fix #3527 
- Extract `NodeManager::create` arguments into three new `Options` structs.
-- `NodeManagerGeneralOptions`, `NodeManagerProjectsOptions` and `NodeManagerTransportOptions`

```rust
pub async fn create(
        ctx: &Context,
        general_options: NodeManagerGeneralOptions,
        projects_options: NodeManagerProjectsOptions<'_>,
        transport_options: NodeManagerTransportOptions,
) -> Result<Self>
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
