### PR TITLE
feat(rust): add addons commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -1,0 +1,125 @@
+use minicbor::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use ockam_core::CowStr;
+#[cfg(feature = "tag")]
+use ockam_core::TypeTag;
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[cbor(map)]
+pub struct Addon<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)]
+    pub tag: TypeTag<1530077>,
+    #[b(1)]
+    #[serde(borrow)]
+    pub id: CowStr<'a>,
+    #[b(2)]
+    #[serde(borrow)]
+    pub description: CowStr<'a>,
+    #[n(3)]
+    pub enabled: bool,
+}
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[cfg_attr(test, derive(Clone))]
+#[cbor(map)]
+pub struct ConfigureAddon<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)]
+    pub tag: TypeTag<8647456>,
+    #[b(1)]
+    #[serde(borrow)]
+    pub tenant: CowStr<'a>,
+    #[b(2)]
+    #[serde(borrow)]
+    pub certificate: CowStr<'a>,
+}
+
+impl<'a> ConfigureAddon<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(tenant: S, certificate: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            tenant: tenant.into(),
+            certificate: certificate.into(),
+        }
+    }
+}
+
+mod node {
+    use minicbor::Decoder;
+    use tracing::trace;
+
+    use ockam_core::api::Request;
+    use ockam_core::{self, Result};
+    use ockam_node::Context;
+
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
+    use crate::nodes::NodeManagerWorker;
+
+    use super::*;
+
+    const TARGET: &str = "ockam_api::cloud::addon";
+    const API_SERVICE: &str = "projects";
+
+    impl NodeManagerWorker {
+        pub(crate) async fn list_addons(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            project_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "list_addons";
+            trace!(target: TARGET, project_id, "listing addons");
+
+            let req_builder = Request::get(format!("/v0/{}/addons", project_id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn configure_addon(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            project_id: &str,
+            addon_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<ConfigureAddon> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "configure_addon";
+            trace!(target: TARGET, project_id, addon_id, "configuring addon");
+
+            let req_builder =
+                Request::put(format!("/v0/{}/addons/{}", project_id, addon_id)).body(req_body);
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+
+        pub(crate) async fn disable_addon(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            project_id: &str,
+            addon_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+
+            let label = "disable_addon";
+            trace!(target: TARGET, project_id, addon_id, "disabling addon");
+
+            let req_builder = Request::delete(format!("/v0/{}/addons/{}", project_id, addon_id));
+            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
+                .await
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -9,6 +9,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::error::ApiError;
 
+pub mod addon;
 pub mod enroll;
 pub mod project;
 pub mod space;
@@ -20,6 +21,8 @@ pub mod subscription;
 /// How to use: when running a command that spawns a background node or use an embedded node
 /// add the env variable. `OCKAM_CONTROLLER_IDENTITY_ID={identity.id-contents} ockam ...`
 pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY_ID";
+
+pub type ProjectAddress = CowStr<'static>;
 
 /// A wrapper around a cloud request with extra fields.
 #[derive(Encode, Decode, Debug)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -687,6 +687,15 @@ impl NodeManagerWorker {
             }
             (Put, ["subscription", id, "unsubscribe"]) => self.unsubscribe(ctx, dec, id).await?,
 
+            // ==*== Addons ==*==
+            (Get, [project_id, "addons"]) => self.list_addons(ctx, dec, project_id).await?,
+            (Put, [project_id, "addons", addon_id]) => {
+                self.configure_addon(ctx, dec, project_id, addon_id).await?
+            }
+            (Delete, [project_id, "addons", addon_id]) => {
+                self.disable_addon(ctx, dec, project_id, addon_id).await?
+            }
+
             // ==*== Messages ==*==
             (Post, ["v0", "message"]) => self.send_message(ctx, req, dec).await?,
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -1,0 +1,196 @@
+use core::fmt::Write;
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use clap::builder::NonEmptyStringValueParser;
+use clap::{Args, Subcommand};
+
+use ockam::Context;
+use ockam_api::cloud::addon::{Addon, ConfigureAddon};
+use ockam_api::cloud::CloudRequestWrapper;
+use ockam_core::api::Request;
+
+use crate::node::util::delete_embedded_node;
+use crate::util::api::CloudOpts;
+use crate::util::output::Output;
+use crate::util::{node_rpc, Rpc};
+use crate::{help, CommandGlobalOpts};
+
+const HELP_DETAIL: &str = "";
+
+#[derive(Clone, Debug, Args)]
+#[command(hide = help::hide(), help_template = help::template(HELP_DETAIL))]
+pub struct AddonCommand {
+    #[command(subcommand)]
+    subcommand: AddonSubcommand,
+
+    #[command(flatten)]
+    cloud_opts: CloudOpts,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum AddonSubcommand {
+    List {
+        /// Project name
+        #[arg(
+            long = "project",
+            id = "project",
+            value_name = "PROJECT_NAME",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        project_name: String,
+    },
+    Disable {
+        /// Project name
+        #[arg(
+            long = "project",
+            id = "project",
+            value_name = "PROJECT_NAME",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        project_name: String,
+
+        /// Addon id/name
+        #[arg(
+            long = "addon",
+            id = "addon",
+            value_name = "ADDON_ID",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        addon_id: String,
+    },
+    #[command(subcommand)]
+    Configure(ConfigureAddonCommand),
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum ConfigureAddonCommand {
+    Okta {
+        /// Project name
+        #[arg(
+            long = "project",
+            id = "project",
+            value_name = "PROJECT_NAME",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        project_name: String,
+
+        /// Plugin tenant URL
+        #[arg(
+            long,
+            id = "tenant",
+            value_name = "TENANT",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        tenant: String,
+
+        /// Certificate. Use either this or --cert-path
+        #[arg(
+            long = "cert",
+            group = "cert",
+            value_name = "CERTIFICATE",
+            value_parser(NonEmptyStringValueParser::new())
+        )]
+        certificate: Option<String>,
+
+        /// Certificate file path. Use either this or --cert
+        #[arg(long = "cert-path", group = "cert", value_name = "CERTIFICATE_PATH")]
+        certificate_path: Option<PathBuf>,
+    },
+}
+
+impl AddonCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, AddonCommand),
+) -> crate::Result<()> {
+    let controller_route = &cmd.cloud_opts.route();
+    let mut rpc = Rpc::embedded(&ctx, &opts).await?;
+
+    let base_endpoint = |project_name: &str| -> crate::Result<String> {
+        let lookup = opts.config.lookup();
+        let project_id = &lookup
+            .get_project(project_name)
+            .context(format!(
+                "Failed to get project {} from config lookup",
+                project_name
+            ))?
+            .id;
+        Ok(format!("{project_id}/addons"))
+    };
+
+    match cmd.subcommand {
+        AddonSubcommand::List { project_name } => {
+            let req = Request::get(base_endpoint(&project_name)?)
+                .body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.parse_and_print_response::<Vec<Addon>>()?;
+        }
+        AddonSubcommand::Disable {
+            project_name,
+            addon_id,
+        } => {
+            let endpoint = format!("{}/{}", base_endpoint(&project_name)?, addon_id);
+            let req = Request::delete(endpoint).body(CloudRequestWrapper::bare(controller_route));
+            rpc.request(req).await?;
+            rpc.is_ok()?;
+        }
+        AddonSubcommand::Configure(cmd) => match cmd {
+            ConfigureAddonCommand::Okta {
+                project_name,
+                tenant,
+                certificate,
+                certificate_path,
+            } => {
+                let certificate = match (certificate, certificate_path) {
+                    (Some(c), _) => c,
+                    (_, Some(p)) => std::fs::read_to_string(p)?,
+                    _ => unreachable!(),
+                };
+                let addon_id = "okta";
+                let endpoint = format!("{}/{}", base_endpoint(&project_name)?, addon_id);
+                let body = ConfigureAddon::new(tenant, certificate);
+                let req =
+                    Request::put(endpoint).body(CloudRequestWrapper::new(body, controller_route));
+                rpc.request(req).await?;
+                rpc.is_ok()?;
+            }
+        },
+    };
+    delete_embedded_node(&opts.config, rpc.node_name()).await;
+    Ok(())
+}
+
+impl Output for Addon<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        let mut w = String::new();
+        write!(w, "Addon:")?;
+        write!(w, "\n  Id: {}", self.id)?;
+        write!(w, "\n  Enabled: {}", self.enabled)?;
+        write!(w, "\n  Description: {}", self.description)?;
+        writeln!(w)?;
+        Ok(w)
+    }
+}
+
+impl Output for Vec<Addon<'_>> {
+    fn output(&self) -> anyhow::Result<String> {
+        if self.is_empty() {
+            return Ok("No addons found".to_string());
+        }
+        let mut w = String::new();
+        for (idx, a) in self.iter().enumerate() {
+            write!(w, "\n{idx}:")?;
+            write!(w, "\n  Id: {}", a.id)?;
+            write!(w, "\n  Enabled: {}", a.enabled)?;
+            write!(w, "\n  Description: {}", a.description)?;
+            writeln!(w)?;
+        }
+        Ok(w)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,4 +1,5 @@
 mod add_enroller;
+mod addon;
 mod create;
 mod delete;
 mod delete_enroller;
@@ -16,6 +17,7 @@ use clap::{Args, Subcommand};
 
 pub use crate::credential::get_credential::GetCredentialCommand;
 pub use add_enroller::AddEnrollerCommand;
+pub use addon::AddonCommand;
 pub use create::CreateCommand;
 pub use delete::DeleteCommand;
 pub use delete_enroller::DeleteEnrollerCommand;
@@ -46,6 +48,7 @@ pub enum ProjectSubcommand {
     ListEnrollers(ListEnrollersCommand),
     DeleteEnroller(DeleteEnrollerCommand),
     Enroll(EnrollCommand),
+    Addon(AddonCommand),
 }
 
 impl ProjectCommand {
@@ -60,6 +63,7 @@ impl ProjectCommand {
             ProjectSubcommand::DeleteEnroller(c) => c.run(options),
             ProjectSubcommand::Enroll(c) => c.run(options),
             ProjectSubcommand::Info(c) => c.run(options),
+            ProjectSubcommand::Addon(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -148,7 +148,7 @@ impl Output for Subscription<'_> {
     }
 }
 
-impl<'a> Output for Vec<Subscription<'a>> {
+impl Output for Vec<Subscription<'_>> {
     fn output(&self) -> anyhow::Result<String> {
         if self.is_empty() {
             return Ok("No subscriptions found".to_string());

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -523,6 +523,25 @@ teardown() {
   assert_success
 }
 
+@test "project addons - list addons" {
+  skip_if_orchestrator_tests_not_enabled
+
+  run --separate-stderr $OCKAM project addon list --project default
+
+  assert_success
+  assert_output "Id: okta\n  Enabled: false"
+}
+
+@test "project addons - configure/disable okta" {
+  skip_if_orchestrator_tests_not_enabled
+
+  run --separate-stderr $OCKAM project addon configure okta --project default --tenant http://my.okta.com --cert certrawcontents
+  assert_success
+
+  run --separate-stderr $OCKAM project addon disable --project default --addon okta
+  assert_success
+}
+
 function skip_if_orchestrator_tests_not_enabled() {
   # shellcheck disable=SC2031
   if [ -z "${ORCHESTRATOR_TESTS}" ]; then


### PR DESCRIPTION
Add commands to access the endpoints described at https://github.com/build-trust/ockam-cloud/pull/229 to manage addons (list, enable/configure, disable).

New commands:

```bash
ockam project addon list --project default

# Enable using --cert
ockam project addon configure okta --project default --tenant http://my.okta.com --cert certrawcontents

# Enable using --cert-path
ockam project addon configure okta --project default --tenant http://my.okta.com --cert-path path/to/cert.txt

ockam project addon disable --project default --addon okta
```