### PR TITLE
Showcase the use of of credentials with the Rust library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,9 +2162,14 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 name = "hello_ockam"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "example_test_helper",
  "hex",
+ "minicbor",
  "ockam",
+ "ockam_api",
+ "ockam_core",
+ "ockam_multiaddr",
  "ockam_transport_udp",
  "ockam_transport_uds",
  "ockam_transport_websocket",

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -12,7 +12,12 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam/default", "ockam_transport_websocket", "serde_json/default"]
+std = ["ockam/default",
+  "ockam_transport_websocket",
+  "serde_json/default",
+  "ockam_multiaddr/std",
+  "ockam_api/std",
+  "ockam_api/authenticators"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
@@ -23,6 +28,9 @@ no_std = ["ockam/no_std"]
 alloc = ["ockam/alloc", "serde_json/alloc"]
 
 [dependencies]
+ockam_core = { path = "../../../implementations/rust/ockam/ockam_core" }
+ockam_multiaddr = { path = "../../../implementations/rust/ockam/ockam_multiaddr" }
+ockam_api = { path = "../../../implementations/rust/ockam/ockam_api" }
 ockam = { path = "../../../implementations/rust/ockam/ockam", default_features = false, features = [
     "software_vault",
 ] }
@@ -32,6 +40,8 @@ ockam_transport_uds = { path = "../../../implementations/rust/ockam/ockam_transp
 serde = { version = "1", default_features = false, features = ["derive"] }
 serde_json = { version = "1.0", default_features = false }
 hex = "0.4"
+minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
+anyhow = "1"
 
 [dev-dependencies]
 rand = { version = "0.8.4", features = ["std_rng"], default-features = false }

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -1,0 +1,106 @@
+use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project, OneTimeCode};
+use ockam::access_control::AllowAll;
+use ockam::identity::credential::Credential;
+use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
+use ockam::remote::RemoteForwarder;
+use ockam::{route, vault::Vault, Context, Result, TcpTransport};
+use ockam_core::IncomingAccessControl;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// This node supports a "control" server on which several "edge" devices can connect
+///
+/// The connections go through the Ockam Orchestrator, via a Forwarder, and a secure channel
+/// can be established to forward messages to an outlet going to a local Python webserver.
+///
+///
+/// This example shows how to:
+///
+///   - retrieve credentials from an authority
+///   - create a Forwarder on the Ockam Orchestrator
+///   - create a TCP outlet with some access control checking the authenticated attributes of the caller
+///
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    // Initialize the TCP transport
+    let tcp = TcpTransport::create(&ctx).await?;
+
+    // Create an Identity for the control node
+    let vault = Vault::create();
+    let control_plane = Identity::create(&ctx, &vault).await?;
+
+    // 1. create a secure channel to the authority
+    //    to retrieve the node credentials
+
+    // Import the authority identity and route from the project.json file
+    let project = import_project("project.json", &vault).await?;
+
+    // create a secure channel to the authority
+    // when creating the channel we check that the opposite side is indeed presenting the authority identity
+    let secure_channel = control_plane
+        .create_secure_channel_extended(
+            project.authority_route.clone(),
+            TrustMultiIdentifiersPolicy::new(vec![project.authority_public_identifier()]),
+            Duration::from_secs(120),
+        )
+        .await?;
+
+    // 2. get credentials using a one-time token
+
+    // create the token obtained with `ockam project enroll --attribute component=control`
+    // you can also copy and paste a token here and parse it with the project/otc_parser function
+    let token: OneTimeCode = create_token("component", "control").await?;
+    println!("token: {token:?}");
+
+    let credentials: Credential = get_credentials(&ctx, route![secure_channel, "authenticator"], token).await?;
+    println!("{credentials}");
+
+    // store the credentials and start a credentials exchange worker which will be
+    // later on to exchange credentials with the edge node
+    control_plane.set_credential(Some(credentials.to_owned())).await;
+    control_plane
+        .start_credentials_exchange_worker(vec![project.authority_public_identity()], "credential_exchange", true)
+        .await?;
+
+    // 3. create an access control policy checking the value of the "component" attribute of the caller
+    let access_control: Arc<dyn IncomingAccessControl> =
+        create_attribute_access_control(control_plane.authenticated_storage().clone(), "component", "edge");
+
+    // 4. create a tcp outlet with the above policy
+    let outlet = tcp
+        .create_outlet_impl("outlet".into(), "127.0.0.1:5000".into(), access_control)
+        .await?;
+    println!("{outlet:?}");
+
+    // 5. create a forwarder on the Ockam orchestrator
+
+    // create a secure channel to the project first
+    // we make sure that we indeed connect to the correct project on the Orchestrator
+    let secure_channel_address = control_plane
+        .create_secure_channel_extended(
+            project.route(),
+            TrustMultiIdentifiersPolicy::new(vec![project.identifier()]),
+            Duration::from_secs(120),
+        )
+        .await?;
+    println!("secure channel to project: {secure_channel_address:?}");
+
+    // present this node credentials to the project
+    control_plane
+        .present_credential(route![secure_channel_address.clone(), "credentials"])
+        .await?;
+
+    // finally create a forwarder using the secure channel to the project
+    let forwarder = RemoteForwarder::create_static(&ctx, secure_channel_address, "control_plane1", AllowAll).await?;
+    println!("forwarder is {forwarder:?}");
+
+    // 6. create a secure channel listener which will allow the edge node to
+    //    start a secure channel when it is ready
+    let secure_channel_listener = control_plane
+        .create_secure_channel_listener("untrusted", TrustEveryonePolicy)
+        .await?;
+    println!("listener is {secure_channel_listener:?}");
+
+    // don't stop the node
+    Ok(())
+}

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -20,8 +20,6 @@ use std::time::Duration;
 ///
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    env::set_var("OCKAM_LOG", "trace");
-
     // Use the TCP transport
     let tcp = TcpTransport::create(&ctx).await?;
 

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -3,7 +3,6 @@ use ockam::identity::credential::Credential;
 use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
 use ockam::{route, vault::Vault, Context, Result, TcpTransport};
 use ockam_core::IncomingAccessControl;
-use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,8 +17,28 @@ use std::time::Duration;
 ///   - create a TCP inlet with some access control checking the authenticated attributes of the caller
 ///   - connect the TCP inlet to a server outlet
 ///
+/// The node needs to be started with:
+///
+///  - a project.json file created with `ockam project information --output json  > project.json`
+///  - a token created by an enroller node with `ockam project enroll --attribute component=edge`
+///
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
+    // create a token (with `ockam project enroll --attribute component=edge`)
+    // In principle this token is provided by another node which has enrolling privileges for the
+    // current project
+    let token: OneTimeCode = create_token("component", "edge").await?;
+    println!("token: {token:?}");
+
+    // set the path of the project information file
+    // In principle this file is provided by the enrolling node by running the command
+    // `ockam project information --output json  > project.json`
+    let project_information_path = "project.json";
+    start_node(ctx, project_information_path, token).await
+}
+
+/// start the edge node
+async fn start_node(ctx: Context, project_information_path: &str, token: OneTimeCode) -> Result<()> {
     // Use the TCP transport
     let tcp = TcpTransport::create(&ctx).await?;
 
@@ -27,11 +46,11 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
     let edge_plane = Identity::create(&ctx, &vault).await?;
 
-    // 1. create a secure channel to the authority
+    // 2. create a secure channel to the authority
     //    to retrieve the node credentials
 
-    // Import the authority identity and route from the project.json file
-    let project = import_project("project.json", &vault).await?;
+    // Import the authority identity and route from the information file
+    let project = import_project(project_information_path, &vault).await?;
 
     // create a secure channel to the authority
     // when creating the channel we check that the opposite side is indeed presenting the authority identity
@@ -42,13 +61,6 @@ async fn main(ctx: Context) -> Result<()> {
             Duration::from_secs(120),
         )
         .await?;
-
-    // 2. get credentials using a one-time token
-
-    // create the token obtained with `ockam project enroll --attribute component=edge`
-    // you can also copy and paste a token here and parse it with the project/otc_parser function
-    let token: OneTimeCode = create_token("component", "edge").await?;
-    println!("token: {token:?}");
 
     let credentials: Credential = get_credentials(&ctx, route![secure_channel, "authenticator"], token).await?;
     println!("{credentials}");

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -1,0 +1,116 @@
+use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project, OneTimeCode};
+use ockam::identity::credential::Credential;
+use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
+use ockam::{route, vault::Vault, Context, Result, TcpTransport};
+use ockam_core::IncomingAccessControl;
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// This node supports an "edge" server which can connect to a "control" node
+/// in order to connect its TCP inlet to the "control" node TCP outlet
+///
+/// The connections go through the Ockam Orchestrator, via the control node Forwarder.
+///
+/// This example shows how to:
+///
+///   - retrieve credentials from an authority
+///   - create a TCP inlet with some access control checking the authenticated attributes of the caller
+///   - connect the TCP inlet to a server outlet
+///
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    env::set_var("OCKAM_LOG", "trace");
+
+    // Use the TCP transport
+    let tcp = TcpTransport::create(&ctx).await?;
+
+    // Create an Identity for the edge plane
+    let vault = Vault::create();
+    let edge_plane = Identity::create(&ctx, &vault).await?;
+
+    // 1. create a secure channel to the authority
+    //    to retrieve the node credentials
+
+    // Import the authority identity and route from the project.json file
+    let project = import_project("project.json", &vault).await?;
+
+    // create a secure channel to the authority
+    // when creating the channel we check that the opposite side is indeed presenting the authority identity
+    let secure_channel = edge_plane
+        .create_secure_channel_extended(
+            project.authority_route(),
+            TrustMultiIdentifiersPolicy::new(vec![project.authority_public_identifier()]),
+            Duration::from_secs(120),
+        )
+        .await?;
+
+    // 2. get credentials using a one-time token
+
+    // create the token obtained with `ockam project enroll --attribute component=edge`
+    // you can also copy and paste a token here and parse it with the project/otc_parser function
+    let token: OneTimeCode = create_token("component", "edge").await?;
+    println!("token: {token:?}");
+
+    let credentials: Credential = get_credentials(&ctx, route![secure_channel, "authenticator"], token).await?;
+    println!("{credentials}");
+
+    // store the credentials and start a credentials exchange worker which will be
+    // later on to exchange credentials with the control node
+    edge_plane.set_credential(Some(credentials.to_owned())).await;
+    edge_plane
+        .start_credentials_exchange_worker(vec![project.authority_public_identity()], "credential_exchange", true)
+        .await?;
+
+    // 3. create an access control policy checking the value of the "component" attribute of the caller
+    let access_control: Arc<dyn IncomingAccessControl> =
+        create_attribute_access_control(edge_plane.authenticated_storage().clone(), "component", "control");
+
+    // 4. create a tcp inlet with the above policy
+
+    // 4.1 first created a secure channel to the project
+    let secure_channel_address = edge_plane
+        .create_secure_channel_extended(
+            project.route(),
+            TrustMultiIdentifiersPolicy::new(vec![project.identifier()]),
+            Duration::from_secs(120),
+        )
+        .await?;
+    println!("secure channel address to the project: {secure_channel_address:?}");
+
+    // 4.2 and send this node credentials to the project
+    edge_plane
+        .present_credential(route![secure_channel_address.clone(), "credentials"])
+        .await?;
+
+    // 4.3 then create a secure channel to the control node (via its forwarder)
+    let secure_channel_listener_route = route![secure_channel_address, "forward_to_control_plane1", "untrusted"];
+    let secure_channel_to_control = edge_plane
+        .create_secure_channel_extended(
+            secure_channel_listener_route.clone(),
+            TrustEveryonePolicy,
+            Duration::from_secs(120),
+        )
+        .await?;
+
+    println!("secure channel address to the control node: {secure_channel_to_control:?}");
+
+    // 4.4 exchange credentials with the control node
+    edge_plane
+        .present_credential_mutual(
+            route![secure_channel_to_control.clone(), "credential_exchange"],
+            vec![&project.authority_public_identity()],
+        )
+        .await?;
+    println!("credential exchange done");
+
+    // 4.5 create a TCP inlet connected to the TCP outlet on the control node
+    let outlet_route = route![secure_channel_to_control, "outlet"];
+    let inlet = tcp
+        .create_inlet_impl("127.0.0.1:7000".into(), outlet_route.clone(), access_control)
+        .await?;
+    println!("the inlet is {inlet:?}");
+
+    // don't stop the node
+    Ok(())
+}

--- a/examples/rust/get_started/examples/11-attribute-based-authentication.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication.rs
@@ -1,0 +1,91 @@
+/// INTRODUCTION
+///
+/// This example shows how to use attribute-based credentials in order to have
+/// several devices connecting to a server, via the Ockam Orchestrator.
+///
+/// The corresponding example using the command-line can be found here: https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.
+///
+/// You first need to:
+///
+///  - create a project with `ockam enroll`
+///  - export the project information with `ockam project information > project.json`
+///
+/// Then you can start:
+///
+///  - a local Python webserver: `python3 -m http.server --bind 127.0.0.1 5000`
+///  - the control node in `11-attribute-based-authentication-control-plane.rs`
+///  - the edge node in `11-attribute-based-authentication-edge-plane.rs`
+///
+/// This will set up a TCP outlet on the control node, connected to the Python webserver
+/// and a TCP inlet on the edge node which can be used to send HTTP requests (at 127.0.0.1:7000).
+///
+/// Then if you execute `curl --fail --head --max-time 10 127.0.0.1:7000` you should get back
+/// a successful response like:
+///
+/// HTTP/1.0 200 OK
+/// Server: SimpleHTTP/0.6 Python/3.9.6
+/// Date: Tue, 07 Feb 2023 15:05:59 GMT
+/// Content-type: text/html; charset=utf-8
+/// Content-Length: 870
+///
+/// and observe that a successful connection has been made on the Python webserver:
+///
+/// ± python3 -m http.server --bind 127.0.0.1 5000                                                                                                                                                                                                                                                                                                                                                                                      default
+///  Serving HTTP on 127.0.0.1 port 5000 (http://127.0.0.1:5000/) ...
+///  127.0.0.1 - - [06/Feb/2023 15:52:20] "HEAD / HTTP/1.1" 200 -
+///
+/// TOPOLOGY
+///
+/// The network we establish between the control node, the edge node and the Orchestrator is the following
+///
+///                   +-------------------------+
+///                   | Edge node               | Inlet <-- 127.0.0.1:7000
+///                   |                         | connected to "outlet" via secure channel
+///                   +-------------------------+
+///                     |                 |
+///  secure channel to  |                 | create secure channel to control
+///  project            |                 | via the forwarder
+///                     v                 |
+///                   +-------------------+-------+                 +--------------+
+///                   | Orchestrator      |       | get credentials | Authority    |
+///                   |                   |       |---------------->|              |
+///                   |                   |       |                 |              |
+///                   +------------forwarder------+                 +--------------+
+///                     ^          to control
+///                     |         ^       |
+///  secure channel to  |  create |       |
+///  project            |         |       v
+///                     |         |    "untrusted"
+///                   +--------------secure channel listener--+
+///                   |                                       |
+///                   | Control node                          | "outlet" --> 127.0.0.1:5000
+///                   |                                       |
+///                   +---------------------------------------+
+///
+///   - we create initially some secure channels to the Orchestrator in order to retrieve credentials
+///     based on a one-time token generated with `ockam project enroll --attribute component=<name of node>`
+///
+///   - then the control node creates a forwarder on the Orchestrator in order to accept TCP traffic without
+///     having to open a port to the internet. It also starts a channel listener ("untrusted", accept all incoming requests for now)
+///
+///   - on its side the edge node starts a secure channel via forwarder (named "forward_to_control_plane1"), to the "untrusted" listener
+///     with the secure channel address it creates an Inlet which will direct TCP traffic via the secure channel to get to the
+///     control node and then to the "outlet" worker to reach the Python webserver
+///
+///   - the outlet is configured to only receive messages from the edge node by checking its authenticated attributes
+///   - the inlet is configured to only receive messages from the control node by checking its authenticated attributes
+///
+/// IMPLEMENTATION
+///
+/// The code for this example can be found in:
+///
+///  - examples/11-attribute-based-authentication-control-plane.rs: for the control node
+///  - examples/11-attribute-based-authentication-edge-plane.rs: for the edge node
+///  - src/project.rs: read the content of the project.json file
+///  - src/token.rs: generate a one-time token using the ockam command line
+///  - src/credentials.rs: retrieve the credentials of a node from an authority (using the token above)
+///  - src/attribute_access_control: example of creating an access control policy for one attribute only
+///
+
+/// unused main function
+fn main() {}

--- a/examples/rust/get_started/examples/11-attribute-based-authentication.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication.rs
@@ -38,31 +38,33 @@
 ///
 /// The network we establish between the control node, the edge node and the Orchestrator is the following
 ///
-///                   +-------------------------+
-///                   | Edge node               | Inlet <-- 127.0.0.1:7000
-///                   |                         | connected to "outlet" via secure channel
-///                   +-------------------------+
-///                     |                 |
-///  secure channel to  |                 | create secure channel to control
-///  project            |                 | via the forwarder
-///                     v                 |
-///                   +-------------------+-------+                 +--------------+
-///                   | Orchestrator      |       | get credentials | Authority    |
-///                   |                   |       |---------------->|              |
-///                   |                   |       |                 |              |
-///                   +------------forwarder------+                 +--------------+
-///                     ^          to control
-///                     |         ^       |
-///  secure channel to  |  create |       |
-///  project            |         |       v
-///                     |         |    "untrusted"
-///                   +--------------secure channel listener--+
-///                   |                                       |
-///                   | Control node                          | "outlet" --> 127.0.0.1:5000
-///                   |                                       |
-///                   +---------------------------------------+
+///       get credentials        +-------------------------------------+
+///       via secure channel     |                                     | Inlet <-- 127.0.0.1:7000
+///              +---------------+              Edge node              | connected to "outlet"
+///              |               |                                     | via secure channel
+///              |               +-------------------------------------+
+///              |                   |                           |
+///              |                   |                           | create secure channel to control
+///              |                   |                           | via the forwarder
+///              v                   v                           |
+///      +--------------+        +-------------------------------+-------+
+///      | Authority    |        |                               |       |
+///      |              |        |             Orchestrator      |       |
+///      |              |        |                               |       |
+///      +--------------+        +---------------------- forwarder ------+
+///              ^                  ^                    to control
+///              |                  |                   ^        |
+///              |                  |            create |        |
+///              |                  |                   |        v
+///              |                  |                   |     "untrusted"  secure channel
+///              |               +---------------------------------------+ listener
+///              |               |                                       |
+///              +---------------|              Control node             | "outlet" --> 127.0.0.1:5000
+///       get credentials        |                                       |
+///       via secure channel     +---------------------------------------+
 ///
-///   - we create initially some secure channels to the Orchestrator in order to retrieve credentials
+///
+///   - we create initially some secure channels to the Authority in order to retrieve credentials
 ///     based on a one-time token generated with `ockam project enroll --attribute component=<name of node>`
 ///
 ///   - then the control node creates a forwarder on the Orchestrator in order to accept TCP traffic without

--- a/examples/rust/get_started/src/attribute_access_control.rs
+++ b/examples/rust/get_started/src/attribute_access_control.rs
@@ -1,0 +1,93 @@
+use ockam::abac::Expr::*;
+use ockam::abac::{eval, Env, Expr};
+use ockam::authenticated_storage::AuthenticatedStorage;
+use ockam::identity::credential::AttributesStorageUtils;
+use ockam::identity::IdentitySecureChannelLocalInfo;
+use ockam::Result;
+use ockam_core::async_trait;
+use ockam_core::compat::boxed::Box;
+use ockam_core::{IncomingAccessControl, RelayMessage};
+use std::fmt::{Debug, Formatter};
+use std::str;
+use std::sync::Arc;
+
+/// Create an IncomingAccessControl which will verify that the sender of
+/// a message has an authenticated attribute with the correct name and value
+pub fn create_attribute_access_control<S>(
+    storage: S,
+    attribute_name: &str,
+    attribute_value: &str,
+) -> Arc<dyn IncomingAccessControl>
+where
+    S: AuthenticatedStorage,
+{
+    let expression = List(vec![
+        Ident("=".into()),
+        Ident(format!("subject.{attribute_name}")),
+        Str(attribute_value.into()),
+    ]);
+    Arc::new(AbacAccessControl::new(storage, expression))
+}
+
+/// This AccessControl uses a storage for authenticated attributes in order
+/// to verify if a policy expression is valid
+pub struct AbacAccessControl<S> {
+    attributes_storage: S,
+    expression: Expr,
+}
+
+impl<S> Debug for AbacAccessControl<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let expression = self.expression.clone();
+        f.write_str(format!("{expression:?}").as_str())
+    }
+}
+
+impl<S> AbacAccessControl<S> {
+    fn new(attributes_storage: S, expression: Expr) -> Self {
+        Self {
+            attributes_storage,
+            expression,
+        }
+    }
+}
+
+#[async_trait]
+impl<S> IncomingAccessControl for AbacAccessControl<S>
+where
+    S: AuthenticatedStorage,
+{
+    /// Return true if the sender of the message is validated by the expression stored in AbacAccessControl
+    async fn is_authorized(&self, msg: &RelayMessage) -> Result<bool> {
+        // Get identity identifier from message metadata:
+        let their_identity_id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info(msg.local_message()) {
+            info.their_identity_id().clone()
+        } else {
+            return Ok(false);
+        };
+
+        // Get identity attributes and populate the environment:
+        let attrs = if let Some(a) =
+            AttributesStorageUtils::get_attributes(&their_identity_id, &self.attributes_storage).await?
+        {
+            a
+        } else {
+            return Ok(false);
+        };
+
+        let mut e = Env::new();
+
+        for (k, v) in &attrs {
+            if let Ok(s) = str::from_utf8(v) {
+                e.put(format!("subject.{k}"), Str(s.to_string()));
+            }
+        }
+
+        // Finally, evaluate the expression and return the result:
+        match eval(&self.expression, &e) {
+            Ok(Bool(b)) => Ok(b),
+            Ok(_) => Ok(false),
+            Err(_) => Ok(false),
+        }
+    }
+}

--- a/examples/rust/get_started/src/credentials.rs
+++ b/examples/rust/get_started/src/credentials.rs
@@ -1,0 +1,26 @@
+use crate::OneTimeCode;
+use anyhow::anyhow;
+use minicbor::Decoder;
+use ockam::identity::credential::Credential;
+use ockam::{Context, Result};
+use ockam_core::api::{Request, Response};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{Error, Route};
+
+/// Using a one-time token created for an identity enrolled with some specific attributes
+/// retrieve its credentials from a central authority
+pub async fn get_credentials(ctx: &Context, authority_route: Route, token: OneTimeCode) -> Result<Credential<'static>> {
+    let request = Request::post("/credential").body(token);
+    let mut buf = Vec::new();
+    request.encode(&mut buf)?;
+
+    let response_bytes: Vec<u8> = ctx.send_and_receive(authority_route.clone(), buf).await?;
+    let mut d = Decoder::new(&response_bytes);
+    let _: Response = d.decode()?;
+    let credentials: Credential = d.decode().map_err(|e| error(format!("{e}")))?;
+    Ok(credentials.to_owned())
+}
+
+fn error(message: String) -> Error {
+    Error::new(Origin::Application, Kind::Invalid, anyhow!(message))
+}

--- a/examples/rust/get_started/src/lib.rs
+++ b/examples/rust/get_started/src/lib.rs
@@ -4,5 +4,14 @@ pub use echoer::*;
 mod hop;
 pub use hop::*;
 
+mod attribute_access_control;
+mod credentials;
 mod logger;
+mod project;
+mod token;
+
+pub use attribute_access_control::*;
+pub use credentials::*;
 pub use logger::*;
+pub use project::*;
+pub use token::*;

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -1,0 +1,102 @@
+use anyhow::anyhow;
+use ockam::identity::{IdentityIdentifier, PublicIdentity};
+use ockam::vault::Vault;
+use ockam_api::multiaddr_to_route;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{Error, Result, Route};
+use ockam_multiaddr::MultiAddr;
+use serde_json::{Map, Value};
+use std::fs::File;
+use std::io::Read;
+use std::str::FromStr;
+
+/// This struct contains the json data exported
+/// when running `ockam project information > project.json`
+pub struct Project {
+    pub project_identifier: IdentityIdentifier,
+    pub authority_public_identity: PublicIdentity,
+    pub authority_route: Route,
+    pub project_route: Route,
+}
+
+/// Accessors for a Project
+impl Project {
+    /// Return the identity identifier of the project
+    pub fn identifier(&self) -> IdentityIdentifier {
+        self.project_identifier.clone()
+    }
+
+    /// Return the public identity of the authority
+    pub fn authority_public_identity(&self) -> PublicIdentity {
+        self.authority_public_identity.clone()
+    }
+
+    /// Return the identifier of the authority
+    pub fn authority_public_identifier(&self) -> IdentityIdentifier {
+        self.authority_public_identity.identifier().clone()
+    }
+
+    /// Return the authority route
+    pub fn authority_route(&self) -> Route {
+        self.authority_route.clone()
+    }
+
+    /// Return the project route
+    pub fn route(&self) -> Route {
+        self.project_route.clone()
+    }
+}
+
+/// Import a project identity into a Vault from a project.json path
+/// and return a Project struct
+pub async fn import_project(path: &str, vault: &Vault) -> Result<Project> {
+    match read_json(path)? {
+        Value::Object(values) => {
+            let project_identifier = IdentityIdentifier::from_str(get_field_as_str(&values, "identity")?.as_str())?;
+
+            let authority_identity = get_field_as_str(&values, "authority_identity")?;
+            let authority_public_identity =
+                PublicIdentity::import(&hex::decode(authority_identity).unwrap(), vault).await?;
+
+            let authority_access_route = get_field_as_str(&values, "authority_access_route")?;
+            let authority_route: Route = multiaddr_to_route(&MultiAddr::from_str(authority_access_route.as_str())?)
+                .ok_or_else(|| error("incorrect multi address"))?;
+
+            let project_access_route = get_field_as_str(&values, "access_route")?;
+            let project_route: Route = multiaddr_to_route(&MultiAddr::from_str(project_access_route.as_str())?)
+                .ok_or_else(|| error("incorrect multi address"))?;
+
+            Ok(Project {
+                project_identifier,
+                authority_public_identity,
+                authority_route,
+                project_route,
+            })
+        }
+        _ => Err(error("incorrect project format")),
+    }
+}
+
+/// Read the contents of a file as JSON
+fn read_json(path: &str) -> Result<Value> {
+    let mut file = File::open(path).map_err(|_| error("Unable to open the file at {path}"))?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    let result: Value =
+        serde_json::from_str(contents.as_ref()).map_err(|e| error(format!("incorrect json content: {e}").as_str()))?;
+    Ok(result)
+}
+
+/// Return the value of a given key as a String (if the field name exists)
+fn get_field_as_str(values: &Map<String, Value>, field_name: &str) -> Result<String> {
+    (*values)
+        .get(field_name)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| error(format!("missing field '{field_name}'").as_str()))
+        .map(|s| s.to_owned())
+}
+
+/// Utility function to create an Error in this file
+fn error(message: &str) -> Error {
+    Error::new(Origin::Application, Kind::Invalid, anyhow!(message.to_string()))
+}

--- a/examples/rust/get_started/src/token.rs
+++ b/examples/rust/get_started/src/token.rs
@@ -1,0 +1,73 @@
+use anyhow::anyhow;
+use minicbor::bytes::ByteArray;
+use minicbor::{Decode, Encode};
+use ockam::Result;
+use ockam_core::compat::rand;
+use ockam_core::compat::rand::RngCore;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::Error;
+use std::process::Command;
+use std::str;
+
+/// Invoke the `ockam` command line in order to create a one-time token for
+/// a given attribute name/value (and the default project on this machine)
+pub async fn create_token(attribute_name: &str, attribute_value: &str) -> Result<OneTimeCode> {
+    let token_output = Command::new("ockam")
+        .args(vec![
+            "project",
+            "enroll",
+            "--attribute",
+            format!("{attribute_name}={attribute_value}").as_str(),
+        ])
+        .env_remove("OCKAM_LOG") // make sure that OCKAM_LOG is not set, otherwise the output will contain more than the token
+        .output()
+        .map_err(|e| error(format!("could not run the `ockam project enroll` successfully: {e:?}")))?;
+
+    // we unwrap the result of decoding the token as UTF-8 since it should be some valid UTF-8 string
+    let token_string = str::from_utf8(token_output.stdout.as_slice()).unwrap().trim();
+    otc_parser(token_string)
+}
+
+/// Parse the token created by the `ockam project enroll --attribute attribute_name=attribute_value` command
+pub fn otc_parser(val: &str) -> Result<OneTimeCode> {
+    let bytes = hex::decode(val).map_err(|e| error(format!("{e}")))?;
+    let code = <[u8; 32]>::try_from(bytes.as_slice()).map_err(|e| error(format!("{e}")))?;
+    Ok(code.into())
+}
+
+/// A one-time code to enroll a member.
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct OneTimeCode {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<5112299>,
+    #[n(1)] code: ByteArray<32>,
+}
+
+impl OneTimeCode {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let mut code = [0; 32];
+        rand::thread_rng().fill_bytes(&mut code);
+        OneTimeCode::from(code)
+    }
+
+    pub fn code(&self) -> &[u8; 32] {
+        &self.code
+    }
+}
+
+impl From<[u8; 32]> for OneTimeCode {
+    fn from(code: [u8; 32]) -> Self {
+        OneTimeCode {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            code: code.into(),
+        }
+    }
+}
+
+fn error(message: String) -> Error {
+    Error::new(Origin::Application, Kind::Invalid, anyhow!(message))
+}


### PR DESCRIPTION
## Current Behavior

We currently a command-line example showing how to use authenticated attributes to [create a TCP portal between a device and its server, using a relay](https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac).

## Proposed Changes

This PR provides an implementation of this scenario only using the Rust library.
In order to support it some code had to be added, with dependencies to additional crates, to:

  - retrieve project information
  - create a one time token (because the CBOR serialization needed to retrieve credentials is very specific)

The next PR will propose a refactoring so that:

  1. the `OneTimeCode` struct is moved to the `ockam_identity` crate so that it becomes available by using the `ockam` crate
  2. 
  3. the example can use the `ockam_command` crate to read the project information (see the `ProjectInfo` struct in `ockam_command`) from a JSON file. This is mostly for convenience. It would also be possible to manually parse the data contained into the project JSON file into the necessary routes and identities


