### PR TITLE
feat(rust): node launch_config optional JSON string

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -129,7 +129,7 @@ pub struct NodeCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum NodeSubcommand {
     #[command(display_order = 800)]
-    Create(CreateCommand),
+    Create(Box<CreateCommand>),
     #[command(display_order = 800)]
     Delete(DeleteCommand),
     #[command(display_order = 800)]


### PR DESCRIPTION
Adds the ability for `ockam node create --launch_config <path>` to optionally take a JSON string instead of a filepath.

See issue https://github.com/build-trust/ockam/issues/3895

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
The `--launch_config` currently only takes a path to a JSON file with the expected configuration data.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Adds parsing of configuration data directly from the string passed to `--launch_config` , falling back to a filepath otherwise.
This makes configuration easier in orchestration use cases where accessing the filesystem is not easy.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [✓] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [✓] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [✓] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [✓] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
