### PR TITLE
chore(rust): attribute `tcp-connection list` no longer required

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -9,7 +9,6 @@ use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_core::api::Request;
 
 #[derive(Args, Clone, Debug)]
-#[command(arg_required_else_help = true)]
 pub struct ListCommand {
     #[command(flatten)]
     node_opts: NodeOpts,


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

The `--node` attribute is currently required for the `tcp-connection list` command, even though it has a default value.

## Proposed Changes

This is a quick hotfix to remove the attribute that requires it. Fixes #4178.
 
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
