### PR TITLE
chore(rust): display identity enrollment time in iso8601 format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
+checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2897,6 +2897,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "time",
  "tinyvec",
  "tracing",
 ]

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -43,6 +43,7 @@ rust-embed      = "6"
 rand            = "0.8"
 serde           = { version = "1.0.152", features = ["derive"] }
 serde_json      = "1.0.91"
+time            = { version = "0.3.17", default-features = false }
 tempfile        = "3.3.0"
 tinyvec         = { version = "1.6.0", features = ["rustc_1_57"] }
 tracing         = { version = "0.1.34", default-features = false }

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
 
 use thiserror::Error;
 
@@ -396,9 +398,13 @@ impl Display for EnrollmentStatus {
             writeln!(f, "Enrolled: no")?;
         }
 
-        match self.created_at.duration_since(UNIX_EPOCH) {
-            Ok(time) => writeln!(f, "Timestamp: {}", time.as_secs())?,
-            Err(err) => writeln!(f, "Error converting SystemTime to POSIX timestamp. {}", err)?,
+        match OffsetDateTime::from(self.created_at).format(&Iso8601::DEFAULT) {
+            Ok(time_str) => writeln!(f, "Timestamp: {}", time_str)?,
+            Err(err) => writeln!(
+                f,
+                "Error formatting OffsetDateTime as Iso8601 String: {}",
+                err
+            )?,
         }
 
         Ok(())


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
Identity enrollment date is displayed as POSIX formatted date.
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Display identity enrollment date as Iso8601 formatted date.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Related Issue
https://github.com/build-trust/ockam/issues/4019

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
