### PR TITLE
update os version of binary builder

### DIFF
--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -1,5 +1,6 @@
 name: Elixir Cache
 description: Elixir Cache
+
 runs:
   using: composite
   steps:

--- a/.github/workflows/ockam-package.yml
+++ b/.github/workflows/ockam-package.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   DEPLOYMENT_NAME: ockam
   ARTIFACT_NAME: ockam
-  ORGANIZATION: build-trust
+  ORGANIZATION: ${{ github.repository_owner }}
 
 jobs:
   build-and-publish-artifact:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -197,20 +197,20 @@ jobs:
         build: [linux_86, linux_armv7, macos, macos_86]
         include:
         - build: linux
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: aarch64-unknown-linux-musl
           use-cross-build: true
         - build: linux_armv7
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: armv7-unknown-linux-musleabihf
           use-cross-build: true
         - build: linux_86
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-musl
-          use-cross-build: false
+          use-cross-build: true
         - build: macos
           os: macos-latest
           rust: stable
@@ -240,7 +240,7 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Install packages (Ubuntu)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         set -x
         use_cross_build=${{ matrix.use-cross-build }}

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -261,7 +261,7 @@ if [[ $IS_DRAFT_RELEASE == true ]]; then
 
   temp_dir=$(mktemp -d)
   pushd "$temp_dir"
-  gh release download "$latest_tag_name" -R $owner/ockam
+  gh release download "$latest_tag_name" -p sha256sums.txt -R $owner/ockam
 
   # TODO Ensure that SHA are cosign verified
   while read -r line; do


### PR DESCRIPTION
GitHub action runner ubuntu:18.04 is being deprecated https://github.com/actions/runner-images/issues/6002, this PR updates our runner image to use ubuntu:20.04