### PR TITLE
refactor(rust): `tcp connection create` use `rpc` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,15 +1,12 @@
 use crate::{
-    util::{api, connect_to, exitcode, extract_address_value},
+    util::{api, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
+use anyhow::Context;
 use clap::Args;
 use colorful::Colorful;
-use ockam::{Context, Route, TCP};
-use ockam_api::{
-    nodes::{models::transport::TransportStatus, NODEMANAGER_ADDR},
-    route_to_multiaddr,
-};
-use ockam_core::api::Status;
+use ockam::{route, Route, TCP};
+use ockam_api::{nodes::models, route_to_multiaddr};
 use serde_json::json;
 use std::net::SocketAddrV4;
 
@@ -38,83 +35,59 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        let cfg = &options.config;
-        let node = extract_address_value(&self.node_opts.from).unwrap_or_else(|_| "".to_string());
-        let port = cfg.get_node_port(&node).unwrap();
+        node_rpc(run_impl, (options, self))
+    }
 
-        connect_to(port, (self, options.clone()), create_connection);
+    fn print_output(
+        &self,
+        node_name: &str,
+        options: &CommandGlobalOpts,
+        response: &models::transport::TransportStatus,
+    ) -> crate::Result<()> {
+        // if output format is json, write json to stdout.
+        match options.global_args.output_format {
+            OutputFormat::Plain => {
+                let from = &self.node_opts.from;
+                let to = response.payload.parse::<SocketAddrV4>()?;
+                if options.global_args.no_color {
+                    println!("\n  Created TCP Connection:");
+                    println!("  • From: /node/{}", from);
+                    println!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port());
+                } else {
+                    println!("\n  Created TCP Connection:");
+                    println!("{}", format!("  • From: /node/{}", from).light_magenta());
+                    println!(
+                        "{}",
+                        format!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port())
+                            .light_magenta()
+                    );
+                }
+            }
+            OutputFormat::Json => {
+                let port = options.config.get_node_port(node_name)?;
+                let route: Route = route![(TCP, format!("localhost:{}", port))]
+                    .modify()
+                    .append_t(TCP, response.payload.to_string())
+                    .into();
+                let multiaddr = route_to_multiaddr(&route)
+                    .context("Couldn't convert given address into `MultiAddr`")?;
+                let json = json!([{"route": multiaddr.to_string() }]);
+                println!("{}", json);
+            }
+        }
+        Ok(())
     }
 }
 
-pub async fn create_connection(
-    ctx: Context,
-    (cmd, opts): (CreateCommand, CommandGlobalOpts),
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let resp: Vec<u8> = match ctx
-        .send_and_receive(
-            base_route.modify().append(NODEMANAGER_ADDR),
-            api::create_tcp_connection(&cmd)?,
-        )
-        .await
-    {
-        Ok(sr_msg) => sr_msg,
-        Err(e) => {
-            eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(exitcode::IOERR);
-        }
-    };
+async fn run_impl(
+    ctx: ockam::Context,
+    (options, command): (CommandGlobalOpts, CreateCommand),
+) -> crate::Result<()> {
+    let node_name = extract_address_value(&command.node_opts.from)?;
+    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let request = api::create_tcp_connection(&command);
+    rpc.request(request).await?;
+    let response = rpc.parse_response::<models::transport::TransportStatus>()?;
 
-    let (response, TransportStatus { payload, .. }) = api::parse_transport_status(&resp)?;
-
-    match response.status() {
-        Some(Status::Ok) => {
-            let r: Route = base_route
-                .modify()
-                .pop_back()
-                .append_t(TCP, payload.to_string())
-                .into();
-            let multiaddr = match route_to_multiaddr(&r) {
-                Some(addr) => addr,
-                None => {
-                    eprintln!("Couldn't convert given address into `MultiAddr`");
-                    std::process::exit(exitcode::SOFTWARE);
-                }
-            };
-
-            let from = cmd.node_opts.from;
-            let to = cmd.address.parse::<SocketAddrV4>().unwrap();
-
-            // if output format is json, write json to stdout.
-            match opts.global_args.output_format {
-                OutputFormat::Plain => {
-                    if opts.global_args.no_color {
-                        eprintln!("\n  Created TCP Connection:");
-                        eprintln!("  • From: /node/{}", from);
-                        eprintln!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port());
-                    } else {
-                        eprintln!("\n  Created TCP Connection:");
-                        eprintln!("{}", format!("  • From: /node/{}", from).light_magenta());
-                        eprintln!(
-                            "{}",
-                            format!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port())
-                                .light_magenta()
-                        );
-                    }
-                }
-                OutputFormat::Json => {
-                    let json = json!([{"route": multiaddr.to_string() }]);
-                    eprintln!("{}", json);
-                }
-            }
-        }
-        _ => {
-            eprintln!(
-                "An error occurred while creating the tcp connection: {}",
-                payload
-            );
-            std::process::exit(exitcode::CANTCREAT);
-        }
-    }
-    Ok(())
+    command.print_output(&node_name, &options, &response)
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -51,7 +51,7 @@ pub(crate) fn list_tcp_listeners() -> RequestBuilder<'static, ()> {
 /// Construct a request to create node tcp connection
 pub(crate) fn create_tcp_connection(
     cmd: &crate::tcp::connection::CreateCommand,
-) -> Result<Vec<u8>> {
+) -> RequestBuilder<'static, models::transport::CreateTransport<'static>> {
     let (tt, addr) = (
         models::transport::TransportMode::Connect,
         cmd.address.clone(),
@@ -59,11 +59,7 @@ pub(crate) fn create_tcp_connection(
 
     let payload =
         models::transport::CreateTransport::new(models::transport::TransportType::Tcp, tt, addr);
-    let mut buf = vec![];
-    Request::post("/node/tcp/connection")
-        .body(payload)
-        .encode(&mut buf)?;
-    Ok(buf)
+    Request::post("/node/tcp/connection").body(payload)
 }
 
 /// Construct a request to create node tcp listener

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -260,6 +260,12 @@ teardown() {
   # TODO: add test for authenticator
 }
 
+@test "create a tcp connection" {
+  run $OCKAM node create n1
+  run $OCKAM tcp-connection create --from n1 --to 127.0.0.1:5000 --output json
+  assert_success
+  assert_output --regexp '[{"route":"/dnsaddr/localhost/tcp/[[:digit:]]+/ip4/127.0.0.1/tcp/5000"}]'
+}
 
 # the below tests will only succeed if already enrolled with `ockam enroll`
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

Currently the `tcp connection create` command is using the `connect_to` abstraction and mapping errors manually using `std::process::exit`

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Closes #3593.

1. Replace `connect_to` by `node_rpc` abstraction.
2. Replace `std::process::exit` by an actual error.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
