### PR TITLE
fix(elixir): fail if unable to verify identity on credential api setup

### DIFF
--- a/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
+++ b/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
@@ -237,8 +237,8 @@ defmodule Ockam.TypedCBOR do
 
   def to_cbor_term(:term, any), do: any
 
-  def to_cbor_term(schema, _) do
-    raise(Exception, "type mismatch, expected schema #{inspect(schema)}")
+  def to_cbor_term(schema, val) do
+    raise(Exception, "type mismatch, expected schema #{inspect(schema)}, value: #{inspect(val)}")
   end
 
   def to_cbor_fields([], _), do: []


### PR DESCRIPTION
## Current Behavior

Currently if identity cannot validate, the `error: reason` key-value pair is added to the list of authorities, which is invalid.

## Proposed Changes

Make authority identities parsing error fail the worker setup.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
