### PR TITLE
fix(rust): cli state dir used on tests on macos

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -66,8 +66,12 @@ impl CliState {
     }
 
     pub fn test() -> Result<Self> {
-        let rnd_dir = Builder::new().prefix("ockam-").tempdir()?;
-        std::env::set_var("OCKAM_HOME", rnd_dir.path());
+        let tests_dir = dirs::home_dir()
+            .ok_or_else(|| CliStateError::NotFound("home dir".to_string()))?
+            .join(".ockam")
+            .join(".tests")
+            .join(random_name());
+        std::env::set_var("OCKAM_HOME", tests_dir);
         Self::new()
     }
 
@@ -577,8 +581,7 @@ impl NodeConfigBuilder {
         self
     }
 
-    pub fn build(self) -> Result<NodeConfig> {
-        let cli_state = CliState::new()?;
+    pub fn build(self, cli_state: &CliState) -> Result<NodeConfig> {
         let vault = match self.vault {
             Some(path) => path,
             None => cli_state.vaults.default()?.path,

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -119,7 +119,7 @@ pub(super) async fn init_node_state(
     let node_config = cli_state::NodeConfigBuilder::default()
         .vault(vault_state.path)
         .identity(identity_state.path)
-        .build()?;
+        .build(&opts.state)?;
     opts.state.nodes.create(node_name, node_config)?;
 
     Ok(())


### PR DESCRIPTION
Using the default temp directory on macos doesn't work. It looks like the OS eagerly moves the files around before the test finishes.

This is solved by creating the temp dir under `~/.ockam/tests`.