### PR TITLE
feat(rust): support node config upgrades

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -54,7 +54,7 @@ fn default_lookup() -> ConfigLookup {
 }
 
 impl ConfigValues for OckamConfig {
-    fn default_values(_node_dir: &Path) -> Self {
+    fn default_values() -> Self {
         Self {
             directories: Some(Self::directories()),
             nodes: BTreeMap::new(),
@@ -199,7 +199,7 @@ impl AuthoritiesConfig {
 }
 
 impl ConfigValues for AuthoritiesConfig {
-    fn default_values(_: &Path) -> Self {
+    fn default_values() -> Self {
         Self::default()
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/config.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/config.rs
@@ -1,7 +1,19 @@
-use crate::config::{Config, ConfigValues};
-pub use commands::*;
+use std::fmt::Formatter;
+use std::io::Write;
+use std::{
+    fmt::Display,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+
+pub use commands::*;
+
+use crate::config::{build_config_path, Config, ConfigValues};
 
 #[derive(Debug)]
 pub struct NodeConfig {
@@ -11,9 +23,28 @@ pub struct NodeConfig {
 
 impl NodeConfig {
     pub fn new(config_dir: &Path) -> anyhow::Result<Self> {
-        let state = Config::load(config_dir, "state")?;
-        let commands = Config::load(config_dir, "commands")?;
+        let version = NodeConfigVersion::load(config_dir)?;
+        let state = match version.state_config_name() {
+            None => Config::default(),
+            Some(path) => Config::load(config_dir, path)?,
+        };
+        let commands = match version.commands_config_name() {
+            None => Config::default(),
+            Some(path) => Config::load(config_dir, path)?,
+        };
         Ok(Self { state, commands })
+    }
+
+    pub fn init_for_new_node(config_dir: &Path) -> anyhow::Result<()> {
+        let v = NodeConfigVersion::latest();
+        for dir in v.dirs() {
+            let path = config_dir.join(dir);
+            if path.exists() {
+                return Err(anyhow!("Config file already exists: {}", path.display()));
+            }
+        }
+        NodeConfigVersion::set_version(config_dir, &v)?;
+        Ok(())
     }
 
     pub fn state(&self) -> &Config<NodeStateConfig> {
@@ -22,6 +53,116 @@ impl NodeConfig {
 
     pub fn commands(&self) -> &Config<Commands> {
         &self.commands
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NodeConfigVersion {
+    V0,
+    V1,
+}
+
+impl NodeConfigVersion {
+    const FILE_NAME: &'static str = "version";
+
+    fn latest() -> Self {
+        Self::V1
+    }
+
+    fn load(config_dir: &Path) -> anyhow::Result<Self> {
+        let version_path = config_dir.join(Self::FILE_NAME);
+        let version = if version_path.exists() {
+            let mut version_file = File::open(version_path)?;
+            let mut version = String::new();
+            version_file.read_to_string(&mut version)?;
+            NodeConfigVersion::from_str(&version)?
+        } else {
+            Self::V0
+        };
+        debug!(%version, "Loaded config");
+        version.upgrade(config_dir)
+    }
+
+    fn upgrade(&self, config_dir: &Path) -> anyhow::Result<Self> {
+        let from = self;
+        let mut final_version = from.clone();
+
+        // Iter through all the versions between `from` and `to`
+        let f = from.to_string().parse::<u8>()?;
+        let mut t = f + 1;
+        while let Ok(ref to) = Self::from_str(&t.to_string()) {
+            debug!(%from, %to, "Upgrading config");
+            final_version = to.clone();
+            #[allow(clippy::single_match)]
+            match (from, to) {
+                (Self::V0, Self::V1) => {
+                    if let (Some(old_config_name), Some(new_config_name)) =
+                        (from.state_config_name(), to.state_config_name())
+                    {
+                        let old_config_path = build_config_path(config_dir, old_config_name);
+                        // If old config path exists, copy to new config path and keep the old one
+                        if old_config_path.exists() {
+                            let new_config_path = build_config_path(config_dir, new_config_name);
+                            std::fs::copy(old_config_path, new_config_path)?;
+                        }
+                        // Create the version file if doesn't exists
+                        Self::set_version(config_dir, to)?;
+                    }
+                }
+                _ => {}
+            }
+            t += 1;
+        }
+        Ok(final_version)
+    }
+
+    fn dirs(&self) -> &'static [&'static str] {
+        match self {
+            Self::V0 => &["config"],
+            Self::V1 => &["state", "commands"],
+        }
+    }
+
+    fn state_config_name(&self) -> Option<&'static str> {
+        match self {
+            Self::V0 => Some("config"),
+            Self::V1 => Some("state"),
+        }
+    }
+
+    fn commands_config_name(&self) -> Option<&'static str> {
+        match self {
+            Self::V0 => None,
+            Self::V1 => Some("commands"),
+        }
+    }
+
+    fn set_version(config_dir: &Path, version: &NodeConfigVersion) -> anyhow::Result<()> {
+        let version_path = config_dir.join(Self::FILE_NAME);
+        let mut version_file = File::create(version_path)?;
+        version_file.write_all(version.to_string().as_bytes())?;
+        Ok(())
+    }
+}
+
+impl Display for NodeConfigVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            NodeConfigVersion::V0 => "0",
+            NodeConfigVersion::V1 => "1",
+        })
+    }
+}
+
+impl FromStr for NodeConfigVersion {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "0" => Ok(Self::V0),
+            "1" => Ok(Self::V1),
+            _ => Err(anyhow!("Unknown version: {}", s)),
+        }
     }
 }
 
@@ -35,11 +176,10 @@ pub struct NodeStateConfig {
     pub identity: Option<Vec<u8>>,
     /// Identity was overridden
     pub identity_was_overridden: bool,
-    pub commands: Commands,
 }
 
 impl ConfigValues for NodeStateConfig {
-    fn default_values(_config_dir: &Path) -> Self {
+    fn default_values() -> Self {
         Self::default()
     }
 }
@@ -61,7 +201,7 @@ mod commands {
     }
 
     impl ConfigValues for Commands {
-        fn default_values(_config_dir: &Path) -> Self {
+        fn default_values() -> Self {
             Self::default()
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -216,15 +216,17 @@ impl OckamConfig {
             return Err(ConfigError::AlreadyExists(name.to_string()).into());
         }
 
-        // Setup logging directory and store it
+        // Create node's state directory
         let state_dir = inner
             .directories
             .as_ref()
             .context("configuration is in an invalid state")?
             .data_local_dir()
             .join(slugify(&format!("node-{}", name)));
-
         create_dir_all(&state_dir).context("failed to create new node state directory")?;
+
+        // Initialize it
+        NodeConfig::init_for_new_node(&state_dir)?;
 
         // Add this node to the config lookup table
         inner.lookup.set_node(name, bind.into());


### PR DESCRIPTION
Fixes https://github.com/build-trust/codebase/issues/435

Implement a basic version system for the node's configuration files. In this PR two versions are introduced:

- V0: previous to the `config.json` -> `state.json` rename that was done at https://github.com/build-trust/ockam/pull/3610. So, last commit using V0 was d3c2474cf
- V1: from 5403c70f69fd7a0d2463fac81ec9ecedb1966f5e

When a V0 node config is detected, an upgrade is performed, creating the `state.json` file from the `config.json` file and adding a `version` file to easily detect the current version.

## How to test

Checkout a version previous to the node config rename (V0 config):
```
$ git checkout d3c2474cf
```

Create a node:
```
$ ockam node create nold
$ ockam identity show -n nold
Pd23966fa83fc39faa4894c334f22baea8f6778b70549adca6a8085c9bcc85d42
```

Stop the node:
```
$ ockam node stop nold
```

Checkout the PR's branch (V1 config):
```
$ git checkout adrian/feat-support-config-upgrades
```

Delete the `default_identity` from the shared `~/.config/ockam-cli/config.json` and the `~/.config/ockam-cli/default_vault.json` file.

Create another node to check that the identity is different:
```
$ ockam node create nnew
$ ockam identity show -n nnew
Pbaff95ddd1d9b9551a5288949d27f8beef0dd5b155dcd9a2c1f23ae37df54733
```

Finally, restart the `nold` node and check that the identity was not modified:
```
$ ockam node start nold
$ ockam identity show -n nold
Pd23966fa83fc39faa4894c334f22baea8f6778b70549adca6a8085c9bcc85d42
```

## Additional tests

Same procedure as before but:
1. Creating the node from `develop` to check that it works from V1 without the `version` file to the V1 with it
2. Creating the node from `adrian/feat-support-config-upgrades` to check that it works from V1 to V1