### PR TITLE
fix(rust): message send deletes --from node config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -83,7 +83,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
         );
 
         // only delete node in case 'from' is empty and embedded node was started before
-        if let None = &cmd.from {
+        if cmd.from.is_none() {
             delete_embedded_node(&opts.config, rpc.node_name()).await;
         }
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -82,7 +82,11 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             String::from_utf8(res).context("Received content is not a valid utf8 string")?
         );
 
-        delete_embedded_node(&opts.config, rpc.node_name()).await;
+        // only delete node in case 'from' is empty and embedded node was started before
+        if let None = &cmd.from {
+            delete_embedded_node(&opts.config, rpc.node_name()).await;
+        }
+
         Ok(())
     }
     go(&mut ctx, &opts, cmd).await


### PR DESCRIPTION


<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

node is always deleted regardless if it was specified as `--from` or embedded node was started

## Proposed Changes

only delete node in case `--from` is empty and embedded node was started before

## References

https://github.com/build-trust/ockam/issues/3609


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
