### PR TITLE
feat(rust): add more information to `EntryNotFound` errors

### DIFF
--- a/implementations/rust/ockam/ockam_vault/src/asymmetric_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/asymmetric_impl.rs
@@ -47,7 +47,11 @@ impl AsymmetricVault for Vault {
         peer_public_key: &PublicKey,
     ) -> Result<KeyId> {
         let entries = self.data.entries.read().await;
-        let entry = entries.get(secret).ok_or(VaultError::EntryNotFound)?;
+        let entry = entries
+            .get(secret)
+            .ok_or(VaultError::EntryNotFound(format!(
+                "diffie hellman secret {secret:?}"
+            )))?;
 
         let dh = Self::ecdh_internal(entry, peer_public_key)?;
 

--- a/implementations/rust/ockam/ockam_vault/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault/src/error.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::string::String;
 use ockam_core::{
     errcode::{Kind, Origin},
     Error,
@@ -5,10 +6,10 @@ use ockam_core::{
 
 /// Represents the failures that can occur in
 /// an Ockam vault
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum VaultError {
     /// Secret does not belong to this vault
-    SecretFromAnotherVault = 1,
+    SecretFromAnotherVault,
     /// Public key is invalid
     InvalidPublicKey,
     /// Unknown ECDH key type
@@ -16,7 +17,7 @@ pub enum VaultError {
     /// Invalid key type
     InvalidKeyType,
     /// Entry not found
-    EntryNotFound,
+    EntryNotFound(String),
     /// Invalid AES key length
     InvalidAesKeyLength,
     /// Invalid Secret length
@@ -53,7 +54,7 @@ impl core::fmt::Display for VaultError {
             Self::InvalidPublicKey => write!(f, "public key is invalid"),
             Self::UnknownEcdhKeyType => write!(f, "unknown ECDH key type"),
             Self::InvalidKeyType => write!(f, "invalid key type"),
-            Self::EntryNotFound => write!(f, "entry not found"),
+            Self::EntryNotFound(entry) => write!(f, "entry not found {entry}"),
             Self::InvalidAesKeyLength => write!(f, "invalid AES key length"),
             Self::InvalidSecretLength => write!(f, "invalid secret length"),
             Self::InvalidHkdfOutputType => write!(f, "invalid HKDF outputtype"),
@@ -83,7 +84,7 @@ impl From<VaultError> for Error {
             | InvalidHkdfOutputType
             | InvalidPrivateKeyLen
             | InvalidX25519SecretLength => Kind::Misuse,
-            UnknownEcdhKeyType | EntryNotFound | SecretNotFound => Kind::NotFound,
+            UnknownEcdhKeyType | EntryNotFound(_) | SecretNotFound => Kind::NotFound,
             _ => Kind::Invalid,
         };
 

--- a/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/hasher_impl.rs
@@ -35,7 +35,9 @@ impl Hasher for Vault {
 
         let ikm: Result<&[u8]> = match ikm {
             Some(ikm) => {
-                let ikm = entries.get(ikm).ok_or(VaultError::EntryNotFound)?;
+                let ikm = entries
+                    .get(ikm)
+                    .ok_or(VaultError::EntryNotFound(format!("hkdf_sha256 {ikm:?}")))?;
                 if ikm.key_attributes().stype() == SecretType::Buffer {
                     Ok(ikm.secret().try_as_key()?.as_ref())
                 } else {
@@ -47,7 +49,9 @@ impl Hasher for Vault {
 
         let ikm = ikm?;
 
-        let salt = entries.get(salt).ok_or(VaultError::EntryNotFound)?;
+        let salt = entries.get(salt).ok_or(VaultError::EntryNotFound(format!(
+            "hkdf_sha256 salt {salt:?}"
+        )))?;
 
         if salt.key_attributes().stype() != SecretType::Buffer {
             return Err(VaultError::InvalidKeyType.into());

--- a/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/signer_impl.rs
@@ -17,7 +17,11 @@ impl Signer for Vault {
         self.preload_from_storage(secret_key).await;
 
         let entries = self.data.entries.read().await;
-        let entry = entries.get(secret_key).ok_or(VaultError::EntryNotFound)?;
+        let entry = entries
+            .get(secret_key)
+            .ok_or(VaultError::EntryNotFound(format!(
+                "signing key {secret_key:?}"
+            )))?;
 
         match entry.key_attributes().stype() {
             SecretType::X25519 => {

--- a/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/file_storage.rs
@@ -222,7 +222,7 @@ impl Storage for FileStorage {
                     }
                 })
                 .map(|le| VaultEntry::new(le.1.key_attributes, le.1.key.clone()))
-                .ok_or(VaultError::EntryNotFound)?)
+                .ok_or(VaultError::EntryNotFound(format!("vault entry {key_id:?}")))?)
         };
         self.read_transaction(t).await
     }
@@ -245,7 +245,9 @@ impl Storage for FileStorage {
                 let vault_entry = VaultEntry::new(removed.1.key_attributes, removed.1.key);
                 Ok((LegacySerializedVault::V1 { entries, next_id }, vault_entry))
             } else {
-                Err(Error::from(VaultError::EntryNotFound))
+                Err(Error::from(VaultError::EntryNotFound(format!(
+                    "vault entry {key_id:?}"
+                ))))
             }
         };
         self.write_transaction(t).await

--- a/implementations/rust/ockam/ockam_vault/src/symmetric_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/symmetric_impl.rs
@@ -19,7 +19,9 @@ impl SymmetricVault for Vault {
         self.preload_from_storage(key_id).await;
 
         let entries = self.data.entries.read().await;
-        let entry = entries.get(key_id).ok_or(VaultError::EntryNotFound)?;
+        let entry = entries
+            .get(key_id)
+            .ok_or(VaultError::EntryNotFound(format!("{key_id:?}")))?;
 
         if entry.key_attributes().stype() != SecretType::Aes {
             return Err(VaultError::AeadAesGcmEncrypt.into());
@@ -68,7 +70,9 @@ impl SymmetricVault for Vault {
         self.preload_from_storage(key_id).await;
 
         let entries = self.data.entries.read().await;
-        let entry = entries.get(key_id).ok_or(VaultError::EntryNotFound)?;
+        let entry = entries
+            .get(key_id)
+            .ok_or(VaultError::EntryNotFound(format!("aes key {key_id:?}")))?;
 
         if entry.key_attributes().stype() != SecretType::Aes {
             return Err(VaultError::AeadAesGcmEncrypt.into());


### PR DESCRIPTION
This can help the logs investigation when an entry is missing from the `Vault`. The messages could be possibly improved with some additional structure since we have a notion of `Origin` in our errors but this PR at least allows us to point faster to the code which created the error.