### PR TITLE
feat(rust): minor improvements

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -43,8 +43,8 @@ pub mod actions {
 
 pub mod resources {
     use ockam_abac::Resource;
-    pub const INLET: Resource = Resource::assert_inline("inlet");
-    pub const OUTLET: Resource = Resource::assert_inline("outlet");
+    pub const INLET: Resource = Resource::assert_inline("tcp-inlet");
+    pub const OUTLET: Resource = Resource::assert_inline("tcp-outlet");
 }
 
 use core::fmt;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -67,11 +67,6 @@ pub struct CreateCommand {
     #[arg(long, short, hide = true)]
     pub skip_defaults: bool,
 
-    /// Enable credential checks
-    #[arg(long, hide = true)]
-    pub enable_credential_checks: bool,
-
-    /// Don't share default identity with this node
     #[arg(long, hide = true)]
     pub no_shared_identity: bool,
 
@@ -108,7 +103,6 @@ impl Default for CreateCommand {
             foreground: false,
             tcp_listener_address: "127.0.0.1:0".to_string(),
             skip_defaults: false,
-            enable_credential_checks: false,
             no_shared_identity: false,
             child_process: false,
             launch_config: None,
@@ -248,7 +242,6 @@ async fn run_foreground_node(
             cmd.node_name.clone(),
             node_dir,
             cmd.skip_defaults || cmd.launch_config.is_some(),
-            cmd.enable_credential_checks,
             identity_override,
         ),
         NodeManagerProjectsOptions::new(
@@ -386,7 +379,6 @@ async fn spawn_background_node(
         verbose,
         cmd.skip_defaults,
         cmd.no_shared_identity,
-        cmd.enable_credential_checks,
         &cmd.node_name,
         &cmd.tcp_listener_address,
         cmd.project.as_deref(),

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -86,7 +86,6 @@ async fn restart_background_node(
         cfg_node.verbose(),           // Previously user-chosen verbosity level
         true,                         // skip-defaults because the node already exists
         false,                        // Default value. TODO: implement persistence of this option
-        false,                        // Default value. TODO: implement persistence of this option
         cfg_node.name(),              // The selected node name
         &cfg_node.addr().to_string(), // The selected node api address
         None,                         // No project information available

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -62,7 +62,6 @@ pub async fn start_embedded_node(ctx: &Context, cfg: &OckamConfig) -> Result<Str
             cmd.node_name.clone(),
             node_dir,
             cmd.skip_defaults || cmd.launch_config.is_some(),
-            cmd.enable_credential_checks,
             identity_override,
         ),
         NodeManagerProjectsOptions::new(

--- a/implementations/rust/ockam/ockam_command/src/util/startup.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/startup.rs
@@ -42,7 +42,6 @@ pub fn spawn_node(
     verbose: u8,
     skip_defaults: bool,
     no_shared_identity: bool,
-    enable_credential_checks: bool,
     name: &str,
     address: &str,
     project: Option<&Path>,
@@ -95,10 +94,6 @@ pub fn spawn_node(
 
     if no_shared_identity {
         args.push("--no-shared-identity".to_string());
-    }
-
-    if enable_credential_checks {
-        args.push("--enable-credential-checks".to_string());
     }
 
     if let Some(c) = invite {


### PR DESCRIPTION
* refactor(rust): rename inlet and outlet policy resources
* refactor(rust): `expect` to `context` to handle errors gracefully
* refactor(rust): remove `--enable-credential-checks` argument