### PR TITLE
feat(rust): support json configuration for enrollers

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use minicbor::{Decode, Encode};
 use ockam_core::{CowBytes, CowStr};
 
@@ -133,17 +131,21 @@ pub struct StartAuthenticatorRequest<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2749734>,
     #[b(1)] addr: CowStr<'a>,
-    #[b(2)] path: &'a Path,
+    #[b(2)] enrollers: CowStr<'a>,
     #[b(3)] proj: CowBytes<'a>
 }
 
 impl<'a> StartAuthenticatorRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>, path: &'a Path, proj: impl Into<CowBytes<'a>>) -> Self {
+    pub fn new(
+        addr: impl Into<CowStr<'a>>,
+        enrollers: impl Into<CowStr<'a>>,
+        proj: impl Into<CowBytes<'a>>,
+    ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             addr: addr.into(),
-            path,
+            enrollers: enrollers.into(),
             proj: proj.into(),
         }
     }
@@ -152,8 +154,8 @@ impl<'a> StartAuthenticatorRequest<'a> {
         &self.addr
     }
 
-    pub fn path(&self) -> &'a Path {
-        self.path
+    pub fn enrollers(&'a self) -> &'a str {
+        &self.enrollers
     }
 
     pub fn project(&'a self) -> &'a [u8] {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -211,7 +211,7 @@ impl NodeManager {
         &mut self,
         ctx: &Context,
         addr: Address,
-        path: &std::path::Path,
+        enrollers: &str,
         proj: &[u8],
     ) -> Result<()> {
         use crate::nodes::registry::AuthenticatorServiceInfo;
@@ -220,7 +220,7 @@ impl NodeManager {
         }
         let db = self.authenticated_storage.async_try_clone().await?;
         let id = self.identity()?.async_try_clone().await?;
-        let au = crate::authenticator::direct::Server::new(proj.to_vec(), db, path, id);
+        let au = crate::authenticator::direct::Server::new(proj.to_vec(), db, enrollers, id)?;
         ctx.start_worker(
             addr.clone(),
             au,
@@ -367,7 +367,12 @@ impl NodeManagerWorker {
             let addr: Address = body.address().into();
 
             node_manager
-                .start_direct_authenticator_service_impl(ctx, addr, body.path(), body.project())
+                .start_direct_authenticator_service_impl(
+                    ctx,
+                    addr,
+                    body.enrollers(),
+                    body.project(),
+                )
                 .await?;
         }
 

--- a/implementations/rust/ockam/ockam_api/tests/auth.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth.rs
@@ -7,7 +7,7 @@ use ockam::route;
 use ockam::vault::Vault;
 use ockam_api::authenticator::direct;
 use ockam_api::authenticator::direct::types::Enroller;
-use ockam_core::{AllowAll, Result};
+use ockam_core::{AllowAll, AsyncTryClone, Result};
 use ockam_identity::{IdentityIdentifier, PublicIdentity, TrustEveryonePolicy};
 use ockam_node::Context;
 use tempfile::NamedTempFile;
@@ -22,15 +22,20 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         let a = Identity::create(ctx, &Vault::create()).await?;
         a.create_secure_channel_listener("api", TrustEveryonePolicy, &InMemoryStorage::new())
             .await?;
-        let exported = a.export().await?;
         let store = InMemoryStorage::new();
-        let auth = direct::Server::new(b"project42".to_vec(), store, tmpf.path(), a);
+        let enrollers = tmpf.path().to_str().expect("path should be a string");
+        let auth = direct::Server::new(
+            b"project42".to_vec(),
+            store,
+            enrollers,
+            a.async_try_clone().await?,
+        )?;
         ctx.start_worker(
             "auth", auth, AllowAll, // Auth checks happen inside the worker
             AllowAll,
         )
         .await?;
-        exported
+        a
     };
 
     // Create an enroller identity:
@@ -55,8 +60,23 @@ async fn credential(ctx: &mut Context) -> Result<()> {
 
     // Configure enroller
     let enrollers = [(enroller.identifier().clone(), Enroller::default())];
-    let mut tmpf = tmpf.reopen().unwrap();
-    serde_json::to_writer(&mut tmpf, &HashMap::from(enrollers)).unwrap();
+    let mut tmpfile = tmpf.reopen().unwrap();
+    serde_json::to_writer(&mut tmpfile, &HashMap::from(enrollers)).unwrap();
+
+    // Re-create the authority with enroller configured
+    ctx.stop_worker("auth").await?;
+    {
+        let store = InMemoryStorage::new();
+        let enrollers = tmpf.path().to_str().expect("path should be a string");
+        let auth = direct::Server::new(
+            b"project42".to_vec(),
+            store,
+            enrollers,
+            authority.async_try_clone().await?,
+        )?;
+        ctx.start_worker("auth", auth, AllowAll, AllowAll).await?;
+    };
+
     let member_attrs = HashMap::from([("role", "member")]);
     c.add_member(member.identifier().clone(), member_attrs)
         .await?;
@@ -70,7 +90,93 @@ async fn credential(ctx: &mut Context) -> Result<()> {
 
     // Get a fresh member credential and verify its validity:
     let cred = c.credential().await?;
-    let pkey = PublicIdentity::import(&authority, &Vault::create())
+    let exported = authority.export().await?;
+    let pkey = PublicIdentity::import(&exported, &Vault::create())
+        .await
+        .unwrap();
+    let data = pkey
+        .verify_credential(&cred, member.identifier(), &Vault::create())
+        .await?;
+    assert_eq!(
+        Some(b"project42".as_slice()),
+        data.attributes().get("project_id")
+    );
+    assert_eq!(Some(b"member".as_slice()), data.attributes().get("role"));
+
+    ctx.stop().await
+}
+
+#[ockam_macros::test]
+async fn json_config(ctx: &mut Context) -> Result<()> {
+    // Create the authority:
+    let authority = {
+        let a = Identity::create(ctx, &Vault::create()).await?;
+        a.create_secure_channel_listener("api", TrustEveryonePolicy, &InMemoryStorage::new())
+            .await?;
+        let store = InMemoryStorage::new();
+        let auth = direct::Server::new(
+            b"project42".to_vec(),
+            store,
+            "{}",
+            a.async_try_clone().await?,
+        )?;
+        ctx.start_worker("auth", auth, AllowAll, AllowAll).await?;
+        a
+    };
+
+    // Create an enroller identity:
+    let enroller = Identity::create(ctx, &Vault::create()).await?;
+
+    // Create a member identity:
+    let member = Identity::create(ctx, &Vault::create()).await?;
+
+    // Connect to the API channel from the enroller:
+    let e2a = enroller
+        .create_secure_channel("api", TrustEveryonePolicy, &InMemoryStorage::new())
+        .await?;
+
+    // Add the member via the enroller's connection:
+    let mut c = direct::Client::new(route![e2a, "auth"], ctx).await?;
+
+    // Enroller is not configured -> fail
+    assert!(c
+        .add_member(member.identifier().clone(), HashMap::new())
+        .await
+        .is_err());
+
+    // Configure enroller
+    let enrollers = [(enroller.identifier().clone(), Enroller::default())];
+    let enrollers_config = serde_json::to_string(&HashMap::from(enrollers)).unwrap();
+
+    // Re-create the authority with enroller configured
+    ctx.stop_worker("auth").await?;
+    {
+        let store = InMemoryStorage::new();
+        let auth = direct::Server::new(
+            b"project42".to_vec(),
+            store,
+            &enrollers_config,
+            authority.async_try_clone().await?,
+        )?;
+        ctx.start_worker("auth", auth, AllowAll, AllowAll).await?;
+    };
+
+    // Add member successfull
+    let member_attrs = HashMap::from([("role", "member")]);
+    c.add_member(member.identifier().clone(), member_attrs)
+        .await?;
+
+    // Open a secure channel from member to authenticator:
+    let m2a = member
+        .create_secure_channel("api", TrustEveryonePolicy, &InMemoryStorage::new())
+        .await?;
+
+    let mut c = direct::Client::new(route![m2a, "auth"], ctx).await?;
+
+    // Get a fresh member credential and verify its validity:
+    let cred = c.credential().await?;
+    let exported = authority.export().await?;
+    let pkey = PublicIdentity::import(&exported, &Vault::create())
         .await
         .unwrap();
     let data = pkey
@@ -105,7 +211,8 @@ async fn update_member_format(ctx: &mut Context) -> Result<()> {
         a.create_secure_channel_listener("api", TrustEveryonePolicy, &InMemoryStorage::new())
             .await?;
         let exported = a.export().await?;
-        let auth = direct::Server::new(b"project42".to_vec(), store, tmpf.path(), a);
+        let enrollers = tmpf.path().to_str().expect("path should be a string");
+        let auth = direct::Server::new(b"project42".to_vec(), store, enrollers, a)?;
         ctx.start_worker(
             "auth", auth, AllowAll, // Auth checks happen inside the worker
             AllowAll,

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use ockam::identity::IdentityIdentifier;
 use ockam_api::DefaultAddress;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VaultConfig {
@@ -48,7 +48,7 @@ pub struct AuthenticatorConfig {
     #[serde(default = "authenticator_default_addr")]
     pub(crate) address: String,
 
-    pub(crate) enrollers: PathBuf,
+    pub(crate) enrollers: String,
 
     pub(crate) project: String,
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -9,7 +9,6 @@ use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::services::StartOktaIdentityProviderRequest;
 use ockam_api::DefaultAddress;
 use ockam_core::api::{Request, RequestBuilder, Status};
-use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, Args)]
 pub struct StartCommand {
@@ -50,7 +49,7 @@ pub enum StartSubCommand {
         addr: String,
 
         #[arg(long)]
-        enrollers: PathBuf,
+        enrollers: String,
 
         #[arg(long)]
         project: String,
@@ -221,7 +220,7 @@ pub async fn start_authenticator_service(
     opts: &CommandGlobalOpts,
     node_name: &str,
     serv_addr: &str,
-    enrollers: &Path,
+    enrollers: &str,
     project: &str,
     tcp: Option<&'_ TcpTransport>,
 ) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -1,7 +1,6 @@
 //! API shim to make it nicer to interact with the ockam messaging API
 
 use regex::Regex;
-use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
@@ -167,7 +166,7 @@ pub(crate) fn start_credentials_service(
 /// Construct a request to start an Authenticator Service
 pub(crate) fn start_authenticator_service<'a>(
     addr: &'a str,
-    enrollers: &'a Path,
+    enrollers: &'a str,
     project: &'a str,
 ) -> RequestBuilder<'static, StartAuthenticatorRequest<'a>> {
     let payload = StartAuthenticatorRequest::new(addr, enrollers, project.as_bytes());


### PR DESCRIPTION
## Current Behavior

Currently enrollers are read from the configured file on each enroller-related operation.
This means that there should be enrollers file and it's updated dynamically.

## Proposed Changes

Closes https://github.com/build-trust/ockam/issues/3896

Make it possible to pass JSON string instead of the file name in the authenticator configuration.

Only read enrollers configuration on service start.

Now to update enrollers configuration, authenticator node should be restarted with the new config.

Also embedding JSON config into the CLI configuration https://github.com/build-trust/ockam/issues/3895 is not supported yet, so in order to configure a node with enrollers, there needs to be a JSON string like that:
```
{
  "startup_services": {
    "authenticator": {
      "enrollers": "{\"P926f7913388ca12134485293c0cc09e53c1b17cc0abc95fb92949336ab8988a5\":{}}",
      "project": "foo"
    },
    "secure_channel_listener": {}
  }
}
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
