### PR TITLE
chore(rust): fix no_std example

### DIFF
--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
@@ -63,7 +63,6 @@ fn entry() -> ! {
 // - ockam::node entrypoint ---------------------------------------------------
 
 use ockam::{
-    authenticated_storage::InMemoryStorage,
     identity::{Identity, TrustEveryonePolicy},
     route,
     vault::Vault,
@@ -78,24 +77,18 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Create an Identity to represent Bob.
     let bob = Identity::create(&ctx, &vault).await?;
 
-    // Create an AuthenticatedStorage to store info about Bob's known Identities.
-    let bob_storage = InMemoryStorage::new();
-
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.
-    bob.create_secure_channel_listener("bob", TrustEveryonePolicy, &bob_storage)
+    bob.create_secure_channel_listener("bob", TrustEveryonePolicy)
         .await?;
 
     // Create an Identity to represent Alice.
     let alice = Identity::create(&ctx, &vault).await?;
 
-    // Create an AuthenticatedStorage to store info about Alice's known Identities.
-    let alice_storage = InMemoryStorage::new();
-
     // As Alice, connect to Bob's secure channel listener and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.
     let channel = alice
-        .create_secure_channel("bob", TrustEveryonePolicy, &alice_storage)
+        .create_secure_channel("bob", TrustEveryonePolicy)
         .await?;
 
     // Send a message, ** THROUGH ** the secure channel,


### PR DESCRIPTION
This no_std example is currently not checked on CI, so it got broken recently. Fixing it. Waiting for @metaclips to reenable that check on CI