### PR TITLE
feat(rust): store default node in the cli state

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -168,7 +168,7 @@ async fn run_impl(
         rpc.request(api::credentials::get_credential(false)).await?;
         if rpc.parse_and_print_response::<Credential>().is_err() {
             eprintln!("failed to fetch membership credential");
-            delete_node(&opts, node_name, true);
+            delete_node(&opts, node_name, true)?;
         }
     }
 
@@ -270,7 +270,7 @@ async fn run_foreground_node(
             }
             Ok(_) | Err(_) => {
                 eprintln!("failed to fetch membership credential");
-                delete_node(&opts, &cmd.node_name, true);
+                delete_node(&opts, &cmd.node_name, true)?;
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -32,7 +32,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
     if cmd.all {
         delete_all_nodes(opts, cmd.force)?;
     } else {
-        delete_node(&opts, &cmd.node_name, cmd.force);
+        delete_node(&opts, &cmd.node_name, cmd.force)?;
         println!("Deleted node '{}'", &cmd.node_name);
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -4,7 +4,6 @@ use std::env::current_exe;
 use std::fs::OpenOptions;
 use std::path::Path;
 use std::process::Command;
-use tracing::trace;
 
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
@@ -155,20 +154,18 @@ pub(super) async fn add_project_authority(
 }
 
 pub async fn delete_embedded_node(opts: &CommandGlobalOpts, name: &str) {
-    delete_node(opts, name, false)
+    let _ = delete_node(opts, name, false);
 }
 
-pub fn delete_node(opts: &CommandGlobalOpts, name: &str, force: bool) {
-    if let Ok(s) = opts.state.nodes.get(name) {
-        trace!(%name, "Deleting node");
-        let _ = s.delete(force);
-    }
+pub fn delete_node(opts: &CommandGlobalOpts, name: &str, force: bool) -> anyhow::Result<()> {
+    opts.state.nodes.delete(name, force)?;
+    Ok(())
 }
 
 pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> anyhow::Result<()> {
     let nodes_states = opts.state.nodes.list()?;
     for s in nodes_states {
-        let _ = s.delete(force);
+        opts.state.nodes.delete(&s.config.name, force)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/build-trust/codebase/issues/477

The first node to be created will be set as the default node, which can be retrieved through the `CliState`, just as the default vault and identity.

When the default node is deleted, the first node in the list will be set as the new default. If there are no nodes, then no there won't be any default (no symlink under the `defaults` dir).

Once we land this, we can start removing the hardcoded "default" value for the `node` arguments and point to the default node instead. I will create new issues for this development.