### PR TITLE
fix(rust): fix broken test by preventing a premature drop

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -46,7 +46,7 @@ impl ConfigValues for OckamConfig {
 impl OckamConfig {
     /// Determine the default storage location for the ockam config
     pub fn dir() -> PathBuf {
-        cli_state::CliState::dir().unwrap()
+        cli_state::CliState::ockam_home_from_environment().unwrap()
     }
 
     /// This function could be zero-copy if we kept the lock on the

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -632,7 +632,7 @@ mod test {
     async fn kafka_portal_worker__metadata_exchange__response_changed(
         context: &mut Context,
     ) -> ockam::Result<()> {
-        crate::test::start_manager_for_tests(context).await?;
+        let _handle = crate::test::start_manager_for_tests(context).await?;
 
         let vault = Vault::create();
         let identity = Identity::create(context, &vault).await?;


### PR DESCRIPTION
## Current Behavior

test `kafka_portal_worker__metadata_exchange__response_changed` fails randomly.
The issue is `OCKAM_HOME` being read multiple times during tests, this creates a race condition between tests, causing random failure.

## Proposed Changes

Having a single read of `OCKAM_HOME` during the command bootstrap and having everyone else rely on a provided path instead.

## NOTES

This makes the patch quite time-consuming, some items that were built using `Default::default()` cannot be built this way anymore,  and it quickly propagates to a sizable piece of the codebase.