### PR TITLE
refactor(elixir): `TypedCBOR.encode()` returns a tuple on success and…

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/api/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/client.ex
@@ -16,7 +16,7 @@ defmodule Ockam.API.Client do
         ) :: {:ok, response :: Ockam.API.Response.t()} | {:error, reason :: any()}
   def sync_request(method, path, body, route, timeout \\ 5_000, self_address \\ nil) do
     request = %Request{id: Request.gen_id(), path: path, method: method, body: body}
-    payload = Request.encode(request)
+    payload = Request.encode!(request)
 
     with {:ok, message} <-
            Ockam.Workers.Call.call_on_current_process(payload, route, timeout, self_address) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/api/client/discovery_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/client/discovery_client.ex
@@ -15,7 +15,7 @@ defmodule Ockam.API.Client.DiscoveryClient do
     case Client.sync_request(
            :put,
            id,
-           ServiceInfo.encode(service_info),
+           ServiceInfo.encode!(service_info),
            api_route,
            timeout,
            self_address

--- a/implementations/elixir/ockam/ockam/lib/ockam/api/discovery/service_info.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/discovery/service_info.ex
@@ -29,8 +29,8 @@ defmodule Ockam.API.Discovery.ServiceInfo do
     end
   end
 
-  def encode_list(service_infos) do
-    service_infos |> Enum.map(&normalize/1) |> NormalizedServiceInfo.encode_list()
+  def encode_list!(service_infos) do
+    service_infos |> Enum.map(&normalize/1) |> NormalizedServiceInfo.encode_list!()
   end
 
   def decode_list(data) do
@@ -47,8 +47,8 @@ defmodule Ockam.API.Discovery.ServiceInfo do
     end
   end
 
-  def encode(%__MODULE__{} = service_info) do
-    normalize(service_info) |> NormalizedServiceInfo.encode()
+  def encode!(%__MODULE__{} = service_info) do
+    normalize(service_info) |> NormalizedServiceInfo.encode!()
   end
 
   def decode(data) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
@@ -27,7 +27,7 @@ defmodule Ockam.API.Request do
     end
   end
 
-  def encode(request) when is_map(request) do
+  def encode!(request) when is_map(request) do
     body = request.body
 
     has_body =
@@ -38,7 +38,7 @@ defmodule Ockam.API.Request do
       end
 
     base =
-      Header.encode(%Header{
+      Header.encode!(%Header{
         id: request.id,
         path: request.path,
         method: request.method,
@@ -103,7 +103,7 @@ defmodule Ockam.API.Request do
         return_route
       ) do
     %Ockam.Message{
-      payload: encode(request),
+      payload: encode!(request),
       onward_route: to_route,
       return_route: return_route,
       local_metadata: local_metadata

--- a/implementations/elixir/ockam/ockam/lib/ockam/api/response.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/response.ex
@@ -25,7 +25,7 @@ defmodule Ockam.API.Response do
     end
   end
 
-  def encode(response) when is_map(response) do
+  def encode!(response) when is_map(response) do
     body = response.body
 
     has_body =
@@ -36,7 +36,7 @@ defmodule Ockam.API.Response do
       end
 
     base =
-      Header.encode(%Header{
+      Header.encode!(%Header{
         id: response.id,
         request_id: response.request_id,
         status: response.status,
@@ -113,7 +113,7 @@ defmodule Ockam.API.Response do
 
   def to_message(%__MODULE__{to_route: to_route} = response, return_route) do
     %Ockam.Message{
-      payload: encode(response),
+      payload: encode!(response),
       onward_route: to_route,
       return_route: return_route
     }

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/api/request.ex
@@ -27,19 +27,19 @@ defmodule Ockam.Identity.API.Request do
   end
 
   def validate_identity_change_history(identity) do
-    TypedCBOR.encode(@validate_identity_change_history, %{identity: identity})
+    TypedCBOR.encode!(@validate_identity_change_history, %{identity: identity})
   end
 
   def create_signature(identity, auth_hash) do
-    TypedCBOR.encode(@create_signature, %{identity: identity, state: auth_hash})
+    TypedCBOR.encode!(@create_signature, %{identity: identity, state: auth_hash})
   end
 
   def verify_signature(identity, proof, auth_hash) do
-    TypedCBOR.encode(@verify_signature, %{identity: identity, state: auth_hash, proof: proof})
+    TypedCBOR.encode!(@verify_signature, %{identity: identity, state: auth_hash, proof: proof})
   end
 
   def compare_identity_change_history(identity, known_identity) do
-    TypedCBOR.encode(@compare_identity_change_history, %{
+    TypedCBOR.encode!(@compare_identity_change_history, %{
       identity: identity,
       known_identity: known_identity
     })

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/api/response.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/api/response.ex
@@ -38,22 +38,22 @@ defmodule Ockam.Identity.API.Response do
   ## For testing purposes
 
   def encode_create(decoded) do
-    TypedCBOR.encode(@create, decoded)
+    TypedCBOR.encode!(@create, decoded)
   end
 
   def encode_validate_identity_change_history(decoded) do
-    TypedCBOR.encode(@validate_identity_change_history, decoded)
+    TypedCBOR.encode!(@validate_identity_change_history, decoded)
   end
 
   def encode_create_signature(decoded) do
-    TypedCBOR.encode(@create_signature, decoded)
+    TypedCBOR.encode!(@create_signature, decoded)
   end
 
   def encode_verify_signature(decoded) do
-    TypedCBOR.encode(@verify_signature, decoded)
+    TypedCBOR.encode!(@verify_signature, decoded)
   end
 
   def encode_compare_identity_change_history(decoded) do
-    TypedCBOR.encode(@compare_identity_change_history, decoded)
+    TypedCBOR.encode!(@compare_identity_change_history, decoded)
   end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/api/request_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/api/request_test.exs
@@ -8,7 +8,7 @@ defmodule Ockam.API.Request.Tests do
   test "Encode/decode" do
     ## Only these 4 firelds are encoded
     request = %Request{id: Request.gen_id(), path: "my_path", method: :get, body: "something"}
-    encoded = Request.encode(request)
+    encoded = Request.encode!(request)
     {:ok, decoded} = Request.decode(encoded)
     assert request == decoded
   end

--- a/implementations/elixir/ockam/ockam/test/ockam/api/response_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/api/response_test.exs
@@ -8,7 +8,7 @@ defmodule Ockam.API.Response.Tests do
   alias Ockam.Message
 
   test "Encode/decode" do
-    ## Only these 4 firelds are encoded
+    ## Only these 4 fields are encoded
     response = %Response{
       id: Response.gen_id(),
       request_id: Request.gen_id(),
@@ -16,7 +16,7 @@ defmodule Ockam.API.Response.Tests do
       body: "something"
     }
 
-    encoded = Response.encode(response)
+    encoded = Response.encode!(response)
     {:ok, decoded} = Response.decode(encoded)
     assert response == decoded
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/api/discovery_api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/discovery_api.ex
@@ -25,7 +25,7 @@ defmodule Ockam.Services.API.Discovery do
   def handle_request(%Request{method: :get, path: ""}, state) do
     case list(state) do
       {infos, state} when is_list(infos) ->
-        {:reply, :ok, ServiceInfo.encode_list(infos), state}
+        {:reply, :ok, ServiceInfo.encode_list!(infos), state}
 
       {:error, _reason} = error ->
         error
@@ -35,7 +35,7 @@ defmodule Ockam.Services.API.Discovery do
   def handle_request(%Request{method: :get, path: id}, state) do
     case get(id, state) do
       {{:ok, info}, state} ->
-        {:reply, :ok, ServiceInfo.encode(info), state}
+        {:reply, :ok, ServiceInfo.encode!(info), state}
 
       {{:error, reason}, state} ->
         {:error, reason, state}

--- a/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
+++ b/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
@@ -263,7 +263,12 @@ defmodule Ockam.TypedCBOR do
   def encode!(schema, d),
     do: CBOR.encode(to_cbor_term(schema, d))
 
-  def encode(schema, d), do: wrap_exception(&encode!(schema, &1), d)
+  def encode(schema, d) do
+    case wrap_exception(&encode!(schema, &1), d) do
+      data when is_binary(data) -> {:ok, data}
+      {:error, _reason} = error -> error
+    end
+  end
 
   def decode!(schema, data) do
     with {:ok, map, rest} <- CBOR.decode(data) do

--- a/implementations/elixir/ockam/ockam_typed_cbor/test/plugin_test.exs
+++ b/implementations/elixir/ockam/ockam_typed_cbor/test/plugin_test.exs
@@ -32,10 +32,12 @@ defmodule Ockam.TypedCBOR.Plugin.Test do
 
   test "encode-decode" do
     p = %Test.Person{name: "Test", age: 23, gender: :male, addresses: [], like_shoes: false}
-    {:ok, ^p, ""} = Test.Person.decode(Test.Person.encode(p))
+    {:ok, data} = Test.Person.encode(p)
+    {:ok, ^p, ""} = Test.Person.decode(data)
 
     p = %Test.Person{p | age: nil}
-    {:ok, ^p, ""} = Test.Person.decode(Test.Person.encode(p))
+    {:ok, data} = Test.Person.encode(p)
+    {:ok, ^p, ""} = Test.Person.decode(data)
 
     p = %Test.Person{
       p
@@ -45,12 +47,15 @@ defmodule Ockam.TypedCBOR.Plugin.Test do
         ]
     }
 
-    {:ok, ^p, ""} = Test.Person.decode(Test.Person.encode(p))
+    {:ok, data} = Test.Person.encode(p)
+    {:ok, ^p, ""} = Test.Person.decode(data)
 
     p = %Test.Person{p | nicknames: ["aa", "bb"]}
-    {:ok, ^p, ""} = Test.Person.decode(Test.Person.encode(p))
+    {:ok, data} = Test.Person.encode(p)
+    {:ok, ^p, ""} = Test.Person.decode(data)
 
-    {:ok, [^p, ^p], ""} = Test.Person.decode_list(Test.Person.encode_list([p, p]))
+    {:ok, data} = Test.Person.encode_list([p, p])
+    {:ok, [^p, ^p], ""} = Test.Person.decode_list(data)
   end
 
   test "encode errors" do


### PR DESCRIPTION
… failure



Fixes #3189

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

`TypedCBOR.encode()` returns a value on success and a tuple `{:error, reason}` on error.

## Proposed Changes

Make `TypedCBOR.encode()` return a tuple `{:ok, data}` on success in symmetry with `TypedCBOR.decode()`. Solution described in #3189

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
