### PR TITLE
feat(elixir): allow configuring idle timeout for workers

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/identity/identity_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/identity/identity_channel.ex
@@ -58,12 +58,14 @@ defmodule Ockam.Identity.SecureChannel do
   defp spawner_options(options) do
     listener_keys = [:address, :inner_address, :restart_type, :authorization]
     handshake_options = Keyword.drop(options, listener_keys)
+    idle_timeout = Keyword.get(options, :idle_timeout, :infinity)
 
     responder_options = [
       address_prefix: "ISC_R_",
       worker_mod: Ockam.Identity.SecureChannel.Data,
       handshake: Ockam.Identity.SecureChannel.Handshake,
       handshake_options: handshake_options,
+      idle_timeout: idle_timeout,
       ## TODO: probably all spawners should do that
       restart_type: :temporary
     ]


### PR DESCRIPTION
Add new option to worker creation: `:idle_timeout`, which can be a number in milliseconds or `:infinity`.

If `idle_timeout` is a number, the worker will terminate if no messages were received during the timeout.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
