### PR TITLE
chore(rust): continue on process not found when killing a node

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -32,7 +32,13 @@ impl Debug for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", Version::short())?;
-        writeln!(f, "{{code: {}, err: {}}}", self.code, self.inner)
+        writeln!(
+            f,
+            "{{code: {}, err: {}, cause: {}}}",
+            self.code,
+            self.inner,
+            self.inner.root_cause()
+        )
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -11,11 +11,11 @@ pub struct DeleteCommand {
     #[arg(default_value_t = default_node_name(), group = "nodes")]
     node_name: String,
 
-    /// Terminate all nodes
+    /// Terminate all node processes and delete all node configurations
     #[arg(long, short, group = "nodes")]
     all: bool,
 
-    /// Clean up config directories and all nodes state directories
+    /// Terminate node process(es) immediately (uses SIGKILL instead of SIGTERM)
     #[arg(display_order = 901, long, short)]
     force: bool,
 }


### PR DESCRIPTION
## Current Behavior
During some actions e.g. `node delete --all` the ockam command fails in certain scenarios with an `IO Error`.

## Proposed Changes
Only warn on `No such process` (Posix ESRCH) during `NodeState::kill_process()` calls.
Print the root cause in the `Display` implementation of `ockam_command::error:Error`.

Fixes https://github.com/build-trust/ockam/issues/4136, but was also reproducible when e.g. killing a node using `kill` which leaves a stale `pid` file in the `nodes` config directory.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
