### PR TITLE
refactor(rust): `tcp connection list` use `rpc` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -35,14 +35,6 @@ pub(crate) fn query_status() -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Construct a request to query node tcp connections
-pub(crate) fn list_tcp_connections() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    let builder = Request::get("/node/tcp/connection");
-    builder.encode(&mut buf)?;
-    Ok(buf)
-}
-
 /// Construct a request to query node tcp listeners
 pub(crate) fn list_tcp_listeners() -> RequestBuilder<'static, ()> {
     Request::get("/node/tcp/listener")

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -276,6 +276,10 @@ teardown() {
   run $OCKAM tcp-connection create --from n1 --to 127.0.0.1:5000 --output json
   assert_success
   assert_output --regexp '[{"route":"/dnsaddr/localhost/tcp/[[:digit:]]+/ip4/127.0.0.1/tcp/5000"}]'
+
+  run $OCKAM tcp-connection list --node n1
+  assert_success
+  assert_output --partial "127.0.0.1:5000"
 }
 
 # the below tests will only succeed if already enrolled with `ockam enroll`


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

Currently the `tcp connection list` command is using the `connect_to` abstraction and mapping errors manually using `std::process::exit`

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Closes #3595.

1. Replace `connect_to` by `node_rpc` abstraction.
2. Replace `std::process::exit` by an actual error.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
