### PR TITLE
refactor(rust): refactor identity create command to use rpc abstraction 

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,12 +1,10 @@
 use crate::help;
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode};
+use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::Status;
-use ockam_core::Route;
+use ockam_core::api::Request;
 
 #[derive(Clone, Debug, Args)]
 #[command(hide = help::hide())]
@@ -16,39 +14,20 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
-        let cfg = options.config;
-        let port = cfg.get_node_port(&self.node_opts.api_node).unwrap();
-
-        connect_to(port, self, create_identity);
-
-        Ok(())
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
     }
 }
 
-pub async fn create_identity(
+async fn run_impl(
     ctx: Context,
-    _cmd: CreateCommand,
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let resp: Vec<u8> = ctx
-        .send_and_receive(
-            base_route.modify().append(NODEMANAGER_ADDR),
-            api::create_identity()?,
-        )
-        .await?;
+    (options, cmd): (CommandGlobalOpts, CreateCommand),
+) -> crate::Result<()> {
+    let mut rpc = Rpc::background(&ctx, &options, &cmd.node_opts.api_node)?;
+    let request = Request::post("/node/identity");
+    rpc.request(request).await?;
+    rpc.parse_response()?;
 
-    let (response, result) = api::parse_create_identity_response(&resp)?;
-
-    match response.status() {
-        Some(Status::Ok) => {
-            println!("Identity {} created!", result.identity_id)
-        }
-        _ => {
-            eprintln!("An error occurred while creating Identity",);
-            std::process::exit(exitcode::CANTCREAT);
-        }
-    }
-
+    println!("Identity created!");
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -26,8 +26,7 @@ impl IdentityCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             IdentitySubcommand::Create(c) => c.run(options),
-            IdentitySubcommand::Show(c) => c.run(options),
+            IdentitySubcommand::Show(c) => c.run(options).unwrap(),
         }
-        .unwrap()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -112,13 +112,6 @@ pub(crate) fn create_vault(path: Option<String>) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Construct a request to create Identity
-pub(crate) fn create_identity() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::post("/node/identity").encode(&mut buf)?;
-    Ok(buf)
-}
-
 /// Construct a request to export Identity
 pub(crate) fn long_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];
@@ -423,17 +416,6 @@ pub(crate) fn parse_create_vault_response(resp: &[u8]) -> Result<Response> {
     let mut dec = Decoder::new(resp);
     let response = dec.decode::<Response>()?;
     Ok(response)
-}
-
-pub(crate) fn parse_create_identity_response(
-    resp: &[u8],
-) -> Result<(Response, models::identity::CreateIdentityResponse<'_>)> {
-    let mut dec = Decoder::new(resp);
-    let response = dec.decode::<Response>()?;
-    Ok((
-        response,
-        dec.decode::<models::identity::CreateIdentityResponse>()?,
-    ))
 }
 
 pub(crate) fn parse_long_identity_response(


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/3561

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

The current implementation is calling std::process::exit, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

It's also using the connect_to function, which can be simplified by using the Rpc utils.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

This implements https://github.com/build-trust/ockam/issues/3561 and moves this command to using rpc 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
