### PR TITLE
feat(rust): add flag to reload enrollers from a file

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -215,13 +215,16 @@ pub struct StartAuthenticatorRequest<'a> {
     #[n(0)] tag: TypeTag<2749734>,
     #[b(1)] addr: CowStr<'a>,
     #[b(2)] enrollers: CowStr<'a>,
-    #[b(3)] proj: CowBytes<'a>
+    #[b(3)] proj: CowBytes<'a>,
+    // FIXME: test id old format still matches with this
+    #[n(4)] reload_enrollers: bool
 }
 
 impl<'a> StartAuthenticatorRequest<'a> {
     pub fn new(
         addr: impl Into<CowStr<'a>>,
         enrollers: impl Into<CowStr<'a>>,
+        reload_enrollers: bool,
         proj: impl Into<CowBytes<'a>>,
     ) -> Self {
         Self {
@@ -229,6 +232,7 @@ impl<'a> StartAuthenticatorRequest<'a> {
             tag: TypeTag,
             addr: addr.into(),
             enrollers: enrollers.into(),
+            reload_enrollers,
             proj: proj.into(),
         }
     }
@@ -239,6 +243,10 @@ impl<'a> StartAuthenticatorRequest<'a> {
 
     pub fn enrollers(&'a self) -> &'a str {
         &self.enrollers
+    }
+
+    pub fn reload_enrollers(&self) -> bool {
+        self.reload_enrollers
     }
 
     pub fn project(&'a self) -> &'a [u8] {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -212,6 +212,7 @@ impl NodeManager {
         ctx: &Context,
         addr: Address,
         enrollers: &str,
+        reload_enrollers: bool,
         proj: &[u8],
     ) -> Result<()> {
         use crate::nodes::registry::AuthenticatorServiceInfo;
@@ -220,7 +221,13 @@ impl NodeManager {
         }
         let db = self.authenticated_storage.async_try_clone().await?;
         let id = self.identity()?.async_try_clone().await?;
-        let au = crate::authenticator::direct::Server::new(proj.to_vec(), db, enrollers, id)?;
+        let au = crate::authenticator::direct::Server::new(
+            proj.to_vec(),
+            db,
+            enrollers,
+            reload_enrollers,
+            id,
+        )?;
         ctx.start_worker(
             addr.clone(),
             au,
@@ -371,6 +378,7 @@ impl NodeManagerWorker {
                     ctx,
                     addr,
                     body.enrollers(),
+                    body.reload_enrollers(),
                     body.project(),
                 )
                 .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -385,6 +385,7 @@ async fn start_services(
                 &node_opts.api_node,
                 &cfg.address,
                 &cfg.enrollers,
+                cfg.reload_enrollers,
                 &cfg.project,
                 Some(tcp),
             )

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -53,6 +53,9 @@ pub struct AuthenticatorConfig {
 
     pub(crate) enrollers: String,
 
+    #[serde(default = "reload_enrollers_default")]
+    pub(crate) reload_enrollers: bool,
+
     pub(crate) project: String,
 
     #[serde(default)]
@@ -117,6 +120,9 @@ fn verifier_default_addr() -> String {
 
 fn authenticator_default_addr() -> String {
     DefaultAddress::AUTHENTICATOR.to_string()
+}
+fn reload_enrollers_default() -> bool {
+    true
 }
 
 fn okta_identity_provider_default_addr() -> String {

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -59,6 +59,9 @@ pub enum StartSubCommand {
 
         #[arg(long)]
         project: String,
+
+        #[arg(long)]
+        reload_enrollers: bool,
     },
     #[command(hide = help::hide())]
     KafkaConsumer {
@@ -170,6 +173,7 @@ async fn run_impl(
         StartSubCommand::Authenticator {
             addr,
             enrollers,
+            reload_enrollers,
             project,
             ..
         } => {
@@ -179,6 +183,7 @@ async fn run_impl(
                 node_name,
                 &addr,
                 &enrollers,
+                reload_enrollers,
                 &project,
                 Some(&tcp),
             )
@@ -299,16 +304,18 @@ pub async fn start_verifier_service(
 }
 
 /// Public so `ockam_command::node::create` can use it.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_authenticator_service(
     ctx: &Context,
     opts: &CommandGlobalOpts,
     node_name: &str,
     serv_addr: &str,
     enrollers: &str,
+    reload_enrollers: bool,
     project: &str,
     tcp: Option<&'_ TcpTransport>,
 ) -> Result<()> {
-    let req = api::start_authenticator_service(serv_addr, enrollers, project);
+    let req = api::start_authenticator_service(serv_addr, enrollers, reload_enrollers, project);
     start_service_impl(ctx, opts, node_name, serv_addr, "Authenticator", req, tcp).await
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -154,9 +154,11 @@ pub(crate) fn start_credentials_service(
 pub(crate) fn start_authenticator_service<'a>(
     addr: &'a str,
     enrollers: &'a str,
+    reload_enrollers: bool,
     project: &'a str,
 ) -> RequestBuilder<'static, StartAuthenticatorRequest<'a>> {
-    let payload = StartAuthenticatorRequest::new(addr, enrollers, project.as_bytes());
+    let payload =
+        StartAuthenticatorRequest::new(addr, enrollers, reload_enrollers, project.as_bytes());
     Request::post("/node/services/authenticator").body(payload)
 }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently authenticator either loads enrollers from a file or reads them from a JSON string. If enrollers file changes it will not reload them.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Add new config flag `reload_enrollers`, which if set to `true` will cause the enrollers file to be read on each enrollers check. This flag is only relevant if `enrollers` configured as a file.

## Compatibility

I couldn't figure out how to make a new flag optional, maybe there is a way to do so, but currently it has to be set.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
