### PR TITLE
refactor: use credential instead of credentials

### DIFF
--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -1,4 +1,4 @@
-use hello_ockam::{create_attribute_access_control, create_token, get_credentials, import_project};
+use hello_ockam::{create_attribute_access_control, create_token, get_credential, import_project};
 use ockam::access_control::AllowAll;
 use ockam::identity::authenticated_storage::{mem::InMemoryStorage, AuthenticatedAttributeStorage};
 use ockam::identity::credential::{Credential, OneTimeCode};
@@ -6,6 +6,7 @@ use ockam::identity::{Identity, TrustEveryonePolicy, TrustMultiIdentifiersPolicy
 
 use ockam::remote::RemoteForwarder;
 use ockam::{route, vault::Vault, AsyncTryClone, Context, Result, TcpTransport};
+use ockam_api::DefaultAddress;
 use ockam_core::IncomingAccessControl;
 use std::sync::Arc;
 use std::time::Duration;
@@ -56,7 +57,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     let control_plane = Identity::create_ext(&ctx, &storage, &vault).await?;
 
     // 2. create a secure channel to the authority
-    //    to retrieve the node credentials
+    //    to retrieve the node credential
 
     // Import the authority identity and route from the information file
     let project = import_project(project_information_path, &vault).await?;
@@ -71,14 +72,15 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         )
         .await?;
 
-    let credentials: Credential = get_credentials(&ctx, route![secure_channel, "authenticator"], token).await?;
-    println!("{credentials}");
+    let credential: Credential =
+        get_credential(&ctx, route![secure_channel, DefaultAddress::AUTHENTICATOR], token).await?;
+    println!("{credential}");
 
-    // store the credentials and start a credentials exchange worker which will be
+    // store the credential and start a credential exchange worker which will be
     // later on to exchange credentials with the edge node
-    control_plane.set_credential(credentials.to_owned()).await;
+    control_plane.set_credential(credential.to_owned()).await;
     control_plane
-        .start_credentials_exchange_worker(
+        .start_credential_exchange_worker(
             vec![project.authority_public_identity()],
             "credential_exchange",
             true,
@@ -109,9 +111,12 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         .await?;
     println!("secure channel to project: {secure_channel_address:?}");
 
-    // present this node credentials to the project
+    // present this node credential to the project
     control_plane
-        .present_credential(route![secure_channel_address.clone(), "credentials"])
+        .present_credential(route![
+            secure_channel_address.clone(),
+            DefaultAddress::CREDENTIALS_SERVICE
+        ])
         .await?;
 
     // finally create a forwarder using the secure channel to the project

--- a/examples/rust/get_started/examples/11-attribute-based-authentication.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication.rs
@@ -1,6 +1,6 @@
 /// INTRODUCTION
 ///
-/// This example shows how to use attribute-based credentials in order to have
+/// This example shows how to use attribute-based credential in order to have
 /// several devices connecting to a server, via the Ockam Orchestrator.
 ///
 /// The corresponding example using the command-line can be found here: https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac.
@@ -38,7 +38,7 @@
 ///
 /// The network we establish between the control node, the edge node and the Orchestrator is the following
 ///
-///       get credentials        +-------------------------------------+
+///       get credential         +-------------------------------------+
 ///       via secure channel     |                                     | Inlet <-- 127.0.0.1:7000
 ///              +---------------+              Edge node              | connected to "outlet"
 ///              |               |                                     | via secure channel
@@ -60,11 +60,11 @@
 ///              |               +---------------------------------------+ listener
 ///              |               |                                       |
 ///              +---------------|              Control node             | "outlet" --> 127.0.0.1:5000
-///       get credentials        |                                       |
+///       get credential         |                                       |
 ///       via secure channel     +---------------------------------------+
 ///
 ///
-///   - we create initially some secure channels to the Authority in order to retrieve credentials
+///   - we create initially some secure channels to the Authority in order to retrieve credential
 ///     based on a one-time token generated with `ockam project enroll --attribute component=<name of node>`
 ///
 ///   - then the control node creates a forwarder on the Orchestrator in order to accept TCP traffic without
@@ -85,7 +85,7 @@
 ///  - examples/11-attribute-based-authentication-edge-plane.rs: for the edge node
 ///  - src/project.rs: read the content of the project.json file
 ///  - src/token.rs: generate a one-time token using the ockam command line
-///  - src/credentials.rs: retrieve the credentials of a node from an authority (using the token above)
+///  - src/credentials.rs: retrieve the credential of a node from an authority (using the token above)
 ///  - src/attribute_access_control: example of creating an access control policy for one attribute only
 ///
 

--- a/examples/rust/get_started/src/credentials.rs
+++ b/examples/rust/get_started/src/credentials.rs
@@ -7,8 +7,8 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{Error, Route};
 
 /// Using a one-time token created for an identity enrolled with some specific attributes
-/// retrieve its credentials from a central authority
-pub async fn get_credentials(ctx: &Context, authority_route: Route, token: OneTimeCode) -> Result<Credential<'static>> {
+/// retrieve its credential from a central authority
+pub async fn get_credential(ctx: &Context, authority_route: Route, token: OneTimeCode) -> Result<Credential<'static>> {
     let request = Request::post("/credential").body(token);
     let mut buf = Vec::new();
     request.encode(&mut buf)?;
@@ -16,8 +16,8 @@ pub async fn get_credentials(ctx: &Context, authority_route: Route, token: OneTi
     let response_bytes: Vec<u8> = ctx.send_and_receive(authority_route.clone(), buf).await?;
     let mut d = Decoder::new(&response_bytes);
     let _: Response = d.decode()?;
-    let credentials: Credential = d.decode().map_err(|e| error(format!("{e}")))?;
-    Ok(credentials.to_owned())
+    let credential: Credential = d.decode().map_err(|e| error(format!("{e}")))?;
+    Ok(credential.to_owned())
 }
 
 fn error(message: String) -> Error {

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -34,7 +34,7 @@ impl DefaultAddress {
     pub const UPPERCASE_SERVICE: &'static str = "uppercase";
     pub const ECHO_SERVICE: &'static str = "echo";
     pub const HOP_SERVICE: &'static str = "hop";
-    pub const CREDENTIAL_SERVICE: &'static str = "credentials";
+    pub const CREDENTIALS_SERVICE: &'static str = "credentials";
     pub const SECURE_CHANNEL_LISTENER: &'static str = "api";
     pub const AUTHENTICATOR: &'static str = "authenticator";
     pub const VERIFIER: &'static str = "verifier";

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
@@ -1,4 +1,4 @@
-//! Credentials request/response types
+//! Credential request/response types
 
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -26,7 +26,7 @@ pub struct CreateInlet<'a> {
     #[n(2)] outlet_addr: MultiAddr,
     /// A human-friendly alias for this portal endpoint
     #[b(3)] alias: Option<CowStr<'a>>,
-    /// Enable credentials authorization.
+    /// Enable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[n(4)] check_credential: Option<bool>,
     /// An authorised identity for secure channels.
@@ -103,7 +103,7 @@ pub struct CreateOutlet<'a> {
     #[b(2)] pub worker_addr: Cow<'a, str>,
     /// A human-friendly alias for this portal endpoint
     #[b(3)] pub alias: Option<CowStr<'a>>,
-    /// Enable credentials authorization.
+    /// Enable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[n(4)] pub check_credential: Option<bool>,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -338,15 +338,15 @@ impl NodeManager {
 
         self.create_secure_channel_listener_impl(
             DefaultAddress::SECURE_CHANNEL_LISTENER.into(),
-            None, // Not checking identifiers here in favor of credentials check
+            None, // Not checking identifiers here in favor of credential check
             None,
             ctx,
         )
         .await?;
 
-        // If we've been configured with authorities, we can start Credentials Exchange service
+        // If we've been configured with authorities, we can start Credential Exchange service
         if self.authorities().is_ok() {
-            self.start_credentials_service_impl(DefaultAddress::CREDENTIAL_SERVICE.into(), false)
+            self.start_credentials_service_impl(DefaultAddress::CREDENTIALS_SERVICE.into(), false)
                 .await?;
         }
 
@@ -500,7 +500,7 @@ impl NodeManagerWorker {
                 self.delete_transport(req, dec).await?.to_vec()?
             }
 
-            // ==*== Credentials ==*==
+            // ==*== Credential ==*==
             (Post, ["node", "credentials", "actions", "get"]) => self
                 .get_credential(req, dec)
                 .await?
@@ -536,45 +536,45 @@ impl NodeManagerWorker {
                 .to_vec()?,
 
             // ==*== Services ==*==
-            (Post, ["node", "services", "vault"]) => {
+            (Post, ["node", "services", DefaultAddress::VAULT_SERVICE]) => {
                 self.start_vault_service(ctx, req, dec).await?.to_vec()?
             }
-            (Post, ["node", "services", "identity"]) => {
+            (Post, ["node", "services", DefaultAddress::IDENTITY_SERVICE]) => {
                 self.start_identity_service(ctx, req, dec).await?.to_vec()?
             }
-            (Post, ["node", "services", "authenticated"]) => self
+            (Post, ["node", "services", DefaultAddress::AUTHENTICATED_SERVICE]) => self
                 .start_authenticated_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
-            (Post, ["node", "services", "uppercase"]) => self
+            (Post, ["node", "services", DefaultAddress::UPPERCASE_SERVICE]) => self
                 .start_uppercase_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
-            (Post, ["node", "services", "echo"]) => {
+            (Post, ["node", "services", DefaultAddress::ECHO_SERVICE]) => {
                 self.start_echoer_service(ctx, req, dec).await?.to_vec()?
             }
-            (Post, ["node", "services", "hop"]) => {
+            (Post, ["node", "services", DefaultAddress::HOP_SERVICE]) => {
                 self.start_hop_service(ctx, req, dec).await?.to_vec()?
             }
-            (Post, ["node", "services", "authenticator"]) => self
+            (Post, ["node", "services", DefaultAddress::AUTHENTICATOR]) => self
                 .start_authenticator_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
-            (Post, ["node", "services", "verifier"]) => {
+            (Post, ["node", "services", DefaultAddress::VERIFIER]) => {
                 self.start_verifier_service(ctx, req, dec).await?.to_vec()?
             }
-            (Post, ["node", "services", "credentials"]) => self
+            (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => self
                 .start_credentials_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
-            (Post, ["node", "services", "okta_identity_provider"]) => self
+            (Post, ["node", "services", DefaultAddress::OKTA_IDENTITY_PROVIDER]) => self
                 .start_okta_identity_provider_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
-            (Post, ["node", "services", "kafka_consumer"]) => {
+            (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
                 self.start_kafka_consumer_service(ctx, req, dec).await?
             }
-            (Post, ["node", "services", "kafka_producer"]) => {
+            (Post, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => {
                 self.start_kafka_producer_service(ctx, req, dec).await?
             }
             (Get, ["node", "services"]) => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -122,7 +122,10 @@ impl NodeManager {
                 debug!(%sc_addr, "One-way credential presentation");
                 self.get_credential_if_needed().await?;
                 identity
-                    .present_credential(route![sc_addr.clone(), DefaultAddress::CREDENTIAL_SERVICE])
+                    .present_credential(route![
+                        sc_addr.clone(),
+                        DefaultAddress::CREDENTIALS_SERVICE
+                    ])
                     .await?;
                 debug!(%sc_addr, "One-way credential presentation success");
             }
@@ -132,7 +135,7 @@ impl NodeManager {
                 let authorities = self.authorities()?;
                 identity
                     .present_credential_mutual(
-                        route![sc_addr.clone(), DefaultAddress::CREDENTIAL_SERVICE],
+                        route![sc_addr.clone(), DefaultAddress::CREDENTIALS_SERVICE],
                         &authorities.public_identities(),
                         &self.attributes_storage,
                     )

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -14,6 +14,7 @@ use crate::nodes::registry::{CredentialsServiceInfo, Registry, VerifierServiceIn
 use crate::nodes::NodeManager;
 use crate::uppercase::Uppercase;
 use crate::vault::VaultService;
+use crate::DefaultAddress;
 use minicbor::Decoder;
 use ockam::{Address, AsyncTryClone, Context, Result};
 use ockam_core::api::{Request, Response, ResponseBuilder};
@@ -92,7 +93,7 @@ impl NodeManager {
         let authorities = self.authorities()?;
 
         identity
-            .start_credentials_exchange_worker(
+            .start_credential_exchange_worker(
                 authorities.public_identities(),
                 addr.clone(),
                 !oneway,
@@ -492,44 +493,59 @@ impl NodeManagerWorker {
         registry: &'a Registry,
     ) -> ResponseBuilder<ServiceList<'a>> {
         let mut list = Vec::new();
-        registry
-            .vault_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "vault")));
-        registry
-            .identity_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "identity")));
-        registry
-            .authenticated_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "authenticated")));
-        registry
-            .uppercase_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "uppercase")));
-        registry
-            .echoer_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "echoer")));
-        registry
-            .hop_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "hop")));
-        registry
-            .verifier_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "verifier")));
-        registry
-            .credentials_services
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "credentials")));
+        registry.vault_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::VAULT_SERVICE,
+            ))
+        });
+        registry.identity_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::IDENTITY_SERVICE,
+            ))
+        });
+        registry.authenticated_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::AUTHENTICATED_SERVICE,
+            ))
+        });
+        registry.uppercase_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::UPPERCASE_SERVICE,
+            ))
+        });
+        registry.echoer_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::ECHO_SERVICE,
+            ))
+        });
+        registry.hop_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::HOP_SERVICE,
+            ))
+        });
+        registry.verifier_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(addr.address(), DefaultAddress::VERIFIER))
+        });
+        registry.credentials_services.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::CREDENTIALS_SERVICE,
+            ))
+        });
 
         #[cfg(feature = "direct-authenticator")]
-        registry
-            .authenticator_service
-            .keys()
-            .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "authenticator")));
+        registry.authenticator_service.keys().for_each(|addr| {
+            list.push(ServiceStatus::new(
+                addr.address(),
+                DefaultAddress::AUTHENTICATOR,
+            ))
+        });
 
         Response::ok(req.id()).body(ServiceList::new(list))
     }

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -109,7 +109,7 @@ fn verifier_default_addr() -> String {
 }
 
 fn credentials_default_addr() -> String {
-    DefaultAddress::CREDENTIAL_SERVICE.to_string()
+    DefaultAddress::CREDENTIALS_SERVICE.to_string()
 }
 
 fn authenticator_default_addr() -> String {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -37,12 +37,12 @@ pub struct CreateCommand {
     #[arg(long, name = "AUTHORIZED", display_order = 900)]
     authorized: Option<IdentityIdentifier>,
 
-    /// Enable credentials authorization.
+    /// Enable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[arg(long, display_order = 900, conflicts_with = "disable_check_credential")]
     check_credential: bool,
 
-    /// Disable credentials authorization.
+    /// Disable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[arg(long, display_order = 900, conflicts_with = "check_credential")]
     disable_check_credential: bool,

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -30,12 +30,12 @@ pub struct CreateCommand {
     #[arg(long, display_order = 902, id = "SOCKET_ADDRESS")]
     to: SocketAddr,
 
-    /// Enable credentials authorization.
+    /// Enable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[arg(long, display_order = 900, conflicts_with = "disable_check_credential")]
     check_credential: bool,
 
-    /// Disable credentials authorization.
+    /// Disable credential authorization.
     /// Defaults to the Node's `enable-credential-checks` value passed upon creation.
     #[arg(long, display_order = 900, conflicts_with = "check_credential")]
     disable_check_credential: bool,

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -18,6 +18,7 @@ use ockam::identity::IdentityIdentifier;
 use ockam::Result;
 use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
 use ockam_api::nodes::*;
+use ockam_api::DefaultAddress;
 use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
 use ockam_core::{Address, CowStr};
@@ -117,7 +118,7 @@ pub(crate) fn list_secure_channel_listener() -> RequestBuilder<'static, ()> {
 /// Construct a request to start a Vault Service
 pub(crate) fn start_vault_service(addr: &str) -> RequestBuilder<'static, StartVaultServiceRequest> {
     let payload = StartVaultServiceRequest::new(addr);
-    Request::post("/node/services/vault").body(payload)
+    Request::post(node_service(DefaultAddress::VAULT_SERVICE)).body(payload)
 }
 
 /// Construct a request to start an Identity Service
@@ -125,7 +126,7 @@ pub(crate) fn start_identity_service(
     addr: &str,
 ) -> RequestBuilder<'static, StartIdentityServiceRequest> {
     let payload = StartIdentityServiceRequest::new(addr);
-    Request::post("/node/services/identity").body(payload)
+    Request::post(node_service(DefaultAddress::IDENTITY_SERVICE)).body(payload)
 }
 
 /// Construct a request to start an Authenticated Service
@@ -133,22 +134,22 @@ pub(crate) fn start_authenticated_service(
     addr: &str,
 ) -> RequestBuilder<'static, StartAuthenticatedServiceRequest> {
     let payload = StartAuthenticatedServiceRequest::new(addr);
-    Request::post("/node/services/authenticated").body(payload)
+    Request::post(node_service(DefaultAddress::AUTHENTICATED_SERVICE)).body(payload)
 }
 
 /// Construct a request to start a Verifier Service
 pub(crate) fn start_verifier_service(addr: &str) -> RequestBuilder<'static, StartVerifierService> {
     let payload = StartVerifierService::new(addr);
-    Request::post("/node/services/verifier").body(payload)
+    Request::post(node_service(DefaultAddress::VERIFIER)).body(payload)
 }
 
-/// Construct a request to start a Credentials Service
+/// Construct a request to start a Credential Service
 pub(crate) fn start_credentials_service(
     addr: &str,
     oneway: bool,
 ) -> RequestBuilder<'static, StartCredentialsService> {
     let payload = StartCredentialsService::new(addr, oneway);
-    Request::post("/node/services/credentials").body(payload)
+    Request::post(node_service(DefaultAddress::CREDENTIALS_SERVICE)).body(payload)
 }
 
 /// Construct a request to start an Authenticator Service
@@ -160,7 +161,7 @@ pub(crate) fn start_authenticator_service<'a>(
 ) -> RequestBuilder<'static, StartAuthenticatorRequest<'a>> {
     let payload =
         StartAuthenticatorRequest::new(addr, enrollers, reload_enrollers, project.as_bytes());
-    Request::post("/node/services/authenticator").body(payload)
+    Request::post(node_service(DefaultAddress::AUTHENTICATOR)).body(payload)
 }
 
 pub(crate) mod credentials {
@@ -180,6 +181,11 @@ pub(crate) mod credentials {
         let b = GetCredentialRequest::new(overwrite);
         Request::post("/node/credentials/actions/get").body(b)
     }
+}
+
+/// Return the path of a service given its name
+fn node_service(service_name: &str) -> String {
+    format!("/node/services/{service_name}")
 }
 
 /// Helpers to create enroll API requests

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -457,7 +457,7 @@ teardown() {
 @test "send a message to a project node from command embedded node, enrolled member on different install" {
   skip  # FIXME  how to send a message to a project m1 is enrolled to?  (with m1 being on a different install
         #       than the admin?.  If we pass project' address directly (instead of /project/ thing), would
-        #       it present credentials? would read authority info from project.json?
+        #       it present credential? would read authority info from project.json?
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM project information --output json  > /tmp/project.json
@@ -565,7 +565,7 @@ teardown() {
   assert_success
 }
 
-@test "inlet/outlet example with credentials, not provided" {
+@test "inlet/outlet example with credential, not provided" {
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM project information default --output json  > /tmp/project.json
@@ -602,12 +602,12 @@ teardown() {
 
   unset OCKAM_HOME
 
-  # Green can't establish secure channel with blue, because it doesn't exchange credentials with it.
+  # Green can't establish secure channel with blue, because it doesn't exchange credential with it.
   run curl --fail --head --max-time 10 127.0.0.1:7000
   assert_failure
 }
 
-@test "inlet (with implicit secure channel creation) / outlet example with credentials, not provided" {
+@test "inlet (with implicit secure channel creation) / outlet example with credential, not provided" {
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM project information default --output json  > /tmp/project.json
@@ -643,7 +643,7 @@ teardown() {
   unset OCKAM_HOME
 }
 
-@test "inlet/outlet example with credentials" {
+@test "inlet/outlet example with credential" {
   skip_if_orchestrator_tests_not_enabled
 
   $OCKAM project information default --output json > /tmp/project.json
@@ -720,7 +720,7 @@ teardown() {
   assert_success
 }
 
-@test "project requiring credentials" {
+@test "project requiring credential" {
   skip_if_orchestrator_tests_not_enabled
   skip_if_long_tests_not_enabled
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "credentials_example"
+name = "credential_example"
 version = "0.1.0"
 authors = ["Ockam Developers"]
 edition = "2021"

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/alice.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/alice.rs
@@ -1,4 +1,4 @@
-use credentials_example::{BOB_LISTENER_ADDRESS, BOB_TCP_ADDRESS, ECHOER};
+use credential_example::{BOB_LISTENER_ADDRESS, BOB_TCP_ADDRESS, ECHOER};
 use ockam::identity::{Identity, IdentityTrait, TrustEveryonePolicy};
 use ockam::vault::{SecretAttributes, SecretPersistence, SecretType, SecretVault, Vault};
 use ockam::{route, Context, Result, TcpTransport, TCP};

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
@@ -1,4 +1,4 @@
-use credentials_example::{BOB_LISTENER_ADDRESS, BOB_TCP_ADDRESS, ECHOER};
+use credential_example::{BOB_LISTENER_ADDRESS, BOB_TCP_ADDRESS, ECHOER};
 use ockam::identity::access_control::IdentityAccessControlBuilder;
 use ockam::identity::{Identity, TrustPublicKeyPolicy};
 use ockam::vault::{PublicKey, SecretType, Vault};

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -31,11 +31,11 @@ use crate::TypeTag;
 
 pub const MAX_CREDENTIAL_VALIDITY: Duration = Duration::from_secs(30 * 24 * 3600);
 
-/// Type to represent data of verified credentials.
+/// Type to represent data of verified credential.
 #[derive(Debug, Encode)]
 pub enum Verified {}
 
-/// Type to represent data of unverified credentials.
+/// Type to represent data of unverified credential.
 #[derive(Debug, Decode)]
 pub enum Unverified {}
 

--- a/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
@@ -25,7 +25,7 @@ impl<S: IdentityAttributeStorage> Debug for CredentialAccessControl<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let attributes = format!("{:?}", self.required_attributes.iter().map(|x| &x.0));
 
-        f.debug_struct("Credentials Access Control")
+        f.debug_struct("Credential Access Control")
             .field("Required attributes", &attributes)
             .finish()
     }

--- a/implementations/rust/ockam/ockam_identity/src/credential/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/identity.rs
@@ -58,7 +58,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
 
     /// Start worker that will be available to receive others attributes and put them into storage,
     /// after successful verification
-    pub async fn start_credentials_exchange_worker(
+    pub async fn start_credential_exchange_worker(
         &self,
         authorities: Vec<PublicIdentity>,
         address: impl Into<Address>,
@@ -85,8 +85,8 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
 
     /// Present credential to other party, route shall use secure channel
     pub async fn present_credential(&self, route: impl Into<Route>) -> Result<()> {
-        let credentials = self.credential.read().await;
-        let credential = credentials.as_ref().ok_or_else(|| {
+        let credential = self.credential.read().await;
+        let credential = credential.as_ref().ok_or_else(|| {
             Error::new(
                 Origin::Application,
                 Kind::Invalid,
@@ -122,8 +122,8 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
         authorities: impl IntoIterator<Item = &PublicIdentity>,
         attributes_storage: &impl IdentityAttributeStorage,
     ) -> Result<()> {
-        let credentials = self.credential.read().await;
-        let credential = credentials.as_ref().ok_or_else(|| {
+        let credential = self.credential.read().await;
+        let credential = credential.as_ref().ok_or_else(|| {
             Error::new(
                 Origin::Application,
                 Kind::Invalid,

--- a/implementations/rust/ockam/ockam_identity/src/credential/worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/worker.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, trace, warn};
 
 const TARGET: &str = "ockam::credential_exchange_worker::service";
 
-/// Worker responsible for receiving and verifying other party's credentials
+/// Worker responsible for receiving and verifying other party's credential
 pub struct CredentialExchangeWorker<
     AS: IdentityAttributeStorage,
     S: AuthenticatedStorage,
@@ -140,8 +140,8 @@ impl<AS: IdentityAttributeStorage, S: AuthenticatedStorage, V: IdentityVault>
                         "Mutual credential presentation request processed successfully with {}",
                         sender
                     );
-                    let credentials = self.identity.credential.read().await;
-                    match credentials.as_ref() {
+                    let credential = self.identity.credential.read().await;
+                    match credential.as_ref() {
                         Some(p) if self.present_back => {
                             warn!("Mutual credential presentation request processed successfully with {}. Responding with own credential...", sender);
                             Response::ok(req.id()).body(p).to_vec()?

--- a/implementations/rust/ockam/ockam_identity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_identity/src/lib.rs
@@ -32,7 +32,7 @@ pub mod change;
 /// Change history of an `Identity`
 pub mod change_history;
 
-/// Credentials support
+/// Credential support
 pub mod credential;
 
 /// Errors

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -31,7 +31,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
     let authorities = vec![authority.to_public().await?];
 
     server
-        .start_credentials_exchange_worker(
+        .start_credential_exchange_worker(
             authorities,
             "credential_exchange",
             false,
@@ -94,7 +94,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
 
     let authorities = vec![authority.to_public().await?];
     client2
-        .start_credentials_exchange_worker(
+        .start_credential_exchange_worker(
             authorities.clone(),
             "credential_exchange",
             true,
@@ -178,7 +178,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
     let authorities = vec![authority.to_public().await?];
 
     server
-        .start_credentials_exchange_worker(
+        .start_credential_exchange_worker(
             authorities,
             "credential_exchange",
             false,

--- a/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_x3dh/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
 
     #[allow(non_snake_case)]
     #[ockam_macros::test]
-    async fn full_flow__correct_credentials__keys_should_match(ctx: &mut Context) -> Result<()> {
+    async fn full_flow__correct_credential__keys_should_match(ctx: &mut Context) -> Result<()> {
         let vault = Vault::create();
 
         let key_exchanger = X3dhNewKeyExchanger::new(vault.async_try_clone().await?);

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[allow(non_snake_case)]
     #[ockam_macros::test]
-    async fn full_flow__correct_credentials__keys_should_match(ctx: &mut Context) -> Result<()> {
+    async fn full_flow__correct_credential__keys_should_match(ctx: &mut Context) -> Result<()> {
         let vault = Vault::create();
 
         let key_exchanger = XXNewKeyExchanger::new(vault.async_try_clone().await.unwrap());


### PR DESCRIPTION
I tried to use the word `credential` instead of `credentials` when talking about a single piece of data holding authenticated attributes. This follows the convention that
```
Credential = 
- Metadata
- Claim(s)
- Proof(s)
```
where proofs are generally signatures and claims are key/values.

I however left the service giving access to credentials as `CredentialsService` (or `/node/service/credentials` in terms of route).

More importantly maybe I used the constant names for services defined in `DefaultAddress` everywhere there were hard-coded strings (for `"authenticator"`, `"verifier"`, etc...).

Thanks for telling me if I missed anything!