### PR TITLE
chore(rust): identity show do not run on embedded node

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,3 @@
-use crate::node::util::delete_embedded_node;
 use crate::node::NodeOpts;
 use crate::util::output::Output;
 use crate::util::{extract_address_value, node_rpc, Rpc};
@@ -39,7 +38,6 @@ async fn run_impl(
         rpc.request(req).await?;
         rpc.parse_and_print_response::<ShortIdentityResponse>()?;
     }
-    delete_embedded_node(&opts.config, &node_name).await;
     Ok(())
 }
 


### PR DESCRIPTION
do not call delete_embedded_node/2, as it is not an embedded node, and end up unlinking the node' state directory..
