### PR TITLE
fix(rust): `node delete` to affect only the `nodes` directory

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -184,9 +184,7 @@ pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> anyhow::Result<
 
     // If force is enabled
     if force {
-        // delete the config and nodes directories
-        opts.config.remove()?;
-        // and all dangling/orphan ockam processes
+        // Delete dangling/orphan ockam processes
         if let Ok(cpid) = get_current_pid() {
             let s = System::new_all();
             for (pid, process) in s.processes() {


### PR DESCRIPTION
`node delete` was deleting everything under the $OCKAM_HOME directory. This PR fix that command so it only deletes nodes.

It also modifies the `ockam reset` command so it deletes the whole $OCKAM_HOME directory.