### PR TITLE
fix(rust): auth0 error message text when failing to validate provider config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -351,7 +351,7 @@ impl Auth0Service {
 
     pub(crate) async fn validate_provider_config(&self) -> Result<()> {
         if let Err(e) = self.device_code().await {
-            return Err(anyhow!("Invalid Auth0 configuration: {e}").into());
+            return Err(anyhow!("Invalid OIDC configuration: {e}").into());
         }
         Ok(())
     }


### PR DESCRIPTION
Closes https://github.com/build-trust/codebase/issues/438