### PR TITLE
refactor(rust): replace `default` with actual default node name

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::util::{delete_all_nodes, delete_node};
+use crate::node::util::{default_node_name, delete_all_nodes, delete_node};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
@@ -7,8 +7,8 @@ use clap::Args;
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Name of the node.
-    #[arg(default_value = "default", group = "nodes")]
-    node_name: String,
+    #[arg(group = "nodes")]
+    node_name: Option<String>,
 
     /// Terminate all nodes
     #[arg(long, short, group = "nodes")]
@@ -32,8 +32,12 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
     if cmd.all {
         delete_all_nodes(opts, cmd.force)?;
     } else {
-        delete_node(&opts, &cmd.node_name, cmd.force)?;
-        println!("Deleted node '{}'", &cmd.node_name);
+        let node_name = &match cmd.node_name {
+            Some(name) => name,
+            None => default_node_name(&opts),
+        };
+        delete_node(&opts, node_name, cmd.force)?;
+        println!("Deleted node '{}'", node_name);
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,3 +1,4 @@
+use crate::node::util::default_node_name;
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
@@ -23,8 +24,7 @@ const IS_NODE_UP_MAX_TIMEOUT: Duration = Duration::from_secs(1);
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Name of the node.
-    #[arg(default_value = "default")]
-    node_name: String,
+    node_name: Option<String>,
 }
 
 impl ShowCommand {
@@ -37,7 +37,11 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = &cmd.node_name;
+    let node_name = &match cmd.node_name {
+        Some(name) => name,
+        None => default_node_name(&opts),
+    };
+
     let tcp = TcpTransport::create(&ctx).await?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, node_name).tcp(&tcp)?.build();
     print_query_status(&mut rpc, node_name, false).await?;

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use ockam::TcpTransport;
 
 use crate::node::show::print_query_status;
-use crate::node::util::spawn_node;
+use crate::node::util::{default_node_name, spawn_node};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 
@@ -12,8 +12,7 @@ use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StartCommand {
     /// Name of the node.
-    #[arg(default_value = "default")]
-    node_name: String,
+    node_name: Option<String>,
 
     #[arg(long, default_value = "false")]
     aws_kms: bool,
@@ -29,7 +28,11 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> crate::Result<()> {
-    let node_name = &cmd.node_name;
+    let node_name = &match cmd.node_name {
+        Some(name) => name,
+        None => default_node_name(&opts),
+    };
+
     let node_state = opts.state.nodes.get(node_name)?;
     node_state.kill_process(false)?;
     let node_setup = node_state.setup()?;

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,3 +1,4 @@
+use crate::node::util::default_node_name;
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
@@ -6,8 +7,7 @@ use clap::Args;
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StopCommand {
     /// Name of the node.
-    #[arg(default_value = "default")]
-    node_name: String,
+    node_name: Option<String>,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
     #[arg(long)]
     force: bool,
@@ -23,7 +23,11 @@ impl StopCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
-    let node_state = opts.state.nodes.get(&cmd.node_name)?;
+    let node_name = &match cmd.node_name {
+        Some(name) => name,
+        None => default_node_name(&opts),
+    };
+    let node_state = opts.state.nodes.get(node_name)?;
     node_state.kill_process(cmd.force)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -238,3 +238,13 @@ pub fn spawn_node(
 
     Ok(())
 }
+
+/// Retreive the default node name from the global options
+pub fn default_node_name(opts: &CommandGlobalOpts) -> String {
+    opts.state
+        .nodes
+        .default()
+        .unwrap_or_else(|_| panic!("No default Node found"))
+        .config
+        .name
+}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -8,6 +8,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
+use crate::node::util::default_node_name;
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{help, CommandGlobalOpts};
@@ -30,8 +31,8 @@ pub struct CreateCommand {
 #[derive(Clone, Debug, Args)]
 pub struct SecureChannelListenerNodeOpts {
     /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE", default_value = "default")]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }
 
 impl CreateCommand {
@@ -48,7 +49,11 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let node = extract_address_value(&cmd.node_opts.at)?;
+    let at = &match cmd.node_opts.at {
+        Some(at) => at,
+        None => default_node_name(&opts),
+    };
+    let node = extract_address_value(at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = Request::post("/node/secure_channel_listener").body(
         CreateSecureChannelListenerRequest::new(&cmd.address, cmd.authorized_identifiers),

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,3 +1,4 @@
+use crate::node::util::default_node_name;
 use crate::util::extract_address_value;
 use crate::util::node_rpc;
 use crate::util::Rpc;
@@ -19,8 +20,8 @@ pub struct CreateCommand {
 #[derive(Clone, Debug, Args)]
 pub struct TCPListenerNodeOpts {
     /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE", default_value = "default")]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }
 
 impl CreateCommand {
@@ -33,7 +34,11 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&cmd.node_opts.at)?;
+    let at_node_name = &match cmd.node_opts.at {
+        Some(name) => name,
+        None => default_node_name(&opts),
+    };
+    let node_name = extract_address_value(at_node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::post("/node/tcp/listener")).await?;
     let response = rpc.parse_response::<models::transport::TransportStatus>()?;


### PR DESCRIPTION
Signed-off-by: mohamed <mohamedabdelfatah2027@gmail.com>

<!-- Thank you for sending a pull request :heart: -->
Closes #3931 
## Current Behavior
All commands having a `node` argument has a hardcoded default node name = `default`

## Proposed Changes
Replace the hardcoded value with the actual default node's name using the [`default`](https://github.com/build-trust/ockam/blob/94e430867a5cc2245ac23e38350c41c95aefd3de/implementations/rust/ockam/ockam_api/src/cli_state.rs#L347) function from `ockam_api`.

I changed all the `node` arguments type from `String` to `Option<String>`. With this, if the node's name isn't provided, the default node's name will be fetched using the helper function `default_node_name` in `ockam_command/src/node/util.rs`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
