### PR TITLE
chore: avoid including nulls in json output on optional fields

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -63,6 +63,7 @@ pub struct Project<'a> {
 
     #[cbor(b(11))]
     #[serde(borrow)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub okta_config: Option<OktaConfig<'a>>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -39,6 +39,7 @@ pub struct ProjectInfo<'a> {
     #[serde(borrow)]
     pub authority_identity: Option<CowStr<'a>>,
     #[serde(borrow)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub okta_config: Option<OktaConfig<'a>>,
 }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
we output json' `nulls`  values when serializing a `None`   `Option`.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
If an optional value is None, don't include it on the output.


<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
