### PR TITLE
feat(rust): add `vault` argument to `secure-channel listener` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -99,13 +99,15 @@ pub struct CreateSecureChannelListenerRequest<'a> {
     #[n(0)] tag: TypeTag<8112242>,
     #[b(1)] pub addr: Cow<'a, str>,
     #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
-    #[b(3)] pub identity: Option<CowStr<'a>>,
+    #[b(3)] pub vault: Option<CowStr<'a>>,
+    #[b(4)] pub identity: Option<CowStr<'a>>,
 }
 
 impl<'a> CreateSecureChannelListenerRequest<'a> {
     pub fn new(
         addr: &Address,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
+        vault: Option<String>,
         identity: Option<String>,
     ) -> Self {
         Self {
@@ -114,6 +116,7 @@ impl<'a> CreateSecureChannelListenerRequest<'a> {
             addr: addr.to_string().into(),
             authorized_identifiers: authorized_identifiers
                 .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
+            vault: vault.map(|x| x.into()),
             identity: identity.map(|x| x.into()),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -340,6 +340,7 @@ impl NodeManager {
             DefaultAddress::SECURE_CHANNEL_LISTENER.into(),
             None, // Not checking identifiers here in favor of credential check
             None,
+            None,
             ctx,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -174,6 +174,9 @@ impl NodeManager {
                 idt_config.get(ctx, self.vault()?).await?
             }
         } else {
+            if vault_name.is_some() {
+                warn!("The optional vault is ignored when an optional identity is not specified. Using the default identity.");
+            }
             self.identity()?.async_try_clone().await?
         };
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -390,6 +390,7 @@ impl NodeManager {
                 Address::from_string(KAFKA_SECURE_CHANNEL_LISTENER_ADDRESS),
                 None,
                 None,
+                None,
                 context,
             )
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -27,6 +27,9 @@ pub struct CreateCommand {
     #[arg(short, long, value_name = "IDENTIFIERS")]
     authorized_identifiers: Option<Vec<IdentityIdentifier>>,
 
+    #[arg(value_name = "VAULT", long)]
+    vault: Option<String>,
+
     #[arg(value_name = "IDENTITY", long)]
     identity: Option<String>,
 }
@@ -60,6 +63,7 @@ async fn run_impl(
         CreateSecureChannelListenerRequest::new(
             &cmd.address,
             cmd.authorized_identifiers,
+            cmd.vault,
             cmd.identity,
         ),
     );

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -27,7 +27,7 @@ pub struct CreateCommand {
     #[arg(short, long, value_name = "IDENTIFIERS")]
     authorized_identifiers: Option<Vec<IdentityIdentifier>>,
 
-    #[arg(value_name = "VAULT", long)]
+    #[arg(value_name = "VAULT", long, requires = "identity")]
     vault: Option<String>,
 
     #[arg(value_name = "IDENTITY", long)]

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -100,6 +100,7 @@ pub(crate) fn create_secure_channel_listener(
     let payload = models::secure_channel::CreateSecureChannelListenerRequest::new(
         addr,
         authorized_identifiers,
+        None,
         identity,
     );
 


### PR DESCRIPTION
The `secure-channel listener` was only accepting an `identity` argument to override the node's default identity, but that wasn't enough for scenarios where the overridden identity is using a vault that is not the node's default.

This PR adds a new `vault` argument to that command to support the following scenarios:

```bash
# Setup
$OCKAM node delete --all &>/dev/null
$OCKAM vault delete v1 &>/dev/null
$OCKAM vault delete v2 &>/dev/null
$OCKAM identity delete i1 &>/dev/null
$OCKAM identity delete i2 &>/dev/null
echo "+ removed state"

$OCKAM vault create v1 &>/dev/null
$OCKAM identity create i1 --vault v1 &>/dev/null
idt1=$($OCKAM identity show i1)

$OCKAM vault create v2 &>/dev/null
$OCKAM identity create i2 --vault v2 &>/dev/null
idt2=$($OCKAM identity show i2)
```

Scenario 1: setting vault/identity at node creation
```bash
$OCKAM node create n1 &>/dev/null
$OCKAM node create n2 &>/dev/null --vault v2 --identity i2
echo "+ setup done"

$OCKAM secure-channel-listener create l --at n2 --authorized-identifiers $idt1 &>/dev/null
echo "+ secure-channel-listener created"
$OCKAM secure-channel create --from n1 --to /node/n2/service/l --authorized $idt2
```

Scenario 2: setting vault/identity at sc listener creation
```bash
$OCKAM node create n1 &>/dev/null
$OCKAM node create n2 &>/dev/null
echo "+ setup done"

$OCKAM secure-channel-listener create l --at n2 --vault v2 --identity i2 --authorized-identifiers $idt1 &>/dev/null
echo "+ secure-channel-listener created"
$OCKAM secure-channel create --from n1 --to /node/n2/service/l --authorized $idt2
```