### PR TITLE
refactor: remove the lifetime annotation on `Credential` and `Attributes`

### DIFF
--- a/examples/rust/get_started/src/credentials.rs
+++ b/examples/rust/get_started/src/credentials.rs
@@ -8,7 +8,7 @@ use ockam_core::{Error, Route};
 
 /// Using a one-time token created for an identity enrolled with some specific attributes
 /// retrieve its credential from a central authority
-pub async fn get_credential(ctx: &Context, authority_route: Route, token: OneTimeCode) -> Result<Credential<'static>> {
+pub async fn get_credential(ctx: &Context, authority_route: Route, token: OneTimeCode) -> Result<Credential> {
     let request = Request::post("/credential").body(token);
     let mut buf = Vec::new();
     request.encode(&mut buf)?;
@@ -17,7 +17,7 @@ pub async fn get_credential(ctx: &Context, authority_route: Route, token: OneTim
     let mut d = Decoder::new(&response_bytes);
     let _: Response = d.decode()?;
     let credential: Credential = d.decode().map_err(|e| error(format!("{e}")))?;
-    Ok(credential.to_owned())
+    Ok(credential)
 }
 
 fn error(message: String) -> Error {

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
@@ -350,7 +350,7 @@ impl Client {
         }
     }
 
-    pub async fn credential(&mut self) -> Result<Credential<'_>> {
+    pub async fn credential(&mut self) -> Result<Credential> {
         let req = Request::post("/credential");
         self.buf = self.request("new-credential", None, &req).await?;
         assert_response_match("credential", &self.buf);
@@ -363,7 +363,7 @@ impl Client {
         }
     }
 
-    pub async fn credential_with(&mut self, c: &OneTimeCode) -> Result<Credential<'_>> {
+    pub async fn credential_with(&mut self, c: &OneTimeCode) -> Result<Credential> {
         let req = Request::post("/credential").body(c);
         self.buf = self.request("new-credential", None, &req).await?;
         assert_response_match("credential", &self.buf);

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -10,10 +10,10 @@ use ockam_core::TypeTag;
 #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
 #[cbor(transparent)]
 #[serde(transparent)]
-pub struct Token<'a>(#[n(0)] pub Cow<'a, str>);
+pub struct Token(#[n(0)] pub String);
 
-impl<'a> Token<'a> {
-    pub fn new(token: impl Into<Cow<'a, str>>) -> Self {
+impl Token {
+    pub fn new(token: impl Into<String>) -> Self {
         Self(token.into())
     }
 }
@@ -155,24 +155,24 @@ pub mod auth0 {
 
     #[derive(serde::Deserialize, Debug)]
     #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
-    pub struct Auth0Token<'a> {
+    pub struct Auth0Token {
         pub token_type: TokenType,
-        pub access_token: Token<'a>,
+        pub access_token: Token,
     }
 
     #[derive(Encode, Decode, Debug)]
     #[cfg_attr(test, derive(Clone))]
     #[rustfmt::skip]
     #[cbor(map)]
-    pub struct AuthenticateAuth0Token<'a> {
+    pub struct AuthenticateAuth0Token {
         #[cfg(feature = "tag")]
         #[n(0)] pub tag: TypeTag<1058055>,
         #[n(1)] pub token_type: TokenType,
-        #[n(2)] pub access_token: Token<'a>,
+        #[n(2)] pub access_token: Token,
     }
 
-    impl<'a> AuthenticateAuth0Token<'a> {
-        pub fn new(token: Auth0Token<'a>) -> Self {
+    impl AuthenticateAuth0Token {
+        pub fn new(token: Auth0Token) -> Self {
             Self {
                 #[cfg(feature = "tag")]
                 tag: TypeTag,
@@ -205,14 +205,14 @@ pub mod enrollment_token {
     #[cfg_attr(test, derive(Decode, Clone))]
     #[rustfmt::skip]
     #[cbor(map)]
-    pub struct RequestEnrollmentToken<'a> {
+    pub struct RequestEnrollmentToken {
         #[cfg(feature = "tag")]
         #[n(0)] pub tag: TypeTag<8560526>,
-        #[b(1)] pub attributes: Attributes<'a>,
+        #[b(1)] pub attributes: Attributes,
     }
 
-    impl<'a> RequestEnrollmentToken<'a> {
-        pub fn new(attributes: Attributes<'a>) -> Self {
+    impl RequestEnrollmentToken {
+        pub fn new(attributes: Attributes) -> Self {
             Self {
                 #[cfg(feature = "tag")]
                 tag: TypeTag,
@@ -225,15 +225,15 @@ pub mod enrollment_token {
     #[cfg_attr(test, derive(Clone))]
     #[rustfmt::skip]
     #[cbor(map)]
-    pub struct EnrollmentToken<'a> {
+    pub struct EnrollmentToken {
         #[cfg(feature = "tag")]
         #[serde(skip)]
         #[n(0)] pub tag: TypeTag<8932763>,
-        #[n(1)] pub token: Token<'a>,
+        #[n(1)] pub token: Token,
     }
 
-    impl<'a> EnrollmentToken<'a> {
-        pub fn new(token: Token<'a>) -> Self {
+    impl EnrollmentToken {
+        pub fn new(token: Token) -> Self {
             Self {
                 #[cfg(feature = "tag")]
                 tag: TypeTag,
@@ -246,14 +246,14 @@ pub mod enrollment_token {
     #[cfg_attr(test, derive(Decode, Clone))]
     #[rustfmt::skip]
     #[cbor(map)]
-    pub struct AuthenticateEnrollmentToken<'a> {
+    pub struct AuthenticateEnrollmentToken {
         #[cfg(feature = "tag")]
         #[n(0)] pub tag: TypeTag<9463780>,
-        #[n(1)] pub token: Token<'a>,
+        #[n(1)] pub token: Token,
     }
 
-    impl<'a> AuthenticateEnrollmentToken<'a> {
-        pub fn new(token: EnrollmentToken<'a>) -> Self {
+    impl AuthenticateEnrollmentToken {
+        pub fn new(token: EnrollmentToken) -> Self {
             Self {
                 #[cfg(feature = "tag")]
                 tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -82,7 +82,7 @@ impl NodeManagerWorker {
         &mut self,
         req: &Request<'_>,
         dec: &mut Decoder<'_>,
-    ) -> Result<Either<ResponseBuilder<Error<'_>>, ResponseBuilder<Credential<'_>>>> {
+    ) -> Result<Either<ResponseBuilder<Error<'_>>, ResponseBuilder<Credential>>> {
         let mut node_manager = self.node_manager.write().await;
         let request: GetCredentialRequest = dec.decode()?;
 

--- a/implementations/rust/ockam/ockam_api/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier.rs
@@ -89,8 +89,8 @@ where
         &self,
         id: Id,
         req: &'a VerifyRequest<'a>,
-        cre: &'a Credential<'a>,
-    ) -> Result<Either<ResponseBuilder<Error<'_>>, CredentialData<'a, Verified>>> {
+        cre: &Credential,
+    ) -> Result<Either<ResponseBuilder<Error<'_>>, CredentialData<Verified>>> {
         let data = CredentialData::try_from(cre)?;
 
         let ident = if let Some(ident) = req.authority(data.unverfied_issuer()) {

--- a/implementations/rust/ockam/ockam_api/src/verifier/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier/types.rs
@@ -22,10 +22,10 @@ pub struct VerifyRequest<'a> {
 #[derive(Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct VerifyResponse<'a> {
+pub struct VerifyResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6845123>,
-    #[b(1)] attrs: Attributes<'a>,
+    #[b(1)] attrs: Attributes,
     #[n(2)] expires: Timestamp
 }
 
@@ -65,8 +65,8 @@ impl<'a> VerifyRequest<'a> {
     }
 }
 
-impl<'a> VerifyResponse<'a> {
-    pub fn new(attrs: Attributes<'a>, expires: Timestamp) -> Self {
+impl VerifyResponse {
+    pub fn new(attrs: Attributes, expires: Timestamp) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -75,7 +75,7 @@ impl<'a> VerifyResponse<'a> {
         }
     }
 
-    pub fn attributes(&self) -> &Attributes<'a> {
+    pub fn attributes(&self) -> &Attributes {
         &self.attrs
     }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -248,7 +248,7 @@ impl Auth0Service {
         &self.0
     }
 
-    pub(crate) async fn token(&self) -> Result<Auth0Token<'_>> {
+    pub(crate) async fn token(&self) -> Result<Auth0Token> {
         let dc = self.device_code().await?;
 
         eprint!(
@@ -323,7 +323,7 @@ impl Auth0Service {
     }
 
     /// Poll for token until it's ready
-    async fn poll_token<'a>(&'a self, dc: DeviceCode<'a>) -> Result<Auth0Token<'_>> {
+    async fn poll_token<'a>(&'a self, dc: DeviceCode<'a>) -> Result<Auth0Token> {
         let client = self.provider().build_http_client()?;
         let token;
         loop {

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -57,7 +57,7 @@ async fn rpc(
             .to(&to)?
             .build()?;
         rpc.request(Request::post("/credential")).await?;
-        rpc.print_response::<Credential<'_>>()?;
+        rpc.print_response::<Credential>()?;
         Ok(())
     }
     let result = go(&mut ctx, &opts, &cmd).await;

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -196,10 +196,10 @@ pub(crate) mod enroll {
 
     use super::*;
 
-    pub(crate) fn auth0(
+    pub(crate) fn auth0<'a>(
         cmd: EnrollCommand,
         token: Auth0Token,
-    ) -> RequestBuilder<CloudRequestWrapper<AuthenticateAuth0Token>> {
+    ) -> RequestBuilder<'a, CloudRequestWrapper<'a, AuthenticateAuth0Token>> {
         let token = AuthenticateAuth0Token::new(token);
         Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(
             token,

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -142,7 +142,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
         self
     }
 
-    pub async fn authenticate(&self) -> Result<Credential<'a>> {
+    pub async fn authenticate(&self) -> Result<Credential> {
         let sc_addr = self
             .secure_channel_to(&OrchestratorEndpoint::Authenticator)
             .await?;
@@ -162,7 +162,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
             Some(token) => client.credential_with(&token).await?,
         };
 
-        Ok(credential.to_owned())
+        Ok(credential)
     }
 
     /// Sends the request and returns  the response

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -231,7 +231,7 @@ impl Output for Vec<Enroller<'_>> {
     }
 }
 
-impl Output for Credential<'_> {
+impl Output for Credential {
     fn output(&self) -> anyhow::Result<String> {
         Ok(self.to_string())
     }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -88,4 +88,5 @@ zeroize = { version = "1.4.2" }
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 rand_xorshift = "0"
+serde_json = "1.0"
 tokio = { version = "1.25", features = ["full"] }

--- a/implementations/rust/ockam/ockam_identity/src/credential/one_time_code.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/one_time_code.rs
@@ -11,7 +11,7 @@ use ockam_core::Result;
 /// A one-time code can be used to enroll
 /// a node with some authenticated attributes
 /// It can be retrieve with a command like `ockam project enroll --attribute component=control`
-#[derive(Debug, Clone, Decode, Encode, PartialEq)]
+#[derive(Debug, Clone, Decode, Encode, PartialEq, Eq)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct OneTimeCode {

--- a/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
@@ -13,12 +13,12 @@ impl PublicIdentity {
     /// Perform a signature check with the given identity.
     ///
     /// If successful, the credential data are returned.
-    pub async fn verify_credential<'a, 'b: 'a>(
+    pub async fn verify_credential(
         &self,
-        credential: &'b Credential<'b>,
+        credential: &Credential,
         subject: &IdentityIdentifier,
         vault: &impl IdentityVault,
-    ) -> Result<CredentialData<'a, Verified>> {
+    ) -> Result<CredentialData<Verified>> {
         let dat = CredentialData::try_from(credential)?;
         if dat.unverfied_key_label() != IdentityStateConst::ROOT_LABEL {
             return Err(Error::new(

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -21,7 +21,7 @@ use ockam_vault::{KeyId, SecretAttributes};
 #[async_try_clone(crate = "ockam_core")]
 pub struct Identity<V: IdentityVault, S: AuthenticatedStorage> {
     id: IdentityIdentifier,
-    pub(crate) credential: Arc<RwLock<Option<Credential<'static>>>>,
+    pub(crate) credential: Arc<RwLock<Option<Credential>>>,
     pub(crate) change_history: Arc<RwLock<IdentityChangeHistory>>,
     pub(crate) ctx: Context,
     pub(crate) authenticated_storage: S,


### PR DESCRIPTION
Since we deserialize the underlying data anyway the lifetime annotations do not bring any performance advantage but make `Credential` harder to use. For example with a lifetime annotation it is a lot harder to provide a `Deserialize` instance

