### PR TITLE
refactor(rust): recipient returns an error instead of a panic

### DIFF
--- a/implementations/rust/ockam/ockam/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam/src/channel/listener.rs
@@ -59,7 +59,7 @@ impl Worker for ChannelListener {
             rx_int_addr,
             tx_int_addr,
         } = msg.as_body();
-        let peer_channel_addr = msg.return_route().recipient();
+        let peer_channel_addr = msg.return_route().recipient()?;
 
         let peer_rx_base: Route = msg.return_route().modify().pop_back().into();
         let peer_rx_pub = peer_rx_base.clone().modify().append(rx_addr.clone()).into();

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -299,7 +299,7 @@ impl Worker for RemoteForwarder {
 
         // FIXME: @ac check that return address is the same
         // We are the final recipient of the message because it's registration response for our Worker
-        if msg.onward_route().recipient() == self.main_address {
+        if msg.onward_route().recipient()? == self.main_address {
             debug!("RemoteForwarder received service message");
 
             let payload =
@@ -313,7 +313,7 @@ impl Worker for RemoteForwarder {
                 let route = msg.return_route();
 
                 info!("RemoteForwarder registered with route: {}", route);
-                let address = match route.clone().recipient().to_string().strip_prefix("0#") {
+                let address = match route.clone().recipient()?.to_string().strip_prefix("0#") {
                     Some(addr) => addr.to_string(),
                     None => return Err(OckamError::InvalidHubResponse.into()),
                 };

--- a/implementations/rust/ockam/ockam_api/src/echoer.rs
+++ b/implementations/rust/ockam/ockam_api/src/echoer.rs
@@ -10,7 +10,7 @@ impl Worker for Echoer {
     type Message = Any;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
-        log::debug!(to = %msg.sender(), "echoing back");
+        log::debug!(to = %msg.sender()?, "echoing back");
         ctx.send(msg.return_route(), NeutralMessage::from(msg.take_payload()))
             .await
     }

--- a/implementations/rust/ockam/ockam_core/src/access_control/local.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/local.rs
@@ -75,10 +75,10 @@ mod tests {
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(external_onward_address.clone(), route![], vec![]),
+            TransportMessage::v1(external_onward_address, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), local_onward_address.clone(), msg);
+        let msg = RelayMessage::new(source_address, local_onward_address, msg);
 
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -137,7 +137,7 @@ mod tests {
             ),
             vec![],
         );
-        let msg = RelayMessage::new(local_source_address.clone(), onward_address.clone(), msg);
+        let msg = RelayMessage::new(local_source_address, onward_address, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 

--- a/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
@@ -81,10 +81,10 @@ mod tests {
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(onward_address2.clone(), route![], vec![]),
+            TransportMessage::v1(onward_address2, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address1.clone(), msg);
+        let msg = RelayMessage::new(source_address, onward_address1, msg);
 
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -112,7 +112,7 @@ mod tests {
             TransportMessage::v1(onward_address2.clone(), route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address2.clone(), msg);
+        let msg = RelayMessage::new(source_address.clone(), onward_address2, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -133,10 +133,10 @@ mod tests {
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(onward_address1.clone(), route![], vec![]),
+            TransportMessage::v1(onward_address1, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address3.clone(), msg);
+        let msg = RelayMessage::new(source_address, onward_address3, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -217,7 +217,7 @@ impl<M: Message> Routed<M> {
     }
     /// Return a copy of the sender address for the wrapped message.
     #[inline]
-    pub fn sender(&self) -> Address {
+    pub fn sender(&self) -> Result<Address> {
         self.local_msg.transport().return_route.recipient()
     }
 

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -185,8 +185,7 @@ impl Route {
         self.inner
             .back()
             .cloned()
-            .map(Ok)
-            .unwrap_or(Err(RouteError::IncompleteRoute.into()))
+            .ok_or_else(|| RouteError::IncompleteRoute.into())
     }
 
     /// Iterate over all addresses of this route.

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
@@ -358,7 +358,7 @@ impl<V: IdentityVault, K: SecureChannelKeyExchanger, S: AuthenticatedStorage>
                 return Err(IdentityError::UnknownChannelMsgDestination.into());
             }
             if self.remote_backwards_compatibility_address.is_none() {
-                self.remote_backwards_compatibility_address = Some(body.return_route.recipient());
+                self.remote_backwards_compatibility_address = Some(body.return_route.recipient()?);
             }
             let body = IdentityChannelMessage::decode(&body.payload)?;
 


### PR DESCRIPTION
This PR takes care of a TODO calling for Route::recipient to return a Result<Address> instead of lying by returning Address but being a partial function that panics under certain situations.

Clippy also complained about a bunch of redundant cloning, so those are addressed here as well, mainly in local.rs and onward.rs.

This is the second attempt at this PR, and the discussion from the first attempt can be found here: https://github.com/build-trust/ockam/pull/4142