### PR TITLE
add null to abac expressions

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/env.rs
+++ b/implementations/rust/ockam/ockam_abac/src/env.rs
@@ -1,64 +1,74 @@
-use crate::error::{EvalError, MergeError};
+use crate::error::MergeError;
 use crate::expr::Expr;
 use ockam_core::compat::collections::BTreeMap;
-use ockam_core::compat::string::{String, ToString};
+use ockam_core::compat::string::String;
 
-#[derive(Debug, Clone, Default)]
-pub struct Env(BTreeMap<String, Expr>);
+#[derive(Debug, Clone)]
+pub struct Env {
+    map: BTreeMap<String, Expr>,
+    null: Expr,
+}
+
+impl Default for Env {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Env {
     pub fn new() -> Self {
-        Env(BTreeMap::new())
+        Env {
+            map: BTreeMap::new(),
+            null: Expr::Null,
+        }
     }
 
-    pub fn get(&self, k: &str) -> Result<&Expr, EvalError> {
-        self.0
-            .get(k)
-            .ok_or_else(|| EvalError::Unbound(k.to_string()))
+    pub fn get(&self, k: &str) -> &Expr {
+        self.map.get(k).unwrap_or(&self.null)
     }
 
     pub fn contains(&self, k: &str) -> bool {
-        self.0.contains_key(k)
+        self.map.contains_key(k)
     }
 
     pub fn put<K: Into<String>, E: Into<Expr>>(&mut self, k: K, v: E) -> &mut Self {
-        self.0.insert(k.into(), v.into());
+        self.map.insert(k.into(), v.into());
         self
     }
 
     pub fn del(&mut self, k: &str) {
-        self.0.remove(k);
+        self.map.remove(k);
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (&str, &Expr)> {
-        self.0.iter().map(|(k, v)| (k.as_str(), v))
+        self.map.iter().map(|(k, v)| (k.as_str(), v))
     }
 
     pub fn clear(&mut self) {
-        self.0.clear()
+        self.map.clear()
     }
 
     pub fn merge(&mut self, other: Env) -> Result<(), MergeError> {
-        for k in other.0.keys() {
-            if self.0.contains_key(k) {
+        for k in other.map.keys() {
+            if self.map.contains_key(k) {
                 return Err(MergeError::BindingExists(k.clone()));
             }
         }
-        for (k, v) in other.0.into_iter() {
-            self.0.insert(k, v);
+        for (k, v) in other.map.into_iter() {
+            self.map.insert(k, v);
         }
         Ok(())
     }
 
     pub fn merge_right(&mut self, other: Env) {
-        for (k, v) in other.0.into_iter() {
-            self.0.insert(k, v);
+        for (k, v) in other.map.into_iter() {
+            self.map.insert(k, v);
         }
     }
 
     pub fn merge_left(&mut self, other: Env) {
-        for (k, v) in other.0.into_iter() {
-            self.0.entry(k).or_insert(v);
+        for (k, v) in other.map.into_iter() {
+            self.map.entry(k).or_insert(v);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_abac/src/error.rs
+++ b/implementations/rust/ockam/ockam_abac/src/error.rs
@@ -16,7 +16,6 @@ pub enum ParseError {
 
 #[derive(Debug)]
 pub enum EvalError {
-    Unbound(String),
     Unknown(String),
     InvalidType(Expr, &'static str),
     Malformed(String),
@@ -36,10 +35,6 @@ impl ParseError {
 impl EvalError {
     pub fn malformed<S: Into<String>>(s: S) -> Self {
         EvalError::Malformed(s.into())
-    }
-
-    pub fn is_unbound(&self) -> bool {
-        matches!(self, EvalError::Unbound(_))
     }
 }
 
@@ -82,7 +77,6 @@ impl fmt::Display for ParseError {
 impl fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            EvalError::Unbound(id) => write!(f, "unbound identifier: {id}"),
             EvalError::Unknown(id) => write!(f, "unknown operator: {id}"),
             EvalError::InvalidType(e, m) => write!(f, "invalid type of expression {e}: {m}"),
             EvalError::Malformed(m) => write!(f, "malformed expression: {m}"),

--- a/implementations/rust/ockam/ockam_abac/src/eval.rs
+++ b/implementations/rust/ockam/ockam_abac/src/eval.rs
@@ -34,7 +34,7 @@ pub fn eval(expr: &Expr, env: &Env) -> Result<Expr, EvalError> {
 
     while let Some(x) = ctrl.pop() {
         match x {
-            Op::Eval(Expr::Ident(id)) => ctrl.push(Op::Eval(env.get(id)?)),
+            Op::Eval(Expr::Ident(id)) => ctrl.push(Op::Eval(env.get(id))),
             Op::Eval(Expr::List(xs))  => match &xs[..] {
                 []                    => args.push(unit()),
                 [Expr::Ident(id), ..] => {

--- a/implementations/rust/ockam/ockam_abac/src/parser.rs
+++ b/implementations/rust/ockam/ockam_abac/src/parser.rs
@@ -93,6 +93,10 @@ pub fn parse(s: &str) -> Result<Option<Expr>, ParseError> {
                     ctrl.push(Op::Value(Expr::Bool(false)));
                     ctrl.push(Op::Next)
                 }
+                Some(Token::Keyword("null")) => {
+                    ctrl.push(Op::Value(Expr::Null));
+                    ctrl.push(Op::Next)
+                }
                 Some(Token::Id(v)) => {
                     ctrl.push(Op::Value(Expr::Ident(v.to_string())));
                     ctrl.push(Op::Next)


### PR DESCRIPTION
Unbound identifiers default to null instead of causing an unbound error during evaluation.