### PR TITLE
chore(rust): rename attr argument to attribute on okta addon config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -109,7 +109,7 @@ pub enum ConfigureAddonCommand {
         client_id: String,
 
         /// Attributes names to copy from Okta userprofile into Ockam credential.
-        #[arg(long = "attr", value_name = "ATTRIBUTE")]
+        #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
         attributes: Vec<String>,
     },
 }


### PR DESCRIPTION
Similar to https://github.com/build-trust/ockam/pull/3791,  but when configuring okta addon