### PR TITLE
fix(rust): fixed copy-pasted TypeTag id

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -41,7 +41,7 @@ impl Space<'_> {
 #[cbor(map)]
 pub struct CreateSpace<'a> {
     #[cfg(feature = "tag")]
-    #[n(0)] pub tag: TypeTag<3888657>,
+    #[n(0)] pub tag: TypeTag<2321503>,
     #[b(1)] pub name: CowStr<'a>,
     #[b(2)] pub users: Vec<CowStr<'a>>,
 }

--- a/implementations/rust/ockam/ockam_core/src/schema.cddl
+++ b/implementations/rust/ockam/ockam_core/src/schema.cddl
@@ -81,7 +81,7 @@ spaces = [* space]
 
 
 create_space = {
-   ?0: 3888657,
+   ?0: 2321503,
     1: space_name
     2: [+ user]
 }


### PR DESCRIPTION
Fixed a copy-pasted TypeTag!

## Proposed Changes

Used a new random number for the specific tag.

## Checks

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).