### PR TITLE
feat(rust): show ockam_command version when printing an error

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -2,6 +2,7 @@ use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter};
 
 use crate::util::ConfigError;
+use crate::version::Version;
 use crate::{exitcode, ExitCode};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -24,13 +25,15 @@ impl Error {
 
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", Version::short())?;
         std::fmt::Debug::fmt(&self.inner, f)
     }
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{code: {}, err: {}}}", self.code, self.inner)
+        writeln!(f, "{}", Version::short())?;
+        writeln!(f, "{{code: {}, err: {}}}", self.code, self.inner)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -387,23 +387,15 @@ where
     T: Send + 'static,
 {
     let (ctx, mut executor) = NodeBuilder::without_access_control().no_logging().build();
-    let r = executor.execute(async move {
+    executor.execute(async move {
         let child_ctx = ctx
             .new_detached(Address::random_local())
             .await
             .expect("Embedded node child ctx can't be created");
         let r = f(child_ctx, a).await;
         stop_node(ctx).await.unwrap();
-        match r {
-            Err(e) => {
-                error!(%e);
-                eprintln!("{e:?}");
-                std::process::exit(e.code());
-            }
-            Ok(v) => v,
-        }
-    })?;
-    Ok(r)
+        r
+    })?
 }
 
 pub fn embedded_node_that_is_not_stopped<A, F, Fut, T>(f: F, a: A) -> crate::Result<T>
@@ -414,21 +406,13 @@ where
     T: Send + 'static,
 {
     let (ctx, mut executor) = NodeBuilder::without_access_control().no_logging().build();
-    let r = executor.execute(async move {
+    executor.execute(async move {
         let child_ctx = ctx
             .new_detached(Address::random_local())
             .await
             .expect("Embedded node child ctx can't be created");
-        match f(child_ctx, a).await {
-            Err(e) => {
-                error!(%e);
-                eprintln!("{e:?}");
-                std::process::exit(e.code());
-            }
-            Ok(v) => v,
-        }
-    })?;
-    Ok(r)
+        f(child_ctx, a).await
+    })?
 }
 
 pub fn find_available_port() -> Result<u16> {


### PR DESCRIPTION
Add binary version to `Debug` and `Display` implementations of the ockam_command::Error type.

