### PR TITLE
eagerly get membership credential

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
@@ -103,7 +103,7 @@ impl OneTimeCode {
     }
 
     pub fn code(&self) -> &[u8; 32] {
-        &*self.code
+        &self.code
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter};
 
 use crate::util::ConfigError;
@@ -66,6 +67,18 @@ impl From<std::io::Error> for Error {
 impl From<ockam_multiaddr::Error> for Error {
     fn from(e: ockam_multiaddr::Error) -> Self {
         Error::new(exitcode::SOFTWARE, e.into())
+    }
+}
+
+impl From<minicbor::decode::Error> for Error {
+    fn from(e: minicbor::decode::Error) -> Self {
+        Error::new(exitcode::DATAERR, e.into())
+    }
+}
+
+impl From<minicbor::encode::Error<Infallible>> for Error {
+    fn from(e: minicbor::encode::Error<Infallible>) -> Self {
+        Error::new(exitcode::DATAERR, e.into())
     }
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -65,7 +65,7 @@ impl fmt::Display for Credential<'_> {
         //TODO: write timestamps on human-readable format. Should we add a dependency for this?
         writeln!(f, " Created: {}", u64::from(credential_data.created))?;
         writeln!(f, " Expires: {}", u64::from(credential_data.expires))?;
-        write!(f, " Attrributes: ")?;
+        write!(f, " Attributes: ")?;
         f.debug_map()
             .entries(
                 credential_data

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity.rs
@@ -23,7 +23,7 @@ impl<V: IdentityVault> Identity<V> {
         *self.credential.write().await = credential;
     }
 
-    pub async fn credential(&self) -> Option<Credential<'_>> {
+    pub async fn credential<'a>(&self) -> Option<Credential<'a>> {
         self.credential.read().await.clone()
     }
 


### PR DESCRIPTION
If a *background* node is created with project information and an enrolment token an immediate attempt to get a membership credential is made. If successful, the credential information is printed to stdout, otherwise an error is reported and the node and its data is removed.

On top of https://github.com/build-trust/ockam/pull/3806.