### PR TITLE
ci: change deprecated workflow set-output command to new syntax

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -156,8 +156,8 @@ jobs:
             [CHANGELOG](https://github.com/build-trust/ockam/blob/ockam_v$ockam_version/implementations/rust/ockam/$name/CHANGELOG.md))";
           done
 
-          echo "::set-output name=version::$ockam_version"
-          echo "::set-output name=tag_name::ockam_v$ockam_version"
+          echo "version=$ockam_version" >> $GITHUB_OUTPUT
+          echo "tag_name=ockam_v$ockam_version" >> $GITHUB_OUTPUT
 
           echo "$text" > release_note.md
           cat release_note.md


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
The Github Action Create Draft Release workflow uses the set-output command to declare output parameters to be used in subsequent steps. This has been deprecated.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Resolves #3647 
The deprecated syntax is replaced by the new syntax.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
