### PR TITLE
feat(rust): complete policy delete functionality

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/parser.rs
+++ b/implementations/rust/ockam/ockam_abac/src/parser.rs
@@ -13,7 +13,7 @@ use wast::lexer::{FloatVal, Lexer, Token};
 fn ident_pattern() -> &'static Regex {
     static INSTANCE: OnceBox<Regex> = OnceBox::new();
     INSTANCE.get_or_init(|| {
-        Box::new(Regex::new("^[a-zA-Z!$%&*/:<=>?~_^][a-zA-Z0-9!$%&*/:<=>?~_^.+-@]*$").unwrap())
+        Box::new(Regex::new("^[a-zA-Z!$%&*/<=>?~_^][a-zA-Z0-9!$%&*/<=>?~_^.+-@]*$").unwrap())
     })
 }
 

--- a/implementations/rust/ockam/ockam_api/src/lmdb.rs
+++ b/implementations/rust/ockam/ockam_api/src/lmdb.rs
@@ -61,7 +61,10 @@ impl LmdbStorage {
         let d = self.clone();
         let t = move || {
             let mut w = d.env.begin_rw_txn().map_err(map_lmdb_err)?;
-            w.del(d.map, &k, None).map_err(map_lmdb_err)?;
+            match w.del(d.map, &k, None) {
+                Ok(()) | Err(lmdb::Error::NotFound) => {}
+                Err(e) => return Err(map_lmdb_err(e)),
+            }
             w.commit().map_err(map_lmdb_err)?;
             Ok(())
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -684,6 +684,13 @@ impl NodeManagerWorker {
                 .get_policy(req, resource, action)
                 .await?
                 .either(ResponseBuilder::to_vec, ResponseBuilder::to_vec)?,
+            (Delete, ["policy", resource, action]) => self
+                .node_manager
+                .read()
+                .await
+                .del_policy(req, resource, action)
+                .await?
+                .to_vec()?,
 
             // ==*== Spaces ==*==
             (Post, ["v0", "spaces"]) => self.create_space(ctx, dec).await?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
@@ -50,4 +50,16 @@ impl NodeManager {
         let p = self.policies.policies(&r).await?;
         Ok(Response::ok(req.id()).body(PolicyList::new(p)))
     }
+
+    pub(super) async fn del_policy(
+        &self,
+        req: &Request<'_>,
+        res: &str,
+        act: &str,
+    ) -> Result<ResponseBuilder<()>> {
+        let r = Resource::new(res);
+        let a = Action::new(act);
+        self.policies.del_policy(&r, &a).await?;
+        Ok(Response::ok(req.id()))
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/policy.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy.rs
@@ -42,6 +42,17 @@ pub enum PolicySubcommand {
         #[arg(short, long)]
         action: Action,
     },
+    Delete {
+        /// Node on which to start the tcp inlet.
+        #[arg(long, display_order = 900, id = "NODE")]
+        at: String,
+
+        #[arg(short, long)]
+        resource: Resource,
+
+        #[arg(short, long)]
+        action: Action,
+    },
     List {
         /// Node on which to start the tcp inlet.
         #[arg(long, display_order = 900, id = "NODE")]
@@ -76,6 +87,13 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, PolicyCommand)) -> R
             rpc.request(req).await?;
             let pol: Policy = rpc.parse_response()?;
             println!("{}", pol.expression())
+        }
+        PolicySubcommand::Delete { at, resource, action } => {
+            let node = extract_address_value(&at)?;
+            let req = Request::delete(policy_path(&resource, &action));
+            let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+            rpc.request(req).await?;
+            rpc.is_ok()?
         }
         PolicySubcommand::List { at, resource } => {
             let node = extract_address_value(&at)?;


### PR DESCRIPTION
Also disallow `':'` in identifiers to ensure resource names can not use it, as `':'` is used as the separator character in the composite LMDB key.

Finally change LMDB's delete functionality to ignore not-found errors. This also affects authenticated attributes.