### PR TITLE
feat(rust):  fixes for influxdb command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -31,7 +31,7 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::project::OktaConfig;
+    use crate::cloud::project::{OktaConfig, InfluxDBTokenLeaseManagerConfig};
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::error::ApiError;
     use crate::nodes::NodeManagerWorker;
@@ -74,6 +74,7 @@ mod node {
         ) -> Result<Vec<u8>> {
             match addon_id {
                 "okta" => self.configure_okta_addon(ctx, dec, project_id).await,
+                "influxdb_token_lease_manager" => self.configure_influxdb_token_lease_manager_addon(ctx, dec, project_id).await,
                 _ => Err(ApiError::generic(&format!("Unknown addon: {addon_id}"))),
             }
         }
@@ -92,6 +93,32 @@ mod node {
             trace!(target: TARGET, project_id, "configuring okta addon");
 
             let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                cloud_route,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
+        }
+
+        async fn configure_influxdb_token_lease_manager_addon(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            project_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: CloudRequestWrapper<InfluxDBTokenLeaseManagerConfig> = dec.decode()?;
+            let cloud_route = req_wrapper.route()?;
+            let req_body = req_wrapper.req;
+
+            let label = "configure_influxdb_token_lease_manager_addon";
+            trace!(target: TARGET, project_id, "configuring influxdb addon");
+
+            let req_builder = Request::put(format!("/v0/{project_id}/addons/influxdb_token_lease_manager")).body(req_body);
             self.request_controller(
                 ctx,
                 label,

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -163,8 +163,8 @@ pub enum ConfigureAddonCommand {
         /// InfluxDB Permissions as a JSON String
         /// https://docs.influxdata.com/influxdb/v2.0/api/#operation/PostAuthorizations
         #[arg(
-            long,
-            group = "permissions",
+            long = "permissions",
+            group = "permissions_group",  //looks like it can't be named the same than an existing field
             value_name = "PERMISSIONS_JSON",
             value_parser(NonEmptyStringValueParser::new())
         )]
@@ -173,8 +173,8 @@ pub enum ConfigureAddonCommand {
         /// InfluxDB Permissions JSON PATH. Use either this or --permissions
         #[arg(
             long = "permissions-path",
-            group = "permissions",
-            value_name = "PERMISSIONS_JSON"
+            group = "permissions_group",
+            value_name = "PERMISSIONS_JSON_PATH"
         )]
         permissions_path: Option<PathBuf>,
 
@@ -333,7 +333,7 @@ async fn run_impl(
                     admin_access_role,
                 );
 
-                let add_on_id = "influxdb";
+                let add_on_id = "influxdb_token_lease_manager";
                 let endpoint = format!("{}/{}", base_endpoint(&project_name)?, add_on_id);
                 let req =
                     Request::put(endpoint).body(CloudRequestWrapper::new(body, controller_route));


### PR DESCRIPTION
@CAOakleyII  Feel free to either merge this and continue from there,   or just use this as a guide and close this PR.

Two small additions/tweaks:
* `Cli ->  NodeManager` call  was done,    added the actual  `NodeManager -> cloud`  here.
(note:  this two steps is unnecessary complex.    It's legacy,  we  haven't had time to get rid of it yet)

* For some reason,  if the name of a group of options collide with an existing field,   one gets weird behavior at runtime like:

```
./ockam- project addon configure influx-db --project default --endpoint-url some-endpoint.test  --token foiwfeoiwwf --org-id 2331 --max-ttl 3600 --permissions-path ./example.json 
error: The argument '--permissions-path <PERMISSIONS_JSON>' cannot be used with:
  --permissions <PERMISSIONS_JSON>
  --permissions-path <PERMISSIONS_JSON>
```

