### PR TITLE
ci: replace deprecated set-output command with GitHub output parameter

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           git checkout -B ${{ github.event.inputs.branch_name }}
           sha=$(git rev-parse HEAD)
-          echo "::set-output name=sha::$sha"
+          echo "sha=$sha" >> $GITHUB_OUTPUT
 
       - name: Import GPG key
         uses: build-trust/.github/actions/import_gpg@custom-actions


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
The Create Release Pull Request workflow uses the deprecated set-output command

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
The deprecated syntax is replaced by the new output parameter syntax
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Resolves #3644 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
