### PR TITLE
chore(rust): address clippy messages

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -83,7 +83,7 @@ impl Serialize for HexByteVec {
         if s.is_human_readable() {
             hex::serde::serialize(&*self.0, s)
         } else {
-            s.serialize_bytes(&*self.0)
+            s.serialize_bytes(&self.0)
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/session/sessions.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/sessions.rs
@@ -170,7 +170,7 @@ impl Key {
 
 impl fmt::Display for Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&*self.0))
+        write!(f, "{}", hex::encode(*self.0))
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 fn hash() {
     let output = Command::new("git")
-        .args(&["rev-parse", "HEAD"])
+        .args(["rev-parse", "HEAD"])
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -106,7 +106,7 @@ pub struct CreateCommand {
 impl Default for CreateCommand {
     fn default() -> Self {
         Self {
-            node_name: hex::encode(&random::<[u8; 4]>()),
+            node_name: hex::encode(random::<[u8; 4]>()),
             foreground: false,
             tcp_listener_address: "127.0.0.1:0".to_string(),
             skip_defaults: false,

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -425,7 +425,7 @@ pub mod run {
                 //  1. Pipe output to next command
                 //  2. Pipe input from previous command
                 //  3. Both 1 and 2
-                let mut child = std::process::Command::new(&exe)
+                let mut child = std::process::Command::new(exe)
                     .args(&args)
                     .stdout(Stdio::piped())
                     .stdin(stdin)
@@ -497,7 +497,7 @@ pub mod run {
                     let mut optional_args = CommandsRunner::ask_for_node_args()?;
                     args.append(&mut optional_args);
                     trace!("Running command {:?}", args);
-                    let status = std::process::Command::new(&exe)
+                    let status = std::process::Command::new(exe)
                         .args(args)
                         .stdout(Stdio::inherit())
                         .stderr(Stdio::inherit())

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -53,5 +53,5 @@ impl SpaceCommand {
 }
 
 pub fn random_name() -> String {
-    hex::encode(&rand::random::<[u8; 4]>())
+    hex::encode(rand::random::<[u8; 4]>())
 }

--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -240,7 +240,7 @@ impl<'a> Request<'a> {
     }
 
     pub fn path(&self) -> &str {
-        &*self.path
+        &self.path
     }
 
     pub fn path_segments<const N: usize>(&self) -> Segments<N> {

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -137,7 +137,7 @@ impl ChangeIdentifier {
     }
     /// Human-readable form of the id
     pub fn to_string_representation(&self) -> String {
-        format!("E_ID.{}", hex::encode(&self.0))
+        format!("E_ID.{}", hex::encode(self.0))
     }
 }
 

--- a/implementations/rust/ockam/ockam_macros/src/async_try_clone_derive.rs
+++ b/implementations/rust/ockam/ockam_macros/src/async_try_clone_derive.rs
@@ -118,12 +118,12 @@ impl<'a> Data<'a> {
             Struct(s) => match &s.fields {
                 syn::Fields::Named(f) => Some(&f.named),
                 _ => {
-                    ctx.error_spanned_by(&input_derive, "the struct must have named fields only");
+                    ctx.error_spanned_by(input_derive, "the struct must have named fields only");
                     None
                 }
             },
             _ => {
-                ctx.error_spanned_by(&input_derive, "this macro can only be used on Structs");
+                ctx.error_spanned_by(input_derive, "this macro can only be used on Structs");
                 None
             }
         };

--- a/implementations/rust/ockam/ockam_macros/src/internals/check.rs
+++ b/implementations/rust/ockam/ockam_macros/src/internals/check.rs
@@ -16,7 +16,7 @@ pub(crate) mod item_fn {
     pub(crate) fn is_async(ctx: &Context, input_fn: &ItemFn) {
         if input_fn.sig.asyncness.is_none() {
             let msg = "the `async` keyword is missing from the function declaration";
-            ctx.error_spanned_by(&input_fn.sig.fn_token, msg);
+            ctx.error_spanned_by(input_fn.sig.fn_token, msg);
         }
     }
 
@@ -43,11 +43,11 @@ pub(crate) mod item_fn {
         if let Some(ockam_ctx) = ockam_ctx {
             if ockam_ctx.and_token.is_none() {
                 let msg = "the `Context` argument must be passed as reference";
-                ctx.error_spanned_by(&ockam_ctx.arg, msg);
+                ctx.error_spanned_by(ockam_ctx.arg, msg);
             }
             if ockam_ctx.mutability.is_none() {
                 let msg = "the `Context` argument must be mutable";
-                ctx.error_spanned_by(&ockam_ctx.arg, msg);
+                ctx.error_spanned_by(ockam_ctx.arg, msg);
             }
         }
     }
@@ -70,12 +70,12 @@ pub(crate) mod item_fn {
                         .iter()
                         .any(|s| s.ident.to_string().contains("Result"))
                     {
-                        ctx.error_spanned_by(&ret_ty, msg);
+                        ctx.error_spanned_by(ret_ty, msg);
                     }
                 }
                 // In any other case, the return type is not valid.
                 _ => {
-                    ctx.error_spanned_by(&ret_ty, msg);
+                    ctx.error_spanned_by(ret_ty, msg);
                 }
             },
         }


### PR DESCRIPTION
## Current Behavior

* `cargo clippy` is emitting some errors and warnings.

<details><summary>clippy output 1</summary><pre>
   Compiling ockam_macros v0.25.0 (/Users/neil/dev/ockam/implementations/rust/ockam/ockam_macros)
warning: the borrowed expression implements the required traits
 --> implementations/rust/ockam/ockam_command/build.rs:5:15
  |
5 |         .args(&["rev-parse", "HEAD"])
  |               ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["rev-parse", "HEAD"]`
  |
  = note: `#[warn(clippy::needless_borrow)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `ockam_command` (build script) generated 1 warning
   Compiling ockam_command v0.77.0 (/Users/neil/dev/ockam/implementations/rust/ockam/ockam_command)
error: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_macros/src/async_try_clone_derive.rs:121:42
    |
121 |                     ctx.error_spanned_by(&input_derive, "the struct must have named fields only");
    |                                          ^^^^^^^^^^^^^ help: change this to: `input_derive`
    |
note: the lint level is defined here
   --> implementations/rust/ockam/ockam_macros/src/lib.rs:7:5
    |
7   |     warnings
    |     ^^^^^^^^
    = note: `#[deny(clippy::needless_borrow)]` implied by `#[deny(warnings)]`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_macros/src/async_try_clone_derive.rs:126:38
    |
126 |                 ctx.error_spanned_by(&input_derive, "this macro can only be used on Structs");
    |                                      ^^^^^^^^^^^^^ help: change this to: `input_derive`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_macros/src/internals/check.rs:19:34
   |
19 |             ctx.error_spanned_by(&input_fn.sig.fn_token, msg);
   |                                  ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `input_fn.sig.fn_token`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_macros/src/internals/check.rs:46:38
   |
46 |                 ctx.error_spanned_by(&ockam_ctx.arg, msg);
   |                                      ^^^^^^^^^^^^^^ help: change this to: `ockam_ctx.arg`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_macros/src/internals/check.rs:50:38
   |
50 |                 ctx.error_spanned_by(&ockam_ctx.arg, msg);
   |                                      ^^^^^^^^^^^^^^ help: change this to: `ockam_ctx.arg`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_macros/src/internals/check.rs:73:46
   |
73 |                         ctx.error_spanned_by(&ret_ty, msg);
   |                                              ^^^^^^^ help: change this to: `ret_ty`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_macros/src/internals/check.rs:78:42
   |
78 |                     ctx.error_spanned_by(&ret_ty, msg);
   |                                          ^^^^^^^ help: change this to: `ret_ty`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `ockam_macros` due to 7 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `ockam_macros` due to 7 previous errors
</pre></details>

<details><summary>clippy output 2</summary><pre>
warning: deref which would be done by auto-deref
   --> implementations/rust/ockam/ockam_core/src/api.rs:243:9
    |
243 |         &*self.path
    |         ^^^^^^^^^^^ help: try this: `&self.path`
    |
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

warning: `ockam_core` (lib) generated 1 warning
warning: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_identity/src/identifiers.rs:140:40
    |
140 |         format!("E_ID.{}", hex::encode(&self.0))
    |                                        ^^^^^^^ help: change this to: `self.0`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `ockam_identity` (lib) generated 1 warning
warning: the borrowed expression implements the required traits
 --> implementations/rust/ockam/ockam_command/build.rs:5:15
  |
5 |         .args(&["rev-parse", "HEAD"])
  |               ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `["rev-parse", "HEAD"]`
  |
  = note: `#[warn(clippy::needless_borrow)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_api/src/session/sessions.rs:173:37
    |
173 |         write!(f, "{}", hex::encode(&*self.0))
    |                                     ^^^^^^^^ help: change this to: `*self.0`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: deref which would be done by auto-deref
  --> implementations/rust/ockam/ockam_api/src/lib.rs:86:31
   |
86 |             s.serialize_bytes(&*self.0)
   |                               ^^^^^^^^ help: try this: `&self.0`
   |
   = note: `#[warn(clippy::explicit_auto_deref)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

warning: `ockam_command` (build script) generated 1 warning
warning: `ockam_api` (lib) generated 2 warnings
    Checking ockam_command v0.77.0 (/Users/neil/dev/ockam/implementations/rust/ockam/ockam_command)
warning: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_command/src/node/create.rs:109:36
    |
109 |             node_name: hex::encode(&random::<[u8; 4]>()),
    |                                    ^^^^^^^^^^^^^^^^^^^^ help: change this to: `random::<[u8; 4]>()`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_command/src/node/util.rs:428:60
    |
428 |                 let mut child = std::process::Command::new(&exe)
    |                                                            ^^^^ help: change this to: `exe`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> implementations/rust/ockam/ockam_command/src/node/util.rs:500:61
    |
500 |                     let status = std::process::Command::new(&exe)
    |                                                             ^^^^ help: change this to: `exe`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
  --> implementations/rust/ockam/ockam_command/src/space/mod.rs:56:17
   |
56 |     hex::encode(&rand::random::<[u8; 4]>())
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `rand::random::<[u8; 4]>()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: `ockam_command` (lib) generated 4 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 3.13s
</pre></details>

## Proposed Changes

* Changed code as per clippy's directions.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

Thanks! :smile: