### PR TITLE
feat(rust): waits until project is ready after okta plugin is enabled

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -122,7 +122,7 @@ async fn default_space<'a>(
             .to_owned()
     };
     config::set_space(&opts.config, &default_space)?;
-    println!("\n{}", default_space.output()?);
+    println!("\n{}\n", default_space.output()?);
     Ok(default_space)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -165,7 +165,7 @@ pub async fn check_project_readiness<'a>(
     config::set_project_id(&opts.config, &project).await?;
 
     if !project.is_ready() {
-        print!("\nProject created. Waiting until it's operative...");
+        print!("Project created. Waiting until it's operative...");
         let cloud_route = &cloud_opts.route();
         loop {
             print!(".");
@@ -177,23 +177,25 @@ pub async fn check_project_readiness<'a>(
             let p = rpc.parse_response::<Project>()?;
             if p.is_ready() {
                 project = p.to_owned();
+                println!();
                 break;
             }
         }
     }
     if !project.is_reachable().await? {
-        print!("\nEstablishing connection (this can take a few minutes)...");
+        print!("Establishing connection (this can take a few minutes)...");
         loop {
             print!(".");
             std::io::stdout().flush()?;
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
             if project.is_reachable().await? {
+                println!();
                 break;
             }
         }
     }
     {
-        print!("\nEstablishing secure channel...");
+        print!("Establishing secure channel...");
         std::io::stdout().flush()?;
         let project_route = project.access_route()?;
         let project_identity = project


### PR DESCRIPTION
The `project addon configure` command now calls the `check_project_readiness` function to check that the project is ready after enabling a plugin, which can take 1-2 minutes to restart the underlying authority node.

I've changed how the `check_project_readiness` outputs the messages to handle newlines properly. The `enroll` output remains unchanged. 

This is the output of the `project addon configure` command:

```bash
➜ ockam project addon configure okta --tenant https://trial-9434859.okta.com/oauth2/default --client-id 0oa2pi8no6Kb04frP697 --attribute email --attribute permission 

Okta addon enabled
Getting things ready for project...
Establishing secure channel...
Okta addon configured successfully
```