### PR TITLE
feat(elixir): identity service with custom vaults

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/api/request.ex
@@ -7,7 +7,11 @@ defmodule Ockam.Identity.API.Request do
   @validate_identity_change_history {:struct, %{identity: %{key: 1, schema: :binary}}}
 
   @create_signature {:struct,
-                     %{identity: %{key: 1, schema: :binary}, state: %{key: 2, schema: :binary}}}
+                     %{
+                       identity: %{key: 1, schema: :binary},
+                       state: %{key: 2, schema: :binary},
+                       vault_name: %{key: 3, schema: :string}
+                     }}
 
   @verify_signature {:struct,
                      %{
@@ -30,8 +34,12 @@ defmodule Ockam.Identity.API.Request do
     TypedCBOR.encode!(@validate_identity_change_history, %{identity: identity})
   end
 
-  def create_signature(identity, auth_hash) do
-    TypedCBOR.encode!(@create_signature, %{identity: identity, state: auth_hash})
+  def create_signature(vault_name, identity, auth_hash) do
+    TypedCBOR.encode!(@create_signature, %{
+      identity: identity,
+      state: auth_hash,
+      vault_name: vault_name
+    })
   end
 
   def verify_signature(identity, proof, auth_hash) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/identity.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/identity.ex
@@ -29,6 +29,16 @@ defmodule Ockam.Identity do
     end
   end
 
+  def get(identity_name) do
+    get(default_implementation(), identity_name)
+  end
+
+  def get(module, identity_name) do
+    with {:ok, data, id} <- module.get(identity_name) do
+      {:ok, {module, data}, id}
+    end
+  end
+
   def make_identity(identity) do
     make_identity(default_implementation(), identity)
   end
@@ -72,8 +82,10 @@ defmodule Ockam.Identity do
 
   @spec create_signature(identity :: t(), auth_hash :: binary()) ::
           {:ok, proof :: proof()} | {:error, reason :: any()}
-  def create_signature({module, data}, auth_hash) do
-    module.create_signature(data, auth_hash)
+  @spec create_signature(identity :: t(), auth_hash :: binary(), vault_name :: String.t() | nil) ::
+          {:ok, proof :: proof()} | {:error, reason :: any()}
+  def create_signature({module, data}, auth_hash, vault_name \\ nil) do
+    module.create_signature(vault_name, data, auth_hash)
   end
 
   @spec verify_signature(

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/secure_channel/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/secure_channel/secure_channel.ex
@@ -17,6 +17,7 @@ defmodule Ockam.Identity.SecureChannel do
 
   Options:
   - identity :: binary() | :dynamic - identity to use in spawned channels, :dynamic will generate a new identity
+  - vault_name :: String.t() | nil - vault to use in the channel, nil to use the default one
   - identity_module (optional) :: module() - module to generate dynamic identity
   - encryption_options (optional) :: Keyword.t() - options for Ockam.SecureChannel.Channel
   - address (optional) :: Ockam.Address.t() - listener address
@@ -82,6 +83,7 @@ defmodule Ockam.Identity.SecureChannel do
 
     with {:ok, identity} <- get_identity(handshake_options) do
       new_handshake_options = Keyword.put(handshake_options, :identity, identity)
+
       new_worker_options = Keyword.put(worker_options, :handshake_options, new_handshake_options)
       {:ok, Keyword.put(options, :worker_options, new_worker_options), state}
     end

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/stub.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/stub.ex
@@ -12,6 +12,10 @@ defmodule Ockam.Identity.Stub do
     {:ok, "DATA_" <> bytes, "ID_" <> bytes}
   end
 
+  def get(_identity_name) do
+    {:error, :not_implemented}
+  end
+
   @spec validate_identity_change_history(contact :: t()) ::
           {:ok, contact_id :: binary()} | {:error, reason :: any()}
   def validate_identity_change_history("DATA_" <> bytes) do
@@ -22,9 +26,9 @@ defmodule Ockam.Identity.Stub do
     {:error, {:invalid_identity, other}}
   end
 
-  @spec create_signature(identity :: t(), auth_hash :: binary()) ::
+  @spec create_signature(vault_name :: String.t() | nil, identity :: t(), auth_hash :: binary()) ::
           {:ok, proof :: proof()} | {:error, reason :: any()}
-  def create_signature(identity, auth_hash) do
+  def create_signature(_vault_name, identity, auth_hash) do
     {:ok, identity <> auth_hash}
   end
 
@@ -34,7 +38,7 @@ defmodule Ockam.Identity.Stub do
           auth_hash :: binary()
         ) :: :ok | {:error, reason :: any()}
   def verify_signature(identity, proof, auth_hash) do
-    {:ok, signature} = create_signature(identity, auth_hash)
+    {:ok, signature} = create_signature(nil, identity, auth_hash)
 
     case proof do
       ^signature -> :ok

--- a/implementations/elixir/ockam/ockam/test/ockam/identity/identity_api_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/identity/identity_api_test.exs
@@ -17,7 +17,7 @@ defmodule Ockam.Identity.API.Tests do
     test "create_signature" do
       identity = "my identity"
       hash = "my hash"
-      data = Request.create_signature(identity, hash)
+      data = Request.create_signature(nil, identity, hash)
       Logger.info("#{inspect(data)}")
       {:ok, %{identity: ^identity, state: ^hash}} = Request.decode_create_signature(data)
     end

--- a/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
+++ b/implementations/elixir/ockam/ockam_typed_cbor/lib/typed_cbor.ex
@@ -11,7 +11,7 @@ defmodule Ockam.TypedCBOR do
       2
 
       iex> to_cbor_term(:integer, "2")
-      ** (Ockam.TypedCBOR.Exception) type mismatch, expected schema :integer
+      ** (Ockam.TypedCBOR.Exception) type mismatch, expected schema :integer, value: "2"
 
       iex> to_cbor_term(:string, "2")
       "2"

--- a/implementations/elixir/ockam/ockam_typed_cbor/test/plugin_test.exs
+++ b/implementations/elixir/ockam/ockam_typed_cbor/test/plugin_test.exs
@@ -65,7 +65,7 @@ defmodule Ockam.TypedCBOR.Plugin.Test do
 
     # Incorrect type
     p = %Test.Person{name: ["Test"], age: 23, gender: :male, addresses: [], like_shoes: false}
-    {:error, "type mismatch, expected schema :string"} = Test.Person.encode(p)
+    {:error, "type mismatch, expected schema :string, value: [\"Test\"]"} = Test.Person.encode(p)
   end
 
   test "decode errors" do

--- a/implementations/rust/ockam/ockam_api/src/identity/models.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/models.rs
@@ -116,6 +116,7 @@ pub struct CreateSignatureRequest<'a> {
     #[n(0)] tag: TypeTag<1019956>,
     #[b(1)] identity: CowBytes<'a>,
     #[b(2)] data: CowBytes<'a>,
+    #[b(3)] vault_name: Option<CowStr<'a>>,
 }
 
 impl<'a> CreateSignatureRequest<'a> {
@@ -125,6 +126,7 @@ impl<'a> CreateSignatureRequest<'a> {
             tag: TypeTag,
             identity: identity.into(),
             data: data.into(),
+            vault_name: None,
         }
     }
     pub fn identity(&self) -> &[u8] {
@@ -132,6 +134,9 @@ impl<'a> CreateSignatureRequest<'a> {
     }
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+    pub fn vault_name(&self) -> Option<String> {
+        self.vault_name.as_ref().map(|x| x.to_string())
     }
 }
 


### PR DESCRIPTION
This allow loading specific `identities` from the identity service,  as well as using specific `vaults` when creating signatures and establishing secure channels. 

Examples:

```
    {:ok, identity, identity_id} = Ockam.Identity.get(some_identity_name)
```
load a named identity from the sidecar (if that's the Identity module used)


```
    Ockam.Services.start_service(
      :identity_secure_channel,
      [identity: own_identity, vault_name: vault_name] ++ options
    )
```
Starts an identity secure channel listener,  using `own_identity`  *and*  using the vault named `vault_name` to perform signatures with that identity.





This paves the way to use `kms` vaults from elixir code through sidecars.

