### PR TITLE
refactor(rust): set default_node_name using clap

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,4 +1,5 @@
-use crate::node::util::{default_node_name, delete_all_nodes, delete_node};
+use crate::node::default_node_name;
+use crate::node::util::{delete_all_nodes, delete_node};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
@@ -7,8 +8,8 @@ use clap::Args;
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct DeleteCommand {
     /// Name of the node.
-    #[arg(group = "nodes")]
-    node_name: Option<String>,
+    #[arg(default_value_t = default_node_name(), group = "nodes")]
+    node_name: String,
 
     /// Terminate all nodes
     #[arg(long, short, group = "nodes")]
@@ -32,12 +33,8 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
     if cmd.all {
         delete_all_nodes(opts, cmd.force)?;
     } else {
-        let node_name = &match cmd.node_name {
-            Some(name) => name,
-            None => default_node_name(&opts),
-        };
-        delete_node(&opts, node_name, cmd.force)?;
-        println!("Deleted node '{}'", node_name);
+        delete_node(&opts, &cmd.node_name, cmd.force)?;
+        println!("Deleted node '{}'", &cmd.node_name);
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -75,7 +75,7 @@ pub struct NodeOpts {
     pub api_node: String,
 }
 
-fn default_node_name() -> String {
+pub fn default_node_name() -> String {
     CliState::new()
         .unwrap()
         .nodes

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,4 +1,4 @@
-use crate::node::util::default_node_name;
+use crate::node::default_node_name;
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
@@ -24,7 +24,8 @@ const IS_NODE_UP_MAX_TIMEOUT: Duration = Duration::from_secs(1);
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct ShowCommand {
     /// Name of the node.
-    node_name: Option<String>,
+    #[arg(default_value_t = default_node_name())]
+    node_name: String,
 }
 
 impl ShowCommand {
@@ -37,10 +38,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = &match cmd.node_name {
-        Some(name) => name,
-        None => default_node_name(&opts),
-    };
+    let node_name = &cmd.node_name;
 
     let tcp = TcpTransport::create(&ctx).await?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, node_name).tcp(&tcp)?.build();

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -2,8 +2,9 @@ use clap::Args;
 
 use ockam::TcpTransport;
 
+use crate::node::default_node_name;
 use crate::node::show::print_query_status;
-use crate::node::util::{default_node_name, spawn_node};
+use crate::node::util::spawn_node;
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 
@@ -12,7 +13,8 @@ use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StartCommand {
     /// Name of the node.
-    node_name: Option<String>,
+    #[arg(default_value_t = default_node_name())]
+    node_name: String,
 
     #[arg(long, default_value = "false")]
     aws_kms: bool,
@@ -28,10 +30,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> crate::Result<()> {
-    let node_name = &match cmd.node_name {
-        Some(name) => name,
-        None => default_node_name(&opts),
-    };
+    let node_name = &cmd.node_name;
 
     let node_state = opts.state.nodes.get(node_name)?;
     node_state.kill_process(false)?;

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,4 @@
-use crate::node::util::default_node_name;
+use crate::node::default_node_name;
 use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
 use clap::Args;
 
@@ -7,7 +7,8 @@ use clap::Args;
 #[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
 pub struct StopCommand {
     /// Name of the node.
-    node_name: Option<String>,
+    #[arg(default_value_t = default_node_name())]
+    node_name: String,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
     #[arg(long)]
     force: bool,
@@ -23,11 +24,7 @@ impl StopCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
-    let node_name = &match cmd.node_name {
-        Some(name) => name,
-        None => default_node_name(&opts),
-    };
-    let node_state = opts.state.nodes.get(node_name)?;
+    let node_state = opts.state.nodes.get(&cmd.node_name)?;
     node_state.kill_process(cmd.force)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -249,13 +249,3 @@ pub fn spawn_node(
 
     Ok(())
 }
-
-/// Retreive the default node name from the global options
-pub fn default_node_name(opts: &CommandGlobalOpts) -> String {
-    opts.state
-        .nodes
-        .default()
-        .unwrap_or_else(|_| panic!("No default Node found"))
-        .config
-        .name
-}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
-use crate::node::util::default_node_name;
+use crate::node::default_node_name;
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{help, CommandGlobalOpts};
@@ -34,8 +34,8 @@ pub struct CreateCommand {
 #[derive(Clone, Debug, Args)]
 pub struct SecureChannelListenerNodeOpts {
     /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE")]
-    pub at: Option<String>,
+    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
+    pub at: String,
 }
 
 impl CreateCommand {
@@ -52,10 +52,8 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let at = &match cmd.node_opts.at {
-        Some(at) => at,
-        None => default_node_name(&opts),
-    };
+    let at = &cmd.node_opts.at;
+
     let node = extract_address_value(at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = Request::post("/node/secure_channel_listener").body(

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,5 +1,5 @@
+use crate::node::default_node_name;
 use crate::{
-    node::util::default_node_name,
     util::{api, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
@@ -14,8 +14,8 @@ use std::net::SocketAddrV4;
 #[derive(Clone, Debug, Args)]
 pub struct TcpConnectionNodeOpts {
     /// Node that will initiate the connection
-    #[arg(global = true, short, long, value_name = "NODE")]
-    pub from: Option<String>,
+    #[arg(global = true, short, long, value_name = "NODE", default_value_t = default_node_name())]
+    pub from: String,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -43,10 +43,8 @@ impl CreateCommand {
         // if output format is json, write json to stdout.
         match opts.global_args.output_format {
             OutputFormat::Plain => {
-                let from = match &self.node_opts.from {
-                    Some(name) => name.clone(),
-                    None => default_node_name(opts),
-                };
+                let from = &self.node_opts.from;
+
                 let to = response.payload.parse::<SocketAddrV4>()?;
                 if opts.global_args.no_color {
                     println!("\n  Created TCP Connection:");
@@ -89,10 +87,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (options, command): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let from = match &command.node_opts.from {
-        Some(name) => name.clone(),
-        None => default_node_name(&options),
-    };
+    let from = &command.node_opts.from;
     let node_name = extract_address_value(from.as_str())?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     let request = api::create_tcp_connection(&command);

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::node::util::default_node_name;
+use crate::node::default_node_name;
 use crate::util::extract_address_value;
 use crate::util::node_rpc;
 use crate::util::Rpc;
@@ -20,8 +20,8 @@ pub struct CreateCommand {
 #[derive(Clone, Debug, Args)]
 pub struct TCPListenerNodeOpts {
     /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE")]
-    pub at: Option<String>,
+    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
+    pub at: String,
 }
 
 impl CreateCommand {
@@ -34,10 +34,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let at_node_name = &match cmd.node_opts.at {
-        Some(name) => name,
-        None => default_node_name(&opts),
-    };
+    let at_node_name = &cmd.node_opts.at;
     let node_name = extract_address_value(at_node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::post("/node/tcp/listener")).await?;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently the node name is set using `Option<String>` and checking whether it is `None` in which case the code will apply the default node name. 

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Since it is possible to extract the default node name from `CliState::new()` instance, I have modified the `default_node_name` method to take in 0 arguments and use it to set the default node name using Clap attributes.

Fixes #4080 

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
