### PR TITLE
ci: change deprecated workflow set-output command to new syntax

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,7 +59,7 @@ jobs:
 
           # Only cache rust build if example blocks code was built
           if [[ ls target ]]; then
-            echo "::set-output name=is_cached::true"
+            echo "is_cached=true" >> $GITHUB_OUTPUT
           fi
 
       - uses: ./.github/actions/cargo_target_dir_pre_cache


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
The Github Action Documentation workflow uses the `set-output` command to declare an output parameter to be used in subsequent steps. This has been deprecated.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Resolves https://github.com/build-trust/ockam/issues/3645
The deprecated syntax is replaced by the new syntax.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
