### PR TITLE
fix(rust): increase timeout used on the `is_node_up` requests

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -14,7 +14,7 @@ use ockam_multiaddr::proto::{DnsAddr, Node, Tcp};
 use ockam_multiaddr::MultiAddr;
 
 const IS_NODE_UP_ATTEMPTS: usize = 50;
-const IS_NODE_UP_TIMEOUT: Duration = Duration::from_millis(100);
+const IS_NODE_UP_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Show Nodes
 #[derive(Clone, Debug, Args)]


### PR DESCRIPTION
Increase timeout from 100ms to 1sec. Probably 100ms is too little to expect a response from a node.