### PR TITLE
Run `CI` on push to develop and on `PR` update

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -29,6 +29,8 @@ on:
       - 'gradlew'
       - 'gradlew.bat'
       - '.github/actions/**'
+    branches:
+      - develop
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  merge_group:
   workflow_dispatch:
   pull_request:
   push:

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -3,7 +3,12 @@ name: Commits
 permissions:
   contents: read
 
-on: [workflow_dispatch, pull_request, push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,6 +37,8 @@ on:
       - 'gradlew'
       - 'gradlew.bat'
       - '.github/actions/**'
+    branches:
+      - develop
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  merge_group:
   workflow_dispatch:
   pull_request:
   push:

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -3,7 +3,12 @@ name: Editorconfig
 permissions:
   contents: read
 
-on: [workflow_dispatch, pull_request, push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -39,6 +39,8 @@ on:
       - 'gradlew'
       - 'gradlew.bat'
       - '.github/actions/**'
+    branches:
+      - develop
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/lint-cargo.yml
+++ b/.github/workflows/lint-cargo.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - "**.toml"
       - "**/Cargo.lock"
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -25,6 +25,8 @@ on:
       - "**/Cargo.lock"
       - "implementations/rust/ockam/ockam_command/tests/commands.bats"
       - ".github/actions/**"
+    branches:
+      - develop
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,8 @@ on:
       - "gradlew"
       - "gradlew.bat"
       - ".github/actions/**"
+    branches:
+      - develop
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,7 +6,12 @@ name: Semgrep
 permissions:
   contents: read
 
-on: [workflow_dispatch, pull_request, push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,6 +17,8 @@ on:
   push:
     paths:
       - "**.sh"
+    branches:
+      - develop
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -6,7 +6,12 @@ name: Shfmt
 permissions:
   contents: read
 
-on: [workflow_dispatch, pull_request, push]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
We are currently running CI `on push` and `on pull_request update` which caused duplicate workflow run. This PR updates all workflows to run when `pull requests` are opened or updated  and only when there a `push to the develop branch`