### PR TITLE
chore(rust) adding rotate-key to CLI

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
@@ -66,3 +66,43 @@ impl<'a> ShortIdentityResponse<'a> {
         }
     }
 }
+
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct RotateKeyResponse<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)] tag: TypeTag<6005979>,
+    #[b(1)] pub label: Cow<'a, str>,
+}
+
+impl<'a> RotateKeyResponse<'a> {
+    pub fn new(label: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            label: label.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct RotateKeyRequest<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)] tag: TypeTag<4029174>,
+    #[b(1)] pub label: Cow<'a, str>,
+}
+
+impl<'a> RotateKeyRequest<'a> {
+    pub fn new(label: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            label: label.into(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -568,6 +568,9 @@ impl NodeManagerWorker {
             (Post, ["node", "identity", "actions", "show", "long"]) => {
                 self.long_identity(req).await?.to_vec()?
             }
+            (Post, ["node", "identity", "actions", "rotate_key"]) => {
+                self.rotate_key(req, dec).await?.to_vec()?
+            }
 
             // ==*== Credentials ==*==
             (Post, ["node", "credentials", "actions", "get"]) => self

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -1,7 +1,9 @@
 mod create;
+mod rotate_key;
 mod show;
 
 pub(crate) use create::CreateCommand;
+pub(crate) use rotate_key::RotateKeyCommand;
 pub(crate) use show::ShowCommand;
 
 use crate::CommandGlobalOpts;
@@ -20,6 +22,8 @@ pub enum IdentitySubcommand {
     Create(CreateCommand),
     /// Print short existing identity, `--full` for long identity
     Show(ShowCommand),
+    /// Rotate Keys,
+    RotateKey(RotateKeyCommand),
 }
 
 impl IdentityCommand {
@@ -27,6 +31,7 @@ impl IdentityCommand {
         match self.subcommand {
             IdentitySubcommand::Create(c) => c.run(options),
             IdentitySubcommand::Show(c) => c.run(options),
+            IdentitySubcommand::RotateKey(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/rotate_key.rs
@@ -1,0 +1,40 @@
+use crate::node::NodeOpts;
+use crate::util::{node_rpc, Rpc};
+use crate::CommandGlobalOpts;
+use clap::Args;
+use ockam::Context;
+use ockam_api::nodes::models::identity::{RotateKeyRequest, RotateKeyResponse};
+use ockam_core::api::Request;
+
+fn default_key_label() -> String {
+    "OCKAM_RK".to_string()
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct RotateKeyCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+    #[arg(short, long, default_value_t=default_key_label())]
+    label: String,
+}
+
+impl RotateKeyCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, RotateKeyCommand),
+) -> crate::Result<()> {
+    let mut rpc = Rpc::background(&ctx, &opts, &cmd.node_opts.api_node)?;
+    // XXX Should this be post?
+    // XXX Is this the best way to pass arguments?
+    let request =
+        Request::post("/node/identity/actions/rotate_key").body(RotateKeyRequest::new(cmd.label));
+    rpc.request(request).await?;
+    rpc.parse_response::<RotateKeyResponse>()?;
+    println!("key rotated!");
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -95,6 +95,23 @@ teardown() {
   assert_output --partial "signatures"
 }
 
+@test "create a node and show its identity then rotate keys" {
+  run $OCKAM node create n1
+  assert_success
+
+  run $OCKAM identity rotate-key --node n1
+  assert_success
+  assert_output --regexp '^key rotated'
+
+  run $OCKAM identity show --node n1
+  assert_success
+  assert_output --regexp '^P'
+
+  run $OCKAM identity rotate-key --node n1
+  assert_success
+  assert_output --regexp '^key rotated'
+}
+
 @test "create a node with a name and do show on it" {
   run $OCKAM node create n1
   assert_success


### PR DESCRIPTION
This commit adds the rotate-key command to the CLI. It can be used via `ockam identity rotate-key --node n1 --label OCKAM_RK` or the label argument can be omitted to use the default label of "OCKAM_RK", e.g. `ockam identity rotate-key --node n1`.

In response to issue: https://github.com/build-trust/ockam/issues/3685

Note: There is a known issue with this command. it will fail after it is executed after `ockam identity show` command. I'm not sure if that error is related to this PR, however i'm sure it's not supposed to fail. 

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

`ockam identity rotate-key` did not exists.

## Proposed Changes

create cli command `ockam identity rotate-key`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
