### PR TITLE
refactor(rust): change log message type to info

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -16,7 +16,7 @@ use socket2::{SockRef, TcpKeepalive};
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Provides the transmit and receive parts of a TCP connection
 #[derive(Debug)]
@@ -254,7 +254,7 @@ impl Worker for TcpSendWorker {
 
             match msg {
                 TcpSendWorkerMsg::ConnectionClosed => {
-                    warn!("Stopping sender due to closed connection {}", self.peer);
+                    info!("Stopping sender due to closed connection {}", self.peer);
                     // No need to stop Receiver as it notified us about connection drop and will
                     // stop itself
                     self.rx_should_be_stopped = false;


### PR DESCRIPTION
Signed-off-by: murex971 <nupur202000@gmail.com>

<!-- Thank you for sending a pull request :heart: -->

FIxes : #4173 

## Current Behavior

Current log message
``` WARN ockam_transport_tcp::workers::sender: Stopping sender due to closed connection 127.0.0.1:62863```

## Proposed Changes

Expected
``` INFO ockam_transport_tcp::workers::sender: Stopping sender due to closed connection 127.0.0.1:62863```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
