### PR TITLE
feat(rust): `check-credential` argument defaults to node's `enable-credential-checks` value

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -26,8 +26,9 @@ pub struct CreateInlet<'a> {
     #[n(2)] outlet_addr: MultiAddr,
     /// A human-friendly alias for this portal endpoint
     #[b(3)] alias: Option<CowStr<'a>>,
-    /// Enable credentials authorization
-    #[n(4)] check_credential: bool,
+    /// Enable credentials authorization.
+    /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
+    #[n(4)] check_credential: Option<bool>,
     /// An authorised identity for secure channels.
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
@@ -35,7 +36,7 @@ pub struct CreateInlet<'a> {
 }
 
 impl<'a> CreateInlet<'a> {
-    pub fn via_project(listen: SocketAddr, to: MultiAddr, check_credential: bool) -> Self {
+    pub fn via_project(listen: SocketAddr, to: MultiAddr, check_credential: Option<bool>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -50,7 +51,7 @@ impl<'a> CreateInlet<'a> {
     pub fn to_node(
         listen: SocketAddr,
         to: MultiAddr,
-        check_credential: bool,
+        check_credential: Option<bool>,
         auth: Option<IdentityIdentifier>,
     ) -> Self {
         Self {
@@ -84,7 +85,7 @@ impl<'a> CreateInlet<'a> {
         self.alias.as_deref()
     }
 
-    pub fn is_check_credential(&self) -> bool {
+    pub fn check_credential(&self) -> Option<bool> {
         self.check_credential
     }
 }
@@ -102,8 +103,9 @@ pub struct CreateOutlet<'a> {
     #[b(2)] pub worker_addr: Cow<'a, str>,
     /// A human-friendly alias for this portal endpoint
     #[b(3)] pub alias: Option<CowStr<'a>>,
-    /// Enable credentials authorization
-    #[n(4)] pub check_credential: bool,
+    /// Enable credentials authorization.
+    /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
+    #[n(4)] pub check_credential: Option<bool>,
 }
 
 impl<'a> CreateOutlet<'a> {
@@ -111,7 +113,7 @@ impl<'a> CreateOutlet<'a> {
         tcp_addr: impl Into<Cow<'a, str>>,
         worker_addr: impl Into<Cow<'a, str>>,
         alias: impl Into<Option<CowStr<'a>>>,
-        check_credential: bool,
+        check_credential: Option<bool>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -51,13 +51,19 @@ pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "ROUTE")]
     to: MultiAddr,
 
-    /// Authorized identity for secure channel connection (optional)
+    /// Authorized identity for secure channel connection
     #[arg(long, name = "AUTHORIZED", display_order = 900)]
     authorized: Option<IdentityIdentifier>,
 
-    /// Enable credentials authorization
-    #[arg(long, short, display_order = 802)]
+    /// Enable credentials authorization.
+    /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
+    #[arg(long, display_order = 900, conflicts_with = "disable_check_credential")]
     check_credential: bool,
+
+    /// Disable credentials authorization.
+    /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
+    #[arg(long, display_order = 900, conflicts_with = "check_credential")]
+    disable_check_credential: bool,
 
     /// Assign a name to this inlet.
     #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser)]
@@ -67,6 +73,16 @@ pub struct CreateCommand {
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         node_rpc(rpc, (options, self));
+    }
+
+    pub fn check_credential(&self) -> Option<bool> {
+        if self.check_credential {
+            Some(true)
+        } else if self.disable_check_credential {
+            Some(false)
+        } else {
+            None
+        }
     }
 }
 
@@ -103,13 +119,14 @@ async fn rpc(ctx: Context, (opts, mut cmd): (CommandGlobalOpts, CreateCommand)) 
     let node = extract_address_value(&cmd.at)?;
 
     let req = {
+        let check_credential = cmd.check_credential();
         let mut payload = if cmd.to.matches(0, &[Project::CODE.into()]) {
             if cmd.authorized.is_some() {
                 return Err(anyhow!("--authorized can not be used with project addresses").into());
             }
-            CreateInlet::via_project(cmd.from, cmd.to, cmd.check_credential)
+            CreateInlet::via_project(cmd.from, cmd.to, check_credential)
         } else {
-            CreateInlet::to_node(cmd.from, cmd.to, cmd.check_credential, cmd.authorized)
+            CreateInlet::to_node(cmd.from, cmd.to, check_credential, cmd.authorized)
         };
         if let Some(a) = cmd.alias {
             payload.set_alias(a)

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -429,14 +429,14 @@ teardown() {
   run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
   assert_success
 
   run bash -c " $OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_blue/service/api \
-              | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/outlet --check-credential"
+              | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/outlet"
   assert_success
 
   # Green can't establish secure channel with blue, because it doesn't exchange credentials with it.
@@ -464,13 +464,13 @@ teardown() {
   run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
   assert_success
 
-  run $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to /project/default/service/forward_to_blue/secure/api/service/outlet --check-credential
+  run $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to /project/default/service/forward_to_blue/secure/api/service/outlet
   assert_success
 
   # Green can't establish secure channel with blue, because it doesn't exchange credentials with it.
@@ -497,14 +497,14 @@ teardown() {
   run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
   assert_success
 
   run bash -c " $OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_blue/service/api \
-              | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/outlet --check-credential"
+              | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to -/service/outlet"
   assert_success
 
   run curl --fail --head --max-time 10 127.0.0.1:7000
@@ -530,13 +530,13 @@ teardown() {
   run $OCKAM project enroll --member $green_identifer --attribute role=member
   assert_success
 
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
   assert_success
 
-  run $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to /project/default/service/forward_to_blue/secure/api/service/outlet --check-credential
+  run $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:7000 --to /project/default/service/forward_to_blue/secure/api/service/outlet
   assert_success
 
   run curl --fail --head --max-time 10 127.0.0.1:7000


### PR DESCRIPTION
The `tcp-inlet create` and `tcp-outlet create` commands now don't have to explicit the `check-credential` value. The node will default to its `enable-credential-checks` value passed upon creation.

These commands can override the node's value using one of the following attributes: `check-credential` and `disable-check-credential`