### PR TITLE
chore(rust): ockam_command: unify help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.10"
+version = "4.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
+checksum = "4ed45cc2c62a3eff523e718d8576ba762c83a3146151093283ac62ae11933a73"
 dependencies = [
  "atty",
  "bitflags",
@@ -536,7 +536,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11cba7abac9b56dfe2f035098cdb3a43946f276e6db83b72c4e692343f9aab9a"
 dependencies = [
- "clap 4.0.10",
+ "clap 4.0.11",
 ]
 
 [[package]]
@@ -2288,7 +2288,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "atty",
- "clap 4.0.10",
+ "clap 4.0.11",
  "clap_complete",
  "cli-table",
  "colorful",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -49,7 +49,7 @@ anyhow = "1"
 async-recursion = { version = "1.0.0" }
 async-trait = "0.1"
 atty = "0.2"
-clap = { version = "4.0.9", features = ["derive", "cargo", "wrap_help"] }
+clap = { version = "4.0.11", features = ["derive", "cargo", "wrap_help"] }
 cli-table = "0.4"
 const-str = "0.4.3"
 crossbeam-channel = "0.5"

--- a/implementations/rust/ockam/ockam_command/src/admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/mod.rs
@@ -8,7 +8,7 @@ mod subscription;
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), after_long_help = help::template(HELP_DETAIL))]
 pub struct AdminCommand {
     #[command(subcommand)]
     pub subcommand: AdminSubCommand,

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -18,7 +18,7 @@ use crate::{help, CommandGlobalOpts};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), after_long_help = help::template(HELP_DETAIL))]
 pub struct SubscriptionCommand {
     #[command(subcommand)]
     subcommand: SubscriptionSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -10,7 +10,7 @@ use ockam_multiaddr::MultiAddr;
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), after_long_help = help::template(HELP_DETAIL))]
 pub struct AuthenticatedCommand {
     #[command(subcommand)]
     subcommand: AuthenticatedSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/completion/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/completion/mod.rs
@@ -28,7 +28,7 @@ About:
 
 /// Generate shell completion scripts
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct CompletionCommand {
     /// The type of shell (bash, zsh, fish)
     #[arg(display_order = 900, long, short)]

--- a/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
@@ -17,7 +17,7 @@ use clap::{Args, Subcommand};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), after_long_help = help::template(HELP_DETAIL))]
 pub struct ConfigurationCommand {
     #[command(subcommand)]
     subcommand: ConfigurationSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -8,10 +8,12 @@ use crate::help;
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 
+const HELP_DETAIL: &str = "";
+
 #[derive(Clone, Debug, Args)]
 #[command(
     hide = help::hide(),
-    help_template = help::template(""),
+    after_long_help = help::template(HELP_DETAIL),
     arg_required_else_help = true,
     subcommand_required = true
 )]

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -29,7 +29,7 @@ const HELP_DETAIL: &str = "";
 
 /// Enroll with Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct EnrollCommand {
     #[command(flatten)]
     pub cloud_opts: CloudOpts,

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -20,7 +20,7 @@ use crate::{help, CommandGlobalOpts};
 #[derive(Clone, Debug, Args)]
 #[command(
     arg_required_else_help = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct CreateCommand {
     /// Name of the forwarder (optional)

--- a/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/mod.rs
@@ -52,7 +52,7 @@ About:
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct ForwarderCommand {
     #[command(subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/help.rs
+++ b/implementations/rust/ockam/ockam_command/src/help.rs
@@ -3,18 +3,10 @@ use colorful::Colorful;
 use syntect::{
     easy::HighlightLines,
     highlighting::{Style, ThemeSet},
+    parsing::Regex,
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},
 };
-
-const TEMPLATE_TOP: &str = "
-{about-with-newline}
-{usage-heading}
-    {usage}
-
-{all-args}
-
-";
 
 const TEMPLATE_BOTTOM: &str = "
 Learn More:
@@ -26,10 +18,9 @@ Feedback:
     on Github https://github.com/build-trust/ockam/discussions/new
 ";
 
-pub(crate) fn template(background: &str) -> &'static str {
-    let mut template: String = TEMPLATE_TOP.to_owned();
+pub(crate) fn template(body: &str) -> &'static str {
+    let mut template: String = body.to_string();
 
-    template.push_str(background);
     template.push_str(TEMPLATE_BOTTOM);
     let highlighted = highlight_syntax(template);
 
@@ -58,8 +49,9 @@ pub fn highlight_syntax(input: String) -> String {
         }
 
         if !in_fenced_block {
-            if line.to_uppercase() == line {
-                highlighted.push(line.to_string().yellow().to_string());
+            let re = Regex::new("^[A-Za-z][A-Za-z0-9 ]+:$".into());
+            if re.is_match(line) {
+                highlighted.push(line.to_string().bold().underlined().to_string());
             } else {
                 highlighted.push(line.to_string());
             }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -147,7 +147,7 @@ Examples:
     term_width = 100,
     about = ABOUT,
     long_about = ABOUT,
-    help_template = help::template(HELP_DETAIL),
+    after_long_help = help::template(HELP_DETAIL),
     version,
     long_version = Version::long(),
     next_help_heading = "Global Options",
@@ -167,7 +167,8 @@ pub struct GlobalArgs {
         global = true,
         long,
         short,
-        help("Print help information"),
+        help("Print help information (-h compact, --help extensive)"),
+        long_help("Print help information (-h displays compact help summary, --help displays extensive help summary"),
         help_heading("Global Options"),
         action = ArgAction::Help
     )]

--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -86,7 +86,7 @@ Examples:
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct MessageCommand {
     #[command(subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -16,7 +16,7 @@ use crate::{help, message::HELP_DETAIL, CommandGlobalOpts};
 
 /// Send messages
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct SendCommand {
     /// The node to send messages from
     #[arg(short, long, value_name = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -39,7 +39,7 @@ use ockam_core::LOCAL;
 
 /// Create Nodes
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Name of the node (Optional).
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -4,7 +4,7 @@ use clap::Args;
 
 /// Delete Nodes
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Name of the node.
     #[arg(default_value = "default", group = "nodes")]

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -4,7 +4,7 @@ use clap::Args;
 
 /// List Nodes
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct ListCommand {}
 
 impl ListCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -121,7 +121,7 @@ Examples:
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct NodeCommand {
     #[command(subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/node/run.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/run.rs
@@ -9,7 +9,7 @@ const HELP_DETAIL: &str = "";
 
 /// Run a node given a configuration file
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct RunCommand {
     pub config: PathBuf,
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -22,7 +22,7 @@ const SEND_RECEIVE_TIMEOUT_SECS: u64 = 1;
 
 /// Show Nodes
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Name of the node.
     #[arg(default_value = "default")]

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -10,7 +10,7 @@ use rand::prelude::random;
 
 /// Start Nodes
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StartCommand {
     /// Name of the node.
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -9,7 +9,7 @@ use rand::prelude::random;
 
 /// Stop Nodes
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StopCommand {
     /// Name of the node.
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -3,6 +3,7 @@ use crate::CommandGlobalOpts;
 use clap::Args;
 use std::io::{self, BufReader, Read, Write};
 
+/// Full Ockam Reset
 #[derive(Clone, Debug, Args)]
 pub struct ResetCommand {
     #[arg(display_order = 901, long, short)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -23,7 +23,7 @@ use ockam_multiaddr::MultiAddr;
 
 /// Create Secure Channels
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node from which to initiate the secure channel (required)
     #[arg(value_name = "NODE", long, display_order = 800)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -17,7 +17,7 @@ use ockam_core::{Address, AddressParseError};
 
 /// Delete Secure Channels
 #[derive(Clone, Debug, Parser)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Node from which to initiate the secure channel (required)
     #[arg(value_name = "NODE", long, display_order = 800)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -19,7 +19,7 @@ use crate::{
 
 /// List Secure Channels
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ListCommand {
     /// Node at which the returned secure channels were initiated (required)
     #[arg(value_name = "NODE", long, display_order = 800)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -12,7 +12,7 @@ use ockam_core::{Address, Route};
 
 /// Create Secure Channel Listeners
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     #[command(flatten)]
     node_opts: SecureChannelListenerNodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -10,7 +10,7 @@ use crate::{help, CommandGlobalOpts};
 
 /// List Secure Channel Listeners
 #[derive(Args, Clone, Debug)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ListCommand {
     /// Node of which secure listeners shall be listed
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
@@ -13,7 +13,7 @@ use clap::{Args, Subcommand};
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct SecureChannelListenerCommand {
     #[command(subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -141,7 +141,7 @@ About:
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    help_template = help::template(HELP_DETAIL)
+    after_long_help = help::template(HELP_DETAIL)
 )]
 pub struct SecureChannelCommand {
     #[command(subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -12,7 +12,7 @@ use ockam_core::Address;
 
 /// Show Secure Channels
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, help_template = help::template(HELP_DETAIL))]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Node
     #[arg(value_name = "NODE", long, display_order = 800)]

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -18,7 +18,7 @@ use crate::{help, CommandGlobalOpts};
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+#[command(hide = help::hide(), after_long_help = help::template(HELP_DETAIL))]
 pub struct SubscriptionCommand {
     #[command(subcommand)]
     subcommand: SubscriptionSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -36,7 +36,7 @@ Examples:
 
 /// Create TCP Inlets
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node on which to start the tcp inlet.
     #[arg(long, display_order = 900, id = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -35,7 +35,7 @@ Examples:
 
 /// Create TCP Outlets
 #[derive(Clone, Debug, Args)]
-#[command(help_template = help::template(HELP_DETAIL))]
+#[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {
     /// Node on which to start the tcp outlet.
     #[arg(long, display_order = 900, id = "NODE")]


### PR DESCRIPTION
## Current Behavior

extended help is always shown, leading to a situations where the important help flags are only visible when utilizing a pager

## Proposed Changes

utilize clap `after_long_help` to differentiate between compact (`-h`) and extensive (`--help`) help
adjust help template to meet headline style from clap v4

## References

https://github.com/build-trust/ockam/issues/3434


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
