### PR TITLE
feat(rust): add `vault show` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -179,6 +179,20 @@ pub struct VaultState {
     pub config: VaultConfig,
 }
 
+impl VaultState {
+    pub fn name(&self) -> Result<String> {
+        self.path
+            .file_stem()
+            .and_then(|s| s.to_os_string().into_string().ok())
+            .ok_or_else(|| {
+                CliStateError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "failed to parse the vault name",
+                ))
+            })
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct VaultConfig {
     path: PathBuf,

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -37,6 +37,10 @@ pub enum VaultSubcommand {
         #[arg(short, long)]
         key_id: String,
     },
+    Show {
+        /// Name of the vault
+        name: Option<String>,
+    },
 }
 
 impl VaultCommand {
@@ -79,6 +83,20 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
             let idt_config = cli_state::IdentityConfig::new(&idt).await;
             opts.state.identities.create(&idt_name, idt_config)?;
             println!("Identity attached to vault: {}", idt_name);
+        }
+        VaultSubcommand::Show { name } => {
+            let name = name.unwrap_or(opts.state.vaults.default()?.name()?);
+            let state = opts.state.vaults.get(&name)?;
+            println!();
+            println!("Vault:");
+            println!("  Name: {}", name);
+            println!(
+                "  Type: {}",
+                match state.config.is_aws() {
+                    true => "AWS KMS",
+                    false => "OCKAM",
+                }
+            );
         }
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -94,6 +94,26 @@ teardown() {
   assert_output --partial "/service/vault_service"
 }
 
+@test "create a vault and do show on it" {
+  vault_name=$(openssl rand -hex 4)
+  run $OCKAM vault create "${vault_name}"
+  assert_success
+
+  run $OCKAM vault show "${vault_name}"
+  assert_success
+  assert_output --partial "Name: ${vault_name}"
+  assert_output --partial "Type: OCKAM"
+
+  vault_name=$(openssl rand -hex 4)
+  run $OCKAM vault create "${vault_name}" --aws-kms
+  assert_success
+
+  run $OCKAM vault show "${vault_name}"
+  assert_success
+  assert_output --partial "Name: ${vault_name}"
+  assert_output --partial "Type: AWS KMS"
+}
+
 @test "create a identity and do show on it" {
   idt_name=$(openssl rand -hex 4)
   run $OCKAM identity create "${idt_name}"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Closes #3933.

Add a new command to show a vault given its name

1. The `name` argument is optional, and if not passed, it will show the default vault.
2. It will show the vault name, its type (kms or ockam)

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
