### PR TITLE
refactor(rust): move `get_final_element` to `extract_node_name`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
@@ -1,4 +1,4 @@
-use crate::{util::get_final_element, CommandGlobalOpts};
+use crate::{util::extract_node_name, CommandGlobalOpts};
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -18,9 +18,7 @@ impl SetDefaultNodeCommand {
 
 fn run_impl(name: &str, options: &CommandGlobalOpts) -> crate::Result<()> {
     options.config.get_node(name)?;
-    options
-        .config
-        .set_default_node(&get_final_element(name).to_owned());
+    options.config.set_default_node(&extract_node_name(name)?);
     options.config.persist_config_updates()?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -12,7 +12,7 @@ use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
 
 use crate::forwarder::HELP_DETAIL;
 use crate::util::output::Output;
-use crate::util::{get_final_element, node_rpc, RpcBuilder};
+use crate::util::{extract_node_name, node_rpc, RpcBuilder};
 use crate::Result;
 use crate::{help, CommandGlobalOpts};
 
@@ -48,7 +48,7 @@ impl CreateCommand {
 
 async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
-    let api_node = get_final_element(&cmd.to);
+    let api_node = extract_node_name(&cmd.to)?;
     let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
 
     let lookup = opts.config.lookup();
@@ -87,7 +87,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
         Request::post("/node/forwarder").body(body)
     };
 
-    let mut rpc = RpcBuilder::new(&ctx, &opts, api_node).tcp(&tcp)?.build();
+    let mut rpc = RpcBuilder::new(&ctx, &opts, &api_node).tcp(&tcp)?.build();
     rpc.request(req).await?;
     rpc.parse_and_print_response::<ForwarderInfo>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, get_final_element};
+use crate::util::{connect_to, exitcode, extract_node_name};
 use crate::CommandGlobalOpts;
 use crate::{node::NodeOpts, util::api};
 use clap::Args;
@@ -17,8 +17,8 @@ pub struct ShowCommand {
 impl ShowCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = options.config;
-        let node = get_final_element(&self.node_opts.api_node);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.api_node)?;
+        let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, self, show_identity);
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -10,7 +10,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::util::api::CloudOpts;
-use crate::util::{get_final_element, node_rpc, RpcBuilder};
+use crate::util::{extract_node_name, node_rpc, RpcBuilder};
 use crate::Result;
 use crate::{help, message::HELP_DETAIL, CommandGlobalOpts};
 
@@ -50,7 +50,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
 
         // Setup environment depending on whether we are sending the message from an embedded node or a background node
         let (api_node, tcp) = if let Some(node) = &cmd.from {
-            let api_node = get_final_element(node).to_string();
+            let api_node = extract_node_name(node)?;
             let tcp = TcpTransport::create(ctx).await?;
             (api_node, Some(tcp))
         } else {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,6 +1,6 @@
 use crate::{
     help,
-    util::{api, exitcode, get_final_element, node_rpc},
+    util::{api, exitcode, extract_node_name, node_rpc},
     CommandGlobalOpts, OutputFormat, Result,
 };
 
@@ -76,7 +76,7 @@ impl CreateCommand {
 
     // Read the `from` argument and return node name
     fn parse_from_node(&self, _config: &ConfigLookup) -> String {
-        get_final_element(&self.from).to_string()
+        extract_node_name(&self.from).unwrap_or_else(|_| "".to_string())
     }
 
     fn print_output(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -1,7 +1,7 @@
 use crate::secure_channel::HELP_DETAIL;
 use crate::{
     help,
-    util::{api, exitcode, get_final_element, node_rpc, Rpc},
+    util::{api, exitcode, extract_node_name, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat, Result,
 };
 use std::str::FromStr;
@@ -35,7 +35,7 @@ impl DeleteCommand {
 
     // Read the `at` argument and return node name
     fn parse_at_node(&self) -> String {
-        get_final_element(&self.at).to_string()
+        extract_node_name(&self.at).unwrap_or_else(|_| "".to_string())
     }
 
     fn print_output(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -1,5 +1,5 @@
 use crate::secure_channel::HELP_DETAIL;
-use crate::util::{api, connect_to, exitcode, get_final_element};
+use crate::util::{api, connect_to, exitcode, extract_node_name};
 use crate::{help, CommandGlobalOpts};
 
 use clap::Args;
@@ -35,8 +35,8 @@ pub struct SecureChannelListenerNodeOpts {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = options.config;
-        let node = get_final_element(&self.node_opts.at);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, self, |ctx, cmd, rte| async {
             create_listener(&ctx, cmd.address, cmd.authorized_identifier, rte).await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -1,7 +1,7 @@
 use crate::secure_channel::HELP_DETAIL;
 use crate::{
     help,
-    util::{api, get_final_element, node_rpc, Rpc},
+    util::{api, extract_node_name, node_rpc, Rpc},
     CommandGlobalOpts, Result,
 };
 use clap::Args;
@@ -30,7 +30,7 @@ impl ShowCommand {
 
     // Read the `at` argument and return node name
     fn parse_at_node(&self) -> String {
-        get_final_element(&self.at).to_string()
+        extract_node_name(&self.at).unwrap_or_else(|_| "".to_string())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    util::{api, connect_to, exitcode, get_final_element},
+    util::{api, connect_to, exitcode, extract_node_name},
     CommandGlobalOpts, OutputFormat,
 };
 use clap::Args;
@@ -39,10 +39,10 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.from);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.from).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
 
-        connect_to(port, (self.clone(), options.clone()), create_connection);
+        connect_to(port, (self, options.clone()), create_connection);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -3,7 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
-use crate::util::get_final_element;
+use crate::util::extract_node_name;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode},
@@ -26,8 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.api_node);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
         connect_to(port, self, delete_connection);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode, get_final_element};
+use crate::util::{api, connect_to, exitcode, extract_node_name};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -18,8 +18,8 @@ pub struct ListCommand {
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.api_node);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, (), list_connections);
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{bind_to_port_check, connect_to, exitcode, get_final_element};
+use crate::util::{bind_to_port_check, connect_to, exitcode, extract_node_name};
 use crate::{help, CommandGlobalOpts};
 use clap::Args;
 use minicbor::Decoder;
@@ -67,8 +67,8 @@ impl CreateCommand {
             ..self
         };
 
-        let node = get_final_element(&command.at);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&command.at)?;
+        let port = cfg.get_node_port(&node).unwrap();
 
         // Check if the port is used by some other services or process
         if !bind_to_port_check(&command.from) {

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{bind_to_port_check, get_final_element};
+use crate::util::{bind_to_port_check, extract_node_name};
 use crate::{
     util::{api, connect_to, exitcode},
     CommandGlobalOpts,
@@ -31,8 +31,8 @@ pub struct TCPListenerNodeOpts {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.at);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
 
         let input_addr = match std::net::SocketAddr::from_str(&self.address) {
             Ok(value) => value,
@@ -48,7 +48,7 @@ impl CreateCommand {
             std::process::exit(exitcode::IOERR);
         }
 
-        connect_to(port, self.clone(), create_listener);
+        connect_to(port, self, create_listener);
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -3,7 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
-use crate::util::get_final_element;
+use crate::util::extract_node_name;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode},
@@ -26,8 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.api_node);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
         connect_to(port, self, delete_listener);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode, get_final_element};
+use crate::util::{api, connect_to, exitcode, extract_node_name};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -18,8 +18,8 @@ pub struct ListCommand {
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = get_final_element(&self.node_opts.api_node);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, (), list_listeners);
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, get_final_element};
+use crate::util::{connect_to, exitcode, extract_node_name};
 use crate::{help, CommandGlobalOpts};
 use clap::Args;
 use minicbor::Decoder;
@@ -60,11 +60,11 @@ impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = &options.config;
         let at = &self.at.clone();
-        let node = get_final_element(at);
-        let port = cfg.get_node_port(node).unwrap();
+        let node = extract_node_name(at)?;
+        let port = cfg.get_node_port(&node).unwrap();
 
         let command = CreateCommand {
-            from: String::from(get_final_element(&self.from)),
+            from: extract_node_name(&self.from)?,
             ..self
         };
 


### PR DESCRIPTION
Changes:

1. `get_final_element` with the suggested impl of `extract_node_name`
2. replaced `extract_node_name` in all the required places
3. added a test case for `extract_node_name` 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
