### PR TITLE
fix(elixir): improvements to metrics cardinality and reporting

### DIFF
--- a/implementations/elixir/ockam/ockam_metrics/lib/application.ex
+++ b/implementations/elixir/ockam/ockam_metrics/lib/application.ex
@@ -42,8 +42,7 @@ defmodule Ockam.Metrics.Application do
   def get_poller_measurements() do
     ockam_measurements = [
       {Ockam.Metrics.TelemetryPoller, :dispatch_worker_count, []},
-      {Ockam.Metrics.TelemetryPoller, :dispatch_secure_channels_count, []},
-      {Ockam.Metrics.TelemetryPoller, :dispatch_tcp_connections, []}
+      {Ockam.Metrics.TelemetryPoller, :dispatch_secure_channels_count, []}
     ]
 
     config_measurements = Application.get_env(:ockam_metrics, :poller_measurements, [])

--- a/implementations/elixir/ockam/ockam_metrics/lib/telemetry_poller.ex
+++ b/implementations/elixir/ockam/ockam_metrics/lib/telemetry_poller.ex
@@ -131,25 +131,6 @@ defmodule Ockam.Metrics.TelemetryPoller do
     end
   end
 
-  def dispatch_tcp_connections() do
-    if application_started?(:ranch) do
-      Enum.map(:ranch.info(), fn {_ref, info} ->
-        connections = Map.get(info, :all_connections, [])
-        port = Map.get(info, :port, 0)
-
-        Telemetry.emit_event([:tcp, :connections],
-          measurements: %{count: connections},
-          metadata: %{port: port}
-        )
-      end)
-    else
-      Logger.error("Cannot report number of TCP connections. :ranch application is not started")
-    end
-  catch
-    type, error ->
-      {type, error}
-  end
-
   defp application_started?(app) do
     case List.keyfind(Application.started_applications(), app, 0) do
       {^app, _description, _version} -> true

--- a/implementations/elixir/ockam/ockam_services/lib/services/api/abac_policies_api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/abac_policies_api.ex
@@ -30,6 +30,14 @@ defmodule Ockam.Services.API.ABAC.PoliciesApi do
     TypedCBOR.encode!({:map, :string, :string}, formatted_policies)
   end
 
+  @doc """
+  Policies are defined for specific action ids.
+  Cardinality should be low even if we use the full path.
+  """
+  @impl true
+  def path_group(""), do: "all"
+  def path_group(path), do: path
+
   @impl true
   def handle_request(%Request{method: :get, path: ""}, state) do
     ## TODO: different access permissions for policies

--- a/implementations/elixir/ockam/ockam_services/lib/services/api/discovery_api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/discovery_api.ex
@@ -21,6 +21,14 @@ defmodule Ockam.Services.API.Discovery do
     {:ok, Map.put(state, :storage, {storage, storage.init(storage_options)})}
   end
 
+  @doc """
+  Path points to a specific service in a small set.
+  Cardinality should be low even if we use the full path.
+  """
+  @impl true
+  def path_group(""), do: "all"
+  def path_group(path), do: path
+
   @impl true
   def handle_request(%Request{method: :get, path: ""}, state) do
     case list(state) do

--- a/implementations/elixir/ockam/ockam_services/lib/services/metrics/metrics.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/metrics/metrics.ex
@@ -13,18 +13,24 @@ defmodule Ockam.Services.Metrics do
       ),
       Metrics.last_value("ockam.credentials.attribute_sets.count"),
       Metrics.counter("ockam.credentials.presented.count", tags: [:identity_id]),
-      Metrics.counter("ockam.credentials.verified.count", tags: [:identity_id, :attributes]),
+      Metrics.counter("ockam.credentials.verified.count", tags: [:identity_id]),
+      Metrics.sum("ockam.credentials.verified.attributes.count",
+        tags: [:identity_id],
+        measurement: fn _measurements, meta ->
+          Map.get(meta, :attributes, 0)
+        end
+      ),
       Metrics.counter("ockam.api.handle_request",
         event_name: [:ockam, :api, :handle_request, :start],
         measurement: :system_time,
-        tags: [:address, :path, :method]
+        tags: [:address, :path_group, :method]
       ),
       Metrics.distribution("ockam.api.handle_request.duration",
         event_name: [:ockam, :api, :handle_request, :stop],
         measurement: :duration,
-        tags: [:address, :path, :method, :status, :reply],
+        tags: [:address, :path_group, :method, :status, :reply],
         unit: {:native, :millisecond},
-        reporter_options: [buckets: [0.01, 0.1, 0.5, 1]]
+        reporter_options: [buckets: [10, 50, 100, 250, 500, 1000]]
       ),
       Metrics.counter("ockam.api.handle_request.decode_error",
         event_name: [:ockam, :api, :handle_request, :decode_error],

--- a/implementations/elixir/ockam/ockam_services/test/services/api_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/api_test.exs
@@ -6,6 +6,9 @@ defmodule Ockam.Services.API.Tests.EchoAPI do
   def handle_request(request, state) do
     {:reply, 200, request.body, state}
   end
+
+  @impl true
+  def path_group(_path), do: "path_group"
 end
 
 defmodule Ockam.Services.API.Test do
@@ -47,11 +50,11 @@ defmodule Ockam.Services.API.Test do
 
     assert [
              {[:ockam, :api, :handle_request, :start],
-              %{metadata: %{method: :get, path: "path"}}},
+              %{metadata: %{method: :get, path_group: "path_group"}}},
              {[:ockam, :api, :handle_request, :stop],
               %{
                 measurements: %{duration: _duration},
-                metadata: %{method: :get, path: "path", reply: true, status: 200}
+                metadata: %{method: :get, path_group: "path_group", reply: true, status: 200}
               }}
            ] = Enum.sort(metrics)
   end


### PR DESCRIPTION
For API workers add new function `path_group/1` to return simplified
path for metrics purposes. By default it will always return "all" and should
be defined in order to report metrics for different paths.

Removed addresses from tags for multiple metrics to reduce cardinality.

Use 1, 10, 50, 100, 500, 1000 ms duration buckets for duration metrics

Report TCP listener liveness metric

Addresses https://github.com/build-trust/ockam/issues/3882 https://github.com/build-trust/ockam/issues/3881 https://github.com/build-trust/ockam/issues/3883

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
