### PR TITLE
chore(rust): pretty print credentials

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -97,7 +97,7 @@ async fn run_impl(
         info!("Enrolled successfully");
         let mut client = Client::new(authenticator_route, &ctx).await?;
         let credential = client.credential().await?;
-        println!("{:?}", credential); //TODO: output in human-readable format
+        println!("{}", credential);
         Ok(())
     } else {
         eprintln!("{}", rpc.parse_err_msg(res, dec));


### PR DESCRIPTION
adds a human readable display for credentials

## Current Behavior
```
Credential { data: CowBytes([167, 1, 1, 2, 161, 1, 162, 106, 112, 114, 111, 106, 101, 99, 116, 95, 105, 100, 88, 36, 51, 98, 54, 50, 52, 53, 54, 101, 45, 48, 52, 57, 57, 45, 52, 48, 99, 56, 45, 98, 51, 49, 57, 45, 55, 49, 51, 101, 98, 56, 97, 97, 54, 50, 52, 97, 100, 114, 111, 108, 101, 70, 109, 101, 109, 98, 101, 114, 3, 120, 65, 80, 101, 50, 48, 56, 97, 56, 56, 52, 54, 55, 98, 55, 99, 50, 102, 52, 50, 101, 102, 54, 57, 102, 52, 51, 55, 99, 55, 52, 49, 100, 48, 52, 56, 50, 97, 53, 102, 54, 102, 54, 55, 53, 49, 56, 52, 52, 51, 99, 48, 100, 49, 52, 100, 50, 50, 49, 49, 56, 53, 97, 99, 98, 97, 54, 4, 120, 65, 80, 48, 52, 51, 57, 54, 101, 98, 101, 99, 51, 102, 100, 50, 51, 50, 52, 52, 97, 57, 48, 52, 99, 99, 97, 52, 55, 52, 99, 99, 55, 101, 55, 97, 97, 100, 57, 51, 56, 99, 57, 51, 52, 51, 48, 57, 97, 99, 56, 49, 57, 51, 102, 52, 99, 50, 53, 56, 55, 98, 51, 57, 99, 57, 50, 5, 104, 79, 67, 75, 65, 77, 95, 82, 75, 6, 26, 99, 86, 173, 160, 7, 26, 99, 126, 58, 160]), signature: CowBytes([54, 207, 235, 12, 97, 236, 25, 24, 7, 222, 194, 168, 91, 248, 140, 165, 239, 202, 246, 34, 231, 110, 25, 240, 43, 58, 149, 168, 198, 13, 230, 63, 243, 210, 226, 69, 73, 159, 126, 223, 197, 64, 237, 232, 25, 163, 25, 81, 200, 196, 88, 180, 94, 185, 142, 216, 189, 221, 207, 121, 235, 254, 171, 12]) }
```

## Proposed Changes
```
---
 Subject: Pe208a88467b7c2f42ef69f437c741d0482a5f6f67518443c0d14d221185acba6
 Issuer: P04396ebec3fd23244a904cca474cc7e7aad938c934309ac8193f4c2587b39c92 (OCKAM_RK)
 Created: 1666624657
 Expires: 1669216657
 Attrributes: {"project_id": "3b62456e-0499-40c8-b319-713eb8aa624a", "role": "member"}

 Signature: 5d78266a376c05606429a0fc641496948d7466700abd245f7c5f4a3bf759ce9e27208e1ca61fb5489a0584dc7f82c8cbb654d8f800880aef4163b17fe5a18402
---
```

Note:  timestamps are displayed as unix epoch,  wasn't sure if it was worth to add a dependency to print them differently.