### PR TITLE
Code freeze automation

### DIFF
--- a/.github/workflows/activate-code-freeze.yml
+++ b/.github/workflows/activate-code-freeze.yml
@@ -1,0 +1,86 @@
+name: Activate/Deactivate Code Freeze CI
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: Branch Name To Create Pull Request
+        required: true
+      set_freeze_state:
+        type: choice
+        description: Set PR Freeze State
+        default: freeze
+        options:
+        - freeze
+        - unfreeze
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  code_freeze_automation:
+    name: Code Freeze Activator Automation
+    runs-on: ubuntu-22.04
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG key
+        uses: build-trust/.github/actions/import_gpg@a6377d3c2dac878b92a0da26cdf3da2856c64840
+        with:
+          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
+          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
+          gpg_name: '${{ secrets.GPG_USER_NAME }}'
+          gpg_email: '${{ secrets.GPG_EMAIL }}'
+
+      - name: Check If PR State Is Frozen
+        run: |
+          if cat .github/workflows/code-freeze.yml | grep 'ON_FREEZE_MODE: false'; then
+            current_state="unfreeze"
+          else
+            current_state="freeze"
+          fi
+
+          if [[ ${{ github.event.inputs.set_freeze_state }} == $current_state ]]; then
+            echo "PR state already set to $current_state"
+            exit 1
+          fi
+
+      - name: Checkout To Specified Branch
+        run: |
+          git checkout -B ${{ github.event.inputs.branch_name }}
+
+      - name: Freeze PRs From Being Merged
+        if: ${{ github.event.inputs.set_freeze_state == 'freeze' }}
+        run: |
+          # Uncomment code that enables code freeze
+          sed -i -e 's/ON_FREEZE_MODE: false/ON_FREEZE_MODE: true/g' .github/workflows/code-freeze.yml
+
+      - name: Unfreeze PRs So That They Can Be Merged
+        if: ${{ github.event.inputs.set_freeze_state == 'unfreeze' }}
+        run: |
+          # Comment code that enables code freeze
+          sed -i -e 's/ON_FREEZE_MODE: true/ON_FREEZE_MODE: false/g' .github/workflows/code-freeze.yml
+
+      - name: Git Add Updated Workflow
+        run: |
+          git add .github/workflows/code-freeze.yml
+
+          if [[ ${{ github.event.inputs.set_freeze_state }} == 'freeze' ]]; then
+            git commit -S -m "ci: freeze pull_requests"
+          else
+            git commit -S -m "ci: unfreeze pull_requests"
+          fi
+
+          git push --set-upstream origin ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -4,83 +4,81 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch_name:
-        description: Branch Name To Create Pull Request
-        required: true
-      set_mergify_pr_state:
-        type: choice
-        description: Set Mergify PR Freeze State
-        default: freeze
-        options:
-        - freeze
-        - unfreeze
+  pull_request:
+  merge_group:
 
 defaults:
   run:
     shell: bash
 
+env:
+  RELEASE_LABEL_NAME: release
+  ON_FREEZE_MODE: false
+
 jobs:
-  code_freeze_automation:
-    name: Code Freeze Automation
+  code_freeze_pr:
+    name: Code Freeze Pull Request
     runs-on: ubuntu-22.04
-    environment: release
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
-      - name: Checkout Repository
+      - name: Checkout To Repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           fetch-depth: 0
 
-      - name: Import GPG key
-        uses: build-trust/.github/actions/import_gpg@a6377d3c2dac878b92a0da26cdf3da2856c64840
-        with:
-          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
-          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
-          gpg_name: '${{ secrets.GPG_USER_NAME }}'
-          gpg_email: '${{ secrets.GPG_EMAIL }}'
-
-      - name: Check If Mergify PR State Is Frozen
+      - name: Block Rust Changes On Code Freeze
+        if: ${{ env.ON_FREEZE_MODE == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if cat .github/mergify.yml | grep '#- -files~=^(implementations/rust)'; then
-            current_state="unfreeze"
-          else
-            current_state="freeze"
+          set -ex
+
+          ockam_team_members="""
+            etorreborre
+            mrinalwadhwa
+            davide-baldo
+            hairyhum
+            glenngillen
+            CAOakleyII
+            BeenzSyed
+            SanjoDeundiak
+            adrianbenavides
+            polvorin
+            mattgreg
+            metaclips
+            mszpakowski
+          """
+
+          default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name  )
+          if git diff origin/"$default_branch" --quiet --name-status -- implementations/rust/ockam; then
+            echo "No Rust changes exiting now"
+            exit 0
           fi
 
-          if [[ ${{ github.event.inputs.set_mergify_pr_state }} == $current_state ]]; then
-            echo "PR state already set to $current_state"
-            exit 1
+          # At this point, there's an update to this event
+          # so we enforce code-freeze rules.
+          # - Block if there is a Rust change
+          # - Bypass if user is an Ockam member and labelled their
+          # PR as release.
+          pr_number_or_branch="${{ github.head_ref || github.ref_name }}"
+
+          # Check if it's a merge-queue CI
+          if [[ $pr_number_or_branch =~ gh-readonly-queue.*/pr\-([0-9]*)\-.* ]]; then
+            pr_number_or_branch="${BASH_REMATCH[1]}"
+            echo "PR number is $pr_number_or_branch"
           fi
 
-      - name: Checkout To Specified Branch
-        run: |
-          git checkout -B ${{ github.event.inputs.branch_name }}
+          pr_data=$(gh pr view $pr_number_or_branch -R exchangen/ockam --json labels,author)
 
-      - name: Freeze PRs From Being Merged
-        if: ${{ github.event.inputs.set_mergify_pr_state == 'freeze' }}
-        run: |
-          # Uncomment code that enables mergify schedule
-          sed -i -e 's/#- -files~=^(implementations\/rust)/- -files~=^(implementations\/rust)/g' .github/mergify.yml
+          labels=$(jq -r '.labels[].name' <<< $pr_data)
+          pr_actor=$(jq -r '.author.login' <<< $pr_data)
 
-      - name: Unfreeze PRs So That They Can Be Merged
-        if: ${{ github.event.inputs.set_mergify_pr_state == 'unfreeze' }}
-        run: |
-          # Comment code that enables mergify schedule
-          sed -i -e 's/- -files~=^(implementations\/rust)/#- -files~=^(implementations\/rust)/g' .github/mergify.yml
-
-      - name: Git Add Mergify Config
-        run: |
-          git add .github/mergify.yml
-
-          if [[ ${{ github.event.inputs.set_mergify_pr_state }} == 'freeze' ]]; then
-            git commit -S -m "ci: freeze mergify"
-          else
-            git commit -S -m "ci: unfreeze mergify"
+          # If the PR is labeled as release and PR is created by a
+          # Ockam team member, then pass.
+          if [[ $labels == *"${{ env.RELEASE_LABEL_NAME }}"* ]]; then
+            if [[ $ockam_team_members == *"$pr_actor"* ]]; then
+              exit 0
+            fi
           fi
 
-          git push --set-upstream origin ${{ github.event.inputs.branch_name }}
+          exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,10 +1,10 @@
 name: Code Freeze CI
 
-permission:
+permissions:
   contents: read
 
-on: 
-  workflow_dispatch
+on:
+  workflow_dispatch:
     inputs:
       branch_name:
         description: Branch Name To Create Pull Request
@@ -26,7 +26,7 @@ jobs:
     name: Code Freeze Automation
     runs-on: ubuntu-22.04
     environment: release
-    permission:
+    permissions:
       contents: write
       pull-requests: write
 
@@ -45,12 +45,11 @@ jobs:
           gpg_email: '${{ secrets.GPG_EMAIL }}'
 
       - name: Check If Mergify PR State Is Frozen
-        id: pr_state
         run: |
           if cat .github/mergify.yml | grep '#- schedule: Mon-Sun'; then
-            current_state='unfreeze'
+            current_state="unfreeze"
           else
-            current_state='freeze'
+            current_state="freeze"
           fi
 
           if [[ ${{ github.event.inputs.set_mergify_pr_state }} == $current_state ]]; then
@@ -58,29 +57,27 @@ jobs:
             exit 1
           fi
 
-          echo "current_state=$current_state" >> GITHUB_OUTPUT
-
       - name: Checkout To Specified Branch
         run: |
           git checkout -B ${{ github.event.inputs.branch_name }}
 
       - name: Freeze PRs From Being Merged
-        if: ${{ steps.pr_state.outputs.current_state == 'freeze' }}
+        if: ${{ github.event.inputs.set_mergify_pr_state == 'freeze' }}
         run: |
           # Uncomment code that enables mergify schedule
-          sed -i -e 's/#- schedule: Mon-Sun/- schedule: Mon-Sun/g' .github/mergify.yml
+          sed -i -e 's/#- -files~=^(implementations/rust)/- -files~=^(implementations/rust)/g' .github/mergify.yml
 
       - name: Unfreeze PRs So That They Can Be Merged
-        if: ${{ steps.pr_state.outputs.current_state == 'unfreeze' }}
+        if: ${{ github.event.inputs.set_mergify_pr_state == 'unfreeze' }}
         run: |
           # Comment code that enables mergify schedule
-          sed -i -e 's/- schedule: Mon-Sun/#- schedule: Mon-Sun/g' .github/mergify.yml
+          sed -i -e 's/- -files~=^(implementations/rust)/#- -files~=^(implementations/rust)/g' .github/mergify.yml
 
       - name: Git Add Mergify Config
         run: |
           git add .github/mergify.yml
 
-          if [[ ${{ steps.pr_state.outputs.current_state }} == 'freeze' ]]; then
+          if [[ ${{ github.event.inputs.set_mergify_pr_state }} == 'freeze' ]]; then
             git commit -S -m "ci: freeze mergify"
           else
             git commit -S -m "ci: unfreeze mergify"

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -9,7 +9,7 @@ on:
       branch_name:
         description: Branch Name To Create Pull Request
         required: true
-      set_pr_state:
+      set_mergify_pr_state:
         type: choice
         description: Set Mergify PR Freeze State
         default: freeze
@@ -53,7 +53,7 @@ jobs:
             current_state='freeze'
           fi
 
-          if [[ ${{ github.event.inputs.set_pr_state }} == $current_state ]]; then
+          if [[ ${{ github.event.inputs.set_mergify_pr_state }} == $current_state ]]; then
             echo "PR state already set to $current_state"
             exit 1
           fi

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,0 +1,89 @@
+name: Code Freeze CI
+
+permission:
+  contents: read
+
+on: 
+  workflow_dispatch
+    inputs:
+      branch_name:
+        description: Branch Name To Create Pull Request
+        required: true
+      set_pr_state:
+        type: choice
+        description: Set Mergify PR Freeze State
+        default: freeze
+        options:
+        - freeze
+        - unfreeze
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  code_freeze_automation:
+    name: Code Freeze Automation
+    runs-on: ubuntu-22.04
+    environment: release
+    permission:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+
+      - name: Import GPG key
+        uses: build-trust/.github/actions/import_gpg@a6377d3c2dac878b92a0da26cdf3da2856c64840
+        with:
+          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
+          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
+          gpg_name: '${{ secrets.GPG_USER_NAME }}'
+          gpg_email: '${{ secrets.GPG_EMAIL }}'
+
+      - name: Check If Mergify PR State Is Frozen
+        id: pr_state
+        run: |
+          if cat .github/mergify.yml | grep '#- schedule: Mon-Sun'; then
+            current_state='unfreeze'
+          else
+            current_state='freeze'
+          fi
+
+          if [[ ${{ github.event.inputs.set_pr_state }} == $current_state ]]; then
+            echo "PR state already set to $current_state"
+            exit 1
+          fi
+
+          echo "current_state=$current_state" >> GITHUB_OUTPUT
+
+      - name: Checkout To Specified Branch
+        run: |
+          git checkout -B ${{ github.event.inputs.branch_name }}
+
+      - name: Freeze PRs From Being Merged
+        if: ${{ steps.pr_state.outputs.current_state == 'freeze' }}
+        run: |
+          # Uncomment code that enables mergify schedule
+          sed -i -e 's/#- schedule: Mon-Sun/- schedule: Mon-Sun/g' .github/mergify.yml
+
+      - name: Unfreeze PRs So That They Can Be Merged
+        if: ${{ steps.pr_state.outputs.current_state == 'unfreeze' }}
+        run: |
+          # Comment code that enables mergify schedule
+          sed -i -e 's/- schedule: Mon-Sun/#- schedule: Mon-Sun/g' .github/mergify.yml
+
+      - name: Git Add Mergify Config
+        run: |
+          git add .github/mergify.yml
+
+          if [[ ${{ steps.pr_state.outputs.current_state }} == 'freeze' ]]; then
+            git commit -S -m "ci: freeze mergify"
+          else
+            git commit -S -m "ci: unfreeze mergify"
+          fi
+
+          git push --set-upstream origin ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check If Mergify PR State Is Frozen
         run: |
-          if cat .github/mergify.yml | grep '#- schedule: Mon-Sun'; then
+          if cat .github/mergify.yml | grep '#- -files~=^(implementations/rust)'; then
             current_state="unfreeze"
           else
             current_state="freeze"
@@ -65,13 +65,13 @@ jobs:
         if: ${{ github.event.inputs.set_mergify_pr_state == 'freeze' }}
         run: |
           # Uncomment code that enables mergify schedule
-          sed -i -e 's/#- -files~=^(implementations/rust)/- -files~=^(implementations/rust)/g' .github/mergify.yml
+          sed -i -e 's/#- -files~=^(implementations\/rust)/- -files~=^(implementations\/rust)/g' .github/mergify.yml
 
       - name: Unfreeze PRs So That They Can Be Merged
         if: ${{ github.event.inputs.set_mergify_pr_state == 'unfreeze' }}
         run: |
           # Comment code that enables mergify schedule
-          sed -i -e 's/- -files~=^(implementations/rust)/#- -files~=^(implementations/rust)/g' .github/mergify.yml
+          sed -i -e 's/- -files~=^(implementations\/rust)/#- -files~=^(implementations\/rust)/g' .github/mergify.yml
 
       - name: Git Add Mergify Config
         run: |

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get commit information from Github (Pull Request)
         if: github.event_name == 'pull_request'
-        run: gh api repos/build-trust/ockam/pulls/${{ github.event.number }}/commits > commits.json
+        run: gh api repos/${{ github.repository_owner }}/ockam/pulls/${{ github.event.number }}/commits > commits.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ockam-package.yml
+++ b/.github/workflows/ockam-package.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   DEPLOYMENT_NAME: ockam
   ARTIFACT_NAME: ockam
-  ORGANIZATION: build-trust
+  ORGANIZATION: ${{ github.repository_owner }}
 
 jobs:
   build-and-publish-artifact:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -197,17 +197,17 @@ jobs:
         build: [linux_86, linux_armv7, macos, macos_86]
         include:
         - build: linux
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: aarch64-unknown-linux-musl
           use-cross-build: true
         - build: linux_armv7
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: armv7-unknown-linux-musleabihf
           use-cross-build: true
         - build: linux_86
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-musl
           use-cross-build: false
@@ -240,7 +240,7 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Install packages (Ubuntu)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         set -x
         use_cross_build=${{ matrix.use-cross-build }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,13 +23,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Get Commit Of Develop
-        id: develop_sha
-        shell: bash
-        run: |
-          develop_sha=$(git ls-remote https://github.com/${{ github.repository_owner }}/ockam.git refs/heads/develop | head -1 | cut -f 1)
-          echo "sha=$develop_sha" >> $GITHUB_OUTPUT
-
       - name: Checkout To Ockam Repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
@@ -43,10 +36,12 @@ jobs:
           gpg_name: '${{ secrets.GPG_USER_NAME }}'
           gpg_email: '${{ secrets.GPG_EMAIL }}'
 
-      - name: Update Tag Commit To That Merged by Mergify On Develop
+      - name: Update Tag Commit To That Merged by Merge Queue On Develop
         shell: bash
         run: |
-          git tag -s -a ${{ github.event.inputs.git_tag }} ${{ steps.develop_sha.outputs.sha }} -m "Ockam Release" -f
+          rust_path_last_commit=$(git log --follow -n 1 --pretty=format:"%H" -- implementations/rust/ockam)
+
+          git tag -s -a ${{ github.event.inputs.git_tag }} $rust_path_last_commit -m "Ockam Release" -f
           git push origin ${{ github.event.inputs.git_tag }} -f
 
       - name: Release GitHub Asset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,18 +5493,18 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.24.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
+checksum = "9a584273ccc2d9311f1dd19dc3fb26054661fa3e373d53ede5d1144ba07a9acd"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wast"
-version = "54.0.0"
+version = "52.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
+checksum = "15942180f265280eede7bc38b239e9770031d1821c02d905284216c645316430"
 dependencies = [
  "leb128",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,18 +5493,18 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a584273ccc2d9311f1dd19dc3fb26054661fa3e373d53ede5d1144ba07a9acd"
+checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wast"
-version = "52.0.3"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15942180f265280eede7bc38b239e9770031d1821c02d905284216c645316430"
+checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
 dependencies = [
  "leb128",
  "memchr",

--- a/tools/scripts/release/approve-deployment.sh
+++ b/tools/scripts/release/approve-deployment.sh
@@ -1,6 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
 if [[ -z $OWNER ]]; then
-    echo "Please specify organization OWNER, e.g. build-trust"
-    exit 1
+  echo "Please specify organization OWNER, e.g. build-trust"
+  exit 1
 fi
 
 function approve_deployment() {

--- a/tools/scripts/release/approve-deployment.sh
+++ b/tools/scripts/release/approve-deployment.sh
@@ -1,0 +1,37 @@
+if [[ -z $OWNER ]]; then
+    echo "Please specify organization OWNER, e.g. build-trust"
+    exit 1
+fi
+
+function approve_deployment() {
+  set -e
+  local repository="$1"
+  local run_id="$2"
+
+  # completed waiting queued in_progress
+  while true; do
+    status=$(gh api -H "Accept: application/vnd.github+json" "/repos/$OWNER/$repository/actions/runs/$run_id" | jq -r '.status')
+    if [[ $status == "completed" ]]; then
+      echo "Run ID $run_id completed"
+      return
+    elif [[ $status == "waiting" ]]; then
+      # Get actions that need to be approved
+      pending_deployments=$(gh api -H "Accept: application/vnd.github+json" "/repos/$OWNER/$repository/actions/runs/$run_id/pending_deployments")
+      pending_length=$(echo "$pending_deployments" | jq '. | length')
+
+      environments=""
+      for ((c = 0; c < pending_length; c++)); do
+        environment=$(echo "$pending_deployments" | jq -r ".[$c].environment.id")
+        environments="$environments $environment"
+      done
+
+      if [[ -n $environments ]]; then
+        jq -n "{environment_ids: [$environments], state: \"approved\", comment: \"Ship It\"}" | gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          "/repos/$OWNER/$repository/actions/runs/$run_id/pending_deployments" --input -
+      fi
+    fi
+    sleep 120
+  done
+}

--- a/tools/scripts/release/code-freeze.sh
+++ b/tools/scripts/release/code-freeze.sh
@@ -2,8 +2,8 @@
 set -e
 
 if [[ -z $OWNER ]]; then
-    echo "Please specify organization OWNER, e.g. build-trust"
-    exit 1
+  echo "Please specify organization OWNER, e.g. build-trust"
+  exit 1
 fi
 
 if [[ -z $IS_DRAFT_RELEASE ]]; then
@@ -15,67 +15,68 @@ code_freeze_branch_name="code_freeze_$(date +'%d-%m-%Y')_$(date +'%s')"
 
 # Check PR to ensure it's merged
 function check_pr_till_merge() {
-    set -e
-    pr_url=$1
+  set -e
+  pr_url=$1
+  pr_state=$(check_pr_status $pr_url)
+  echo "Code freeze PR $pr_url not merged, please merge PR to start release."
+
+  while [[ $pr_state != 'MERGED' ]]; do
+    if [[ $pr_state == 'CLOSED' ]]; then
+      echo "PR was closed without merging... exiting script"
+      exit 1
+    fi
+
+    sleep 5
     pr_state=$(check_pr_status $pr_url)
+  done
 
-    echo "Code freeze PR $pr_url not merged, please merge PR to start release."
-
-    while [[ $pr_state != 'MERGED' ]]; do
-        if [[ $pr_state == 'CLOSED' ]]; then
-            echo "PR was closed without failing exiting script"
-            exit 1
-        fi
-
-        sleep 5
-        pr_state=$(check_pr_status $pr_url)
-    done
-
-    echo "PR $pr_url merge, kickstarting release."
+  echo "PR $pr_url merge, kickstarting release."
 }
 
 function check_pr_status() {
-    set -e
-    pr_url=$1
-    pr_state=$(gh pr view "$pr_url" --json state -R ${OWNER}/ockam | jq -r '.state')
-    echo "$pr_state"
+  set -e
+  pr_url=$1
+  pr_state=$(gh pr view "$pr_url" --json state -R ${OWNER}/ockam | jq -r '.state')
+  echo "$pr_state"
 }
 
 function start_code_freeze_workflow() {
-    set -e
-    freeze_state="$1"
+  set -e
+  freeze_state="$1"
 
-    gh workflow run code-freeze.yml --ref develop \
-        -F branch_name="$code_freeze_branch_name" -F set_mergify_pr_state="$freeze_state"  -R $OWNER/ockam
+  gh workflow run code-freeze.yml --ref develop \
+    -F branch_name="$code_freeze_branch_name" -F set_mergify_pr_state="$freeze_state" -R $OWNER/ockam
 
-    # Sleep for 10 seconds to ensure we are not affected by Github API downtime.
-    sleep 10
-    # Wait for workflow run
-    run_id=$(gh run list --workflow=code-freeze.yml -b develop -u "$GITHUB_USERNAME" -L 1 -R $OWNER/ockam --json databaseId | jq -r .[0].databaseId)
+  # Sleep for 10 seconds to ensure we are not affected by Github API downtime.
+  sleep 10
 
-    approve_deployment "ockam" "$run_id" &
-    gh run watch "$run_id" --exit-status -R $OWNER/ockam
+  # Wait for workflow run
+  run_id=$(gh run list --workflow=code-freeze.yml -b develop -u "$GITHUB_USERNAME" -L 1 -R $OWNER/ockam --json databaseId | jq -r .[0].databaseId)
+  approve_deployment "ockam" "$run_id" &
+
+  gh run watch "$run_id" --exit-status -R $OWNER/ockam
 }
 
 function create_pr() {
-    pr_title="$1"
-    body="$2"
-    # Merge PR to a new branch to kickstart workflow
-    pr_url=$(gh pr create --title "$pr_title" --body "$body" \
-        --base develop -H "${code_freeze_branch_name}" -r mrinalwadhwa -R $OWNER/ockam)
-    
-    check_pr_till_merge $pr_url
+  pr_title="$1"
+  body="$2"
+
+  # Merge PR to a new branch to kickstart workflow
+  pr_url=$(gh pr create --title "$pr_title" --body "$body" \
+    --base develop -H "${code_freeze_branch_name}" -r mrinalwadhwa -R $OWNER/ockam)
+
+  check_pr_till_merge $pr_url
 }
 
 # If it's a draft release, then we create a PR that perform code freeze
 if [[ $IS_DRAFT_RELEASE == true ]]; then
-    echo "Kickstarting code freeze workflow"
-    start_code_freeze_workflow "freeze"
-    echo "Creating PR"
-    create_pr "Ockam code freeze $(date +'%d-%m-%Y')" --body "This PR freezes Rust code PR merge."
+  echo "Kickstarting code freeze workflow"
+  start_code_freeze_workflow "freeze"
+  echo "Creating PR"
+  create_pr "Ockam code freeze $(date +'%d-%m-%Y')" "This PR freezes Rust code PR merge."
 elif [[ $IS_DRAFT_RELEASE == false ]]; then
-    echo "Kickstarting code unfreeze workflow"
-    start_code_freeze_workflow "unfreeze"
-    echo "Creating PR"
-    create_pr "Ockam code unfreeze $(date +'%d-%m-%Y')" --body "This PR unfreezes Rust code PR merge."
+  echo "Kickstarting code unfreeze workflow"
+  start_code_freeze_workflow "unfreeze"
+  echo "Creating PR"
+  create_pr "Ockam code unfreeze $(date +'%d-%m-%Y')" "This PR unfreezes Rust code PR merge."
 fi

--- a/tools/scripts/release/code-freeze.sh
+++ b/tools/scripts/release/code-freeze.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ -z $OWNER ]]; then
+    echo "Please specify organization OWNER, e.g. build-trust"
+    exit 1
+fi
+
+if [[ -z $IS_DRAFT_RELEASE ]]; then
+  echo "Please set IS_DRAFT_RELEASE env to \`true\` or \`false\` if to release as \`draft\` or to \`production\`"
+  exit 1
+fi
+
+code_freeze_branch_name="code_freeze_$(date +'%d-%m-%Y')_$(date +'%s')"
+
+# Check PR to ensure it's merged
+function check_pr_till_merge() {
+    set -e
+    pr_url=$1
+    pr_state=$(check_pr_status $pr_url)
+
+    echo "Code freeze PR $pr_url not merged, please merge PR to start release."
+
+    while [[ $pr_state != 'MERGED' ]]; do
+        if [[ $pr_state == 'CLOSED' ]]; then
+            echo "PR was closed without failing exiting script"
+            exit 1
+        fi
+
+        sleep 5
+        pr_state=$(check_pr_status $pr_url)
+    done
+
+    echo "PR $pr_url merge, kickstarting release."
+}
+
+function check_pr_status() {
+    set -e
+    pr_url=$1
+    pr_state=$(gh pr view "$pr_url" --json state -R ${OWNER}/ockam | jq -r '.state')
+    echo "$pr_state"
+}
+
+function start_code_freeze_workflow() {
+    set -e
+    freeze_state="$1"
+
+    gh workflow run code-freeze.yml --ref develop \
+        -F branch_name="$code_freeze_branch_name" -F set_mergify_pr_state="$freeze_state"  -R $OWNER/ockam
+
+    # Sleep for 10 seconds to ensure we are not affected by Github API downtime.
+    sleep 10
+    # Wait for workflow run
+    run_id=$(gh run list --workflow=code-freeze.yml -b develop -u "$GITHUB_USERNAME" -L 1 -R $OWNER/ockam --json databaseId | jq -r .[0].databaseId)
+
+    approve_deployment "ockam" "$run_id" &
+    gh run watch "$run_id" --exit-status -R $OWNER/ockam
+}
+
+function create_pr() {
+    pr_title="$1"
+    body="$2"
+    # Merge PR to a new branch to kickstart workflow
+    pr_url=$(gh pr create --title "$pr_title" --body "$body" \
+        --base develop -H "${code_freeze_branch_name}" -r mrinalwadhwa -R $OWNER/ockam)
+    
+    check_pr_till_merge $pr_url
+}
+
+# If it's a draft release, then we create a PR that perform code freeze
+if [[ $IS_DRAFT_RELEASE == true ]]; then
+    echo "Kickstarting code freeze workflow"
+    start_code_freeze_workflow "freeze"
+    echo "Creating PR"
+    create_pr "Ockam code freeze $(date +'%d-%m-%Y')" --body "This PR freezes Rust code PR merge."
+elif [[ $IS_DRAFT_RELEASE == false ]]; then
+    echo "Kickstarting code unfreeze workflow"
+    start_code_freeze_workflow "unfreeze"
+    echo "Creating PR"
+    create_pr "Ockam code unfreeze $(date +'%d-%m-%Y')" --body "This PR unfreezes Rust code PR merge."
+fi

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -42,7 +42,6 @@ if [[ -z $IS_DRAFT_RELEASE ]]; then
   exit 1
 fi
 
-
 function ockam_bump() {
   set -e
   gh workflow run create-release-pull-request.yml --ref develop -F branch_name="$release_name" -F git_tag="$GIT_TAG" -F ockam_bump_modified_release="$OCKAM_BUMP_MODIFIED_RELEASE" \

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -58,7 +58,7 @@ function ockam_bump() {
   gh run watch "$run_id" --exit-status -R $OWNER/ockam
 
   # Merge PR to a new branch to kickstart workflow
-  gh pr create --title "Ockam Release $(date +'%d-%m-%Y')" --body "Ockam release" \
+  gh pr create --title "Ockam Release $(date +'%d-%m-%Y')" --body "Ockam release" --label "release" \
     --base develop -H "${release_name}" -r mrinalwadhwa -R $OWNER/ockam
 }
 


### PR DESCRIPTION
This PR adds code-freeze automation during GitHub release. It ensures that we block merge of Rust code (basically block merge pull requests that updates `implementations/rust` directory) till a production release is made. Updated release entails

On release script startup
- We create a PR that enables code freeze. Script waits on PR to be merged by an administrator. After merge of PR, Rust code-freeze starts, and Elixir and CI PRs are mergeable.
- Draft release is created (release candidate)
- Draft release is tested. (during this period, there will be a code-freeze)
- Production release, crate publish, homebrew release, etc is made
- Script creates a PR that disables code-freeze, so that rust code becomes mergeable again

## How code freeze works
Our current merge workflow ensures that sets of workflows pass before merge queue merges PRs, this PR adds a new workflow that fails status check if there is a code-freeze and a PR has Rust change which will then block merging.
Note: It's required to add `Code Freeze CI` to list of required workflows for merge queue in branch protection rule.

## How to bypass code-freeze
During release, we bump all updated crates versions, and generate changelogs this updates are made in the `implementation/rust` path, which is the path that's un-mergeable during code-freeze. To bypass this blockage during code-freeze, PR for crate release `MUST` 
- Have a `label named release`  (included with the `auto-merge` label)
- Be created by a member of the `build-trust developers team` @build-trust/developers
