### PR TITLE
chore(rust): add comment about always starting echoer service

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -356,6 +356,8 @@ impl NodeManager {
             }
         }
 
+        // Always start the echoer service as ockam_api::Medic assumes it will be
+        // started unconditionally on every node. It's used for liveness checks.
         s.start_echoer_service_impl(ctx, DefaultAddress::ECHO_SERVICE.into())
             .await?;
 


### PR DESCRIPTION
## Current Behavior

When an `ockam_api::NodeManagerWorker` is initialised, the code that starts the `echoer` service is apart from the code that starts the other default services.

This means that the `echoer` service does not mirror what the other services do. For example, if `ockam node create n1 --skip-defaults` is run then the `echoer` service is started and the other default services are not.

In my opinion, the `echoer` serivce should behave like the other default services. 

## Proposed Changes

Move the code for starting the `echoer` service to be with the code that starts the other default services. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

Thanks! :smile: