### PR TITLE
Split `AccessControl` trait 

### DIFF
--- a/implementations/rust/ockam/ockam/src/forwarder.rs
+++ b/implementations/rust/ockam/ockam/src/forwarder.rs
@@ -3,8 +3,8 @@ use core::str::from_utf8;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::{
-    AccessControl, Address, AllowOnwardAddress, Any, DenyAll, LocalMessage, Result, Route, Routed,
-    TransportMessage, Worker,
+    Address, AllowOnwardAddress, Any, DenyAll, IncomingAccessControl, LocalMessage, Result, Route,
+    Routed, TransportMessage, Worker,
 };
 use ockam_node::WorkerBuilder;
 use tracing::info;
@@ -16,7 +16,7 @@ use tracing::info;
 /// compatible client for this server.
 #[non_exhaustive]
 pub struct ForwardingService {
-    forwarders_incoming_access_control: Arc<dyn AccessControl>,
+    forwarders_incoming_access_control: Arc<dyn IncomingAccessControl>,
 }
 
 impl ForwardingService {
@@ -24,8 +24,8 @@ impl ForwardingService {
     pub async fn create(
         ctx: &Context,
         address: impl Into<Address>,
-        service_incoming_access_control: impl AccessControl,
-        forwarders_incoming_access_control: impl AccessControl,
+        service_incoming_access_control: impl IncomingAccessControl,
+        forwarders_incoming_access_control: impl IncomingAccessControl,
     ) -> Result<()> {
         let s = Self {
             forwarders_incoming_access_control: Arc::new(forwarders_incoming_access_control),
@@ -73,7 +73,7 @@ impl Forwarder {
         ctx: &Context,
         forward_route: Route,
         registration_payload: Vec<u8>,
-        incoming_access_control: Arc<dyn AccessControl>,
+        incoming_access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<()> {
         let random_address = Address::random_tagged("Forwarder.service");
 

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -10,8 +10,8 @@ use ockam_core::compat::{
     vec::Vec,
 };
 use ockam_core::{
-    AccessControl, Address, AllowAll, AllowSourceAddress, Any, Decodable, DenyAll, Mailbox,
-    Mailboxes, Result, Route, Routed, Worker,
+    Address, AllowAll, AllowSourceAddress, Any, Decodable, DenyAll, Mailbox, Mailboxes,
+    OutgoingAccessControl, Result, Route, Routed, Worker,
 };
 use ockam_node::{DelayedEvent, WorkerBuilder};
 use serde::{Deserialize, Serialize};
@@ -80,7 +80,7 @@ impl RemoteForwarder {
         ctx: &Context,
         hub_route: impl Into<Route>,
         alias: impl Into<String>,
-        outgoing_access_control: impl AccessControl,
+        outgoing_access_control: impl OutgoingAccessControl,
     ) -> Result<RemoteForwarderInfo> {
         let main_address = Address::random_tagged("RemoteForwarder.static.main");
         let heartbeat_address = Address::random_tagged("RemoteForwarder.static.heartbeat");
@@ -143,7 +143,7 @@ impl RemoteForwarder {
     pub async fn create(
         ctx: &Context,
         hub_route: impl Into<Route>,
-        outgoing_access_control: impl AccessControl,
+        outgoing_access_control: impl OutgoingAccessControl,
     ) -> Result<RemoteForwarderInfo> {
         let main_address = Address::random_tagged("RemoteForwarder.ephemeral.main");
         let heartbeat_address = Address::random_tagged("RemoteForwarder.ephemeral.heartbeat");
@@ -201,7 +201,7 @@ impl RemoteForwarder {
         ctx: &Context,
         hub_route: impl Into<Route>,
         alias: impl Into<String>,
-        outgoing_access_control: impl AccessControl,
+        outgoing_access_control: impl OutgoingAccessControl,
     ) -> Result<RemoteForwarderInfo> {
         let main_address = Address::random_tagged("RemoteForwarder.static_w/o_heartbeats.main");
         let heartbeat_address =

--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -3,7 +3,7 @@ use ockam_core::compat::boxed::Box;
 use ockam_core::compat::format;
 use ockam_core::compat::string::ToString;
 use ockam_core::{async_trait, RelayMessage};
-use ockam_core::{AccessControl, Result};
+use ockam_core::{IncomingAccessControl, Result};
 use ockam_identity::authenticated_storage::AuthenticatedStorage;
 use ockam_identity::{credential::AttributesStorageUtils, IdentitySecureChannelLocalInfo};
 use tracing as log;
@@ -51,7 +51,7 @@ impl<P, S> PolicyAccessControl<P, S> {
 }
 
 #[async_trait]
-impl<P, S> AccessControl for PolicyAccessControl<P, S>
+impl<P, S> IncomingAccessControl for PolicyAccessControl<P, S>
 where
     S: AuthenticatedStorage + fmt::Debug,
     P: PolicyStorage + fmt::Debug,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -14,7 +14,7 @@ use ockam::{Address, Result};
 use ockam_abac::expr::{and, eq, ident, str};
 use ockam_abac::{Action, Env, PolicyAccessControl, PolicyStorage, Resource};
 use ockam_core::api::{Request, Response, ResponseBuilder};
-use ockam_core::{AccessControl, AllowAll};
+use ockam_core::{AllowAll, IncomingAccessControl};
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::proto::{Project, Secure, Service};
 use ockam_multiaddr::{MultiAddr, Protocol};
@@ -31,7 +31,7 @@ impl NodeManager {
         r: &Resource,
         a: &Action,
         project_id: Option<String>,
-    ) -> Result<Arc<dyn AccessControl>> {
+    ) -> Result<Arc<dyn IncomingAccessControl>> {
         if let Some(pid) = project_id {
             // Populate environment with known attributes:
             let mut env = Env::new();
@@ -331,7 +331,7 @@ fn replacer(
     bind: String,
     addr: MultiAddr,
     auth: Option<IdentityIdentifier>,
-    access: Arc<dyn AccessControl>,
+    access: Arc<dyn IncomingAccessControl>,
 ) -> Replacer {
     Box::new(move |prev| {
         let addr = addr.clone();

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use ockam_core::compat::{sync::Arc, vec::Vec};
 use ockam_core::{
-    AccessControl, Address, AllowAll, AllowOnwardAddresses, AllowSourceAddress, DenyAll,
-    LocalOnwardOnly, Mailbox, Mailboxes, Result, Route,
+    Address, AllowAll, AllowOnwardAddresses, AllowSourceAddress, DenyAll, LocalOnwardOnly, Mailbox,
+    Mailboxes, OutgoingAccessControl, Result, Route,
 };
 use ockam_node::{Context, WorkerBuilder};
 use serde::{Deserialize, Serialize};
@@ -163,7 +163,8 @@ impl SecureChannel {
             // Communicate to the other side of the channel
             Arc::new(AllowAll),
         );
-        let outgoing_access_control: Arc<dyn AccessControl> = match wrapped_outgoing_address {
+        let outgoing_access_control: Arc<dyn OutgoingAccessControl> = match wrapped_outgoing_address
+        {
             // FIXME: @ac Also deny to other secure channels
             None => Arc::new(LocalOnwardOnly), // Prevent exploit of using our node as an authorized proxy
             Some(outgoing_address) => Arc::new(AllowOnwardAddresses(vec![

--- a/implementations/rust/ockam/ockam_channel/src/secure_channel_decryptor.rs
+++ b/implementations/rust/ockam/ockam_channel/src/secure_channel_decryptor.rs
@@ -5,8 +5,8 @@ use crate::{
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::{boxed::Box, string::String, vec::Vec};
 use ockam_core::{
-    async_trait, route, AccessControl, AllowOnwardAddress, AllowSourceAddresses, LocalSourceOnly,
-    Mailboxes,
+    async_trait, route, AllowOnwardAddress, AllowSourceAddresses, IncomingAccessControl,
+    LocalSourceOnly, Mailboxes,
 };
 use ockam_core::{
     Address, Any, Decodable, LocalMessage, Result, Route, Routed, TransportMessage, Worker,
@@ -237,7 +237,7 @@ impl<V: SecureChannelVault, K: SecureChannelKeyExchanger> SecureChannelDecryptor
             self.remote_route.clone(),
             self.vault.async_try_clone().await?,
         );
-        let incoming_access_control: Arc<dyn AccessControl> =
+        let incoming_access_control: Arc<dyn IncomingAccessControl> =
             if !self.allowed_encryptor_sources.is_empty() {
                 Arc::new(AllowSourceAddresses(self.allowed_encryptor_sources.clone()))
             } else {

--- a/implementations/rust/ockam/ockam_core/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control.rs
@@ -2,18 +2,18 @@ use crate::compat::boxed::Box;
 use crate::{RelayMessage, Result};
 use core::fmt::Debug;
 
-/// Defines the interface for message flow authorization.
+/// Defines the interface for incoming message flow authorization.
 ///
 /// # Examples
 ///
 /// ```
 /// # use ockam_core::{Result, async_trait};
-/// # use ockam_core::{AccessControl, RelayMessage};
+/// # use ockam_core::{IncomingAccessControl, RelayMessage};
 /// #[derive(Debug)]
 /// pub struct IdentityIdAccessControl;
 ///
 /// #[async_trait]
-/// impl AccessControl for IdentityIdAccessControl {
+/// impl IncomingAccessControl for IdentityIdAccessControl {
 ///     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
 ///         // ...
 ///         // some authorization logic that returns one of:
@@ -27,7 +27,37 @@ use core::fmt::Debug;
 ///
 #[async_trait]
 #[allow(clippy::wrong_self_convention)]
-pub trait AccessControl: Debug + Send + Sync + 'static {
+pub trait IncomingAccessControl: Debug + Send + Sync + 'static {
+    /// Return true if the message is allowed to pass, and false if not.
+    async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool>;
+}
+
+/// Defines the interface for outgoing message flow authorization.
+///
+/// # Examples
+///
+/// ```
+/// # use ockam_core::{Result, async_trait};
+/// # use ockam_core::{OutgoingAccessControl, RelayMessage};
+/// #[derive(Debug)]
+/// pub struct LocalAccessControl;
+///
+/// #[async_trait]
+/// impl OutgoingAccessControl for LocalAccessControl {
+///     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
+///         // ...
+///         // some authorization logic that returns one of:
+///         //   ockam_core::allow()
+///         //   ockam_core::deny()
+///         // ...
+/// #       ockam_core::deny()
+///     }
+/// }
+/// ```
+///
+#[async_trait]
+#[allow(clippy::wrong_self_convention)]
+pub trait OutgoingAccessControl: Debug + Send + Sync + 'static {
     /// Return true if the message is allowed to pass, and false if not.
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool>;
 }

--- a/implementations/rust/ockam/ockam_core/src/access_control/all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/all.rs
@@ -1,15 +1,15 @@
-use crate::access_control::AccessControl;
+use crate::access_control::IncomingAccessControl;
 use crate::{async_trait, compat::boxed::Box, RelayMessage, Result};
 
 /// Allows message that are allowed buy both AccessControls
 #[derive(Debug)]
-pub struct AllAccessControl<F: AccessControl, S: AccessControl> {
+pub struct AllAccessControl<F: IncomingAccessControl, S: IncomingAccessControl> {
     // TODO: Extend for more than 2 policies
     first: F,
     second: S,
 }
 
-impl<F: AccessControl, S: AccessControl> AllAccessControl<F, S> {
+impl<F: IncomingAccessControl, S: IncomingAccessControl> AllAccessControl<F, S> {
     /// Constructor
     pub fn new(first: F, second: S) -> Self {
         AllAccessControl { first, second }
@@ -17,7 +17,9 @@ impl<F: AccessControl, S: AccessControl> AllAccessControl<F, S> {
 }
 
 #[async_trait]
-impl<F: AccessControl, S: AccessControl> AccessControl for AllAccessControl<F, S> {
+impl<F: IncomingAccessControl, S: IncomingAccessControl> IncomingAccessControl
+    for AllAccessControl<F, S>
+{
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         Ok(self.first.is_authorized(relay_msg).await?
             && self.second.is_authorized(relay_msg).await?)

--- a/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/allow_all.rs
@@ -1,13 +1,20 @@
-use crate::access_control::AccessControl;
+use crate::access_control::IncomingAccessControl;
 use crate::compat::boxed::Box;
-use crate::{RelayMessage, Result};
+use crate::{OutgoingAccessControl, RelayMessage, Result};
 
 /// An Access Control type that allows all messages to pass through.
 #[derive(Debug)]
 pub struct AllowAll;
 
 #[async_trait]
-impl AccessControl for AllowAll {
+impl IncomingAccessControl for AllowAll {
+    async fn is_authorized(&self, _relay_msg: &RelayMessage) -> Result<bool> {
+        crate::allow()
+    }
+}
+
+#[async_trait]
+impl OutgoingAccessControl for AllowAll {
     async fn is_authorized(&self, _relay_msg: &RelayMessage) -> Result<bool> {
         crate::allow()
     }
@@ -19,7 +26,7 @@ mod tests {
     use crate::compat::future::poll_once;
     use crate::{route, Address, LocalMessage, RelayMessage, TransportMessage};
 
-    use super::{AccessControl, AllowAll};
+    use super::{AllowAll, IncomingAccessControl};
 
     #[test]
     fn test_allow_all() {

--- a/implementations/rust/ockam/ockam_core/src/access_control/any.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/any.rs
@@ -1,16 +1,16 @@
-use crate::access_control::AccessControl;
+use crate::access_control::IncomingAccessControl;
 use crate::{async_trait, compat::boxed::Box, RelayMessage, Result};
 
 use core::fmt::{self, Debug};
 
 /// Allows message that are allowed buy either AccessControls
-pub struct AnyAccessControl<F: AccessControl, S: AccessControl> {
+pub struct AnyAccessControl<F: IncomingAccessControl, S: IncomingAccessControl> {
     // TODO: Extend for more than 2 policies
     first: F,
     second: S,
 }
 
-impl<F: AccessControl, S: AccessControl> AnyAccessControl<F, S> {
+impl<F: IncomingAccessControl, S: IncomingAccessControl> AnyAccessControl<F, S> {
     /// Constructor
     pub fn new(first: F, second: S) -> Self {
         AnyAccessControl { first, second }
@@ -18,14 +18,16 @@ impl<F: AccessControl, S: AccessControl> AnyAccessControl<F, S> {
 }
 
 #[async_trait]
-impl<F: AccessControl, S: AccessControl> AccessControl for AnyAccessControl<F, S> {
+impl<F: IncomingAccessControl, S: IncomingAccessControl> IncomingAccessControl
+    for AnyAccessControl<F, S>
+{
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         Ok(self.first.is_authorized(relay_msg).await?
             || self.second.is_authorized(relay_msg).await?)
     }
 }
 
-impl<F: AccessControl, S: AccessControl> Debug for AnyAccessControl<F, S> {
+impl<F: IncomingAccessControl, S: IncomingAccessControl> Debug for AnyAccessControl<F, S> {
     fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AllowAny({:?} OR {:?})", self.first, self.second)
     }

--- a/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/deny_all.rs
@@ -1,13 +1,20 @@
-use crate::access_control::AccessControl;
+use crate::access_control::IncomingAccessControl;
 use crate::compat::boxed::Box;
-use crate::{RelayMessage, Result};
+use crate::{OutgoingAccessControl, RelayMessage, Result};
 
 /// An Access Control type that blocks all messages from passing through.
 #[derive(Debug)]
 pub struct DenyAll;
 
 #[async_trait]
-impl AccessControl for DenyAll {
+impl IncomingAccessControl for DenyAll {
+    async fn is_authorized(&self, _relay_msg: &RelayMessage) -> Result<bool> {
+        crate::deny()
+    }
+}
+
+#[async_trait]
+impl OutgoingAccessControl for DenyAll {
     async fn is_authorized(&self, _relay_msg: &RelayMessage) -> Result<bool> {
         crate::deny()
     }
@@ -19,7 +26,7 @@ mod tests {
     use crate::compat::future::poll_once;
     use crate::{route, Address, LocalMessage, RelayMessage, TransportMessage};
 
-    use super::{AccessControl, DenyAll};
+    use super::{DenyAll, IncomingAccessControl};
 
     #[test]
     fn test_deny_all() {

--- a/implementations/rust/ockam/ockam_core/src/access_control/local.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/local.rs
@@ -1,12 +1,12 @@
 use crate::compat::boxed::Box;
-use crate::{AccessControl, RelayMessage, Result, LOCAL};
+use crate::{IncomingAccessControl, OutgoingAccessControl, RelayMessage, Result, LOCAL};
 
 /// Allows only messages to local workers
 #[derive(Debug)]
 pub struct LocalOnwardOnly;
 
 #[async_trait]
-impl AccessControl for LocalOnwardOnly {
+impl OutgoingAccessControl for LocalOnwardOnly {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         let next_hop = relay_msg.onward_route().next()?;
 
@@ -24,7 +24,7 @@ impl AccessControl for LocalOnwardOnly {
 pub struct LocalSourceOnly;
 
 #[async_trait]
-impl AccessControl for LocalSourceOnly {
+impl IncomingAccessControl for LocalSourceOnly {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         if relay_msg.source().transport_type() != LOCAL {
             return crate::deny();
@@ -38,8 +38,8 @@ impl AccessControl for LocalSourceOnly {
 mod tests {
     use crate::compat::future::poll_once;
     use crate::{
-        route, AccessControl, Address, LocalMessage, LocalOnwardOnly, LocalSourceOnly,
-        RelayMessage, Result, TransportMessage, TransportType,
+        route, Address, IncomingAccessControl, LocalMessage, LocalOnwardOnly, LocalSourceOnly,
+        OutgoingAccessControl, RelayMessage, Result, TransportMessage, TransportType,
     };
 
     #[test]

--- a/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
@@ -1,6 +1,6 @@
 use crate::compat::boxed::Box;
 use crate::compat::vec::Vec;
-use crate::{AccessControl, Address, RelayMessage, Result};
+use crate::{Address, OutgoingAccessControl, RelayMessage, Result};
 
 /// An Access Control type that allows messages to the given onward address to go through
 /// Note that onward and destination addresses are different in some cases
@@ -8,7 +8,7 @@ use crate::{AccessControl, Address, RelayMessage, Result};
 pub struct AllowOnwardAddress(pub Address);
 
 #[async_trait]
-impl AccessControl for AllowOnwardAddress {
+impl OutgoingAccessControl for AllowOnwardAddress {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         let onward_route = relay_msg.onward_route();
 
@@ -27,7 +27,7 @@ impl AccessControl for AllowOnwardAddress {
 pub struct AllowOnwardAddresses(pub Vec<Address>);
 
 #[async_trait]
-impl AccessControl for AllowOnwardAddresses {
+impl OutgoingAccessControl for AllowOnwardAddresses {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         let onward_route = relay_msg.onward_route();
 
@@ -44,8 +44,8 @@ impl AccessControl for AllowOnwardAddresses {
 mod tests {
     use crate::compat::future::poll_once;
     use crate::{
-        route, AccessControl, Address, AllowOnwardAddress, AllowOnwardAddresses, LocalMessage,
-        RelayMessage, Result, TransportMessage,
+        route, Address, AllowOnwardAddress, AllowOnwardAddresses, LocalMessage,
+        OutgoingAccessControl, RelayMessage, Result, TransportMessage,
     };
 
     #[test]

--- a/implementations/rust/ockam/ockam_core/src/access_control/source.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/source.rs
@@ -1,6 +1,6 @@
 use crate::compat::boxed::Box;
 use crate::compat::vec::Vec;
-use crate::{AccessControl, Address, RelayMessage, Result};
+use crate::{Address, IncomingAccessControl, RelayMessage, Result};
 
 /// An Access Control type that allows messages from the given source address to go through
 /// Note that it's based on source address, not a first hop of return_route, which may be different
@@ -9,7 +9,7 @@ use crate::{AccessControl, Address, RelayMessage, Result};
 pub struct AllowSourceAddress(pub Address);
 
 #[async_trait]
-impl AccessControl for AllowSourceAddress {
+impl IncomingAccessControl for AllowSourceAddress {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         if &self.0 == relay_msg.source() {
             crate::allow()
@@ -26,7 +26,7 @@ impl AccessControl for AllowSourceAddress {
 pub struct AllowSourceAddresses(pub Vec<Address>);
 
 #[async_trait]
-impl AccessControl for AllowSourceAddresses {
+impl IncomingAccessControl for AllowSourceAddresses {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         if self.0.contains(relay_msg.source()) {
             crate::allow()
@@ -40,8 +40,8 @@ impl AccessControl for AllowSourceAddresses {
 mod tests {
     use crate::compat::future::poll_once;
     use crate::{
-        route, AccessControl, Address, AllowSourceAddress, AllowSourceAddresses, LocalMessage,
-        RelayMessage, Result, TransportMessage,
+        route, Address, AllowSourceAddress, AllowSourceAddresses, IncomingAccessControl,
+        LocalMessage, RelayMessage, Result, TransportMessage,
     };
 
     #[test]

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -1,11 +1,11 @@
-use crate::access_control::AccessControl;
+use crate::access_control::IncomingAccessControl;
 use crate::compat::rand::{distributions::Standard, prelude::Distribution, random, Rng};
 use crate::compat::{
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
 };
-use crate::{debugger, DenyAll, RelayMessage, Result};
+use crate::{debugger, DenyAll, OutgoingAccessControl, RelayMessage, Result};
 use core::cmp::Ordering;
 use core::fmt::{self, Debug, Display};
 use core::ops::Deref;
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone)]
 pub struct Mailbox {
     address: Address,
-    incoming: Arc<dyn AccessControl>,
-    outgoing: Arc<dyn AccessControl>,
+    incoming: Arc<dyn IncomingAccessControl>,
+    outgoing: Arc<dyn OutgoingAccessControl>,
 }
 
 impl Debug for Mailbox {
@@ -49,11 +49,11 @@ impl PartialEq for Mailbox {
 impl Eq for Mailbox {}
 
 impl Mailbox {
-    /// Create a new `Mailbox` with the given [`Address`] and [`AccessControl`]
+    /// Create a new `Mailbox` with the given [`Address`], [`IncomingAccessControl`] and [`OutgoingAccessControl`]
     pub fn new(
         address: impl Into<Address>,
-        incoming: Arc<dyn AccessControl>,
-        outgoing: Arc<dyn AccessControl>,
+        incoming: Arc<dyn IncomingAccessControl>,
+        outgoing: Arc<dyn OutgoingAccessControl>,
     ) -> Self {
         Self {
             address: address.into(),
@@ -73,12 +73,12 @@ impl Mailbox {
     pub fn address(&self) -> &Address {
         &self.address
     }
-    /// Return a reference to the incoming [`AccessControl`] for this mailbox
-    pub fn incoming_access_control(&self) -> &Arc<dyn AccessControl> {
+    /// Return a reference to the [`IncomingAccessControl`] for this mailbox
+    pub fn incoming_access_control(&self) -> &Arc<dyn IncomingAccessControl> {
         &self.incoming
     }
-    /// Return a reference to the outgoing [`AccessControl`] for this mailbox
-    pub fn outgoing_access_control(&self) -> &Arc<dyn AccessControl> {
+    /// Return a reference to the [`OutgoingAccessControl`] for this mailbox
+    pub fn outgoing_access_control(&self) -> &Arc<dyn OutgoingAccessControl> {
         &self.outgoing
     }
 }
@@ -110,11 +110,11 @@ impl Mailboxes {
     }
 
     /// Create a new collection of `Mailboxes` for the given
-    /// [`Address`] with the given [`AccessControl`]
+    /// [`Address`] with [`IncomingAccessControl`] and [`OutgoingAccessControl`]
     pub fn main(
         address: impl Into<Address>,
-        incoming_access_control: Arc<dyn AccessControl>,
-        outgoing_access_control: Arc<dyn AccessControl>,
+        incoming_access_control: Arc<dyn IncomingAccessControl>,
+        outgoing_access_control: Arc<dyn OutgoingAccessControl>,
     ) -> Self {
         Self {
             main_mailbox: Mailbox::new(

--- a/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/access_control/identity_access_control.rs
@@ -1,5 +1,5 @@
 use crate::{IdentityIdentifier, IdentitySecureChannelLocalInfo};
-use ockam_core::access_control::AccessControl;
+use ockam_core::access_control::IncomingAccessControl;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{RelayMessage, Result};
@@ -26,7 +26,7 @@ impl IdentityAccessControlBuilder {
 pub struct IdentityAnyIdAccessControl;
 
 #[async_trait]
-impl AccessControl for IdentityAnyIdAccessControl {
+impl IncomingAccessControl for IdentityAnyIdAccessControl {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         Ok(IdentitySecureChannelLocalInfo::find_info(relay_msg.local_message()).is_ok())
     }
@@ -51,7 +51,7 @@ impl IdentityIdAccessControl {
 }
 
 #[async_trait]
-impl AccessControl for IdentityIdAccessControl {
+impl IncomingAccessControl for IdentityIdAccessControl {
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
         if let Ok(msg_identity_id) =
             IdentitySecureChannelLocalInfo::find_info(relay_msg.local_message())

--- a/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
@@ -2,7 +2,7 @@ use crate::authenticated_storage::AuthenticatedStorage;
 use crate::credential::AttributesStorageUtils;
 use crate::IdentitySecureChannelLocalInfo;
 use core::fmt::{Debug, Formatter};
-use ockam_core::access_control::AccessControl;
+use ockam_core::access_control::IncomingAccessControl;
 use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::Result;
 use ockam_core::{async_trait, compat::boxed::Box, RelayMessage};
@@ -33,7 +33,7 @@ impl<S: AuthenticatedStorage> Debug for CredentialAccessControl<S> {
 }
 
 #[async_trait]
-impl<S: AuthenticatedStorage> AccessControl for CredentialAccessControl<S> {
+impl<S: AuthenticatedStorage> IncomingAccessControl for CredentialAccessControl<S> {
     async fn is_authorized(&self, relay_message: &RelayMessage) -> Result<bool> {
         if let Ok(msg_identity_id) =
             IdentitySecureChannelLocalInfo::find_info(relay_message.local_message())

--- a/implementations/rust/ockam/ockam_node/src/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context.rs
@@ -13,9 +13,9 @@ use core::{
 use ockam_core::compat::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use ockam_core::{
     errcode::{Kind, Origin},
-    AccessControl, Address, AllowAll, AllowOnwardAddress, AsyncTryClone, DenyAll, Error,
-    LocalMessage, Mailboxes, Message, Processor, RelayMessage, Result, Route, TransportMessage,
-    TransportType, Worker,
+    Address, AllowAll, AllowOnwardAddress, AsyncTryClone, DenyAll, Error, IncomingAccessControl,
+    LocalMessage, Mailboxes, Message, OutgoingAccessControl, Processor, RelayMessage, Result,
+    Route, TransportMessage, TransportType, Worker,
 };
 use ockam_core::{LocalInfo, Mailbox};
 
@@ -205,8 +205,8 @@ impl Context {
     pub async fn new_detached(
         &self,
         address: impl Into<Address>,
-        incoming: impl AccessControl,
-        outgoing: impl AccessControl,
+        incoming: impl IncomingAccessControl,
+        outgoing: impl OutgoingAccessControl,
     ) -> Result<DetachedContext> {
         let mailboxes = Mailboxes::main(address.into(), Arc::new(incoming), Arc::new(outgoing));
         let ctx = self.new_detached_impl(mailboxes).await?;
@@ -266,10 +266,6 @@ impl Context {
     /// of your worker to complete you can use
     /// [`wait_for()`](Self::wait_for).
     ///
-    /// The worker will inherit its [`AccessControl`] from this
-    /// context. Use [`WorkerBuilder`] to start a worker with custom
-    /// access control.
-    ///
     /// ```rust
     /// use ockam_core::{AllowAll, Result, Worker, worker};
     /// use ockam_node::Context;
@@ -290,8 +286,8 @@ impl Context {
         &self,
         address: impl Into<Address>,
         worker: NW,
-        incoming: impl AccessControl,
-        outgoing: impl AccessControl,
+        incoming: impl IncomingAccessControl,
+        outgoing: impl OutgoingAccessControl,
     ) -> Result<()>
     where
         NM: Message + Send + 'static,
@@ -315,15 +311,12 @@ impl Context {
     /// message events, consider using
     /// [`start_worker()`](Self::start_worker) instead!
     ///
-    /// The processor will inherit its [`AccessControl`] from this
-    /// context. Use [`ProcessorBuilder`] to start a worker with custom
-    /// access control.
     pub async fn start_processor<P>(
         &self,
         address: impl Into<Address>,
         processor: P,
-        incoming: impl AccessControl,
-        outgoing: impl AccessControl,
+        incoming: impl IncomingAccessControl,
+        outgoing: impl OutgoingAccessControl,
     ) -> Result<()>
     where
         P: Processor<Context = Context>,

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -4,10 +4,10 @@ use crate::{relay::ProcessorRelay, Context, NodeMessage};
 use ockam_core::compat::sync::Arc;
 use ockam_core::{
     errcode::{Kind, Origin},
-    AccessControl, Address, Error, Mailboxes, Processor, Result,
+    Address, Error, IncomingAccessControl, Mailboxes, OutgoingAccessControl, Processor, Result,
 };
 
-/// Start a [`Processor`] with a custom [`AccessControl`] configuration
+/// Start a [`Processor`] with a custom [`IncomingAccessControl`] and [`OutgoingAccessControl`] configuration
 ///
 /// Any incoming messages for the processor will first be subject to the
 /// configured `AccessControl` before it is passed on to
@@ -29,8 +29,8 @@ where
 {
     /// Create a processor which uses the given access control
     pub fn with_access_control<AC>(
-        incoming_access_control: Arc<dyn AccessControl>,
-        outgoing_access_control: Arc<dyn AccessControl>,
+        incoming_access_control: Arc<dyn IncomingAccessControl>,
+        outgoing_access_control: Arc<dyn OutgoingAccessControl>,
         address: impl Into<Address>,
         processor: P,
     ) -> Self {

--- a/implementations/rust/ockam/ockam_node/src/worker_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/worker_builder.rs
@@ -4,10 +4,11 @@ use crate::{relay::WorkerRelay, Context, NodeMessage};
 use ockam_core::compat::sync::Arc;
 use ockam_core::{
     errcode::{Kind, Origin},
-    AccessControl, Address, Error, Mailboxes, Message, Result, Worker,
+    Address, Error, IncomingAccessControl, Mailboxes, Message, OutgoingAccessControl, Result,
+    Worker,
 };
 
-/// Start a [`Worker`] with a custom [`AccessControl`] configuration
+/// Start a [`Worker`] with a custom [`IncomingAccessControl`] and [`OutgoingAccessControl`] configuration
 ///
 /// Any incoming messages for the worker will first be subject to the
 /// configured `AccessControl` before it is passed on to
@@ -30,8 +31,8 @@ where
 {
     /// Create a worker which uses the given access control
     pub fn with_access_control(
-        incoming_access_control: Arc<dyn AccessControl>,
-        outgoing_access_control: Arc<dyn AccessControl>,
+        incoming_access_control: Arc<dyn IncomingAccessControl>,
+        outgoing_access_control: Arc<dyn OutgoingAccessControl>,
         address: impl Into<Address>,
         worker: W,
     ) -> Self {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -5,7 +5,7 @@ use ockam_core::{
     compat::{boxed::Box, sync::Arc},
     DenyAll,
 };
-use ockam_core::{AccessControl, Address, Mailboxes, Processor, Result, Route};
+use ockam_core::{Address, IncomingAccessControl, Mailboxes, Processor, Result, Route};
 use ockam_node::{Context, ProcessorBuilder};
 use ockam_transport_core::TransportError;
 use tokio::net::TcpListener;
@@ -19,7 +19,7 @@ use tracing::{debug, error};
 pub(crate) struct TcpInletListenProcessor {
     inner: TcpListener,
     outlet_listener_route: Route,
-    access_control: Arc<dyn AccessControl>,
+    access_control: Arc<dyn IncomingAccessControl>,
 }
 
 impl TcpInletListenProcessor {
@@ -28,7 +28,7 @@ impl TcpInletListenProcessor {
         ctx: &Context,
         outlet_listener_route: Route,
         addr: SocketAddr,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<(Address, SocketAddr)> {
         let waddr = Address::random_tagged("TcpInletListenProcessor");
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
@@ -1,5 +1,5 @@
 use crate::{PortalMessage, TcpPortalWorker, TcpRouterHandle};
-use ockam_core::{async_trait, AccessControl, Result, Routed, Worker};
+use ockam_core::{async_trait, IncomingAccessControl, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 use std::sync::Arc;
@@ -12,12 +12,12 @@ use tracing::debug;
 /// [`TcpTransport::create_outlet`](crate::TcpTransport::create_outlet).
 pub(crate) struct TcpOutletListenWorker {
     peer: String,
-    access_control: Arc<dyn AccessControl>,
+    access_control: Arc<dyn IncomingAccessControl>,
 }
 
 impl TcpOutletListenWorker {
     /// Create a new `TcpOutletListenWorker`
-    pub(crate) fn new(peer: String, access_control: Arc<dyn AccessControl>) -> Self {
+    pub(crate) fn new(peer: String, access_control: Arc<dyn IncomingAccessControl>) -> Self {
         Self {
             peer,
             access_control,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
@@ -2,8 +2,8 @@ use crate::{PortalInternalMessage, PortalMessage, TcpPortalRecvProcessor};
 use core::time::Duration;
 use ockam_core::compat::{boxed::Box, net::SocketAddr, sync::Arc};
 use ockam_core::{
-    async_trait, AccessControl, AllowAll, AllowOnwardAddresses, AllowSourceAddress, Decodable,
-    DenyAll, Mailbox, Mailboxes,
+    async_trait, AllowAll, AllowOnwardAddresses, AllowSourceAddress, Decodable, DenyAll,
+    IncomingAccessControl, Mailbox, Mailboxes,
 };
 use ockam_core::{Address, Any, Result, Route, Routed, Worker};
 use ockam_node::{Context, ProcessorBuilder, WorkerBuilder};
@@ -60,7 +60,7 @@ impl TcpPortalWorker {
         stream: TcpStream,
         peer: SocketAddr,
         ping_route: Route,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<Address> {
         Self::start(
             ctx,
@@ -78,7 +78,7 @@ impl TcpPortalWorker {
         ctx: &Context,
         peer: SocketAddr,
         pong_route: Route,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<Address> {
         Self::start(
             ctx,
@@ -98,7 +98,7 @@ impl TcpPortalWorker {
         state: State,
         stream: Option<TcpStream>,
         type_name: TypeName,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<Address> {
         let internal_address = Address::random_tagged("TcpPortalWorker_internal");
         let remote_address = Address::random_tagged("TcpPortalWorker_remote");

--- a/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/router/handle.rs
@@ -8,7 +8,7 @@ use ockam_core::{
     compat::{boxed::Box, sync::Arc},
     DenyAll,
 };
-use ockam_core::{AccessControl, Address, AsyncTryClone, Result, Route};
+use ockam_core::{Address, AsyncTryClone, IncomingAccessControl, Result, Route};
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 use tracing::debug;
@@ -187,7 +187,7 @@ impl TcpRouterHandle {
         &self,
         outlet_listener_route: impl Into<Route>,
         addr: impl Into<SocketAddr>,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<(Address, SocketAddr)> {
         let socket_addr = addr.into();
         TcpInletListenProcessor::start(

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -1,4 +1,4 @@
-use ockam_core::access_control::AccessControl;
+use ockam_core::access_control::IncomingAccessControl;
 use ockam_core::compat::{boxed::Box, net::SocketAddr, sync::Arc};
 use ockam_core::{Address, AsyncTryClone, DenyAll, Mailboxes, Result, Route};
 use ockam_node::{Context, WorkerBuilder};
@@ -135,7 +135,7 @@ impl TcpTransport {
         &self,
         bind_addr: impl Into<String>,
         outlet_route: impl Into<Route>,
-        access_control: impl AccessControl,
+        access_control: impl IncomingAccessControl,
     ) -> Result<(Address, SocketAddr)> {
         self.create_inlet_impl(
             bind_addr.into(),
@@ -153,7 +153,7 @@ impl TcpTransport {
         &self,
         bind_addr: String,
         outlet_route: Route,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<(Address, SocketAddr)> {
         let bind_addr = parse_socket_addr(bind_addr)?;
         self.router_handle
@@ -203,7 +203,7 @@ impl TcpTransport {
         &self,
         address: impl Into<Address>,
         peer: impl Into<String>,
-        access_control: impl AccessControl,
+        access_control: impl IncomingAccessControl,
     ) -> Result<()> {
         self.create_outlet_impl(address.into(), peer.into(), Arc::new(access_control))
             .await
@@ -218,7 +218,7 @@ impl TcpTransport {
         &self,
         address: Address,
         peer: String,
-        access_control: Arc<dyn AccessControl>,
+        access_control: Arc<dyn IncomingAccessControl>,
     ) -> Result<()> {
         let worker = TcpOutletListenWorker::new(peer, access_control.clone());
         WorkerBuilder::with_mailboxes(


### PR DESCRIPTION
Initially `AccessControl` trait was used only for incoming message filtering, after that we realized that outgoing messages should also be filtered, but the same `AccessControl` trait was used, since it looks the same. Splitting `AccessControl` trait into `IncomingAccessControl` and `OutgoingAccessControl` traits helps us to avoid mistakes with passing wrong implementations, for example some implementations make sense for both incoming and outgoing cases (e.g. `AllowAll`, `DenyAll`), hence, they implement both traits, others may make sense only for incoming (e.g. identity or credentials related) or outgoing (e.g. local onward only)