### PR TITLE
fix(rust): type untyped rpc::parse_response() calls

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -4,6 +4,7 @@ use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
+use ockam_api::nodes::models::identity::CreateIdentityResponse;
 use ockam_core::api::Request;
 
 #[derive(Clone, Debug, Args)]
@@ -26,8 +27,7 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &options, &cmd.node_opts.api_node)?;
     let request = Request::post("/node/identity");
     rpc.request(request).await?;
-    rpc.parse_response()?;
-
-    println!("Identity created!");
+    let res = rpc.parse_response::<CreateIdentityResponse>()?;
+    println!("Identity {} created!", res.identity_id);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -18,7 +18,7 @@ pub struct CreateCommand {
     #[command(flatten)]
     node_opts: Option<NodeOpts>,
 
-    #[arg(short, long, conflicts_with = "node")]
+    #[arg(long, conflicts_with = "node")]
     vault_name: Option<String>,
 
     /// Path to the Vault storage file
@@ -39,7 +39,7 @@ async fn run_impl(ctx: Context, (options, cmd): (CommandGlobalOpts, CreateComman
         let request = Request::post("/node/vault").body(CreateVaultRequest::new(cmd.path));
 
         rpc.request(request).await?;
-        rpc.parse_response()?;
+        rpc.is_ok()?;
 
         println!("Vault created for the Node {}!", node_name);
     } else if let Some(vault_name) = cmd.vault_name {

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -147,6 +147,34 @@ teardown() {
   assert_output --partial "/service/"
 }
 
+@test "vault create" {
+  run $OCKAM node create n1 --skip-defaults
+  assert_success
+
+  run $OCKAM vault create --node n1
+  assert_success
+
+  # Should not be able to create a vault when one exists
+  run $OCKAM vault create --node n1
+  assert_failure
+}
+
+@test "identity create" {
+  run $OCKAM node create n1 --skip-defaults
+  assert_success
+
+  # Need a vault to create an identity
+  run $OCKAM vault create --node n1
+  assert_success
+
+  run $OCKAM identity create --node n1
+  assert_success
+
+  # Should not be able to create an identity when one exists
+  run $OCKAM identity create --node n1
+  assert_failure
+}
+
 @test "create a secure channel between two nodes and send message through it" {
   $OCKAM node create n1
   $OCKAM node create n2


### PR DESCRIPTION

## Current Behavior

The `ockam vault create` and `ockam identity create` commands fail to parse responses from `ockam_api`.

For example... 

```
> ockam node create n1 --skip-defaults
> ockam vault create --node n1
Failed to decode response body: end of input bytes
```

```
> ockam node create n1 --skip-defaults
> ockam identity create --node n1
Failed to decode response body: unexpected type map at position 18: expected array
```

## Proposed Changes

* Type the untyped uses of `Rpc::parse_response()` so that `ockam_command` correctly parse responses from `ockam_api`.
* Added tests in `commands.bats`.

Now (inc. check that we can't create multiple vaults or identities)...

```
> ockam node create n1 --skip-defaults
> ockam vault create --node n1
Vault created!
> ockam vault create --node n1
An error occurred while processing the request. Status code: 500 InternalServerError. Message: failed to handle request: Vault already exists
```

```
> ockam node create n1 --skip-defaults
> ockam identity create --node n1
Identity created!
> ockam identity create --node n1
An error occurred while processing the request. Status code: 500 InternalServerError. Message: failed to handle request: Identity already exists
```

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
