### PR TITLE
fix(rust): retrieve node's identity from state and not through nodemanager

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -5,7 +5,6 @@ use clap::Args;
 use colorful::Colorful;
 use core::time::Duration;
 use ockam::TcpTransport;
-use ockam_api::nodes::models::identity::ShortIdentityResponse;
 use ockam_api::nodes::models::portal::{InletList, OutletList};
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::nodes::models::transport::TransportList;
@@ -146,15 +145,14 @@ pub async fn print_query_status(
     wait_until_ready: bool,
 ) -> anyhow::Result<()> {
     let cli_state = cli_state::CliState::new()?;
+    let node_state = cli_state.nodes.get(node_name)?;
     if !is_node_up(rpc, wait_until_ready).await? {
-        let node_state = cli_state.nodes.get(node_name)?;
         let node_port = node_state.setup()?.default_tcp_listener()?.addr.port();
         print_node_info(node_port, node_name, false, None, None, None, None, None);
     } else {
         // Get short id for the node
-        rpc.request(api::short_identity()).await?;
-        let default_id = match rpc.parse_response::<ShortIdentityResponse>() {
-            Ok(resp) => String::from(resp.identity_id),
+        let default_id = match node_state.config.identity_config() {
+            Ok(resp) => resp.identifier.to_string(),
             Err(_) => String::from("None"),
         };
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -51,11 +51,6 @@ pub(crate) fn create_tcp_connection(
     Request::post("/node/tcp/connection").body(payload)
 }
 
-/// Construct a request to print Identity Id
-pub(crate) fn short_identity() -> RequestBuilder<'static, ()> {
-    Request::post("/node/identity/actions/show/short")
-}
-
 /// Construct a request to print a list of services for the given node
 pub(crate) fn list_services() -> RequestBuilder<'static, ()> {
     Request::get("/node/services")


### PR DESCRIPTION
The function we use to print a node's status was querying the NodeManager to retrieve its identity. That endpoint was removed and instead must be read from its state.