### PR TITLE
feat(rust): allow the route macro to use both routes and addresses

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/routing/macros.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/macros.rs
@@ -10,14 +10,14 @@
 /// let route = route!["address1", "address2", "address3".to_string(), address4];
 /// ```
 ///
-/// [`Address`]: crate::Address
+/// [`Address`]: Into<Route>
 /// [`Route`]: crate::Route
 #[macro_export]
 macro_rules! route {
     ($($x:expr),* $(,)?) => ({
         #[allow(unused_mut)]
         let mut r = $crate::Route::new();
-        $(r = r.append($x);)*
+        $(r = r.append_route($x.into());)*
         $crate::Route::from(r)
     });
 }
@@ -36,11 +36,20 @@ mod tests {
     fn test2() {
         use crate::compat::string::ToString;
         let address: Address = random();
-        let _route = route!["str", "STR2", "STR3".to_string(), address];
+        let route1 = route!["str", "STR2", "STR3".to_string(), address];
+        let _route2 = route![route1.clone(), "str1", route1];
     }
 
     #[test]
     fn test3() {
         let _route = route!["str",];
+    }
+
+    #[test]
+    fn test4() {
+        let route1 = route!["s1", "s2"];
+        let route2 = route!["s4"];
+        let route3 = route![route1, "s3", route2];
+        assert_eq!(route3, route!["s1", "s2", "s3", "s4"])
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -1,6 +1,6 @@
 use crate::{
     compat::{collections::VecDeque, string::String, vec::Vec},
-    route, Address, Result, RouteError, TransportType,
+    Address, Result, RouteError, TransportType,
 };
 use core::fmt::{self, Display};
 use serde::{Deserialize, Serialize};
@@ -234,7 +234,7 @@ impl From<RouteBuilder<'_>> for Route {
 /// A single address can represent a valid route.
 impl<T: Into<Address>> From<T> for Route {
     fn from(addr: T) -> Self {
-        route![addr]
+        Route::create(vec![addr])
     }
 }
 
@@ -338,6 +338,29 @@ impl RouteBuilder<'_> {
             .into_iter()
             .rev()
             .for_each(|addr| self.inner.push_front(addr));
+        self
+    }
+
+    /// Append a full route to an existing route.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use ockam_core::{route, Route, RouteBuilder};
+    /// let mut route_a: Route = route!["1#alice", "bob"];
+    /// let route_b: Route = route!["1#carol", "dave"];
+    ///
+    /// // ["1#alice", "0#bob", "1#carol", "0#dave"]
+    /// let route: Route = route_a.modify()
+    ///     .append_route(route_b)
+    ///     .into();
+    /// ```
+    ///
+    pub fn append_route(mut self, route: Route) -> Self {
+        route
+            .inner
+            .into_iter()
+            .for_each(|addr| self.inner.push_back(addr));
         self
     }
 

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 use core::time::Duration;
 use ockam_core::compat::sync::Arc;
-use ockam_core::{route, AllowAll, Any, DenyAll, Mailboxes, Result, Routed, Worker};
+use ockam_core::{route, Address, AllowAll, Any, DenyAll, Mailboxes, Result, Routed, Worker};
 use ockam_identity::access_control::IdentityAccessControlBuilder;
 use ockam_identity::api::{DecryptionResponse, EncryptionRequest, EncryptionResponse};
 use ockam_identity::{
@@ -352,7 +352,7 @@ async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Res
     let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
 
     let n = rand::random::<u8>() % 5 + 4;
-    let mut channels = vec![];
+    let mut channels: Vec<Address> = vec![];
     for i in 0..n {
         bob.create_secure_channel_listener(i.to_string(), bob_trust_policy.clone())
             .await?;


### PR DESCRIPTION
to create larger routes.

Here is a small example
```
let route1 = route!["s1", "s2"];
let route2 = route!["s4"];
let route3 = route![route1, "s3", route2];
assert_eq!(route3, route!["s1", "s2", "s3", "s4"])
```


