### PR TITLE
fix(rust): keep project id as string

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -108,7 +108,7 @@ pub struct NodeManager {
     enable_credential_checks: bool,
     vault: Option<Vault>,
     identity: Option<Identity<Vault>>,
-    project_id: Option<Vec<u8>>,
+    project_id: Option<String>,
     projects: Arc<BTreeMap<String, ProjectLookup>>,
     authorities: Option<Authorities>,
     pub(crate) authenticated_storage: LmdbStorage,
@@ -158,9 +158,9 @@ impl NodeManager {
     }
 
     /// Available only for member nodes
-    pub(crate) fn project_id(&self) -> Result<&Vec<u8>> {
+    pub(crate) fn project_id(&self) -> Result<&str> {
         self.project_id
-            .as_ref()
+            .as_deref()
             .ok_or_else(|| ApiError::generic("Project id is not set"))
     }
 }
@@ -194,14 +194,14 @@ impl NodeManagerGeneralOptions {
 
 pub struct NodeManagerProjectsOptions<'a> {
     ac: Option<&'a AuthoritiesConfig>,
-    project_id: Option<Vec<u8>>,
+    project_id: Option<String>,
     projects: BTreeMap<String, ProjectLookup>,
 }
 
 impl<'a> NodeManagerProjectsOptions<'a> {
     pub fn new(
         ac: Option<&'a AuthoritiesConfig>,
-        project_id: Option<Vec<u8>>,
+        project_id: Option<String>,
         projects: BTreeMap<String, ProjectLookup>,
     ) -> Self {
         Self {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -26,10 +26,10 @@ const INLET_WORKER: &str = "inlet-worker";
 const OUTER_CHAN: &str = "outer-chan";
 
 impl NodeManager {
-    fn access_control(&self, project_id: Option<Vec<u8>>) -> Result<Arc<dyn AccessControl>> {
+    fn access_control(&self, project_id: Option<String>) -> Result<Arc<dyn AccessControl>> {
         if let Some(pid) = project_id {
             let required_attributes = vec![
-                (PROJECT_ID.to_string(), pid),
+                (PROJECT_ID.to_string(), pid.into_bytes()),
                 (ROLE.to_string(), b"member".to_vec()),
             ];
             Ok(Arc::new(CredentialAccessControl::new(
@@ -141,7 +141,7 @@ impl NodeManagerWorker {
                         node_manager
                             .projects
                             .get(&*p)
-                            .map(|info| info.id.as_bytes().to_vec())
+                            .map(|info| info.id.to_string())
                     } else {
                         None
                     }
@@ -237,7 +237,7 @@ impl NodeManagerWorker {
         let worker_addr = Address::from(worker_addr.as_ref());
 
         let access_control = node_manager.access_control(if check_credential {
-            Some(node_manager.project_id()?.clone())
+            Some(node_manager.project_id()?.to_string())
         } else {
             None
         })?;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -199,7 +199,7 @@ async fn run_foreground_node(
         Some(path) => {
             let s = tokio::fs::read_to_string(path).await?;
             let p: ProjectInfo = serde_json::from_str(&s)?;
-            let project_id = p.id.as_bytes().to_vec();
+            let project_id = p.id.to_string();
             project::config::set_project(cfg, &(&p).into()).await?;
             add_project_authority(p, &cmd.node_name, cfg).await?;
             Some(project_id)

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -43,7 +43,7 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
         Some(path) => {
             let s = tokio::fs::read_to_string(path).await?;
             let p: ProjectInfo = serde_json::from_str(&s)?;
-            let project_id = p.id.as_bytes().to_vec();
+            let project_id = p.id.to_string();
             project::config::set_project(cfg, &(&p).into()).await?;
             add_project_authority(p, &cmd.node_name, cfg).await?;
             Some(project_id)


### PR DESCRIPTION
Unless required there is no need to turn the string into a byte vector.