### PR TITLE
Refactor: use the `OneTimeCode` coming from the identity crate

### DIFF
--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -1,7 +1,7 @@
-use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project, OneTimeCode};
+use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project};
 use ockam::access_control::AllowAll;
 use ockam::identity::authenticated_storage::{mem::InMemoryStorage, AuthenticatedAttributeStorage};
-use ockam::identity::credential::Credential;
+use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
 
 use ockam::remote::RemoteForwarder;

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -1,6 +1,6 @@
-use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project, OneTimeCode};
+use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project};
 use ockam::identity::authenticated_storage::{mem::InMemoryStorage, AuthenticatedAttributeStorage};
-use ockam::identity::credential::Credential;
+use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
 use ockam::{route, vault::Vault, AsyncTryClone, Context, Result, TcpTransport};
 use ockam_core::IncomingAccessControl;

--- a/examples/rust/get_started/src/credentials.rs
+++ b/examples/rust/get_started/src/credentials.rs
@@ -1,7 +1,6 @@
-use crate::OneTimeCode;
 use anyhow::anyhow;
 use minicbor::Decoder;
-use ockam::identity::credential::Credential;
+use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::{Context, Result};
 use ockam_core::api::{Request, Response};
 use ockam_core::errcode::{Kind, Origin};

--- a/examples/rust/get_started/src/token.rs
+++ b/examples/rust/get_started/src/token.rs
@@ -1,13 +1,11 @@
 use anyhow::anyhow;
-use minicbor::bytes::ByteArray;
-use minicbor::{Decode, Encode};
+use ockam::identity::credential::OneTimeCode;
 use ockam::Result;
-use ockam_core::compat::rand;
-use ockam_core::compat::rand::RngCore;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Error;
 use std::process::Command;
 use std::str;
+use std::str::FromStr;
 
 /// Invoke the `ockam` command line in order to create a one-time token for
 /// a given attribute name/value (and the default project on this machine)
@@ -25,47 +23,7 @@ pub async fn create_token(attribute_name: &str, attribute_value: &str) -> Result
 
     // we unwrap the result of decoding the token as UTF-8 since it should be some valid UTF-8 string
     let token_string = str::from_utf8(token_output.stdout.as_slice()).unwrap().trim();
-    otc_parser(token_string)
-}
-
-/// Parse the token created by the `ockam project enroll --attribute attribute_name=attribute_value` command
-pub fn otc_parser(val: &str) -> Result<OneTimeCode> {
-    let bytes = hex::decode(val).map_err(|e| error(format!("{e}")))?;
-    let code = <[u8; 32]>::try_from(bytes.as_slice()).map_err(|e| error(format!("{e}")))?;
-    Ok(code.into())
-}
-
-/// A one-time code to enroll a member.
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct OneTimeCode {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<5112299>,
-    #[n(1)] code: ByteArray<32>,
-}
-
-impl OneTimeCode {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        let mut code = [0; 32];
-        rand::thread_rng().fill_bytes(&mut code);
-        OneTimeCode::from(code)
-    }
-
-    pub fn code(&self) -> &[u8; 32] {
-        &self.code
-    }
-}
-
-impl From<[u8; 32]> for OneTimeCode {
-    fn from(code: [u8; 32]) -> Self {
-        OneTimeCode {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            code: code.into(),
-        }
-    }
+    OneTimeCode::from_str(token_string)
 }
 
 fn error(message: String) -> Error {


### PR DESCRIPTION
Instead of the temporary one in the credentials example.
