### PR TITLE
fix(rust): update project readiness check to include authority

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -78,6 +78,8 @@ impl ConfluentConfigResponse<'_> {
 }
 
 mod node {
+    use std::time::Duration;
+
     use minicbor::{Decode, Decoder, Encode};
     use ockam::AsyncTryClone;
     use tracing::trace;
@@ -88,7 +90,9 @@ mod node {
 
     use crate::cloud::addon::ConfluentConfig;
     use crate::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig};
-    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
+    use crate::cloud::{
+        BareCloudRequestWrapper, CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT,
+    };
     use crate::error::ApiError;
     use crate::nodes::NodeManagerWorker;
 
@@ -179,7 +183,7 @@ mod node {
             let req_builder =
                 Request::put(format!("/v0/{project_id}/addons/{addon_id}")).body(req_body);
 
-            self.request_controller(
+            self.request_controller_with_timeout(
                 ctx,
                 label,
                 None,
@@ -187,6 +191,7 @@ mod node {
                 API_SERVICE,
                 req_builder,
                 ident,
+                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -19,6 +19,8 @@ impl Token {
 }
 
 mod node {
+    use std::time::Duration;
+
     use minicbor::Decoder;
     use tracing::trace;
 
@@ -29,7 +31,7 @@ mod node {
 
     use crate::cloud::enroll::auth0::AuthenticateAuth0Token;
     use crate::cloud::enroll::enrollment_token::{EnrollmentToken, RequestEnrollmentToken};
-    use crate::cloud::CloudRequestWrapper;
+    use crate::cloud::{CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT};
     use crate::nodes::NodeManagerWorker;
     use ockam_identity::credential::Attributes;
 
@@ -55,7 +57,7 @@ mod node {
                 inner.identity()?.async_try_clone().await?
             };
 
-            self.request_controller(
+            self.request_controller_with_timeout(
                 ctx,
                 api_service,
                 None,
@@ -63,6 +65,7 @@ mod node {
                 api_service,
                 req_builder,
                 ident,
+                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }
@@ -118,7 +121,7 @@ mod node {
             };
 
             trace!(target: TARGET, "authenticating token");
-            self.request_controller(
+            self.request_controller_with_timeout(
                 ctx,
                 api_service,
                 None,
@@ -126,6 +129,7 @@ mod node {
                 api_service,
                 req_builder,
                 ident,
+                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -174,6 +174,7 @@ mod node {
             .await
         }
 
+        #[allow(clippy::too_many_arguments)]
         pub(super) async fn request_controller_with_timeout<T>(
             &mut self,
             ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -334,6 +334,8 @@ impl<'a> AddEnroller<'a> {
 }
 
 mod node {
+    use std::time::Duration;
+
     use minicbor::Decoder;
     use tracing::trace;
 
@@ -342,7 +344,9 @@ mod node {
     use ockam_node::Context;
 
     use crate::cli_state;
-    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
+    use crate::cloud::{
+        BareCloudRequestWrapper, CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT,
+    };
     use crate::nodes::NodeManagerWorker;
 
     use super::*;
@@ -386,7 +390,7 @@ mod node {
                 }
             };
 
-            self.request_controller(
+            self.request_controller_with_timeout(
                 ctx,
                 label,
                 "create_project",
@@ -394,6 +398,7 @@ mod node {
                 "projects",
                 req_builder,
                 ident,
+                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use clap::Args;
+use ockam_api::cloud::ORCHESTRATOR_RESTART_TIMEOUT;
 use rand::prelude::random;
 
 use ockam::Context;
@@ -51,11 +54,10 @@ async fn run_impl(
     let space_id = space::config::try_get_space(&opts.config, &cmd.space_name)?;
     let node_name = start_embedded_node(ctx, &opts, None).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
-    rpc.request(api::project::create(
-        &cmd.project_name,
-        &space_id,
-        &cmd.cloud_opts.route(),
-    ))
+    rpc.request_with_timeout(
+        api::project::create(&cmd.project_name, &space_id, &cmd.cloud_opts.route()),
+        Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
+    )
     .await?;
     let project = rpc.parse_response::<Project>()?;
     let project =

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -177,8 +177,9 @@ pub async fn check_project_readiness<'a>(
     tcp: Option<&TcpTransport>,
     mut project: Project<'a>,
 ) -> Result<Project<'a>> {
-    // 3 Mins (180 Seconds) per strategy with 5 second intervals
-    let retry_strategy = FixedInterval::from_millis(5000).take(36);
+    // Total of 10 Mins sleep strategy with 5 second intervals between each retry
+    let total_sleep_time_ms = 10 * 60 * 1000;
+    let retry_strategy = FixedInterval::from_millis(5000).take(total_sleep_time_ms / 5000);
 
     // Persist project config prior to checking readiness which might take a while
     config::set_project_id(&opts.config, &project).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _};
+use colorful::Colorful;
 use ockam_core::api::Request;
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::Retry;
@@ -194,13 +195,14 @@ pub async fn check_project_readiness<'a>(
 
             // Handle the project show request result
             // so we can provide better errors in the case orchestrator does not respond timely
-            if let Ok(_) = rpc
+            if rpc
                 .request(api::project::show(&project_id, cloud_route))
                 .await
+                .is_ok()
             {
                 let p = rpc.parse_response::<Project>()?;
                 if p.is_ready() {
-                    println!("✅");
+                    println!(" {}", "✔︎".light_green());
                     return Ok(p.to_owned());
                 }
             }
@@ -220,7 +222,7 @@ pub async fn check_project_readiness<'a>(
             // Handle the reachable result, so we can provide better errors in the case a project isn't
             if let Ok(reachable) = project.is_reachable().await {
                 if reachable {
-                    println!("✅");
+                    println!(" {}", "✔︎".light_green());
                     return Ok(());
                 }
             }
@@ -259,7 +261,7 @@ pub async fn check_project_readiness<'a>(
             {
                 // Try to delete secure channel, ignore result.
                 let _ = delete_secure_channel(ctx, opts, api_node, tcp, &sc_addr).await;
-                println!("✅");
+                println!(" {}", "✔︎".light_green());
                 return Ok(());
             }
             print!(".");
@@ -295,7 +297,7 @@ pub async fn check_project_readiness<'a>(
             {
                 // Try to delete secure channel, ignore result.
                 let _ = delete_secure_channel(ctx, opts, api_node, tcp, &sc_addr).await;
-                println!("✅");
+                println!(" {}", "✔︎".light_green());
                 return Ok(());
             }
 

--- a/implementations/rust/ockam/ockam_node/src/api.rs
+++ b/implementations/rust/ockam/ockam_node/src/api.rs
@@ -2,6 +2,7 @@
 
 use crate::Context;
 use core::fmt::Display;
+use core::time::Duration;
 use minicbor::Encode;
 use ockam_core::api::RequestBuilder;
 use ockam_core::compat::sync::Arc;
@@ -49,6 +50,38 @@ where
     // TODO: Check IdentityId is the same we sent message to?
     // TODO: Check response id matches request id?
     let vec: Vec<u8> = ctx.send_and_receive(route, buf).await?;
+    Ok(vec)
+}
+
+/// Encode request header and body (if any), send the package to the server and returns its response.
+pub async fn request_with_timeout<T, R>(
+    ctx: &Context,
+    label: &str,
+    #[allow(unused_variables)] struct_name: impl Into<Option<&str>>,
+    route: R,
+    req: RequestBuilder<'_, T>,
+    timeout: Duration,
+) -> Result<Vec<u8>>
+where
+    T: Encode<()>,
+    R: Into<Route> + Display,
+{
+    let buf = req.to_vec()?;
+    #[cfg(feature = "tag")]
+    assert_request_match(struct_name, &buf, cddl());
+    trace! {
+        target:  "ockam_node",
+        id     = %req.header().id(),
+        method = ?req.header().method(),
+        path   = %req.header().path(),
+        body   = %req.header().has_body(),
+        "-> {label}"
+    };
+    // TODO: Check IdentityId is the same we sent message to?
+    // TODO: Check response id matches request id?
+    let vec: Vec<u8> = ctx
+        .send_and_receive_with_timeout(route, buf, timeout)
+        .await?;
     Ok(vec)
 }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

Currently the check project readiness function only attempts to establish a secure channel with the project and NOT the project authority.

When sending API calls to orchestrator the api calls will also time out within 30seconds

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

Checking the project readiness should also include testing a secure channel to the project authority.

API Calls made to orchestrator that can possibly require longer responses due to pod/node restarts, have a timeout increased to 180seconds.


<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
