### PR TITLE
`ockam enroll` twice should not be an error

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -982,9 +982,6 @@ impl ProjectsState {
         let path = {
             let mut path = self.dir.clone();
             path.push(format!("{name}.json"));
-            if path.exists() {
-                return Err(CliStateError::AlreadyExists(format!("project `{name}`")));
-            }
             path
         };
         let contents = serde_json::to_string(&config)?;


### PR DESCRIPTION
## Current Behavior
`ockam enroll` throws an error if an existing configuration is present.

## Proposed Changes
Ovewrite any existing file with the new configuration.

Resolves #4319 

## Checks
- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.
