### PR TITLE
fix(shell): Guarantee ansi escape codes over any *nix shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ info() {
   local _no_color='\033[0m'
 
   if $_ansi_escapes_are_valid; then
-    echo "  ${_green} INFO${_no_color} $1"
+    printf "  ${_green} INFO${_no_color} $1\n"
   else
     echo "   INFO $1"
   fi
@@ -60,7 +60,7 @@ error() {
   echo
 
   if $_ansi_escapes_are_valid; then
-    echo "   ${_red}ERROR${_no_color} $1"
+    printf "   ${_red}ERROR${_no_color} $1\n"
   else
     echo "   ERROR $1"
   fi
@@ -81,7 +81,7 @@ heading() {
   local _no_color='\033[0m'
 
   if $_ansi_escapes_are_valid; then
-    echo "${_orange}        $1${_no_color}"
+    printf "${_orange}        $1${_no_color}\n"
   else
     echo "${_orange}        $1${_no_color}"
   fi
@@ -189,7 +189,7 @@ main() {
   echo "          ockam"
   echo
   heading "LEARN MORE:"
-  echo "        Learn more at https://docs.ockam.io/get-started#command"
+  echo "        Learn more at https://docs.ockam.io"
   echo
   heading "FEEDBACK:"
   echo "        If you have any questions or feedback, please start a discussion"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

The `echo` command is used in the current install.sh for lines with ansi escape codes (colors). Echo is implemented a bit differently in each shell, often with a `-e` flag to escape the color codes.

## Proposed Changes

Rather than use `echo`, this targets the `printf` command for those calls. This requires a newline (printf does not automatically add that), but otherwise should be a drop in replacement compliant with all Posix shells.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
