### PR TITLE
refactor(rust): show help when no args passed on `vault create` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -10,22 +10,21 @@ use ockam_api::config::cli;
 use ockam_api::nodes::models::vault::CreateVaultRequest;
 use ockam_core::api::Request;
 use ockam_vault::storage::FileStorage;
-use ockam_vault::Vault;
 use slug::slugify;
-use std::sync::Arc;
 
 /// Create vaults
 #[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true)]
 pub struct CreateCommand {
     #[command(flatten)]
     node_opts: Option<NodeOpts>,
 
-    #[arg(long, conflicts_with = "node")]
-    vault_name: Option<String>,
-
     /// Path to the Vault storage file
-    #[arg(short, long)]
+    #[arg(short, long, requires = "node")]
     pub path: Option<String>,
+
+    #[arg(long = "name", conflicts_with = "node")]
+    vault_name: Option<String>,
 }
 
 impl CreateCommand {
@@ -35,43 +34,34 @@ impl CreateCommand {
 }
 
 async fn run_impl(ctx: Context, (options, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
-    if let Some(node_opts) = cmd.node_opts {
-        let node_name = node_opts.api_node.clone();
-        let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
-        let request = Request::post("/node/vault").body(CreateVaultRequest::new(cmd.path));
-
-        rpc.request(request).await?;
-        rpc.is_ok()?;
-
-        println!("Vault created for the Node {}!", node_name);
-    } else if let Some(vault_name) = cmd.vault_name {
-        create_new_vault(vault_name.clone()).await?;
+    match (cmd.node_opts, cmd.vault_name) {
+        (Some(node_opts), None) => {
+            let node_name = node_opts.api_node.clone();
+            let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+            let request = Request::post("/node/vault").body(CreateVaultRequest::new(cmd.path));
+            rpc.request(request).await?;
+            rpc.is_ok()?;
+            println!("Vault created for the Node {}!", node_name);
+        }
+        (None, Some(vault_name)) => {
+            let dirs = cli::OckamConfig::directories();
+            let dir = dirs
+                .config_dir()
+                .to_path_buf()
+                .join("vaults")
+                .join(slugify(&format!("vault-{}", vault_name)));
+            if dir.as_path().exists() {
+                return Err(crate::error::Error::new(
+                    CANTCREAT,
+                    anyhow!("Vault with name {} already exists!", vault_name),
+                ));
+            }
+            tokio::fs::create_dir_all(dir.as_path()).await?;
+            let file = dir.join("vault.json");
+            let _ = FileStorage::create(file.clone()).await?;
+            println!("Vault created with name: {}!", vault_name);
+        }
+        _ => unreachable!(),
     }
-
-    Ok(())
-}
-
-async fn create_new_vault(vault_name: String) -> Result<()> {
-    let directories = cli::OckamConfig::directories();
-    let dir = directories
-        .config_dir()
-        .to_path_buf()
-        .join("vaults")
-        .join(slugify(&format!("vault-{}", vault_name)));
-
-    if dir.as_path().exists() {
-        return Err(crate::error::Error::new(
-            CANTCREAT,
-            anyhow!("Vault with name {} already exists!", vault_name),
-        ));
-    } else {
-        tokio::fs::create_dir_all(dir.as_path()).await?;
-        let file = dir.join("vault.json");
-        let storage = FileStorage::create(file.clone()).await?;
-        let _ = Vault::new(Some(Arc::new(storage)));
-
-        println!("Vault created with name: {}!", vault_name);
-    }
-
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -159,11 +159,11 @@ teardown() {
   assert_failure
 
   vault_name=$(openssl rand -hex 4)
-  run $OCKAM vault create --vault-name "${vault_name}"
+  run $OCKAM vault create --name "${vault_name}"
   assert_success
 
   # Should not be able to create a vault when one exists
-  run $OCKAM vault create --vault-name "${vault_name}"
+  run $OCKAM vault create --name "${vault_name}"
   assert_failure
 }
 


### PR DESCRIPTION
When rebasing this PR https://github.com/build-trust/ockam/pull/3716 I messed up and I forced-pushed a previous version of the changes.

This PR brings back what's missing.