### PR TITLE
feat(rust): add command to set the default identity

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/default.rs
@@ -1,0 +1,43 @@
+use crate::CommandGlobalOpts;
+use anyhow::anyhow;
+use clap::Args;
+use ockam_api::cli_state::CliStateError;
+
+/// Set the default identity
+#[derive(Clone, Debug, Args)]
+pub struct DefaultCommand {
+    /// Name of the identity to be set as default
+    name: String,
+}
+
+impl DefaultCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        if let Err(e) = run_impl(options, self) {
+            eprintln!("{e:?}");
+            std::process::exit(e.code());
+        }
+    }
+}
+
+fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
+    let state = opts.state.identities;
+    // Check if exists
+    match state.get(&cmd.name) {
+        Ok(idt) => {
+            // If it exists, warn the user and exit
+            if state.is_default(&idt.name)? {
+                Err(anyhow!("Identity '{}' is already the default", &cmd.name).into())
+            }
+            // Otherwise, set it as default
+            else {
+                state.set_default(&idt.name)?;
+                println!("Identity '{}' is now the default", &cmd.name,);
+                Ok(())
+            }
+        }
+        Err(err) => match err {
+            CliStateError::NotFound(_) => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
+            _ => Err(err.into()),
+        },
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -5,8 +5,10 @@ use clap::Args;
 use ockam::Context;
 use ockam_api::cli_state::CliStateError;
 
+/// Delete an identity
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
+    /// Name of the identity to be deleted
     name: String,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod default;
 mod delete;
 mod list;
 mod show;
@@ -8,6 +9,7 @@ pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 pub(crate) use show::ShowCommand;
 
+use crate::identity::default::DefaultCommand;
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 
@@ -26,6 +28,9 @@ pub enum IdentitySubcommand {
     Show(ShowCommand),
     /// Print all existing identities, `--full` for long identities
     List(ListCommand),
+    /// Set the default identity
+    Default(DefaultCommand),
+    /// Delete an identity
     Delete(DeleteCommand),
 }
 
@@ -36,6 +41,7 @@ impl IdentityCommand {
             IdentitySubcommand::Show(c) => c.run(options),
             IdentitySubcommand::List(c) => c.run(options),
             IdentitySubcommand::Delete(c) => c.run(options),
+            IdentitySubcommand::Default(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
Adds command to manually set the default identity:

`ockam identity default {name}`