### PR TITLE
fix(rust): get default node stop manual error handling

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
@@ -1,19 +1,30 @@
-use crate::{util::exitcode, CommandGlobalOpts};
+use anyhow::anyhow;
 use clap::Args;
+
+use crate::exitcode::UNAVAILABLE;
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct GetDefaultNodeCommand {}
 
 impl GetDefaultNodeCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        match options.config.get_default_node() {
-            Some(name) => {
-                println!("Current Default Node: {}", name)
-            }
-            None => {
-                eprintln!("Default Node is not set");
-                std::process::exit(exitcode::UNAVAILABLE);
-            }
+        if let Err(e) = run_impl(options) {
+            eprintln!("{}", e);
+            std::process::exit(e.code());
         }
+    }
+}
+
+fn run_impl(opts: CommandGlobalOpts) -> crate::Result<()> {
+    match opts.config.get_default_node() {
+        Some(name) => {
+            println!("Current Default Node: {}", name);
+            Ok(())
+        }
+        None => Err(crate::error::Error::new(
+            UNAVAILABLE,
+            anyhow!("Default Node is not set"),
+        )),
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Closes #3558 

## Current Behavior

As mentioned in #3558 : The current implementation is calling std::process::exit, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Propogate errors to the caller and call system::error::exit only once with appropriate error code.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
