### PR TITLE
refactor(rust): refactored identity show command to use rpc abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
@@ -1,5 +1,6 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
+use serde::Serialize;
 
 use ockam_core::CowBytes;
 
@@ -26,11 +27,12 @@ impl<'a> CreateIdentityResponse<'a> {
     }
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct LongIdentityResponse<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip)]
     #[n(0)] tag: TypeTag<7961643>,
     #[b(1)] pub identity: CowBytes<'a>,
 }
@@ -45,11 +47,12 @@ impl<'a> LongIdentityResponse<'a> {
     }
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct ShortIdentityResponse<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip)]
     #[n(0)] tag: TypeTag<5773131>,
     #[b(1)] pub identity_id: Cow<'a, str>,
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -26,7 +26,7 @@ impl IdentityCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             IdentitySubcommand::Create(c) => c.run(options),
-            IdentitySubcommand::Show(c) => c.run(options).unwrap(),
+            IdentitySubcommand::Show(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -94,13 +94,6 @@ pub(crate) fn delete_tcp_connection(
     Ok(buf)
 }
 
-/// Construct a request to export Identity
-pub(crate) fn long_identity() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::post("/node/identity/actions/show/long").encode(&mut buf)?;
-    Ok(buf)
-}
-
 /// Construct a request to print Identity Id
 pub(crate) fn short_identity() -> RequestBuilder<'static, ()> {
     Request::post("/node/identity/actions/show/short")
@@ -391,17 +384,6 @@ pub(crate) fn parse_transport_status(
     Ok((
         response,
         dec.decode::<models::transport::TransportStatus>()?,
-    ))
-}
-
-pub(crate) fn parse_long_identity_response(
-    resp: &[u8],
-) -> Result<(Response, models::identity::LongIdentityResponse<'_>)> {
-    let mut dec = Decoder::new(resp);
-    let response = dec.decode::<Response>()?;
-    Ok((
-        response,
-        dec.decode::<models::identity::LongIdentityResponse>()?,
     ))
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -75,6 +75,15 @@ teardown() {
   assert_success
 }
 
+@test "create a node and show its identity" {
+  run $OCKAM node create n1
+  assert_success
+
+  run $OCKAM identity show --node n1
+  assert_success
+  assert_output --regexp '^P'
+}
+
 @test "create a node with a name and do show on it" {
   run $OCKAM node create n1
   assert_success


### PR DESCRIPTION
## Current Behavior

The current implementation in identity show command is calling std::process::exit, which is something we want to stop using to handle errors properly and give the user a better-formatted output when a command fails.

## Proposed Changes

Relating to issue #3562 
1) Changed the implementation to use the node_rpc method as being used in [subscription](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_command/src/subscription.rs#L52) command
2) Added implementations of `ockam_command::util::output` for `ShortIdentityResponse` and `LongIdentityResponse` to maintain current code quality and style
3) Marked 2 functions that were being used before as `allow(unused)` to prevent linting errors.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->