### PR TITLE
refactor(rust): `tcp connection delete` use `rpc` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -52,18 +52,6 @@ pub(crate) fn create_tcp_connection(
     Request::post("/node/tcp/connection").body(payload)
 }
 
-/// Construct a request to delete node tcp connection
-pub(crate) fn delete_tcp_connection(
-    cmd: &crate::tcp::connection::DeleteCommand,
-) -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::delete("/node/tcp/connection")
-        .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force))
-        .encode(&mut buf)?;
-
-    Ok(buf)
-}
-
 /// Construct a request to print Identity Id
 pub(crate) fn short_identity() -> RequestBuilder<'static, ()> {
     Request::post("/node/identity/actions/show/short")
@@ -324,12 +312,6 @@ pub(crate) mod project {
 }
 
 ////////////// !== parsers
-
-/// Parse the base response without the inner payload
-pub(crate) fn parse_response(resp: &[u8]) -> Result<Response> {
-    let mut dec = Decoder::new(resp);
-    Ok(dec.decode::<Response>()?)
-}
 
 pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Result<Response> {
     let mut dec = Decoder::new(resp);

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 pub use addon::AddonCommand;
 pub use config::*;
-use ockam::{route, Address, Context, NodeBuilder, Route, TcpTransport, TCP};
+use ockam::{Address, Context, NodeBuilder, Route, TcpTransport, TCP};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_api::{config::cli::NodeConfigOld, nodes::models::base::NodeStatus};
 use ockam_core::api::{RequestBuilder, Response, Status};
@@ -305,49 +305,6 @@ pub async fn stop_node(mut ctx: Context) -> Result<()> {
         eprintln!("an error occurred while shutting down local node: {}", e);
     }
     Ok(())
-}
-
-/// Connect to a remote node (on localhost for now)
-///
-/// This function requires the "remote" port, some command payload,
-/// and a user function to run.  It uses `embedded_node` internally,
-/// while also configuring a TcpTransport and connecting to another
-/// node.
-///
-pub fn connect_to<A, F, Fut>(port: u16, a: A, lambda: F)
-where
-    A: Send + Sync + 'static,
-    F: FnOnce(Context, A, Route) -> Fut + Send + Sync + 'static,
-    Fut: core::future::Future<Output = Result<()>> + Send + 'static,
-{
-    let res = embedded_node(
-        move |ctx, a| async move {
-            let tcp = match TcpTransport::create(&ctx).await {
-                Ok(tcp) => tcp,
-                Err(e) => {
-                    eprintln!("Failed to create TcpTransport. {e}");
-                    error!(%e);
-                    std::process::exit(exitcode::CANTCREAT);
-                }
-            };
-            if let Err(e) = tcp.connect(format!("localhost:{}", port)).await {
-                eprintln!("Failed to connect to node. {e}");
-                error!(%e);
-                std::process::exit(exitcode::IOERR);
-            }
-            let route = route![(TCP, format!("localhost:{}", port))];
-            if let Err(e) = lambda(ctx, a, route).await {
-                eprintln!("Encountered an error in command handler code. {e}");
-                error!(%e);
-                std::process::exit(exitcode::IOERR);
-            }
-            Ok(())
-        },
-        a,
-    );
-    if let Err(e) = res {
-        eprintln!("Ockam node failed: {:?}", e,);
-    }
 }
 
 pub fn node_rpc<A, F, Fut>(f: F, a: A)

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -307,7 +307,7 @@ teardown() {
   # TODO: add test for authenticator
 }
 
-@test "create a tcp connection" {
+@test "create a tcp connection, delete a tcp connection" {
   run $OCKAM node create n1
   run $OCKAM tcp-connection create --from n1 --to 127.0.0.1:5000 --output json
   assert_success
@@ -316,6 +316,15 @@ teardown() {
   run $OCKAM tcp-connection list --node n1
   assert_success
   assert_output --partial "127.0.0.1:5000"
+
+  id=$($OCKAM tcp-connection list --node n1 | grep -o "[0-9a-f]\{32\}")
+  run $OCKAM tcp-connection delete --node n1 $id
+  assert_success
+  assert_output "Tcp connection \`$id\` successfully deleted"
+
+  run $OCKAM tcp-connection list --node n1
+  assert_success
+  refute_output --partial "127.0.0.1:5000"
 }
 
 # the below tests will only succeed if already enrolled with `ockam enroll`


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

Currently the `tcp connection delete` command is using the `connect_to` abstraction.

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Closes #3594.

1. Replace `connect_to` by `node_rpc` abstraction.
2. Remove unused `connect_to` and `parse_response`
3. Add `delete a tcp connection` test

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
