### PR TITLE
feat(rust):add ockam node logs subcommand

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -1,0 +1,40 @@
+use crate::node::default_node_name;
+use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
+use clap::Args;
+use std::path::PathBuf;
+
+/// Get the stdout/stderr log file of a node
+#[derive(Clone, Debug, Args)]
+#[command(
+    after_long_help = help::template(HELP_DETAIL)
+)]
+pub struct LogCommand {
+    /// Name of the node.
+    #[arg(default_value_t = default_node_name())]
+    node_name: String,
+
+    /// Show the standard error log file.
+    #[arg(long = "err")]
+    show_err: bool,
+}
+
+impl LogCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        if let Err(e) = run_impl(opts, self) {
+            eprintln!("{}", e);
+            std::process::exit(e.code());
+        }
+    }
+}
+
+fn run_impl(opts: CommandGlobalOpts, cmd: LogCommand) -> crate::Result<PathBuf> {
+    let node_state = opts.state.nodes.get(&cmd.node_name)?;
+
+    let log_file_path = if cmd.show_err {
+        node_state.stderr_log()
+    } else {
+        node_state.stdout_log()
+    };
+    println!("{}", log_file_path.display());
+    Ok(log_file_path)
+}

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 pub(crate) use create::CreateCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
+use logs::LogCommand;
 use ockam_api::cli_state::CliState;
 use show::ShowCommand;
 use start::StartCommand;
@@ -13,6 +14,7 @@ use crate::{help, CommandGlobalOpts};
 mod create;
 mod delete;
 mod list;
+mod logs;
 mod show;
 mod start;
 mod stop;
@@ -41,6 +43,7 @@ pub enum NodeSubcommand {
     #[command(display_order = 800)]
     List(ListCommand),
     #[command(display_order = 800)]
+    Logs(LogCommand),
     Show(ShowCommand),
     #[command(display_order = 800)]
     Start(StartCommand),
@@ -57,6 +60,7 @@ impl NodeCommand {
             NodeSubcommand::Show(c) => c.run(options),
             NodeSubcommand::Start(c) => c.run(options),
             NodeSubcommand::Stop(c) => c.run(options),
+            NodeSubcommand::Logs(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

No subcommand exists to get node logs
-Closes #4129

## Proposed Changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
-Added ockam node logs subcommand
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
