### PR TITLE
ci(rust): cache build output in "ockam command test" workflow

### DIFF
--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_branch }}
 
+      - name: Use cache cargo_home
+        uses: ./.github/actions/cargo_home_cache
+      - name: Use cache cargo_target
+        uses: ./.github/actions/cargo_target_dir_cache
+
       - name: Build Binary
         shell: bash
         run: |
@@ -70,3 +75,6 @@ jobs:
           export PATH=$(pwd)/target/debug:$PATH;
           cd implementations/rust/ockam/ockam_command/tests;
           bats commands.bats;
+
+      - name: Prep cache cargo_target before persisting
+        uses: ./.github/actions/cargo_target_dir_pre_cache


### PR DESCRIPTION
## Current Behavior

CI workflow "Ockam Command Test" builds the Ockam CLI from scratch on every run. 

There may be a reason why caching is not used here. If there's not, then maybe this PR will help.

## Proposed Changes

Add caching of build output, so it can be reused on subsequent builds and shorten run time. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

Cheers! :smile: