### PR TITLE
feat(rust): store vault name on idt config (cli state)

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -90,8 +90,8 @@ pub(super) async fn init_node_state(
     identity: Option<&String>,
 ) -> anyhow::Result<()> {
     // Get vault specified in the argument, or get the default
-    let vault_state = if let Some(v) = vault {
-        opts.state.vaults.get(v)?
+    let vault_state = if let Some(name) = vault {
+        opts.state.vaults.get(name)?
     }
     // Or get the default
     else if let Ok(v) = opts.state.vaults.default() {
@@ -113,7 +113,8 @@ pub(super) async fn init_node_state(
         let vault = vault_state.config.get().await?;
         let identity_name = hex::encode(random::<[u8; 4]>());
         let identity = Identity::create(ctx, &vault).await?;
-        let identity_config = cli_state::IdentityConfig::new(&identity).await;
+        let identity_config =
+            cli_state::IdentityConfig::new(&identity, &vault_state.name()?).await?;
         opts.state
             .identities
             .create(&identity_name, identity_config)?

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -562,7 +562,7 @@ mod tests {
         cli_state.vaults.create(&v_name, v_config).await?;
 
         let idt = Identity::create(ctx, &v).await?;
-        let idt_config = IdentityConfig::new(&idt).await;
+        let idt_config = IdentityConfig::new(&idt, &v_name).await?;
         cli_state
             .identities
             .create(&cli_state::random_name(), idt_config)?;


### PR DESCRIPTION
This will be needed to complete the issues related to adding the optional `--identity` to some commands (ex: https://github.com/build-trust/ockam/issues/3906). With this information, we will be able to retrieve an identity without forcing the user to provide a vault.

I've also added a method to read the authorities config from the node's state, which will be needed for the credentials commands issues.