### PR TITLE
feat(rust): add default value for `to` argument and change the `attributes` argument name

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -31,11 +31,11 @@ pub struct EnrollCommand {
     #[arg(long, short)]
     member: IdentityIdentifier,
 
-    #[arg(long, short)]
+    #[arg(long, short, default_value = "/project/default/service/authenticator")]
     to: MultiAddr,
 
     /// Attributes in `key=value` format to be attached to the member
-    #[arg(long = "attr", value_name = "ATTRIBUTE")]
+    #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
     attributes: Vec<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -424,9 +424,9 @@ teardown() {
   assert_success
   blue_identifer=$($OCKAM identity show -n blue)
 
-  run $OCKAM project enroll --member $blue_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $blue_identifer --attribute role=member
   assert_success
-  run $OCKAM project enroll --member $green_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
@@ -459,9 +459,9 @@ teardown() {
   assert_success
   blue_identifer=$($OCKAM identity show -n blue)
 
-  run $OCKAM project enroll --member $blue_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $blue_identifer --attribute role=member
   assert_success
-  run $OCKAM project enroll --member $green_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
@@ -492,9 +492,9 @@ teardown() {
   assert_success
   blue_identifer=$($OCKAM identity show -n blue)
 
-  run $OCKAM project enroll --member $blue_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $blue_identifer --attribute role=member
   assert_success
-  run $OCKAM project enroll --member $green_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
@@ -525,9 +525,9 @@ teardown() {
   assert_success
   blue_identifer=$($OCKAM identity show -n blue)
 
-  run $OCKAM project enroll --member $blue_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $blue_identifer --attribute role=member
   assert_success
-  run $OCKAM project enroll --member $green_identifer --to /project/default/service/authenticator --attr role=member
+  run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential


### PR DESCRIPTION
Apply the following changes to the `project enroll` command:
- change `–attr` to `–attribute`
- make `--to` attribute optional
