### PR TITLE
[shell-global-defaults]

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,10 @@ name: Documentation
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,10 +59,11 @@ jobs:
       - name: Check that example source and guide code blocks match
         id: cache
         run: |
+          set -ex
           OCKAM_HOME=$PWD bash -ex tools/docs/check_documentation.sh
 
           # Only cache rust build if example blocks code was built
-          if [[ ls target ]]; then
+          if ls target; then
             echo "is_cached=true" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Removed runs-on from job and created defaults block for ubuntu-20.04

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Shell is set within each job of the documentation.yml
- At present there is one job but in the future there may be more

## Proposed Changes

Change to abstract the shell each job runs on into a global defaults block
- allows less repetition of code when future jobs are created which use the same shell to run on

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
