### PR TITLE
use word boundaries in crate publish script

### DIFF
--- a/tools/scripts/release/crate-publish.sh
+++ b/tools/scripts/release/crate-publish.sh
@@ -19,7 +19,7 @@ for crate in "${updated_crates[@]}"; do
   bumped_crates[$name]=true
 done
 
-crates_specified_to_be_excluded=("$OCKAM_PUBLISH_EXCLUDE_CRATES")
+IFS=" " read -r -a crates_specified_to_be_excluded <<<"$OCKAM_PUBLISH_EXCLUDE_CRATES"
 exclude_string=""
 
 # Get crates that are indicated to be excluded.


### PR DESCRIPTION
This script fixesa use cases where empty arrays are not properly handled
```bash
val=" "
convert_array=("$val")
for v in "${convert_array[@]}"; do
   echo "This should not be called"
done
```
We now appropriately handle this with [IFS](https://www.baeldung.com/linux/ifs-shell-variable)