### PR TITLE
fix(rust): remove hide default value attribute

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -7,7 +7,7 @@ use clap::Args;
 #[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Name of the node.
-    #[arg(default_value = "default", hide_default_value = true, group = "nodes")]
+    #[arg(default_value = "default", group = "nodes")]
     node_name: String,
 
     /// Terminate all nodes


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Closes #3552 

## Current Behavior

As described in #3552: node subcommands have node_name as the first argument. The commands that act on existing nodes should default to the "default" node and should not hide this value.

Currently, this is only done correctly in the node show command.

## Proposed Changes

remove attribute hide_default_value from node_name argument

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
