### PR TITLE
feat(elixir): reduce CI time by building only vault and ffi from the rust side

### DIFF
--- a/implementations/elixir/build.gradle
+++ b/implementations/elixir/build.gradle
@@ -28,8 +28,8 @@ ext {
   }
 }
 
-task rustBuild {
-  dependsOn gradle.includedBuild('rust').task(':build')
+task rustVaultBuild {
+  dependsOn gradle.includedBuild('rust').task(':build_vault')
 }
 
 task checkLocalHexAndRebar {
@@ -80,7 +80,7 @@ taskDeps = ['checkLocalHexAndRebar']
 apps.each { app ->
   task "test_${app.name}" {
     if(app.name == 'ockam_vault_software') {
-      dependsOn rustBuild
+      dependsOn rustVaultBuild
     }
     dependsOn checkLocalHexAndRebar
     doLast {

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -90,6 +90,15 @@ task build {
   }
 }
 
+task build_vault {
+  doLast {
+    exec {
+      environment environmentVars()
+      commandLine cargo('--locked', 'build', '-p', 'ockam_vault', '-p', 'ockam-ffi')
+    }
+  }
+}
+
 task build_examples {
   doLast {
     exec {


### PR DESCRIPTION
## Current Behavior

When elixir needs to validate the vault it builds an optimized version of every package of rust ockam implementation.
CI times up to 8 minutes.

## Proposed Changes

Reduce the scope only to `ockam_vault` and `ockam-ffi` to reduce build time.
CI times up to 3 minutes.

Being the check that takes the most time, the CI overall should reduce by at least 2x.