### PR TITLE
fix(rust): project info was not persisted properly

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -18,8 +18,7 @@ use ockam_core::api::Status;
 
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::check_project_readiness;
-use crate::project::util::config::set_project;
-use crate::space::util::config::set_space;
+use crate::space::util::config;
 use crate::util::api::CloudOpts;
 use crate::util::output::Output;
 use crate::util::{api, node_rpc, RpcBuilder};
@@ -122,7 +121,7 @@ async fn default_space<'a>(
             .expect("already checked that is not empty")
             .to_owned()
     };
-    set_space(&opts.config, &default_space)?;
+    config::set_space(&opts.config, &default_space)?;
     println!("\n{}", default_space.output()?);
     Ok(default_space)
 }
@@ -165,7 +164,6 @@ async fn default_project<'a>(
     };
     let project =
         check_project_readiness(ctx, opts, cloud_opts, node_name, None, default_project).await?;
-    set_project(&opts.config, &project).await?;
     println!("{}", project.output()?);
     Ok(project)
 }


### PR DESCRIPTION
Configuration changes were not being persisted in the following situations:
1. `project create`: was not calling `config::set_project` after calling `check_project_readiness`. The configuration is now persisted inside the `check_project_readiness` to avoid that mistake
2. `set_project_unchecked`: was not calling `config::set_project` after modifying the config

Another change is that the `set_project_unchecked` has been simplified and now it only persists the project's id (has been renamed to `set_project_id`).