### PR TITLE
test(rust): fix flaky tests from ockam_api::auth

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -103,6 +103,13 @@ pub mod rand {
         pub use super::not_random::OsRng;
     }
 
+    /// Generates a random String of length 16.
+    #[cfg(feature = "std")]
+    pub fn random_string() -> String {
+        use rand::distributions::{Alphanumeric, DistString};
+        Alphanumeric.sample_string(&mut thread_rng(), 16)
+    }
+
     /// Placeholders for various features from 'rand' that are not
     /// supported on no_std targets.
     ///


### PR DESCRIPTION
Related to https://github.com/build-trust/ockam/issues/4046

`ockam_api::auth` tests that were stopping and starting a worker with the same name were failing on CI. I couldn't reproduce this in my local env. To fix this, I've refactored the tests so the recreated worker has a different name from the stopped worker.