### PR TITLE
refactor(rust): refactor `tcp listener delete` command to use rpc abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -93,16 +93,6 @@ pub(crate) fn delete_tcp_connection(
     Ok(buf)
 }
 
-/// Construct a request to delete node tcp connection
-pub(crate) fn delete_tcp_listener(cmd: &crate::tcp::listener::DeleteCommand) -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::delete("/node/tcp/listener")
-        .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force))
-        .encode(&mut buf)?;
-
-    Ok(buf)
-}
-
 /// Construct a request to export Identity
 pub(crate) fn long_identity() -> Result<Vec<u8>> {
     let mut buf = vec![];


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Closes #3598 

## Current Behavior

The current implementation is calling std::process::exit, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

## Proposed Changes

As described in #3598, this refactoring addresses use of rpc abstraction, providing friendly messages to the user and removing manual error handling done using the system exit command. 

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
