### PR TITLE
fix(rust): refactor `get_credential_impl` so it works with the provided identity

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
@@ -14,14 +14,16 @@ pub struct GetCredentialRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8479533>,
     #[n(1)] overwrite: bool,
+    #[n(2)] pub identity_name: Option<String>,
 }
 
 impl GetCredentialRequest {
-    pub fn new(overwrite: bool) -> Self {
+    pub fn new(overwrite: bool, identity_name: Option<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             overwrite,
+            identity_name,
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -34,7 +34,7 @@ pub struct CreateSecureChannelRequest<'a> {
     #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
     #[n(3)] pub credential_exchange_mode: CredentialExchangeMode,
     #[n(4)] pub timeout: Option<Duration>,
-    #[b(5)] pub identity: Option<CowStr<'a>>,
+    #[b(5)] pub identity_name: Option<CowStr<'a>>,
 }
 
 impl<'a> CreateSecureChannelRequest<'a> {
@@ -42,7 +42,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
         addr: &MultiAddr,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
         credential_exchange_mode: CredentialExchangeMode,
-        identity: Option<String>,
+        identity_name: Option<String>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -52,7 +52,7 @@ impl<'a> CreateSecureChannelRequest<'a> {
                 .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
             credential_exchange_mode,
             timeout: None,
-            identity: identity.map(|x| x.into()),
+            identity_name: identity_name.map(|x| x.into()),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -502,7 +502,7 @@ impl NodeManagerWorker {
 
             // ==*== Credential ==*==
             (Post, ["node", "credentials", "actions", "get"]) => self
-                .get_credential(req, dec)
+                .get_credential(req, dec, ctx)
                 .await?
                 .either(ResponseBuilder::to_vec, ResponseBuilder::to_vec)?,
             (Post, ["node", "credentials", "actions", "present"]) => {

--- a/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get_credential.rs
@@ -13,6 +13,9 @@ pub struct GetCredentialCommand {
 
     #[arg(long)]
     pub overwrite: bool,
+
+    #[arg(long = "identity", value_name = "IDENTITY")]
+    identity: Option<String>,
 }
 
 impl GetCredentialCommand {
@@ -34,7 +37,10 @@ async fn run_impl(
     cmd: GetCredentialCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
-    rpc.request(api::credentials::get_credential(cmd.overwrite))
-        .await?;
+    rpc.request(api::credentials::get_credential(
+        cmd.overwrite,
+        cmd.identity,
+    ))
+    .await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -198,7 +198,8 @@ async fn run_impl(
     // Do we need to eagerly fetch a project membership credential?
     let get_credential = cmd.project.is_some() && cmd.token.is_some();
     if get_credential {
-        rpc.request(api::credentials::get_credential(false)).await?;
+        rpc.request(api::credentials::get_credential(false, cmd.identity))
+            .await?;
         if rpc.parse_and_print_response::<Credential>().is_err() {
             eprintln!("failed to fetch membership credential");
             delete_node(&opts, node_name, true)?;
@@ -314,7 +315,7 @@ async fn run_foreground_node(
     }
 
     if get_credential {
-        let req = api::credentials::get_credential(false).to_vec()?;
+        let req = api::credentials::get_credential(false, cmd.identity).to_vec()?;
         let res: Vec<u8> = ctx.send_and_receive(NODEMANAGER_ADDR, req).await?;
         let mut d = Decoder::new(&res);
         match d.decode::<Response>() {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -177,8 +177,11 @@ pub(crate) mod credentials {
         Request::post("/node/credentials/actions/present").body(b)
     }
 
-    pub(crate) fn get_credential<'r>(overwrite: bool) -> RequestBuilder<'r, GetCredentialRequest> {
-        let b = GetCredentialRequest::new(overwrite);
+    pub(crate) fn get_credential<'r>(
+        overwrite: bool,
+        identity_name: Option<String>,
+    ) -> RequestBuilder<'r, GetCredentialRequest> {
+        let b = GetCredentialRequest::new(overwrite, identity_name);
         Request::post("/node/credentials/actions/get").body(b)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -254,12 +254,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
                     project_route,
                     &project_identity.to_string(),
                     self.credential_exchange_mode,
-                    None, //self.identity.clone(),
-                          //FIXME:  passing an identity here is broken.  Credential is retrieved and
-                          //associated with the identity,  but that identity object is _not_ the one that
-                          //is used latter to establish the security channel (due to clonning, etc).
-                          //Not passing identity here works as the embedded node was started with this
-                          //identity as the default one anyway.
+                    self.identity.clone(),
                 )
                 .await?
             }


### PR DESCRIPTION
Previously, the `get_credential_impl` function on the `NodeManager` always used its internal identity (the node's default identity) to get its credential.

That function has been refactored so it always works on the passed identity. As a consequence, the `create_secure_channel_impl` will now use the same identity to both retrieve the credential and create the secure channel.