### PR TITLE
feat(rust): add kafka commands to request starting the producer/consumer services

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -39,6 +39,8 @@ impl DefaultAddress {
     pub const AUTHENTICATOR: &'static str = "authenticator";
     pub const VERIFIER: &'static str = "verifier";
     pub const OKTA_IDENTITY_PROVIDER: &'static str = "okta";
+    pub const KAFKA_CONSUMER: &'static str = "kafka_consumer";
+    pub const KAFKA_PRODUCER: &'static str = "kafka_producer";
 }
 
 pub mod actions {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,8 +1,91 @@
 use minicbor::{Decode, Encode};
 use ockam_core::{CowBytes, CowStr};
+use std::net::Ipv4Addr;
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use ockam_multiaddr::MultiAddr;
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct StartServiceRequest<'a, T> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<3470984>,
+    #[b(1)] addr: CowStr<'a>,
+    #[n(2)] req: T,
+}
+
+impl<'a, T> StartServiceRequest<'a, T> {
+    pub fn new<S: Into<CowStr<'a>>>(req: T, addr: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addr: addr.into(),
+            req,
+        }
+    }
+
+    pub fn address(&'a self) -> &'a str {
+        &self.addr
+    }
+
+    pub fn request(&'a self) -> &'a T {
+        &self.req
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct StartKafkaConsumerRequest<'a> {
+    #[b(1)] ip: CowStr<'a>,
+    #[n(2)] ports: Vec<u16>,
+    #[b(3)] forwarding_addr: CowStr<'a>,
+    #[b(4)] route_to_client: Option<CowStr<'a>>,
+}
+
+impl<'a> StartKafkaConsumerRequest<'a> {
+    pub fn new(
+        ip: Ipv4Addr,
+        ports: Vec<u16>,
+        forwarding_addr: MultiAddr,
+        route_to_client: Option<MultiAddr>,
+    ) -> Self {
+        Self {
+            ip: ip.to_string().into(),
+            ports,
+            forwarding_addr: forwarding_addr.to_string().into(),
+            route_to_client: route_to_client.map(|s| s.to_string().into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct StartKafkaProducerRequest<'a> {
+    #[b(1)] ip: CowStr<'a>,
+    #[n(2)] ports: Vec<u16>,
+    #[b(3)] forwarding_addr: CowStr<'a>,
+    #[b(4)] route_to_client: Option<CowStr<'a>>,
+}
+
+impl<'a> StartKafkaProducerRequest<'a> {
+    pub fn new(
+        ip: Ipv4Addr,
+        ports: Vec<u16>,
+        forwarding_addr: MultiAddr,
+        route_to_client: Option<MultiAddr>,
+    ) -> Self {
+        Self {
+            ip: ip.to_string().into(),
+            ports,
+            forwarding_addr: forwarding_addr.to_string().into(),
+            route_to_client: route_to_client.map(|s| s.to_string().into()),
+        }
+    }
+}
 
 /// Request body when instructing a node to start a Vault service
 #[derive(Debug, Clone, Decode, Encode)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -544,6 +544,12 @@ impl NodeManagerWorker {
                 .start_okta_identity_provider_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
+            (Post, ["node", "services", "kafka_consumer"]) => {
+                self.start_kafka_consumer_service(ctx, req, dec).await?
+            }
+            (Post, ["node", "services", "kafka_producer"]) => {
+                self.start_kafka_producer_service(ctx, req, dec).await?
+            }
             (Get, ["node", "services"]) => {
                 let node_manager = self.node_manager.read().await;
                 self.list_services(req, &node_manager.registry).to_vec()?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -6,7 +6,8 @@ use crate::identity::IdentityService;
 use crate::nodes::models::services::{
     ServiceList, ServiceStatus, StartAuthenticatedServiceRequest, StartAuthenticatorRequest,
     StartCredentialsService, StartEchoerServiceRequest, StartHopServiceRequest,
-    StartIdentityServiceRequest, StartOktaIdentityProviderRequest, StartUppercaseServiceRequest,
+    StartIdentityServiceRequest, StartKafkaConsumerRequest, StartKafkaProducerRequest,
+    StartOktaIdentityProviderRequest, StartServiceRequest, StartUppercaseServiceRequest,
     StartVaultServiceRequest, StartVerifierService,
 };
 use crate::nodes::registry::{CredentialsServiceInfo, Registry, VerifierServiceInfo};
@@ -448,6 +449,32 @@ impl NodeManagerWorker {
             .await?;
 
         Ok(Response::ok(req.id()))
+    }
+
+    pub(super) async fn start_kafka_consumer_service<'a>(
+        &mut self,
+        _ctx: &Context,
+        req: &'a Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<Vec<u8>> {
+        let body: StartServiceRequest<StartKafkaConsumerRequest> = dec.decode()?;
+        let _addr: Address = body.address().into();
+        let _body_req = body.request();
+        // TODO: @confluent - start kafka consumer service
+        Ok(Response::ok(req.id()).to_vec()?)
+    }
+
+    pub(super) async fn start_kafka_producer_service<'a>(
+        &mut self,
+        _ctx: &Context,
+        req: &'a Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<Vec<u8>> {
+        let body: StartServiceRequest<StartKafkaProducerRequest> = dec.decode()?;
+        let _addr: Address = body.address().into();
+        let _body_req = body.request();
+        // TODO: @confluent - start kafka producer service
+        Ok(Response::ok(req.id()).to_vec()?)
     }
 
     pub(super) fn list_services<'a>(

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 pub(crate) use create::CreateCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
+use ockam_api::cli_state::CliState;
 use show::ShowCommand;
 use start::StartCommand;
 use stop::StopCommand;
@@ -69,7 +70,16 @@ pub struct NodeOpts {
         value_name = "NODE",
         short,
         long,
-        default_value = "default"
+        default_value_t = default_node_name()
     )]
     pub api_node: String,
+}
+
+fn default_node_name() -> String {
+    CliState::new()
+        .unwrap()
+        .nodes
+        .default()
+        .map(|n| n.config.name)
+        .unwrap_or_else(|_| "default".to_string())
 }


### PR DESCRIPTION
Related issue https://github.com/build-trust/ockam/issues/4012

This PR only adds the commands to request the initialization of the services. The services are not developed yet so I've added a couple of TODO's with the `@confluent` tag.