### PR TITLE
chore(rust): refactor setting enrollment status

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -422,7 +422,7 @@ pub struct IdentityState {
 }
 
 impl IdentityState {
-    pub fn save(&self) -> Result<()> {
+    fn persist(&self) -> Result<()> {
         let contents = serde_json::to_string(&self.config)?;
         std::fs::write(&self.path, contents)?;
         Ok(())
@@ -442,6 +442,11 @@ impl IdentityState {
             }
         }
         Ok(())
+    }
+
+    pub fn set_enrollment_status(&mut self) -> Result<()> {
+        self.config.enrollment_status = Some(EnrollmentStatus::enrolled());
+        self.persist()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -11,7 +11,6 @@ use tokio_retry::{strategy::ExponentialBackoff, Retry};
 use tracing::{debug, info};
 
 use ockam::Context;
-use ockam_api::cli_state::EnrollmentStatus;
 use ockam_api::cloud::enroll::auth0::*;
 use ockam_api::cloud::project::{OktaAuth0, Project};
 use ockam_api::cloud::space::Space;
@@ -372,8 +371,7 @@ async fn update_enrolled_identity(
 
     for mut identity in identities {
         if node_identity.identifier() == &identity.config.identifier {
-            identity.config.enrollment_status = Some(EnrollmentStatus::enrolled());
-            identity.save()?;
+            identity.set_enrollment_status()?;
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

The `save()` method on IdentityState is public and EnrollmentStatus is updated from externally.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Rename `save()` method to `persist()` and make it private. 
Add a `set_enrollment_status()` method on IdentityState.

Closes https://github.com/build-trust/ockam/issues/4124

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
