### PR TITLE
fix(rust): restart node's default services if create started them

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/config.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/config.rs
@@ -174,6 +174,8 @@ pub struct NodeStateConfig {
     pub identity: Option<Vec<u8>>,
     /// Identity was overridden
     pub identity_was_overridden: bool,
+    /// skip_defaults specified on node creation
+    pub skip_defaults_used: bool,
 }
 
 impl ConfigValues for NodeStateConfig {

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -183,9 +183,14 @@ async fn run_impl(
         }
     }
 
+    // Persist skip_defaults usage
+    let node_config = cfg.node(&cmd.node_name)?;
+    let state = node_config.state();
+    state.write().skip_defaults_used = cmd.skip_defaults;
+    state.persist_config_updates()?;
+
     // Run init and startup commands
     if let Some(config_path) = &cmd.config {
-        let node_config = cfg.node(&cmd.node_name)?;
         let commands = CommandsRunner::new(config_path.clone())?;
         node_config.commands().set(commands.commands)?;
         CommandsRunner::run_node_init(config_path).context("Failed to run init commands")?;

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -56,7 +56,9 @@ async fn run_impl(
     }
 
     // Restart node
-    restart_background_node(&opts, &cmd).await?;
+    let node_config = cfg.node(node_name)?;
+    let skip_defaults = node_config.state().read().skip_defaults_used;
+    restart_background_node(&opts, &cmd, skip_defaults).await?;
 
     // Print node status
     let tcp = TcpTransport::create(&ctx).await?;
@@ -75,6 +77,7 @@ async fn run_impl(
 async fn restart_background_node(
     opts: &CommandGlobalOpts,
     cmd: &StartCommand,
+    skip_defaults: bool,
 ) -> crate::Result<()> {
     let cfg = &opts.config;
     let cfg_node = cfg.get_node(&cmd.node_name)?;
@@ -84,7 +87,7 @@ async fn restart_background_node(
     spawn_node(
         &opts.config,
         cfg_node.verbose(),           // Previously user-chosen verbosity level
-        true,                         // skip-defaults because the node already exists
+        skip_defaults,                //
         cfg_node.name(),              // The selected node name
         &cfg_node.addr().to_string(), // The selected node api address
         None,                         // No project information available

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -126,6 +126,30 @@ teardown() {
   assert_output "HELLO"
 }
 
+@test "check node re-starts default services depending on --skip-defaults" {
+  # Not using --skip-defaults, node should re-start with default
+  # services running
+  run $OCKAM node create n1
+  assert_success
+  assert_output --partial "/service/vault_service"
+
+  $OCKAM node stop n1
+  run $OCKAM node start n1
+  assert_success
+  assert_output --partial "/service/vault_service"
+
+  # When using --skip-defaults, node should NOT re-start with default
+  # services running
+  run $OCKAM node create n2 --skip-defaults
+  assert_success
+  refute_output --partial "/service/vault_service"
+
+  $OCKAM node stop n2
+  run $OCKAM node start n2
+  assert_success
+  refute_output --partial "/service/vault_service"
+}
+
 @test "create two nodes and send message from one to the other - with /node in --from argument" {
   $OCKAM node create n1
   $OCKAM node create n2


### PR DESCRIPTION
## Current Behavior

Related to issue #3234.

The CLI `ockam node create` command has a hidden argument `—skip-defaults` which prevents a node from creating a vault, creating an identity and starting default services.

Regardless of whether `--skip-defaults` was used with `ockam node create`, `ockam node start` __always__ re-starts a node using `--skip-defaults`. 

This leads to unexpected behaviour...

```bash
ockam node create n1
# n1's default services are running here

ockam node stop n1
ockam node start n1
# n1's default services NOT running here
```

If a node is created with configuration, the behaviour is also unexpected.

```bash
ockam service start vault my_vault --node n1 --export config.json --export-section on-node-startup

ockam node create n1 --config config.json
# n1's my_vault & default services are running here

ockam node stop n1
ockam node start n1
# n1's my_vault service is running here, but default services are NOT

```

## Proposed Changes

* When `ockam node create` runs, persist to `NodeConfig` whether `--skip-defaults` was used.
* In `ockam node start`, only use `--skip-defaults` if that option was used when the node was created.
* Added test to `ockam_command/tests/commands.bats`.

Fixes #3234 (hopefully).

I was working on another fix where `ockam node create` and `ockam node start` only used `--skip-defaults` if there were no `CommandsRunner` commands. But this PR's fix seems simpler and allows a user to not `--skip-defaults` and provide commands.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

Thanks! :smile: