### PR TITLE
chore(rust): add ockam status command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
 dependencies = [
- "bstr 1.0.1",
+ "bstr 1.1.0",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -466,7 +466,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "num-integer",
  "ryu",
  "time",
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca0852af221f458706eb0725c03e4ed6c46af9ac98e6a689d5e634215d594dd"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
  "once_cell",
@@ -825,7 +825,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.3",
+ "terminal_size",
 ]
 
 [[package]]
@@ -952,16 +952,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size 0.1.17",
  "unicode-width",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1388,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
+checksum = "bd5f0c7e4bd266b8ab2550e6238d2e74977c23c15536ac7be45e9c95e2e3fbbb"
 
 [[package]]
 name = "doc-comment"
@@ -2087,15 +2086,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -2138,7 +2128,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes 1.3.0",
  "fnv",
- "itoa 1.0.4",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -2179,7 +2169,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2280,7 +2270,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.42.0",
@@ -2303,9 +2293,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jni"
@@ -2789,11 +2779,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3374,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pathdiff"
@@ -3506,9 +3496,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -3894,14 +3884,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
@@ -3946,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rustyline"
@@ -3986,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safemem"
@@ -4079,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
@@ -4161,7 +4151,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -4173,7 +4163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -4558,16 +4548,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
@@ -4626,7 +4606,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "serde",
  "time-core",
  "time-macros",
@@ -4929,9 +4909,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -20,6 +20,7 @@ mod reset;
 mod secure_channel;
 mod service;
 mod space;
+mod status;
 mod subscription;
 mod tcp;
 mod terminal;
@@ -45,6 +46,7 @@ use reset::ResetCommand;
 use secure_channel::{listener::SecureChannelListenerCommand, SecureChannelCommand};
 use service::ServiceCommand;
 use space::SpaceCommand;
+use status::StatusCommand;
 use tcp::{
     connection::TcpConnectionCommand, inlet::TcpInletCommand, listener::TcpListenerCommand,
     outlet::TcpOutletCommand,
@@ -242,6 +244,8 @@ pub enum OckamSubcommand {
     #[command(display_order = 802)]
     Project(ProjectCommand),
     #[command(display_order = 803)]
+    Status(StatusCommand),
+    #[command(display_order = 804)]
     Reset(ResetCommand),
 
     #[command(display_order = 811)]
@@ -321,6 +325,7 @@ impl OckamCommand {
             OckamSubcommand::Node(c) => c.run(options),
             OckamSubcommand::Policy(c) => c.run(options),
             OckamSubcommand::Project(c) => c.run(options),
+            OckamSubcommand::Status(c) => c.run(options),
             OckamSubcommand::Space(c) => c.run(options),
             OckamSubcommand::TcpConnection(c) => c.run(options),
             OckamSubcommand::TcpInlet(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -1,0 +1,125 @@
+use crate::util::{api, node_rpc, RpcBuilder};
+use crate::Result;
+use crate::{exitcode, CommandGlobalOpts};
+use anyhow::anyhow;
+use clap::Args;
+use ockam::{Context, TcpTransport};
+use ockam_api::cli_state::{IdentityState, NodeState};
+use ockam_api::nodes::models::base::NodeStatus;
+use ockam_identity::Identity;
+use ockam_vault::Vault;
+use std::time::Duration;
+
+/// Display Ockam status
+#[derive(Clone, Debug, Args)]
+pub struct StatusCommand {
+    /// Show status for all identities, default: enrolled only
+    #[arg(long, short)]
+    all: bool,
+}
+
+struct NodeDetails {
+    identity: Identity<Vault>,
+    state: NodeState,
+    status: String,
+}
+
+impl StatusCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, (options, self));
+    }
+}
+
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, StatusCommand)) -> Result<()> {
+    run_impl(&ctx, opts, cmd).await
+}
+
+async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: StatusCommand) -> Result<()> {
+    let node_states = match opts.state.nodes.list() {
+        Ok(nodes) => nodes,
+        Err(_err) => {
+            return Err(crate::Error::new(
+                exitcode::IOERR,
+                anyhow!("No nodes registered on this system!"),
+            ));
+        }
+    };
+
+    let mut node_details: Vec<NodeDetails> = vec![];
+    for node_state in &node_states {
+        let node_infos = NodeDetails {
+            identity: node_state.config.identity(ctx).await?,
+            state: node_state.clone(),
+            status: get_node_status(ctx, &opts, node_state).await?,
+        };
+        node_details.push(node_infos);
+    }
+
+    let mut status_identities: Vec<IdentityState> = vec![];
+    for identity in opts.state.identities.list()? {
+        if cmd.all {
+            status_identities.push(identity)
+        } else {
+            match &identity.config.enrollment_status {
+                Some(_enrollment) => status_identities.push(identity),
+                None => (),
+            }
+        }
+    }
+
+    print_status(&opts, status_identities, node_details).await?;
+
+    Ok(())
+}
+
+async fn get_node_status(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    node_state: &NodeState,
+) -> Result<String> {
+    let mut node_status: String = "Stopped".to_string();
+
+    let tcp = TcpTransport::create(ctx).await?;
+    let mut rpc = RpcBuilder::new(ctx, opts, &node_state.config.name)
+        .tcp(&tcp)?
+        .build();
+    if rpc
+        .request_with_timeout(api::query_status(), Duration::from_millis(200))
+        .await
+        .is_ok()
+    {
+        let resp = rpc.parse_response::<NodeStatus>()?;
+        node_status = resp.status.to_string();
+    }
+
+    Ok(node_status)
+}
+
+async fn print_status(
+    opts: &CommandGlobalOpts,
+    identities: Vec<IdentityState>,
+    mut node_details: Vec<NodeDetails>,
+) -> Result<()> {
+    let default_identity = opts.state.identities.default()?;
+
+    for (i_idx, identity) in identities.iter().enumerate() {
+        println!("Identity[{}]", i_idx);
+        if default_identity.config.identifier == identity.config.identifier {
+            println!("{:2}Default: yes", "")
+        }
+        for line in identity.to_string().lines() {
+            println!("{:2}{}", "", line);
+        }
+
+        node_details.retain(|nd| nd.identity.identifier() == &identity.config.identifier);
+        if !node_details.is_empty() {
+            println!("{:2}Linked Nodes:", "");
+            for (n_idx, node) in node_details.iter().enumerate() {
+                println!("{:4}Node[{}]:", "", n_idx);
+                println!("{:6}Name: {}", "", node.state.config.name);
+                println!("{:6}Status: {}", "", node.status)
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Current Behavior
No `status` command available.

## Proposed Changes
Introduce `status` command, providing information about enrolled or all active identities and linked nodes.

Solves https://github.com/build-trust/ockam/issues/3460

## Checks
- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
