### PR TITLE
fix(rust): deleting an identity won't affect the default

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,5 +1,9 @@
+use crate::util::node_rpc;
 use crate::CommandGlobalOpts;
+use anyhow::anyhow;
 use clap::Args;
+use ockam::Context;
+use ockam_api::cli_state::CliStateError;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -8,15 +12,27 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(options, self) {
-            eprintln!("{e:?}");
-            std::process::exit(e.code());
-        }
+        node_rpc(run_impl, (options, self))
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
-    opts.state.identities.delete(&cmd.name)?;
-    println!("Identity '{}' deleted", cmd.name);
-    Ok(())
+async fn run_impl(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    let state = opts.state.identities;
+    // Check if exists
+    match state.get(&cmd.name) {
+        // If it exists, proceed
+        Ok(_) => {
+            state.delete(&cmd.name).await?;
+            println!("Identity '{}' deleted", cmd.name);
+            Ok(())
+        }
+        // Return the appropriate error
+        Err(err) => match err {
+            CliStateError::NotFound(_) => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
+            _ => Err(err.into()),
+        },
+    }
 }


### PR DESCRIPTION
Previously, if the deleted identity was the default, the next available identity would be set as the new default. This has been removed.

Also, the command output has been modified so it returns a better message when trying to remove an identity that doesn't exist.