### PR TITLE
refactor(rust): adapt `request_controller` to accept an optional ident

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -53,8 +53,16 @@ mod node {
             trace!(target: TARGET, project_id, "listing addons");
 
             let req_builder = Request::get(format!("/v0/{project_id}/addons"));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
 
         pub(crate) async fn configure_addon(
@@ -84,8 +92,16 @@ mod node {
             trace!(target: TARGET, project_id, "configuring okta addon");
 
             let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
 
         pub(crate) async fn disable_addon(
@@ -102,8 +118,16 @@ mod node {
             trace!(target: TARGET, project_id, addon_id, "disabling addon");
 
             let req_builder = Request::delete(format!("/v0/{project_id}/addons/{addon_id}"));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -55,6 +55,7 @@ mod node {
                 cloud_route,
                 api_service,
                 req_builder,
+                None,
             )
             .await
         }
@@ -81,6 +82,7 @@ mod node {
                 cloud_route,
                 "projects",
                 req_builder,
+                None,
             )
             .await
         }
@@ -105,6 +107,7 @@ mod node {
                 cloud_route,
                 api_service,
                 req_builder,
+                None,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -68,11 +68,12 @@ mod node {
     use std::str::FromStr;
 
     use minicbor::Encode;
+    use ockam_vault::Vault;
     use rust_embed::EmbeddedFile;
 
     use ockam_core::api::RequestBuilder;
     use ockam_core::{self, route, Address, Result, Route};
-    use ockam_identity::{IdentityIdentifier, TrustIdentifierPolicy};
+    use ockam_identity::{Identity, IdentityIdentifier, TrustIdentifierPolicy};
     use ockam_node::api::request;
     use ockam_node::Context;
 
@@ -134,6 +135,7 @@ mod node {
     }
 
     impl NodeManagerWorker {
+        #[allow(clippy::too_many_arguments)]
         pub(super) async fn request_controller<T>(
             &mut self,
             ctx: &mut Context,
@@ -142,10 +144,15 @@ mod node {
             cloud_route: impl Into<Route>,
             api_service: &str,
             req: RequestBuilder<'_, T>,
+            ident: Option<Identity<Vault>>,
         ) -> Result<Vec<u8>>
         where
             T: Encode<()>,
         {
+            match ident {
+                Some(_ident) => None::<T>,
+                None => None,
+            };
             let mut node_manger = self.get().write().await;
             let cloud_route = cloud_route.into();
             let sc = node_manger.controller_secure_channel(cloud_route).await?;

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -308,6 +308,7 @@ mod node {
                 cloud_route,
                 "projects",
                 req_builder,
+                None,
             )
             .await
         }
@@ -324,7 +325,7 @@ mod node {
             trace!(target: TARGET, "listing projects");
 
             let req_builder = Request::get("/v0");
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
 
@@ -341,7 +342,7 @@ mod node {
             trace!(target: TARGET, %project_id, "getting project");
 
             let req_builder = Request::get(format!("/v0/{project_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
 
@@ -359,7 +360,7 @@ mod node {
             trace!(target: TARGET, %space_id, %project_id, "deleting project");
 
             let req_builder = Request::delete(format!("/v0/{space_id}/{project_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
 
@@ -377,7 +378,7 @@ mod node {
             trace!(target: TARGET, %project_id, "adding enroller");
 
             let req_builder = Request::post(format!("/v0/{project_id}/enrollers")).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
 
@@ -394,7 +395,7 @@ mod node {
             trace!(target: TARGET, %project_id, "listing enrollers");
 
             let req_builder = Request::get(format!("/v0/{project_id}/enrollers"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
 
@@ -413,7 +414,7 @@ mod node {
 
             let req_builder =
                 Request::delete(format!("/v0/{project_id}/enrollers/{enroller_identity_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
                 .await
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -92,6 +92,7 @@ mod node {
                 cloud_route,
                 "spaces",
                 req_builder,
+                None,
             )
             .await
         }
@@ -108,7 +109,7 @@ mod node {
             trace!(target: TARGET, "listing spaces");
 
             let req_builder = Request::get("/v0/");
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
                 .await
         }
 
@@ -125,7 +126,7 @@ mod node {
             trace!(target: TARGET, space = %id, space = %id, "getting space");
 
             let req_builder = Request::get(format!("/v0/{id}"));
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
                 .await
         }
 
@@ -142,7 +143,7 @@ mod node {
             trace!(target: TARGET, space = %id, "deleting space");
 
             let req_builder = Request::delete(format!("/v0/{id}"));
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder)
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
                 .await
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -115,8 +115,16 @@ mod node {
             trace!(target: TARGET, subscription = %id, "unsubscribing");
 
             let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
 
         pub(crate) async fn update_subscription_space(
@@ -133,8 +141,16 @@ mod node {
             trace!(target: TARGET, subscription = %id, "updating subscription space");
 
             let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
         pub(crate) async fn update_subscription_contact_info(
             &mut self,
@@ -150,8 +166,16 @@ mod node {
             trace!(target: TARGET, subscription = %id, "updating subscription contact info");
 
             let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
         pub(crate) async fn list_subscriptions(
             &mut self,
@@ -165,8 +189,16 @@ mod node {
             trace!(target: TARGET, "listing subscriptions");
 
             let req_builder = Request::get("/v0/");
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
         pub(crate) async fn get_subscription(
             &mut self,
@@ -181,8 +213,16 @@ mod node {
             trace!(target: TARGET, subscription = %id, "getting subscription");
 
             let req_builder = Request::get(format!("/v0/{}", id));
-            self.request_controller(ctx, label, None, cloud_route, API_SERVICE, req_builder)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
         }
         pub(crate) async fn activate_subscription(
             &mut self,
@@ -204,6 +244,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
+                None,
             )
             .await
         }


### PR DESCRIPTION
## Current Behavior

The request_controller function creates a secure_channel to the passed cloud_route, but it's always using the node's default identity.

## Proposed Changes

This PR adds an optional `Identity` parameter to the `request_controller` function in `ockam::ockam_api`, and passes in a default `None` for that parameter in each call to that function.

Solves #3903


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
