### PR TITLE
refactor(elixir): session handshake and worker option names

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/session/count_to.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/session/count_to.ex
@@ -8,8 +8,8 @@ defmodule Ockam.Examples.Session.CountTo do
 
   def create_spawner() do
     responder_options = [
-      worker_mod: DataWorker,
-      handshake: Ockam.Examples.Session.CountTo.Handshake,
+      data_worker_mod: DataWorker,
+      handshake_mod: Ockam.Examples.Session.CountTo.Handshake,
       handshake_options: [count_to: 10]
     ]
 
@@ -23,9 +23,9 @@ defmodule Ockam.Examples.Session.CountTo do
 
   def create_initiator(init_route) do
     Session.Initiator.create(
-      worker_mod: DataWorker,
+      data_worker_mod: DataWorker,
       init_route: init_route,
-      handshake: Ockam.Examples.Session.CountTo.Handshake,
+      handshake_mod: Ockam.Examples.Session.CountTo.Handshake,
       handshake_options: [count_to: 10]
     )
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/session/pipe_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/session/pipe_channel.ex
@@ -17,8 +17,8 @@ defmodule Ockam.Examples.Session.PipeChannel do
     spawner_options = [
       worker_mod: Session.Responder,
       worker_options: [
-        worker_mod: PipeChannel.Simple,
-        handshake: PipeChannel.Handshake,
+        data_worker_mod: PipeChannel.Simple,
+        handshake_mod: PipeChannel.Handshake,
         handshake_options: [
           pipe_mod: ResendPipe,
           sender_options: [confirm_timeout: 200]
@@ -31,8 +31,8 @@ defmodule Ockam.Examples.Session.PipeChannel do
 
   def create_responder() do
     responder_options = [
-      worker_mod: PipeChannel.Simple,
-      handshake: PipeChannel.Handshake,
+      data_worker_mod: PipeChannel.Simple,
+      handshake_mod: PipeChannel.Handshake,
       handshake_options: [
         pipe_mod: ResendPipe,
         sender_options: [confirm_timeout: 200]
@@ -45,9 +45,9 @@ defmodule Ockam.Examples.Session.PipeChannel do
   def create_initiator(init_route) do
     Session.Initiator.create_and_wait(
       init_route: init_route,
-      worker_mod: PipeChannel.Simple,
-      worker_options: [],
-      handshake: PipeChannel.Handshake,
+      data_worker_mod: PipeChannel.Simple,
+      data_worker_options: [],
+      handshake_mod: PipeChannel.Handshake,
       handshake_options: [
         pipe_mod: ResendPipe,
         sender_options: [confirm_timeout: 200]

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/session/routing.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/session/routing.ex
@@ -22,8 +22,8 @@ defmodule Ockam.Examples.Session.Routing do
 
   def create_spawner() do
     responder_options = [
-      worker_mod: DataWorker,
-      worker_options: [messages: [:message_from_options]]
+      data_worker_mod: DataWorker,
+      data_worker_options: [messages: [:message_from_options]]
     ]
 
     spawner_options = [
@@ -36,8 +36,8 @@ defmodule Ockam.Examples.Session.Routing do
 
   def create_responder() do
     responder_options = [
-      worker_mod: DataWorker,
-      worker_options: [messages: [:message_from_options]]
+      data_worker_mod: DataWorker,
+      data_worker_options: [messages: [:message_from_options]]
     ]
 
     Session.Responder.create(responder_options)
@@ -45,8 +45,8 @@ defmodule Ockam.Examples.Session.Routing do
 
   def create_initiator(init_route) do
     Session.Initiator.create(
-      worker_mod: DataWorker,
-      worker_options: [messages: [:message_from_options_initiator]],
+      data_worker_mod: DataWorker,
+      data_worker_options: [messages: [:message_from_options_initiator]],
       init_route: init_route
     )
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/secure_channel/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/secure_channel/secure_channel.ex
@@ -60,8 +60,8 @@ defmodule Ockam.Identity.SecureChannel do
 
     responder_options = [
       address_prefix: "ISC_R_",
-      worker_mod: Ockam.Identity.SecureChannel.Data,
-      handshake: Ockam.Identity.SecureChannel.Handshake,
+      data_worker_mod: Ockam.Identity.SecureChannel.Data,
+      handshake_mod: Ockam.Identity.SecureChannel.Handshake,
       handshake_options: handshake_options,
       idle_timeout: idle_timeout,
       ## TODO: probably all spawners should do that
@@ -156,9 +156,9 @@ defmodule Ockam.Identity.SecureChannel do
       initiator_options = [
         address_prefix: "ISC_I_",
         address: Keyword.get(options, :address),
-        worker_mod: Ockam.Identity.SecureChannel.Data,
+        data_worker_mod: Ockam.Identity.SecureChannel.Data,
         init_route: init_route,
-        handshake: Ockam.Identity.SecureChannel.Handshake,
+        handshake_mod: Ockam.Identity.SecureChannel.Handshake,
         handshake_options: options
       ]
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/initiator.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/initiator.ex
@@ -26,9 +26,9 @@ defmodule Ockam.Messaging.PipeChannel.Initiator do
 
     Session.Initiator.create(
       init_route: init_route,
-      worker_mod: PipeChannel.Simple,
-      worker_options: [],
-      handshake: PipeChannel.Handshake,
+      data_worker_mod: PipeChannel.Simple,
+      data_worker_options: [],
+      handshake_mod: PipeChannel.Handshake,
       handshake_options: [
         pipe_mod: pipe_mod,
         sender_options: sender_options,

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/responder.ex
@@ -29,8 +29,8 @@ defmodule Ockam.Messaging.PipeChannel.Responder do
       address_options ++
         [
           init_message: init_message,
-          worker_mod: PipeChannel.Simple,
-          handshake: PipeChannel.Handshake,
+          data_worker_mod: PipeChannel.Simple,
+          handshake_mod: PipeChannel.Handshake,
           handshake_options: [
             pipe_mod: pipe_mod,
             sender_options: sender_options,

--- a/implementations/elixir/ockam/ockam/test/ockam/session/session_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/session/session_test.exs
@@ -12,8 +12,8 @@ defmodule Ockam.Session.Tests do
     {:ok, initiator} =
       Session.Initiator.create(
         init_route: [me],
-        handshake: Handshake,
-        worker_mod: DataModule
+        handshake_mod: Handshake,
+        data_worker_mod: DataModule
       )
 
     on_exit(fn ->
@@ -34,8 +34,8 @@ defmodule Ockam.Session.Tests do
 
     {:ok, responder} =
       Session.Responder.create(
-        handshake: Handshake,
-        worker_mod: DataModule,
+        handshake_mod: Handshake,
+        data_worker_mod: DataModule,
         handshake_options: [reply_to: [me]]
       )
 
@@ -44,8 +44,8 @@ defmodule Ockam.Session.Tests do
     {:ok, initiator} =
       Session.Initiator.create(
         init_route: [responder_inner],
-        handshake: Handshake,
-        worker_mod: DataModule
+        handshake_mod: Handshake,
+        data_worker_mod: DataModule
       )
 
     on_exit(fn ->
@@ -67,8 +67,8 @@ defmodule Ockam.Session.Tests do
 
     {:ok, responder} =
       Session.Responder.create(
-        handshake: Handshake,
-        worker_mod: DataModule
+        handshake_mod: Handshake,
+        data_worker_mod: DataModule
       )
 
     {:ok, responder_inner} = Ockam.AsymmetricWorker.get_inner_address(responder)
@@ -76,8 +76,8 @@ defmodule Ockam.Session.Tests do
     {:ok, initiator} =
       Session.Initiator.create(
         init_route: [responder_inner],
-        worker_mod: DataModule,
-        handshake: Handshake,
+        data_worker_mod: DataModule,
+        handshake_mod: Handshake,
         handshake_options: [reply_to: [me]]
       )
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

NA
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Apply a variable name refactor as suggested in https://github.com/build-trust/ockam/issues/3653

I'm not familiar with the code, but I'd like to make sure that you want to rename `worker_mod` to `data_mod`. I was wondering if `data_worker_mod` could be more meaningful. What do you think @hairyhum ?

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
