### PR TITLE
feat(rust): add `identity` arg to `cloudopts` in `ockam_command`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -321,7 +321,10 @@ pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Resu
 pub(crate) const OCKAM_CONTROLLER_ADDR: &str = "OCKAM_CONTROLLER_ADDR";
 
 #[derive(Clone, Debug, Args)]
-pub struct CloudOpts;
+pub struct CloudOpts {
+    #[arg(long = "identity", value_name = "IDENTITY")]
+    identity: Option<String>,
+}
 
 impl CloudOpts {
     pub fn route(&self) -> MultiAddr {


### PR DESCRIPTION
## Current Behavior

Whenever `CloudOpts`, there is no representation for an alias or name of an identity.

## Proposed Changes

This PR solves #3904 by adding a new optional argument to all the commands using `CloudOpts`.
This argument is named `identity`, of type `Option<String>`, and represents the alias/name
of an identity. 

## Checks

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.