### PR TITLE
refactor(rust): 'tcp connection delete' command to  use 'rpc' abstraction 

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,14 +1,8 @@
+use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::{node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
-use ockam::{Context, Route};
-use ockam_api::nodes::NODEMANAGER_ADDR;
-use ockam_core::api::{Response, Status};
-
-use crate::util::extract_address_value;
-use crate::{
-    node::NodeOpts,
-    util::{api, connect_to, exitcode},
-    CommandGlobalOpts,
-};
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
 
 #[derive(Clone, Debug, Args)]
 #[command(arg_required_else_help = true)]
@@ -23,46 +17,21 @@ pub struct DeleteCommand {
     #[arg(long)]
     pub force: bool,
 }
-
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        let cfg = &options.config;
-        let node =
-            extract_address_value(&self.node_opts.api_node).unwrap_or_else(|_| "".to_string());
-        let port = cfg.get_node_port(&node).unwrap();
-        connect_to(port, self, delete_connection);
+        node_rpc(run_impl, (options, self))
     }
 }
-
-pub async fn delete_connection(
-    ctx: Context,
-    cmd: DeleteCommand,
-    mut base_route: Route,
-) -> anyhow::Result<()> {
-    let resp: Vec<u8> = match ctx
-        .send_and_receive(
-            base_route.modify().append(NODEMANAGER_ADDR),
-            api::delete_tcp_connection(&cmd)?,
-        )
-        .await
-    {
-        Ok(sr_msg) => sr_msg,
-        Err(e) => {
-            eprintln!("Wasn't able to send or receive `Message`: {}", e);
-            std::process::exit(exitcode::IOERR);
-        }
-    };
-    let r: Response = api::parse_response(&resp)?;
-
-    match r.status() {
-        Some(Status::Ok) => println!("Tcp connection `{}` successfully delete", cmd.id),
-        _ => {
-            eprintln!("Failed to delete tcp connection");
-            if !cmd.force {
-                eprintln!("You may have to provide --force to delete the API transport");
-                std::process::exit(exitcode::UNAVAILABLE);
-            }
-        }
-    }
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let req = Request::delete("/node/tcp/connection")
+        .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force));
+    rpc.request(req).await?;
+    rpc.is_ok()?;
+    println!("Tcp connection `{}` successfully deleted", cmd.id);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -52,18 +52,6 @@ pub(crate) fn create_tcp_connection(
     Request::post("/node/tcp/connection").body(payload)
 }
 
-/// Construct a request to delete node tcp connection
-pub(crate) fn delete_tcp_connection(
-    cmd: &crate::tcp::connection::DeleteCommand,
-) -> Result<Vec<u8>> {
-    let mut buf = vec![];
-    Request::delete("/node/tcp/connection")
-        .body(models::transport::DeleteTransport::new(&cmd.id, cmd.force))
-        .encode(&mut buf)?;
-
-    Ok(buf)
-}
-
 /// Construct a request to print Identity Id
 pub(crate) fn short_identity() -> RequestBuilder<'static, ()> {
     Request::post("/node/identity/actions/show/short")
@@ -321,12 +309,6 @@ pub(crate) mod project {
 }
 
 ////////////// !== parsers
-
-/// Parse the base response without the inner payload
-pub(crate) fn parse_response(resp: &[u8]) -> Result<Response> {
-    let mut dec = Decoder::new(resp);
-    Ok(dec.decode::<Response>()?)
-}
 
 pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Result<Response> {
     let mut dec = Decoder::new(resp);

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -318,6 +318,20 @@ teardown() {
   assert_output --partial "127.0.0.1:5000"
 }
 
+@test "create a tcp connection and then delete it " {
+  run $OCKAM node create n1
+  run $OCKAM tcp-connection create --from n1 --to 127.0.0.1:5000 --output json
+  assert_success
+  id=$($OCKAM tcp-connection list --node n1 | grep -o "[0-9a-f]\{32\}")
+  run $OCKAM tcp-connection delete --node n1 $id
+  assert_success
+  assert_output "Tcp connection \`$id\` successfully deleted"
+  run $OCKAM tcp-connection list --node n1
+  assert_success
+  refute_output --partial "127.0.0.1:5000"
+
+}
+
 # the below tests will only succeed if already enrolled with `ockam enroll`
 
 @test "send a message to a project node from command embedded node" {


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Closes https://github.com/build-trust/ockam/issues/3594

## Current Behavior

'tcp connection delete' command currently uses the 'connect_to' function, and calls std::process::exit , which needs to be changed as mentioned in #3594 


<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Refactored the tcp connection delete command by using Rpc utils, as proposed by #3594 

1. Replaced connect_to by node_rpc abstraction.
2. Added a test to create a node and then delete it in command.bats, to test the functionality of refactored delete command.
3 Removed now unused functions connect_to , parse_response and delete_tcp_connection.



## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
