### PR TITLE
feat(rust): inter process access to file-based vaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2715,7 @@ dependencies = [
  "arrayref",
  "curve25519-dalek",
  "ed25519-dalek",
+ "fs2",
  "hex",
  "hkdf",
  "ockam_core",

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -775,8 +775,11 @@ mod tests {
                             entry.path().read_dir().unwrap().for_each(|entry| {
                                 let entry = entry.unwrap();
                                 let file_name = entry.file_name().into_string().unwrap();
-                                found_entries.push(format!("{dir_name}/{entry_name}/{file_name}"));
-                                assert_eq!(file_name, format!("{vault_name}-storage.json"));
+                                if !file_name.ends_with(".lock") {
+                                    found_entries
+                                        .push(format!("{dir_name}/{entry_name}/{file_name}"));
+                                    assert_eq!(file_name, format!("{vault_name}-storage.json"));
+                                }
                             });
                         } else {
                             assert_eq!(entry_name, format!("{vault_name}.json"));

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -77,6 +77,7 @@ hex = { version = "0.4", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+fs2 = "0.4.3"
 
 [dev-dependencies]
 tokio = { version = "1.8", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
@@ -1,22 +1,24 @@
 use crate::VaultError;
+use fs2::FileExt; //locking
 use ockam_core::compat::boxed::Box;
+use ockam_core::errcode::{Kind, Origin};
 use ockam_core::vault::storage::Storage;
 use ockam_core::vault::{KeyId, SecretAttributes, SecretKey, SecretPersistence, VaultEntry};
-use ockam_core::{async_trait, Result};
-use ockam_node::compat::asynchronous::RwLock;
+use ockam_core::{async_trait, Error, Result};
+use ockam_node::tokio::task::{self, JoinError};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use tracing::debug;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 struct LegacyVaultEntry {
     key_id: Option<String>,
     key_attributes: SecretAttributes,
     key: SecretKey,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "version")]
 #[non_exhaustive]
 enum LegacySerializedVault {
@@ -26,131 +28,77 @@ enum LegacySerializedVault {
     },
 }
 
-type Data = RwLock<BTreeMap<KeyId, VaultEntry>>;
-
 /// File Storage
+/* There are three files involved
+ * - The actual vault file
+ * - A temp file used to avoid data lost during writtes:  vault is entirely
+ *   written to the temp file, then file renamed.
+ * - A "lock" file.  It's used to control inter-process access to the vault.
+ *   Before reading or writting to the vault, first need to get a shared or exclusive lock
+ *   on this file.  We don't lock over the vault file directly, because doesn't play well with
+ *   the file rename we do */
 pub struct FileStorage {
     path: PathBuf,
     temp_path: PathBuf,
-    data: Data,
+    lock_path: PathBuf,
+}
+
+fn map_join_err(err: JoinError) -> Error {
+    Error::new(Origin::Application, Kind::Io, err)
+}
+fn map_io_err(err: std::io::Error) -> Error {
+    Error::new(Origin::Application, Kind::Io, err)
 }
 
 impl FileStorage {
-    async fn deserialize(vault_bytes: &[u8]) -> Result<Data> {
-        let vault: LegacySerializedVault =
-            serde_json::from_slice(vault_bytes).map_err(|_| VaultError::InvalidStorageData)?;
-
-        let data = Data::default();
-
-        match vault {
-            LegacySerializedVault::V1 { entries, .. } => {
-                let mut data_lock = data.write().await;
-                for entry in entries {
-                    let entry = entry.1;
-                    if entry.key_attributes.persistence() != SecretPersistence::Persistent {
-                        continue;
-                    }
-
-                    let key_id = match entry.key_id {
-                        Some(key_id) => key_id,
-                        None => continue,
-                    };
-
-                    data_lock.insert(key_id, VaultEntry::new(entry.key_attributes, entry.key));
-                }
-            }
-        }
-
-        Ok(data)
-    }
-
-    async fn serialize(&self) -> Result<Vec<u8>> {
-        let entries = self.data.read().await;
-
-        let legacy_entries = entries
-            .iter()
-            .map(|(k, e)| {
-                (
-                    0,
-                    LegacyVaultEntry {
-                        key_id: Some(k.clone()),
-                        key_attributes: e.key_attributes(),
-                        key: e.key().clone(),
-                    },
-                )
-            })
-            .collect();
-
-        let v = LegacySerializedVault::V1 {
-            entries: legacy_entries,
-            next_id: 0,
-        };
-
-        serde_json::to_vec(&v).map_err(|_| VaultError::StorageError.into())
-    }
-
-    fn get_temp_path(path: &Path) -> PathBuf {
-        let tmp_ext = match path.extension() {
-            None => ".tmp".to_string(),
-            Some(e) => format!("{}.tmp", e.to_str().unwrap()),
-        };
-
-        path.with_extension(tmp_ext)
-    }
-
-    async fn flush_to_file(&self) -> Result<()> {
-        let data = self.serialize().await?;
-
-        use std::io::prelude::*;
-        use std::os::unix::prelude::*;
-
-        let _ = std::fs::remove_file(&self.temp_path);
-
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            // `create_new` means we error if it exists. This ensures the mode we
-            // provide is respect (the `mode(0o600)` is only used if creating the
-            // file)
-            .create_new(true)
-            .mode(0o600) // TODO: not portable, what about windows?
-            .open(&self.temp_path)
-            .map_err(|_| VaultError::StorageError)?;
-        file.write_all(&data)
-            .map_err(|_| VaultError::StorageError)?;
-        file.flush().map_err(|_| VaultError::StorageError)?;
-        file.sync_all().map_err(|_| VaultError::StorageError)?;
-
-        std::fs::rename(&self.temp_path, &self.path).map_err(|_| VaultError::StorageError)?;
-
-        Ok(())
-    }
-
     /// Create FileStorage using file at given Path
     /// If file doesn't exist, it will be created
     pub async fn init(&mut self) -> Result<()> {
-        self.data = if !self.path.exists() {
-            Default::default()
-        } else {
-            let vault_bytes = std::fs::read(&self.path).map_err(|_| VaultError::StorageError)?;
-            Self::deserialize(&vault_bytes).await?
-        };
-
-        let _ = std::fs::remove_file(&self.temp_path);
-
-        self.flush_to_file().await?;
-
+        // This can block, but only when first initializing and just need to write an empty vault.
+        // So didn't bother to do it async
+        let lock_file = Self::open_lock_file(&self.lock_path)?;
+        lock_file.lock_exclusive().map_err(map_io_err)?;
+        if !self.path.exists() {
+            let empty = LegacySerializedVault::V1 {
+                entries: Vec::new(),
+                next_id: 0,
+            };
+            Self::flush_to_file(&self.path, &self.temp_path, &empty)?;
+        }
+        lock_file.unlock().map_err(map_io_err)?;
         Ok(())
+    }
+
+    fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+        match path.extension() {
+            None => path.with_extension(suffix),
+            Some(e) => path.with_extension(format!("{}{}", e.to_str().unwrap(), suffix)),
+        }
+    }
+
+    fn load(path: &PathBuf) -> Result<LegacySerializedVault> {
+        let file = File::open(path).map_err(map_io_err)?;
+        let reader = BufReader::new(file);
+        Ok(serde_json::from_reader(reader).map_err(|_| VaultError::InvalidStorageData)?)
+    }
+
+    fn open_lock_file(lock_path: &PathBuf) -> Result<File> {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(lock_path)
+            .map_err(map_io_err)
     }
 
     /// Constructor.
     /// NOTE: Doesn't initialize the storage. Call [`FileStorage::init()`] or use [`FileStorage::create()`]
     pub fn new(path: PathBuf) -> Self {
-        let tmp_path = Self::get_temp_path(&path);
-
+        let temp_path = Self::path_with_suffix(&path, ".tmp");
+        let lock_path = Self::path_with_suffix(&path, ".lock");
         Self {
             path,
-            temp_path: tmp_path,
-            data: Default::default(),
+            temp_path,
+            lock_path,
         }
     }
 
@@ -162,48 +110,144 @@ impl FileStorage {
         Ok(s)
     }
 
-    /// Clear the Storage
-    pub async fn clear(&self) {
-        if self.path.exists() {
-            debug!("Note: removing previous file at {:?}", &self.path);
-            let _ = std::fs::remove_file(&self.path);
-        }
+    // Flush vault to target, using temp_path as intermediary file.
+    fn flush_to_file(
+        target: &PathBuf,
+        temp_path: &PathBuf,
+        vault: &LegacySerializedVault,
+    ) -> Result<()> {
+        let data = serde_json::to_vec(vault).map_err(|_| VaultError::StorageError)?;
+        use std::io::prelude::*;
+        use std::os::unix::prelude::*;
+        let _ = std::fs::remove_file(temp_path);
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            // `create_new` means we error if it exists. This ensures the mode we
+            // provide is respect (the `mode(0o600)` is only used if creating the
+            // file)
+            .create_new(true)
+            .mode(0o600) // TODO: not portable, what about windows?
+            .open(temp_path)
+            .map_err(|_| VaultError::StorageError)?;
+        file.write_all(&data)
+            .map_err(|_| VaultError::StorageError)?;
+        file.flush().map_err(|_| VaultError::StorageError)?;
+        file.sync_all().map_err(|_| VaultError::StorageError)?;
+        std::fs::rename(temp_path, target).map_err(|_| VaultError::StorageError)?;
+        Ok(())
+    }
 
-        let _ = std::fs::remove_file(&self.temp_path);
+    async fn write_transaction<F, R>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(LegacySerializedVault) -> Result<(LegacySerializedVault, R)> + Send + 'static,
+        R: Send + 'static,
+    {
+        let lock_path = self.lock_path.clone();
+        let temp_path = self.temp_path.clone();
+        let path = self.path.clone();
+        let tr = move || -> Result<R> {
+            let file = FileStorage::open_lock_file(&lock_path)?;
+            file.lock_exclusive().map_err(map_io_err)?;
+            let vault_data = FileStorage::load(&path)?;
+            let (modified_vault, result) = f(vault_data)?;
+            FileStorage::flush_to_file(&path, &temp_path, &modified_vault)?;
+            // if something goes wrong it will be unlocked once the file handler get closed anyway
+            file.unlock().map_err(map_io_err)?;
+            Ok(result)
+        };
+        task::spawn_blocking(tr).await.map_err(map_join_err)?
+    }
+
+    async fn read_transaction<F, R>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(LegacySerializedVault) -> Result<R> + Send + 'static,
+        R: Send + 'static,
+    {
+        let path = self.path.clone();
+        let lock_path = self.lock_path.clone();
+        let tr = move || {
+            let file = FileStorage::open_lock_file(&lock_path)?;
+            file.lock_shared().map_err(map_io_err)?;
+            let vault_data = FileStorage::load(&path)?;
+            let r = f(vault_data)?;
+            // if something goes wrong it will be unlocked once the file handler get closed anyway
+            file.unlock().map_err(map_io_err)?;
+            Ok(r)
+        };
+        task::spawn_blocking(tr).await.map_err(map_join_err)?
     }
 }
 
 #[async_trait]
 impl Storage for FileStorage {
     async fn store(&self, key_id: &KeyId, key: &VaultEntry) -> Result<()> {
-        let _ = self.data.write().await.insert(key_id.clone(), key.clone());
-
-        self.flush_to_file().await?;
-
-        Ok(())
+        let key_id = key_id.clone();
+        let attributes = key.key_attributes();
+        let key = key.key().clone();
+        let t = move |v: LegacySerializedVault| {
+            let new_entry = (
+                0,
+                LegacyVaultEntry {
+                    key_id: Some(key_id),
+                    key_attributes: attributes,
+                    key,
+                },
+            );
+            let LegacySerializedVault::V1 {
+                mut entries,
+                next_id,
+            } = v;
+            entries.push(new_entry);
+            Ok((LegacySerializedVault::V1 { entries, next_id }, ()))
+        };
+        self.write_transaction(t).await
     }
 
     async fn load(&self, key_id: &KeyId) -> Result<VaultEntry> {
-        Ok(self
-            .data
-            .read()
-            .await
-            .get(key_id)
-            .ok_or(VaultError::EntryNotFound)?
-            .clone())
+        let key_id = key_id.clone();
+        let t = move |v: LegacySerializedVault| -> Result<VaultEntry> {
+            let LegacySerializedVault::V1 {
+                entries,
+                next_id: _,
+            } = v;
+            Ok(entries
+                .iter()
+                .find(|x| {
+                    if let Some(id) = &x.1.key_id {
+                        id.eq(&key_id)
+                            && x.1.key_attributes.persistence() == SecretPersistence::Persistent
+                    } else {
+                        false
+                    }
+                })
+                .map(|le| VaultEntry::new(le.1.key_attributes, le.1.key.clone()))
+                .ok_or(VaultError::EntryNotFound)?)
+        };
+        self.read_transaction(t).await
     }
 
     async fn delete(&self, key_id: &KeyId) -> Result<VaultEntry> {
-        let entry = self
-            .data
-            .write()
-            .await
-            .remove(key_id)
-            .ok_or(VaultError::EntryNotFound)?;
-
-        self.flush_to_file().await?;
-
-        Ok(entry)
+        let key_id = key_id.clone();
+        let t = move |v: LegacySerializedVault| -> Result<(LegacySerializedVault, VaultEntry)> {
+            let LegacySerializedVault::V1 {
+                mut entries,
+                next_id,
+            } = v;
+            if let Some(index) = entries.iter_mut().position(|(_, entry)| {
+                if let Some(id) = &entry.key_id {
+                    id.eq(&key_id)
+                } else {
+                    false
+                }
+            }) {
+                let removed = entries.swap_remove(index);
+                let vault_entry = VaultEntry::new(removed.1.key_attributes, removed.1.key);
+                Ok((LegacySerializedVault::V1 { entries, next_id }, vault_entry))
+            } else {
+                Err(Error::from(VaultError::EntryNotFound))
+            }
+        };
+        self.write_transaction(t).await
     }
 }
 
@@ -211,6 +255,7 @@ impl Storage for FileStorage {
 mod tests {
     use super::*;
     use crate::Vault;
+    use ockam_core::compat::join;
     use ockam_core::compat::rand::RngCore;
     use ockam_core::vault::{SecretType, SecretVault};
     use rand::thread_rng;
@@ -251,5 +296,50 @@ mod tests {
         assert_eq!(attributes20, attributes21);
         let attributes31 = vault.secret_attributes_get(&key_id3).await;
         assert!(attributes31.is_err());
+    }
+
+    #[tokio::test]
+    #[allow(non_snake_case)]
+    async fn vault_syncronization() {
+        let mut rng = thread_rng();
+        let mut rand_id = [0u8; 32];
+
+        rng.fill_bytes(&mut rand_id);
+        let rand_id1 = hex::encode(&rand_id);
+
+        rng.fill_bytes(&mut rand_id);
+
+        let dir = std::env::temp_dir();
+        let storage = FileStorage::create(dir.join(rand_id1)).await.unwrap();
+
+        let storage = Arc::new(storage);
+        let vault = Vault::new(Some(storage.clone()));
+
+        let attributes1 =
+            SecretAttributes::new(SecretType::Ed25519, SecretPersistence::Persistent, 0);
+        let attributes2 =
+            SecretAttributes::new(SecretType::Ed25519, SecretPersistence::Persistent, 0);
+        let attributes3 =
+            SecretAttributes::new(SecretType::Ed25519, SecretPersistence::Persistent, 0);
+
+        let (key_id1, key_id2, key_id3) = join!(
+            vault.secret_generate(attributes1),
+            vault.secret_generate(attributes2),
+            vault.secret_generate(attributes3)
+        );
+
+        let key_id1 = key_id1.unwrap();
+        let key_id2 = key_id2.unwrap();
+        let key_id3 = key_id3.unwrap();
+
+        let (attributes12, attributes22, attributes32) = join!(
+            vault.secret_attributes_get(&key_id1),
+            vault.secret_attributes_get(&key_id2),
+            vault.secret_attributes_get(&key_id3)
+        );
+
+        assert_eq!(attributes1, attributes12.unwrap());
+        assert_eq!(attributes2, attributes22.unwrap());
+        assert_eq!(attributes3, attributes32.unwrap());
     }
 }


### PR DESCRIPTION
https://github.com/build-trust/codebase/issues/479

Implement locking through the [fs2](https://crates.io/crates/fs2) crate ([flock](https://linux.die.net/man/2/flock)' based advisory locks), to allow concurrent inter-process access to file vaults. 

This:
* Acquire an appropriate (shared or exclusive) lock before reading or writing the vault
* The above is done _every time_ we access the vault (no local cache)
* This allows synchronization between different processes, not only inside the same one. 
* Keep using the same json based vault file structure


Since no attempt is done to try to optimize it, this assumes that the rate of vault read and writes is relatively low, and that the # of keys on any given file-backed vault isn't to big neither as to the read/writes and serialization/deserialization becoming a bottleneck even on low # of operations.  


Simplistically,  it works as this:
```
use fs2::FileExt;
use std::env;

fn main() {
    let args: Vec<String> = env::args().collect();
    let path = &args[1];
    let text = &args[2];
    let tmp_path = format!("{}.temp", path);
    let lock_path = format!("{}.lock", path);
    let f = std::fs::OpenOptions::new().write(true).create(true).open(lock_path).expect("can't open lock file");
    f.lock_exclusive();
    let contents = std::fs::read_to_string(path).expect("Can't read file");
    std::thread::sleep(std::time::Duration::from_secs(5));  //add some delay to easily test contention
    std::fs::write(&tmp_path, format!("{}\n{}", contents, text)); //write the content back, with the added text
    std::fs::rename(&tmp_path, path);
    f.unlock();
}
```



