### PR TITLE
ci: ockam-builder - install commitlint

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -73,8 +73,11 @@ RUN set -xe; \
     tar -xf "${NODEJS_PACKAGE}" -C /opt/; \
     mv "/opt/node-v${NODEJS_VERSION}-${NODEJS_OS}" "${NODEJS_HOME}"; \
     rm -rf "${NODEJS_PACKAGE}"; \
+    PATH="${NODEJS_HOME}/bin:$PATH" \
 # Setup Commitlint
-    npm install --location=global @commitlint/cli@17.1.1 \
+# set user to root in order to be able to install global dependencies
+    npm --global config set user root && \
+    npm install --global @commitlint/cli@17.1.1 \
 # Setup rust
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -73,6 +73,8 @@ RUN set -xe; \
     tar -xf "${NODEJS_PACKAGE}" -C /opt/; \
     mv "/opt/node-v${NODEJS_VERSION}-${NODEJS_OS}" "${NODEJS_HOME}"; \
     rm -rf "${NODEJS_PACKAGE}"; \
+# Setup Commitlint
+    npm install --location=global @commitlint/cli@17.1.1 \
 # Setup rust
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -8,6 +8,7 @@ ARG NODEJS_VERSION=16.13.1
 ARG COSIGN_VERSION=1.9.0
 ARG MOLD_VERSION=1.3.1
 ARG SHFMT_VERSION=3.5.1
+ARG COMMITLINT_VERSION=17.1.1
 
 ARG ELIXIR_SHA256=5e8251c5d2557373ecfab986fa481844a2f659597abbfb623f45ad3a1974bb1f
 
@@ -77,7 +78,7 @@ RUN set -xe; \
 # Setup Commitlint
 # set user to root in order to be able to install global dependencies
     npm --global config set user root && \
-    npm install --global @commitlint/cli@17.1.1 \
+    npm install --global @commitlint/cli@${COMMITLINT_VERSION} \
 # Setup rust
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes \


### PR DESCRIPTION
Part of #3664 

## Proposed Changes

Installs commitlint using npm in the ockam-builder docker image to be used in github workflow

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
