### PR TITLE
fallback to a stable buildkit version

### DIFF
--- a/.github/workflows/ockam-package.yml
+++ b/.github/workflows/ockam-package.yml
@@ -91,7 +91,13 @@ jobs:
       - uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
 
       - id: buildx
-        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        uses: docker/setup-buildx-action@165fe681b849eec43aaa64d786b9ec53e690475f
+        # TODO: change after new buildkit version gets fixed
+        # https://github.com/moby/buildkit/issues/3347
+        # https://github.com/docker/build-push-action/issues/761
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Build And Publish As Draft
         run: |


### PR DESCRIPTION
Docker buildx fails due to a server error, more information on the issue here https://github.com/docker/build-push-action/issues/761. This PR adds a temporary fix which pins the version of buildkit https://github.com/docker/build-push-action/issues/761#issuecomment-1385511949