### PR TITLE
feat(rust): enforce certificate pinning on okta tenants

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
-use ockam_core::{self, async_trait};
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
@@ -32,8 +31,6 @@ mod node {
     use crate::cloud::CloudRequestWrapper;
     use crate::nodes::NodeManagerWorker;
     use ockam_identity::credential::Attributes;
-
-    use super::*;
 
     const TARGET: &str = "ockam_api::cloud::enroll";
 
@@ -116,11 +113,6 @@ mod node {
 
 pub mod auth0 {
     use super::*;
-
-    #[async_trait::async_trait]
-    pub trait Auth0TokenProvider: Send + Sync + 'static {
-        async fn token(&self) -> ockam_core::Result<Auth0Token<'_>>;
-    }
 
     // Req/Res types
 
@@ -246,68 +238,6 @@ pub mod enrollment_token {
                 tag: TypeTag,
                 token: token.token,
             }
-        }
-    }
-}
-
-#[cfg(test)]
-#[allow(non_snake_case)]
-pub(crate) mod tests {
-    use quickcheck::{Arbitrary, Gen};
-
-    use crate::cloud::enroll::enrollment_token::{AuthenticateEnrollmentToken, EnrollmentToken};
-    use crate::cloud::enroll::Token;
-
-    use super::*;
-
-    pub(crate) mod auth0 {
-        use crate::cloud::enroll::auth0::*;
-
-        use super::*;
-
-        pub struct MockAuth0Service;
-
-        #[async_trait::async_trait]
-        impl Auth0TokenProvider for MockAuth0Service {
-            async fn token(&self) -> ockam_core::Result<Auth0Token<'_>> {
-                Ok(Auth0Token {
-                    token_type: TokenType::Bearer,
-                    access_token: Token::new("access_token"),
-                })
-            }
-        }
-
-        #[derive(Debug, Clone)]
-        struct RandomAuthorizedAuth0Token(AuthenticateAuth0Token<'static>);
-
-        impl Arbitrary for RandomAuthorizedAuth0Token {
-            fn arbitrary(g: &mut Gen) -> Self {
-                RandomAuthorizedAuth0Token(AuthenticateAuth0Token::new(Auth0Token {
-                    token_type: TokenType::Bearer,
-                    access_token: Token::arbitrary(g),
-                }))
-            }
-        }
-    }
-
-    mod enrollment_token {
-        use super::*;
-
-        #[derive(Debug, Clone)]
-        struct RandomAuthorizedEnrollmentToken(AuthenticateEnrollmentToken<'static>);
-
-        impl Arbitrary for RandomAuthorizedEnrollmentToken {
-            fn arbitrary(g: &mut Gen) -> Self {
-                RandomAuthorizedEnrollmentToken(AuthenticateEnrollmentToken::new(
-                    EnrollmentToken::new(Token::arbitrary(g)),
-                ))
-            }
-        }
-    }
-
-    impl Arbitrary for Token<'static> {
-        fn arbitrary(g: &mut Gen) -> Self {
-            Token(String::arbitrary(g).into())
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -175,6 +175,7 @@ impl OktaConfig<'_> {
 pub struct OktaAuth0 {
     pub tenant: String,
     pub client_id: String,
+    pub certificate: String,
 }
 
 impl From<OktaConfig<'_>> for OktaAuth0 {
@@ -182,6 +183,7 @@ impl From<OktaConfig<'_>> for OktaAuth0 {
         Self {
             tenant: c.tenant.to_string(),
             client_id: c.client_id.to_string(),
+            certificate: c.certificate.to_string(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -191,7 +191,7 @@ impl NodeManager {
             ));
         }
         let db = self.authenticated_storage.async_try_clone().await?;
-        let au = crate::okta::Server::new(proj.to_vec(), db, tenant, certificate);
+        let au = crate::okta::Server::new(proj.to_vec(), db, tenant, certificate)?;
         ctx.start_worker(addr.clone(), au).await?;
         self.registry
             .okta_identity_provider_services

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -158,6 +158,9 @@ async fn run_impl(
                 certificate_path,
                 client_id,
             } => {
+                //TODO: should check here that the client_id, tenant and certificate are correct.
+                //      Could do the first part of the oauth flow and request a device code,
+                //      if we can't get one, something is wrong with the config
                 let certificate = match (certificate, certificate_path) {
                     (Some(c), _) => c,
                     (_, Some(p)) => std::fs::read_to_string(p)?,

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use anyhow::{anyhow, Context as _};
 use ockam::Context;
-use ockam_api::cloud::enroll::auth0::{Auth0TokenProvider, AuthenticateAuth0Token};
+use ockam_api::cloud::enroll::auth0::AuthenticateAuth0Token;
 use ockam_api::cloud::project::OktaAuth0;
 use ockam_core::api::{Request, Status};
 use ockam_multiaddr::MultiAddr;

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -280,6 +280,7 @@ pub mod config {
         let okta = project.okta_config.as_ref().map(|o| OktaAuth0 {
             tenant: o.tenant.to_string(),
             client_id: o.client_id.to_string(),
+            certificate: o.certificate.to_string(),
         });
         config.set_project_alias(
             project.name.to_string(),


### PR DESCRIPTION
## Current Behavior
Okta addon can configure a certificate to pin,  but it's not used.


## Proposed Changes
Do certificate pinning both on client (token generation)   as well as server (verification, userprofile retrieval). 


## Notes

AFAIK to do certificate pinning on th[e  http client we use,  the way to do is to disable all built in root certificates,](https://github.com/seanmonstar/reqwest/issues/298)  then explicitly add the certificate we want to allow.    This means that the *entire* chain must be supplied on configuration,   using something like:

```
openssl s_client -showcerts -connect $okta_tenant:443 </dev/null | sed -n -e '/-.BEGIN/,/-.END/ p' >   tenant.cert
```

 
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
