### PR TITLE
refactor(rust): all functions from ockam_command now return a `crate::Result`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -1,6 +1,7 @@
 use crate::help;
 use crate::util::embedded_node;
-use anyhow::{anyhow, Result};
+use crate::Result;
+use anyhow::anyhow;
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use ockam::compat::collections::HashMap;

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -78,7 +78,7 @@ async fn enroll(
     opts: &CommandGlobalOpts,
     cmd: &EnrollCommand,
     node_name: &str,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let auth0 = Auth0Service::new(Auth0Provider::Auth0);
     let token = auth0.token().await?;
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
@@ -92,7 +92,7 @@ async fn enroll(
         Ok(())
     } else {
         eprintln!("{}", rpc.parse_err_msg(res, dec));
-        Err(anyhow!("Failed to enroll"))
+        Err(anyhow!("Failed to enroll").into())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/forwarder/create.rs
@@ -78,7 +78,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
 }
 
 impl Output for ForwarderInfo<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         Ok(format!("/service/{}", self.remote_address()))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,6 +1,6 @@
 use crate::util::output::Output;
 use crate::util::print_output;
-use crate::CommandGlobalOpts;
+use crate::{CommandGlobalOpts, Result};
 use anyhow::anyhow;
 use clap::{Args, ValueEnum};
 use core::fmt::Write;
@@ -61,7 +61,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
 }
 
 impl Output for LongIdentityResponse<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         let id: IdentityChangeHistory = serde_bare::from_slice(self.identity.0.as_ref())?;
         write!(w, "{id}")?;
@@ -70,7 +70,7 @@ impl Output for LongIdentityResponse<'_> {
 }
 
 impl Output for ShortIdentityResponse<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "{}", self.identity_id)?;
         Ok(w)

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -19,7 +19,7 @@ use crate::util::node_rpc;
 use crate::util::{bind_to_port_check, embedded_node_that_is_not_stopped, exitcode};
 use crate::{
     help, node::show::print_query_status, node::HELP_DETAIL, project, util::find_available_port,
-    CommandGlobalOpts,
+    CommandGlobalOpts, Result,
 };
 use crate::{node::util::spawn_node, util::parse_node_name};
 use crate::{
@@ -142,7 +142,7 @@ impl CreateCommand {
         }
     }
 
-    fn overwrite_addr(&self) -> anyhow::Result<Self> {
+    fn overwrite_addr(&self) -> Result<Self> {
         let cmd = self.clone();
         let addr: SocketAddr = if &cmd.tcp_listener_address == "127.0.0.1:0" {
             let port = find_available_port().context("failed to acquire available port")?;
@@ -157,7 +157,7 @@ impl CreateCommand {
     }
 }
 
-fn parse_launch_config(config_or_path: &str) -> anyhow::Result<Config> {
+fn parse_launch_config(config_or_path: &str) -> Result<Config> {
     match serde_json::from_str::<Config>(config_or_path) {
         Ok(c) => Ok(c),
         Err(_) => {
@@ -366,7 +366,7 @@ async fn start_services(
     addr: SocketAddr,
     node_opts: super::NodeOpts,
     opts: &CommandGlobalOpts,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let config = {
         if let Some(sc) = &cfg.startup_services {
             sc.clone()
@@ -482,8 +482,8 @@ async fn spawn_background_node(
     Ok(())
 }
 
-fn otc_parser(val: &str) -> anyhow::Result<OneTimeCode> {
+fn otc_parser(val: &str) -> Result<OneTimeCode> {
     let bytes = hex::decode(val)?;
-    let code = <[u8; 32]>::try_from(bytes.as_slice())?;
+    let code = <[u8; 32]>::try_from(bytes.as_slice()).context("Failed to parse OTC")?;
     Ok(code.into())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,6 +1,6 @@
 use crate::node::default_node_name;
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
-use crate::{help, node::HELP_DETAIL, CommandGlobalOpts};
+use crate::{help, node::HELP_DETAIL, CommandGlobalOpts, Result};
 use clap::Args;
 use colorful::Colorful;
 use core::time::Duration;
@@ -153,7 +153,7 @@ pub async fn print_query_status(
     node_name: &str,
     wait_until_ready: bool,
     is_default: bool,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let cli_state = cli_state::CliState::new()?;
     let node_state = cli_state.nodes.get(node_name)?;
     if !is_node_up(rpc, wait_until_ready).await? {
@@ -219,7 +219,7 @@ pub async fn print_query_status(
 /// appear to be 'up', retry the test at time intervals up to
 /// a maximum number of retries. A use case for this is to
 /// allow a node time to start up and become ready.
-async fn is_node_up(rpc: &mut Rpc<'_>, wait_until_ready: bool) -> anyhow::Result<bool> {
+async fn is_node_up(rpc: &mut Rpc<'_>, wait_until_ready: bool) -> Result<bool> {
     let attempts = match wait_until_ready {
         true => IS_NODE_UP_MAX_ATTEMPTS,
         false => 1,

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use clap::Args;
 use rand::prelude::random;
 
@@ -49,8 +48,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
 ) -> crate::Result<()> {
-    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)
-        .context(format!("Space '{}' does not exist", cmd.space_name))?;
+    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)?;
     let node_name = start_embedded_node(ctx, &opts, None).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::create(

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use clap::Args;
 
 use ockam::Context;
@@ -42,8 +41,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
 ) -> crate::Result<()> {
-    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)
-        .context(format!("Space '{}' does not exist", cmd.space_name))?;
+    let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)?;
 
     let node_name = start_embedded_node(ctx, &opts, None).await?;
     let controller_route = &cmd.cloud_opts.route();

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -128,7 +128,7 @@ impl Runner {
 fn project_authority<'a>(
     input: &MultiAddr,
     map: &'a ConfigLookup,
-) -> anyhow::Result<Option<&'a ProjectAuthority>> {
+) -> Result<Option<&'a ProjectAuthority>> {
     if let Some(proto) = input.first() {
         if proto.code() == proto::Project::CODE {
             let proj = proto.cast::<proto::Project>().expect("project protocol");
@@ -136,10 +136,10 @@ fn project_authority<'a>(
                 if let Some(a) = &p.authority {
                     return Ok(Some(a));
                 } else {
-                    return Err(anyhow!("missing authority in project {:?}", &*proj));
+                    return Err(anyhow!("missing authority in project {:?}", &*proj).into());
                 }
             } else {
-                return Err(anyhow!("unknown project {}", &*proj));
+                return Err(anyhow!("unknown project {}", &*proj).into());
             }
         }
     }
@@ -149,7 +149,7 @@ fn project_authority<'a>(
 /// Replaces the first `/project` with the given address.
 ///
 /// Assumes (and asserts!) that the first protocol is a `/project`.
-pub fn replace_project(input: &MultiAddr, with: &MultiAddr) -> anyhow::Result<MultiAddr> {
+pub fn replace_project(input: &MultiAddr, with: &MultiAddr) -> Result<MultiAddr> {
     let mut iter = input.iter();
     let first = iter.next().map(|p| p.code());
     assert_eq!(first, Some(proto::Project::CODE));

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::str::FromStr;
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{anyhow, Context as _};
 use ockam_core::api::Request;
 use tracing::debug;
 
@@ -17,7 +17,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 use crate::project::enroll::replace_project;
 use crate::util::api::CloudOpts;
 use crate::util::{api, RpcBuilder};
-use crate::{CommandGlobalOpts, OckamConfig};
+use crate::{CommandGlobalOpts, OckamConfig, Result};
 
 pub fn clean_projects_multiaddr(
     input: MultiAddr,
@@ -313,9 +313,9 @@ pub mod config {
     async fn set(config: &OckamConfig, project: &Project<'_>) -> Result<()> {
         if !project.is_ready() {
             trace!("Project is not ready yet {}", project.output()?);
-            return Err(anyhow!(
-                "Project is not ready yet, wait a few seconds and try again"
-            ));
+            return Err(
+                anyhow!("Project is not ready yet, wait a few seconds and try again").into(),
+            );
         }
 
         config.set_project_alias(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -56,7 +56,7 @@ impl CreateCommand {
         cloud_addr: &MultiAddr,
         api_node: &str,
         tcp: &TcpTransport,
-    ) -> anyhow::Result<MultiAddr> {
+    ) -> Result<MultiAddr> {
         let (to, meta) = clean_multiaddr(&self.to, &opts.state)
             .context(format!("Could not convert {} into route", &self.to))?;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -11,7 +11,7 @@ use ockam_core::{Address, Route};
 use crate::node::default_node_name;
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
-use crate::{help, CommandGlobalOpts};
+use crate::{help, CommandGlobalOpts, Result};
 
 /// Create Secure Channel Listeners
 #[derive(Clone, Debug, Args)]
@@ -82,7 +82,7 @@ pub async fn create_listener(
     authorized_identifiers: Option<Vec<IdentityIdentifier>>,
     identity: Option<String>,
     mut base_route: Route,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let resp: Vec<u8> = ctx
         .send_and_receive(
             base_route.modify().append(NODEMANAGER_ADDR),

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -1,4 +1,5 @@
-use anyhow::{anyhow, Context, Result};
+use crate::Result;
+use anyhow::Context as _;
 use ockam::identity::IdentityIdentifier;
 use ockam_api::DefaultAddress;
 use serde::{Deserialize, Serialize};
@@ -97,8 +98,9 @@ pub struct Config {
 impl Config {
     pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
         let s = std::fs::read_to_string(path.as_ref())
-            .with_context(|| anyhow!("failed to read {:?}", path.as_ref()))?;
-        serde_json::from_str(&s).with_context(|| anyhow!("invalid config {:?}", path.as_ref()))
+            .context(format!("failed to read {:?}", path.as_ref()))?;
+        let c = serde_json::from_str(&s).context(format!("invalid config {:?}", path.as_ref()))?;
+        Ok(c)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -2,7 +2,8 @@ use crate::node::NodeOpts;
 use crate::service::config::OktaIdentityProviderConfig;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
-use anyhow::{anyhow, Result};
+use crate::Result;
+use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use minicbor::Encode;
 use ockam::{Context, TcpTransport};
@@ -281,7 +282,7 @@ where
         }
         _ => {
             eprintln!("{}", rpc.parse_err_msg(res, dec));
-            Err(anyhow!("Failed to start {serv_name} service"))
+            Err(anyhow!("Failed to start {serv_name} service").into())
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/util.rs
@@ -2,9 +2,10 @@ use core::fmt::Write;
 use ockam_api::nodes::models::services::ServiceList;
 
 use crate::util::output::Output;
+use crate::Result;
 
 impl Output for ServiceList<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         if self.list.is_empty() {
             return Ok("No services found".to_string());
         }

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -13,7 +13,7 @@ use crate::node::util::delete_embedded_node;
 use crate::util::api::CloudOpts;
 use crate::util::output::Output;
 use crate::util::{node_rpc, Rpc};
-use crate::{help, CommandGlobalOpts};
+use crate::{help, CommandGlobalOpts, Result};
 
 const HELP_DETAIL: &str = "";
 
@@ -132,7 +132,7 @@ pub mod utils {
 }
 
 impl Output for Subscription<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Subscription")?;
         write!(w, "\n  Id: {}", self.id)?;
@@ -150,7 +150,7 @@ impl Output for Subscription<'_> {
 }
 
 impl Output for Vec<Subscription<'_>> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No subscriptions found".to_string());
         }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -4,7 +4,6 @@ use crate::util::{
 use crate::Result;
 use crate::{help, CommandGlobalOpts};
 use anyhow::anyhow;
-use anyhow::ensure;
 use clap::Args;
 use ockam::identity::IdentityIdentifier;
 use ockam::{Context, TcpTransport};
@@ -105,10 +104,10 @@ async fn rpc(ctx: Context, (opts, mut cmd): (CommandGlobalOpts, CreateCommand)) 
     Ok(())
 }
 
-fn alias_parser(arg: &str) -> anyhow::Result<String> {
-    ensure! {
-        !arg.contains(':'),
-        "an inlet alias must not contain ':' characters"
+fn alias_parser(arg: &str) -> Result<String> {
+    if arg.contains(':') {
+        Err(anyhow!("an inlet alias must not contain ':' characters").into())
+    } else {
+        Ok(arg.to_string())
     }
-    Ok(arg.to_string())
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,6 +1,6 @@
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{help, CommandGlobalOpts};
-use anyhow::ensure;
+use crate::{help, CommandGlobalOpts, Result};
+use anyhow::anyhow;
 use clap::Args;
 use ockam::Context;
 use ockam_api::{
@@ -94,10 +94,10 @@ fn make_api_request<'a>(cmd: CreateCommand) -> crate::Result<RequestBuilder<'a, 
     Ok(request)
 }
 
-fn alias_parser(arg: &str) -> anyhow::Result<String> {
-    ensure! {
-        !arg.contains(':'),
-        "an outlet alias must not contain ':' characters"
+fn alias_parser(arg: &str) -> Result<String> {
+    if arg.contains(':') {
+        Err(anyhow!("an inlet alias must not contain ':' characters").into())
+    } else {
+        Ok(arg.to_string())
     }
-    Ok(arg.to_string())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -15,7 +15,6 @@ use ockam_api::nodes::models::services::{
 use tracing::trace;
 
 use ockam::identity::IdentityIdentifier;
-use ockam::Result;
 use ockam_api::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
 use ockam_api::nodes::*;
 use ockam_api::DefaultAddress;
@@ -25,6 +24,7 @@ use ockam_core::{Address, CowStr};
 use ockam_multiaddr::MultiAddr;
 
 use crate::util::DEFAULT_CONTROLLER_ADDRESS;
+use crate::Result;
 
 ////////////// !== generators
 
@@ -357,11 +357,11 @@ impl CloudOpts {
 
 ////////////// !== validators
 
-pub(crate) fn validate_cloud_resource_name(s: &str) -> anyhow::Result<()> {
+pub(crate) fn validate_cloud_resource_name(s: &str) -> Result<()> {
     let project_name_regex = Regex::new(r"^[a-zA-Z0-9]+([a-zA-Z0-9-_\.]?[a-zA-Z0-9])*$").unwrap();
     let is_project_name_valid = project_name_regex.is_match(s);
     if !is_project_name_valid {
-        Err(anyhow!("Invalid name"))
+        Err(anyhow!("Invalid name").into())
     } else {
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -2,7 +2,7 @@
 
 use std::{ops::Deref, path::PathBuf, sync::RwLockReadGuard};
 
-use anyhow::Result;
+use crate::Result;
 use tracing::trace;
 
 use ockam::identity::IdentityIdentifier;
@@ -104,7 +104,7 @@ impl AuthoritiesConfig {
         let mut cfg = self.inner.write();
         cfg.add_authority(i, a);
         drop(cfg);
-        self.inner.persist_config_updates()
+        Ok(self.inner.persist_config_updates()?)
     }
 
     pub fn snapshot(&self) -> cli::AuthoritiesConfig {

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -7,9 +7,9 @@ use crate::{
         ProjectInfo,
     },
     util::Rpc,
-    CommandGlobalOpts,
+    CommandGlobalOpts, Result,
 };
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
 use minicbor::{Decode, Encode};
 use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::Context;

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -6,6 +6,7 @@ use ockam_api::cloud::project::{Enroller, Project};
 
 use crate::project::ProjectInfo;
 use crate::util::comma_separated;
+use crate::Result;
 use colorful::Colorful;
 use ockam_api::cloud::space::Space;
 use ockam_api::nodes::models::secure_channel::{
@@ -33,23 +34,23 @@ use ockam_core::route;
 /// }
 ///
 /// impl Output for MyType {
-///     fn output(&self) -> anyhow::Result<String> {
+///     fn output(&self) -> Result<String> {
 ///         Ok(self.to_string())
 ///     }
 /// }
 /// ```
 pub trait Output {
-    fn output(&self) -> anyhow::Result<String>;
+    fn output(&self) -> Result<String>;
 }
 
 impl<O: Output> Output for &O {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         (*self).output()
     }
 }
 
 impl Output for Space<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Space")?;
         write!(w, "\n  Id: {}", self.id)?;
@@ -60,7 +61,7 @@ impl Output for Space<'_> {
 }
 
 impl Output for Vec<Space<'_>> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No spaces found".to_string());
         }
@@ -85,7 +86,7 @@ impl Output for Vec<Space<'_>> {
 }
 
 impl Output for Project<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Project")?;
         write!(w, "\n  Id: {}", self.id)?;
@@ -104,7 +105,7 @@ impl Output for Project<'_> {
 }
 
 impl Output for ProjectInfo<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let pi = self
             .identity
             .as_ref()
@@ -122,7 +123,7 @@ impl Output for ProjectInfo<'_> {
 }
 
 impl Output for Vec<Project<'_>> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No projects found".to_string());
         }
@@ -157,7 +158,7 @@ impl Output for Vec<Project<'_>> {
 }
 
 impl Output for CreateSecureChannelResponse<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let addr = route_to_multiaddr(&route![self.addr.to_string()])
             .context("Invalid Secure Channel Address")?
             .to_string();
@@ -166,7 +167,7 @@ impl Output for CreateSecureChannelResponse<'_> {
 }
 
 impl Output for ShowSecureChannelResponse<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let s = match &self.channel {
             Some(addr) => {
                 format!(
@@ -196,7 +197,7 @@ impl Output for ShowSecureChannelResponse<'_> {
 }
 
 impl Output for Enroller<'_> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Enroller")?;
         write!(w, "\n  Identity id: {}", self.identity_id)?;
@@ -206,7 +207,7 @@ impl Output for Enroller<'_> {
 }
 
 impl Output for Vec<Enroller<'_>> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No enrollers found".to_string());
         }
@@ -232,13 +233,13 @@ impl Output for Vec<Enroller<'_>> {
 }
 
 impl Output for Credential {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         Ok(self.to_string())
     }
 }
 
 impl Output for Vec<u8> {
-    fn output(&self) -> anyhow::Result<String> {
+    fn output(&self) -> Result<String> {
         Ok(hex::encode(self))
     }
 }


### PR DESCRIPTION
To avoid problems with conversions between `crate::Result` and `anyhow::Result`, now all functions from `ockam_command` return the local error.