### PR TITLE
feat(rust): Add default subcommand to node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -598,6 +598,9 @@ impl NodesState {
             path
         };
         let link = self.default_path()?;
+        // Remove file link if it exists
+        let _ = std::fs::remove_file(&link);
+        // Create link to new default node
         std::os::unix::fs::symlink(original, link)?;
         self.get(name)
     }

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,0 +1,32 @@
+use crate::node::default_node_name;
+use crate::node::util::{check_default, set_default_node};
+use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
+use clap::Args;
+
+/// Changes default node
+#[derive(Clone, Debug, Args)]
+#[command(after_long_help = help::template(HELP_DETAIL))]
+pub struct DefaultCommand {
+    /// Name of the node.
+    #[arg(default_value_t = default_node_name())]
+    node_name: String,
+}
+
+impl DefaultCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        if let Err(e) = run_impl(opts, self) {
+            eprintln!("{e}");
+            std::process::exit(e.code());
+        }
+    }
+}
+
+fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
+    if check_default(&opts, &cmd.node_name) {
+        println!("Already set to default node");
+    } else {
+        set_default_node(&opts, &cmd.node_name)?;
+        println!("Set node '{}' as default", &cmd.node_name);
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 
 pub(crate) use create::CreateCommand;
+use default::DefaultCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
 use logs::LogCommand;
@@ -12,6 +13,7 @@ use stop::StopCommand;
 use crate::{help, CommandGlobalOpts};
 
 mod create;
+mod default;
 mod delete;
 mod list;
 mod logs;
@@ -49,6 +51,8 @@ pub enum NodeSubcommand {
     Start(StartCommand),
     #[command(display_order = 800)]
     Stop(StopCommand),
+    #[command(display_order = 800)]
+    Default(DefaultCommand),
 }
 
 impl NodeCommand {
@@ -61,6 +65,7 @@ impl NodeCommand {
             NodeSubcommand::Start(c) => c.run(options),
             NodeSubcommand::Stop(c) => c.run(options),
             NodeSubcommand::Logs(c) => c.run(options),
+            NodeSubcommand::Default(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -239,6 +239,18 @@ pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> Result<()> {
     Ok(())
 }
 
+pub fn set_default_node(opts: &CommandGlobalOpts, name: &str) -> anyhow::Result<()> {
+    opts.state.nodes.set_default(name)?;
+    Ok(())
+}
+
+pub fn check_default(opts: &CommandGlobalOpts, name: &str) -> bool {
+    if let Ok(default) = opts.state.nodes.default() {
+        return default.config.name == name;
+    }
+    false
+}
+
 /// A utility function to spawn a new node into foreground mode
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_node(


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Resolves #4212 

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Added command 
```
ockam node default <node_name>
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
