### PR TITLE
feat(elixir): add explicit api liveness metric

### DIFF
--- a/implementations/elixir/ockam/ockam_metrics/lib/application.ex
+++ b/implementations/elixir/ockam/ockam_metrics/lib/application.ex
@@ -40,6 +40,7 @@ defmodule Ockam.Metrics.Application do
   def get_poller_measurements() do
     ockam_measurements = [
       {Ockam.Metrics.TelemetryPoller, :dispatch_worker_count, []},
+      {Ockam.Metrics.TelemetryPoller, :dispatch_api_worker_count, []},
       {Ockam.Metrics.TelemetryPoller, :dispatch_secure_channels_count, []},
       {Ockam.Metrics.TelemetryPoller, :dispatch_tcp_connections, []}
     ]

--- a/implementations/elixir/ockam/ockam_metrics/lib/telemetry_poller.ex
+++ b/implementations/elixir/ockam/ockam_metrics/lib/telemetry_poller.ex
@@ -34,6 +34,23 @@ defmodule Ockam.Metrics.TelemetryPoller do
       end
     end
 
+    @api_worker_address "api"
+
+    def dispatch_api_worker_count() do
+      ## Report API worker livensess
+
+      if application_started?(:ockam) do
+        api_workers =
+          Enum.filter(Ockam.Node.list_workers(), fn {address, _pid, _module} ->
+            address == @api_worker_address
+          end)
+
+        Telemetry.emit_event([:workers, :api],
+          measurements: %{count: Enum.count(api_workers)}
+        )
+      end
+    end
+
     @channel_data_mod Ockam.Identity.SecureChannel.Data
     @channel_handshake_mod Ockam.Identity.SecureChannel.Handshake
 

--- a/implementations/elixir/ockam/ockam_metrics/lib/telemetry_prometheus.ex
+++ b/implementations/elixir/ockam/ockam_metrics/lib/telemetry_prometheus.ex
@@ -136,6 +136,7 @@ defmodule Ockam.Metrics.Prometheus do
 
     [
       last_value("ockam.workers.type.count", tags: [:type]),
+      last_value("ockam.workers.api.count"),
       last_value("ockam.tcp.connections.count", tags: [:port]),
       last_value("vm.total_run_queue_lengths.total"),
       last_value("vm.total_run_queue_lengths.io"),


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently we expose count for all live workers, but when they die, we continue emitting a last value metric for them, which .

## Proposed Changes

In order to monitor API worker liveness we can explicitly look for a worker with an `api` address and report whether it's up or not.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
