### PR TITLE
chore(rust): fix for `node create /node/n1` bug

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -148,7 +148,7 @@ impl CreateCommand {
     fn parse_node_name(&self) -> crate::Result<Self> {
         let cmd = self.clone();
 
-        if self.node_name.starts_with('/') {
+        if self.node_name.contains('/') {
             if self.node_name.starts_with("/node/") {
                 let node_name = extract_address_value(&self.node_name)?;
                 return Ok(Self { node_name, ..cmd });

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -21,7 +21,7 @@ use crate::{
     help, node::show::print_query_status, node::HELP_DETAIL, project, util::find_available_port,
     CommandGlobalOpts,
 };
-use crate::{node::util::spawn_node, util::extract_address_value};
+use crate::{node::util::spawn_node, util::parse_node_name};
 use crate::{
     node::util::{add_project_authority_from_project_info, init_node_state},
     util::RpcBuilder,
@@ -144,23 +144,6 @@ impl CreateCommand {
             ..cmd
         })
     }
-
-    fn parse_node_name(&self) -> crate::Result<Self> {
-        let cmd = self.clone();
-
-        if self.node_name.contains('/') {
-            if self.node_name.starts_with("/node/") {
-                let node_name = extract_address_value(&self.node_name)?;
-                return Ok(Self { node_name, ..cmd });
-            } else {
-                return Err(crate::Error::new(
-                    exitcode::IOERR,
-                    anyhow!("Error: A MultiAddr node must follow the format /node/{{name}}"),
-                ));
-            }
-        }
-        Ok(Self { ..cmd })
-    }
 }
 
 fn parse_launch_config(config_or_path: &str) -> anyhow::Result<Config> {
@@ -177,8 +160,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let cmd = cmd.parse_node_name()?;
-    let node_name = &cmd.node_name;
+    let node_name = &parse_node_name(&cmd.node_name)?;
 
     if cmd.child_process {
         return Err(crate::Error::new(
@@ -223,14 +205,15 @@ async fn run_foreground_node(
     (opts, cmd, addr): (CommandGlobalOpts, CreateCommand, SocketAddr),
 ) -> crate::Result<()> {
     let cfg = &opts.config;
+    let node_name = parse_node_name(&cmd.node_name)?;
 
     // This node was initially created as a foreground node
     // and there is no existing state for it yet.
-    if !cmd.child_process && opts.state.nodes.get(&cmd.node_name).is_err() {
+    if !cmd.child_process && opts.state.nodes.get(&node_name).is_err() {
         init_node_state(
             &ctx,
             &opts,
-            &cmd.node_name,
+            &node_name,
             cmd.vault.as_ref(),
             cmd.identity.as_ref(),
         )
@@ -243,7 +226,7 @@ async fn run_foreground_node(
             let p: ProjectInfo = serde_json::from_str(&s)?;
             let project_id = p.id.to_string();
             project::config::set_project(cfg, &(&p).into()).await?;
-            add_project_authority_from_project_info(p, &cmd.node_name, cfg).await?;
+            add_project_authority_from_project_info(p, &node_name, cfg).await?;
             Some(project_id)
         }
         None => None,
@@ -256,7 +239,7 @@ async fn run_foreground_node(
     let bind = cmd.tcp_listener_address;
     tcp.listen(&bind).await?;
 
-    let node_state = opts.state.nodes.get(&cmd.node_name)?;
+    let node_state = opts.state.nodes.get(&node_name)?;
     let setup_config = node_state.setup()?;
     node_state.set_setup(
         &setup_config
@@ -273,7 +256,7 @@ async fn run_foreground_node(
         &ctx,
         NodeManagerGeneralOptions::new(cmd.node_name.clone(), cmd.launch_config.is_some()),
         NodeManagerProjectsOptions::new(
-            Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
+            Some(&cfg.authorities(&node_name)?.snapshot()),
             project_id,
             projects,
             cmd.token,
@@ -296,7 +279,7 @@ async fn run_foreground_node(
 
     if let Some(path) = &cmd.launch_config {
         let node_opts = super::NodeOpts {
-            api_node: cmd.node_name.clone(),
+            api_node: node_name.clone(),
         };
         start_services(&ctx, &tcp, path, addr, node_opts, &opts).await?
     }
@@ -312,13 +295,13 @@ async fn run_foreground_node(
             }
             Ok(_) | Err(_) => {
                 eprintln!("failed to fetch membership credential");
-                delete_node(&opts, &cmd.node_name, true)?;
+                delete_node(&opts, &node_name, true)?;
             }
         }
     }
 
     if cmd.exit_on_eof {
-        stop_node_on_eof(&mut ctx, &opts, &cmd.node_name).await?;
+        stop_node_on_eof(&mut ctx, &opts, &node_name).await?;
     }
 
     Ok(())
@@ -437,11 +420,13 @@ async fn spawn_background_node(
         ));
     }
 
+    let node_name = parse_node_name(&cmd.node_name)?;
+
     // Create node state, including the vault and identity if don't exist
     init_node_state(
         ctx,
         opts,
-        &cmd.node_name,
+        &node_name,
         cmd.vault.as_ref(),
         cmd.identity.as_ref(),
     )
@@ -452,7 +437,7 @@ async fn spawn_background_node(
     spawn_node(
         opts,
         opts.global_args.verbose,
-        &cmd.node_name,
+        &node_name,
         &cmd.tcp_listener_address,
         cmd.project.as_deref(),
         cmd.token.as_ref(),


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Whenever a node is created via `node create <node_name>` and `node_name` is a `MultiAddr` String, an IO error is produced. 

## Proposed Changes

This PR fixes #4137 by adding a `parse_node_name()` function before the node's creation that uses the `extract_address_value` util (when applicable) to circumvent this.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
