### PR TITLE
feat(rust): moved optional `identity_name` to higher level `cloudrequest` struct

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -33,15 +33,17 @@ pub struct CloudRequestWrapper<'a, T> {
     #[n(0)] pub tag: TypeTag<8956240>,
     #[b(1)] pub req: T,
     #[b(2)] route: CowStr<'a>,
+    #[b(3)] pub identity_name: Option<CowStr<'a>>,
 }
 
 impl<'a, T> CloudRequestWrapper<'a, T> {
-    pub fn new(req: T, route: &MultiAddr) -> Self {
+    pub fn new<S: Into<CowStr<'a>>>(req: T, route: &MultiAddr, identity_name: Option<S>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             req,
             route: route.to_string().into(),
+            identity_name: identity_name.map(|x| x.into()),
         }
     }
 
@@ -58,7 +60,11 @@ pub type BareCloudRequestWrapper<'a> = CloudRequestWrapper<'a, ()>;
 
 impl<'a> BareCloudRequestWrapper<'a> {
     pub fn bare(route: &MultiAddr) -> Self {
-        Self::new((), route)
+        Self {
+            req: (),
+            route: route.to_string().into(),
+            identity_name: None,
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -636,7 +636,6 @@ mod tests {
                 services: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
                 users: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
                 enforce_credentials: None,
-                identity_name: None,
             })
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -277,7 +277,6 @@ pub struct CreateProject<'a> {
     #[b(2)] pub services: Vec<CowStr<'a>>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
     #[b(4)] pub enforce_credentials: Option<bool>,
-    #[b(5)] pub identity_name: Option<CowStr<'a>>
 }
 
 impl<'a> CreateProject<'a> {
@@ -286,14 +285,12 @@ impl<'a> CreateProject<'a> {
         enforce_credentials: Option<bool>,
         users: &'a [T],
         services: &'a [T],
-        identity_name: Option<S>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             name: name.into(),
             enforce_credentials,
-            identity_name: identity_name.map(|x| x.into()),
             services: services.iter().map(|x| CowStr::from(x.as_ref())).collect(),
             users: users.iter().map(|x| CowStr::from(x.as_ref())).collect(),
         }
@@ -371,9 +368,10 @@ mod node {
 
             let req_builder = Request::post(format!("/v0/{space_id}")).body(&req_body);
             let cli_state = cli_state::CliState::new()?;
+
             let ident = {
                 let inner = self.get().read().await;
-                match &req_body.identity_name {
+                match &req_wrapper.identity_name {
                     Some(existing_identity_name) => {
                         let identity_cfg = cli_state
                             .identities

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -8,6 +8,7 @@ use ockam::Context;
 use ockam_api::cloud::subscription::{ActivateSubscription, Subscription};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
+use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::subscription::utils;
@@ -152,8 +153,12 @@ async fn run_impl(
             let json =
                 std::fs::read_to_string(&json).context(format!("failed to read {:?}", &json))?;
             let b = ActivateSubscription::existing(space, json);
-            let req =
-                Request::post("subscription").body(CloudRequestWrapper::new(b, controller_route));
+            let req = Request::post("subscription").body(CloudRequestWrapper::new(
+                b,
+                controller_route,
+                None::<CowStr>,
+            ));
+
             rpc.request(req).await?;
             rpc.parse_and_print_response::<Subscription>()?;
         }
@@ -202,7 +207,11 @@ async fn run_impl(
                     .await?;
                     let req =
                         Request::put(format!("subscription/{}/contact_info", subscription_id))
-                            .body(CloudRequestWrapper::new(json, controller_route));
+                            .body(CloudRequestWrapper::new(
+                                json,
+                                controller_route,
+                                None::<CowStr>,
+                            ));
                     rpc.request(req).await?;
                     rpc.parse_and_print_response::<Subscription>()?;
                 }
@@ -221,7 +230,11 @@ async fn run_impl(
                     )
                     .await?;
                     let req = Request::put(format!("subscription/{}/space_id", subscription_id))
-                        .body(CloudRequestWrapper::new(new_space_id, controller_route));
+                        .body(CloudRequestWrapper::new(
+                            new_space_id,
+                            controller_route,
+                            None::<CowStr>,
+                        ));
                     rpc.request(req).await?;
                     rpc.parse_and_print_response::<Subscription>()?;
                 }

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -149,7 +149,6 @@ async fn default_project<'a>(
             &space.id,
             None,
             &cloud_opts.route(),
-            None,
         ))
         .await?;
         rpc.parse_response::<Project>()?.to_owned()

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -16,6 +16,7 @@ use ockam_api::cloud::addon::{Addon, ConfluentConfig};
 use ockam_api::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig, Project};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
+use ockam_core::CowStr;
 
 use crate::enroll::{Auth0Provider, Auth0Service};
 use crate::node::util::delete_embedded_node;
@@ -320,8 +321,11 @@ async fn run_impl(
                     // Do request
                     let addon_id = "okta";
                     let endpoint = format!("{}/{}", base_endpoint(&project_name)?, addon_id);
-                    let req = Request::put(endpoint)
-                        .body(CloudRequestWrapper::new(body, controller_route));
+                    let req = Request::put(endpoint).body(CloudRequestWrapper::new(
+                        body,
+                        controller_route,
+                        None::<CowStr>,
+                    ));
                     rpc.request(req).await?;
                     rpc.is_ok()?;
                     println!("Okta addon enabled");
@@ -377,8 +381,11 @@ async fn run_impl(
 
                     let add_on_id = "influxdb_token_lease_manager";
                     let endpoint = format!("{}/{}", base_endpoint(&project_name)?, add_on_id);
-                    let req = Request::put(endpoint)
-                        .body(CloudRequestWrapper::new(body, controller_route));
+                    let req = Request::put(endpoint).body(CloudRequestWrapper::new(
+                        body,
+                        controller_route,
+                        None::<CowStr>,
+                    ));
 
                     rpc.request(req).await?;
                     rpc.is_ok()?;
@@ -424,8 +431,11 @@ async fn run_impl(
                     let body = ConfluentConfig::new(bootstrap_server, api_key, api_secret);
                     let addon_id = "confluent";
                     let endpoint = format!("{}/{}", base_endpoint(&project_name)?, addon_id);
-                    let req = Request::put(endpoint)
-                        .body(CloudRequestWrapper::new(body, controller_route));
+                    let req = Request::put(endpoint).body(CloudRequestWrapper::new(
+                        body,
+                        controller_route,
+                        None::<CowStr>,
+                    ));
                     rpc.request(req).await?;
                     rpc.is_ok()?;
                     println!("Confluent addon enabled");

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,7 +62,6 @@ async fn run_impl(
         &space_id,
         cmd.enforce_credentials,
         &cmd.cloud_opts.route(),
-        None,
     ))
     .await?;
     let project = rpc.parse_response::<Project>()?;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -19,7 +19,7 @@ use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
 use ockam_api::nodes::*;
 use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
-use ockam_core::Address;
+use ockam_core::{Address, CowStr};
 use ockam_multiaddr::MultiAddr;
 
 use crate::util::DEFAULT_CONTROLLER_ADDRESS;
@@ -190,8 +190,11 @@ pub(crate) mod enroll {
         token: Auth0Token,
     ) -> RequestBuilder<CloudRequestWrapper<AuthenticateAuth0Token>> {
         let token = AuthenticateAuth0Token::new(token);
-        Request::post("v0/enroll/auth0")
-            .body(CloudRequestWrapper::new(token, &cmd.cloud_opts.route()))
+        Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(
+            token,
+            &cmd.cloud_opts.route(),
+            None::<CowStr>,
+        ))
     }
 }
 
@@ -205,7 +208,11 @@ pub(crate) mod space {
 
     pub(crate) fn create(cmd: &CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
         let b = CreateSpace::new(&cmd.name, &cmd.admins);
-        Request::post("v0/spaces").body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
+        Request::post("v0/spaces").body(CloudRequestWrapper::new(
+            b,
+            &cmd.cloud_opts.route(),
+            None::<CowStr>,
+        ))
     }
 
     pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
@@ -240,17 +247,13 @@ pub(crate) mod project {
         space_id: &'a str,
         enforce_credentials: Option<bool>,
         cloud_route: &'a MultiAddr,
-        identity_name: Option<&'a str>,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(
-            project_name,
-            enforce_credentials,
-            &[],
-            &[],
-            identity_name,
-        );
-        Request::post(format!("v0/projects/{}", space_id))
-            .body(CloudRequestWrapper::new(b, cloud_route))
+        let b = CreateProject::new::<&str, &str>(project_name, enforce_credentials, &[], &[]);
+        Request::post(format!("v0/projects/{}", space_id)).body(CloudRequestWrapper::new(
+            b,
+            cloud_route,
+            None::<CowStr>,
+        ))
     }
 
     pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
@@ -277,8 +280,9 @@ pub(crate) mod project {
         cmd: &AddEnrollerCommand,
     ) -> RequestBuilder<CloudRequestWrapper<AddEnroller>> {
         let b = AddEnroller::new(&cmd.enroller_identity_id, cmd.description.as_deref());
-        Request::post(format!("v0/project-enrollers/{}", cmd.project_id))
-            .body(CloudRequestWrapper::new(b, &cmd.cloud_opts.route()))
+        Request::post(format!("v0/project-enrollers/{}", cmd.project_id)).body(
+            CloudRequestWrapper::new(b, &cmd.cloud_opts.route(), None::<CowStr>),
+        )
     }
 
     pub(crate) fn list_enrollers(


### PR DESCRIPTION

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently, a NodeManager instance will use its internal identity/vault pair for every request it does to the cloud nodes (i.e. all the methods under [ockam_api::cloud](https://github.com/build-trust/ockam/tree/fa3728544bf0ceeb231fae61503b29a70f00cb70/implementations/rust/ockam/ockam_api/src/cloud)).

At https://github.com/build-trust/ockam/issues/3905 (solved at https://github.com/build-trust/ockam/pull/3977) the identity_name was added to the CreateProject struct, so we can use a custom identity on the project create command. We want to extend that behaviour to every cloud endpoint.

## Proposed Changes

This is an initial attempt at solving https://github.com/build-trust/ockam/issues/4056 by moving the `identity_name` logic from the `CreateProject` struct to the `CloudRequestWrapper` endpoint. A handful of calls to `CloudRequestWrapper::new()` (that now relies on a new `identity_name` field) now pass `None::<CowStr>` as a default `identity_name`.

For the `BareCloudRequestWrapper` type alias, a `None` parameter is also provided.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
