### PR TITLE
feat(rust): NodeState implement check whether a node is running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "thiserror",
  "time",
@@ -3803,6 +3804,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -4663,6 +4686,7 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
+ "rayon",
  "winapi",
 ]
 

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -54,6 +54,7 @@ directories     = "4"
 dirs            = "4.0.0"
 thiserror       = "1.0"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+sysinfo         = "0.27"
 
 [dependencies.ockam_core]
 version          = "0.73.0"

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::SystemTime;
+use sysinfo::{Pid, System, SystemExt};
 
 use crate::lmdb::LmdbStorage;
 use ockam::compat::tokio;
@@ -733,6 +734,16 @@ impl NodeState {
     pub fn set_pid(&self, pid: i32) -> Result<()> {
         std::fs::write(self.path.join("pid"), pid.to_string())?;
         Ok(())
+    }
+
+    pub fn is_running(&self) -> bool {
+        if let Ok(Some(pid)) = self.pid() {
+            let mut sys = System::new();
+            sys.refresh_processes();
+            sys.process(Pid::from(pid as usize)).is_some()
+        } else {
+            false
+        }
     }
 
     pub fn stdout_log(&self) -> PathBuf {


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

There is no explicit way to easily check if a node is running or is stopped without sending a message to it.
Resolves https://github.com/build-trust/ockam/issues/4174

## Proposed Changes

NodeState implement a function called `is_running` with fn signature:
 ```
pub fn is_running(&self) -> bool {}
 ```
That returns `true` if pid file is in its state directory and the process is running in the system `/proc/{pid}/status`, otherwise returns `false`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
