### PR TITLE
feat(rust): make the portal message struct public

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -29,7 +29,7 @@ mod portal;
 mod router;
 mod workers;
 
-pub(crate) use portal::*;
+pub use portal::*;
 pub(crate) use router::*;
 pub(crate) use workers::*;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
@@ -6,6 +6,6 @@ mod portal_worker;
 
 pub(crate) use inlet_listener::*;
 pub(crate) use outlet_listener::*;
-pub(crate) use portal_message::*;
+pub use portal_message::*;
 pub(crate) use portal_receiver::*;
 pub(crate) use portal_worker::*;


### PR DESCRIPTION
This is necessary in order to be able to create access controls which are inspecting the payload

## Current Behavior

At the moment we can create TCP inlets and outlets and specify what should be the `IncomingAccessControl`. 
However, in some cases, we might want to create access controls which depend on the exact content of the `RelayMessage`. In order to do this we need to be able to deserialize the `PortalMessage` contained in the `RelayMessage` and extract the payload if there is one.

## Proposed Changes

Make the `PortalMessage` struct public in the `ockam_transport_tcp` crate.
