### PR TITLE
docs: fix line breaks for api docs

### DIFF
--- a/documentation/reference/API.md
+++ b/documentation/reference/API.md
@@ -83,9 +83,9 @@ To describe an API, we can use the following format:
 Worker address: "cats"
 
 #### See the cats face
-Method: GET
-Path: ":cat_name/face"
-Request: ""
+Method: GET \
+Path: ":cat_name/face" \
+Request: "" \
 Response: cats_face_response
 
 Errors:
@@ -102,9 +102,9 @@ whiskers_count = uint
 ```
 
 #### Pet the cat
-Method: PUT
-Path: ":cat_name/pet"
-Request: pet_cat_request
+Method: PUT \
+Path: ":cat_name/pet" \
+Request: pet_cat_request \
 Response: purr_response
 
 Errors:
@@ -130,6 +130,8 @@ volume_db = uint
 
 `Request` and `Response` describe the body format in CDDL,
 it's recommended to use CBOR for request and response bodies.
+
+Note: `\ ` at the line ends are there to format markdown line breaks properly
 
 More examples of API docs can be found in the [API reference folder](./api)
 

--- a/documentation/reference/api/credential_exchange.md
+++ b/documentation/reference/api/credential_exchange.md
@@ -8,13 +8,13 @@ Implemented in `Ockam.Services.API.CredentialExchange`
 
 
 #### Present credential
-Method: POST
-Path: "actions/present"
-Request: Credential
+Method: POST \
+Path: "actions/present" \
+Request: Credential \
 Response: ""
 
 Errors:
-400 - credential is invalid
-400 - secure channel required
+- 400 - credential is invalid
+- 400 - secure channel required
 
 Where `Credential` is a binary with credential received from credential exchange.

--- a/documentation/reference/api/discovery.md
+++ b/documentation/reference/api/discovery.md
@@ -9,26 +9,26 @@ Implemented in `Ockam.Services.API.Discovery`
 **NOTE: this API is a work in progress**
 
 #### List services
-Method: GET
-Path: ""
-Request: ""
+Method: GET \
+Path: "" \
+Request: "" \
 Response: [+ service_info]
 
 #### Show service
-Method: GET
-Path: ":service_id"
-Request: ""
+Method: GET \
+Path: ":service_id" \
+Request: "" \
 Response: service_info
 
 #### Register service
-Method: PUT
-Path: ":service_id"
-Request: service_info
+Method: PUT \
+Path: ":service_id" \
+Request: service_info \
 Response: ""
 
 Errors:
-400 - cannot decode service_info
-405 - method not allowed
+- 400 - cannot decode service_info
+- 405 - method not allowed
 
 Some backends do not support service registration and will always return status 405
 

--- a/documentation/reference/api/orchestrator/auth0.md
+++ b/documentation/reference/api/orchestrator/auth0.md
@@ -8,14 +8,14 @@ Authorization:
 **Requires connection via secure channel**
 
 #### Enroll with auth0
-Method: POST
-Path: "v0/enroll"
-Request: enroll_request
+Method: POST \
+Path: "v0/enroll" \
+Request: enroll_request \
 Response: ""
 
 Errors:
-400 - invalid request format
-400 - invalid token type
+- 400 - invalid request format
+- 400 - invalid token type
 
 Where:
 ```

--- a/documentation/reference/api/orchestrator/project/addons.md
+++ b/documentation/reference/api/orchestrator/project/addons.md
@@ -10,37 +10,37 @@ Authorization:
 
 
 #### List addons
-Method: GET
-Path: "/v0/:project_id/addons"
-Request: ""
+Method: GET \
+Path: "/v0/:project_id/addons" \
+Request: "" \
 Response: AddonItem
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to list addons from the project
+- 404 - project not found
+- 401 - current identity does not have permission to list addons from the project
 
 #### Enable addon
-Method: PUT
-Path: "/v0/:project_id/addons/:addon_id"
-Request: SpecificAddonConfig
+Method: PUT \
+Path: "/v0/:project_id/addons/:addon_id" \
+Request: SpecificAddonConfig \
 Response: ""
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to enable addons from the project
-400 - addon config is invalid
-400 - addon_id is invalid/unknown
+- 404 - project not found
+- 401 - current identity does not have permission to enable addons from the project
+- 400 - addon config is invalid
+- 400 - addon_id is invalid/unknown
 
 #### Disable addon
-Method: DELETE
-Path: "/v0/:project_id/addons/:addon_id"
-Request: ""
+Method: DELETE \
+Path: "/v0/:project_id/addons/:addon_id" \
+Request: "" \
 Response: ""
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to disable addons from the project
-400 - addon_id is invalid/unknown
+- 404 - project not found
+- 401 - current identity does not have permission to disable addons from the project
+- 400 - addon_id is invalid/unknown
 
 
 Where:

--- a/documentation/reference/api/orchestrator/project/enrollers.md
+++ b/documentation/reference/api/orchestrator/project/enrollers.md
@@ -9,34 +9,34 @@ Authorization:
 - Identity needs to be enrolled to the Orchestrator Controller via [Auth0](./auth0.md)
 
 #### List enrollers
-Method: GET
-Path: "/v0/:project_id/enrollers"
-Request: ""
+Method: GET \
+Path: "/v0/:project_id/enrollers" \
+Request: "" \
 Response: `[+ enroller]`
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to get enrollers from the project
+- 404 - project not found
+- 401 - current identity does not have permission to get enrollers from the project
 
 #### Create enroller
-Method: POST
-Path: "/v0/:project_id/enrollers"
-Request: CreateRequest
+Method: POST \
+Path: "/v0/:project_id/enrollers" \
+Request: CreateRequest \
 Response: enroller
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to create enrollers in the project
+- 404 - project not found
+- 401 - current identity does not have permission to create enrollers in the project
 
 #### Delete enroller
-Method: DELETE
-Path: /v0/:project_id/enrollers/:enroller
-Request: ""
+Method: DELETE \
+Path: /v0/:project_id/enrollers/:enroller \
+Request: "" \
 Response: ""
 
 Errors:
-404 - project not found
-401 - current identity does not have permission to delete enrollers in the project
+- 404 - project not found
+- 401 - current identity does not have permission to delete enrollers in the project
 
 Where:
 ```

--- a/documentation/reference/api/orchestrator/projects.md
+++ b/documentation/reference/api/orchestrator/projects.md
@@ -9,55 +9,55 @@ Authorization:
 - Identity needs to be enrolled to the Orchestrator Controller via [Auth0](./auth0.md)
 
 #### List projects
-Method: GET
-Path: "/v0"
-Request: ""
+Method: GET \
+Path: "/v0" \
+Request: "" \
 Response: `[+ project]`
 
 #### Create project for space
-Method: POST
-Path: "/v0/:space_id"
-Request: create_request
+Method: POST \
+Path: "/v0/:space_id" \
+Request: create_request \
 Response: project
 
 Errors:
-401 - current identity does not have permission to create a project for that space
-409 - name should be unique
-400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*`
-400 - invalid request format
+- 401 - current identity does not have permission to create a project for that space
+- 409 - name should be unique
+- 400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*`
+- 400 - invalid request format
 
 #### Show project
-Method: GET
-Path: /v0/:project_id
-Request: ""
+Method: GET \
+Path: /v0/:project_id \
+Request: "" \
 Response: project
 
 Errors:
-404 - not found
-401 - current identity does not have permission to show the project
+- 404 - not found
+- 401 - current identity does not have permission to show the project
 
 #### Update project
-Mathod: PUT
-Path: /v0/:project_id
-Request: update_request
+Method: PUT \
+Path: /v0/:project_id \
+Request: update_request \
 Response: project
 
 Errors:
-404 - not found
-401 - current identity does not have permission to update the project
-409 - name should be unique
-400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
-400 - invalid request format
+- 404 - not found
+- 401 - current identity does not have permission to update the project
+- 409 - name should be unique
+- 400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
+- 400 - invalid request format
 
 #### Delete project
-Method: DELETE
-Path: /v0/:space_id/:project_id
-Request: ""
+Method: DELETE \
+Path: /v0/:space_id/:project_id \
+Request: "" \
 Response: ""
 
 Errors:
-404 - not found
-401 - current identity does not have permission to delete the project
+- 404 - not found
+- 401 - current identity does not have permission to delete the project
 
 Where:
 ```

--- a/documentation/reference/api/orchestrator/spaces.md
+++ b/documentation/reference/api/orchestrator/spaces.md
@@ -9,32 +9,32 @@ Authorization:
 - Identity needs to be enrolled to the Orchestrator Controller via [Auth0](./auth0.md)
 
 #### List spaces
-Method: GET
-Path: "/v0"
-Request: ""
+Method: GET \
+Path: "/v0" \
+Request: "" \
 Response: `[+ space]`
 
 #### Create space
-Method: POST
-Path: "/v0"
-Request: create_request
+Method: POST \
+Path: "/v0" \
+Request: create_request \
 Response: space
 
 Errors:
-401 - current user does not have permission to create a space
-409 - name should be unique
-400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
-400 - invalid request format
+- 401 - current user does not have permission to create a space
+- 409 - name should be unique
+- 400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
+- 400 - invalid request format
 
 #### Show space
-Method: GET
-Path: /v0/:space_id
-Request: ""
+Method: GET \
+Path: /v0/:space_id \
+Request: "" \
 Response: space
 
 Errors:
-404 - not found
-401 - current user does not have permission to show the space
+- 404 - not found
+- 401 - current user does not have permission to show the space
 
 #### Update space
 Mathod: PUT
@@ -43,23 +43,23 @@ Request: update_request
 Response: space
 
 Errors:
-404 - not found
-401 - current user does not have permission to update the space
-409 - name should be unique
-400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
-400 - invalid request format
+- 404 - not found
+- 401 - current user does not have permission to update the space
+- 409 - name should be unique
+- 400 - invalid name, it should match the regexp: `^([[:alnum:]])+([-_\.]?[[:alnum:]])*$`
+- 400 - invalid request format
 
 **WARNING**: updating spaces is not recommended. This API may be removed in the future
 
 #### Delete space
-Method: DELETE
-Path: /v0/:space_id
-Request: ""
+Method: DELETE \
+Path: /v0/:space_id \
+Request: "" \
 Response: ""
 
 Errors:
-404 - not found
-401 - current user does not have permission to delete the space
+- 404 - not found
+- 401 - current user does not have permission to delete the space
 
 Where:
 ```

--- a/documentation/reference/api/policies.md
+++ b/documentation/reference/api/policies.md
@@ -7,30 +7,30 @@ Worker address: "abac_policies"
 Implemented in `Ockam.Services.API.ABAC.PoliciesApi`
 
 #### List policies
-Method: GET
-Path: ""
-Request: ""
+Method: GET \
+Path: "" \
+Request: "" \
 Response: `{* action_id => policy_rule}`
 
 #### Show policy
-Method: GET
-Path: action_id
-Request: ""
+Method: GET \
+Path: action_id \
+Request: "" \
 Response: policy_rule
 
 #### Set policy
-Method: PUT
-Path: action_id
-Request: policy_rule
+Method: PUT \
+Path: action_id \
+Request: policy_rule \
 Response: ""
 
 Errors:
-400 - cannot decode policy
+- 400 - cannot decode policy
 
 #### Delete policy
-Method: DELETE
-Path: action_id
-Request: ""
+Method: DELETE \
+Path: action_id \
+Request: "" \
 Response: ""
 
 Where:


### PR DESCRIPTION
Use `\ ` to force line breaks in API descriptions and `- ` for errors

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
