### PR TITLE
fix(rust): named identities allowed on lease command, add test cases

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::service::message::SendMessage;
 use ockam_core::api::{Request, RequestBuilder};
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::{CloudOpts, ProjectOpts};
 use crate::util::{extract_address_value, node_rpc, RpcBuilder};
 use crate::Result;
@@ -57,7 +57,14 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             let tcp = TcpTransport::create(ctx).await?;
             (api_node, Some(tcp))
         } else {
-            let api_node = start_embedded_node(ctx, opts, Some(&cmd.project_opts)).await?;
+            let api_node = start_embedded_node_with_vault_and_identity(
+                ctx,
+                opts,
+                None,
+                cmd.cloud_opts.identity.as_ref(),
+                Some(&cmd.project_opts),
+            )
+            .await?;
             (api_node, None)
         };
 


### PR DESCRIPTION
named identites are now supported on `message send` and `lease *` commands. A proper credential is requested and used in these cases.  New test cases added.

Left some FIXME and TODO for things that are workarounds,   or that need to be fixed.