### PR TITLE
docs(rust): make `node` commands short docs clearer

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -46,7 +46,7 @@ use ockam_core::{
 
 use super::util::delete_node;
 
-/// Create Nodes
+/// Create node
 #[derive(Clone, Debug, Args)]
 #[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -2,7 +2,7 @@ use crate::node::util::{delete_all_nodes, delete_node};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
-/// Delete Nodes
+/// Delete a node
 #[derive(Clone, Debug, Args)]
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -6,7 +6,7 @@ use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::base::NodeStatus;
 use std::time::Duration;
 
-/// List Nodes
+/// List nodes
 #[derive(Clone, Debug, Args)]
 #[command(after_long_help = help::template(HELP_DETAIL))]
 pub struct ListCommand {}

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -114,7 +114,7 @@ Examples:
 ```
 ";
 
-/// Manage Nodes
+/// Manage nodes
 #[derive(Clone, Debug, Args)]
 #[command(
     arg_required_else_help = true,

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 const IS_NODE_UP_MAX_ATTEMPTS: usize = 50;
 const IS_NODE_UP_MAX_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Show Nodes
+/// Show node details
 #[derive(Clone, Debug, Args)]
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ShowCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -7,7 +7,7 @@ use crate::node::util::spawn_node;
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 
-/// Start Nodes
+/// Start a node
 #[derive(Clone, Debug, Args)]
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StartCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,7 +1,7 @@
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
-/// Stop Nodes
+/// Stop a node
 #[derive(Clone, Debug, Args)]
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StopCommand {


### PR DESCRIPTION
## Current Behavior

When finding what I can do with `ockam nodes` in command line, I was given short descriptions for commands, but from those descriptions I assumed different usage than what is actually expected.

E.g. based on description `Stop Nodes` I expected the `ockam node stop` to stop all nodes. Wrong assumption of course, but still, making the description `Stop a node` would reveal the intent much better, at least for me.

## Proposed Changes

Just changed the short docs for the command line, aligned with how I understood those commands.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. See https://github.com/build-trust/ockam-contributors/pull/159