### PR TITLE
feat(rust): added command to list a node's services in `ockam::command`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -62,6 +62,8 @@ pub type BareCloudRequestWrapper<'a> = CloudRequestWrapper<'a, ()>;
 impl<'a> BareCloudRequestWrapper<'a> {
     pub fn bare(route: &MultiAddr) -> Self {
         Self {
+            #[cfg(feature = "tag")]
+            tag: Default::default(),
             req: (),
             route: route.to_string().into(),
             identity_name: None,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -2,6 +2,8 @@ use minicbor::{Decode, Encode};
 use ockam_core::{CowBytes, CowStr};
 use std::net::Ipv4Addr;
 
+use serde::Serialize;
+
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 use ockam_multiaddr::MultiAddr;
@@ -356,7 +358,7 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
     }
 }
 
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Serialize, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct ServiceStatus<'a> {
@@ -378,7 +380,7 @@ impl<'a> ServiceStatus<'a> {
 }
 
 /// Response body for listing services
-#[derive(Debug, Clone, Decode, Encode)]
+#[derive(Debug, Clone, Serialize, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct ServiceList<'a> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -363,6 +363,7 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
 #[cbor(map)]
 pub struct ServiceStatus<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<8542064>,
     #[b(2)] pub addr: CowStr<'a>,
     #[b(3)] pub service_type: CowStr<'a>,
@@ -385,6 +386,7 @@ impl<'a> ServiceStatus<'a> {
 #[cbor(map)]
 pub struct ServiceList<'a> {
     #[cfg(feature = "tag")]
+    #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<9587601>,
     #[b(1)] pub list: Vec<ServiceStatus<'a>>
 }

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -1,0 +1,40 @@
+use clap::Args;
+use ockam::{Context, TcpTransport};
+
+use ockam_api::nodes::models::services::ServiceList;
+
+use crate::util::{api, node_rpc, RpcBuilder};
+use crate::CommandGlobalOpts;
+
+/// List service(s) of a given node
+#[derive(Clone, Debug, Args)]
+pub struct ListCommand {
+    /// Name of the node.
+    #[arg(display_order = 900)]
+    pub node_name: String,
+}
+
+impl ListCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, (options, self));
+    }
+}
+
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+    run_impl(&mut ctx, opts, cmd).await
+}
+
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListCommand,
+) -> crate::Result<()> {
+    let node_name = cmd.node_name;
+    let tcp = TcpTransport::create(&ctx).await?;
+
+    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).tcp(&tcp)?.build();
+    rpc.request(api::list_services()).await?;
+    rpc.parse_and_print_response::<ServiceList>()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -3,15 +3,15 @@ use ockam::{Context, TcpTransport};
 
 use ockam_api::nodes::models::services::ServiceList;
 
-use crate::util::{api, node_rpc, RpcBuilder};
+use crate::node::NodeOpts;
+use crate::util::{api, extract_address_value, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 /// List service(s) of a given node
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    /// Name of the node.
-    #[arg(display_order = 900)]
-    pub node_name: String,
+    #[command(flatten)]
+    pub node_opts: NodeOpts,
 }
 
 impl ListCommand {
@@ -29,8 +29,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = cmd.node_name;
-    let tcp = TcpTransport::create(&ctx).await?;
+    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let tcp = TcpTransport::create(ctx).await?;
 
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).tcp(&tcp)?.build();
     rpc.request(api::list_services()).await?;

--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+pub(crate) mod list;
 pub(crate) mod start;
 
 pub(crate) use start::StartCommand;
@@ -6,6 +7,8 @@ pub(crate) use start::StartCommand;
 use crate::help;
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
+
+use list::ListCommand;
 
 #[derive(Clone, Debug, Args)]
 #[command(hide = help::hide())]
@@ -18,12 +21,15 @@ pub struct ServiceCommand {
 pub enum ServiceSubcommand {
     #[command(display_order = 900)]
     Start(StartCommand),
+    #[command(display_order = 901)]
+    List(ListCommand),
 }
 
 impl ServiceCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             ServiceSubcommand::Start(c) => c.run(options),
+            ServiceSubcommand::List(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod config;
 pub(crate) mod list;
 pub(crate) mod start;
+pub(crate) mod util;
 
 pub(crate) use start::StartCommand;
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -16,6 +16,7 @@ use ockam_core::api::{Request, RequestBuilder, Status};
 use ockam_multiaddr::MultiAddr;
 use std::net::Ipv4Addr;
 
+/// Start a specified service
 #[derive(Clone, Debug, Args)]
 pub struct StartCommand {
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/service/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/util.rs
@@ -1,0 +1,24 @@
+use core::fmt::Write;
+use ockam_api::nodes::models::services::ServiceList;
+
+use crate::util::output::Output;
+
+impl Output for ServiceList<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        if self.list.is_empty() {
+            return Ok("No services found".to_string());
+        }
+
+        let mut w = String::new();
+        write!(w, "Services:")?;
+
+        let services_list = self.list.clone();
+        for service in services_list {
+            write!(w, "\n  Service: ")?;
+            write!(w, "\n    Type: {}", service.service_type)?;
+            write!(w, "\n    Address: /service/{}", service.addr)?;
+        }
+
+        Ok(w)
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -3,7 +3,6 @@ use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
 use ockam::identity::credential::Credential;
 use ockam_api::cloud::project::{Enroller, Project};
-use ockam_api::nodes::models::services::ServiceList;
 
 use crate::project::ProjectInfo;
 use crate::util::comma_separated;
@@ -235,25 +234,5 @@ impl Output for Vec<Enroller<'_>> {
 impl Output for Credential<'_> {
     fn output(&self) -> anyhow::Result<String> {
         Ok(self.to_string())
-    }
-}
-
-impl Output for ServiceList<'_> {
-    fn output(&self) -> anyhow::Result<String> {
-        if self.list.is_empty() {
-            return Ok("No services found".to_string());
-        }
-
-        let mut w = String::new();
-        write!(w, "Services:")?;
-
-        let services_list = self.list.clone();
-        for service in services_list {
-            write!(w, "\n  Service: ")?;
-            write!(w, "\n    Type: {}", service.service_type)?;
-            write!(w, "\n    Address: /service/{}", service.addr)?;
-        }
-
-        Ok(w)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -3,6 +3,7 @@ use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
 use ockam::identity::credential::Credential;
 use ockam_api::cloud::project::{Enroller, Project};
+use ockam_api::nodes::models::services::ServiceList;
 
 use crate::project::ProjectInfo;
 use crate::util::comma_separated;
@@ -234,5 +235,25 @@ impl Output for Vec<Enroller<'_>> {
 impl Output for Credential<'_> {
     fn output(&self) -> anyhow::Result<String> {
         Ok(self.to_string())
+    }
+}
+
+impl Output for ServiceList<'_> {
+    fn output(&self) -> anyhow::Result<String> {
+        if self.list.is_empty() {
+            return Ok("No services found".to_string());
+        }
+
+        let mut w = String::new();
+        write!(w, "Services:")?;
+
+        let services_list = self.list.clone();
+        for service in services_list {
+            write!(w, "\n  Service: ")?;
+            write!(w, "\n    Type: {}", service.service_type)?;
+            write!(w, "\n    Address: /service/{}", service.addr)?;
+        }
+
+        Ok(w)
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

There is no command in to list a node's services.

## Proposed Changes

This PR solves https://github.com/build-trust/ockam/issues/4094 by adding a new `service list` subcommand to `ockam_command::service`. A missing help indicator from the `service start` command has also been added.

Closes https://github.com/build-trust/ockam/issues/4094

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
