### PR TITLE
feat(rust): copy custom attributes from okta profiles into credentials

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -140,16 +140,28 @@ pub struct OktaConfig<'a> {
 
     #[serde(borrow)]
     #[cbor(b(3))] pub client_id: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(4))] pub attributes: Vec<CowStr<'a>>,
 }
 
 impl<'a> OktaConfig<'a> {
-    pub fn new<S: Into<CowStr<'a>>>(tenant: S, certificate: S, client_id: S) -> Self {
+    pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(
+        tenant: S,
+        certificate: S,
+        client_id: S,
+        attributes: &'a [T],
+    ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             tenant: tenant.into(),
             certificate: certificate.into(),
             client_id: client_id.into(),
+            attributes: attributes
+                .iter()
+                .map(|x| CowStr::from(x.as_ref()))
+                .collect(),
         }
     }
 }
@@ -167,6 +179,7 @@ impl OktaConfig<'_> {
             tenant: self.tenant.to_owned(),
             certificate: self.certificate.to_owned(),
             client_id: self.client_id.to_owned(),
+            attributes: self.attributes.iter().map(|x| x.to_owned()).collect(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -203,17 +203,25 @@ pub struct StartOktaIdentityProviderRequest<'a> {
     #[b(1)] addr: &'a str,
     #[b(2)] tenant: &'a str,
     #[b(3)] certificate: &'a str,
-    #[b(4)] proj: &'a ByteSlice
+    #[b(4)] attributes: Vec<&'a str>,
+    #[b(5)] proj: &'a ByteSlice
 }
 
 impl<'a> StartOktaIdentityProviderRequest<'a> {
-    pub fn new(addr: &'a str, tenant: &'a str, certificate: &'a str, proj: &'a [u8]) -> Self {
+    pub fn new(
+        addr: &'a str,
+        tenant: &'a str,
+        certificate: &'a str,
+        attributes: Vec<&'a str>,
+        proj: &'a [u8],
+    ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             addr,
             tenant,
             certificate,
+            attributes,
             proj: proj.into(),
         }
     }
@@ -229,6 +237,9 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
     }
     pub fn project(&self) -> &'a [u8] {
         self.proj
+    }
+    pub fn attributes(&self) -> &Vec<&'a str> {
+        &self.attributes
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -178,6 +178,7 @@ impl NodeManager {
         addr: Address,
         tenant: &str,
         certificate: &str,
+        attributes: &[&str],
         proj: &[u8],
     ) -> Result<()> {
         use crate::nodes::registry::OktaIdentityProviderServiceInfo;
@@ -191,7 +192,7 @@ impl NodeManager {
             ));
         }
         let db = self.authenticated_storage.async_try_clone().await?;
-        let au = crate::okta::Server::new(proj.to_vec(), db, tenant, certificate)?;
+        let au = crate::okta::Server::new(proj.to_vec(), db, tenant, certificate, attributes)?;
         ctx.start_worker(addr.clone(), au).await?;
         self.registry
             .okta_identity_provider_services
@@ -306,6 +307,7 @@ impl NodeManagerWorker {
                 addr,
                 body.tenant(),
                 body.certificate(),
+                body.attributes(),
                 body.project(),
             )
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -107,6 +107,10 @@ pub enum ConfigureAddonCommand {
             value_parser(NonEmptyStringValueParser::new())
         )]
         client_id: String,
+
+        /// Attributes to copy from Okta userprofile into Ockam credential.
+        #[arg(long, id = "attributes", value_name = "ATTRIBUTES")]
+        attributes: Vec<String>,
     },
 }
 
@@ -158,6 +162,7 @@ async fn run_impl(
                 certificate,
                 certificate_path,
                 client_id,
+                attributes,
             } => {
                 let certificate = match (certificate, certificate_path) {
                     (Some(c), _) => c,
@@ -165,7 +170,7 @@ async fn run_impl(
                     _ => unreachable!(),
                 };
 
-                let okta_config = OktaConfig::new(tenant, certificate, client_id);
+                let okta_config = OktaConfig::new(tenant, certificate, client_id, &attributes);
                 let body = okta_config.clone();
 
                 // Validate okta configuration

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -67,6 +67,8 @@ pub struct OktaIdentityProviderConfig {
 
     pub(crate) project: String,
 
+    pub(crate) attributes: Vec<String>,
+
     #[serde(default)]
     pub(crate) disabled: bool,
 }

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -241,6 +241,7 @@ pub async fn start_okta_identity_provider(
         &cfg.address,
         &cfg.tenant,
         &cfg.certificate,
+        cfg.attributes.iter().map(|s| s as &str).collect(),
         cfg.project.as_bytes(),
     );
     let req = Request::post("/node/services/okta_identity_provider").body(payload);


### PR DESCRIPTION
When configuring the okta' addon,  allow to pass `--attributes` argument to specify which attributes from the okta userprofile to include in the ockam credential.

Example:
```
ockam project addon configure okta --project default  --tenant $OKTA_TENANT --client-id $OKTA_CLIENT_ID  --cert-path $PATH_TO_OKTA_CERT --attributes email --attributes name
```
This will copy the `email`  and `name`  attributes from the okta profile to the ockam credential.