### PR TITLE
set default shell to bash in shfmt workflow

### DIFF
--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   lint:
     name: Shfmt - Lint


### PR DESCRIPTION
Signed-off-by: Rishi Kumar Ray <rishi.ray@knoldus.com>

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
Currently the shft workflow doesn't have a default shell option at job level


<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
set default shell to bash in publish crates workflow


## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
