### PR TITLE
feat(rust): standarize where authority stores membership information

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -227,7 +227,7 @@ impl NodeManager {
         if self.registry.authenticator_service.contains_key(&addr) {
             return Err(ApiError::generic("Authenticator service already started"));
         }
-        let db = self.authenticated_storage.async_try_clone().await?;
+        let db = self.attributes_storage.async_try_clone().await?;
         let id = self.identity()?.async_try_clone().await?;
         let au = crate::authenticator::direct::Server::new(
             proj.to_vec(),
@@ -235,7 +235,8 @@ impl NodeManager {
             enrollers,
             reload_enrollers,
             id,
-        )?;
+        )
+        .await?;
         ctx.start_worker(
             addr.clone(),
             au,

--- a/implementations/rust/ockam/ockam_api/tests/auth.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use ockam::authenticated_storage::AuthenticatedStorage;
+use ockam::authenticated_storage::AuthenticatedAttributeStorage;
 use ockam::identity::authenticated_storage::mem::InMemoryStorage;
 use ockam::identity::Identity;
 use ockam::route;
@@ -30,11 +30,12 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         let enrollers = tmpf.path().to_str().expect("path should be a string");
         let auth = direct::Server::new(
             b"project42".to_vec(),
-            store,
+            AuthenticatedAttributeStorage::new(store),
             enrollers,
             true,
             a.async_try_clone().await?,
-        )?;
+        )
+        .await?;
         ctx.start_worker(
             &auth_worker_addr,
             auth,
@@ -115,11 +116,12 @@ async fn json_config(ctx: &mut Context) -> Result<()> {
         let store = InMemoryStorage::new();
         let auth = direct::Server::new(
             b"project42".to_vec(),
-            store,
+            AuthenticatedAttributeStorage::new(store),
             "{}",
             false,
             a.async_try_clone().await?,
-        )?;
+        )
+        .await?;
         ctx.start_worker(&auth_worker_addr, auth, AllowAll, AllowAll)
             .await?;
         a
@@ -156,11 +158,12 @@ async fn json_config(ctx: &mut Context) -> Result<()> {
         let store = InMemoryStorage::new();
         let auth = direct::Server::new(
             b"project42".to_vec(),
-            store,
+            AuthenticatedAttributeStorage::new(store),
             &enrollers_config,
             false,
             authority.async_try_clone().await?,
-        )?;
+        )
+        .await?;
         ctx.start_worker(&auth_worker_addr, auth, AllowAll, AllowAll)
             .await?;
     };
@@ -186,71 +189,6 @@ async fn json_config(ctx: &mut Context) -> Result<()> {
     let pkey = PublicIdentity::import(&exported, &Vault::create())
         .await
         .unwrap();
-    let data = pkey
-        .verify_credential(&cred, member.identifier(), &Vault::create())
-        .await?;
-    assert_eq!(
-        Some(b"project42".as_slice()),
-        data.attributes().get("project_id")
-    );
-    assert_eq!(Some(b"member".as_slice()), data.attributes().get("role"));
-
-    ctx.stop().await
-}
-
-#[ockam_macros::test]
-async fn update_member_format(ctx: &mut Context) -> Result<()> {
-    let mut tmpf = NamedTempFile::new().unwrap();
-    serde_json::to_writer(&mut tmpf, &HashMap::<IdentityIdentifier, Enroller>::new()).unwrap();
-    // Create the authority:
-    let store = InMemoryStorage::new();
-
-    // Create a member identity:
-    let member = Identity::create(ctx, &Vault::create()).await?;
-
-    // Member was enrolled, with the old format
-    let tru = minicbor::to_vec(true)?;
-    store
-        .set(member.identifier().key_id(), "member".to_string(), tru)
-        .await?;
-    let authority = {
-        let a = Identity::create(ctx, &Vault::create()).await?;
-        a.create_secure_channel_listener("api", TrustEveryonePolicy)
-            .await?;
-        let exported = a.export().await?;
-        let enrollers = tmpf.path().to_str().expect("path should be a string");
-        let auth = direct::Server::new(b"project42".to_vec(), store, enrollers, false, a)?;
-        ctx.start_worker(
-            "auth", auth, AllowAll, // Auth checks happen inside the worker
-            AllowAll,
-        )
-        .await?;
-        exported
-    };
-
-    // Open a secure channel from member to authenticator:
-    let m2a = member
-        .create_secure_channel("api", TrustEveryonePolicy)
-        .await?;
-
-    let mut c = direct::Client::new(route![m2a, "auth"], ctx).await?;
-
-    // Get a fresh member credential and verify its validity. Data is loaded and
-    // transformed from the legacy format:
-    let cred = c.credential().await?;
-    let pkey = PublicIdentity::import(&authority, &Vault::create())
-        .await
-        .unwrap();
-    let data = pkey
-        .verify_credential(&cred, member.identifier(), &Vault::create())
-        .await?;
-    assert_eq!(
-        Some(b"project42".as_slice()),
-        data.attributes().get("project_id")
-    );
-
-    // Get the credential again.  It would have been updated on the store already.
-    let cred = c.credential().await?;
     let data = pkey
         .verify_credential(&cred, member.identifier(), &Vault::create())
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -12,8 +12,11 @@ use ockam_identity::change_history::IdentityChangeHistory;
 pub struct ShowCommand {
     #[arg(default_value_t = default_identity_name())]
     name: String,
-    #[arg(short, long)]
+
+    #[arg(short, long, group = "full_opt")]
     full: bool,
+    #[arg(long, group = "full_opt")]
+    hex: bool,
 }
 
 impl ShowCommand {
@@ -32,7 +35,10 @@ fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
         );
     }
     let state = opts.state.identities.get(&cmd.name)?;
-    if cmd.full {
+    if cmd.hex {
+        let identity = state.config.change_history.export()?;
+        print_output(identity, &opts.global_args.output_format)?;
+    } else if cmd.full {
         let identity = state.config.change_history.export()?;
         let output = LongIdentityResponse::new(identity);
         print_output(output, &opts.global_args.output_format)?;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -473,6 +473,9 @@ async fn spawn_background_node(
         cmd.trusted_identities.as_ref(),
         cmd.trusted_identities_file.as_ref(),
         cmd.reload_from_trusted_identities_file.as_ref(),
+        cmd.launch_config
+            .as_ref()
+            .map(|config| serde_json::to_string(config).unwrap()),
     )?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -60,6 +60,7 @@ async fn run_impl(
         None,               // No trusted identities
         None,               // "
         None,               // "
+        None,               // No launch config available
     )?;
 
     // Print node status

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -85,7 +85,7 @@ impl Runner {
                 &node_name,
                 a,
                 &replace_project(&self.cmd.to, a.address())?,
-                None, //for now always the default identity
+                self.cmd.cloud_opts.identity.clone(),
             )
             .await?;
             for proto in self.cmd.to.iter().skip(1) {

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -236,3 +236,9 @@ impl Output for Credential {
         Ok(self.to_string())
     }
 }
+
+impl Output for Vec<u8> {
+    fn output(&self) -> anyhow::Result<String> {
+        Ok(hex::encode(self))
+    }
+}

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -438,7 +438,7 @@ teardown() {
   \"authority_access_route\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\",
   \"authority_identity\" : \"$authority_identity_full\"}" > /tmp/project.json
 
-  # m1 is a member (it's on the set of pre-trusted identifier) so it can get it's own credential
+  # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
   run $OCKAM project authenticate --project-path /tmp/project.json --identity m1
   assert_success
   assert_output --partial "sample_val"

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -417,7 +417,7 @@ teardown() {
   run $OCKAM identity create m2
   run $OCKAM identity create m3
   enroller_identifier=$($OCKAM identity show enroller)
-  authority_identity_full=$($OCKAM identity show --hex authority)
+  authority_identity_full=$($OCKAM identity show --full --encoding hex authority)
   m1_identifier=$($OCKAM identity show m1)
   m2_identifier=$($OCKAM identity show m2)
 

--- a/implementations/rust/ockam/ockam_command/tests/commands.bats
+++ b/implementations/rust/ockam/ockam_command/tests/commands.bats
@@ -409,6 +409,53 @@ teardown() {
   refute_output --partial "127.0.0.1:5000"
 }
 
+@test "standalone authority, enrollers, members" {
+  run $OCKAM identity create authority
+  run $OCKAM identity create enroller
+  # m1 will be pre-authenticated on authority.  m2 will be added directly, m3 will be added through enrollment token
+  run $OCKAM identity create m1
+  run $OCKAM identity create m2
+  run $OCKAM identity create m3
+  enroller_identifier=$($OCKAM identity show enroller)
+  authority_identity_full=$($OCKAM identity show --hex authority)
+  m1_identifier=$($OCKAM identity show m1)
+  m2_identifier=$($OCKAM identity show m2)
+
+  # To startup an authority, we need some boilerplate setup in place.
+  # Create an enrollers file,  with the identity of the enroller we want
+  echo "{\"$enroller_identifier\": {}}" > /tmp/enrollers.json
+  # Create a launch configuration json file,  to be used to start the authority node
+  echo '{"startup_services" : {"authenticator" : {"enrollers" : "/tmp/enrollers.json", "project" : "1"}, "secure_channel_listener": {}}}' >  /tmp/auth_launch_config.json
+
+  # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
+  run $OCKAM node create --tcp-listener-address=0.0.0.0:4200 --identity authority --launch-config /tmp/auth_launch_config.json --trusted-identities "{\"$m1_identifier\": {\"sample_attr\" : \"sample_val\"}}"  authority
+  assert_success
+
+  echo "{\"id\": \"1\",
+  \"name\" : \"default\",
+  \"identity\" : \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\",
+  \"access_route\" : \"/dnsaddr/127.0.0.1/tcp/4000/service/api\",
+  \"authority_access_route\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\",
+  \"authority_identity\" : \"$authority_identity_full\"}" > /tmp/project.json
+
+  # m1 is a member (it's on the set of pre-trusted identifier) so it can get it's own credential
+  run $OCKAM project authenticate --project-path /tmp/project.json --identity m1
+  assert_success
+  assert_output --partial "sample_val"
+
+  run $OCKAM project enroll --identity enroller --project-path /tmp/project.json --member $m2_identifier --attribute sample_attr=m2_member
+  assert_success
+
+  run $OCKAM project authenticate --project-path /tmp/project.json --identity m2
+  assert_success
+  assert_output --partial "m2_member"
+
+  token=$($OCKAM project enroll --identity enroller --project-path /tmp/project.json  --attribute sample_attr=m3_member)
+  run $OCKAM project authenticate --project-path /tmp/project.json --identity m3  --token $token
+  assert_success
+  assert_output --partial "m3_member"
+}
+
 # the below tests will only succeed if already enrolled with `ockam enroll`
 
 @test "send a message to a project node from command embedded node" {

--- a/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
+++ b/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
@@ -37,6 +37,10 @@ pub struct AttributesEntry {
 }
 
 impl AttributesEntry {
+    //TODO: since we are converting from HashMap to BTreeMap in different parts,
+    //      it will make sense to have a constructor here taking a HashMap and doing
+    //      the conversion here.   Better:  standarize on either of the above for attributes.
+
     /// Constructor
     pub fn new(
         attrs: BTreeMap<String, Vec<u8>>,


### PR DESCRIPTION
makes the authority store membership (authenticated identity attributes) information using the standard method for that.  This opens the way to use ABAC to identity enrollers latter on.
Also:
- tweak  enroller'  `project enroll` command to be able to actually work with a project.json file
- add an "hex"  export format to  `identity show`   (to export the full change history as hex string.   This is used to populate a project.json to be able to contact an standalone authority node)
- allow authority node to be run on background  (so far it only worked on foreground)
- add bats test [with a standalone authority](https://github.com/build-trust/ockam/pull/4274/files#diff-76069ee844324858f89f101eb1c6788f22573c9d945ccb48fede3136c3c427d7)


After this change,   since the storage is the same, the pre-trusted identities support is available to authority nodes,  as well as the commands to inspect the authority' authenticated identities table  (both where added for  "normal" nodes  [here](https://github.com/build-trust/ockam/pull/4243)):
```
$ockam authenticated list [ addr ] 
▐ Identifier: P2b7344b142ad96231df68f24e9b45b1ceadfc11674a140a21ce09873d23dd9db
▐ Attributes: {"location":"ny","type":"sensor"}
▐ Added At: 1676553756
▐ Expires At: -
▐ Attested By: Pd311fb0cf1aaf2b0cd83d9e3748f83d263e4ee7c46e85cdc2767d3b9bcfc573b

▐ Identifier: P98bcfa2969ba8da0654e9dc80a33341eaf456dab43deb6dc82bfaaa544bb34a8
▐ Attributes: {"location":"sf","type":"sensor"}
▐ Added At: 1676553753
▐ Expires At: -
▐ Attested By: Pd311fb0cf1aaf2b0cd83d9e3748f83d263e4ee7c46e85cdc2767d3b9bcfc573b

▐ Identifier: Pb0dbffd908eea053ee184e0cece3c69ee709e7fa1dbc46161cc665987ff6d9c0
▐ Attributes: {"sample_attr":"sample_val"}
▐ Added At: 1676553741
▐ Expires At: -
▐ Attested By: -
``` 

In the above example there where 3 members registered on the authority:   - 
- `Pb0dbffd908eea053ee184e0cece3c69ee709e7fa1dbc46161cc665987ff6d9c0`   was passed as a pre-trusted identifier at authority' creation,  so it isn't attested by anyone. 
- `P98bcfa2969ba8da0654e9dc80a33341eaf456dab43deb6dc82bfaaa544bb34a8` and `P2b7344b142ad96231df68f24e9b45b1ceadfc11674a140a21ce09873d23dd9db`  were added by enroller `Pd311fb0cf1aaf2b0cd83d9e3748f83d263e4ee7c46e85cdc2767d3b9bcfc573b`.

Both have no expiration date,  we don't expire _members_  from authority right now.
