### PR TITLE
fix(rust): fix credentials-check usage on portals and sec. channel commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -35,6 +35,7 @@ pub struct CreateSecureChannelRequest<'a> {
     #[n(3)] pub credential_exchange_mode: CredentialExchangeMode,
     #[n(4)] pub timeout: Option<Duration>,
     #[b(5)] pub identity: Option<CowStr<'a>>,
+    #[n(6)] pub check_credentials: Option<bool>,
 }
 
 impl<'a> CreateSecureChannelRequest<'a> {
@@ -42,6 +43,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
         addr: &MultiAddr,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
         credential_exchange_mode: CredentialExchangeMode,
+        check_credentials: Option<bool>,
         identity: Option<String>,
     ) -> Self {
         Self {
@@ -51,6 +53,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
             authorized_identifiers: authorized_identifiers
                 .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
             credential_exchange_mode,
+            check_credentials,
             timeout: None,
             identity: identity.map(|x| x.into()),
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -350,7 +350,7 @@ impl NodeManager {
                 let i = Some(vec![i]);
                 let m = CredentialExchangeMode::Oneway;
                 let w = self
-                    .create_secure_channel_impl(r, i, m, timeout, None, ctx)
+                    .create_secure_channel_impl(r, i, m, None, timeout, None, ctx)
                     .await?;
                 let a = MultiAddr::default().try_with(addr.iter().skip(1))?;
                 return Ok((try_address_to_multiaddr(&w)?, a));
@@ -364,7 +364,7 @@ impl NodeManager {
             let i = auth.clone().map(|i| vec![i]);
             let m = CredentialExchangeMode::Mutual;
             let w = self
-                .create_secure_channel_impl(r, i, m, timeout, None, ctx)
+                .create_secure_channel_impl(r, i, m, None, timeout, None, ctx)
                 .await?;
             return Ok((try_address_to_multiaddr(&w)?, b));
         }
@@ -376,7 +376,7 @@ impl NodeManager {
             let i = auth.clone().map(|i| vec![i]);
             let m = CredentialExchangeMode::Mutual;
             let w = self
-                .create_secure_channel_impl(r, i, m, timeout, None, ctx)
+                .create_secure_channel_impl(r, i, m, None, timeout, None, ctx)
                 .await?;
             return Ok((try_address_to_multiaddr(&w)?, MultiAddr::default()));
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -11,7 +11,7 @@ use minicbor::Decoder;
 use ockam::compat::asynchronous::RwLock;
 use ockam::compat::tokio::time::timeout;
 use ockam::{Address, AsyncTryClone, Result};
-use ockam_abac::expr::{and, eq, ident, str};
+use ockam_abac::expr::{eq, ident, str};
 use ockam_abac::{Action, Env, PolicyAccessControl, PolicyStorage, Resource};
 use ockam_core::api::{Request, Response, ResponseBuilder};
 use ockam_core::{AllowAll, IncomingAccessControl};
@@ -42,10 +42,7 @@ impl NodeManager {
             // Check if a policy exists for (resource, action) and if not, then
             // create a default entry:
             if self.policies.get_policy(r, a).await?.is_none() {
-                let fallback = and([
-                    eq([ident("resource.project_id"), ident("subject.project_id")]),
-                    eq([ident("subject.role"), str("member")]),
-                ]);
+                let fallback = eq([ident("resource.project_id"), ident("subject.project_id")]);
                 self.policies.set_policy(r, a, &fallback).await?
             }
             let store = self.authenticated_storage.clone();

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -21,7 +21,7 @@ pub struct LogCommand {
 impl LogCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         if let Err(e) = run_impl(opts, self) {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(e.code());
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -119,6 +119,7 @@ pub async fn create_secure_channel_to_project(
         project_access_route,
         Some(authorized_identifier),
         credential_exchange_mode,
+        None,
         identity,
     );
     let req = Request::post("/node/secure_channel").body(payload);
@@ -143,6 +144,7 @@ pub async fn create_secure_channel_to_authority(
         addr,
         Some(allowed),
         CredentialExchangeMode::None,
+        Some(false),
         identity,
     );
     let req = Request::post("/node/secure_channel").body(payload);

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -32,13 +32,8 @@ pub struct CreateCommand {
 
     /// Enable credentials authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
-    #[arg(long, display_order = 900, conflicts_with = "disable_check_credential")]
+    #[arg(long, display_order = 900, default_value = "false")]
     check_credential: bool,
-
-    /// Disable credentials authorization.
-    /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
-    #[arg(long, display_order = 900, conflicts_with = "check_credential")]
-    disable_check_credential: bool,
 
     /// Assign a name to this outlet.
     #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser)]
@@ -51,13 +46,7 @@ impl CreateCommand {
     }
 
     pub fn check_credential(&self) -> Option<bool> {
-        if self.check_credential {
-            Some(true)
-        } else if self.disable_check_credential {
-            Some(false)
-        } else {
-            None
-        }
+        Some(self.check_credential)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -526,7 +526,7 @@ teardown() {
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM node create blue
-  $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   $OCKAM forwarder create blue --at /project/default --to /node/blue
 
   $OCKAM node create green
@@ -541,7 +541,7 @@ teardown() {
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM node create blue
-  $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   $OCKAM forwarder create blue --at /project/default --to /node/blue
 
   $OCKAM node create green
@@ -575,7 +575,7 @@ teardown() {
   assert_success
 
   export OCKAM_HOME=/tmp/ockam
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   assert_success
 
   run $OCKAM forwarder create blue --at /project/default --to /node/blue
@@ -617,7 +617,7 @@ teardown() {
   assert_success
 
   export OCKAM_HOME=/tmp/ockam
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
@@ -654,7 +654,7 @@ teardown() {
   assert_success
 
   OCKAM_HOME=/tmp/ockam
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   assert_success
   run  $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"
@@ -693,7 +693,7 @@ teardown() {
   run $OCKAM policy set --at blue --resource tcp-outlet --expression '(= subject.app "app1")'
   assert_success
 
-  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
+  run $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000 --check-credential
   assert_success
   run $OCKAM forwarder create blue --at /project/default --to /node/blue
   assert_output --partial "forward_to_blue"


### PR DESCRIPTION
## Bug description

Once we are enrolled, every tcp-outlet will be created with an access control rule that only allows access from inlets pointing to the project node. A similar problem happens with the `secure-channel create` command.

## Fix applied

`tcp-outlet create` command will have check_credentials=false by default. The tcp-inlet will have a small hack to automatically enable credentials only if the target route is a project; will be disabled in any other case. This won’t work if going through an explicit secure channel from the inlet to the project (as the route won't explicitly reference the project).

A more correct fix would be to better use access control rules at the command layer. Since a user starts with no projects, maybe `IdentityIdAccessControl` could be a good default (better than `AllowAll`). For the other use case (access an outlet from a forwarder on a project node), we should explicitly pass a flag to indicate that it should use the background node’s project id to set up the access control.

* ✅ [CI bats](https://github.com/build-trust/ockam-artifacts/actions/runs/4132950204)
* ❗ [ABAC example](https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac) not working entirely. The tcp-outlet doesn’t seem to apply the credential checks
