### PR TITLE
Stricter ABAC lang

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/env.rs
+++ b/implementations/rust/ockam/ockam_abac/src/env.rs
@@ -1,74 +1,64 @@
-use crate::error::MergeError;
+use crate::error::{EvalError, MergeError};
 use crate::expr::Expr;
 use ockam_core::compat::collections::BTreeMap;
-use ockam_core::compat::string::String;
+use ockam_core::compat::string::{String, ToString};
 
-#[derive(Debug, Clone)]
-pub struct Env {
-    map: BTreeMap<String, Expr>,
-    null: Expr,
-}
-
-impl Default for Env {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+#[derive(Debug, Clone, Default)]
+pub struct Env(BTreeMap<String, Expr>);
 
 impl Env {
     pub fn new() -> Self {
-        Env {
-            map: BTreeMap::new(),
-            null: Expr::Null,
-        }
+        Env(BTreeMap::new())
     }
 
-    pub fn get(&self, k: &str) -> &Expr {
-        self.map.get(k).unwrap_or(&self.null)
+    pub fn get(&self, k: &str) -> Result<&Expr, EvalError> {
+        self.0
+            .get(k)
+            .ok_or_else(|| EvalError::Unbound(k.to_string()))
     }
 
     pub fn contains(&self, k: &str) -> bool {
-        self.map.contains_key(k)
+        self.0.contains_key(k)
     }
 
     pub fn put<K: Into<String>, E: Into<Expr>>(&mut self, k: K, v: E) -> &mut Self {
-        self.map.insert(k.into(), v.into());
+        self.0.insert(k.into(), v.into());
         self
     }
 
     pub fn del(&mut self, k: &str) {
-        self.map.remove(k);
+        self.0.remove(k);
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (&str, &Expr)> {
-        self.map.iter().map(|(k, v)| (k.as_str(), v))
+        self.0.iter().map(|(k, v)| (k.as_str(), v))
     }
 
     pub fn clear(&mut self) {
-        self.map.clear()
+        self.0.clear()
     }
 
     pub fn merge(&mut self, other: Env) -> Result<(), MergeError> {
-        for k in other.map.keys() {
-            if self.map.contains_key(k) {
+        for k in other.0.keys() {
+            if self.0.contains_key(k) {
                 return Err(MergeError::BindingExists(k.clone()));
             }
         }
-        for (k, v) in other.map.into_iter() {
-            self.map.insert(k, v);
+        for (k, v) in other.0.into_iter() {
+            self.0.insert(k, v);
         }
         Ok(())
     }
 
     pub fn merge_right(&mut self, other: Env) {
-        for (k, v) in other.map.into_iter() {
-            self.map.insert(k, v);
+        for (k, v) in other.0.into_iter() {
+            self.0.insert(k, v);
         }
     }
 
     pub fn merge_left(&mut self, other: Env) {
-        for (k, v) in other.map.into_iter() {
-            self.map.entry(k).or_insert(v);
+        for (k, v) in other.0.into_iter() {
+            self.0.entry(k).or_insert(v);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_abac/src/error.rs
+++ b/implementations/rust/ockam/ockam_abac/src/error.rs
@@ -12,6 +12,7 @@ pub enum ParseError {
     Float(ParseFloatError),
     Other(wast::Error),
     Message(String),
+    TypeMismatch(Expr, Expr),
 }
 
 #[derive(Debug)]
@@ -19,6 +20,7 @@ pub enum EvalError {
     Unbound(String),
     Unknown(String),
     InvalidType(Expr, &'static str),
+    TypeMismatch(Expr, Expr),
     Malformed(String),
 }
 
@@ -75,6 +77,7 @@ impl fmt::Display for ParseError {
             ParseError::Int(e) => write!(f, "{e}"),
             ParseError::Utf8(e) => write!(f, "{e}"),
             ParseError::Message(m) => f.write_str(m),
+            ParseError::TypeMismatch(a, b) => write!(f, "{a} and {b} are not of the same type"),
         }
     }
 }
@@ -86,6 +89,7 @@ impl fmt::Display for EvalError {
             EvalError::Unknown(id) => write!(f, "unknown operator: {id}"),
             EvalError::InvalidType(e, m) => write!(f, "invalid type of expression {e}: {m}"),
             EvalError::Malformed(m) => write!(f, "malformed expression: {m}"),
+            EvalError::TypeMismatch(a, b) => write!(f, "{a} and {b} are not of the same type"),
         }
     }
 }
@@ -99,6 +103,7 @@ impl std::error::Error for ParseError {
             ParseError::Int(e) => Some(e),
             ParseError::Utf8(e) => Some(e),
             ParseError::Message(_) => None,
+            ParseError::TypeMismatch(..) => None,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_abac/src/error.rs
+++ b/implementations/rust/ockam/ockam_abac/src/error.rs
@@ -16,6 +16,7 @@ pub enum ParseError {
 
 #[derive(Debug)]
 pub enum EvalError {
+    Unbound(String),
     Unknown(String),
     InvalidType(Expr, &'static str),
     Malformed(String),
@@ -35,6 +36,10 @@ impl ParseError {
 impl EvalError {
     pub fn malformed<S: Into<String>>(s: S) -> Self {
         EvalError::Malformed(s.into())
+    }
+
+    pub fn is_unbound(&self) -> bool {
+        matches!(self, EvalError::Unbound(_))
     }
 }
 
@@ -77,6 +82,7 @@ impl fmt::Display for ParseError {
 impl fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            EvalError::Unbound(id) => write!(f, "unbound identifier: {id}"),
             EvalError::Unknown(id) => write!(f, "unknown operator: {id}"),
             EvalError::InvalidType(e, m) => write!(f, "invalid type of expression {e}: {m}"),
             EvalError::Malformed(m) => write!(f, "malformed expression: {m}"),

--- a/implementations/rust/ockam/ockam_abac/src/eval.rs
+++ b/implementations/rust/ockam/ockam_abac/src/eval.rs
@@ -34,7 +34,7 @@ pub fn eval(expr: &Expr, env: &Env) -> Result<Expr, EvalError> {
 
     while let Some(x) = ctrl.pop() {
         match x {
-            Op::Eval(Expr::Ident(id)) => ctrl.push(Op::Eval(env.get(id))),
+            Op::Eval(Expr::Ident(id)) => ctrl.push(Op::Eval(env.get(id)?)),
             Op::Eval(Expr::List(xs))  => match &xs[..] {
                 []                    => args.push(unit()),
                 [Expr::Ident(id), ..] => {

--- a/implementations/rust/ockam/ockam_abac/src/expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/expr.rs
@@ -4,6 +4,9 @@ use minicbor::{Decode, Encode};
 use ockam_core::compat::string::String;
 use ockam_core::compat::vec::{vec, Vec};
 
+#[cfg(test)]
+use quickcheck::{Arbitrary, Gen};
+
 use crate::ParseError;
 
 #[derive(Debug, Clone, Encode, Decode)]
@@ -73,7 +76,8 @@ impl PartialEq for Expr {
                         ctrl.push((a, b))
                     }
                 }
-                _ => return false
+                (Expr::Null, Expr::Null) => {}
+                _                        => return false
             }
         }
 
@@ -119,7 +123,8 @@ impl PartialOrd for Expr {
                         return result
                     }
                 }
-                _ => return None
+                (Expr::Null, Expr::Null) => { result = Some(Ordering::Equal) }
+                _                        => return None
             }
             if Some(Ordering::Equal) != result {
                 return result
@@ -339,6 +344,36 @@ impl FromStr for Expr {
 }
 
 #[cfg(test)]
+impl Arbitrary for Expr {
+    fn arbitrary(g: &mut Gen) -> Self {
+        fn gen_string() -> String {
+            use rand::distributions::{Alphanumeric, DistString};
+            let mut s = Alphanumeric.sample_string(&mut rand::thread_rng(), 23);
+            s.retain(|c| !['(', ')', '[', ']'].contains(&c));
+            s.insert(0, 'a');
+            s
+        }
+        match g.choose(&[1, 2, 3, 4, 5, 6, 7, 8]).unwrap() {
+            1 => Expr::Str(gen_string()),
+            2 => Expr::Int(i64::arbitrary(g)),
+            3 => Expr::Float({
+                let x = f64::arbitrary(g);
+                if x.is_nan() {
+                    1.0
+                } else {
+                    x
+                }
+            }),
+            4 => Expr::Bool(bool::arbitrary(g)),
+            5 => Expr::Ident(gen_string()),
+            6 => Expr::Seq(Arbitrary::arbitrary(g)),
+            7 => Expr::List(Arbitrary::arbitrary(g)),
+            _ => Expr::Null,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::Expr;
     use crate::{eval, parser::parse, Env};
@@ -346,93 +381,12 @@ mod tests {
     use ockam_core::compat::string::ToString;
     use quickcheck::{Arbitrary, Gen, QuickCheck};
 
-    #[derive(Debug, Clone)]
-    struct Xpr {
-        contains_null: bool,
-        expr: Expr,
-    }
-
-    impl Arbitrary for Xpr {
-        fn arbitrary(g: &mut Gen) -> Self {
-            fn gen_string() -> String {
-                use rand::distributions::{Alphanumeric, DistString};
-                let mut s = Alphanumeric.sample_string(&mut rand::thread_rng(), 23);
-                s.retain(|c| !['(', ')', '[', ']'].contains(&c));
-                s.insert(0, 'a');
-                s
-            }
-            match g.choose(&[1, 2, 3, 4, 5, 6, 7, 8]).unwrap() {
-                1 => Xpr {
-                    contains_null: false,
-                    expr: Expr::Str(gen_string()),
-                },
-                2 => Xpr {
-                    contains_null: false,
-                    expr: Expr::Int(i64::arbitrary(g)),
-                },
-                3 => Xpr {
-                    contains_null: false,
-                    expr: Expr::Float({
-                        let x = f64::arbitrary(g);
-                        if x.is_nan() {
-                            1.0
-                        } else {
-                            x
-                        }
-                    }),
-                },
-                4 => Xpr {
-                    contains_null: false,
-                    expr: Expr::Bool(bool::arbitrary(g)),
-                },
-                5 => Xpr {
-                    contains_null: false,
-                    expr: Expr::Ident(gen_string()),
-                },
-                6 => {
-                    let mut b = false;
-                    let vec: Vec<Xpr> = Arbitrary::arbitrary(g);
-                    let mut seq: Vec<Expr> = Vec::new();
-                    for x in vec {
-                        b |= x.contains_null;
-                        seq.push(x.expr);
-                    }
-                    Xpr {
-                        contains_null: b,
-                        expr: Expr::Seq(seq),
-                    }
-                }
-                7 => {
-                    let mut b = false;
-                    let vec: Vec<Xpr> = Arbitrary::arbitrary(g);
-                    let mut seq: Vec<Expr> = Vec::new();
-                    for x in vec {
-                        b |= x.contains_null;
-                        seq.push(x.expr);
-                    }
-                    Xpr {
-                        contains_null: b,
-                        expr: Expr::List(seq),
-                    }
-                }
-                _ => Xpr {
-                    contains_null: true,
-                    expr: Expr::Null,
-                },
-            }
-        }
-    }
-
     #[test]
     fn write_read() {
-        fn property(e: Xpr) -> bool {
-            let s = e.expr.to_string();
+        fn property(e: Expr) -> bool {
+            let s = e.to_string();
             let x = parse(&s).unwrap();
-            if e.contains_null {
-                Some(e.expr) != x
-            } else {
-                Some(e.expr) == x
-            }
+            Some(e) == x
         }
         QuickCheck::new()
             .gen(Gen::new(4))
@@ -443,11 +397,11 @@ mod tests {
 
     #[test]
     fn symm_eq() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr == b.expr {
-                assert_eq!(b.expr, a.expr);
-                assert_eq!(a.expr.partial_cmp(&b.expr), Some(Ordering::Equal));
-                assert_eq!(b.expr.partial_cmp(&a.expr), Some(Ordering::Equal))
+        fn property(a: Expr, b: Expr) {
+            if a == b {
+                assert_eq!(b, a);
+                assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
+                assert_eq!(b.partial_cmp(&a), Some(Ordering::Equal))
             }
         }
         QuickCheck::new()
@@ -459,9 +413,9 @@ mod tests {
 
     #[test]
     fn trans_eq() {
-        fn property(a: Xpr, b: Xpr, c: Xpr) {
-            if a.expr == b.expr && b.expr == c.expr {
-                assert_eq!(a.expr, c.expr)
+        fn property(a: Expr, b: Expr, c: Expr) {
+            if a == b && b == c {
+                assert_eq!(a, c)
             }
         }
         QuickCheck::new()
@@ -473,12 +427,12 @@ mod tests {
 
     #[test]
     fn not_eq() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr != b.expr {
-                assert!(!(a.expr == b.expr))
+        fn property(a: Expr, b: Expr) {
+            if a != b {
+                assert!(!(a == b))
             }
-            if !(a.expr == b.expr) {
-                assert!(a.expr != b.expr)
+            if !(a == b) {
+                assert!(a != b)
             }
         }
         QuickCheck::new()
@@ -490,12 +444,12 @@ mod tests {
 
     #[test]
     fn lt() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr.partial_cmp(&b.expr) == Some(Ordering::Less) {
-                assert!(a.expr < b.expr)
+        fn property(a: Expr, b: Expr) {
+            if a.partial_cmp(&b) == Some(Ordering::Less) {
+                assert!(a < b)
             }
-            if a.expr < b.expr {
-                assert_eq!(a.expr.partial_cmp(&b.expr), Some(Ordering::Less))
+            if a < b {
+                assert_eq!(a.partial_cmp(&b), Some(Ordering::Less))
             }
         }
         QuickCheck::new()
@@ -507,12 +461,12 @@ mod tests {
 
     #[test]
     fn lt_eq() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr <= b.expr {
-                assert!(a.expr < b.expr || a.expr == b.expr)
+        fn property(a: Expr, b: Expr) {
+            if a <= b {
+                assert!(a < b || a == b)
             }
-            if a.expr < b.expr || a.expr == b.expr {
-                assert!(a.expr <= b.expr)
+            if a < b || a == b {
+                assert!(a <= b)
             }
         }
         QuickCheck::new()
@@ -524,12 +478,12 @@ mod tests {
 
     #[test]
     fn gt() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr.partial_cmp(&b.expr) == Some(Ordering::Greater) {
-                assert!(a.expr > b.expr)
+        fn property(a: Expr, b: Expr) {
+            if a.partial_cmp(&b) == Some(Ordering::Greater) {
+                assert!(a > b)
             }
-            if a.expr > b.expr {
-                assert_eq!(a.expr.partial_cmp(&b.expr), Some(Ordering::Greater))
+            if a > b {
+                assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater))
             }
         }
         QuickCheck::new()
@@ -541,12 +495,12 @@ mod tests {
 
     #[test]
     fn gt_eq() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr >= b.expr {
-                assert!(a.expr > b.expr || a.expr == b.expr)
+        fn property(a: Expr, b: Expr) {
+            if a >= b {
+                assert!(a > b || a == b)
             }
-            if a.expr > b.expr || a.expr == b.expr {
-                assert!(a.expr >= b.expr)
+            if a > b || a == b {
+                assert!(a >= b)
             }
         }
         QuickCheck::new()
@@ -558,9 +512,9 @@ mod tests {
 
     #[test]
     fn trans_lt() {
-        fn property(a: Xpr, b: Xpr, c: Xpr) {
-            if a.expr < b.expr && b.expr < c.expr {
-                assert!(a.expr < c.expr)
+        fn property(a: Expr, b: Expr, c: Expr) {
+            if a < b && b < c {
+                assert!(a < c)
             }
         }
         QuickCheck::new()
@@ -572,9 +526,9 @@ mod tests {
 
     #[test]
     fn trans_gt() {
-        fn property(a: Xpr, b: Xpr, c: Xpr) {
-            if a.expr > b.expr && b.expr > c.expr {
-                assert!(a.expr > c.expr)
+        fn property(a: Expr, b: Expr, c: Expr) {
+            if a > b && b > c {
+                assert!(a > c)
             }
         }
         QuickCheck::new()
@@ -586,12 +540,12 @@ mod tests {
 
     #[test]
     fn dual() {
-        fn property(a: Xpr, b: Xpr) {
-            if a.expr > b.expr {
-                assert!(b.expr < a.expr)
+        fn property(a: Expr, b: Expr) {
+            if a > b {
+                assert!(b < a)
             }
-            if b.expr < a.expr {
-                assert!(a.expr > b.expr)
+            if b < a {
+                assert!(a > b)
             }
         }
         QuickCheck::new()

--- a/implementations/rust/ockam/ockam_abac/src/expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/expr.rs
@@ -18,8 +18,7 @@ pub enum Expr {
     #[n(4)] Bool  (#[n(0)] bool),
     #[n(5)] Ident (#[n(0)] String),
     #[n(6)] Seq   (#[n(0)] Vec<Expr>),
-    #[n(7)] List  (#[n(0)] Vec<Expr>),
-    #[n(8)] Null
+    #[n(7)] List  (#[n(0)] Vec<Expr>)
 }
 
 #[derive(Debug, Clone, Encode, Decode)]
@@ -29,8 +28,7 @@ pub enum Val {
     #[n(2)] Int   (#[n(0)] i64),
     #[n(3)] Float (#[n(0)] f64),
     #[n(4)] Bool  (#[n(0)] bool),
-    #[n(5)] Seq   (#[n(0)] Vec<Val>),
-    #[n(6)] Null
+    #[n(5)] Seq   (#[n(0)] Vec<Val>)
 }
 
 impl From<Val> for Expr {
@@ -41,7 +39,6 @@ impl From<Val> for Expr {
             Val::Float(f) => Expr::Float(f),
             Val::Bool(b) => Expr::Bool(b),
             Val::Seq(s) => Expr::Seq(s.into_iter().map(Expr::from).collect()),
-            Val::Null => Expr::Null,
         }
     }
 }
@@ -76,8 +73,7 @@ impl PartialEq for Expr {
                         ctrl.push((a, b))
                     }
                 }
-                (Expr::Null, Expr::Null) => {}
-                _                        => return false
+                _ => return false
             }
         }
 
@@ -123,8 +119,7 @@ impl PartialOrd for Expr {
                         return result
                     }
                 }
-                (Expr::Null, Expr::Null) => { result = Some(Ordering::Equal) }
-                _                        => return None
+                _ => return None
             }
             if Some(Ordering::Equal) != result {
                 return result
@@ -265,7 +260,6 @@ impl fmt::Display for Expr {
             match e {
                 Op::Show(Expr::Str(s)) => write!(f, "{s:?}")?,
                 Op::Show(Expr::Int(i)) => write!(f, "{i}")?,
-                Op::Show(Expr::Null)   => f.write_str("null")?,
                 Op::Show(Expr::Float(x)) => {
                     if x.is_nan() {
                         f.write_str("nan")?
@@ -353,7 +347,7 @@ impl Arbitrary for Expr {
             s.insert(0, 'a');
             s
         }
-        match g.choose(&[1, 2, 3, 4, 5, 6, 7, 8]).unwrap() {
+        match g.choose(&[1, 2, 3, 4, 5, 6, 7]).unwrap() {
             1 => Expr::Str(gen_string()),
             2 => Expr::Int(i64::arbitrary(g)),
             3 => Expr::Float({
@@ -367,8 +361,7 @@ impl Arbitrary for Expr {
             4 => Expr::Bool(bool::arbitrary(g)),
             5 => Expr::Ident(gen_string()),
             6 => Expr::Seq(Arbitrary::arbitrary(g)),
-            7 => Expr::List(Arbitrary::arbitrary(g)),
-            _ => Expr::Null,
+            _ => Expr::List(Arbitrary::arbitrary(g)),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_abac/src/parser.rs
+++ b/implementations/rust/ockam/ockam_abac/src/parser.rs
@@ -1,5 +1,5 @@
-use crate::error::ParseError;
 use crate::expr::Expr;
+use crate::{error::ParseError, EvalError};
 use core::str;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::format;
@@ -136,6 +136,11 @@ pub fn parse(s: &str) -> Result<Option<Expr>, ParseError> {
                     }
                 }
                 v.reverse();
+                for (x, y) in v.iter().zip(v.iter().skip(1)) {
+                    if let Err(EvalError::TypeMismatch(x, y)) = x.equals(y) {
+                        return Err(ParseError::TypeMismatch(x, y))
+                    }
+                }
                 ctrl.push(Op::Value(Expr::Seq(v)));
                 ctrl.push(Op::Next)
             }

--- a/implementations/rust/ockam/ockam_abac/src/parser.rs
+++ b/implementations/rust/ockam/ockam_abac/src/parser.rs
@@ -93,10 +93,6 @@ pub fn parse(s: &str) -> Result<Option<Expr>, ParseError> {
                     ctrl.push(Op::Value(Expr::Bool(false)));
                     ctrl.push(Op::Next)
                 }
-                Some(Token::Keyword("null")) => {
-                    ctrl.push(Op::Value(Expr::Null));
-                    ctrl.push(Op::Next)
-                }
                 Some(Token::Id(v)) => {
                     ctrl.push(Op::Value(Expr::Ident(v.to_string())));
                     ctrl.push(Op::Next)


### PR DESCRIPTION
Some proposals to tweak ABAC processing:

- Reverts the addition of `null` and brings back `EvalError::unbound`.
- Returns an error when comparing values of different types instead of evaluating to `false`.
- Requires sequences to be homogeneous.