### PR TITLE
feat(rust): always enforce-credentials on cli

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -276,13 +276,11 @@ pub struct CreateProject<'a> {
     #[b(1)] pub name: CowStr<'a>,
     #[b(2)] pub services: Vec<CowStr<'a>>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
-    #[b(4)] pub enforce_credentials: Option<bool>,
 }
 
 impl<'a> CreateProject<'a> {
     pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(
         name: S,
-        enforce_credentials: Option<bool>,
         users: &'a [T],
         services: &'a [T],
     ) -> Self {
@@ -290,7 +288,6 @@ impl<'a> CreateProject<'a> {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             name: name.into(),
-            enforce_credentials,
             services: services.iter().map(|x| CowStr::from(x.as_ref())).collect(),
             users: users.iter().map(|x| CowStr::from(x.as_ref())).collect(),
         }
@@ -635,7 +632,6 @@ mod tests {
                 name: String::arbitrary(g).into(),
                 services: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
                 users: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
-                enforce_credentials: None,
             })
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -161,7 +161,6 @@ async fn default_project<'a>(
         rpc.request(api::project::create(
             "default",
             &space.id,
-            None,
             &cloud_opts.route(),
         ))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -120,7 +120,6 @@ pub enum ConfigureAddonCommand {
         #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
         attributes: Vec<String>,
     },
-    #[command(hide = help::hide())]
     InfluxDb {
         /// Ockam Project Name
         #[arg(

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -192,6 +192,7 @@ pub enum ConfigureAddonCommand {
         #[arg(
             long = "user-access-role",
             id = "user-access-role",
+            hide = true,
             value_name = "USER_ACCESS_ROLE",
             value_parser(NonEmptyStringValueParser::new())
         )]
@@ -201,6 +202,7 @@ pub enum ConfigureAddonCommand {
         #[arg(
             long = "adamin-access-role",
             id = "admin-access-role",
+            hide = true,
             value_name = "ADMIN_ACCESS_ROLE",
             value_parser(NonEmptyStringValueParser::new())
         )]

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -14,7 +14,7 @@ use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::ProjectInfo;
 use crate::util::api::{CloudOpts, ProjectOpts};
 use crate::util::{node_rpc, RpcBuilder};
-use crate::{help, CommandGlobalOpts};
+use crate::CommandGlobalOpts;
 
 use crate::project::util::create_secure_channel_to_authority;
 use ockam_api::authenticator::direct::Client;
@@ -23,7 +23,6 @@ use ockam_api::DefaultAddress;
 
 /// Authenticate with a project node
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide())]
 pub struct AuthCommand {
     #[arg(long = "okta", group = "authentication_method")]
     okta: bool,

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -22,10 +22,6 @@ pub struct CreateCommand {
     #[arg(display_order = 1002, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true, value_parser = validate_project_name)]
     pub project_name: String,
 
-    // Enforce credentials for member access to the project node
-    #[arg(long, display_order = 1003)]
-    pub enforce_credentials: Option<bool>,
-
     #[command(flatten)]
     pub cloud_opts: CloudOpts,
 
@@ -60,7 +56,6 @@ async fn run_impl(
     rpc.request(api::project::create(
         &cmd.project_name,
         &space_id,
-        cmd.enforce_credentials,
         &cmd.cloud_opts.route(),
     ))
     .await?;

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -15,11 +15,11 @@ use crate::node::NodeOpts;
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{CloudOpts, ProjectOpts};
 use crate::util::{node_rpc, RpcBuilder};
-use crate::{help, CommandGlobalOpts, Result};
+use crate::{CommandGlobalOpts, Result};
 
 /// An authorised enroller can add members to a project.
 #[derive(Clone, Debug, Args)]
-#[command(hide = help::hide(), arg_required_else_help = true)]
+#[command(arg_required_else_help = true)]
 pub struct EnrollCommand {
     /// Orchestrator address to resolve projects present in the `at` argument
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -255,10 +255,9 @@ pub(crate) mod project {
     pub(crate) fn create<'a>(
         project_name: &'a str,
         space_id: &'a str,
-        enforce_credentials: Option<bool>,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(project_name, enforce_credentials, &[], &[]);
+        let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
         Request::post(format!("v0/projects/{}", space_id)).body(CloudRequestWrapper::new(
             b,
             cloud_route,

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -435,7 +435,7 @@ teardown() {
   run $OCKAM space create "${space_name}"
   assert_success
 
-  run $OCKAM project create "${space_name}" "${project_name}" --enforce-credentials false
+  run $OCKAM project create "${space_name}" "${project_name}"
   assert_success
 
   run --separate-stderr $OCKAM message send hello --to "/project/${project_name}/service/echo"
@@ -687,7 +687,7 @@ teardown() {
   run $OCKAM space create "${space_name}"
   assert_success
 
-  run $OCKAM project create "${space_name}" "${project_name}" --enforce-credentials true
+  run $OCKAM project create "${space_name}" "${project_name}"
   assert_success
 
   $OCKAM project information "${project_name}" --output json  > "/tmp/${project_name}_project.json"


### PR DESCRIPTION
- Unhide the following commands:
    - ockam project enroll
    - ockam project authenticate 
    - ockam project addon configure influx-db

- Remove the `enforce_credentials` argument on the `ockam project create`.