### PR TITLE
reduce `ockam_transport_uds` keywords

### DIFF
--- a/implementations/rust/ockam/ockam_transport_uds/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_uds/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/build-trust/ockam"
 repository = "https://github.com/build-trust/ockam/implementations/rust/ockam/ockam_transport_uds"
 readme = "README.md"
-keywords = ["ockam", "crypto", "network", "networking", "uds", "unix", "domain", "sockets"]
+keywords = ["ockam", "crypto", "network", "networking", "uds"]
 categories = [
     "cryptography",
     "asynchronous",


### PR DESCRIPTION
To upload a crate to crates.io, we need the number of keywords to be < 5 else it fails
```bash
  the remote server responded with an error: invalid upload request: invalid length 8, expected at most 5 keywords per crate at line 1 column 1824
```
This PR reduces the number of keywords to 5