### PR TITLE
feat(rust): add influxdb addon config

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -31,7 +31,7 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::project::OktaConfig;
+    use crate::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig};
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::error::ApiError;
     use crate::nodes::NodeManagerWorker;
@@ -74,6 +74,10 @@ mod node {
         ) -> Result<Vec<u8>> {
             match addon_id {
                 "okta" => self.configure_okta_addon(ctx, dec, project_id).await,
+                "influxdb_token_lease_manager" => {
+                    self.configure_influxdb_token_lease_manager_addon(ctx, dec, project_id)
+                        .await
+                }
                 _ => Err(ApiError::generic(&format!("Unknown addon: {addon_id}"))),
             }
         }
@@ -92,6 +96,35 @@ mod node {
             trace!(target: TARGET, project_id, "configuring okta addon");
 
             let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
+        }
+
+        async fn configure_influxdb_token_lease_manager_addon(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            project_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<InfluxDBTokenLeaseManagerConfig> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "configure_influxdb_token_lease_manager_addon";
+            trace!(target: TARGET, project_id, "configuring influxdb addon");
+
+            let req_builder = Request::put(format!(
+                "/v0/{project_id}/addons/influxdb_token_lease_manager"
+            ))
+            .body(req_body);
             self.request_controller(
                 ctx,
                 label,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -201,6 +201,63 @@ impl From<OktaConfig<'_>> for OktaAuth0 {
     }
 }
 
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct InfluxDBTokenLeaseManagerConfig<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))] pub tag: TypeTag<4166488>,
+
+    #[serde(borrow)]
+    #[cbor(b(1))] pub endpoint: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(2))] pub token: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(3))] pub org_id: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(4))] pub permissions: CowStr<'a>,
+
+    #[cbor(b(5))] pub max_ttl_secs: i32,
+
+    #[serde(borrow)]
+    #[cbor(b(6))] pub user_access_rule: Option<CowStr<'a>>,
+
+    #[serde(borrow)]
+    #[cbor(b(7))] pub admin_access_rule: Option<CowStr<'a>>,
+}
+
+impl<'a> InfluxDBTokenLeaseManagerConfig<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(
+        endpoint: S,
+        token: S,
+        org_id: S,
+        permissions: S,
+        max_ttl_secs: i32,
+        user_access_rule: Option<S>,
+        admin_access_rule: Option<S>,
+    ) -> Self {
+        let uar: Option<CowStr<'a>> = user_access_rule.map(|s| s.into());
+
+        let aar: Option<CowStr<'a>> = admin_access_rule.map(|s| s.into());
+
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            endpoint: endpoint.into(),
+            token: token.into(),
+            org_id: org_id.into(),
+            permissions: permissions.into(),
+            max_ttl_secs,
+            user_access_rule: uar,
+            admin_access_rule: aar,
+        }
+    }
+}
+
 #[derive(Encode, Decode, Debug)]
 #[cfg_attr(test, derive(Clone))]
 #[rustfmt::skip]


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Ockam Command, project addon configure does not support influxdb

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

These changes will allow a user to configure their project with an influxdb lease manager using ockam command.

Example
```sh
ockam project addon configure influx-db --project default --endpoint-url some-endpoint.test  --token foiwfeoiwwf --org-id 2331 --max-ttl 3600 --permissions-path ./example.json 
```
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
