### PR TITLE
3186 multiple identity node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/config.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/config.rs
@@ -12,6 +12,8 @@ use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 
 pub use commands::*;
+use ockam_core::compat::collections::HashMap;
+use ockam_identity::{Identity, IdentityIdentifier};
 
 use crate::config::{build_config_path, Config, ConfigValues};
 
@@ -175,7 +177,8 @@ pub struct NodeStateConfig {
     /// Vault info
     pub vault_path: Option<PathBuf>,
     /// Exported identity value
-    pub identity: Option<Vec<u8>>,
+    //pub identity: Option<Vec<u8>>,
+    pub identity: Option<HashMap<IdentityIdentifier, Identity<Vec<u8>>>>,
     /// Identity was overridden
     pub identity_was_overridden: bool,
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Node can have only one identity

## Proposed Changes

Instead of having one identity, let's use `HashMap<IdentityIdentifier, Identity<Vault>>` for manager and `Vec<Vec<u8>>` for config.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
