### PR TITLE
feat(rust): implement vaults delete command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -28,7 +28,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
             .into());
         }
     }
-    opts.state.identities.delete(&cmd.name)?;
+    opts.state.identities.delete_by_name(&cmd.name)?;
     println!("Identity '{}' deleted", cmd.name);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -41,6 +41,10 @@ pub enum VaultSubcommand {
         /// Name of the vault
         name: Option<String>,
     },
+    Delete {
+        /// Name of the vault
+        name: String,
+    },
 }
 
 impl VaultCommand {
@@ -104,6 +108,41 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
                     false => "OCKAM",
                 }
             );
+        }
+        VaultSubcommand::Delete { name } => {
+            let vault = opts.state.vaults.get(&name)?;
+            let identity_states = opts.state.identities.list()?;
+            let nodes = opts.state.nodes.list()?;
+
+            let mut removable_identities = Vec::default();
+            for identity_state in identity_states {
+                if identity_state
+                    .config
+                    .get(&ctx, &vault.config.get().await?)
+                    .await
+                    .is_ok()
+                {
+                    for node in &nodes {
+                        if node.config.identity_config()?.identifier
+                            == identity_state.config.identifier
+                        {
+                            return Err(anyhow!(
+                                "Can't delete vault '{}' because it is currently in use by node '{}'",
+                                &name,
+                                &node.config.name
+                            ).into());
+                        }
+                    }
+                    removable_identities.push(identity_state);
+                }
+            }
+            for identity_state in &removable_identities {
+                opts.state.identities.delete_by_state(identity_state)?;
+                println!("Identity '{}' deleted", identity_state.name);
+            }
+
+            opts.state.vaults.delete_by_state(&vault)?;
+            println!("Vault '{}' deleted", name);
         }
     }
     Ok(())


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Missing `vault delete` command

## Proposed Changes

Implement `vault delete` command so that vaults can be deleted via `vault delete ${vault_name}` when they are not in use by any existing node.

Fix issue #3936

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
