### PR TITLE
run rust workflow on update to elixir code

### DIFF
--- a/.github/actions/cargo_home_cache/action.yml
+++ b/.github/actions/cargo_home_cache/action.yml
@@ -1,7 +1,7 @@
 name: CARGO_HOME Cache
 description: CARGO_HOME Cache
 runs:
-  using: "composite"
+  using: composite
   steps:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -1,7 +1,7 @@
 name: CARGO_TARGET_DIR Cache
 description: CARGO_TARGET_DIR Cache
 runs:
-  using: "composite"
+  using: composite
   steps:
     - run: rustc --version > rustc_version.txt && cat rustc_version.txt
       shell: bash

--- a/.github/actions/cargo_target_dir_pre_cache/action.yml
+++ b/.github/actions/cargo_target_dir_pre_cache/action.yml
@@ -1,7 +1,7 @@
 name: CARGO_TARGET_DIR Pre Cache
 description: CARGO_TARGET_DIR Pre Cache
 runs:
-  using: "composite"
+  using: composite
   steps:
     - shell: bash
       run: |

--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -1,7 +1,7 @@
 name: Elixir Cache
 description: Elixir Cache
 runs:
-  using: "composite"
+  using: composite
   steps:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -1,7 +1,7 @@
 name: Gradle Cache
 description: Gradle Home Cache
 runs:
-  using: "composite"
+  using: composite
   steps:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,13 @@ on:
       - "gradlew"
       - "gradlew.bat"
       - ".github/actions/**"
+      # This is a temporary fix.
+      # To allow merge queue to merge PRs, we need Rust and Elixir
+      # workflows to pass successfully. This PR ensures we also
+      # run Rust workflows on update to Elixir code.
+      - '**.ex'
+      - '**.exs'
+      - '**/mix.lock'
   push:
     paths:
       - ".github/workflows/rust.yml"
@@ -32,6 +39,13 @@ on:
       - "gradlew"
       - "gradlew.bat"
       - ".github/actions/**"
+      # This is a temporary fix.
+      # To allow merge queue to merge PRs, we need Rust and Elixir
+      # workflows to pass successfully. This PR ensures we also
+      # run Rust workflows on update to Elixir code.
+      - '**.ex'
+      - '**.exs'
+      - '**/mix.lock'
     branches:
       - develop
   schedule:


### PR DESCRIPTION
This PR ensures we run rust workflows when there is a PR that updates Elixir code. This allows the merge queue to merge PRs