### PR TITLE
build: add "coverage" profile to cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,16 @@ members = [
 ]
 
 exclude = ["implementations/rust/ockam/ockam_examples/example_projects"]
+
+# Coverage profile for generating code coverage with grcov.
+#
+# See https://github.com/rust-lang/rust/issues/78011.
+#
+[profile.coverage]
+panic = "abort"
+opt-level = 0
+overflow-checks = false
+incremental = false
+codegen-units = 1
+inherits = "test"
+

--- a/implementations/rust/DEVELOP.md
+++ b/implementations/rust/DEVELOP.md
@@ -83,7 +83,7 @@ Get a code coverage report:
 ```
 cargo +nightly install grcov
 
-env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort --cfg tokio_unstable" RUSTDOCFLAGS="-Cpanic=abort" cargo +nightly test
+env CARGO_INCREMENTAL=0 RUSTFLAGS="-Zprofile -Clink-dead-code --cfg tokio_unstable" cargo +nightly test --profile coverage
 
 grcov --llvm . -s . --binary-path ./target/debug/ -t html --branch --ignore-not-existing -o ./target/debug/coverage/
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Documented code coverage commands do not work.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

* Create a profile for Cargo so that rustc flags are properly passed.
* Update documentation so that the new profile is used when generating code coverage docs.

See https://github.com/rust-lang/rust/issues/78011.

Closes #3553.

## Testing

This was tested locally. A copy of the generated test results are available here: [coverage.zip](https://github.com/build-trust/ockam/files/9730077/coverage.zip)


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
