### PR TITLE
feat(rust): add optional --identity argument to secure-channel create

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -33,7 +33,8 @@ pub struct CreateSecureChannelRequest<'a> {
     #[b(1)] pub addr: CowStr<'a>,
     #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
     #[n(3)] pub credential_exchange_mode: CredentialExchangeMode,
-    #[n(4)] pub timeout: Option<Duration>
+    #[n(4)] pub timeout: Option<Duration>,
+    #[b(5)] pub identity: Option<CowStr<'a>>,
 }
 
 impl<'a> CreateSecureChannelRequest<'a> {
@@ -41,6 +42,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
         addr: &MultiAddr,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
         credential_exchange_mode: CredentialExchangeMode,
+        identity: Option<String>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -50,6 +52,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
                 .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
             credential_exchange_mode,
             timeout: None,
+            identity: identity.map(|x| x.into()),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -34,7 +34,7 @@ impl NodeManagerWorker {
         debug!(addr = %req.address(), alias = ?req.alias(), "Handling CreateForwarder request");
 
         let (sec_chan, suffix) = node_manager
-            .connect(req.address(), req.authorized(), None)
+            .connect(req.address(), req.authorized(), None, ctx)
             .await?;
 
         let full = sec_chan.clone().try_with(&suffix)?;
@@ -117,7 +117,7 @@ fn replacer(
                 let mut this = manager.write().await;
                 let _ = this.delete_secure_channel(&prev).await;
                 let timeout = Some(util::MAX_CONNECT_TIME);
-                let (sec, rest) = this.connect(&addr, auth, timeout).await?;
+                let (sec, rest) = this.connect(&addr, auth, timeout, ctx.as_ref()).await?;
                 let a = sec.clone().try_with(&rest)?;
                 let r = multiaddr_to_route(&a)
                     .ok_or_else(|| ApiError::message(format!("invalid multiaddr: {a}")))?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,23 +1,24 @@
 use crate::{
     help,
-    util::{api, exitcode, extract_address_value, node_rpc},
+    util::{exitcode, extract_address_value, node_rpc},
     CommandGlobalOpts, OutputFormat, Result,
 };
 
 use anyhow::Context as _;
 use clap::Args;
 use colorful::Colorful;
+use ockam_core::api::Request;
 use serde_json::json;
 
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::api::CloudOpts;
 use crate::util::{is_tty, RpcBuilder};
 use ockam::{identity::IdentityIdentifier, route, Context, TcpTransport};
-use ockam_api::config::lookup::ConfigLookup;
 use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
 use ockam_api::{
     clean_multiaddr, nodes::models::secure_channel::CreateSecureChannelResponse, route_to_multiaddr,
 };
+use ockam_api::{config::lookup::ConfigLookup, nodes::models};
 use ockam_multiaddr::MultiAddr;
 
 /// Create Secure Channels
@@ -39,6 +40,9 @@ pub struct CreateCommand {
     /// Orchestrator address to resolve projects present in the `at` argument
     #[command(flatten)]
     cloud_opts: CloudOpts,
+
+    #[arg(value_name = "IDENTITY", long, display_order = 802)]
+    identity: Option<String>,
 }
 
 impl CreateCommand {
@@ -162,8 +166,14 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
 
     // Delegate the request to create a secure channel to the from node.
     let mut rpc = RpcBuilder::new(&ctx, &opts, from).tcp(&tcp)?.build();
-    let request =
-        api::create_secure_channel(to, authorized_identifiers, CredentialExchangeMode::Mutual);
+
+    let payload = models::secure_channel::CreateSecureChannelRequest::new(
+        to,
+        authorized_identifiers,
+        CredentialExchangeMode::Mutual,
+        cmd.identity.clone(),
+    );
+    let request = Request::post("/node/secure_channel").body(payload);
 
     rpc.request(request).await?;
     let response = rpc.parse_response::<CreateSecureChannelResponse>()?;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -16,7 +16,6 @@ use tracing::trace;
 use ockam::identity::IdentityIdentifier;
 use ockam::Result;
 use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
-use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
 use ockam_api::nodes::*;
 use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
@@ -74,20 +73,6 @@ pub(crate) fn list_outlets() -> RequestBuilder<'static, ()> {
 /// Construct a request builder to list all secure channels on the given node
 pub(crate) fn list_secure_channels() -> RequestBuilder<'static, ()> {
     Request::get("/node/secure_channel")
-}
-
-/// Construct a request to create Secure Channels
-pub(crate) fn create_secure_channel(
-    addr: &MultiAddr,
-    authorized_identifiers: Option<Vec<IdentityIdentifier>>,
-    credential_exchange_mode: CredentialExchangeMode,
-) -> RequestBuilder<'static, models::secure_channel::CreateSecureChannelRequest<'static>> {
-    let payload = models::secure_channel::CreateSecureChannelRequest::new(
-        addr,
-        authorized_identifiers,
-        credential_exchange_mode,
-    );
-    Request::post("/node/secure_channel").body(payload)
 }
 
 pub(crate) fn delete_secure_channel(


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->
Closes #3906 
## Proposed Changes

in `ockam_command` : add optional --identity argument to secure-channel create. The `Option<String>` argument is sent to `ockam_api` in the request. 

in `ockam_api`: the `create_secure_channel_impl` function checks if the `identity` argument is provided, otherwise use `self.identity()`


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
