### PR TITLE
feat(rust): add optional --identity argument to secure-channel-listener create

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -99,19 +99,26 @@ pub struct CreateSecureChannelListenerRequest<'a> {
     #[n(0)] tag: TypeTag<8112242>,
     #[b(1)] pub addr: Cow<'a, str>,
     #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
+    #[b(3)] pub identity: Option<CowStr<'a>>,
 }
 
 impl<'a> CreateSecureChannelListenerRequest<'a> {
-    pub fn new(addr: &Address, authorized_identifiers: Option<Vec<IdentityIdentifier>>) -> Self {
+    pub fn new(
+        addr: &Address,
+        authorized_identifiers: Option<Vec<IdentityIdentifier>>,
+        identity: Option<String>,
+    ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             addr: addr.to_string().into(),
             authorized_identifiers: authorized_identifiers
                 .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
+            identity: identity.map(|x| x.into()),
         }
     }
 }
+
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
@@ -130,6 +137,7 @@ impl<'a> DeleteSecureChannelRequest<'a> {
         }
     }
 }
+
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -314,6 +314,8 @@ impl NodeManager {
         self.create_secure_channel_listener_impl(
             DefaultAddress::SECURE_CHANNEL_LISTENER.into(),
             None, // Not checking identifiers here in favor of credentials check
+            None,
+            ctx,
         )
         .await?;
 
@@ -504,7 +506,7 @@ impl NodeManagerWorker {
                 self.show_secure_channel(req, dec).await?.to_vec()?
             }
             (Post, ["node", "secure_channel_listener"]) => self
-                .create_secure_channel_listener(req, dec)
+                .create_secure_channel_listener(req, dec, ctx)
                 .await?
                 .to_vec()?,
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -363,9 +363,10 @@ async fn start_services(
         if !cfg.disabled {
             let adr = Address::from((LOCAL, cfg.address));
             let ids = cfg.authorized_identifiers;
+            let identity = cfg.identity;
             let rte = addr.clone().into();
             println!("starting secure-channel listener ...");
-            secure_channel_listener::create_listener(ctx, adr, ids, rte).await?;
+            secure_channel_listener::create_listener(ctx, adr, ids, identity, rte).await?;
         }
     }
     if let Some(cfg) = config.verifier {

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -32,6 +32,9 @@ pub struct SecureChannelListenerConfig {
 
     #[serde(default)]
     pub(crate) disabled: bool,
+
+    #[serde(default)]
+    pub(crate) identity: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -93,10 +93,12 @@ pub(crate) fn show_secure_channel(
 pub(crate) fn create_secure_channel_listener(
     addr: &Address,
     authorized_identifiers: Option<Vec<IdentityIdentifier>>,
+    identity: Option<String>,
 ) -> Result<Vec<u8>> {
     let payload = models::secure_channel::CreateSecureChannelListenerRequest::new(
         addr,
         authorized_identifiers,
+        identity,
     );
 
     let mut buf = vec![];
@@ -349,7 +351,6 @@ pub(crate) fn validate_cloud_resource_name(s: &str) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod test {
-
     use crate::util::api::validate_cloud_resource_name;
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/3907

## Proposed Changes

in `ockam_command`: new optional --identity argument to the secure-channel-listener create command.

in `ockam_api`:  the request handler on ockam_api refactored so it prioritizes the passed optional Identity if available, or default to the self.identity() if not.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
