### PR TITLE
fix(rust): vault deletion logic from `CliState`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod auth;
 pub mod authenticator;
-#[allow(unused)]
 pub mod cli_state;
 pub mod cloud;
 pub mod config;

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,5 +1,4 @@
 use crate::CommandGlobalOpts;
-use anyhow::anyhow;
 use clap::Args;
 
 #[derive(Clone, Debug, Args)]
@@ -17,18 +16,7 @@ impl DeleteCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
-    let identity_state = opts.state.identities.get(&cmd.name)?;
-    for node in opts.state.nodes.list()? {
-        if node.config.identity_config()?.identifier == identity_state.config.identifier {
-            return Err(anyhow!(
-                "Can't delete identity '{}' because is currently in use by node '{}'",
-                &cmd.name,
-                &node.config.name
-            )
-            .into());
-        }
-    }
-    opts.state.identities.delete_by_name(&cmd.name)?;
+    opts.state.identities.delete(&cmd.name)?;
     println!("Identity '{}' deleted", cmd.name);
     Ok(())
 }


### PR DESCRIPTION
When deleting a vault it doesn't have to affect identities, as they can be loaded using any available vault.

Bug introduced at: https://github.com/build-trust/ockam/pull/4106 which caused orchestrator CI tests to fail.

Orchestrator CI ✅ : https://github.com/build-trust/ockam-artifacts/actions/runs/3984269164