### PR TITLE
refactor(rust): change `vault create` command to use `rpc` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -103,15 +103,6 @@ pub(crate) fn delete_tcp_listener(cmd: &crate::tcp::listener::DeleteCommand) -> 
     Ok(buf)
 }
 
-/// Construct a request to create a Vault
-pub(crate) fn create_vault(path: Option<String>) -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::post("/node/vault")
-        .body(models::vault::CreateVaultRequest::new(path))
-        .encode(&mut buf)?;
-    Ok(buf)
-}
-
 /// Construct a request to export Identity
 pub(crate) fn long_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];
@@ -410,12 +401,6 @@ pub(crate) fn parse_transport_status(
         response,
         dec.decode::<models::transport::TransportStatus>()?,
     ))
-}
-
-pub(crate) fn parse_create_vault_response(resp: &[u8]) -> Result<Response> {
-    let mut dec = Decoder::new(resp);
-    let response = dec.decode::<Response>()?;
-    Ok(response)
 }
 
 pub(crate) fn parse_long_identity_response(

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -23,6 +23,5 @@ impl VaultCommand {
         match self.subcommand {
             VaultSubcommand::Create(c) => c.run(options),
         }
-        .unwrap()
     }
 }


### PR DESCRIPTION
## Current Behavior

The current implementation is calling `std::process::exit`, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

It's also using the `connect_to` function, which can be simplified by using the `Rpc` utils.

## Proposed Changes

Following #3564 this PR:
* Uses `node_rpc` in the `run` function, invoking the new `run_impl`. Propagated errors will be handled now in that function.
* Changes the invokation of `connect_to`, `api::create_vault` and `api::parse_create_vault_response` with the use of the `Rpc` abstraction (using `Rpc::request` and `Rpc::parse_response` instead.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

