### PR TITLE
chore(rust): hide node default value for node start/stop within help

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -13,7 +13,7 @@ use rand::prelude::random;
 #[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct StartCommand {
     /// Name of the node.
-    #[arg(default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     node_name: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -12,7 +12,7 @@ use rand::prelude::random;
 #[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
 pub struct StopCommand {
     /// Name of the node.
-    #[arg(default_value_t = hex::encode(&random::<[u8;4]>()))]
+    #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     node_name: String,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
     #[arg(long)]


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

default random node name hex value is show during help

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

default random node name hex value is hidden during help

## Reference
https://github.com/build-trust/ockam/issues/3231

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
