### PR TITLE
feat(rust): fix errors in ockam status command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -1,6 +1,6 @@
 use crate::util::{api, node_rpc, RpcBuilder};
+use crate::CommandGlobalOpts;
 use crate::Result;
-use crate::{exitcode, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam::{Context, TcpTransport};
@@ -36,22 +36,18 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, StatusCommand)) -> R
 }
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: StatusCommand) -> Result<()> {
-    let node_states = match opts.state.nodes.list() {
-        Ok(nodes) => nodes,
-        Err(_err) => {
-            return Err(crate::Error::new(
-                exitcode::IOERR,
-                anyhow!("No nodes registered on this system!"),
-            ));
-        }
-    };
+    let node_states = opts.state.nodes.list()?;
+    if node_states.is_empty() {
+        return Err(anyhow!("No nodes registered on this system!").into());
+    }
 
     let mut node_details: Vec<NodeDetails> = vec![];
+    let tcp = TcpTransport::create(ctx).await?;
     for node_state in &node_states {
         let node_infos = NodeDetails {
             identity: node_state.config.identity(ctx).await?,
             state: node_state.clone(),
-            status: get_node_status(ctx, &opts, node_state).await?,
+            status: get_node_status(ctx, &opts, node_state, &tcp).await?,
         };
         node_details.push(node_infos);
     }
@@ -77,12 +73,11 @@ async fn get_node_status(
     ctx: &Context,
     opts: &CommandGlobalOpts,
     node_state: &NodeState,
+    tcp: &TcpTransport,
 ) -> Result<String> {
     let mut node_status: String = "Stopped".to_string();
-
-    let tcp = TcpTransport::create(ctx).await?;
     let mut rpc = RpcBuilder::new(ctx, opts, &node_state.config.name)
-        .tcp(&tcp)?
+        .tcp(tcp)?
         .build();
     if rpc
         .request_with_timeout(api::query_status(), Duration::from_millis(200))
@@ -101,6 +96,12 @@ async fn print_status(
     identities: Vec<IdentityState>,
     mut node_details: Vec<NodeDetails>,
 ) -> Result<()> {
+    if identities.is_empty() {
+        return Err(anyhow!(
+            "No enrolled identities found! Try passing the `--all` argument to see all identities."
+        )
+        .into());
+    }
     let default_identity = opts.state.identities.default()?;
 
     for (i_idx, identity) in identities.iter().enumerate() {


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/4096

## Current Behavior

`ockam status`

1. Is failing with IO error when no nodes are registered.
2. When running on a fresh install the command exits successfully without showing any output.
3. Fails when there is more than 1 node registered

## Proposed Changes

1. Checking if the list of node states is empty, if so fail with appropriate message.
2. Checking if the list of identities is empty, if so fail with appropriate message.
3. Share `TcpTransport` between `Rpc`s for different nodes. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
