### PR TITLE
feat(rust): override inlet policy when starting kafka services

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -135,8 +135,8 @@ where
             }
         };
 
-        //add the identity itself as a subject parameter
-        environment.put("subject.identity", str(id.to_string()));
+        //add the identifier itself as a subject parameter
+        environment.put("subject.identifier", str(id.to_string()));
 
         // Finally, evaluate the expression and return the result:
         match eval(&expr, &environment) {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -363,7 +363,7 @@ impl NodeManager {
                     &resources::INLET,
                     &actions::HANDLE_MESSAGE,
                     &eq([
-                        ident("subject.identity"),
+                        ident("subject.identifier"),
                         str(identity_identifier.to_string()),
                     ]),
                 )


### PR DESCRIPTION
The current node manager policy expects the project identity to have `project_id` attribute, but currently, this is not true. When starting the kafka service it overrides the policy, checking if the secure channel identity is the same as the project.

## Current Behavior

A manual policy override is needed to make the kafka demo work:
`ockam policy set --at consumer -r tcp-inlet -a handle_message -e true`

## Proposed Changes
The policy override is automatic and specific for the project identity, no manual policy override is needed