### PR TITLE
feat(rust): make the okta tenant config more generic

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -133,7 +133,7 @@ pub struct OktaConfig<'a> {
     #[cbor(n(0))] pub tag: TypeTag<6434814>,
 
     #[serde(borrow)]
-    #[cbor(b(1))] pub tenant: CowStr<'a>,
+    #[cbor(b(1))] pub tenant_base_url: CowStr<'a>,
 
     #[serde(borrow)]
     #[cbor(b(2))] pub certificate: CowStr<'a>,
@@ -147,7 +147,7 @@ pub struct OktaConfig<'a> {
 
 impl<'a> OktaConfig<'a> {
     pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(
-        tenant: S,
+        tenant_base_url: S,
         certificate: S,
         client_id: S,
         attributes: &'a [T],
@@ -155,7 +155,7 @@ impl<'a> OktaConfig<'a> {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            tenant: tenant.into(),
+            tenant_base_url: tenant_base_url.into(),
             certificate: certificate.into(),
             client_id: client_id.into(),
             attributes: attributes
@@ -176,7 +176,7 @@ impl OktaConfig<'_> {
         OktaConfig {
             #[cfg(feature = "tag")]
             tag: self.tag.to_owned(),
-            tenant: self.tenant.to_owned(),
+            tenant_base_url: self.tenant_base_url.to_owned(),
             certificate: self.certificate.to_owned(),
             client_id: self.client_id.to_owned(),
             attributes: self.attributes.iter().map(|x| x.to_owned()).collect(),
@@ -186,7 +186,7 @@ impl OktaConfig<'_> {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OktaAuth0 {
-    pub tenant: String,
+    pub tenant_base_url: String,
     pub client_id: String,
     pub certificate: String,
 }
@@ -194,7 +194,7 @@ pub struct OktaAuth0 {
 impl From<OktaConfig<'_>> for OktaAuth0 {
     fn from(c: OktaConfig) -> Self {
         Self {
-            tenant: c.tenant.to_string(),
+            tenant_base_url: c.tenant_base_url.to_string(),
             client_id: c.client_id.to_string(),
             certificate: c.certificate.to_string(),
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -201,7 +201,7 @@ pub struct StartOktaIdentityProviderRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2291842>,
     #[b(1)] addr: &'a str,
-    #[b(2)] tenant: &'a str,
+    #[b(2)] tenant_base_url: &'a str,
     #[b(3)] certificate: &'a str,
     #[b(4)] attributes: Vec<&'a str>,
     #[b(5)] proj: &'a ByteSlice
@@ -210,7 +210,7 @@ pub struct StartOktaIdentityProviderRequest<'a> {
 impl<'a> StartOktaIdentityProviderRequest<'a> {
     pub fn new(
         addr: &'a str,
-        tenant: &'a str,
+        tenant_base_url: &'a str,
         certificate: &'a str,
         attributes: Vec<&'a str>,
         proj: &'a [u8],
@@ -219,7 +219,7 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             addr,
-            tenant,
+            tenant_base_url,
             certificate,
             attributes,
             proj: proj.into(),
@@ -229,8 +229,8 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
     pub fn address(&self) -> &'a str {
         self.addr
     }
-    pub fn tenant(&self) -> &'a str {
-        self.tenant
+    pub fn tenant_base_url(&self) -> &'a str {
+        self.tenant_base_url
     }
     pub fn certificate(&self) -> &'a str {
         self.certificate

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -176,7 +176,7 @@ impl NodeManager {
         &mut self,
         ctx: &Context,
         addr: Address,
-        tenant: &str,
+        tenant_base_url: &str,
         certificate: &str,
         attributes: &[&str],
         proj: &[u8],
@@ -192,7 +192,8 @@ impl NodeManager {
             ));
         }
         let db = self.authenticated_storage.async_try_clone().await?;
-        let au = crate::okta::Server::new(proj.to_vec(), db, tenant, certificate, attributes)?;
+        let au =
+            crate::okta::Server::new(proj.to_vec(), db, tenant_base_url, certificate, attributes)?;
         ctx.start_worker(addr.clone(), au).await?;
         self.registry
             .okta_identity_provider_services
@@ -305,7 +306,7 @@ impl NodeManagerWorker {
             .start_okta_identity_provider_service_impl(
                 ctx,
                 addr,
-                body.tenant(),
+                body.tenant_base_url(),
                 body.certificate(),
                 body.attributes(),
                 body.project(),

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -16,7 +16,7 @@ const MEMBER: &str = "member";
 pub struct Server<S> {
     project: Vec<u8>,
     store: S,
-    tenant: String,
+    tenant_base_url: String,
     certificate: reqwest::Certificate,
     attributes: Vec<String>,
 }
@@ -49,7 +49,7 @@ where
     pub fn new(
         project: Vec<u8>,
         store: S,
-        tenant: &str,
+        tenant_base_url: &str,
         certificate: &str,
         attributes: &[&str],
     ) -> Result<Self> {
@@ -58,7 +58,7 @@ where
         Ok(Server {
             project,
             store,
-            tenant: tenant.to_string(),
+            tenant_base_url: tenant_base_url.to_string(),
             certificate,
             attributes: attributes.iter().map(|s| s.to_string()).collect(),
         })
@@ -111,10 +111,7 @@ where
             .build()
             .map_err(|err| ApiError::generic(&err.to_string()))?;
         let res = client
-            .get(format!(
-                "https://{}/oauth2/default/v1/userinfo",
-                &self.tenant
-            ))
+            .get(format!("{}/v1/userinfo", &self.tenant_base_url))
             .header("Authorization", format!("Bearer {}", token))
             .send()
             .await;

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -188,14 +188,15 @@ impl Auth0Provider {
     fn device_code_url(&self) -> String {
         match self {
             Self::Auth0 => "https://account.ockam.io/oauth/device/code".to_string(),
-            Self::Okta(d) => format!("https://{}/oauth2/default/v1/device/authorize", &d.tenant),
+            // See https://developer.okta.com/docs/reference/api/oidc/#composing-your-base-url
+            Self::Okta(d) => format!("{}/v1/device/authorize", &d.tenant_base_url),
         }
     }
 
     fn token_request_url(&self) -> String {
         match self {
             Self::Auth0 => "https://account.ockam.io/oauth/token".to_string(),
-            Self::Okta(d) => format!("https://{}/oauth2/default/v1/token", &d.tenant),
+            Self::Okta(d) => format!("{}/v1/token", &d.tenant_base_url),
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -80,11 +80,11 @@ pub enum ConfigureAddonCommand {
         /// Plugin tenant URL
         #[arg(
             long,
-            id = "tenant",
+            id = "tenant_base_url",
             value_name = "TENANT",
             value_parser(NonEmptyStringValueParser::new())
         )]
-        tenant: String,
+        tenant_base_url: String,
 
         /// Certificate. Use either this or --cert-path
         #[arg(
@@ -158,7 +158,7 @@ async fn run_impl(
         AddonSubcommand::Configure(cmd) => match cmd {
             ConfigureAddonCommand::Okta {
                 project_name,
-                tenant,
+                tenant_base_url,
                 certificate,
                 certificate_path,
                 client_id,
@@ -170,7 +170,8 @@ async fn run_impl(
                     _ => unreachable!(),
                 };
 
-                let okta_config = OktaConfig::new(tenant, certificate, client_id, &attributes);
+                let okta_config =
+                    OktaConfig::new(tenant_base_url, certificate, client_id, &attributes);
                 let body = okta_config.clone();
 
                 // Validate okta configuration

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -278,7 +278,7 @@ pub mod config {
         )
         .await?;
         let okta = project.okta_config.as_ref().map(|o| OktaAuth0 {
-            tenant: o.tenant.to_string(),
+            tenant_base_url: o.tenant_base_url.to_string(),
             client_id: o.client_id.to_string(),
             certificate: o.certificate.to_string(),
         });

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -61,7 +61,7 @@ pub struct OktaIdentityProviderConfig {
     #[serde(default = "okta_identity_provider_default_addr")]
     pub(crate) address: String,
 
-    pub(crate) tenant: String,
+    pub(crate) tenant_base_url: String,
 
     pub(crate) certificate: String,
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -239,7 +239,7 @@ pub async fn start_okta_identity_provider(
 ) -> Result<()> {
     let payload = StartOktaIdentityProviderRequest::new(
         &cfg.address,
-        &cfg.tenant,
+        &cfg.tenant_base_url,
         &cfg.certificate,
         cfg.attributes.iter().map(|s| s as &str).collect(),
         cfg.project.as_bytes(),


### PR DESCRIPTION
## Current Behavior
Configuring the okta addon allow to pass a tenant _domain_

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Configure the addon with a okta [base url](https://developer.okta.com/docs/reference/api/oidc/#composing-your-base-url
)  instead, as it's more generic and requires less assumptions to be made in our side.
