### PR TITLE
remove quote on exclude crate string

### DIFF
--- a/tools/scripts/release/crate-publish.sh
+++ b/tools/scripts/release/crate-publish.sh
@@ -9,6 +9,9 @@ if [[ -z $OCKAM_PUBLISH_TOKEN ]]; then
   exit 1
 fi
 
+# Get the tag before release
+GIT_TAG=$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))
+
 source tools/scripts/release/crates-to-publish.sh
 
 declare -A bumped_crates
@@ -70,4 +73,4 @@ if [[ $OCKAM_PUBLISH_RECENT_FAILURE == true ]]; then
   done
 fi
 
-echo y | cargo release release --config tools/scripts/release/release.toml --no-tag --no-verify --no-dev-version "$exclude_string" --token "$OCKAM_PUBLISH_TOKEN" --execute
+echo y | cargo release release --config tools/scripts/release/release.toml --no-tag --no-verify --no-dev-version $exclude_string --token "$OCKAM_PUBLISH_TOKEN" --execute


### PR DESCRIPTION
Fix crate publish script where exclude command is treated as a script instead of a command. We also get the last git tag so that we can publish crates that have been updated.