### PR TITLE
refactor: move the `OneTimeCode` struct from the ockam_api crate to the ockam_identity crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "ockam_transport_tcp",
  "ockam_vault",
  "quickcheck",
+ "quickcheck_macros",
  "rand 0.8.5",
  "rand_xorshift",
  "serde",
@@ -3696,6 +3697,17 @@ dependencies = [
  "env_logger",
  "log",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
@@ -3,13 +3,15 @@ pub mod types;
 use core::{fmt, str};
 use lru::LruCache;
 use minicbor::{Decoder, Encode};
+use ockam::identity::authenticated_storage::AuthenticatedStorage;
+use ockam::identity::credential::{Credential, OneTimeCode, SchemaId};
+use ockam::identity::{
+    Identity, IdentityIdentifier, IdentitySecureChannelLocalInfo, IdentityVault,
+};
 use ockam_core::api::{self, assert_request_match, assert_response_match};
 use ockam_core::api::{Error, Method, Request, RequestBuilder, Response, ResponseBuilder, Status};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{self, Address, DenyAll, Result, Route, Routed, Worker};
-use ockam_identity::authenticated_storage::AuthenticatedStorage;
-use ockam_identity::credential::{Credential, SchemaId};
-use ockam_identity::{Identity, IdentityIdentifier, IdentitySecureChannelLocalInfo, IdentityVault};
 use ockam_node::Context;
 use serde_json as json;
 use std::collections::HashMap;
@@ -19,7 +21,7 @@ use std::time::{Duration, Instant};
 use tracing::{trace, warn};
 use types::AddMember;
 
-use crate::authenticator::direct::types::{CreateToken, OneTimeCode};
+use crate::authenticator::direct::types::CreateToken;
 
 use self::types::Enroller;
 

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
@@ -1,6 +1,4 @@
-use minicbor::bytes::ByteArray;
 use minicbor::{Decode, Encode};
-use ockam::compat::rand::{self, RngCore};
 use ockam_core::CowStr;
 use ockam_identity::IdentityIdentifier;
 use serde::{Deserialize, Serialize};
@@ -81,38 +79,5 @@ impl<'a> CreateToken<'a> {
             .into_iter()
             .map(|(k, v)| (k.into_owned(), v.into_owned()))
             .collect()
-    }
-}
-
-/// A one-time code to enroll a member.
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct OneTimeCode {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<5112299>,
-    #[n(1)] code: ByteArray<32>,
-}
-
-impl OneTimeCode {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        let mut code = [0; 32];
-        rand::thread_rng().fill_bytes(&mut code);
-        OneTimeCode::from(code)
-    }
-
-    pub fn code(&self) -> &[u8; 32] {
-        &self.code
-    }
-}
-
-impl From<[u8; 32]> for OneTimeCode {
-    fn from(code: [u8; 32]) -> Self {
-        OneTimeCode {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            code: code.into(),
-        }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -3,6 +3,8 @@
 use minicbor::Decoder;
 
 use ockam::compat::asynchronous::RwLock;
+use ockam::identity::credential::OneTimeCode;
+use ockam::identity::{Identity, IdentityIdentifier, PublicIdentity};
 use ockam::{Address, Context, ForwardingService, Result, Routed, TcpTransport, Worker};
 use ockam_core::api::{Error, Method, Request, Response, ResponseBuilder, Status};
 use ockam_core::compat::{
@@ -12,7 +14,6 @@ use ockam_core::compat::{
 };
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{AllowAll, AsyncTryClone};
-use ockam_identity::{Identity, IdentityIdentifier, PublicIdentity};
 use ockam_multiaddr::proto::{Project, Secure};
 use ockam_multiaddr::{MultiAddr, Protocol};
 use ockam_node::tokio;
@@ -25,7 +26,6 @@ use std::time::Duration;
 
 use super::models::secure_channel::CredentialExchangeMode;
 use super::registry::Registry;
-use crate::authenticator::direct::types::OneTimeCode;
 use crate::cli_state::CliState;
 use crate::config::cli::AuthoritiesConfig;
 use crate::config::lookup::ProjectLookup;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use minicbor::Decoder;
-use ockam_identity::credential::Credential;
+use ockam::identity::credential::{Credential, OneTimeCode};
 use rand::prelude::random;
 use tokio::io::AsyncBufReadExt;
 
@@ -31,7 +31,6 @@ use ockam::{Address, AsyncTryClone, TCP};
 use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::transport::CreateTransportJson;
 use ockam_api::{
-    authenticator::direct::types::OneTimeCode,
     nodes::models::transport::{TransportMode, TransportType},
     nodes::{
         service::{

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -7,9 +7,9 @@ use std::fs::OpenOptions;
 use std::path::Path;
 use std::process::Command;
 
+use ockam::identity::credential::OneTimeCode;
 use ockam::identity::{Identity, PublicIdentity};
 use ockam::{Context, TcpTransport};
-use ockam_api::authenticator::direct::types::OneTimeCode;
 use ockam_api::cli_state;
 use ockam_api::config::cli;
 use ockam_api::nodes::models::transport::{TransportMode, TransportType};

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -1,8 +1,9 @@
 use clap::Args;
+use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _};
+use ockam::identity::credential::OneTimeCode;
 use ockam::Context;
-use ockam_api::authenticator::direct::types::OneTimeCode;
 use ockam_api::cloud::enroll::auth0::AuthenticateAuth0Token;
 use ockam_api::cloud::project::OktaAuth0;
 use ockam_core::api::{Request, Status};
@@ -27,7 +28,7 @@ pub struct AuthCommand {
     #[arg(long = "okta", group = "authentication_method")]
     okta: bool,
 
-    #[arg(long = "token", group = "authentication_method", value_name = "ENROLLMENT TOKEN", value_parser = otc_parser)]
+    #[arg(long = "token", group = "authentication_method", value_name = "ENROLLMENT TOKEN", value_parser = OneTimeCode::from_str)]
     token: Option<OneTimeCode>,
 
     #[command(flatten)]
@@ -149,11 +150,4 @@ async fn authenticate_through_okta(
         eprintln!("{}", rpc.parse_err_msg(res, dec));
         Err(anyhow!("Failed to enroll").into())
     }
-}
-
-//TODO: copy-pasted from node/create.rs
-fn otc_parser(val: &str) -> anyhow::Result<OneTimeCode> {
-    let bytes = hex::decode(val)?;
-    let code = <[u8; 32]>::try_from(bytes.as_slice())?;
-    Ok(code.into())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -2,9 +2,10 @@ use clap::Args;
 use std::collections::HashMap;
 
 use anyhow::{anyhow, Context as _};
+use ockam::identity::credential::OneTimeCode;
 use ockam::identity::IdentityIdentifier;
 use ockam::Context;
-use ockam_api::authenticator::direct::types::{AddMember, CreateToken, OneTimeCode};
+use ockam_api::authenticator::direct::types::{AddMember, CreateToken};
 use ockam_api::config::lookup::{ConfigLookup, ProjectAuthority};
 use ockam_core::api::Request;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
@@ -113,7 +114,7 @@ impl Runner {
                 .body(CreateToken::new().with_attributes(self.cmd.attributes()?));
             rpc.request(req).await?;
             let res: OneTimeCode = rpc.parse_response()?;
-            println!("{}", hex::encode(res.code()))
+            println!("{}", res.to_string())
         }
 
         delete_embedded_node(&self.opts, &node_name).await;

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -11,15 +11,13 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use minicbor::{Decode, Encode};
+use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::Context;
 use ockam_api::{
-    authenticator::direct::{types::OneTimeCode, Client},
-    config::lookup::ProjectLookup,
-    nodes::models::secure_channel::CredentialExchangeMode,
-    DefaultAddress,
+    authenticator::direct::Client, config::lookup::ProjectLookup,
+    nodes::models::secure_channel::CredentialExchangeMode, DefaultAddress,
 };
 use ockam_core::api::RequestBuilder;
-use ockam_identity::credential::Credential;
 use ockam_multiaddr::MultiAddr;
 use tracing::info;
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -30,5 +30,12 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
         .arg("project-id");
     cmd.assert().success();
 
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(prefix_args)
+        .arg("authenticate")
+        .arg("--token")
+        .arg("02043d7bc316467b25b8df7118f4d1ba4b1911284236a3f94d8017ac7faff625");
+    cmd.assert().success();
+
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -86,5 +86,6 @@ ockam_transport_tcp = { path = "../ockam_transport_tcp" }
 ockam_vault = { path = "../ockam_vault", version = "^0.70.0" }
 zeroize = { version = "1.4.2" }
 quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 rand_xorshift = "0"
 tokio = { version = "1.25", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -6,7 +6,9 @@ mod storage_utils;
 mod worker;
 
 pub mod access_control;
+pub mod one_time_code;
 
+pub use one_time_code::*;
 pub use storage_utils::*;
 
 use crate::IdentityIdentifier;

--- a/implementations/rust/ockam/ockam_identity/src/credential/one_time_code.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/one_time_code.rs
@@ -1,0 +1,114 @@
+use core::str::FromStr;
+use minicbor::bytes::ByteArray;
+use minicbor::{Decode, Encode};
+use ockam_core::compat::rand;
+use ockam_core::compat::rand::RngCore;
+use ockam_core::compat::string::{String, ToString};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::Error;
+use ockam_core::Result;
+
+/// A one-time code can be used to enroll
+/// a node with some authenticated attributes
+/// It can be retrieve with a command like `ockam project enroll --attribute component=control`
+#[derive(Debug, Clone, Decode, Encode, PartialEq)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct OneTimeCode {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<5112299>,
+    #[n(1)] code: ByteArray<32>,
+}
+
+impl OneTimeCode {
+    /// Create a random token
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let mut code = [0; 32];
+        rand::thread_rng().fill_bytes(&mut code);
+        OneTimeCode::from(code)
+    }
+
+    /// Return the code as a byte slice
+    pub fn code(&self) -> &[u8; 32] {
+        &self.code
+    }
+}
+
+impl From<[u8; 32]> for OneTimeCode {
+    /// Create a OneTimeCode from a byte slice
+    fn from(code: [u8; 32]) -> Self {
+        OneTimeCode {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            code: code.into(),
+        }
+    }
+}
+
+impl FromStr for OneTimeCode {
+    type Err = Error;
+
+    /// Create a OneTimeCode from a string slice
+    /// The code is expected to be encoded as hexadecimal
+    fn from_str(s: &str) -> Result<Self> {
+        let bytes = hex::decode(s).map_err(|e| error(format!("{e}")))?;
+        let code: OneTimeCode = OneTimeCode::from(
+            <[u8; 32]>::try_from(bytes.as_slice()).map_err(|e| error(format!("{e}")))?,
+        );
+        Ok(code)
+    }
+}
+
+impl ToString for OneTimeCode {
+    /// Return the OneTimeCode as a String
+    /// It is encoded as hexadecimal
+    fn to_string(&self) -> String {
+        hex::encode(self.code())
+    }
+}
+
+/// Create an Identity Error
+fn error(message: String) -> Error {
+    Error::new(Origin::Identity, Kind::Invalid, message.as_str())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use quickcheck::{Arbitrary, Gen};
+    use quickcheck_macros::quickcheck;
+
+    #[quickcheck]
+    fn test_from_to_string(one_time_code: OneTimeCode) -> bool {
+        OneTimeCode::from_str(one_time_code.to_string().as_str()).ok() == Some(one_time_code)
+    }
+
+    impl Arbitrary for OneTimeCode {
+        fn arbitrary(g: &mut Gen) -> Self {
+            OneTimeCode::from(Bytes32::arbitrary(g).bytes)
+        }
+    }
+
+    /// Newtype to generate an arbitrary array of 32 bytes
+    /// This can be refactored into a ockam_quickcheck crate if we accumulate
+    /// more useful arbitraries which can be shared by several crates
+    #[derive(Clone)]
+    struct Bytes32 {
+        bytes: [u8; 32],
+    }
+
+    impl Arbitrary for Bytes32 {
+        fn arbitrary(g: &mut Gen) -> Bytes32 {
+            let init: [u8; 32] = <[u8; 32]>::default();
+            Bytes32 {
+                bytes: init.map(|_| <u8>::arbitrary(g)),
+            }
+        }
+
+        /// there is no meaningful shrinking in general for a random array of bytes
+        fn shrink(&self) -> Box<dyn Iterator<Item = Bytes32>> {
+            Box::new(std::iter::empty())
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the `OneTimeCode` struct to the same crate as the `Credential` struct.

When retrieving credentials we can send a `OneTimeCode` and get back a `Credential` so it makes sense to put them together in the same crate.

Additional improvements:

  - I better encapsulated the encoding / decoding of the `OneTimeCode` as a `String`
  - I removed some duplicated code to parse a `OneTimeCode`
  - I added a command line arguments parsing test for authenticated with a token