### PR TITLE
chore(rust): allow to store custom attributes for issuing credentials

### DIFF
--- a/implementations/rust/ockam/ockam_api/tests/auth.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use ockam::authenticated_storage::AuthenticatedStorage;
 use ockam::identity::authenticated_storage::mem::InMemoryStorage;
 use ockam::identity::Identity;
 use ockam::route;
@@ -70,6 +71,67 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         Some(b"project42".as_slice()),
         data.attributes().get("project_id")
     );
+    assert_eq!(Some(b"member".as_slice()), data.attributes().get("role"));
+
+    ctx.stop().await
+}
+
+#[ockam_macros::test]
+async fn update_member_format(ctx: &mut Context) -> Result<()> {
+    let mut tmpf = NamedTempFile::new().unwrap();
+    serde_json::to_writer(&mut tmpf, &HashMap::<IdentityIdentifier, Enroller>::new()).unwrap();
+    // Create the authority:
+    let store = InMemoryStorage::new();
+
+    // Create a member identity:
+    let member = Identity::create(ctx, &Vault::create()).await?;
+
+    // Member was enrolled, with the old format
+    let tru = minicbor::to_vec(true)?;
+    store
+        .set(member.identifier().key_id(), "member".to_string(), tru)
+        .await?;
+    let authority = {
+        let a = Identity::create(ctx, &Vault::create()).await?;
+        a.create_secure_channel_listener("api", TrustEveryonePolicy, &InMemoryStorage::new())
+            .await?;
+        let exported = a.export().await?;
+        let auth = direct::Server::new(b"project42".to_vec(), store, tmpf.path(), a);
+        ctx.start_worker("auth", auth).await?;
+        exported
+    };
+
+    // Open a secure channel from member to authenticator:
+    let m2a = member
+        .create_secure_channel("api", TrustEveryonePolicy, &InMemoryStorage::new())
+        .await?;
+
+    let mut c = direct::Client::new(route![m2a, "auth"], ctx).await?;
+
+    // Get a fresh member credential and verify its validity. Data is loaded and
+    // transformed from the legacy format:
+    let cred = c.credential().await?;
+    let pkey = PublicIdentity::import(&authority, &Vault::create())
+        .await
+        .unwrap();
+    let data = pkey
+        .verify_credential(&cred, member.identifier(), &Vault::create())
+        .await?;
+    assert_eq!(
+        Some(b"project42".as_slice()),
+        data.attributes().get("project_id")
+    );
+
+    // Get the credential again.  It would have been updated on the store already.
+    let cred = c.credential().await?;
+    let data = pkey
+        .verify_credential(&cred, member.identifier(), &Vault::create())
+        .await?;
+    assert_eq!(
+        Some(b"project42".as_slice()),
+        data.attributes().get("project_id")
+    );
+    assert_eq!(Some(b"member".as_slice()), data.attributes().get("role"));
 
     ctx.stop().await
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
Up to now, we store just a boolean indicating that given identity identifier is a _member_ of the project.  When issuing credentials, this was checked and a `role=member` credential was issued

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
This change allows to store attributes instead of a boolean, paving the way to attach different attributes and values to credentials issued by a given authority (ej,  role other than 'member').

Code and test is added to ensure new code can interpret the legacy format.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
