### PR TITLE
refactor(rust): recipient returns an error instead of panicking

### DIFF
--- a/implementations/rust/ockam/ockam/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam/src/channel/listener.rs
@@ -59,7 +59,7 @@ impl Worker for ChannelListener {
             rx_int_addr,
             tx_int_addr,
         } = msg.as_body();
-        let peer_channel_addr = msg.return_route().recipient();
+        let peer_channel_addr = msg.return_route().recipient()?;
 
         let peer_rx_base: Route = msg.return_route().modify().pop_back().into();
         let peer_rx_pub = peer_rx_base.clone().modify().append(rx_addr.clone()).into();

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -299,7 +299,7 @@ impl Worker for RemoteForwarder {
 
         // FIXME: @ac check that return address is the same
         // We are the final recipient of the message because it's registration response for our Worker
-        if msg.onward_route().recipient() == self.main_address {
+        if msg.onward_route().recipient()? == self.main_address {
             debug!("RemoteForwarder received service message");
 
             let payload =
@@ -313,7 +313,7 @@ impl Worker for RemoteForwarder {
                 let route = msg.return_route();
 
                 info!("RemoteForwarder registered with route: {}", route);
-                let address = match route.clone().recipient().to_string().strip_prefix("0#") {
+                let address = match route.clone().recipient()?.to_string().strip_prefix("0#") {
                     Some(addr) => addr.to_string(),
                     None => return Err(OckamError::InvalidHubResponse.into()),
                 };

--- a/implementations/rust/ockam/ockam_api/src/echoer.rs
+++ b/implementations/rust/ockam/ockam_api/src/echoer.rs
@@ -10,7 +10,7 @@ impl Worker for Echoer {
     type Message = Any;
 
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<Any>) -> Result<()> {
-        log::debug!(to = %msg.sender(), "echoing back");
+        log::debug!(to = %msg.sender()?, "echoing back");
         ctx.send(msg.return_route(), NeutralMessage::from(msg.take_payload()))
             .await
     }

--- a/implementations/rust/ockam/ockam_core/src/message.rs
+++ b/implementations/rust/ockam/ockam_core/src/message.rs
@@ -217,7 +217,7 @@ impl<M: Message> Routed<M> {
     }
     /// Return a copy of the sender address for the wrapped message.
     #[inline]
-    pub fn sender(&self) -> Address {
+    pub fn sender(&self) -> Result<Address> {
         self.local_msg.transport().return_route.recipient()
     }
 

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -172,7 +172,7 @@ impl Route {
     /// let route: Route = route!["1#alice", "bob"];
     ///
     /// // "0#bob"
-    /// let final_hop: Address = route.recipient();
+    /// let final_hop: Address = route.recipient()?;
     ///
     /// // ["1#alice", "0#bob"]
     /// route
@@ -183,11 +183,11 @@ impl Route {
     ///
     /// `TODO` For consistency we should not panic and return a
     /// Result<&Address> instead of an Address.clone().
-    pub fn recipient(&self) -> Address {
+    pub fn recipient(&self) -> Result<Address> {
         self.inner
             .back()
             .cloned()
-            .expect("Route::recipient failed on invalid Route!")
+            .ok_or_else(|| RouteError::IncompleteRoute.into())
     }
 
     /// Iterate over all addresses of this route.
@@ -429,7 +429,7 @@ mod tests {
         let mut route = route![address, "b"];
         assert_eq!(route.next().unwrap(), &Address::from_string("0#a"));
         assert_eq!(route.next().unwrap(), &Address::from_string("0#a"));
-        assert_eq!(route.recipient(), Address::from_string("0#b"));
+        assert_eq!(route.recipient().unwrap(), Address::from_string("0#b"));
         assert_eq!(route.step().unwrap(), Address::from_string("0#a"));
         assert_eq!(route.step().unwrap(), Address::from_string("0#b"));
     }
@@ -438,7 +438,7 @@ mod tests {
     fn test_route_create() {
         let addresses = vec!["node-1", "node-2"];
         let route = Route::create(addresses);
-        assert_eq!(route.recipient(), Address::from_string("0#node-2"));
+        assert_eq!(route.recipient().unwrap(), Address::from_string("0#node-2"));
     }
 
     #[test]
@@ -451,7 +451,7 @@ mod tests {
         let s = " node-1 =>node-2=> node-3 ";
         let mut route = Route::parse(s).unwrap();
         assert_eq!(route.next().unwrap(), &Address::from_string("0#node-1"));
-        assert_eq!(route.recipient(), Address::from_string("0#node-3"));
+        assert_eq!(route.recipient().unwrap(), Address::from_string("0#node-3"));
         let _ = route.step();
         assert_eq!(route.next().unwrap(), &Address::from_string("0#node-2"));
     }
@@ -466,12 +466,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Route::recipient failed on invalid Route!")]
-    fn test_route_no_recipient() {
+    fn test_route_no_recipient() -> Result<(), ()> {
         let mut route = Route::parse("node-1=>node-2").unwrap();
         let _ = route.step();
         let _ = route.step();
-        route.recipient();
+        match route.recipient() {
+            Ok(_) => Err(()),
+            Err(_) => Ok(()),
+        }
     }
 
     #[test]

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
@@ -358,7 +358,7 @@ impl<V: IdentityVault, K: SecureChannelKeyExchanger, S: AuthenticatedStorage>
                 return Err(IdentityError::UnknownChannelMsgDestination.into());
             }
             if self.remote_backwards_compatibility_address.is_none() {
-                self.remote_backwards_compatibility_address = Some(body.return_route.recipient());
+                self.remote_backwards_compatibility_address = Some(body.return_route.recipient()?);
             }
             let body = IdentityChannelMessage::decode(&body.payload)?;
 


### PR DESCRIPTION
This PR takes care of a TODO calling for Route::recipient to return a Result

Instead of lying by returning Address but being a partial function that panics under certain situations.

Clippy also complained about a bunch of redundant cloning, so those are addressed here as well, mainly in local.rs and onward.rs.

This is the third attempt at correctly creating the PR.  The second can be found here: https://github.com/build-trust/ockam/pull/4156