### PR TITLE
read release shasum file content as an array

### DIFF
--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -251,7 +251,7 @@ if [[ $IS_DRAFT_RELEASE == true ]]; then
 
   # TODO Ensure that SHA are cosign verified
   while read -r line; do
-    file=("$line")
+    IFS=" " read -r -a file <<<"$line"
     if [[ ${file[1]} == *".so"* || ${file[1]} == *".sig"* ]]; then
       continue
     fi


### PR DESCRIPTION
We were reading `release` shasum file as a string instead of an array https://github.com/build-trust/ockam/blob/d5540f07187477a53a249fb9c6f0eb26426eb0e7/tools/scripts/release/release.sh#L254 This PR ensures we accurately output the SHA content as `binary_name`:`sha` so that it can be parsed by our workflow.
Failing CI https://github.com/build-trust/ockam/actions/runs/3423272909/jobs/5701671147#step:5:7