### PR TITLE
refactor(rust): avoid using non-borrowing cbor fields

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -258,12 +258,14 @@ pub struct Enroller<'a> {
 }
 
 impl<'a> AddEnroller<'a> {
-    pub fn new<S: Into<CowStr<'a>>>(identity_id: S, description: Option<S>) -> Self {
+    pub fn new(
+        identity_id: impl Into<CowStr<'a>>,
+        description: Option<impl Into<CowStr<'a>>>,
+    ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             identity_id: identity_id.into(),
-
             description: description.map(|s| s.into()),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
@@ -3,7 +3,7 @@
 // TODO: split up this file into sub modules
 
 use minicbor::{Decode, Encode};
-use ockam_core::compat::borrow::Cow;
+use ockam_core::CowStr;
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -19,8 +19,8 @@ use ockam_core::TypeTag;
 pub struct NodeStatus<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6586555>,
-    #[n(1)] pub node_name: Cow<'a, str>,
-    #[n(2)] pub status: Cow<'a, str>,
+    #[b(1)] pub node_name: CowStr<'a>,
+    #[b(2)] pub status: CowStr<'a>,
     #[n(3)] pub workers: u32,
     #[n(4)] pub pid: i32,
     #[n(5)] pub transports: u32,
@@ -28,8 +28,8 @@ pub struct NodeStatus<'a> {
 
 impl<'a> NodeStatus<'a> {
     pub fn new(
-        node_name: &'a str,
-        status: &'a str,
+        node_name: impl Into<CowStr<'a>>,
+        status: impl Into<CowStr<'a>>,
         workers: u32,
         pid: i32,
         transports: u32,
@@ -37,8 +37,8 @@ impl<'a> NodeStatus<'a> {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            node_name: Cow::Borrowed(node_name),
-            status: Cow::Borrowed(status),
+            node_name: node_name.into(),
+            status: status.into(),
             workers,
             pid,
             transports,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -19,7 +19,7 @@ pub struct CreateInlet<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<1407961>,
     /// The address the portal should listen at.
-    #[b(1)] listen_addr: SocketAddr,
+    #[n(1)] listen_addr: SocketAddr,
     /// The peer address.
     /// This can either be the address of an already
     /// created outlet, or a forwarding mechanism via ockam cloud.

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use minicbor::{bytes::ByteSlice, Decode, Encode};
-use ockam_core::compat::borrow::Cow;
+use minicbor::{Decode, Encode};
+use ockam_core::{CowBytes, CowStr};
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -13,11 +13,11 @@ use ockam_core::TypeTag;
 pub struct StartVaultServiceRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9798850>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: CowStr<'a>,
 }
 
 impl<'a> StartVaultServiceRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -33,11 +33,11 @@ impl<'a> StartVaultServiceRequest<'a> {
 pub struct StartIdentityServiceRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6129106>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: CowStr<'a>,
 }
 
 impl<'a> StartIdentityServiceRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -53,11 +53,11 @@ impl<'a> StartIdentityServiceRequest<'a> {
 pub struct StartAuthenticatedServiceRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5179596>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: CowStr<'a>,
 }
 
 impl<'a> StartAuthenticatedServiceRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -73,11 +73,11 @@ impl<'a> StartAuthenticatedServiceRequest<'a> {
 pub struct StartUppercaseServiceRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8177400>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: CowStr<'a>,
 }
 
 impl<'a> StartUppercaseServiceRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -93,11 +93,11 @@ impl<'a> StartUppercaseServiceRequest<'a> {
 pub struct StartEchoerServiceRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7636656>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: CowStr<'a>,
 }
 
 impl<'a> StartEchoerServiceRequest<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -112,32 +112,32 @@ impl<'a> StartEchoerServiceRequest<'a> {
 pub struct StartAuthenticatorRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2749734>,
-    #[b(1)] addr: &'a str,
+    #[b(1)] addr: CowStr<'a>,
     #[b(2)] path: &'a Path,
-    #[b(3)] proj: &'a ByteSlice
+    #[b(3)] proj: CowBytes<'a>
 }
 
 impl<'a> StartAuthenticatorRequest<'a> {
-    pub fn new(addr: &'a str, path: &'a Path, proj: &'a [u8]) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>, path: &'a Path, proj: impl Into<CowBytes<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr,
+            addr: addr.into(),
             path,
             proj: proj.into(),
         }
     }
 
-    pub fn address(&self) -> &'a str {
-        self.addr
+    pub fn address(&'a self) -> &'a str {
+        &self.addr
     }
 
     pub fn path(&self) -> &'a Path {
         self.path
     }
 
-    pub fn project(&self) -> &'a [u8] {
-        self.proj
+    pub fn project(&'a self) -> &'a [u8] {
+        &self.proj
     }
 }
 
@@ -147,20 +147,20 @@ impl<'a> StartAuthenticatorRequest<'a> {
 pub struct StartVerifierService<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9580740>,
-    #[b(1)] addr: &'a str,
+    #[b(1)] addr: CowStr<'a>,
 }
 
 impl<'a> StartVerifierService<'a> {
-    pub fn new(addr: &'a str) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr,
+            addr: addr.into(),
         }
     }
 
-    pub fn address(&self) -> &'a str {
-        self.addr
+    pub fn address(&'a self) -> &'a str {
+        &self.addr
     }
 }
 
@@ -170,22 +170,22 @@ impl<'a> StartVerifierService<'a> {
 pub struct StartCredentialsService<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6467937>,
-    #[b(1)] addr: &'a str,
+    #[b(1)] addr: CowStr<'a>,
     #[n(2)] oneway: bool,
 }
 
 impl<'a> StartCredentialsService<'a> {
-    pub fn new(addr: &'a str, oneway: bool) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>, oneway: bool) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr,
+            addr: addr.into(),
             oneway,
         }
     }
 
-    pub fn address(&self) -> &'a str {
-        self.addr
+    pub fn address(&'a self) -> &'a str {
+        &self.addr
     }
 
     pub fn oneway(&self) -> bool {
@@ -200,45 +200,45 @@ impl<'a> StartCredentialsService<'a> {
 pub struct StartOktaIdentityProviderRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2291842>,
-    #[b(1)] addr: &'a str,
-    #[b(2)] tenant_base_url: &'a str,
-    #[b(3)] certificate: &'a str,
+    #[b(1)] addr: CowStr<'a>,
+    #[b(2)] tenant_base_url: CowStr<'a>,
+    #[b(3)] certificate: CowStr<'a>,
     #[b(4)] attributes: Vec<&'a str>,
-    #[b(5)] proj: &'a ByteSlice
+    #[b(5)] proj: CowBytes<'a>
 }
 
 impl<'a> StartOktaIdentityProviderRequest<'a> {
     pub fn new(
-        addr: &'a str,
-        tenant_base_url: &'a str,
-        certificate: &'a str,
+        addr: impl Into<CowStr<'a>>,
+        tenant_base_url: impl Into<CowStr<'a>>,
+        certificate: impl Into<CowStr<'a>>,
         attributes: Vec<&'a str>,
-        proj: &'a [u8],
+        proj: impl Into<CowBytes<'a>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr,
-            tenant_base_url,
-            certificate,
+            addr: addr.into(),
+            tenant_base_url: tenant_base_url.into(),
+            certificate: certificate.into(),
             attributes,
             proj: proj.into(),
         }
     }
 
-    pub fn address(&self) -> &'a str {
-        self.addr
+    pub fn address(&'a self) -> &'a str {
+        &self.addr
     }
-    pub fn tenant_base_url(&self) -> &'a str {
-        self.tenant_base_url
+    pub fn tenant_base_url(&'a self) -> &'a str {
+        &self.tenant_base_url
     }
-    pub fn certificate(&self) -> &'a str {
-        self.certificate
+    pub fn certificate(&'a self) -> &'a str {
+        &self.certificate
     }
-    pub fn project(&self) -> &'a [u8] {
-        self.proj
+    pub fn project(&'a self) -> &'a [u8] {
+        &self.proj
     }
-    pub fn attributes(&self) -> &Vec<&'a str> {
+    pub fn attributes(&self) -> &[&str] {
         &self.attributes
     }
 }
@@ -249,12 +249,12 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
 pub struct ServiceStatus<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8542064>,
-    #[n(2)] pub addr: Cow<'a, str>,
-    #[n(3)] pub service_type: Cow<'a, str>,
+    #[b(2)] pub addr: CowStr<'a>,
+    #[b(3)] pub service_type: CowStr<'a>,
 }
 
 impl<'a> ServiceStatus<'a> {
-    pub fn new(addr: impl Into<Cow<'a, str>>, service_type: impl Into<Cow<'a, str>>) -> Self {
+    pub fn new(addr: impl Into<CowStr<'a>>, service_type: impl Into<CowStr<'a>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -271,7 +271,7 @@ impl<'a> ServiceStatus<'a> {
 pub struct ServiceList<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9587601>,
-    #[n(1)] pub list: Vec<ServiceStatus<'a>>
+    #[b(1)] pub list: Vec<ServiceStatus<'a>>
 }
 
 impl<'a> ServiceList<'a> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
@@ -1,5 +1,5 @@
 use minicbor::{Decode, Encode};
-use ockam_core::compat::borrow::Cow;
+use ockam_core::CowStr;
 use std::fmt::{self, Display};
 
 #[cfg(feature = "tag")]
@@ -13,18 +13,17 @@ use ockam_core::TypeTag;
 #[cbor(map)]
 pub struct CreateTransport<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<1503320>,
+    #[n(0)] tag: TypeTag<1503320>,
     /// The type of transport to create
     #[n(1)] pub tt: TransportType,
     /// The mode the transport should operate in
     #[n(2)] pub tm: TransportMode,
     /// The address payload for the transport
-    #[n(3)] pub addr: Cow<'a, str>,
+    #[b(3)] pub addr: CowStr<'a>,
 }
 
 impl<'a> CreateTransport<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(tt: TransportType, tm: TransportMode, addr: S) -> Self {
+    pub fn new<S: Into<CowStr<'a>>>(tt: TransportType, tm: TransportMode, addr: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -41,16 +40,15 @@ impl<'a> CreateTransport<'a> {
 #[cbor(map)]
 pub struct DeleteTransport<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)]
-    tag: TypeTag<4739996>,
+    #[n(0)] tag: TypeTag<4739996>,
     /// The transport ID to delete
-    #[n(1)] pub tid: Cow<'a, str>,
+    #[b(1)] pub tid: CowStr<'a>,
     /// The user has indicated that deleting the API transport is A-OK
     #[n(2)] pub force: bool,
 }
 
 impl<'a> DeleteTransport<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(tid: S, force: bool) -> Self {
+    pub fn new<S: Into<CowStr<'a>>>(tid: S, force: bool) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -118,16 +116,16 @@ pub struct TransportStatus<'a> {
     /// The mode the transport should operate in
     #[n(3)] pub tm: TransportMode,
     /// The status payload
-    #[n(4)] pub payload: Cow<'a, str>,
+    #[b(4)] pub payload: CowStr<'a>,
     /// Transport ID inside the node manager
     ///
     /// We use this as a kind of URI to be able to address a transport
     /// by a unique value for specific updates and deletion events.
-    #[n(5)] pub tid: Cow<'a, str>,
+    #[b(5)] pub tid: CowStr<'a>,
 }
 
 impl<'a> TransportStatus<'a> {
-    pub fn new<S: Into<Cow<'a, str>>>(
+    pub fn new<S: Into<CowStr<'a>>>(
         tt: TransportType,
         tm: TransportMode,
         payload: S,
@@ -151,7 +149,7 @@ impl<'a> TransportStatus<'a> {
 pub struct TransportList<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5212817>,
-    #[n(1)] pub list: Vec<TransportStatus<'a>>
+    #[b(1)] pub list: Vec<TransportStatus<'a>>
 }
 
 impl<'a> TransportList<'a> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -525,7 +525,7 @@ impl NodeManagerWorker {
                 let node_manager = self.node_manager.read().await;
                 Response::ok(req.id())
                     .body(NodeStatus::new(
-                        node_manager.node_name.as_str(),
+                        &node_manager.node_name,
                         "Running",
                         ctx.list_workers().await?.len() as u32,
                         std::process::id() as i32,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -75,9 +75,9 @@ impl NodeManagerWorker {
                 .iter()
                 .map(|(alias, info)| {
                     InletStatus::new(
-                        info.bind_addr.as_str(),
+                        &info.bind_addr,
                         info.worker_addr.to_string(),
-                        alias.as_str(),
+                        alias,
                         None,
                         info.outlet_route.to_string(),
                     )
@@ -96,12 +96,7 @@ impl NodeManagerWorker {
                 .outlets
                 .iter()
                 .map(|(alias, info)| {
-                    OutletStatus::new(
-                        info.tcp_addr.as_str(),
-                        info.worker_addr.to_string(),
-                        alias.as_str(),
-                        None,
-                    )
+                    OutletStatus::new(&info.tcp_addr, info.worker_addr.to_string(), alias, None)
                 })
                 .collect(),
         ))

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
@@ -84,7 +84,7 @@ impl NodeManagerWorker {
         let body: DeleteTransport = dec.decode()?;
         info!("Handling request to delete transport: {}", body.tid);
 
-        let tid: Alias = body.tid.into();
+        let tid: Alias = body.tid.to_string();
 
         if node_manager.api_transport_id == tid && !body.force {
             warn!("User requested to delete the API transport without providing force OP flag...");

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -157,23 +157,27 @@ pub async fn print_query_status(
         };
 
         // Get list of services for the node
+        let mut rpc = rpc.clone();
         rpc.request(api::list_services()).await?;
         let services = rpc.parse_response::<ServiceList>()?;
 
         // Get list of TCP listeners for node
+        let mut rpc = rpc.clone();
         rpc.request(api::list_tcp_listeners()).await?;
         let tcp_listeners = rpc.parse_response::<TransportList>()?;
 
         // Get list of Secure Channel Listeners
+        let mut rpc = rpc.clone();
         rpc.request(api::list_secure_channel_listener()).await?;
         let secure_channel_listeners = rpc.parse_response::<Vec<String>>()?;
 
         // Get list of inlets
+        let mut rpc = rpc.clone();
         rpc.request(api::list_inlets()).await?;
         let inlets = rpc.parse_response::<InletList>()?;
 
         // Get list of outlets
-        let mut rpc = rpc.clone(); // Clone Rpc so we can use above InletList (which has borrows) later
+        let mut rpc = rpc.clone();
         rpc.request(api::list_outlets()).await?;
         let outlets = rpc.parse_response::<OutletList>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -232,7 +232,7 @@ pub(crate) mod space {
     use super::*;
 
     pub(crate) fn create(cmd: &CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
-        let b = CreateSpace::new(cmd.name.as_str(), &cmd.admins);
+        let b = CreateSpace::new(&cmd.name, &cmd.admins);
         Request::post("v0/spaces").body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
     }
 
@@ -297,10 +297,7 @@ pub(crate) mod project {
     pub(crate) fn add_enroller(
         cmd: &AddEnrollerCommand,
     ) -> RequestBuilder<CloudRequestWrapper<AddEnroller>> {
-        let b = AddEnroller::new(
-            cmd.enroller_identity_id.as_str(),
-            cmd.description.as_deref(),
-        );
+        let b = AddEnroller::new(&cmd.enroller_identity_id, cmd.description.as_deref());
         Request::post(format!("v0/project-enrollers/{}", cmd.project_id))
             .body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
     }

--- a/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
+++ b/implementations/rust/ockam/ockam_core/src/cbor_utils/cow_str.rs
@@ -46,6 +46,12 @@ impl<'a> From<&'a str> for CowStr<'a> {
     }
 }
 
+impl<'a> From<&'a String> for CowStr<'a> {
+    fn from(s: &'a String) -> Self {
+        CowStr(Cow::Borrowed(s.as_str()))
+    }
+}
+
 impl From<String> for CowStr<'_> {
     fn from(s: String) -> Self {
         CowStr(Cow::Owned(s))


### PR DESCRIPTION
## Proposed Changes

Refactor `ockam_command` & `ockam_api` so that CBOR structs avoid using non-borrowing fields and make use of `CowStr` and `CowBytes`. This is all in aid of making the code base more consistent and, hopefully, memory efficient.

Also added `impl From<&String> for CowStr` to help reduce repeated code.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
