### PR TITLE
#3732 improve the help message for `ockam identity show --help`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -158,6 +158,13 @@ impl NodeCommand {
 #[derive(Clone, Debug, Args)]
 pub struct NodeOpts {
     /// Override the default API node
-    #[arg(global = true, id = "node", short, long, default_value = "default")]
+    #[arg(
+        global = true,
+        id = "node",
+        value_name = "NODE",
+        short,
+        long,
+        default_value = "default"
+    )]
     pub api_node: String,
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

 See issue #3732. The current behaviour for the `ockam identity show --help` command is to display:
```
$ ockam identity show --help
Options:
  -n, --node <node>
```
We want to display instead
```
$ ockam identity show --help
Options:
  -n, --node <NODE>
```
## Proposed Changes

The change was fully described in the original description :-).
> set the value_name to NODE 

I haven't seen any unit or `bats` tests for help text, maybe that is something to consider for the future.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
