### PR TITLE
test(rust): disable flaky tests

### DIFF
--- a/implementations/rust/ockam/ockam_api/tests/auth.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth.rs
@@ -106,6 +106,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     ctx.stop().await
 }
 
+#[ignore]
 #[ockam_macros::test]
 async fn json_config(ctx: &mut Context) -> Result<()> {
     // Create the authority:

--- a/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
@@ -3,6 +3,7 @@ use ockam_core::{route, AllowAll, Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_transport_websocket::{WebSocketTransport, WS};
 
+#[ignore]
 #[ockam_macros::test]
 async fn send_receive(ctx: &mut Context) -> Result<()> {
     let transport = WebSocketTransport::create(ctx).await?;


### PR DESCRIPTION
- auth json_config: it works locally but for some reason it fails on CI when restarting the auth worker

- websocket send_receive: it's been failing a lot lately. Since this crate has been pretty much untouched for a while, let's disable the test for now.
