### PR TITLE
refactor(rust): iterate over all nodes while deleting with all flag

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -222,8 +222,17 @@ pub fn delete_node(opts: &CommandGlobalOpts, name: &str, force: bool) -> anyhow:
 
 pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> anyhow::Result<()> {
     let nodes_states = opts.state.nodes.list()?;
+    let mut deletion_errors = Vec::new();
     for s in nodes_states {
-        opts.state.nodes.delete(&s.config.name, force)?;
+        if let Err(e) = opts.state.nodes.delete(&s.config.name, force) {
+            deletion_errors.push((s.config.name.clone(), e));
+        }
+    }
+    if !deletion_errors.is_empty() {
+        return Err(anyhow!(
+            "errors while deleting nodes: {:?}",
+            deletion_errors
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: murex971 <nupur202000@gmail.com>

<!-- Thank you for sending a pull request :heart: -->

Fixes #4195 

## Current Behavior

Currently the loop gets exited whenever error is returned by a node.

## Proposed Changes

A vector is initialised before `for` loop that collects all the errors and returns all the errors at the end of loop. 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
