### PR TITLE
refactor(rust): reduce repeated logic, make use of `rpc`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -131,12 +131,12 @@ impl<'a> CreateOutlet<'a> {
 pub struct InletStatus<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9302588>,
-    #[b(1)] pub bind_addr: Cow<'a, str>,
-    #[b(2)] pub worker_addr: Cow<'a, str>,
-    #[b(3)] pub alias: Cow<'a, str>,
+    #[b(1)] pub bind_addr: CowStr<'a>,
+    #[b(2)] pub worker_addr: CowStr<'a>,
+    #[b(3)] pub alias: CowStr<'a>,
     /// An optional status payload
-    #[b(4)] pub payload: Option<Cow<'a, str>>,
-    #[b(5)] pub outlet_route: Cow<'a, str>,
+    #[b(4)] pub payload: Option<CowStr<'a>>,
+    #[b(5)] pub outlet_route: CowStr<'a>,
 }
 
 impl<'a> InletStatus<'a> {
@@ -153,11 +153,11 @@ impl<'a> InletStatus<'a> {
     }
 
     pub fn new(
-        bind_addr: impl Into<Cow<'a, str>>,
-        worker_addr: impl Into<Cow<'a, str>>,
-        alias: impl Into<Cow<'a, str>>,
-        payload: impl Into<Option<Cow<'a, str>>>,
-        outlet_route: impl Into<Cow<'a, str>>,
+        bind_addr: impl Into<CowStr<'a>>,
+        worker_addr: impl Into<CowStr<'a>>,
+        alias: impl Into<CowStr<'a>>,
+        payload: impl Into<Option<CowStr<'a>>>,
+        outlet_route: impl Into<CowStr<'a>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -178,11 +178,11 @@ impl<'a> InletStatus<'a> {
 pub struct OutletStatus<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<4012569>,
-    #[b(1)] pub tcp_addr: Cow<'a, str>,
-    #[b(2)] pub worker_addr: Cow<'a, str>,
-    #[b(3)] pub alias: Cow<'a, str>,
+    #[b(1)] pub tcp_addr: CowStr<'a>,
+    #[b(2)] pub worker_addr: CowStr<'a>,
+    #[b(3)] pub alias: CowStr<'a>,
     /// An optional status payload
-    #[b(4)] pub payload: Option<Cow<'a, str>>,
+    #[b(4)] pub payload: Option<CowStr<'a>>,
 }
 
 impl<'a> OutletStatus<'a> {
@@ -198,10 +198,10 @@ impl<'a> OutletStatus<'a> {
     }
 
     pub fn new(
-        tcp_addr: impl Into<Cow<'a, str>>,
-        worker_addr: impl Into<Cow<'a, str>>,
-        alias: impl Into<Cow<'a, str>>,
-        payload: impl Into<Option<Cow<'a, str>>>,
+        tcp_addr: impl Into<CowStr<'a>>,
+        worker_addr: impl Into<CowStr<'a>>,
+        alias: impl Into<CowStr<'a>>,
+        payload: impl Into<Option<CowStr<'a>>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -66,9 +66,9 @@ impl NodeManagerWorker {
                 .iter()
                 .map(|(alias, info)| {
                     InletStatus::new(
-                        &info.bind_addr,
+                        info.bind_addr.as_str(),
                         info.worker_addr.to_string(),
-                        alias,
+                        alias.as_str(),
                         None,
                         info.outlet_route.to_string(),
                     )
@@ -87,7 +87,12 @@ impl NodeManagerWorker {
                 .outlets
                 .iter()
                 .map(|(alias, info)| {
-                    OutletStatus::new(&info.tcp_addr, info.worker_addr.to_string(), alias, None)
+                    OutletStatus::new(
+                        info.tcp_addr.as_str(),
+                        info.worker_addr.to_string(),
+                        alias.as_str(),
+                        None,
+                    )
                 })
                 .collect(),
         ))

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,6 +1,8 @@
-use crate::util::{connect_to, exitcode, verify_pids};
+use crate::util::{exitcode, node_rpc, verify_pids, RpcBuilder};
 use crate::{help, node::show::print_query_status, node::HELP_DETAIL, CommandGlobalOpts};
+use anyhow::anyhow;
 use clap::Args;
+use ockam::TcpTransport;
 
 /// List Nodes
 #[derive(Clone, Debug, Args)]
@@ -9,32 +11,41 @@ pub struct ListCommand {}
 
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        let cfg = &options.config;
-        let node_names = {
-            let inner = cfg.inner();
-
-            if inner.nodes.is_empty() {
-                println!("No nodes registered on this system!");
-                std::process::exit(exitcode::IOERR);
-            }
-
-            // Before printing node state we have to verify it.  This
-            // happens by sending a QueryStatus request to every node on
-            // record.  If the function fails, then it is assumed not to
-            // be up.  Also, if the function returns, but yields a
-            // different pid, then we update the pid stored in the config.
-            // This should only happen if the node has failed in the past,
-            // and has been restarted by something that is not this CLI.
-            inner.nodes.iter().map(|(name, _)| name.clone()).collect()
-        };
-        verify_pids(cfg, node_names);
-
-        cfg.inner().nodes.iter().for_each(|(node_name, node_cfg)| {
-            connect_to(
-                node_cfg.port(),
-                (cfg.clone(), node_name.clone(), false),
-                print_query_status,
-            )
-        });
+        node_rpc(run_impl, (options, self))
     }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, _cmd): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let cfg = &opts.config;
+
+    // Before printing node states we verify them.
+    // We send a QueryStatus request to every node on
+    // record. If the response yields a different pid to the
+    // one in config, we update the pid stored in the config.
+    // This should only happen if the node has failed in the past,
+    // and has been restarted by something that is not this CLI.
+    let node_names: Vec<_> = {
+        let inner = cfg.inner();
+        if inner.nodes.is_empty() {
+            return Err(crate::Error::new(
+                exitcode::IOERR,
+                anyhow!("No nodes registered on this system!"),
+            ));
+        }
+        inner.nodes.iter().map(|(name, _)| name.clone()).collect()
+    };
+    let tcp = TcpTransport::create(&ctx).await?;
+    verify_pids(&ctx, &opts, &tcp, cfg, &node_names).await?;
+
+    // Print node states
+    for node_name in &node_names {
+        let mut rpc = RpcBuilder::new(&ctx, &opts, node_name).tcp(&tcp)?.build();
+        let port = cfg.get_node_port(node_name)?;
+        print_query_status(&mut rpc, port, node_name, false).await?;
+    }
+
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -29,10 +29,8 @@ use crate::util::DEFAULT_CONTROLLER_ADDRESS;
 ////////////// !== generators
 
 /// Construct a request to query node status
-pub(crate) fn query_status() -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::get("/node").encode(&mut buf)?;
-    Ok(buf)
+pub(crate) fn query_status() -> RequestBuilder<'static, ()> {
+    Request::get("/node")
 }
 
 /// Construct a request to query node tcp listeners
@@ -331,49 +329,6 @@ pub(crate) mod project {
 pub(crate) fn parse_response(resp: &[u8]) -> Result<Response> {
     let mut dec = Decoder::new(resp);
     Ok(dec.decode::<Response>()?)
-}
-
-/// Parse the returned status response
-pub(crate) fn parse_status(resp: &[u8]) -> Result<models::base::NodeStatus> {
-    let mut dec = Decoder::new(resp);
-    let _ = dec.decode::<Response>()?;
-    Ok(dec.decode::<models::base::NodeStatus>()?)
-}
-
-/// Parse the returned status response
-pub(crate) fn parse_tcp_list(resp: &[u8]) -> Result<models::transport::TransportList> {
-    let mut dec = Decoder::new(resp);
-    let _ = dec.decode::<Response>()?;
-    Ok(dec.decode::<models::transport::TransportList>()?)
-}
-
-pub(crate) fn parse_short_identity_response(
-    resp: &[u8],
-) -> Result<(Response, models::identity::ShortIdentityResponse<'_>)> {
-    let mut dec = Decoder::new(resp);
-    let response = dec.decode::<Response>()?;
-    Ok((
-        response,
-        dec.decode::<models::identity::ShortIdentityResponse>()?,
-    ))
-}
-
-pub(crate) fn parse_list_services_response(resp: &[u8]) -> Result<models::services::ServiceList> {
-    let mut dec = Decoder::new(resp);
-    let _ = dec.decode::<Response>()?;
-    Ok(dec.decode::<models::services::ServiceList>()?)
-}
-
-pub(crate) fn parse_list_inlets_response(resp: &[u8]) -> Result<models::portal::InletList> {
-    let mut dec = Decoder::new(resp);
-    let _ = dec.decode::<Response>()?;
-    Ok(dec.decode::<models::portal::InletList>()?)
-}
-
-pub(crate) fn parse_list_outlets_response(resp: &[u8]) -> Result<models::portal::OutletList> {
-    let mut dec = Decoder::new(resp);
-    let _ = dec.decode::<Response>()?;
-    Ok(dec.decode::<models::portal::OutletList>()?)
 }
 
 pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Result<Response> {


### PR DESCRIPTION
## Current Behavior

In `ockam_command/node`...
* `show.rs` has duplicate code.
*  `list.rs`, `create.rs` and `start.rs` are using `connect_to()` and not the newer `Rpc`. 

## Proposed Changes

* Simplify code and remove duplicates. 
* Use `Rpc` where possible.
* Avoid `std::process::exit()` where possible.

Note: `InletList` and `OutletList` changed to use non-borrowing fields so that `Rpc` instances can be re-used.

Apologies for the large PR, but `list`, `create` and `start` depend on `show`, so it kind of makes sense to do the changes as one. :pray:

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
