### PR TITLE
ci: replace deprecated set-output command with output parameter in Co…

### DIFF
--- a/.github/workflows/ockam-package.yml
+++ b/.github/workflows/ockam-package.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           tag_name="${{ github.event.inputs.tag }}"
           version=${tag_name:7}
-          echo ::set-output name=image::"ghcr.io/${ORGANIZATION}/$ARTIFACT_NAME:${version}-draft"
+          echo "image=ghcr.io/${ORGANIZATION}/$ARTIFACT_NAME:${version}-draft" >> $GITHUB_OUTPUT
 
       - name: Update Docker Template
         shell: bash
@@ -126,7 +126,7 @@ jobs:
         run: |
           tag_name="${{ github.event.inputs.tag }}"
           version=${tag_name:7}
-          echo ::set-output name=version::"${version}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
 
       - name: Deploy Latest Image
         shell: bash


### PR DESCRIPTION
…ntainer Release workflow

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
The Ockam Container Release workflow uses the deprecated set-output command

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
The deprecated syntax is replaced by the new output parameter syntax
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Resolves #3646 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
