### PR TITLE
refactor(rust): `ockam_command::service::start` to use rpc

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -25,6 +25,5 @@ impl ServiceCommand {
         match self.subcommand {
             ServiceSubcommand::Start(c) => c.run(options),
         }
-        .unwrap()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -1,11 +1,16 @@
 //! API shim to make it nicer to interact with the ockam messaging API
 
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Context;
 use clap::Args;
 // TODO: maybe we can remove this cross-dependency inside the CLI?
 use minicbor::Decoder;
+use ockam_api::nodes::models::services::{
+    StartAuthenticatedServiceRequest, StartAuthenticatorRequest, StartCredentialsService,
+    StartIdentityServiceRequest, StartVaultServiceRequest, StartVerifierService,
+};
 use tracing::trace;
 
 use ockam::identity::IdentityIdentifier;
@@ -197,36 +202,50 @@ pub(crate) fn list_secure_channel_listener() -> RequestBuilder<'static, ()> {
 }
 
 /// Construct a request to start a Vault Service
-pub(crate) fn start_vault_service(addr: &str) -> Result<Vec<u8>> {
-    let payload = models::services::StartVaultServiceRequest::new(addr);
-
-    let mut buf = vec![];
-    Request::post("/node/services/vault")
-        .body(payload)
-        .encode(&mut buf)?;
-    Ok(buf)
+pub(crate) fn start_vault_service(addr: &str) -> RequestBuilder<'static, StartVaultServiceRequest> {
+    let payload = StartVaultServiceRequest::new(addr);
+    Request::post("/node/services/vault").body(payload)
 }
 
 /// Construct a request to start an Identity Service
-pub(crate) fn start_identity_service(addr: &str) -> Result<Vec<u8>> {
-    let payload = models::services::StartIdentityServiceRequest::new(addr);
-
-    let mut buf = vec![];
-    Request::post("/node/services/identity")
-        .body(payload)
-        .encode(&mut buf)?;
-    Ok(buf)
+pub(crate) fn start_identity_service(
+    addr: &str,
+) -> RequestBuilder<'static, StartIdentityServiceRequest> {
+    let payload = StartIdentityServiceRequest::new(addr);
+    Request::post("/node/services/identity").body(payload)
 }
 
 /// Construct a request to start an Authenticated Service
-pub(crate) fn start_authenticated_service(addr: &str) -> Result<Vec<u8>> {
-    let payload = models::services::StartAuthenticatedServiceRequest::new(addr);
+pub(crate) fn start_authenticated_service(
+    addr: &str,
+) -> RequestBuilder<'static, StartAuthenticatedServiceRequest> {
+    let payload = StartAuthenticatedServiceRequest::new(addr);
+    Request::post("/node/services/authenticated").body(payload)
+}
 
-    let mut buf = vec![];
-    Request::post("/node/services/authenticated")
-        .body(payload)
-        .encode(&mut buf)?;
-    Ok(buf)
+/// Construct a request to start a Verifier Service
+pub(crate) fn start_verifier_service(addr: &str) -> RequestBuilder<'static, StartVerifierService> {
+    let payload = StartVerifierService::new(addr);
+    Request::post("/node/services/verifier").body(payload)
+}
+
+/// Construct a request to start a Credentials Service
+pub(crate) fn start_credentials_service(
+    addr: &str,
+    oneway: bool,
+) -> RequestBuilder<'static, StartCredentialsService> {
+    let payload = StartCredentialsService::new(addr, oneway);
+    Request::post("/node/services/credentials").body(payload)
+}
+
+/// Construct a request to start an Authenticator Service
+pub(crate) fn start_authenticator_service<'a>(
+    addr: &'a str,
+    enrollers: &'a Path,
+    project: &'a str,
+) -> RequestBuilder<'static, StartAuthenticatorRequest<'a>> {
+    let payload = StartAuthenticatorRequest::new(addr, enrollers, project.as_bytes());
+    Request::post("/node/services/authenticator").body(payload)
 }
 
 pub(crate) mod credentials {

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -202,6 +202,43 @@ teardown() {
   assert_success
 }
 
+@test "create a node and start services" {
+  $OCKAM node create n1
+
+  # Check we can start service, but only once with the same name
+  run $OCKAM service start vault my_vault --node n1
+  assert_success
+  run $OCKAM service start vault my_vault --node n1
+  assert_failure
+
+  # Check we can start service, but only once with the same name
+  run $OCKAM service start identity my_identity --node n1
+  assert_success
+  run $OCKAM service start identity my_identity --node n1
+  assert_failure
+
+  # Check we can start service, but only once with the same name
+  run $OCKAM service start authenticated my_authenticated --node n1
+  assert_success
+  run $OCKAM service start authenticated my_authenticated --node n1
+  assert_failure
+
+  # Check we can start service, but only once with the same name
+  run $OCKAM service start verifier --addr my_verifier --node n1
+  assert_success
+  run $OCKAM service start verifier --addr my_verifier --node n1
+  assert_failure
+
+  # Check we can start service, but only once with the same name
+  run $OCKAM service start credentials --addr my_credentials --node n1
+  assert_success
+  run $OCKAMservice start credentials --addr my_credentials --node n1
+  assert_failure
+
+  # TODO: add test for authenticator
+}
+
+
 # the below tests will only succeed if already enrolled with `ockam enroll`
 
 @test "send a message to a project node from command embedded node" {


### PR DESCRIPTION
## Current Behavior

* `ockam_command::service::start` uses the `util::connect_to()` and `Context::send_and_receive()` way of working.
* Issue #3241 proposes using `util::Rpc` instead. 

## Proposed Changes

* Refactor `ockam_command::service::start` to use `util::Rpc`.
* Refactor `NodeManager` so all `start_service` requests respond with errors in the same way and error text is passed to `ockam_command`.
* Add test to `commands.bats` for `ockam service start ...`.

Note: Rust nightly fails in the same way as it does in the Ockam repo.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
