### PR TITLE
feat(rust): add command to enable confluent addon

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -23,8 +23,70 @@ pub struct Addon<'a> {
     pub enabled: bool,
 }
 
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct ConfluentConfig<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))] pub tag: TypeTag<1697996>,
+
+    #[serde(borrow)]
+    #[cbor(b(1))] pub bootstrap_server: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(2))] pub api_key: CowStr<'a>,
+
+    #[serde(borrow)]
+    #[cbor(b(3))] pub api_secret: CowStr<'a>,
+}
+
+impl<'a> ConfluentConfig<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(bootstrap_server: S, api_key: S, api_secret: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            bootstrap_server: bootstrap_server.into(),
+            api_key: api_key.into(),
+            api_secret: api_secret.into(),
+        }
+    }
+}
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct ConfluentConfigResponse<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))] pub tag: TypeTag<6434816>,
+
+    #[serde(borrow)]
+    #[cbor(b(1))] pub bootstrap_server: CowStr<'a>,
+}
+
+impl<'a> ConfluentConfigResponse<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(bootstrap_server: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            bootstrap_server: bootstrap_server.into(),
+        }
+    }
+}
+
+impl ConfluentConfigResponse<'_> {
+    pub fn to_owned<'r>(&self) -> ConfluentConfigResponse<'r> {
+        ConfluentConfigResponse {
+            #[cfg(feature = "tag")]
+            tag: self.tag.to_owned(),
+            bootstrap_server: self.bootstrap_server.to_owned(),
+        }
+    }
+}
+
 mod node {
-    use minicbor::Decoder;
+    use minicbor::{Decode, Decoder, Encode};
     use ockam::AsyncTryClone;
     use tracing::trace;
 
@@ -32,6 +94,7 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
+    use crate::cloud::addon::ConfluentConfig;
     use crate::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig};
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::error::ApiError;
@@ -80,69 +143,48 @@ mod node {
             addon_id: &str,
         ) -> Result<Vec<u8>> {
             match addon_id {
-                "okta" => self.configure_okta_addon(ctx, dec, project_id).await,
+                "okta" => {
+                    self.configure_addon_impl::<OktaConfig>(ctx, dec, project_id, addon_id)
+                        .await
+                }
                 "influxdb_token_lease_manager" => {
-                    self.configure_influxdb_token_lease_manager_addon(ctx, dec, project_id)
+                    self.configure_addon_impl::<InfluxDBTokenLeaseManagerConfig>(
+                        ctx, dec, project_id, addon_id,
+                    )
+                    .await
+                }
+                "confluent" => {
+                    self.configure_addon_impl::<ConfluentConfig>(ctx, dec, project_id, addon_id)
                         .await
                 }
                 _ => Err(ApiError::generic(&format!("Unknown addon: {addon_id}"))),
             }
         }
 
-        async fn configure_okta_addon(
+        async fn configure_addon_impl<'a, T: Encode<()> + Decode<'a, ()>>(
             &mut self,
             ctx: &mut Context,
-            dec: &mut Decoder<'_>,
+            dec: &mut Decoder<'a>,
             project_id: &str,
+            addon_id: &str,
         ) -> Result<Vec<u8>> {
-            let req_wrapper: CloudRequestWrapper<OktaConfig> = dec.decode()?;
+            let ident = self
+                .get()
+                .read()
+                .await
+                .identity()?
+                .async_try_clone()
+                .await?;
+
+            let label = "configure_addon";
+            trace!(target: TARGET, project_id, addon_id, "configuring addon");
+
+            let req_wrapper: CloudRequestWrapper<T> = dec.decode()?;
             let cloud_route = req_wrapper.route()?;
             let req_body = req_wrapper.req;
 
-            let label = "configure_okta_addon";
-            trace!(target: TARGET, project_id, "configuring okta addon");
-
-            let req_builder = Request::put(format!("/v0/{project_id}/addons/okta")).body(req_body);
-
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
-            self.request_controller(
-                ctx,
-                label,
-                None,
-                cloud_route,
-                API_SERVICE,
-                req_builder,
-                ident,
-            )
-            .await
-        }
-
-        async fn configure_influxdb_token_lease_manager_addon(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
-            project_id: &str,
-        ) -> Result<Vec<u8>> {
-            let req_wrapper: CloudRequestWrapper<InfluxDBTokenLeaseManagerConfig> = dec.decode()?;
-            let cloud_route = req_wrapper.route()?;
-            let req_body = req_wrapper.req;
-
-            let label = "configure_influxdb_token_lease_manager_addon";
-            trace!(target: TARGET, project_id, "configuring influxdb addon");
-
-            let req_builder = Request::put(format!(
-                "/v0/{project_id}/addons/influxdb_token_lease_manager"
-            ))
-            .body(req_body);
-
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
+            let req_builder =
+                Request::put(format!("/v0/{project_id}/addons/{addon_id}")).body(req_body);
 
             self.request_controller(
                 ctx,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
+use crate::cloud::addon::ConfluentConfigResponse;
 use ockam_core::AsyncTryClone;
 use ockam_core::CowStr;
 use ockam_core::Result;
@@ -66,6 +67,11 @@ pub struct Project<'a> {
     #[serde(borrow)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub okta_config: Option<OktaConfig<'a>>,
+
+    #[cbor(b(12))]
+    #[serde(borrow)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confluent_config: Option<ConfluentConfigResponse<'a>>,
 }
 
 impl Clone for Project<'_> {
@@ -90,6 +96,7 @@ impl Project<'_> {
             authority_access_route: self.authority_access_route.as_ref().map(|x| x.to_owned()),
             authority_identity: self.authority_identity.as_ref().map(|x| x.to_owned()),
             okta_config: self.okta_config.as_ref().map(|x| x.to_owned()),
+            confluent_config: self.confluent_config.as_ref().map(|x| x.to_owned()),
         }
     }
 
@@ -614,6 +621,7 @@ mod tests {
                 authority_identity: bool::arbitrary(g)
                     .then(|| hex::encode(<Vec<u8>>::arbitrary(g)).into()),
                 okta_config: None,
+                confluent_config: None,
             })
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,4 +1,3 @@
-use crate::help;
 use crate::util::node_rpc;
 use crate::CommandGlobalOpts;
 use clap::Args;
@@ -8,7 +7,6 @@ use ockam_identity::Identity;
 use rand::prelude::random;
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide())]
 pub struct CreateCommand {
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     name: String,


### PR DESCRIPTION
- Add new command to enable the Confluent addon
- Refactor the `ockam_api` endpoint to avoid duplicating the `configure_{}_addon` functions
- Add a bats test to test the `list`/`enable`/`disable` flow for all addons. It's disabled for now until the dev environment gets this functionality deployed 