### PR TITLE
fix(rust): generalize `extract_node_name` so it can correctly parse other protocols

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
@@ -1,4 +1,4 @@
-use crate::{util::extract_node_name, CommandGlobalOpts};
+use crate::{util::extract_address_value, CommandGlobalOpts};
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -18,7 +18,9 @@ impl SetDefaultNodeCommand {
 
 fn run_impl(name: &str, options: &CommandGlobalOpts) -> crate::Result<()> {
     options.config.get_node(name)?;
-    options.config.set_default_node(&extract_node_name(name)?);
+    options
+        .config
+        .set_default_node(&extract_address_value(name)?);
     options.config.persist_config_updates()?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -12,7 +12,7 @@ use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
 
 use crate::forwarder::HELP_DETAIL;
 use crate::util::output::Output;
-use crate::util::{extract_node_name, node_rpc, RpcBuilder};
+use crate::util::{extract_address_value, node_rpc, RpcBuilder};
 use crate::Result;
 use crate::{help, CommandGlobalOpts};
 
@@ -48,7 +48,7 @@ impl CreateCommand {
 
 async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
-    let api_node = extract_node_name(&cmd.to)?;
+    let api_node = extract_address_value(&cmd.to)?;
     let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
 
     let lookup = opts.config.lookup();

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, extract_node_name};
+use crate::util::{connect_to, exitcode, extract_address_value};
 use crate::CommandGlobalOpts;
 use crate::{node::NodeOpts, util::api};
 use clap::Args;
@@ -17,7 +17,7 @@ pub struct ShowCommand {
 impl ShowCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = options.config;
-        let node = extract_node_name(&self.node_opts.api_node)?;
+        let node = extract_address_value(&self.node_opts.api_node)?;
         let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, self, show_identity);

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -10,7 +10,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::util::api::CloudOpts;
-use crate::util::{extract_node_name, node_rpc, RpcBuilder};
+use crate::util::{extract_address_value, node_rpc, RpcBuilder};
 use crate::Result;
 use crate::{help, message::HELP_DETAIL, CommandGlobalOpts};
 
@@ -50,7 +50,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
 
         // Setup environment depending on whether we are sending the message from an embedded node or a background node
         let (api_node, tcp) = if let Some(node) = &cmd.from {
-            let api_node = extract_node_name(node)?;
+            let api_node = extract_address_value(node)?;
             let tcp = TcpTransport::create(ctx).await?;
             (api_node, Some(tcp))
         } else {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,6 +1,6 @@
 use crate::{
     help,
-    util::{api, exitcode, extract_node_name, node_rpc},
+    util::{api, exitcode, extract_address_value, node_rpc},
     CommandGlobalOpts, OutputFormat, Result,
 };
 
@@ -76,7 +76,7 @@ impl CreateCommand {
 
     // Read the `from` argument and return node name
     fn parse_from_node(&self, _config: &ConfigLookup) -> String {
-        extract_node_name(&self.from).unwrap_or_else(|_| "".to_string())
+        extract_address_value(&self.from).unwrap_or_else(|_| "".to_string())
     }
 
     fn print_output(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -1,7 +1,7 @@
 use crate::secure_channel::HELP_DETAIL;
 use crate::{
     help,
-    util::{api, exitcode, extract_node_name, node_rpc, Rpc},
+    util::{api, exitcode, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat, Result,
 };
 use std::str::FromStr;
@@ -35,7 +35,7 @@ impl DeleteCommand {
 
     // Read the `at` argument and return node name
     fn parse_at_node(&self) -> String {
-        extract_node_name(&self.at).unwrap_or_else(|_| "".to_string())
+        extract_address_value(&self.at).unwrap_or_else(|_| "".to_string())
     }
 
     fn print_output(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -1,5 +1,5 @@
 use crate::secure_channel::HELP_DETAIL;
-use crate::util::{api, connect_to, exitcode, extract_node_name};
+use crate::util::{api, connect_to, exitcode, extract_address_value};
 use crate::{help, CommandGlobalOpts};
 
 use clap::Args;
@@ -35,7 +35,7 @@ pub struct SecureChannelListenerNodeOpts {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = options.config;
-        let node = extract_node_name(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
+        let node = extract_address_value(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, self, |ctx, cmd, rte| async {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -1,7 +1,7 @@
 use crate::secure_channel::HELP_DETAIL;
 use crate::{
     help,
-    util::{api, extract_node_name, node_rpc, Rpc},
+    util::{api, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, Result,
 };
 use clap::Args;
@@ -30,7 +30,7 @@ impl ShowCommand {
 
     // Read the `at` argument and return node name
     fn parse_at_node(&self) -> String {
-        extract_node_name(&self.at).unwrap_or_else(|_| "".to_string())
+        extract_address_value(&self.at).unwrap_or_else(|_| "".to_string())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    util::{api, connect_to, exitcode, extract_node_name},
+    util::{api, connect_to, exitcode, extract_address_value},
     CommandGlobalOpts, OutputFormat,
 };
 use clap::Args;
@@ -39,7 +39,7 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = extract_node_name(&self.node_opts.from).unwrap_or_else(|_| "".to_string());
+        let node = extract_address_value(&self.node_opts.from).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, (self, options.clone()), create_connection);

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -3,7 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
-use crate::util::extract_node_name;
+use crate::util::extract_address_value;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode},
@@ -26,7 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let node =
+            extract_address_value(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
         connect_to(port, self, delete_connection);
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,5 +1,5 @@
 use crate::node::NodeOpts;
-use crate::util::{api, connect_to, exitcode, extract_node_name};
+use crate::util::{api, connect_to, exitcode, extract_address_value};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -18,7 +18,8 @@ pub struct ListCommand {
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let node =
+            extract_address_value(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
 
         connect_to(port, (), list_connections);

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{bind_to_port_check, connect_to, exitcode, extract_node_name};
+use crate::util::{bind_to_port_check, connect_to, exitcode, extract_address_value};
 use crate::{help, CommandGlobalOpts};
 use clap::Args;
 use minicbor::Decoder;
@@ -67,7 +67,7 @@ impl CreateCommand {
             ..self
         };
 
-        let node = extract_node_name(&command.at)?;
+        let node = extract_address_value(&command.at)?;
         let port = cfg.get_node_port(&node).unwrap();
 
         // Check if the port is used by some other services or process

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{bind_to_port_check, extract_node_name};
+use crate::util::{bind_to_port_check, extract_address_value};
 use crate::{
     util::{api, connect_to, exitcode},
     CommandGlobalOpts,
@@ -31,7 +31,7 @@ pub struct TCPListenerNodeOpts {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = extract_node_name(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
+        let node = extract_address_value(&self.node_opts.at).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
 
         let input_addr = match std::net::SocketAddr::from_str(&self.address) {

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -3,7 +3,7 @@ use ockam::{Context, Route};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Response, Status};
 
-use crate::util::extract_node_name;
+use crate::util::extract_address_value;
 use crate::{
     node::NodeOpts,
     util::{api, connect_to, exitcode},
@@ -26,7 +26,8 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         let cfg = &options.config;
-        let node = extract_node_name(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
+        let node =
+            extract_address_value(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
         let port = cfg.get_node_port(&node).unwrap();
         connect_to(port, self, delete_listener);
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,4 +1,4 @@
-use crate::util::{connect_to, exitcode, extract_node_name};
+use crate::util::{connect_to, exitcode, extract_address_value};
 use crate::{help, CommandGlobalOpts};
 use clap::Args;
 use minicbor::Decoder;
@@ -60,11 +60,11 @@ impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) -> anyhow::Result<()> {
         let cfg = &options.config;
         let at = &self.at.clone();
-        let node = extract_node_name(at)?;
+        let node = extract_address_value(at)?;
         let port = cfg.get_node_port(&node).unwrap();
 
         let command = CreateCommand {
-            from: extract_node_name(&self.from)?,
+            from: extract_address_value(&self.from)?,
             ..self
         };
 


### PR DESCRIPTION
Fixes the following CI error https://github.com/build-trust/ockam/actions/runs/3213149939/jobs/5252607024#step:5:98 that was introduced at https://github.com/build-trust/ockam/pull/3608

The function `extract_node_name` was failing on the `tcp-outlet create` command when passing the `--from /service/outlet` argument, as it only worked with the `node` protocol.

Now, the function has been renamed to `extract_address_value` and it can be used to extract the address from `node`, `service` and `project` protocols.