### PR TITLE
feat(rust): added optional `identity_name` field to `createproject`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -25,6 +25,7 @@ pub struct Addon<'a> {
 
 mod node {
     use minicbor::Decoder;
+    use ockam::AsyncTryClone;
     use tracing::trace;
 
     use ockam_core::api::Request;
@@ -53,6 +54,11 @@ mod node {
             trace!(target: TARGET, project_id, "listing addons");
 
             let req_builder = Request::get(format!("/v0/{project_id}/addons"));
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -60,7 +66,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -96,6 +102,11 @@ mod node {
             trace!(target: TARGET, project_id, "configuring okta addon");
 
             let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -103,7 +114,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -151,6 +162,11 @@ mod node {
             trace!(target: TARGET, project_id, addon_id, "disabling addon");
 
             let req_builder = Request::delete(format!("/v0/{project_id}/addons/{addon_id}"));
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -158,7 +174,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -136,6 +136,11 @@ mod node {
                 "/v0/{project_id}/addons/influxdb_token_lease_manager"
             ))
             .body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -143,7 +148,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -55,9 +55,10 @@ mod node {
 
             let req_builder = Request::get(format!("/v0/{project_id}/addons"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -103,9 +104,10 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -137,9 +139,10 @@ mod node {
             ))
             .body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -168,9 +171,10 @@ mod node {
 
             let req_builder = Request::delete(format!("/v0/{project_id}/addons/{addon_id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -23,6 +23,7 @@ mod node {
     use tracing::trace;
 
     use ockam_core::api::Request;
+    use ockam_core::AsyncTryClone;
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
@@ -48,6 +49,11 @@ mod node {
             let api_service = "auth0_authenticator";
 
             trace!(target: TARGET, "executing auth0 flow");
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 api_service,
@@ -55,7 +61,7 @@ mod node {
                 cloud_route,
                 api_service,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -75,6 +81,11 @@ mod node {
             trace!(target: TARGET, "generating tokens");
 
             let req_builder = Request::post("v0/").body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -82,7 +93,7 @@ mod node {
                 cloud_route,
                 "projects",
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -99,6 +110,10 @@ mod node {
             let req_builder = Request::post("v0/enroll").body(req_body);
             let api_service = "enrollment_token_authenticator";
 
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             trace!(target: TARGET, "authenticating token");
             self.request_controller(
                 ctx,
@@ -107,7 +122,7 @@ mod node {
                 cloud_route,
                 api_service,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -50,9 +50,10 @@ mod node {
 
             trace!(target: TARGET, "executing auth0 flow");
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -82,9 +83,10 @@ mod node {
 
             let req_builder = Request::post("v0/").body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -110,9 +112,10 @@ mod node {
             let req_builder = Request::post("v0/enroll").body(req_body);
             let api_service = "enrollment_token_authenticator";
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             trace!(target: TARGET, "authenticating token");
             self.request_controller(

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -2,12 +2,11 @@ use std::str::FromStr;
 
 use minicbor::{Decode, Encode};
 
+use crate::error::ApiError;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 use ockam_core::{CowStr, Result, Route};
 use ockam_multiaddr::MultiAddr;
-
-use crate::error::ApiError;
 
 pub mod addon;
 pub mod enroll;
@@ -117,8 +116,11 @@ mod node {
         }
 
         /// Returns a secure channel between the node and the controller.
-        async fn controller_secure_channel(&mut self, route: impl Into<Route>) -> Result<Address> {
-            let identity = self.identity()?;
+        async fn controller_secure_channel(
+            &mut self,
+            route: impl Into<Route>,
+            identity: Identity<Vault>,
+        ) -> Result<Address> {
             let route = route.into();
             // Create secure channel for the given route using the orchestrator identity.
             trace!(target: TARGET, %route, "Creating orchestrator secure channel");
@@ -144,18 +146,16 @@ mod node {
             cloud_route: impl Into<Route>,
             api_service: &str,
             req: RequestBuilder<'_, T>,
-            ident: Option<Identity<Vault>>,
+            ident: Identity<Vault>,
         ) -> Result<Vec<u8>>
         where
             T: Encode<()>,
         {
-            match ident {
-                Some(_ident) => None::<T>,
-                None => None,
-            };
             let mut node_manger = self.get().write().await;
             let cloud_route = cloud_route.into();
-            let sc = node_manger.controller_secure_channel(cloud_route).await?;
+            let sc = node_manger
+                .controller_secure_channel(cloud_route, ident)
+                .await?;
             let route = route![&sc.to_string(), api_service];
             let res = request(ctx, label, schema, route, req).await;
             ctx.stop_worker(sc).await?;

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -364,25 +364,25 @@ mod node {
 
             let req_builder = Request::post(format!("/v0/{space_id}")).body(&req_body);
             let cli_state = cli_state::CliState::new()?;
-            let inner = self.get().read().await;
-            let ident = match &req_body.identity_name {
-                Some(existing_identity_name) => {
-                    let identity_cfg = cli_state
-                        .identities
-                        .get(existing_identity_name.as_ref())?
-                        .config;
-                    match identity_cfg.get(ctx, inner.vault()?).await {
-                        Ok(idt) => idt,
-                        Err(_) => {
-                            let vault_cfg = cli_state.vaults.default()?.config;
-                            identity_cfg.get(ctx, &vault_cfg.get().await?).await?
+            let ident = {
+                let inner = self.get().read().await;
+                match &req_body.identity_name {
+                    Some(existing_identity_name) => {
+                        let identity_cfg = cli_state
+                            .identities
+                            .get(existing_identity_name.as_ref())?
+                            .config;
+                        match identity_cfg.get(ctx, inner.vault()?).await {
+                            Ok(idt) => idt,
+                            Err(_) => {
+                                let vault_cfg = cli_state.vaults.default()?.config;
+                                identity_cfg.get(ctx, &vault_cfg.get().await?).await?
+                            }
                         }
                     }
+                    None => inner.identity()?.async_try_clone().await?,
                 }
-                None => inner.identity()?.async_try_clone().await?,
             };
-
-            drop(inner);
 
             self.request_controller(
                 ctx,
@@ -409,9 +409,10 @@ mod node {
 
             let req_builder = Request::get("/v0");
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -439,9 +440,10 @@ mod node {
 
             let req_builder = Request::get(format!("/v0/{project_id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -470,9 +472,10 @@ mod node {
 
             let req_builder = Request::delete(format!("/v0/{space_id}/{project_id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -501,9 +504,10 @@ mod node {
 
             let req_builder = Request::post(format!("/v0/{project_id}/enrollers")).body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -531,9 +535,10 @@ mod node {
 
             let req_builder = Request::get(format!("/v0/{project_id}/enrollers"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -563,9 +568,10 @@ mod node {
             let req_builder =
                 Request::delete(format!("/v0/{project_id}/enrollers/{enroller_identity_id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
+use ockam_core::AsyncTryClone;
 use ockam_core::CowStr;
 use ockam_core::Result;
 #[cfg(feature = "tag")]
@@ -269,7 +270,7 @@ pub struct CreateProject<'a> {
     #[b(2)] pub services: Vec<CowStr<'a>>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
     #[b(4)] pub enforce_credentials: Option<bool>,
-    #[b(5)] pub identity_name: Option<String>
+    #[b(5)] pub identity_name: Option<CowStr<'a>>
 }
 
 impl<'a> CreateProject<'a> {
@@ -278,14 +279,14 @@ impl<'a> CreateProject<'a> {
         enforce_credentials: Option<bool>,
         users: &'a [T],
         services: &'a [T],
-        identity_name: Option<String>,
+        identity_name: Option<S>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             name: name.into(),
             enforce_credentials,
-            identity_name,
+            identity_name: identity_name.map(|x| x.into()),
             services: services.iter().map(|x| CowStr::from(x.as_ref())).collect(),
             users: users.iter().map(|x| CowStr::from(x.as_ref())).collect(),
         }
@@ -361,18 +362,27 @@ mod node {
             let label = "create_project";
             trace!(target: TARGET, %space_id, project_name = %req_body.name, "creating project");
 
-            let req_builder = Request::post(format!("/v0/{space_id}")).body(req_body);
+            let req_builder = Request::post(format!("/v0/{space_id}")).body(&req_body);
             let cli_state = cli_state::CliState::new()?;
+            let inner = self.get().read().await;
+            let ident = match &req_body.identity_name {
+                Some(existing_identity_name) => {
+                    let identity_cfg = cli_state
+                        .identities
+                        .get(existing_identity_name.as_ref())?
+                        .config;
+                    match identity_cfg.get(ctx, inner.vault()?).await {
+                        Ok(idt) => idt,
+                        Err(_) => {
+                            let vault_cfg = cli_state.vaults.default()?.config;
+                            identity_cfg.get(ctx, &vault_cfg.get().await?).await?
+                        }
+                    }
+                }
+                None => inner.identity()?.async_try_clone().await?,
+            };
 
-            let default_vault = cli_state.vaults.default()?.config.get().await?;
-            let ident = Some(
-                cli_state
-                    .identities
-                    .default()?
-                    .config
-                    .get(ctx, &default_vault)
-                    .await?,
-            );
+            drop(inner);
 
             self.request_controller(
                 ctx,
@@ -398,8 +408,21 @@ mod node {
             trace!(target: TARGET, "listing projects");
 
             let req_builder = Request::get("/v0");
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
 
         pub(crate) async fn get_project(
@@ -415,8 +438,21 @@ mod node {
             trace!(target: TARGET, %project_id, "getting project");
 
             let req_builder = Request::get(format!("/v0/{project_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
 
         pub(crate) async fn delete_project(
@@ -433,8 +469,21 @@ mod node {
             trace!(target: TARGET, %space_id, %project_id, "deleting project");
 
             let req_builder = Request::delete(format!("/v0/{space_id}/{project_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
 
         pub(crate) async fn add_project_enroller(
@@ -451,8 +500,21 @@ mod node {
             trace!(target: TARGET, %project_id, "adding enroller");
 
             let req_builder = Request::post(format!("/v0/{project_id}/enrollers")).body(req_body);
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
 
         pub(crate) async fn list_project_enrollers(
@@ -468,8 +530,21 @@ mod node {
             trace!(target: TARGET, %project_id, "listing enrollers");
 
             let req_builder = Request::get(format!("/v0/{project_id}/enrollers"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
 
         pub(crate) async fn delete_project_enroller(
@@ -487,8 +562,21 @@ mod node {
 
             let req_builder =
                 Request::delete(format!("/v0/{project_id}/enrollers/{enroller_identity_id}"));
-            self.request_controller(ctx, label, None, cloud_route, "projects", req_builder, None)
-                .await
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                "projects",
+                req_builder,
+                ident,
+            )
+            .await
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -87,9 +87,10 @@ mod node {
 
             let req_builder = Request::post("/v0/").body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -116,9 +117,10 @@ mod node {
 
             let req_builder = Request::get("/v0/");
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await
@@ -138,9 +140,10 @@ mod node {
 
             let req_builder = Request::get(format!("/v0/{id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await
@@ -160,9 +163,10 @@ mod node {
 
             let req_builder = Request::delete(format!("/v0/{id}"));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -62,6 +62,7 @@ mod node {
     use tracing::trace;
 
     use ockam_core::api::Request;
+    use ockam_core::AsyncTryClone;
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
@@ -85,6 +86,11 @@ mod node {
             trace!(target: TARGET, space = %req_body.name, "creating space");
 
             let req_builder = Request::post("/v0/").body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -92,7 +98,7 @@ mod node {
                 cloud_route,
                 "spaces",
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -109,7 +115,12 @@ mod node {
             trace!(target: TARGET, "listing spaces");
 
             let req_builder = Request::get("/v0/");
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await
         }
 
@@ -126,7 +137,12 @@ mod node {
             trace!(target: TARGET, space = %id, space = %id, "getting space");
 
             let req_builder = Request::get(format!("/v0/{id}"));
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await
         }
 
@@ -143,7 +159,12 @@ mod node {
             trace!(target: TARGET, space = %id, "deleting space");
 
             let req_builder = Request::delete(format!("/v0/{id}"));
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, None)
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
+            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
                 .await
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -1,6 +1,7 @@
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
+use ockam_core::AsyncTryClone;
 use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -115,6 +116,11 @@ mod node {
             trace!(target: TARGET, subscription = %id, "unsubscribing");
 
             let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -122,7 +128,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -141,6 +147,11 @@ mod node {
             trace!(target: TARGET, subscription = %id, "updating subscription space");
 
             let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -148,7 +159,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -166,6 +177,11 @@ mod node {
             trace!(target: TARGET, subscription = %id, "updating subscription contact info");
 
             let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -173,7 +189,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -189,6 +205,11 @@ mod node {
             trace!(target: TARGET, "listing subscriptions");
 
             let req_builder = Request::get("/v0/");
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -196,7 +217,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -213,6 +234,11 @@ mod node {
             trace!(target: TARGET, subscription = %id, "getting subscription");
 
             let req_builder = Request::get(format!("/v0/{}", id));
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -220,7 +246,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }
@@ -237,6 +263,11 @@ mod node {
             trace!(target: TARGET, space_id = ?req_body.space_id, space_name = ?req_body.space_name, "activating subscription");
 
             let req_builder = Request::post("/v0/activate").body(req_body);
+
+            let inner = self.get().read().await;
+            let ident = inner.identity()?.async_try_clone().await?;
+            drop(inner);
+
             self.request_controller(
                 ctx,
                 label,
@@ -244,7 +275,7 @@ mod node {
                 cloud_route,
                 API_SERVICE,
                 req_builder,
-                None,
+                ident,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -117,9 +117,10 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -148,9 +149,10 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -178,9 +180,10 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -206,9 +209,10 @@ mod node {
 
             let req_builder = Request::get("/v0/");
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -235,9 +239,10 @@ mod node {
 
             let req_builder = Request::get(format!("/v0/{}", id));
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,
@@ -264,9 +269,10 @@ mod node {
 
             let req_builder = Request::post("/v0/activate").body(req_body);
 
-            let inner = self.get().read().await;
-            let ident = inner.identity()?.async_try_clone().await?;
-            drop(inner);
+            let ident = {
+                let inner = self.get().read().await;
+                inner.identity()?.async_try_clone().await?
+            };
 
             self.request_controller(
                 ctx,

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -149,6 +149,7 @@ async fn default_project<'a>(
             &space.id,
             None,
             &cloud_opts.route(),
+            None,
         ))
         .await?;
         rpc.parse_response::<Project>()?.to_owned()

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,6 +62,7 @@ async fn run_impl(
         &space_id,
         cmd.enforce_credentials,
         &cmd.cloud_opts.route(),
+        None,
     ))
     .await?;
     let project = rpc.parse_response::<Project>()?;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -256,8 +256,15 @@ pub(crate) mod project {
         space_id: &'a str,
         enforce_credentials: Option<bool>,
         cloud_route: &'a MultiAddr,
+        identity_name: Option<String>,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(project_name, enforce_credentials, &[], &[]);
+        let b = CreateProject::new::<&str, &str>(
+            project_name,
+            enforce_credentials,
+            &[],
+            &[],
+            identity_name,
+        );
         Request::post(format!("v0/projects/{}", space_id))
             .body(CloudRequestWrapper::new(b, cloud_route))
     }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -256,7 +256,7 @@ pub(crate) mod project {
         space_id: &'a str,
         enforce_credentials: Option<bool>,
         cloud_route: &'a MultiAddr,
-        identity_name: Option<String>,
+        identity_name: Option<&'a str>,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
         let b = CreateProject::new::<&str, &str>(
             project_name,


### PR DESCRIPTION
## Current Behavior

`CreateProject` has no default name for identities.

## Proposed Changes

This PR solves #3905 by adding the requested `identity_name` field to `CreateProject` requests, as well as by adding the `ident` argument to its corresponding `request_controller`. 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
