### PR TITLE
fix(rust): replace atty dependency with is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -1677,7 +1677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11dcc7e4d79a8c89b9ab4c6f5c30b1fc4a83c420792da3542fd31179ed5f517"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.35.11",
  "windows-sys 0.36.1",
 ]
 
@@ -2081,6 +2081,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2242,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2265,18 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes 1.0.3",
+ "rustix 0.36.5",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2324,6 +2355,12 @@ name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lmdb-rkv"
@@ -2719,7 +2756,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -2873,7 +2910,6 @@ dependencies = [
  "assert_cmd",
  "async-recursion",
  "async-trait",
- "atty",
  "clap 4.0.14",
  "clap_complete",
  "clap_mangen",
@@ -2886,6 +2922,8 @@ dependencies = [
  "dirs",
  "flate2",
  "hex",
+ "io-lifetimes 1.0.3",
+ "is-terminal",
  "itertools",
  "minicbor",
  "nix 0.26.1",
@@ -3876,10 +3914,24 @@ checksum = "fbb2fda4666def1433b1b05431ab402e42a1084285477222b72d6c564c417cef"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.7.3",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
  "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.3",
+ "libc",
+ "linux-raw-sys 0.1.3",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4539,7 +4591,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
 dependencies = [
- "rustix",
+ "rustix 0.35.11",
  "windows-sys 0.36.1",
 ]
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -54,7 +54,6 @@ test = false
 anyhow = "1"
 async-recursion = { version = "1.0.0" }
 async-trait = "0.1"
-atty = "0.2"
 clap = { version = "4.0.11", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.0.3"
 clap_mangen = "0.2.4"
@@ -66,6 +65,8 @@ directories = "4"
 dirs = "4.0.0"
 flate2 = "1.0.24"
 hex = "0.4"
+io-lifetimes = "1"
+is-terminal = "0.4"
 itertools = "0.10"
 minicbor = { version = "0.18.0", features = ["derive", "alloc", "half"] }
 nix = "0.26"

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -5,14 +5,13 @@ use crate::{
 };
 
 use anyhow::Context as _;
-use atty::Stream;
 use clap::Args;
 use colorful::Colorful;
 use serde_json::json;
 
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::api::CloudOpts;
-use crate::util::RpcBuilder;
+use crate::util::{is_tty, RpcBuilder};
 use ockam::{identity::IdentityIdentifier, route, Context, TcpTransport};
 use ockam_api::config::lookup::ConfigLookup;
 use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
@@ -90,7 +89,7 @@ impl CreateCommand {
             Some(multiaddr) => {
                 // if stdout is not interactive/tty write the secure channel address to it
                 // in case some other program is trying to read it as piped input
-                if !atty::is(Stream::Stdout) {
+                if !is_tty(std::io::stdout()) {
                     println!("{}", multiaddr)
                 }
 
@@ -102,7 +101,7 @@ impl CreateCommand {
 
                 // if stderr is interactive/tty and we haven't been asked to be quiet
                 // and output format is plain then write a plain info to stderr.
-                if atty::is(Stream::Stderr)
+                if is_tty(std::io::stderr())
                     && !options.global_args.quiet
                     && options.global_args.output_format == OutputFormat::Plain
                 {
@@ -132,7 +131,7 @@ impl CreateCommand {
             None => {
                 // if stderr is interactive/tty and we haven't been asked to be quiet
                 // and output format is plain then write a plain info to stderr.
-                if atty::is(Stream::Stderr)
+                if is_tty(std::io::stderr())
                     && !options.global_args.quiet
                     && options.global_args.output_format == OutputFormat::Plain
                 {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -6,10 +6,10 @@ use crate::{
 };
 use std::str::FromStr;
 
-use atty::Stream;
 use colorful::Colorful;
 use serde_json::json;
 
+use crate::util::is_tty;
 use clap::Parser;
 use ockam::{route, Context};
 use ockam_api::{nodes::models::secure_channel::DeleteSecureChannelResponse, route_to_multiaddr};
@@ -52,7 +52,7 @@ impl DeleteCommand {
                     Some(multiaddr) => {
                         // if stdout is not interactive/tty write the secure channel address to it
                         // in case some other program is trying to read it as piped input
-                        if !atty::is(Stream::Stdout) {
+                        if !is_tty(std::io::stdout()) {
                             println!("{}", multiaddr)
                         }
 
@@ -64,7 +64,7 @@ impl DeleteCommand {
 
                         // if stderr is interactive/tty and we haven't been asked to be quiet
                         // and output format is plain then write a plain info to stderr.
-                        if atty::is(Stream::Stderr)
+                        if is_tty(std::io::stderr())
                             && !options.global_args.quiet
                             && options.global_args.output_format == OutputFormat::Plain
                         {
@@ -88,7 +88,7 @@ impl DeleteCommand {
                     None => {
                         // if stderr is interactive/tty and we haven't been asked to be quiet
                         // and output format is plain then write a plain info to stderr.
-                        if atty::is(Stream::Stderr)
+                        if is_tty(std::io::stderr())
                             && !options.global_args.quiet
                             && options.global_args.output_format == OutputFormat::Plain
                         {
@@ -107,7 +107,7 @@ impl DeleteCommand {
             None => {
                 // if stderr is interactive/tty and we haven't been asked to be quiet
                 // and output format is plain then write a plain info to stderr.
-                if atty::is(Stream::Stderr)
+                if is_tty(std::io::stderr())
                     && !options.global_args.quiet
                     && options.global_args.output_format == OutputFormat::Plain
                 {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -1,4 +1,3 @@
-use atty::Stream;
 use clap::Args;
 use colorful::Colorful;
 
@@ -10,7 +9,7 @@ use ockam_core::{route, Address};
 use serde_json::json;
 
 use crate::secure_channel::HELP_DETAIL;
-use crate::util::RpcBuilder;
+use crate::util::{is_tty, RpcBuilder};
 use crate::{
     exitcode, help,
     util::{api, node_rpc},
@@ -78,7 +77,7 @@ impl ListCommand {
 
             // if stdout is not interactive/tty write the secure channel address to it
             // in case some other program is trying to read it as piped input
-            if !atty::is(Stream::Stdout) {
+            if !is_tty(std::io::stdout()) {
                 println!("{}", at)
             }
 
@@ -117,7 +116,7 @@ impl ListCommand {
 
 #[inline]
 fn has_plain_stderr(options: &CommandGlobalOpts) -> bool {
-    atty::is(Stream::Stderr)
+    is_tty(std::io::stderr())
         && !options.global_args.quiet
         && options.global_args.output_format == OutputFormat::Plain
 }
@@ -153,7 +152,7 @@ async fn rpc(
     let responses = results?;
 
     if let Err(e) = command.print_output(&options, channel_identifiers, responses) {
-        if atty::is(Stream::Stderr)
+        if is_tty(std::io::stderr())
             && !options.global_args.quiet
             && options.global_args.output_format == OutputFormat::Plain
         {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -509,6 +509,11 @@ pub fn bind_to_port_check(address: &SocketAddr) -> bool {
     TcpListener::bind((ip, port)).is_ok()
 }
 
+pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {
+    use is_terminal::IsTerminal;
+    s.is_terminal()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam-artifacts/issues/98

Also, `atty` is pretty much unmaintained, while `is-terminal` has recent activity.