### PR TITLE
fix(rust): unused manifest key warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,3 @@ overflow-checks = false
 incremental = false
 codegen-units = 1
 inherits = "test"
-
-[ockam_command.metadata.cross.target.aarch64-unknown-linux-musl]
-dockerfile = "./tools/cross/Cross.Dockerfile.aarch64"
-
-[ockam_command.metadata.cross.target.armv7-unknown-linux-musleabihf]
-dockerfile = "./tools/cross/Cross.Dockerfile.armv7"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -26,6 +26,12 @@ rust-version = "1.58.1"
 publish = true
 version = "0.77.0"
 
+[package.metadata.cross.target.aarch64-unknown-linux-musl]
+dockerfile = "../../../../tools/cross/Cross.Dockerfile.aarch64"
+
+[package.metadata.cross.target.armv7-unknown-linux-musleabihf]
+dockerfile = "../../../../tools/cross/Cross.Dockerfile.armv7"
+
 [[bin]]
 # You may be wondering "Why are the tests and docs disabled?". The long and
 # short of it is: To avoid certain bugs in `rustdoc`, `cargo`, and other tools


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Closes #3801.

Fix `warning: unused manifest key: ockam_command` in `Cargo.toml`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
