### PR TITLE
chore(elixir): fix flakey tests

### DIFF
--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/inlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/inlet_manager_test.exs
@@ -12,6 +12,14 @@ defmodule Ockam.Kafka.Interceptor.InletManager.Test do
     {:ok, _manager} =
       InletManager.start_link([base_port, allowed_ports, base_route, outlet_prefix])
 
+    on_exit(fn ->
+      try do
+        GenServer.stop(InletManager)
+      catch
+        _type, _reason -> :ok
+      end
+    end)
+
     inlets = InletManager.list_inlets()
 
     assert map_size(inlets) == 0
@@ -41,6 +49,14 @@ defmodule Ockam.Kafka.Interceptor.InletManager.Test do
 
     {:ok, _manager} =
       InletManager.start_link([base_port, allowed_ports, base_route, outlet_prefix])
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(InletManager)
+      catch
+        _type, _reason -> :ok
+      end
+    end)
 
     :ok = InletManager.set_inlets([1])
     inlets = InletManager.list_inlets()

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
@@ -139,6 +139,20 @@ defmodule Ockam.Kafka.Interceptor.Test do
 
     {:ok, _pid} = Ockam.Kafka.Interceptor.OutletManager.start_link([outlet_prefix, false, []])
 
+    on_exit(fn ->
+      try do
+        GenServer.stop(OutletManager)
+      catch
+        _type, _reason -> :ok
+      end
+
+      try do
+        GenServer.stop(InletManager)
+      catch
+        _type, _reason -> :ok
+      end
+    end)
+
     {:ok, _pid, "kafka_interceptor"} =
       Ockam.Transport.Portal.Interceptor.start_link(
         address: "kafka_interceptor",

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
@@ -11,6 +11,14 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
 
     {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
 
+    on_exit(fn ->
+      try do
+        GenServer.stop(OutletManager)
+      catch
+        _type, _reason -> :ok
+      end
+    end)
+
     [] = OutletManager.get_existing_outlets(outlet_prefix)
     [] = OutletManager.get_outlets()
 
@@ -42,6 +50,14 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl_options = []
 
     {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
+
+    on_exit(fn ->
+      try do
+        GenServer.stop(OutletManager)
+      catch
+        _type, _reason -> :ok
+      end
+    end)
 
     to_create = [
       %Outlet{

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
@@ -9,7 +9,7 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = false
     ssl_options = []
 
-    {:ok, _manager} = OutletManager.start_link([outlet_prefix, ssl, ssl_options])
+    {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
 
     [] = OutletManager.get_existing_outlets(outlet_prefix)
     [] = OutletManager.get_outlets()
@@ -41,7 +41,7 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = true
     ssl_options = []
 
-    {:ok, _manager} = OutletManager.start_link([outlet_prefix, ssl, ssl_options])
+    {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
 
     to_create = [
       %Outlet{

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
@@ -9,7 +9,7 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = false
     ssl_options = []
 
-    {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
+    {:ok, _manager} = OutletManager.start_link([outlet_prefix, ssl, ssl_options])
 
     on_exit(fn ->
       try do
@@ -49,7 +49,7 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = true
     ssl_options = []
 
-    {:ok, _manager} = start_supervised({OutletManager, [outlet_prefix, ssl, ssl_options]})
+    {:ok, _manager} = OutletManager.start_link([outlet_prefix, ssl, ssl_options])
 
     on_exit(fn ->
       try do

--- a/implementations/elixir/ockam/ockam_services/test/services/api_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/api_test.exs
@@ -46,6 +46,9 @@ defmodule Ockam.Services.API.Test do
 
     assert %{status: 200, body: ^body} = resp
 
+    # NOTE: the reason for sleep is to limit the chance of a race condition occuring
+    #       where metrics are fetched before they get inserted into ets table
+    :timer.sleep(50)
     metrics = TelemetryListener.get_metrics(@telemetry_table)
 
     assert [


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

1. ~When `ockam_services` is compiled we're getting a warning: `warning: function authorize/3 is private, @impl attribute is always discarded for private functions/macros`~ This has been resolved in another PR by making the function public
2. The services API test sometimes fails because metrics are fetched before they get inserted into the ets table
3. Kafka `OutletManager` and `InletManager` is being started unsupervised and sometimes doesn't terminate before the next test started, leading to the other test's failure.

## Proposed Changes

1. ~Removed the `@impl` attribute always discarded for private functions/macros`~ This has been resolved in another PR by making the function public
2. Added 50ms sleep interval before getting metrics to limit the chance of the test failing
3. Making sure kafka `OutletManager` and `InletManager`s exit before test finishes running

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
