### PR TITLE
feat(rust): always load policy from storage

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -10,6 +10,8 @@ use tracing as log;
 
 use crate::eval::eval;
 use crate::expr::str;
+use crate::traits::PolicyStorage;
+use crate::types::{Action, Resource};
 use crate::{Env, Expr};
 
 /// Evaluates a policy expression against an environment of attributes.
@@ -17,22 +19,26 @@ use crate::{Env, Expr};
 /// Attributes come from a pre-populated environment and are augmented
 /// by subject attributes from credential data.
 #[derive(Debug)]
-pub struct PolicyAccessControl<S> {
-    expression: Expr,
+pub struct PolicyAccessControl<P, S> {
+    resource: Resource,
+    action: Action,
+    policies: P,
     attributes: S,
     environment: Env,
     overwrite: bool,
 }
 
-impl<S> PolicyAccessControl<S> {
+impl<P, S> PolicyAccessControl<P, S> {
     /// Create a new `PolicyAccessControl`.
     ///
     /// The policy expression is evaluated by getting subject attributes from
     /// the given authenticated storage, adding them the given environment,
     /// which may already contain other resource, action or subject attributes.
-    pub fn new(policy: Expr, store: S, env: Env) -> Self {
+    pub fn new(policies: P, store: S, r: Resource, a: Action, env: Env) -> Self {
         Self {
-            expression: policy,
+            resource: r,
+            action: a,
+            policies,
             attributes: store,
             environment: env,
             overwrite: false,
@@ -45,21 +51,58 @@ impl<S> PolicyAccessControl<S> {
 }
 
 #[async_trait]
-impl<S> AccessControl for PolicyAccessControl<S>
+impl<P, S> AccessControl for PolicyAccessControl<P, S>
 where
     S: AuthenticatedStorage + fmt::Debug,
+    P: PolicyStorage + fmt::Debug,
 {
     async fn is_authorized(&self, msg: &LocalMessage) -> Result<bool> {
-        let id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info(msg) {
-            info.their_identity_id().clone()
+        // Load the policy expression for resource and action:
+        let expr = if let Some(expr) = self
+            .policies
+            .get_policy(&self.resource, &self.action)
+            .await?
+        {
+            if let Expr::Bool(b) = expr {
+                // If the policy is a constant there is no need to populate
+                // the environment or look for message metadata.
+                return Ok(b);
+            } else {
+                expr
+            }
         } else {
+            // If no policy exists for this resource and action access is denied:
+            log::debug! {
+                resource = %self.resource,
+                action   = %self.action,
+                "no policy found; access denied"
+            }
             return Ok(false);
         };
 
+        // Get identity identifier from message metadata:
+        let id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info(msg) {
+            info.their_identity_id().clone()
+        } else {
+            log::debug! {
+                resource = %self.resource,
+                action   = %self.action,
+                "identity identifier not found; access denied"
+            }
+            return Ok(false);
+        };
+
+        // Get identity attributes and populate the environment:
         let attrs =
             if let Some(a) = AttributesStorageUtils::get_attributes(&id, &self.attributes).await? {
                 a
             } else {
+                log::debug! {
+                    resource = %self.resource,
+                    action   = %self.action,
+                    id       = %id,
+                    "attributes not found; access denied"
+                }
                 return Ok(false);
             };
 
@@ -67,33 +110,71 @@ where
 
         for (k, v) in &attrs {
             if k.find(|c: char| c.is_whitespace()).is_some() {
-                log::warn!(%id, key = %k, "attribute key with whitespace ignored")
+                log::warn! {
+                    resource = %self.resource,
+                    action   = %self.action,
+                    id       = %id,
+                    key      = %k,
+                    "attribute key with whitespace ignored"
+                }
             }
             match str::from_utf8(v) {
                 Ok(s) => {
                     if !self.overwrite && e.contains(k) {
-                        log::debug!(%id, key = %k, "attribute already present");
+                        log::debug! {
+                            resource = %self.resource,
+                            action   = %self.action,
+                            id       = %id,
+                            key      = %k,
+                            "attribute already present"
+                        }
                         continue;
                     }
                     e.put(format!("subject.{k}"), str(s.to_string()));
                 }
                 Err(e) => {
-                    log::warn!(%id, err = %e, key = %k, "failed to interpret attribute as string")
+                    log::warn! {
+                        resource = %self.resource,
+                        action   = %self.action,
+                        id       = %id,
+                        key      = %k,
+                        err      = %e,
+                        "failed to interpret attribute as string"
+                    }
                 }
             }
         }
 
-        match eval(&self.expression, &e) {
+        // Finally, evaluate the expression and return the result:
+        match eval(&expr, &e) {
             Ok(Expr::Bool(b)) => {
-                log::debug!(%id, is_authorized = %b, "policy evaluated");
+                log::debug! {
+                    resource      = %self.resource,
+                    action        = %self.action,
+                    id            = %id,
+                    is_authorized = %b,
+                    "policy evaluated"
+                }
                 Ok(b)
             }
             Ok(x) => {
-                log::warn!(%id, expr = %x, "evaluation did not yield a boolean result");
+                log::warn! {
+                    resource = %self.resource,
+                    action   = %self.action,
+                    id       = %id,
+                    expr     = %x,
+                    "evaluation did not yield a boolean result"
+                }
                 Ok(false)
             }
             Err(e) => {
-                log::warn!(%id, err = %e, "policy evaluation failed");
+                log::warn! {
+                    resource = %self.resource,
+                    action   = %self.action,
+                    id       = %id,
+                    err      = %e,
+                    "policy evaluation failed"
+                }
                 Ok(false)
             }
         }


### PR DESCRIPTION
The current `PolicyAccessControl` keeps a policy expression in memory and only reads identity attributes when determining if a message is authorised or not. The policy storage is not used, except when initially creating a `PolicyAccessControl` value.

As a potential alternative, this PR implements a more flexible but slower approach where the policy expression is always read from the underlying policy storage and therefore reflects any changes to policies immediately. If no policy is found, access is denied.

To allow updating policies of inlets and outlets, they may be given alias names which can then be used as resource names to link them to policies.