### PR TITLE
fix(rust): apply `clippy --fix` after upgrading to 1.67.0

### DIFF
--- a/implementations/rust/ockam/ockam/src/pipe2/sender.rs
+++ b/implementations/rust/ockam/ockam/src/pipe2/sender.rs
@@ -46,7 +46,7 @@ impl Worker for PipeSender {
         );
 
         match (msg.msg_addr(), self.peer.as_ref()) {
-            (ref addr, Some(&PeerRoute::Listener(_, ref _self))) if addr == _self => {
+            (ref addr, Some(PeerRoute::Listener(_, _self))) if addr == _self => {
                 let return_route = msg.return_route();
                 self.peer = Some(PeerRoute::Peer(return_route.clone()));
 

--- a/implementations/rust/ockam/ockam_abac/src/expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/expr.rs
@@ -261,7 +261,7 @@ impl fmt::Display for Expr {
                             f.write_str("+inf")?
                         }
                     } else {
-                        write!(f, "{:?}", x)?
+                        write!(f, "{x:?}")?
                     }
                 }
                 Op::Show(Expr::Bool(b)) => write!(f, "{b}")?,

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -120,7 +120,7 @@ impl VaultsState {
     pub async fn create(&self, name: &str, config: VaultConfig) -> Result<VaultState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if path.exists() {
                 return Err(CliStateError::AlreadyExists(format!("vault `{name}`")));
             }
@@ -138,7 +138,7 @@ impl VaultsState {
     pub fn get(&self, name: &str) -> Result<VaultState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("vault `{name}`")));
             }
@@ -201,7 +201,7 @@ impl VaultsState {
     pub fn set_default(&self, name: &str) -> Result<VaultState> {
         let original = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("vault `{name}`")));
             }
@@ -311,7 +311,7 @@ impl IdentitiesState {
     pub fn create(&self, name: &str, config: IdentityConfig) -> Result<IdentityState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if path.exists() {
                 return Err(CliStateError::AlreadyExists(format!("identity `{name}`")));
             }
@@ -332,7 +332,7 @@ impl IdentitiesState {
     pub fn get(&self, name: &str) -> Result<IdentityState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("identity `{name}`")));
             }
@@ -402,7 +402,7 @@ impl IdentitiesState {
     pub fn set_default(&self, name: &str) -> Result<IdentityState> {
         let original = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("identity `{name}`")));
             }
@@ -956,7 +956,7 @@ impl ProjectsState {
     pub async fn create(&self, name: &str, config: Project<'_>) -> Result<ProjectState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if path.exists() {
                 return Err(CliStateError::AlreadyExists(format!("project `{name}`")));
             }
@@ -974,7 +974,7 @@ impl ProjectsState {
     pub fn get(&self, name: &str) -> Result<ProjectState> {
         let path = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("project `{name}`")));
             }
@@ -995,7 +995,7 @@ impl ProjectsState {
     pub fn set_default(&self, name: &str) -> Result<ProjectState> {
         let original = {
             let mut path = self.dir.clone();
-            path.push(format!("{}.json", name));
+            path.push(format!("{name}.json"));
             if !path.exists() {
                 return Err(CliStateError::NotFound(format!("project `{name}`")));
             }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -52,7 +52,7 @@ impl<'a, T> CloudRequestWrapper<'a, T> {
         let maddr = MultiAddr::from_str(self.route.as_ref())
             .map_err(|_err| ApiError::generic(&format!("Invalid route: {}", self.route)))?;
         crate::multiaddr_to_route(&maddr)
-            .ok_or_else(|| ApiError::generic(&format!("Invalid MultiAddr: {}", maddr)))
+            .ok_or_else(|| ApiError::generic(&format!("Invalid MultiAddr: {maddr}")))
     }
 }
 
@@ -106,10 +106,7 @@ mod node {
             match StaticFiles::get("controller.id") {
                 Some(EmbeddedFile { data, .. }) => {
                     let s = core::str::from_utf8(data.as_ref()).map_err(|err| {
-                        ApiError::generic(&format!(
-                            "Failed to parse controller identity id: {}",
-                            err
-                        ))
+                        ApiError::generic(&format!("Failed to parse controller identity id: {err}"))
                     })?;
                     trace!(idt = %s, "Read controller identity id from file");
                     IdentityIdentifier::from_str(s)

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -115,7 +115,7 @@ mod node {
             let label = "unsubscribe";
             trace!(target: TARGET, subscription = %id, "unsubscribing");
 
-            let req_builder = Request::put(format!("/v0/{}/unsubscribe", id));
+            let req_builder = Request::put(format!("/v0/{id}/unsubscribe"));
 
             let ident = {
                 let inner = self.get().read().await;
@@ -147,7 +147,7 @@ mod node {
             let label = "list_sbuscriptions";
             trace!(target: TARGET, subscription = %id, "updating subscription space");
 
-            let req_builder = Request::put(format!("/v0/{}/space_id", id)).body(req_body);
+            let req_builder = Request::put(format!("/v0/{id}/space_id")).body(req_body);
 
             let ident = {
                 let inner = self.get().read().await;
@@ -178,7 +178,7 @@ mod node {
             let label = "update_subscription_contact_info";
             trace!(target: TARGET, subscription = %id, "updating subscription contact info");
 
-            let req_builder = Request::put(format!("/v0/{}/contact_info", id)).body(req_body);
+            let req_builder = Request::put(format!("/v0/{id}/contact_info")).body(req_body);
 
             let ident = {
                 let inner = self.get().read().await;
@@ -237,7 +237,7 @@ mod node {
             let label = "get_subscription";
             trace!(target: TARGET, subscription = %id, "getting subscription");
 
-            let req_builder = Request::get(format!("/v0/{}", id));
+            let req_builder = Request::get(format!("/v0/{id}"));
 
             let ident = {
                 let inner = self.get().read().await;

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -45,14 +45,14 @@ impl ConfigLookup {
 
     pub fn set_space(&mut self, id: &str, name: &str) {
         self.map.insert(
-            format!("/space/{}", name),
+            format!("/space/{name}"),
             LookupValue::Space(SpaceLookup { id: id.to_string() }),
         );
     }
 
     pub fn get_space(&self, name: &str) -> Option<&SpaceLookup> {
         self.map
-            .get(&format!("/space/{}", name))
+            .get(&format!("/space/{name}"))
             .and_then(|value| match value {
                 LookupValue::Space(space) => Some(space),
                 _ => None,
@@ -60,7 +60,7 @@ impl ConfigLookup {
     }
 
     pub fn remove_space(&mut self, name: &str) -> Option<LookupValue> {
-        self.map.remove(&format!("/space/{}", name))
+        self.map.remove(&format!("/space/{name}"))
     }
 
     pub fn remove_spaces(&mut self) {
@@ -70,12 +70,12 @@ impl ConfigLookup {
     /// Store a project route and identifier as lookup
     pub fn set_project(&mut self, name: String, proj: ProjectLookup) {
         self.map
-            .insert(format!("/project/{}", name), LookupValue::Project(proj));
+            .insert(format!("/project/{name}"), LookupValue::Project(proj));
     }
 
     pub fn get_project(&self, name: &str) -> Option<&ProjectLookup> {
         self.map
-            .get(&format!("/project/{}", name))
+            .get(&format!("/project/{name}"))
             .and_then(|value| match value {
                 LookupValue::Project(project) => Some(project),
                 _ => None,
@@ -83,7 +83,7 @@ impl ConfigLookup {
     }
 
     pub fn remove_project(&mut self, name: &str) -> Option<LookupValue> {
-        self.map.remove(&format!("/project/{}", name))
+        self.map.remove(&format!("/project/{name}"))
     }
 
     pub fn remove_projects(&mut self) {
@@ -137,9 +137,9 @@ impl fmt::Display for InternetAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(
             match self {
-                Self::Dns(addr, port) => format!("{}:{}", addr, port),
-                Self::V4(v4) => format!("{}", v4),
-                Self::V6(v6) => format!("{}", v6),
+                Self::Dns(addr, port) => format!("{addr}:{port}"),
+                Self::V4(v4) => format!("{v4}"),
+                Self::V6(v6) => format!("{v6}"),
             }
             .as_str(),
         )

--- a/implementations/rust/ockam/ockam_api/src/config/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/mod.rs
@@ -114,5 +114,5 @@ pub fn build_config_path(config_dir: &Path, config_name: &str) -> PathBuf {
 }
 
 fn build_config_file_name(config_name: &str) -> String {
-    format!("{}.json", config_name)
+    format!("{config_name}.json")
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -678,7 +678,7 @@ impl NodeManagerWorker {
             _ => {
                 warn!(%method, %path, "Called invalid endpoint");
                 Response::bad_request(req.id())
-                    .body(format!("Invalid endpoint: {}", path))
+                    .body(format!("Invalid endpoint: {path}"))
                     .to_vec()?
             }
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -35,7 +35,7 @@ impl<'a> SendMessage<'a> {
         let maddr = MultiAddr::from_str(self.route.as_ref())
             .map_err(|_err| ApiError::generic(&format!("Invalid route: {}", self.route)))?;
         crate::multiaddr_to_route(&maddr)
-            .ok_or_else(|| ApiError::generic(&format!("Invalid MultiAddr: {}", maddr)))
+            .ok_or_else(|| ApiError::generic(&format!("Invalid MultiAddr: {maddr}")))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -112,7 +112,7 @@ where
             .map_err(|err| ApiError::generic(&err.to_string()))?;
         let res = client
             .get(format!("{}/v1/userinfo", &self.tenant_base_url))
-            .header("Authorization", format!("Bearer {}", token))
+            .header("Authorization", format!("Bearer {token}"))
             .send()
             .await;
         if let Ok(res) = res {

--- a/implementations/rust/ockam/ockam_api/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier.rs
@@ -107,7 +107,7 @@ where
             Ok(data) => data,
             Err(err) => {
                 let err = Error::new("/verify")
-                    .with_message(format!("error verifying a credential: {}", err));
+                    .with_message(format!("error verifying a credential: {err}"));
                 return Ok(Either::Left(Response::forbidden(id).body(err)));
             }
         };

--- a/implementations/rust/ockam/ockam_api/tests/vault.rs
+++ b/implementations/rust/ockam/ockam_api/tests/vault.rs
@@ -47,7 +47,7 @@ async fn full_flow(ctx: &mut Context) -> Result<()> {
     let key_id = res.key_id().to_string();
 
     // Get public key
-    let req = Request::get(format!("secrets/{}/public_key", key_id)).body(key_id.clone());
+    let req = Request::get(format!("secrets/{key_id}/public_key")).body(key_id.clone());
 
     let mut sending_buf = Vec::new();
     req.encode(&mut sending_buf)?;

--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -6,7 +6,7 @@ fn hash() {
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }
 
 fn main() {

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -181,7 +181,7 @@ async fn run_impl(
                 space_id,
             )
             .await?;
-            let req = Request::put(format!("subscription/{}/unsubscribe", subscription_id))
+            let req = Request::put(format!("subscription/{subscription_id}/unsubscribe"))
                 .body(CloudRequestWrapper::bare(controller_route));
             rpc.request(req).await?;
             rpc.parse_and_print_response::<Subscription>()?;
@@ -206,12 +206,9 @@ async fn run_impl(
                     )
                     .await?;
                     let req =
-                        Request::put(format!("subscription/{}/contact_info", subscription_id))
-                            .body(CloudRequestWrapper::new(
-                                json,
-                                controller_route,
-                                None::<CowStr>,
-                            ));
+                        Request::put(format!("subscription/{subscription_id}/contact_info")).body(
+                            CloudRequestWrapper::new(json, controller_route, None::<CowStr>),
+                        );
                     rpc.request(req).await?;
                     rpc.parse_and_print_response::<Subscription>()?;
                 }
@@ -229,7 +226,7 @@ async fn run_impl(
                         space_id,
                     )
                     .await?;
-                    let req = Request::put(format!("subscription/{}/space_id", subscription_id))
+                    let req = Request::put(format!("subscription/{subscription_id}/space_id"))
                         .body(CloudRequestWrapper::new(
                             new_space_id,
                             controller_route,

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -49,7 +49,7 @@ pub enum AuthenticatedSubcommand {
 impl AuthenticatedCommand {
     pub fn run(self) {
         if let Err(e) = embedded_node(run_impl, self.subcommand) {
-            eprintln!("Ockam node failed: {:?}", e,);
+            eprintln!("Ockam node failed: {e:?}",);
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -10,7 +10,7 @@ pub struct GetCommand {
 impl GetCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         if let Err(e) = run_impl(options, self) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
@@ -8,7 +8,7 @@ pub struct GetDefaultNodeCommand {}
 impl GetDefaultNodeCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         if let Err(e) = run_impl(options) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/configuration/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/list.rs
@@ -15,7 +15,7 @@ impl ListCommand {
             // in the future
             #[allow(irrefutable_let_patterns)]
             if let LookupValue::Address(addr) = value {
-                println!("Node:    {}\nAddress: {}\n", alias, addr);
+                println!("Node:    {alias}\nAddress: {addr}\n");
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
@@ -10,7 +10,7 @@ pub struct SetDefaultNodeCommand {
 impl SetDefaultNodeCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         if let Err(e) = run_impl(&self.name, &options) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -47,7 +47,7 @@ impl Output for LongIdentityResponse<'_> {
     fn output(&self) -> anyhow::Result<String> {
         let mut w = String::new();
         let id: IdentityChangeHistory = serde_bare::from_slice(self.identity.0.as_ref())?;
-        write!(w, "{}", id)?;
+        write!(w, "{id}")?;
         Ok(w)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/manpages.rs
+++ b/implementations/rust/ockam/ockam_command/src/manpages.rs
@@ -42,7 +42,7 @@ impl ManpagesCommand {
     pub fn run(self) {
         let man_dir = match get_man_page_directory(&self.dir) {
             Ok(path) => path,
-            Err(error) => panic!("Error getting man page directory: {:?}", error),
+            Err(error) => panic!("Error getting man page directory: {error:?}"),
         };
         let clap_command = <OckamCommand as CommandFactory>::command();
         generate_man_pages(man_dir.as_path(), &clap_command, None, self.no_compression);
@@ -136,7 +136,7 @@ fn generate_man_page(
 fn remove_ascii_controls(input: Vec<u8>) -> Vec<u8> {
     let input_as_str = match str::from_utf8(&input) {
         Ok(input) => input,
-        Err(e) => panic!("Input contains non UTF-8 sequence: {}", e),
+        Err(e) => panic!("Input contains non UTF-8 sequence: {e}"),
     };
 
     let mut result: Vec<u8> = Default::default();

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -23,7 +23,7 @@ pub struct DeleteCommand {
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         if let Err(e) = run_impl(opts, self) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -62,7 +62,7 @@ fn print_node_info(
 ) {
     println!();
     println!("Node:");
-    println!("  Name: {}", node_name);
+    println!("  Name: {node_name}");
     println!(
         "  Status: {}",
         match status_is_up {
@@ -74,16 +74,16 @@ fn print_node_info(
     println!("  Route To Node:");
     let mut m = MultiAddr::default();
     if m.push_back(Node::new(node_name)).is_ok() {
-        println!("    Short: {}", m);
+        println!("    Short: {m}");
     }
 
     let mut m = MultiAddr::default();
     if m.push_back(DnsAddr::new("localhost")).is_ok() && m.push_back(Tcp::new(node_port)).is_ok() {
-        println!("    Verbose: {}", m);
+        println!("    Verbose: {m}");
     }
 
     if let Some(id) = default_id {
-        println!("  Identity: {}", id);
+        println!("  Identity: {id}");
     }
 
     if let Some(list) = tcp_listeners {
@@ -101,7 +101,7 @@ fn print_node_info(
         for e in list {
             println!("    Listener:");
             if let Some(ma) = addr_to_multiaddr(e) {
-                println!("      Address: {}", ma);
+                println!("      Address: {ma}");
             }
         }
     }
@@ -113,7 +113,7 @@ fn print_node_info(
             println!("      Listen Address: {}", e.bind_addr);
             if let Some(r) = Route::parse(e.outlet_route.as_ref()) {
                 if let Some(ma) = route_to_multiaddr(&r) {
-                    println!("      Route To Outlet: {}", ma);
+                    println!("      Route To Outlet: {ma}");
                 }
             }
         }
@@ -123,7 +123,7 @@ fn print_node_info(
             println!("      Forward Address: {}", e.tcp_addr);
 
             if let Some(ma) = addr_to_multiaddr(e.worker_addr.as_ref()) {
-                println!("      Address: {}", ma);
+                println!("      Address: {ma}");
             }
         }
     }
@@ -134,7 +134,7 @@ fn print_node_info(
             println!("    Service:");
             println!("      Type: {}", e.service_type);
             if let Some(ma) = addr_to_multiaddr(e.addr.as_ref()) {
-                println!("      Address: {}", ma);
+                println!("      Address: {ma}");
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -19,7 +19,7 @@ pub struct StopCommand {
 impl StopCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         if let Err(e) = run_impl(opts, self) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/project/addon.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon.rs
@@ -267,8 +267,7 @@ async fn run_impl(
         let project_id = &lookup
             .get_project(project_name)
             .context(format!(
-                "Failed to get project {} from config lookup",
-                project_name
+                "Failed to get project {project_name} from config lookup"
             ))?
             .id;
         Ok(format!("{project_id}/addons"))
@@ -527,8 +526,7 @@ pub fn query_certificate_chain(domain: &str) -> anyhow::Result<String> {
     stream
         .write_all(
             format!(
-                "GET / HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n",
-                domain
+                "GET / HTTP/1.1\r\nHost: {domain}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n"
             )
                 .as_bytes(),
         )

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -98,7 +98,7 @@ async fn run_impl(
         for proto in service.iter() {
             addr.push_back_value(&proto)?;
         }
-        ockam_api::multiaddr_to_route(&addr).context(format!("Invalid MultiAddr {}", addr))?
+        ockam_api::multiaddr_to_route(&addr).context(format!("Invalid MultiAddr {addr}"))?
     };
 
     let mut client = Client::new(authenticator_route, &ctx).await?;
@@ -107,7 +107,7 @@ async fn run_impl(
         None => client.credential().await?,
         Some(token) => client.credential_with(&token).await?,
     };
-    println!("{}", credential);
+    println!("{credential}");
     delete_embedded_node(&opts, &node_name).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -69,7 +69,7 @@ pub async fn get_projects_secure_channels_from_config_lookup(
             // This shouldn't fail, as we did a refresh above if we found any missing project.
             let p = cfg_lookup
                 .get_project(name)
-                .context(format!("Failed to get project {} from config lookup", name))?;
+                .context(format!("Failed to get project {name} from config lookup"))?;
             let id = p
                 .identity_id
                 .as_ref()

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -13,7 +13,7 @@ impl ResetCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         if self.yes || get_user_confirmation() {
             if let Err(e) = run_impl(opts) {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 std::process::exit(e.code());
             }
         }
@@ -27,10 +27,10 @@ fn run_impl(opts: CommandGlobalOpts) -> crate::Result<()> {
 
 fn get_user_confirmation() -> bool {
     let prompt = "Please confirm the you really want a full reset (y/N) ";
-    print!("{}", prompt);
+    print!("{prompt}");
     if io::stdout().flush().is_err() {
         // If stdout wasn't flushed properly, fallback to println
-        println!("{}", prompt);
+        println!("{prompt}");
     }
     let stdin = BufReader::new(io::stdin());
     stdin

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -91,13 +91,13 @@ impl CreateCommand {
                 // if stdout is not interactive/tty write the secure channel address to it
                 // in case some other program is trying to read it as piped input
                 if !is_tty(std::io::stdout()) {
-                    println!("{}", multiaddr)
+                    println!("{multiaddr}")
                 }
 
                 // if output format is json, write json to stdout.
                 if options.global_args.output_format == OutputFormat::Json {
                     let json = json!([{ "address": multiaddr.to_string() }]);
-                    println!("{}", json);
+                    println!("{json}");
                 }
 
                 // if stderr is interactive/tty and we haven't been asked to be quiet
@@ -108,15 +108,15 @@ impl CreateCommand {
                 {
                     if options.global_args.no_color {
                         eprintln!("\n  Created Secure Channel:");
-                        eprintln!("  • From: /node/{}", parsed_from);
+                        eprintln!("  • From: /node/{parsed_from}");
                         eprintln!("  •   To: {} ({})", &self.to, &parsed_to);
-                        eprintln!("  •   At: {}", multiaddr);
+                        eprintln!("  •   At: {multiaddr}");
                     } else {
                         eprintln!("\n  Created Secure Channel:");
 
                         // From:
                         eprint!("{}", "  • From: ".light_magenta());
-                        eprintln!("{}", format!("/node/{}", parsed_from).light_yellow());
+                        eprintln!("{}", format!("/node/{parsed_from}").light_yellow());
 
                         // To:
                         eprint!("{}", "  •   To: ".light_magenta());
@@ -137,8 +137,7 @@ impl CreateCommand {
                     && options.global_args.output_format == OutputFormat::Plain
                 {
                     eprintln!(
-                        "Could not convert returned secure channel address {} into a multiaddr",
-                        route
+                        "Could not convert returned secure channel address {route} into a multiaddr"
                     );
                 }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -53,13 +53,13 @@ impl DeleteCommand {
                         // if stdout is not interactive/tty write the secure channel address to it
                         // in case some other program is trying to read it as piped input
                         if !is_tty(std::io::stdout()) {
-                            println!("{}", multiaddr)
+                            println!("{multiaddr}")
                         }
 
                         // if output format is json, write json to stdout.
                         if options.global_args.output_format == OutputFormat::Json {
                             let json = json!([{ "address": multiaddr.to_string() }]);
-                            println!("{}", json);
+                            println!("{json}");
                         }
 
                         // if stderr is interactive/tty and we haven't been asked to be quiet
@@ -77,7 +77,7 @@ impl DeleteCommand {
 
                                 // At:
                                 eprintln!("{}", "  •        At: ".light_magenta());
-                                eprintln!("{}", format!("/node/{}", parsed_at).light_yellow());
+                                eprintln!("{}", format!("/node/{parsed_at}").light_yellow());
 
                                 // Address:
                                 eprintln!("{}", "  •   Address: ".light_magenta());
@@ -93,8 +93,7 @@ impl DeleteCommand {
                             && options.global_args.output_format == OutputFormat::Plain
                         {
                             eprintln!(
-                                "Could not convert returned secure channel route {} into a multiaddr",
-                                route
+                                "Could not convert returned secure channel route {route} into a multiaddr"
                             );
                         }
 
@@ -117,7 +116,7 @@ impl DeleteCommand {
                     );
                 }
 
-                println!("channel with address {} not found", address)
+                println!("channel with address {address} not found")
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -48,8 +48,7 @@ impl ListCommand {
             let at = {
                 let channel_route = &route![channel_address];
                 let channel_multiaddr = route_to_multiaddr(channel_route).ok_or(format!(
-                    "Failed to convert route {} to multi-address",
-                    channel_route
+                    "Failed to convert route {channel_route} to multi-address"
                 ))?;
                 channel_multiaddr.to_string()
             };
@@ -61,30 +60,29 @@ impl ListCommand {
                 let parts: Vec<&str> = show_route.split(" => ").collect();
                 if parts.len() != 2 {
                     return Err(format!(
-                        "Invalid route received from show channel response -- {}",
-                        show_route
+                        "Invalid route received from show channel response -- {show_route}"
                     ));
                 }
 
                 let r1 = &route![*parts.first().unwrap()];
                 let r2 = &route![*parts.get(1).unwrap()];
                 let ma1 = route_to_multiaddr(r1)
-                    .ok_or(format!("Failed to convert route {} to multi-address", r1))?;
+                    .ok_or(format!("Failed to convert route {r1} to multi-address"))?;
                 let ma2 = route_to_multiaddr(r2)
-                    .ok_or(format!("Failed to convert route {} to multi-address", r2))?;
-                format!("{}{}", ma1, ma2)
+                    .ok_or(format!("Failed to convert route {r2} to multi-address"))?;
+                format!("{ma1}{ma2}")
             };
 
             // if stdout is not interactive/tty write the secure channel address to it
             // in case some other program is trying to read it as piped input
             if !is_tty(std::io::stdout()) {
-                println!("{}", at)
+                println!("{at}")
             }
 
             // if output format is json, write json to stdout.
             if options.global_args.output_format == OutputFormat::Json {
                 let json = json!([{ "address": at }]);
-                println!("{}", json);
+                println!("{json}");
             }
 
             // if stderr is interactive/tty and we haven't been asked to be quiet
@@ -92,13 +90,13 @@ impl ListCommand {
             if has_plain_stderr(options) {
                 println!("\n    Secure Channel:");
                 if options.global_args.no_color {
-                    eprintln!("      • From: /node/{}", from);
-                    eprintln!("      •   To: {}", to);
-                    eprintln!("      •   At: {}", at);
+                    eprintln!("      • From: /node/{from}");
+                    eprintln!("      •   To: {to}");
+                    eprintln!("      •   At: {at}");
                 } else {
                     // From:
                     eprint!("{}", "      • From: ".light_magenta());
-                    eprintln!("{}", format!("/node/{}", from).light_yellow());
+                    eprintln!("{}", format!("/node/{from}").light_yellow());
 
                     // To:
                     eprint!("{}", "      •   To: ".light_magenta());
@@ -156,7 +154,7 @@ async fn rpc(
             && !options.global_args.quiet
             && options.global_args.output_format == OutputFormat::Plain
         {
-            eprintln!("{}", e);
+            eprintln!("{e}");
         }
         std::process::exit(exitcode::PROTOCOL)
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -41,7 +41,7 @@ async fn run_impl(
         &cmd.node_opts.api_node
     );
     for addr in res {
-        println!("  {}", addr);
+        println!("  {addr}");
     }
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -43,7 +43,7 @@ pub mod config {
             None => {
                 refresh_spaces(ctx, opts, api_node, controller_route).await?;
                 Ok(try_get_space(&opts.config, space_name)
-                    .context(format!("Space '{}' does not exist", space_name))?)
+                    .context(format!("Space '{space_name}' does not exist"))?)
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -105,7 +105,7 @@ async fn print_status(
     let default_identity = opts.state.identities.default()?;
 
     for (i_idx, identity) in identities.iter().enumerate() {
-        println!("Identity[{}]", i_idx);
+        println!("Identity[{i_idx}]");
         if default_identity.config.identifier == identity.config.identifier {
             println!("{:2}Default: yes", "")
         }

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -75,7 +75,7 @@ async fn run_impl(
                 space_id,
             )
             .await?;
-            let req = Request::get(format!("subscription/{}", subscription_id))
+            let req = Request::get(format!("subscription/{subscription_id}"))
                 .body(CloudRequestWrapper::bare(controller_route));
             rpc.request(req).await?;
             rpc.parse_and_print_response::<Subscription>()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -48,11 +48,11 @@ impl CreateCommand {
                 let to = response.payload.parse::<SocketAddrV4>()?;
                 if opts.global_args.no_color {
                     println!("\n  Created TCP Connection:");
-                    println!("  • From: /node/{}", from);
+                    println!("  • From: /node/{from}");
                     println!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port());
                 } else {
                     println!("\n  Created TCP Connection:");
-                    println!("{}", format!("  • From: /node/{}", from).light_magenta());
+                    println!("{}", format!("  • From: /node/{from}").light_magenta());
                     println!(
                         "{}",
                         format!("  •   To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port())
@@ -69,14 +69,14 @@ impl CreateCommand {
                     .default_tcp_listener()?
                     .addr
                     .port();
-                let route: Route = route![(TCP, format!("localhost:{}", port))]
+                let route: Route = route![(TCP, format!("localhost:{port}"))]
                     .modify()
                     .append_t(TCP, response.payload.to_string())
                     .into();
                 let multiaddr = route_to_multiaddr(&route)
                     .context("Couldn't convert given address into `MultiAddr`")?;
                 let json = json!([{"route": multiaddr.to_string() }]);
-                println!("{}", json);
+                println!("{json}");
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -48,7 +48,7 @@ async fn run_impl(
         .default_tcp_listener()?
         .addr
         .port();
-    let mut base_route = route![(TCP, format!("localhost:{}", port))];
+    let mut base_route = route![(TCP, format!("localhost:{port}"))];
     let r: Route = base_route
         .modify()
         .pop_back()

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -78,7 +78,7 @@ pub async fn run_impl(
 
     let addr = route_to_multiaddr(&route![worker_addr.to_string()])
         .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
-    println!("{}", addr);
+    println!("{addr}");
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -233,14 +233,14 @@ pub(crate) mod space {
         id: &str,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
-        Request::get(format!("v0/spaces/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
+        Request::get(format!("v0/spaces/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 
     pub(crate) fn delete<'a>(
         id: &str,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
-        Request::delete(format!("v0/spaces/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
+        Request::delete(format!("v0/spaces/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 }
 
@@ -258,7 +258,7 @@ pub(crate) mod project {
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
         let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
-        Request::post(format!("v0/projects/{}", space_id)).body(CloudRequestWrapper::new(
+        Request::post(format!("v0/projects/{space_id}")).body(CloudRequestWrapper::new(
             b,
             cloud_route,
             None::<CowStr>,
@@ -273,7 +273,7 @@ pub(crate) mod project {
         id: &str,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
-        Request::get(format!("v0/projects/{}", id)).body(CloudRequestWrapper::bare(cloud_route))
+        Request::get(format!("v0/projects/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 
     pub(crate) fn delete<'a>(
@@ -281,7 +281,7 @@ pub(crate) mod project {
         project_id: &'a str,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
-        Request::delete(format!("v0/projects/{}/{}", space_id, project_id))
+        Request::delete(format!("v0/projects/{space_id}/{project_id}"))
             .body(CloudRequestWrapper::bare(cloud_route))
     }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -305,7 +305,7 @@ where
             serde_json::to_string_pretty(&b).context("Failed to serialize output")?
         }
     };
-    println!("{}", o);
+    println!("{o}");
     Ok(b)
 }
 
@@ -316,7 +316,7 @@ where
 /// TODO: We may want to change this behaviour in the future.
 pub async fn stop_node(mut ctx: Context) -> Result<()> {
     if let Err(e) = ctx.stop().await {
-        eprintln!("an error occurred while shutting down local node: {}", e);
+        eprintln!("an error occurred while shutting down local node: {e}");
     }
     Ok(())
 }
@@ -501,7 +501,7 @@ pub fn parse_node_name(input: &str) -> anyhow::Result<String> {
             Ok(maddr) => maddr,
             Err(e) => {
                 // Tested with input strings with large tcp numbers. e.g: `node create /node/n1/tcp/28273829`
-                err_message.push_str(&format!("\n{}", e));
+                err_message.push_str(&format!("\n{e}"));
                 return Err(anyhow!(err_message));
             }
         };

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -112,7 +112,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
 
         let proj = config_lookup
             .get_project(proj_name)
-            .context(format!("Unknown project {}", proj_name))?;
+            .context(format!("Unknown project {proj_name}"))?;
 
         self.project_lookup = Some(proj.clone());
         Ok(self)

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -107,7 +107,7 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
             let idt_name = cli_state::random_name();
             let idt_config = cli_state::IdentityConfig::new(&idt).await;
             opts.state.identities.create(&idt_name, idt_config)?;
-            println!("Identity attached to vault: {}", idt_name);
+            println!("Identity attached to vault: {idt_name}");
         }
         VaultSubcommand::Show { name } => {
             let name = name.unwrap_or(opts.state.vaults.default()?.name()?);
@@ -123,7 +123,7 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
                 return Err(anyhow!("No vaults registered on this system!").into());
             }
             for (idx, vault) in states.iter().enumerate() {
-                println!("Vault[{}]:", idx);
+                println!("Vault[{idx}]:");
                 for line in vault.to_string().lines() {
                     println!("{:2}{}", "", line)
                 }
@@ -131,7 +131,7 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
         }
         VaultSubcommand::Delete { name } => {
             opts.state.vaults.delete(&name).await?;
-            println!("Vault '{}' deleted", name);
+            println!("Vault '{name}' deleted");
         }
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -8,10 +8,7 @@ impl Version {
     pub(crate) fn long() -> &'static str {
         let crate_version = crate_version!();
         let git_hash = env!("GIT_HASH");
-        let message = format!(
-            "{}\n\nCompiled from (git hash): {}",
-            crate_version, git_hash
-        );
+        let message = format!("{crate_version}\n\nCompiled from (git hash): {git_hash}");
         Box::leak(message.into_boxed_str())
     }
 

--- a/implementations/rust/ockam/ockam_core/src/access_control/any.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/any.rs
@@ -28,7 +28,7 @@ impl<F: IncomingAccessControl, S: IncomingAccessControl> IncomingAccessControl
 }
 
 impl<F: IncomingAccessControl, S: IncomingAccessControl> Debug for AnyAccessControl<F, S> {
-    fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "AllowAny({:?} OR {:?})", self.first, self.second)
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/access_control/local.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/local.rs
@@ -75,10 +75,10 @@ mod tests {
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(external_onward_address.clone(), route![], vec![]),
+            TransportMessage::v1(external_onward_address, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), local_onward_address.clone(), msg);
+        let msg = RelayMessage::new(source_address, local_onward_address, msg);
 
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -137,7 +137,7 @@ mod tests {
             ),
             vec![],
         );
-        let msg = RelayMessage::new(local_source_address.clone(), onward_address.clone(), msg);
+        let msg = RelayMessage::new(local_source_address, onward_address, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 

--- a/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
@@ -81,10 +81,10 @@ mod tests {
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(onward_address2.clone(), route![], vec![]),
+            TransportMessage::v1(onward_address2, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address1.clone(), msg);
+        let msg = RelayMessage::new(source_address, onward_address1, msg);
 
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -112,7 +112,7 @@ mod tests {
             TransportMessage::v1(onward_address2.clone(), route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address2.clone(), msg);
+        let msg = RelayMessage::new(source_address.clone(), onward_address2, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 
@@ -133,10 +133,10 @@ mod tests {
         assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
 
         let msg = LocalMessage::new(
-            TransportMessage::v1(onward_address1.clone(), route![], vec![]),
+            TransportMessage::v1(onward_address1, route![], vec![]),
             vec![],
         );
-        let msg = RelayMessage::new(source_address.clone(), onward_address3.clone(), msg);
+        let msg = RelayMessage::new(source_address, onward_address3, msg);
 
         assert!(poll_once(async { ac.is_authorized(&msg).await })?);
 

--- a/implementations/rust/ockam/ockam_core/src/routing/address.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address.rs
@@ -22,7 +22,7 @@ pub struct Mailbox {
 }
 
 impl Debug for Mailbox {
-    fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{} {{in:{:?} out:{:?}}}",
@@ -91,7 +91,7 @@ pub struct Mailboxes {
 }
 
 impl Debug for Mailboxes {
-    fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{:?} + {:?}",
@@ -436,7 +436,7 @@ impl Display for Address {
 }
 
 impl Debug for Address {
-    fn fmt<'a>(&'a self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         <Self as Display>::fmt(self, f)
     }
 }

--- a/implementations/rust/ockam/ockam_macros/src/internals/check.rs
+++ b/implementations/rust/ockam/ockam_macros/src/internals/check.rs
@@ -39,7 +39,7 @@ pub(crate) mod item_fn {
         ockam_ctx
     }
 
-    pub(crate) fn ockam_ctx_is_mut_ref<'a>(ctx: &Context, ockam_ctx: &Option<FnVariable<'a>>) {
+    pub(crate) fn ockam_ctx_is_mut_ref(ctx: &Context, ockam_ctx: &Option<FnVariable>) {
         if let Some(ockam_ctx) = ockam_ctx {
             if ockam_ctx.and_token.is_none() {
                 let msg = "the `Context` argument must be passed as reference";

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -415,7 +415,7 @@ impl MultiAddr {
     /// Remove and return the last protocol component.
     ///
     /// O(n) in the number of protocols.
-    pub fn pop_back<'a, 'b>(&'a mut self) -> Option<ProtoValue<'b>> {
+    pub fn pop_back<'b>(&mut self) -> Option<ProtoValue<'b>> {
         let iter = ValidBytesIter(iter::BytesIter::with_registry(
             &self.dat[self.off..],
             self.reg.clone(),

--- a/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/04-routing-over-ble-transport-initiator.rs
@@ -32,7 +32,7 @@ async fn async_main(mut ctx: Context) -> Result<()> {
 
     // Wait to receive a reply and print it.
     let reply = ctx.receive::<String>().await?;
-    println!("[main] App Received: {}", reply); // should print "Hello Ockam!"
+    println!("[main] App Received: {reply}"); // should print "Hello Ockam!"
 
     // Stop all workers, stop the node, cleanup and return.
     ctx.stop().await

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -45,7 +45,7 @@ async fn async_main(mut ctx: Context) -> Result<()> {
 
     // Wait to receive a reply and print it.
     let reply = ctx.receive::<String>().await?;
-    println!("[main] App Received: {}", reply); // should print "Hello Ockam!"
+    println!("[main] App Received: {reply}"); // should print "Hello Ockam!"
 
     // Stop all workers, stop the node, cleanup and return.
     ctx.stop().await

--- a/implementations/rust/ockam/ockam_transport_uds/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/lib.rs
@@ -62,7 +62,7 @@ fn address_from_socket_addr(sock_addr: &SocketAddr) -> Result<Address> {
         }
     };
 
-    let address: Address = format!("{}#{}", UDS, path_str).into();
+    let address: Address = format!("{UDS}#{path_str}").into();
 
     Ok(address)
 }

--- a/implementations/rust/ockam/ockam_transport_uds/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/router/handle.rs
@@ -118,7 +118,7 @@ impl UdsRouterHandle {
         accepts.extend(
             pair.paths()
                 .iter()
-                .map(|x| Address::from_string(format!("{}#{}", UDS, x))),
+                .map(|x| Address::from_string(format!("{UDS}#{x}"))),
         );
         let self_addr = pair.tx_addr();
 

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
@@ -111,9 +111,9 @@ impl UdsSendWorker {
             "responder"
         };
 
-        let tx_addr = Address::random_tagged(&format!("UdsSendWorker_tx_addr_{}", role_str));
-        let int_addr = Address::random_tagged(&format!("UdsSendWorker_int_addr_{}", role_str));
-        let rx_addr = Address::random_tagged(&format!("UdsRecvProcessor_{}", role_str));
+        let tx_addr = Address::random_tagged(&format!("UdsSendWorker_tx_addr_{role_str}"));
+        let int_addr = Address::random_tagged(&format!("UdsSendWorker_int_addr_{role_str}"));
+        let rx_addr = Address::random_tagged(&format!("UdsRecvProcessor_{role_str}"));
         let sender = UdsSendWorker::new(router_handle, stream, peer.clone(), int_addr, rx_addr);
         Ok((
             sender,


### PR DESCRIPTION
I got some lint errors after upgrading to 1.67.0.

All but a couple of changes were done automatically running `cargo clippy --fix`.