### PR TITLE
make downloading latest release a 1 liner

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,14 +146,13 @@ download() {
   if [ "$2" ]; then
     _version="$2"
     _url="$_download_base_url/ockam_$_version/$_binary_file_name"
-  else
-    _url=$(curl --proto '=https' --tlsv1.2 --silent --fail --show-error "$_api")
-    _url=$(echo "$_url" | grep -i browser_download_url | grep "$_binary_file_name" | head -1 | awk '{print $NF}')
-    _url=$(echo "$_url" | sed -e 's/^"//' -e 's/"$//') # remove quotes
-    _version=$(echo "$_url" | awk -F'/' '{print $(NF-1)}' | cut -d '_' -f2) # change "ockam_v0.75.0" to "v0.75.0"
-  fi
 
-  info "Installing $_version"
+    info "Installing $_version"
+  else
+    _url="https://github.com/build-trust/ockam/releases/latest/download/$_binary_file_name"
+
+    info "Installing latest version"
+  fi
 
   info "Dowloading $_url"
   curl --proto '=https' --tlsv1.2 --location --silent --fail --show-error --output "ockam" "$_url"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Downloading the latest version isn't a 1 liner.

## Proposed Changes

fix https://github.com/build-trust/ockam/issues/3535

## Checks


- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
