### PR TITLE
refactor(rust): `node start` reads from the config file to execute the `on_node_startup` commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -34,7 +34,7 @@ pub struct OckamConfig {
     #[serde(skip)]
     pub directories: Option<ProjectDirs>,
     #[serde(default = "default_nodes")]
-    pub nodes: BTreeMap<String, NodeConfig>,
+    pub nodes: BTreeMap<String, NodeConfigOld>,
 
     #[serde(default = "default_lookup")]
     pub lookup: ConfigLookup,
@@ -45,7 +45,7 @@ pub struct OckamConfig {
     pub default: Option<String>,
 }
 
-fn default_nodes() -> BTreeMap<String, NodeConfig> {
+fn default_nodes() -> BTreeMap<String, NodeConfigOld> {
     BTreeMap::new()
 }
 
@@ -102,21 +102,17 @@ Otherwise your OS or OS configuration may not be supported!",
 /// the CLI.  The config is updated periodically but writes to it
 /// don't have to be synced to consumers.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct NodeConfig {
+pub struct NodeConfigOld {
     #[serde(default = "default_name")]
-    pub name: String,
-
+    name: String,
     #[serde(default = "default_addr")]
-    pub addr: InternetAddress,
-
+    addr: InternetAddress,
     #[serde(default = "default_port")]
-    pub port: u16,
-
+    port: u16,
     #[serde(default = "default_verbose")]
-    pub verbose: u8,
-
+    verbose: u8,
     pub pid: Option<i32>,
-    pub state_dir: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
 }
 
 fn default_name() -> String {
@@ -130,6 +126,50 @@ fn default_port() -> u16 {
 }
 fn default_verbose() -> u8 {
     0
+}
+
+impl NodeConfigOld {
+    pub fn new(
+        name: String,
+        addr: InternetAddress,
+        port: u16,
+        verbose: u8,
+        pid: Option<i32>,
+        state_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            name,
+            addr,
+            port,
+            verbose,
+            pid,
+            state_dir,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn addr(&self) -> &InternetAddress {
+        &self.addr
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn verbose(&self) -> u8 {
+        self.verbose
+    }
+
+    pub fn pid(&self) -> Option<i32> {
+        self.pid
+    }
+
+    pub fn state_dir(&self) -> Option<&Path> {
+        self.state_dir.as_deref()
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/config.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/config.rs
@@ -1,9 +1,32 @@
-use crate::config::ConfigValues;
+use crate::config::{Config, ConfigValues};
+pub use commands::*;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+#[derive(Debug)]
+pub struct NodeConfig {
+    state: Config<NodeStateConfig>,
+    commands: Config<Commands>,
+}
+
+impl NodeConfig {
+    pub fn new(config_dir: &Path) -> anyhow::Result<Self> {
+        let state = Config::load(config_dir, "state")?;
+        let commands = Config::load(config_dir, "commands")?;
+        Ok(Self { state, commands })
+    }
+
+    pub fn state(&self) -> &Config<NodeStateConfig> {
+        &self.state
+    }
+
+    pub fn commands(&self) -> &Config<Commands> {
+        &self.commands
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub struct NodeManConfig {
+pub struct NodeStateConfig {
     /// Lmdb file location
     pub authenticated_storage_path: Option<PathBuf>,
     /// Vault info
@@ -12,10 +35,177 @@ pub struct NodeManConfig {
     pub identity: Option<Vec<u8>>,
     /// Identity was overridden
     pub identity_was_overridden: bool,
+    pub commands: Commands,
 }
 
-impl ConfigValues for NodeManConfig {
+impl ConfigValues for NodeStateConfig {
     fn default_values(_config_dir: &Path) -> Self {
         Self::default()
+    }
+}
+
+mod commands {
+    use super::*;
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+    #[cfg_attr(test, derive(Eq, PartialEq))]
+    pub struct Commands {
+        /// Run when executing the `node run` command.
+        pub run: Option<RunNode>,
+        /// Run when the node is created.
+        #[serde(default)]
+        pub on_node_init: Vec<Command>,
+        /// Run after initialization is done. Will rerun on every node restart.
+        #[serde(default)]
+        pub on_node_startup: Vec<Command>,
+    }
+
+    impl ConfigValues for Commands {
+        fn default_values(_config_dir: &Path) -> Self {
+            Self::default()
+        }
+    }
+
+    impl Config<Commands> {
+        pub fn set(&self, cmds: Commands) -> anyhow::Result<()> {
+            {
+                let mut inner = self.write();
+                inner.run = cmds.run;
+                inner.on_node_init = cmds.on_node_init;
+                inner.on_node_startup = cmds.on_node_startup;
+            }
+            self.persist_config_updates()?;
+            Ok(())
+        }
+    }
+
+    impl Command {
+        pub fn new(command: String, pipe: Option<bool>) -> Self {
+            if pipe.is_none() {
+                Command::String(command)
+            } else {
+                Command::Obj(CommandObj {
+                    command: Some(command),
+                    args: None,
+                    pipe,
+                })
+            }
+        }
+
+        /// Return the `args` field as a Vec of strings.
+        pub fn args(&self) -> Vec<String> {
+            match self {
+                Command::String(s) => s.split_whitespace().map(|s| s.to_string()).collect(),
+                Command::Obj(o) => o.args(),
+            }
+        }
+
+        pub fn pipe_output(&self) -> bool {
+            match self {
+                Command::String(_) => false,
+                Command::Obj(o) => o.pipe_output(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+    #[cfg_attr(test, derive(Eq, PartialEq))]
+    pub struct RunNode {
+        pub name: String,
+        pub args: Option<CommandArgs>,
+    }
+
+    impl RunNode {
+        /// Return the `args` field as a Vec of strings.
+        pub fn args<P: AsRef<Path>>(&self, path: P, exe: &str) -> Vec<String> {
+            let mut args: Vec<String> = format!("{} node create {}", exe, self.name)
+                .split_whitespace()
+                .map(|x| x.to_string())
+                .collect();
+            if let Some(a) = &self.args {
+                args.extend(a.args());
+            }
+            args.extend([
+                "--config".to_string(),
+                path.as_ref().to_str().expect("Invalid path").to_string(),
+            ]);
+            args
+        }
+    }
+
+    impl From<RunNode> for Command {
+        fn from(r: RunNode) -> Self {
+            let args = match r.args {
+                Some(args) => match args {
+                    CommandArgs::String(s) => s,
+                    CommandArgs::Vec(v) => v.join(" "),
+                },
+                None => String::new(),
+            };
+            Command::String(format!("node create {} {}", r.name, args))
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde(untagged)]
+    #[cfg_attr(test, derive(Eq, PartialEq))]
+    pub enum Command {
+        String(String),
+        Obj(CommandObj),
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    #[cfg_attr(test, derive(Eq, PartialEq))]
+    pub struct CommandObj {
+        pub command: Option<String>,
+        pub args: Option<CommandArgs>,
+        /// Pipes output to the next command.
+        pub pipe: Option<bool>,
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+    #[serde(untagged)]
+    pub enum CommandArgs {
+        String(String),
+        Vec(Vec<String>),
+    }
+
+    impl CommandArgs {
+        pub fn args(&self) -> Vec<String> {
+            match self {
+                CommandArgs::String(s) => s.split_whitespace().map(|s| s.to_string()).collect(),
+                // `join` and `split` to convert to single-value entries.
+                // E.g. ["--flag", "--arg value"] -> ["--flag", "--arg", "value"]
+                CommandArgs::Vec(v) => v
+                    .join(" ")
+                    .split(' ')
+                    .map(|s| s.to_string())
+                    .filter(|x| !x.is_empty())
+                    .collect(),
+            }
+        }
+    }
+
+    impl CommandObj {
+        /// Return the `args` field as a Vec of strings.
+        fn args(&self) -> Vec<String> {
+            let mut args = Vec::new();
+            // Collect args from `command` and `args`
+            if let Some(command) = &self.command {
+                args.extend(command.split_whitespace().map(|s| s.to_string()));
+            }
+            if let Some(a) = &self.args {
+                args.extend(a.args());
+            }
+            // Add `--pipe` if needed. This can be used by commands to output a different message based on this flag.
+            if self.pipe_output() {
+                args.push("--pipe".to_string());
+            }
+            args
+        }
+
+        fn pipe_output(&self) -> bool {
+            self.pipe.unwrap_or(false)
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -1,4 +1,4 @@
-mod config;
+pub mod config;
 pub mod registry;
 
 pub mod service;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/identity.rs
@@ -33,10 +33,9 @@ impl NodeManager {
         let identifier = identity.identifier().clone();
         let exported_identity = identity.export().await?;
 
-        self.config.inner().write().unwrap().identity = Some(exported_identity);
-        self.config
-            .persist_config_updates()
-            .map_err(map_anyhow_err)?;
+        let state = self.config.state();
+        state.write().identity = Some(exported_identity);
+        state.persist_config_updates().map_err(map_anyhow_err)?;
 
         self.identity = Some(identity);
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/vault.rs
@@ -38,10 +38,9 @@ impl NodeManager {
         let vault_storage = FileStorage::create(path.clone()).await?;
         let vault = Vault::new(Some(Arc::new(vault_storage)));
 
-        self.config.inner().write().unwrap().vault_path = Some(path);
-        self.config
-            .persist_config_updates()
-            .map_err(map_anyhow_err)?;
+        let state = self.config.state();
+        state.write().vault_path = Some(path);
+        state.persist_config_updates().map_err(map_anyhow_err)?;
 
         self.vault = Some(vault);
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -329,7 +329,7 @@ pub fn run() {
 
 impl OckamCommand {
     pub fn run(self) {
-        let config = OckamConfig::load();
+        let config = OckamConfig::load().expect("Failed to load config");
         let options = CommandGlobalOpts::new(self.global_args, config);
 
         // If test_argument_parser is true, command arguments are checked

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -31,7 +31,7 @@ impl ListCommand {
 
         cfg.inner().nodes.iter().for_each(|(node_name, node_cfg)| {
             connect_to(
-                node_cfg.port,
+                node_cfg.port(),
                 (cfg.clone(), node_name.clone(), false),
                 print_query_status,
             )

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use clap::Args;
 use colorful::Colorful;
 use minicbor::Decoder;
-use ockam_api::config::cli::NodeConfig;
+use ockam_api::config::cli::NodeConfigOld;
 use ockam_api::nodes::models::portal::{InletList, OutletList};
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::nodes::models::transport::TransportList;
@@ -33,7 +33,7 @@ impl ShowCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
         let port = match cfg.inner().nodes.get(&self.node_name) {
-            Some(cfg) => cfg.port,
+            Some(cfg) => cfg.port(),
             None => {
                 eprintln!("No such node available.  Run `ockam node list` to list available nodes");
                 std::process::exit(exitcode::IOERR);
@@ -52,7 +52,7 @@ impl ShowCommand {
 // clippy to stop complainaing about it.
 #[allow(clippy::too_many_arguments)]
 fn print_node_info(
-    node_cfg: &NodeConfig,
+    node_cfg: &NodeConfigOld,
     node_name: &str,
     status: &str,
     default_id: &str,
@@ -81,7 +81,7 @@ fn print_node_info(
 
     let mut m = MultiAddr::default();
     if m.push_back(DnsAddr::new("localhost")).is_ok()
-        && m.push_back(Tcp::new(node_cfg.port)).is_ok()
+        && m.push_back(Tcp::new(node_cfg.port())).is_ok()
     {
         println!("    Verbose: {}", m);
     }

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,12 +1,19 @@
+use anyhow::{anyhow, Context as _};
+use clap::Args;
+use nix::unistd::Pid;
+use rand::prelude::random;
+
+use ockam::Context;
+
+use crate::node::show::print_query_status;
+use crate::node::util::run::CommandsRunner;
+use crate::util::{connect_to, embedded_node};
 use crate::{
     help,
     node::HELP_DETAIL,
     util::{exitcode, startup::spawn_node},
     CommandGlobalOpts,
 };
-use clap::Args;
-use nix::unistd::Pid;
-use rand::prelude::random;
 
 /// Start Nodes
 #[derive(Clone, Debug, Args)]
@@ -19,37 +26,67 @@ pub struct StartCommand {
 
 impl StartCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        let cfg = &opts.config;
-        let cfg_node = cfg
-            .get_node(&self.node_name)
-            .expect("failed to load node config");
-
-        // First we check whether a PID was registered and if it is still alive.
-        if let Some(pid) = cfg_node.pid {
-            // Note: On CI machines where <defunct> processes can occur,
-            // the below `kill 0 pid` can imply a killed process is okay.
-            let res = nix::sys::signal::kill(Pid::from_raw(pid), None);
-
-            if res.is_ok() {
-                eprintln!(
-                    "Node '{}' already appears to be running as PID {}",
-                    self.node_name, pid
-                );
-                std::process::exit(exitcode::IOERR);
-            }
+        if let Err(e) = run_impl(opts, self) {
+            eprintln!("{}", e);
+            std::process::exit(e.code());
         }
-
-        // Construct the arguments list and re-execute the ockam
-        // CLI in foreground mode to re-start the node
-        spawn_node(
-            &opts.config,               // Ockam configuration
-            cfg_node.verbose,           // Previously user-chosen verbosity level
-            true,                       // skip-defaults because the node already exists
-            false,                      // Default value. TODO: implement persistence of this option
-            false,                      // Default value. TODO: implement persistence of this option
-            &cfg_node.name,             // The selected node name
-            &cfg_node.addr.to_string(), // The selected node api address
-            None,                       // No project information available
-        );
     }
+}
+
+fn run_impl(opts: CommandGlobalOpts, cmd: StartCommand) -> crate::Result<()> {
+    let cfg = &opts.config;
+    let cfg_node = cfg.get_node(&cmd.node_name)?;
+
+    // First we check whether a PID was registered and if it is still alive.
+    if let Some(pid) = cfg_node.pid() {
+        // Note: On CI machines where <defunct> processes can occur,
+        // the below `kill 0 pid` can imply a killed process is okay.
+        let res = nix::sys::signal::kill(Pid::from_raw(pid), None);
+        if res.is_ok() {
+            return Err(crate::Error::new(
+                exitcode::IOERR,
+                anyhow!(
+                    "Node '{}' already appears to be running as PID {}",
+                    cmd.node_name,
+                    pid
+                ),
+            ));
+        }
+    }
+
+    embedded_node(restart_background_node, (opts.clone(), cmd.clone()))?;
+    connect_to(
+        cfg_node.port(),
+        (cfg.clone(), cmd.node_name.clone(), true),
+        print_query_status,
+    );
+    if let Ok(cfg) = cfg.node(&cmd.node_name) {
+        CommandsRunner::run_node_startup(cfg.commands().config_path())
+            .context("Failed to startup commands")?;
+    }
+
+    Ok(())
+}
+
+async fn restart_background_node(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, StartCommand),
+) -> crate::Result<()> {
+    let cfg = &opts.config;
+    let cfg_node = cfg.get_node(&cmd.node_name)?;
+
+    // Construct the arguments list and re-execute the ockam
+    // CLI in foreground mode to start the newly created node
+    spawn_node(
+        &opts.config,
+        cfg_node.verbose(),           // Previously user-chosen verbosity level
+        true,                         // skip-defaults because the node already exists
+        false,                        // Default value. TODO: implement persistence of this option
+        false,                        // Default value. TODO: implement persistence of this option
+        cfg_node.name(),              // The selected node name
+        &cfg_node.addr().to_string(), // The selected node api address
+        None,                         // No project information available
+    )?;
+
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -318,7 +318,7 @@ pub mod config {
     }
 
     pub fn get_project(config: &OckamConfig, name: &str) -> Option<String> {
-        let inner = config.writelock_inner();
+        let inner = config.write();
         inner.lookup.get_project(name).map(|s| s.id.clone())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -49,7 +49,7 @@ pub mod config {
     }
 
     pub fn try_get_space(config: &OckamConfig, name: &str) -> Option<String> {
-        let inner = config.writelock_inner();
+        let inner = config.write();
         inner.lookup.get_space(name).map(|s| s.id.clone())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -7,9 +7,10 @@ use slug::slugify;
 use tracing::{error, trace};
 
 use ockam::identity::IdentityIdentifier;
-pub use ockam_api::config::cli::NodeConfig;
+use ockam_api::config::cli::NodeConfigOld;
 use ockam_api::config::lookup::ProjectLookup;
 use ockam_api::config::{cli, lookup::ConfigLookup, lookup::InternetAddress, Config};
+use ockam_api::nodes::config::NodeConfig;
 
 /// A simple wrapper around the main configuration structure to add
 /// local config utility/ query functions
@@ -43,16 +44,26 @@ pub enum ConfigError {
 }
 
 impl OckamConfig {
-    pub fn load() -> Self {
+    pub fn load() -> Result<OckamConfig> {
         let directories = cli::OckamConfig::directories();
         let config_dir = directories.config_dir();
-        let inner = Config::<cli::OckamConfig>::load(config_dir, "config");
-        inner.writelock_inner().directories = Some(directories);
-        Self { inner }
+        let inner = Config::<cli::OckamConfig>::load(config_dir, "config")?;
+        inner.write().directories = Some(directories);
+        Ok(Self { inner })
+    }
+
+    pub fn node(&self, name: &str) -> Result<NodeConfig> {
+        let directories = cli::OckamConfig::directories();
+        let nodes_dir = directories.data_local_dir();
+        let node_dir = nodes_dir.join(format!("node-{name}"));
+        if !node_dir.exists() {
+            return Err(ConfigError::NotFound(name.to_string()).into());
+        }
+        NodeConfig::new(&node_dir)
     }
 
     pub fn remove(self) -> Result<()> {
-        let inner = self.inner.writelock_inner();
+        let inner = self.inner.write();
         // Try to delete the config directory. If the directory is not found,
         // we continue. Otherwise, we return the error.
         let config_dir = inner
@@ -83,23 +94,22 @@ impl OckamConfig {
     }
 
     pub fn get_default_vault_path(&self) -> Option<PathBuf> {
-        self.inner.readlock_inner().default_vault_path.clone()
+        self.inner.read().default_vault_path.clone()
     }
 
     pub fn get_default_identity(&self) -> Option<Vec<u8>> {
-        self.inner.readlock_inner().default_identity.clone()
+        self.inner.read().default_identity.clone()
     }
 
     /// Get the node state directory
     pub fn get_node_dir(&self, name: &str) -> Result<PathBuf> {
-        let inner = self.inner.readlock_inner();
+        let inner = self.inner.read();
         let n = inner
             .nodes
             .get(name)
             .ok_or_else(|| ConfigError::NotFound(name.to_string()))?;
         let node_path = n
-            .state_dir
-            .as_ref()
+            .state_dir()
             .ok_or_else(|| ConfigError::NotLocal(name.to_string()))?;
         Ok(PathBuf::new().join(node_path))
     }
@@ -114,12 +124,12 @@ impl OckamConfig {
 
     /// Get the API port used by a node
     pub fn get_node_port(&self, name: &str) -> Result<u16> {
-        let inner = self.inner.readlock_inner();
+        let inner = self.inner.read();
         let port = inner
             .nodes
             .get(name)
             .context("No such node available. Run `ockam node list` to list available nodes")?
-            .port;
+            .port();
 
         Ok(port)
     }
@@ -127,25 +137,25 @@ impl OckamConfig {
     /// In the future this will actually refer to the watchdog pid or
     /// no pid at all but we'll see
     pub fn get_node_pid(&self, name: &str) -> Result<Option<i32>> {
-        let inner = self.inner.readlock_inner();
+        let inner = self.inner.read();
         Ok(inner
             .nodes
             .get(name)
             .ok_or_else(|| ConfigError::NotFound(name.to_string()))?
-            .pid)
+            .pid())
     }
 
     /// Check whether another node has been registered with this API
     /// port.  This doesn't catch all port collision errors, but will
     /// get us most of the way there in terms of starting a new node.
     pub fn port_is_used(&self, port: u16) -> bool {
-        let inner = self.inner.readlock_inner();
-        inner.nodes.iter().any(|(_, n)| n.port == port)
+        let inner = self.inner.read();
+        inner.nodes.iter().any(|(_, n)| n.port() == port)
     }
 
     /// Get only a single node configuration
-    pub fn get_node(&self, node: &str) -> Result<NodeConfig> {
-        let inner = self.inner.readlock_inner();
+    pub fn get_node(&self, node: &str) -> Result<NodeConfigOld> {
+        let inner = self.inner.read();
         inner
             .nodes
             .get(node)
@@ -154,8 +164,8 @@ impl OckamConfig {
     }
 
     /// Get the current version the selected node configuration
-    pub fn select_node<'a>(&'a self, o: &'a str) -> Option<NodeConfig> {
-        let inner = self.inner.readlock_inner();
+    pub fn select_node<'a>(&'a self, o: &'a str) -> Option<NodeConfigOld> {
+        let inner = self.inner.read();
         inner.nodes.get(o).map(Clone::clone)
     }
 
@@ -164,8 +174,8 @@ impl OckamConfig {
     /// The convention is to name the main log `node-name.log` and the
     /// supplementary log `node-name.log.stderr`
     pub fn node_log_paths(&self, node_name: &str) -> Option<(PathBuf, PathBuf)> {
-        let inner = self.inner.readlock_inner();
-        let base = inner.nodes.get(node_name)?.state_dir.as_ref()?;
+        let inner = self.inner.read();
+        let base = inner.nodes.get(node_name)?.state_dir()?;
         // TODO: sluggify node names
         Some((
             base.join(format!("{}.log", node_name)),
@@ -175,7 +185,7 @@ impl OckamConfig {
 
     /// Get read access to the inner raw configuration
     pub fn inner(&self) -> RwLockReadGuard<'_, cli::OckamConfig> {
-        self.inner.readlock_inner()
+        self.inner.read()
     }
 
     /// Get a lookup table
@@ -185,22 +195,22 @@ impl OckamConfig {
 
     pub fn authorities(&self, node: &str) -> Result<AuthoritiesConfig> {
         let path = self.get_node_dir_raw(node)?;
-        Ok(AuthoritiesConfig::load(path))
+        AuthoritiesConfig::load(path)
     }
 
     ///////////////////// WRITE ACCESSORS //////////////////////////////
 
     pub fn set_default_vault_path(&self, default_vault_path: Option<PathBuf>) {
-        self.inner.writelock_inner().default_vault_path = default_vault_path
+        self.inner.write().default_vault_path = default_vault_path
     }
 
     pub fn set_default_identity(&self, default_identity: Option<Vec<u8>>) {
-        self.inner.writelock_inner().default_identity = default_identity;
+        self.inner.write().default_identity = default_identity;
     }
 
     /// Add a new node to the configuration for future lookup
     pub fn create_node(&self, name: &str, bind: SocketAddr, verbose: u8) -> Result<()> {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
 
         if inner.nodes.contains_key(name) {
             return Err(ConfigError::AlreadyExists(name.to_string()).into());
@@ -227,14 +237,14 @@ impl OckamConfig {
         // Add this node to the main node table
         inner.nodes.insert(
             name.to_string(),
-            NodeConfig {
-                name: name.to_string(),
-                port: bind.port(),
-                addr: bind.into(),
+            NodeConfigOld::new(
+                name.to_string(),
+                bind.into(),
+                bind.port(),
                 verbose,
-                state_dir: Some(state_dir),
-                pid: None,
-            },
+                None,
+                Some(state_dir),
+            ),
         );
         Ok(())
     }
@@ -244,7 +254,7 @@ impl OckamConfig {
     /// Since this is an idempotent operation and there could be multiple nodes performing the same
     /// deletion operation, we don't return an error if the node doesn't exist.
     pub fn remove_node(&self, name: &str) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         // If we are removing the first node also remove the default value
         match &inner.default {
             Some(default_node_name) if default_node_name == name => inner.default = None,
@@ -256,7 +266,7 @@ impl OckamConfig {
 
     /// Update the pid of an existing node process
     pub fn set_node_pid(&self, name: &str, pid: impl Into<Option<i32>>) -> Result<()> {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
 
         if !inner.nodes.contains_key(name) {
             return Err(ConfigError::NotFound(name.to_string()).into());
@@ -267,27 +277,27 @@ impl OckamConfig {
     }
 
     pub fn set_node_alias(&self, alias: String, addr: InternetAddress) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.set_node(&alias, addr);
     }
 
     pub fn set_space_alias(&self, id: &str, name: &str) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.set_space(id, name);
     }
 
     pub fn remove_space_alias(&self, name: &str) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.remove_space(name);
     }
 
     pub fn remove_spaces_alias(&self) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.remove_spaces();
     }
 
     pub fn set_project_alias(&self, name: String, proj: ProjectLookup) -> Result<()> {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         trace! {
             id = %proj.id,
             name = %name,
@@ -300,22 +310,22 @@ impl OckamConfig {
     }
 
     pub fn remove_project_alias(&self, name: &str) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.remove_project(name);
     }
 
     pub fn remove_projects_alias(&self) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.lookup.remove_projects();
     }
 
     pub fn set_default_node(&self, name: &String) {
-        let mut inner = self.inner.writelock_inner();
+        let mut inner = self.inner.write();
         inner.default = Some(name.to_string());
     }
 
     pub fn get_default_node(&self) -> Option<String> {
-        let inner = self.inner.readlock_inner();
+        let inner = self.inner.read();
         inner.default.clone()
     }
 }
@@ -326,19 +336,19 @@ pub struct AuthoritiesConfig {
 }
 
 impl AuthoritiesConfig {
-    pub fn load(dir: PathBuf) -> Self {
-        let inner = Config::<cli::AuthoritiesConfig>::load(&dir, "authorities");
-        Self { inner }
+    pub fn load(dir: PathBuf) -> Result<Self> {
+        let inner = Config::<cli::AuthoritiesConfig>::load(&dir, "authorities")?;
+        Ok(Self { inner })
     }
 
     pub fn add_authority(&self, i: IdentityIdentifier, a: cli::Authority) -> Result<()> {
-        let mut cfg = self.inner.writelock_inner();
+        let mut cfg = self.inner.write();
         cfg.add_authority(i, a);
         drop(cfg);
         self.inner.persist_config_updates()
     }
 
     pub fn snapshot(&self) -> cli::AuthoritiesConfig {
-        self.inner.readlock_inner().clone()
+        self.inner.read().clone()
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -114,6 +114,19 @@ teardown() {
   assert_output "HELLO"
 }
 
+@test "create node with a startup command, stop it and restart it" {
+  echo '{"on_node_startup": ["secure-channel create --from /node/n1 --to /node/n2/service/api"]}' > "$BATS_TMPDIR/configuration.json"
+  $OCKAM node create n2
+  $OCKAM node create n1 --config $BATS_TMPDIR/configuration.json
+  $OCKAM node stop n1
+
+  run --separate-stderr $OCKAM node start n1
+
+  assert_success
+  assert_output --partial "Running command 'secure-channel create --from /node/n1 --to /node/n2/service/api'"
+  assert_output --partial "/service/"
+}
+
 @test "create a secure channel between two nodes and send message through it" {
   $OCKAM node create n1
   $OCKAM node create n2


### PR DESCRIPTION
Continuation of https://github.com/build-trust/ockam/pull/3607

The `node create` command stores the `--config` contents when available in the node's directory so
it can be used later by the `node start` command to execute the commands from the
`on_node_startup` section.

The now renamed `NodeConfigOld` will be slowly deprecated as we continue splitting the different config files.