### PR TITLE
fix(rust): let recreate foreground nodes with launchconfig

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -205,7 +205,8 @@ async fn run_foreground_node(
     let cfg = &opts.config;
 
     // This node was initially created as a foreground node
-    if !cmd.child_process {
+    // and there is no existing state for it yet.
+    if !cmd.child_process && opts.state.nodes.get(&cmd.node_name).is_err() {
         init_node_state(
             &ctx,
             &opts,


### PR DESCRIPTION
if the state data for a node already exists when creating it, just reuse it.

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

If a foreground running node terminates (lets say,  it's running as a docker container and the container is stopped/terminated),  trying to start it again fails as there is existing state already.    There is a `node start` command for nodes, but not useful as we need launch configuration to start further services.  (we should revisit what's the intended usage of `node start`)

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
If at the moment of the `node create` call there is already state for that node,  pick it up from there.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

