### PR TITLE
ci: lint cargo.lock in CI

### DIFF
--- a/.github/workflows/lint-cargo.yml
+++ b/.github/workflows/lint-cargo.yml
@@ -1,0 +1,47 @@
+name: Lint Cargo.lock
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: SHA to test workflow
+  pull_request:
+    paths:
+      - "**.toml"
+      - "**/Cargo.lock"
+  push:
+    paths:
+      - "**.toml"
+      - "**/Cargo.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint_cargo_lock:
+    name: Rust - Lint Cargo.lock
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
+      - uses: ./.github/actions/cargo_home_cache
+      - uses: ./.github/actions/cargo_target_dir_cache
+      - name: Check whether Cargo.lock is same as CI-generated Cargo.lock
+        run: |
+          old_hash=`sha384sum Cargo.lock`
+          rm Cargo.lock
+          RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check
+          expected_hash=`sha384sum Cargo.lock`
+          if [ "$old_hash" = "$expected_hash" ]; then
+              echo "Cargo.lock hash matches CI-generated Cargo.lock hash"
+          else
+              echo "Cargo.lock hash does not match CI-generated Cargo.lock hash. Expected: $expected_hash Got: $old_hash" && exit 1
+          fi
+      - uses: ./.github/actions/cargo_target_dir_pre_cache


### PR DESCRIPTION
## Current Behavior

When a PR updates `Cargo.lock` file, we should ensure that the lock file was generated by `cargo command` and not tampered with. 

## Proposed Changes

Add the following jobs to CI `rust.yml` workflow:

   - Gets the current SHA of Cargo.lock generated by PR/user.
   - Deleting the current Cargo.lock
   - Generating a new Cargo.lock, possibly calling cargo check command.
   - Getting the SHA of the new lock file
   - Ensure the SHA generated by user PR is same as that of CI

Addresses #3572

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.