### PR TITLE
fix(rust): commands shows concise errors with a more human-readable format

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -154,7 +154,7 @@ impl<'a> Rpc<'a> {
             .await
             .map_err(|_err| {
                 // Overwrite error to swallow inner cause and hide it from end-user
-                anyhow!("The request timed out, please try again")
+                anyhow!("The request timed out, please make sure the command's arguments are correct or try again")
             })?;
         Ok(())
     }
@@ -174,7 +174,7 @@ impl<'a> Rpc<'a> {
             .await
             .map_err(|_err| {
                 // Overwrite error to swallow inner cause and hide it from end-user
-                anyhow!("The request timed out, please try again")
+                anyhow!("The request timed out, please make sure the command's arguments are correct or try again")
             })?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_node/src/api.rs
+++ b/implementations/rust/ockam/ockam_node/src/api.rs
@@ -24,7 +24,7 @@ where
     req.encode(&mut buf)?;
     assert_request_match(struct_name, &buf);
     trace! {
-        target:  "ockam_api",
+        target:  "ockam_node",
         id     = %req.header().id(),
         method = ?req.header().method(),
         path   = %req.header().path(),


### PR DESCRIPTION
On `ockam_command`, when a `ctx.receive` or `ctx.send_and_receive` call times out it will now show the following error:

```bash
The request timed out, please try again
```

instead of:

```bash
Version 0.80.0, hash: 3e8f61c11df56d116321c92926ef45aafbe16c2d
Version 0.80.0, hash: 3e8f61c11df56d116321c92926ef45aafbe16c2d
{code: 70, err: Failed to receive response from node, cause: deadline has elapsed}


Caused by:
    0: Failed to receive response from node
    1: deadline has elapsed
    2: deadline has elapsed
```

## Another example

Validation errors happening within ockam_command will look like:

```bash
Argument '--to' is invalid. Caused by: `node `n1`` not found
```

instead of:

```bash
Version 0.80.0, hash: 3e8f61c11df56d116321c92926ef45aafbe16c2d
Argument '--to' is invalid

Caused by:
    0: `node `n1`` not found
    1: `node `n1`` not found
```

## Underlying problem: nested errors

If you observe the first example, the `Version 0.80...` string and the description and cause messages are duplicated. This happens because there is a nested conversion happening between `anyhow` and `ockam_command` errors. This can be fixed by changing the signature of the `ockam_command` methods to return an `ockam_command::Error` instead of an `anyhow::Error`. This is out of the scope of this PR, but will be addressed shortly.

To avoid confusion, I've removed printing the binary version. I've found cases where it's printed three times. This can be readded after fixing the problem described above.