### PR TITLE
feat(rust): add option to create vaults without nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -1,16 +1,25 @@
 use crate::node::NodeOpts;
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use crate::Result;
 use clap::Args;
 use ockam::Context;
+use ockam_api::config::cli;
 use ockam_api::nodes::models::vault::CreateVaultRequest;
 use ockam_core::api::Request;
+use ockam_vault::storage::FileStorage;
+use ockam_vault::Vault;
+use slug::slugify;
+use std::sync::Arc;
 
 /// Create vaults
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     #[command(flatten)]
-    node_opts: NodeOpts,
+    node_opts: Option<NodeOpts>,
+
+    #[arg(short, long, conflicts_with = "node")]
+    vault_name: Option<String>,
 
     /// Path to the Vault storage file
     #[arg(short, long)]
@@ -23,16 +32,41 @@ impl CreateCommand {
     }
 }
 
-async fn run_impl(
-    ctx: Context,
-    (options, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
-    let mut rpc = Rpc::background(&ctx, &options, &cmd.node_opts.api_node)?;
-    let request = Request::post("/node/vault").body(CreateVaultRequest::new(cmd.path));
+async fn run_impl(ctx: Context, (options, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+    if let Some(node_opts) = cmd.node_opts {
+        let node_name = node_opts.api_node.clone();
+        let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+        let request = Request::post("/node/vault").body(CreateVaultRequest::new(cmd.path));
 
-    rpc.request(request).await?;
-    rpc.parse_response()?;
+        rpc.request(request).await?;
+        rpc.parse_response()?;
 
-    println!("Vault created!");
+        println!("Vault created for the Node {}!", node_name);
+    } else if let Some(vault_name) = cmd.vault_name {
+        create_new_vault(vault_name.clone()).await?;
+    }
+
+    Ok(())
+}
+
+async fn create_new_vault(vault_name: String) -> Result<()> {
+    let directories = cli::OckamConfig::directories();
+    let dir = directories
+        .config_dir()
+        .to_path_buf()
+        .join("vaults")
+        .join(slugify(&format!("vault-{}", vault_name)));
+
+    if dir.as_path().exists() {
+        println!("Vault with name {} already exists!", vault_name);
+    } else {
+        tokio::fs::create_dir_all(dir.as_path()).await?;
+        let file = dir.join("vault.json");
+        let storage = FileStorage::create(file.clone()).await?;
+        let _ = Vault::new(Some(Arc::new(storage)));
+
+        println!("Vault created with name: {}!", vault_name);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/3683

# Added

- New vaults are created under `CONFIG_DIR/vaults` eg: `CONFIG_DIR/vaults/v1/vault.json`

# OUTPUT

![image](https://user-images.githubusercontent.com/38526063/197385077-98f79a6c-4bd5-4e30-9249-aa0ad054bf90.png)

default value

![image](https://user-images.githubusercontent.com/38526063/197385096-04e0fd7e-f2f6-4c14-9856-1d93c94f100c.png)



<!-- Thank you for sending a pull request :heart: -->



<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
