### PR TITLE
fix(rust): Show help output when no args passed

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -31,6 +31,7 @@ pub struct SubscriptionCommand {
 pub enum SubscriptionSubcommand {
     /// Show the details of a single subscription.
     /// You can use either the subscription ID or the space ID.
+    #[command(arg_required_else_help = true)]
     Show {
         /// Subscription ID
         #[arg(group = "id")]


### PR DESCRIPTION
ref: #3739

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

The subscription show command panics when no argument is passed because the arguments are optional and the group attribute is configured so that it doesn't require any of them.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Displaying help menu when no arguments are passed.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
