### PR TITLE
fix(rust): fix vault locking on nfs volumes

### DIFF
--- a/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
@@ -85,6 +85,7 @@ impl FileStorage {
     fn open_lock_file(lock_path: &PathBuf) -> Result<File> {
         std::fs::OpenOptions::new()
             .write(true)
+            .read(true)
             .create(true)
             .open(lock_path)
             .map_err(map_io_err)


### PR DESCRIPTION
the lock file must be opened with read permissions in order to obtain a shared lock on it.  Write permission is not enough.  This was working on local filesystem but failed on attached volumes on the cloud.
