### PR TITLE
refactor(rust): change `tcp outlet create` to use `rpc` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -19,7 +19,7 @@ pub enum TcpOutletSubCommand {
 impl TcpOutletCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
-            TcpOutletSubCommand::Create(c) => c.run(options).unwrap(),
+            TcpOutletSubCommand::Create(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
## Current Behavior

The current implementation is calling `std::process::exit`, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

It's also using the `connect_to` function, which can be simplified by using the `Rpc` utils.

## Proposed Changes

* `run` method (main entry point of the subcommand) contain a single line of code calling a function `run_impl` that returns a `crate::Result<()>`.
* remove uses of `std::process::exit` and delegates the error mapping.
* `run` method return `()`. The `node_rpc` function handles the errors`.
* Use of `rpc` abstraction with a background node instead of `connect_to`

Close #3600 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
