### PR TITLE
feat(rust): Reduce output for short help command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -223,15 +223,20 @@ pub enum OutputFormat {
 pub struct ExportCommandArgs {
     /// Export the command input to a file.
     /// Used to run a set of commands after creating a node with `ockam node create --run commands.json`
-    #[arg(global = true, long = "export")]
+    #[arg(global = true, long = "export", hide_short_help = true)]
     export_path: Option<PathBuf>,
 
     /// Section of the config file to export the command to.
-    #[arg(global = true, long = "export-section", value_enum)]
+    #[arg(
+        global = true,
+        long = "export-section",
+        hide_short_help = true,
+        value_enum
+    )]
     section: Option<CommandSection>,
 
     /// Flag to indicate that the exported command should pipe its output.
-    #[arg(global = true, long, action = ArgAction::SetTrue)]
+    #[arg(global = true, long, hide_short_help = true, action = ArgAction::SetTrue)]
     pipe: Option<bool>,
 }
 


### PR DESCRIPTION
Resolves #3741 
Reduces amount of information When help is invoked using `ockam -h` as opposed to `ockam --help`

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Invoking ` ockam -h ` shows the full argument description, as does ` ockam --help `

## Proposed Changes

Invoking ` ockam -h ` shows the abbreviated help output as opposed to ` ockam --help `, which will continue to show the full output.
Resolves: #3741 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
