### PR TITLE
fix(rust): cleanup

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
@@ -52,16 +52,16 @@ pub struct Enroller {}
 #[derive(Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateInvite<'a> {
+pub struct CreateToken<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2502742>,
     #[b(1)] attributes: HashMap<CowStr<'a>, CowStr<'a>>,
 }
 
-impl<'a> CreateInvite<'a> {
+impl<'a> CreateToken<'a> {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        CreateInvite {
+        CreateToken {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             attributes: HashMap::new(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
@@ -7,8 +7,6 @@ use ockam_core::compat::borrow::Cow;
 use ockam_core::TypeTag;
 use ockam_multiaddr::MultiAddr;
 
-use crate::authenticator::direct::types::OneTimeCode;
-
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
@@ -16,7 +14,6 @@ pub struct GetCredentialRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8479533>,
     #[n(1)] overwrite: bool,
-    #[n(2)] code: Option<OneTimeCode>,
 }
 
 impl GetCredentialRequest {
@@ -25,21 +22,11 @@ impl GetCredentialRequest {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             overwrite,
-            code: None,
         }
-    }
-
-    pub fn with_invitation_code(mut self, c: OneTimeCode) -> Self {
-        self.code = Some(c);
-        self
     }
 
     pub fn is_overwrite(&self) -> bool {
         self.overwrite
-    }
-
-    pub fn invitation_code(&self) -> Option<&OneTimeCode> {
-        self.code.as_ref()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -76,7 +76,7 @@ pub struct CreateCommand {
 
     /// An enrollment token to allow this node to enroll into a project.
     #[arg(long = "enrollment-token", value_name = "ENROLLMENT_TOKEN", value_parser = otc_parser)]
-    invite: Option<OneTimeCode>,
+    token: Option<OneTimeCode>,
 
     /// JSON config to setup a foreground node
     ///
@@ -109,7 +109,7 @@ impl Default for CreateCommand {
             no_watchdog: false,
             project: None,
             config: None,
-            invite: None,
+            token: None,
         }
     }
 }
@@ -248,7 +248,7 @@ async fn run_foreground_node(
             Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
             project_id,
             projects,
-            cmd.invite,
+            cmd.token,
         ),
         NodeManagerTransportOptions::new(
             (TransportType::Tcp, TransportMode::Listen, bind),
@@ -382,7 +382,7 @@ async fn spawn_background_node(
         &cmd.node_name,
         &cmd.tcp_listener_address,
         cmd.project.as_deref(),
-        cmd.invite.as_ref(),
+        cmd.token.as_ref(),
     )?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use anyhow::{anyhow, Context as _};
 use ockam::identity::IdentityIdentifier;
 use ockam::Context;
-use ockam_api::authenticator::direct::types::{AddMember, CreateInvite, OneTimeCode};
+use ockam_api::authenticator::direct::types::{AddMember, CreateToken, OneTimeCode};
 use ockam_api::config::lookup::{ConfigLookup, ProjectAuthority};
 use ockam_core::api::Request;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
@@ -95,7 +95,7 @@ impl Runner {
             .build();
 
         // If an identity identifier is given add it as a member, otherwise
-        // request an invitation code that a future member can use to get a
+        // request an enrollment token that a future member can use to get a
         // credential.
         if let Some(id) = &self.cmd.member {
             debug!(addr = %to, member = %id, attrs = ?self.cmd.attributes, "requesting to add member");
@@ -104,9 +104,9 @@ impl Runner {
             rpc.request(req).await?;
             rpc.is_ok()?;
         } else {
-            debug!(addr = %to, attrs = ?self.cmd.attributes, "requesting invite");
-            let req = Request::post("/invites")
-                .body(CreateInvite::new().with_attributes(self.cmd.attributes()?));
+            debug!(addr = %to, attrs = ?self.cmd.attributes, "requesting token");
+            let req = Request::post("/tokens")
+                .body(CreateToken::new().with_attributes(self.cmd.attributes()?));
             rpc.request(req).await?;
             let res: OneTimeCode = rpc.parse_response()?;
             println!("{}", hex::encode(res.code()))

--- a/implementations/rust/ockam/ockam_core/src/schema.cddl
+++ b/implementations/rust/ockam/ockam_core/src/schema.cddl
@@ -236,6 +236,16 @@ add_member = {
      1: identity_id,
 }
 
+create_token = {
+	?0: 2502742,
+     1: {* text => text } ;; attributes
+}
+
+onetime_code = {
+    ?0: 5112299,
+	 1: bytes    ;; 32 bytes code
+}
+
 ;;; Subscription ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 activate_request = {


### PR DESCRIPTION
- Renamed `CreateInvite` to `CreateToken`
- Renamed `/invitations` endpoint to `/tokens`
- Removed unused field form `GetCredentialRequest`
- Added definitions to schema.cddl