### PR TITLE
feat(elixir): abstraction to implement rest-like endpoints

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/api/endpoint.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/endpoint.ex
@@ -1,0 +1,132 @@
+defmodule Ockam.Services.API.Endpoint do
+  defmodule DispatchTable do
+    def compile_dispatch_table(rules) do
+      catch_all_rule = {:_, :not_found, %{}}
+
+      case Enum.all?(rules, fn
+             {_auth_type, method, <<"/", _rest::binary>> = _path, handler}
+             when method in [:get, :post, :put, :delete] and
+                    is_function(handler, 3) ->
+               true
+
+             _bad_rule ->
+               false
+           end) do
+        true ->
+          table =
+            Enum.reduce(rules, %{}, fn {auth_type, method, <<"/", _rest::binary>> = path, handler},
+                                       acc ->
+              rule = {path, handler, %{auth_type: auth_type}}
+              Map.update(acc, method, [rule], &[rule | &1])
+            end)
+
+          {:ok,
+           table
+           |> Enum.map(fn {method, rules} ->
+             {method, :cowboy_router.compile([{:_, Enum.reverse([catch_all_rule | rules])}])}
+           end)
+           |> Enum.into(%{})}
+
+        false ->
+          {:error, :bad_dispatch_rules}
+      end
+    end
+
+    # Paths *must* start with a "/" (due to how cowboy' routing works)
+    def match(dispatch_table, method, <<"/", _rest::binary>> = path) do
+      case Map.get(dispatch_table, method) do
+        nil ->
+          :error
+
+        table ->
+          req = %{host: "controller", path: path}
+
+          case :cowboy_router.execute(req, %{dispatch: table}) do
+            {:ok, %{}, %{handler: :not_found}} ->
+              :error
+
+            {:ok, %{bindings: bindings}, %{handler: handler, handler_opts: opts}} ->
+              {:ok, handler, bindings, Map.get(opts, :auth_type)}
+          end
+      end
+    end
+
+    def match(_dispatch_table, _method, _path) do
+      :error
+    end
+  end
+
+  @callback routes() :: [
+              {auth_type :: any(), method :: atom(), path :: String.t(), handler :: atom()}
+            ]
+
+  @callback authorize(auth_type :: any(), req :: %Ockam.API.Request{}, bindings :: map()) ::
+              true | false | {true, values :: map()}
+
+  defmacro __using__(_options) do
+    quote do
+      @doc false
+      use Ockam.Services.API
+
+      @behaviour Ockam.Services.API.Endpoint
+
+      alias Ockam.API.Request
+      alias Ockam.Services.API.Endpoint.DispatchTable
+
+      @impl true
+      def handle_request(%Request{method: method, path: path} = req, state) do
+        case DispatchTable.match(
+               state.dispatch_table,
+               method,
+               path
+             ) do
+          {:ok, handler, bindings, auth_type} ->
+            case authorize(auth_type, req, bindings) do
+              false ->
+                {:error, 401}
+
+              true ->
+                dispatch(handler, req, bindings, %{}, state)
+
+              {true, extra_data} ->
+                dispatch(handler, req, bindings, extra_data, state)
+
+              {:error, reason} ->
+                {:error, reason}
+            end
+
+          :error ->
+            {:error, :not_found}
+        end
+      end
+
+      @impl true
+      def setup(_options, state) do
+        routes = routes()
+
+        case DispatchTable.compile_dispatch_table(routes) do
+          {:ok, dispatch_table} ->
+            {:ok, Map.put(state, :dispatch_table, dispatch_table)}
+
+          error ->
+            error
+        end
+      end
+
+      defp dispatch(handler, req, bindings, extra_data, state) do
+        case handler.(req, bindings, extra_data) do
+          {:ok, body} ->
+            {:reply, :ok, body, state}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end
+
+      @impl true
+      defp authorize(_auth_type, _req, _bindings), do: true
+
+      defoverridable authorize: 3
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam_services/mix.exs
+++ b/implementations/elixir/ockam/ockam_services/mix.exs
@@ -57,7 +57,10 @@ defmodule Ockam.Services.MixProject do
       ## Token lease manager
       {:httpoison, "~> 1.8"},
       {:poison, "~> 4.0.1"},
-      {:postgrex, "~> 0.15.10"}
+      {:postgrex, "~> 0.15.10"},
+
+      ## Used for Ockam.Services.API.Endpoint' dispatch table implementation
+      {:cowboy, "~> 2.9.0"}
     ]
   end
 

--- a/implementations/elixir/ockam/ockam_services/test/services/api_endpoint_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/api_endpoint_test.exs
@@ -1,0 +1,71 @@
+defmodule Ockam.Services.API.Tests.EndpointAPI do
+  @moduledoc false
+  use Ockam.Services.API.Endpoint
+
+  alias Ockam.API.Request
+  @impl true
+  def routes() do
+    [
+      {:all, :get, "/", &list/3},
+      {:member, :get, "/:id/:role", &show/3},
+      {:admin, :put, "/item/:id/:role", &edit/3}
+    ]
+  end
+
+  def list(_req, %{}, %{}), do: {:ok, "LIST"}
+  def show(_req, %{id: id}, %{auth_data: auth_data}), do: {:ok, id <> auth_data}
+  def edit(%Request{body: body}, %{id: _id}, %{}), do: {:ok, body}
+
+  # Note: an actual implementation will look at the identity information attached to the request,
+  # for example, to perform authentication.  Here we just pass a "role" in the url as it's easier to setup
+  # the test.
+  @impl true
+  def authorize(:all, _req, _bindings), do: true
+  def authorize(:member, _req, %{id: "a", role: "member"}), do: {true, %{auth_data: "EXTRA"}}
+  def authorize(:admin, _req, %{id: "a", role: "admin"}), do: true
+  def authorize(_auth_type, _req, _bindings), do: false
+end
+
+defmodule Ockam.Services.API.Tests.Endpoint do
+  use ExUnit.Case
+
+  alias Ockam.API.Client
+  alias Ockam.Services.API.Tests.EndpointAPI
+
+  setup_all do
+    {:ok, api} = EndpointAPI.create(address: "endpoint")
+    [api: api]
+  end
+
+  test "list all authorized", %{api: api} do
+    {:ok, resp} = Client.sync_request(:get, "/", nil, [api])
+    assert %{status: 200, body: "LIST"} = resp
+  end
+
+  test "get authorized", %{api: api} do
+    {:ok, resp} = Client.sync_request(:get, "/a/member", nil, [api])
+    assert %{status: 200, body: "aEXTRA"} = resp
+  end
+
+  test "get not authorized", %{api: api} do
+    {:ok, resp} = Client.sync_request(:get, "/a/other", nil, [api])
+    assert %{status: 401} = resp
+    {:ok, resp} = Client.sync_request(:get, "/b/member", nil, [api])
+    assert %{status: 401} = resp
+  end
+
+  test "put authorized", %{api: api} do
+    {:ok, resp} = Client.sync_request(:put, "/item/a/admin", "SOME", [api])
+    assert %{status: 200, body: "SOME"} = resp
+  end
+
+  test "put not authorized", %{api: api} do
+    {:ok, resp} = Client.sync_request(:put, "/item/a/member", "SOME", [api])
+    assert %{status: 401} = resp
+  end
+
+  test "not found", %{api: api} do
+    {:ok, resp} = Client.sync_request(:get, "/item", nil, [api])
+    assert %{status: 404} = resp
+  end
+end


### PR DESCRIPTION
allow to define routes and handlers, handle path bindings and provide user-implemented authorization rules for endpoints.

Route definitions have the pattern
` {auth_type :: any(), method :: atom(), path :: String.t(), handler :: atom()}` 
  
`auth_type`  is any term.     It will be passed to the `authorize` callback to perform custom authorization on that particular endpoint. 


Example from test cases:
```
defmodule Ockam.Services.API.Tests.EndpointAPI do
  use Ockam.Services.API.Endpoint
  alias Ockam.API.Request

  @impl true
  def routes() do
    [
      {:all, :get, "/", &list/3},
      {:member, :get, "/:id/:role", &show/3},
      {:admin, :put, "/item/:id/:role", &edit/3}
    ]
  end

  def list(_req, %{}, %{}), do: {:ok, "LIST"}
  def show(_req, %{id: id}, %{auth_data: auth_data}), do: {:ok, id <> auth_data}
  def edit(%Request{body: body}, %{id: _id}, %{}), do: {:ok, body}

  # Note: an actual implementation will look at the identity information attached to the request.
  # In this example we just pass a "role" in the url as it's easier to setup the test.
  def authorize(:all, _req, _bindings), do: true
  def authorize(:member, _req, %{id: "a", role: "member"}), do: {true, %{auth_data: "EXTRA"}}
  def authorize(:admin, _req, %{id: "a", role: "admin"}), do: true
  def authorize(_auth_type, _req, _bindings), do: false
end
```
