### PR TITLE
feat(rust): add okta auth command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -670,6 +670,7 @@ impl NodeManagerWorker {
 
             // ==*== Enroll ==*==
             (Post, ["v0", "enroll", "auth0"]) => self.enroll_auth0(ctx, dec).await?,
+            (Post, ["v0", "enroll", "okta"]) => self.enroll_okta(ctx, dec).await?,
             (Get, ["v0", "enroll", "token"]) => self.generate_enrollment_token(ctx, dec).await?,
             (Put, ["v0", "enroll", "token"]) => {
                 self.authenticate_enrollment_token(ctx, dec).await?

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info};
 
 use ockam::Context;
 use ockam_api::cloud::enroll::auth0::*;
-use ockam_api::cloud::project::Project;
+use ockam_api::cloud::project::{OktaAuth0, Project};
 use ockam_api::cloud::space::Space;
 use ockam_api::error::ApiError;
 use ockam_core::api::Status;
@@ -63,7 +63,7 @@ async fn enroll(
     cmd: &EnrollCommand,
     node_name: &str,
 ) -> anyhow::Result<()> {
-    let auth0 = Auth0Service;
+    let auth0 = Auth0Service::new(Auth0Provider::Auth0);
     let token = auth0.token().await?;
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
     rpc.request(api::enroll::auth0(cmd.clone(), token)).await?;
@@ -168,12 +168,51 @@ async fn default_project<'a>(
     Ok(project)
 }
 
-pub struct Auth0Service;
+pub enum Auth0Provider {
+    Auth0,
+    Okta(OktaAuth0),
+}
+
+impl Auth0Provider {
+    fn client_id(&self) -> &str {
+        match self {
+            Self::Auth0 => "c1SAhEjrJAqEk6ArWjGjuWX11BD2gK8X",
+            Self::Okta(d) => &d.client_id,
+        }
+    }
+
+    const fn scopes(&self) -> &'static str {
+        "profile openid email"
+    }
+
+    fn device_code_url(&self) -> String {
+        match self {
+            Self::Auth0 => "https://account.ockam.io/oauth/device/code".to_string(),
+            Self::Okta(d) => format!(
+                "https://{}/oauth2/default/v1/device/authorize",
+                &d.tenant_url
+            ),
+        }
+    }
+
+    fn token_request_url(&self) -> String {
+        match self {
+            Self::Auth0 => "https://account.ockam.io/oauth/token".to_string(),
+            Self::Okta(d) => format!("https://{}/oauth2/default/v1/token", &d.tenant_url),
+        }
+    }
+}
+
+pub struct Auth0Service(Auth0Provider);
 
 impl Auth0Service {
-    const DOMAIN: &'static str = "account.ockam.io";
-    const CLIENT_ID: &'static str = "c1SAhEjrJAqEk6ArWjGjuWX11BD2gK8X";
-    const SCOPES: &'static str = "profile openid email";
+    pub fn new(provider: Auth0Provider) -> Self {
+        Self(provider)
+    }
+
+    fn provider(&self) -> &Auth0Provider {
+        &self.0
+    }
 }
 
 #[async_trait::async_trait]
@@ -186,9 +225,12 @@ impl Auth0TokenProvider for Auth0Service {
             let res = Retry::spawn(retry_strategy, move || {
                 let client = reqwest::Client::new();
                 client
-                    .post(format!("https://{}/oauth/device/code", Self::DOMAIN))
+                    .post(self.provider().device_code_url())
                     .header("content-type", "application/x-www-form-urlencoded")
-                    .form(&[("client_id", Self::CLIENT_ID), ("scope", Self::SCOPES)])
+                    .form(&[
+                        ("client_id", self.provider().client_id()),
+                        ("scope", self.provider().scopes()),
+                    ])
                     .send()
             })
             .await
@@ -257,10 +299,10 @@ impl Auth0TokenProvider for Auth0Service {
         let tokens_res;
         loop {
             let res = client
-                .post(format!("https://{}/oauth/token", Self::DOMAIN))
+                .post(self.provider().token_request_url())
                 .header("content-type", "application/x-www-form-urlencoded")
                 .form(&[
-                    ("client_id", Self::CLIENT_ID),
+                    ("client_id", self.provider().client_id()),
                     ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
                     ("device_code", &device_code_res.device_code),
                 ])

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -1,0 +1,119 @@
+use clap::Args;
+
+use anyhow::{anyhow, Context as _};
+use ockam::Context;
+use ockam_api::cloud::enroll::auth0::{Auth0TokenProvider, AuthenticateAuth0Token};
+use ockam_api::cloud::project::OktaAuth0;
+use ockam_api::nodes::models::secure_channel::{
+    CreateSecureChannelResponse, CredentialExchangeMode,
+};
+use ockam_core::api::{Request, Status};
+use ockam_multiaddr::MultiAddr;
+use tracing::{debug, info};
+
+use crate::enroll::{Auth0Provider, Auth0Service};
+use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::project::ProjectInfo;
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, RpcBuilder};
+use crate::{help, CommandGlobalOpts};
+use std::path::PathBuf;
+
+/// Authenticate using okta addon
+#[derive(Clone, Debug, Args)]
+#[command(hide = help::hide())]
+pub struct AuthCommand {
+    /// Project config file
+    #[arg(long = "project", value_name = "PROJECT_JSON_PATH")]
+    project: PathBuf,
+
+    #[command(flatten)]
+    cloud_opts: CloudOpts,
+}
+
+impl AuthCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, AuthCommand),
+) -> crate::Result<()> {
+    let node_name = start_embedded_node(&ctx, &opts.config).await?;
+
+    // TODO's
+    //  - The secure channel setup is copy-pasted from ockam_command::project::enroll
+    //  and should be easier/more direct way to do it.
+    //  - The api's okta enroll is not used, remove it
+
+    // Read (okta and authority) project parameters from project.json
+    let s = tokio::fs::read_to_string(cmd.project).await?;
+    let p: ProjectInfo = serde_json::from_str(&s)?;
+
+    // Get auth0 token
+    let okta_config: OktaAuth0 = p.okta_config.context("Okta addon not configured")?.into();
+    let auth0 = Auth0Service::new(Auth0Provider::Okta(okta_config));
+    let token = auth0.token().await?;
+
+    // Create secure channel to the okta_authenticator service at the project's authority node
+    let addr = {
+        let authority_access_route: MultiAddr = p
+            .authority_access_route
+            .context("Authority route not configured")?
+            .as_ref()
+            .try_into()
+            .context("Invalid authority route")?;
+
+        // Return address to the "okta_authenticator" worker on the authority node through a secure channel
+        let mut addr = secure_channel(&ctx, &opts, &authority_access_route, &node_name).await?;
+        let service = MultiAddr::try_from("/service/okta_authenticator")?;
+        for proto in service.iter() {
+            addr.push_back_value(&proto)?;
+        }
+        addr
+    };
+
+    // Send enroll request to authority node
+    let token = AuthenticateAuth0Token::new(token);
+    let req = Request::post("v0/enroll").body(token);
+    let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).to(&addr)?.build();
+    debug!(addr = %addr, "enrolling");
+    rpc.request(req).await?;
+    let (res, dec) = rpc.check_response()?;
+    let res = if res.status() == Some(Status::Ok) {
+        info!("Enrolled successfully");
+        Ok(())
+    } else if res.status() == Some(Status::BadRequest) {
+        info!("Already enrolled");
+        Ok(())
+    } else {
+        eprintln!("{}", rpc.parse_err_msg(res, dec));
+        Err(anyhow!("Failed to enroll").into())
+    };
+    delete_embedded_node(&opts.config, &node_name).await;
+    res
+}
+
+async fn secure_channel(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    authority_route: &MultiAddr,
+    //authority_identifier: IdentityIdentifier,
+    node_name: &str,
+) -> anyhow::Result<MultiAddr> {
+    let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
+    debug!(%authority_route, "establishing secure channel to project authority");
+    //TODO: check authority' identity
+    rpc.request(api::create_secure_channel(
+        authority_route,
+        // Some(allowed),
+        None, //Do this means all are ok?
+        CredentialExchangeMode::None,
+    ))
+    .await?;
+    let res = rpc.parse_response::<CreateSecureChannelResponse>()?;
+    let addr = res.addr()?;
+    Ok(addr)
+}

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -3,6 +3,7 @@ use clap::Args;
 
 use ockam::identity::IdentityIdentifier;
 use ockam::Context;
+use ockam_api::cloud::project::OktaConfig;
 use ockam_api::cloud::project::Project;
 use ockam_core::CowStr;
 
@@ -37,6 +38,8 @@ pub struct ProjectInfo<'a> {
     pub authority_access_route: Option<CowStr<'a>>,
     #[serde(borrow)]
     pub authority_identity: Option<CowStr<'a>>,
+    #[serde(borrow)]
+    pub okta_config: Option<OktaConfig<'a>>,
 }
 
 impl<'a> From<Project<'a>> for ProjectInfo<'a> {
@@ -48,6 +51,7 @@ impl<'a> From<Project<'a>> for ProjectInfo<'a> {
             access_route: p.access_route,
             authority_access_route: p.authority_access_route,
             authority_identity: p.authority_identity,
+            okta_config: p.okta_config,
         }
     }
 }
@@ -61,6 +65,7 @@ impl<'a> From<&ProjectInfo<'a>> for Project<'a> {
             access_route: p.access_route.clone(),
             authority_access_route: p.authority_access_route.clone(),
             authority_identity: p.authority_identity.clone(),
+            okta_config: p.okta_config.clone(),
             ..Default::default()
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,5 +1,6 @@
 mod add_enroller;
 mod addon;
+mod auth;
 mod create;
 mod delete;
 mod delete_enroller;
@@ -27,6 +28,7 @@ pub use list::ListCommand;
 pub use list_enrollers::ListEnrollersCommand;
 pub use show::ShowCommand;
 
+use crate::project::auth::AuthCommand;
 use crate::CommandGlobalOpts;
 
 /// Manage Projects in Ockam Orchestrator
@@ -49,6 +51,7 @@ pub enum ProjectSubcommand {
     DeleteEnroller(DeleteEnrollerCommand),
     Enroll(EnrollCommand),
     Addon(AddonCommand),
+    Authenticate(AuthCommand),
 }
 
 impl ProjectCommand {
@@ -64,6 +67,7 @@ impl ProjectCommand {
             ProjectSubcommand::Enroll(c) => c.run(options),
             ProjectSubcommand::Info(c) => c.run(options),
             ProjectSubcommand::Addon(c) => c.run(options),
+            ProjectSubcommand::Authenticate(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
Add new command to authenticate a project using its okta settings previously configured. 

The workflow of the okta plugin is:

- `project addon configure okta`: the user passes the okta's certificate, tenant and client_id as arguments. These data will be attached to an existing project. After this, the controller will return the okta data when retrieving that project, and this data will be stored in the lookup table
- `project authenticate`: given an exported `project.json`, a "support engineer" can authenticate the project's okta data. An access_token will be generated through the okta enroll workflow and then it will be sent to the project's authority node to validate it

Note: the TODO's from `ockam_command/src/project/auth.rs` will be addressed in a separate PR shortly.