### PR TITLE
feat(rust): added cmd to delete a tcp-outlet by alias and node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -112,6 +112,8 @@ impl<'a> CreateOutlet<'a> {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct DeleteOutlet<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<1193889>,
     /// The alias of the TCP outlet to be deleted
     #[b(1)] pub alias: CowStr<'a>,
     #[b(2)] pub addr: CowStr<'a>

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -116,18 +116,14 @@ pub struct DeleteOutlet<'a> {
     #[n(0)] tag: TypeTag<1193889>,
     /// The alias of the TCP outlet to be deleted
     #[b(1)] pub alias: CowStr<'a>,
-    #[b(2)] pub addr: CowStr<'a>
 }
 
 impl<'a> DeleteOutlet<'a> {
-    pub fn new(
-        alias: impl Into<CowStr<'a>>,
-        addr: impl Into<CowStr<'a>>,
-
-    ) -> Self {
+    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
         Self {
+             #[cfg(feature = "tag")]
+            tag: TypeTag,
             alias: alias.into(),
-            addr: addr.into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -11,7 +11,7 @@ use ockam_core::TypeTag;
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;
 
-/// Request body to create an inlet or outlet
+/// Request body to create an inlet
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
@@ -76,7 +76,7 @@ impl<'a> CreateInlet<'a> {
     }
 }
 
-/// Request body to create an inlet or outlet
+/// Request body to create an outlet
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
@@ -103,6 +103,29 @@ impl<'a> CreateOutlet<'a> {
             tcp_addr: tcp_addr.into(),
             worker_addr: worker_addr.into(),
             alias: alias.into(),
+        }
+    }
+}
+
+/// Request body to delete an outlet
+#[derive(Clone, Debug, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteOutlet<'a> {
+    /// The alias of the TCP outlet to be deleted
+    #[b(1)] pub alias: CowStr<'a>,
+    #[b(2)] pub addr: CowStr<'a>
+}
+
+impl<'a> DeleteOutlet<'a> {
+    pub fn new(
+        alias: impl Into<CowStr<'a>>,
+        addr: impl Into<CowStr<'a>>,
+
+    ) -> Self {
+        Self {
+            alias: alias.into(),
+            addr: addr.into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -121,7 +121,7 @@ pub struct DeleteOutlet<'a> {
 impl<'a> DeleteOutlet<'a> {
     pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
         Self {
-             #[cfg(feature = "tag")]
+            #[cfg(feature = "tag")]
             tag: TypeTag,
             alias: alias.into(),
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -663,6 +663,7 @@ impl NodeManagerWorker {
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
+
             (Delete, ["node", "portal"]) => todo!(),
 
             // ==*== Workers ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -662,6 +662,7 @@ impl NodeManagerWorker {
             }
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
+            (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "portal"]) => todo!(),
 
             // ==*== Workers ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -342,7 +342,6 @@ impl NodeManagerWorker {
                     &alias,
                 );
 
-
                 if let Some(successfully_removed_outlet) = removed_outlet {
                     Response::ok(req.id()).body(OutletStatus::new(
                         addr.into_owned(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -1,7 +1,7 @@
 use crate::error::ApiError;
 use crate::nodes::connection::Connection;
 use crate::nodes::models::portal::{
-    CreateInlet, CreateOutlet, InletList, InletStatus, OutletList, OutletStatus,
+    CreateInlet, CreateOutlet, InletList, InletStatus, OutletList, OutletStatus, DeleteOutlet,
 };
 use crate::nodes::registry::{InletInfo, OutletInfo, Registry};
 use crate::nodes::service::random_alias;
@@ -11,7 +11,7 @@ use crate::{local_multiaddr_to_route, try_multiaddr_to_addr};
 use minicbor::Decoder;
 use ockam::compat::asynchronous::RwLock;
 use ockam::compat::tokio::time::timeout;
-use ockam::{Address, AsyncTryClone, Result};
+use ockam::{Address, AsyncTryClone, Result, TCP};
 use ockam_abac::expr::{eq, ident, str};
 use ockam_abac::{Action, Env, PolicyAccessControl, PolicyStorage, Resource};
 use ockam_core::api::{Request, Response, ResponseBuilder};
@@ -308,6 +308,62 @@ impl NodeManagerWorker {
                 Response::bad_request(req.id()).body(OutletStatus::new(
                     tcp_addr,
                     worker_addr.to_string(),
+                    alias,
+                    Some(e.to_string().into()),
+                ))
+            }
+        })
+    }
+
+    pub(super) async fn delete_outlet<'a>(
+        &mut self,
+        req: &Request<'_>,
+        dec: &mut Decoder<'_>,
+    ) -> Result<ResponseBuilder<OutletStatus<'a>>> {
+        let mut node_manager = self.node_manager.write().await;
+        let DeleteOutlet {
+            alias,
+            addr,
+        } = dec.decode()?;
+
+        let alias = alias.into_owned();
+        info!("Handling request to delete outlet portal");
+
+        let tcp_addr = Address::new(TCP, addr.clone().into_owned());
+        let res = node_manager
+            .tcp_transport
+            .stop_outlet(tcp_addr)
+            .await;
+
+        Ok(match res {
+            Ok(_) => {
+                // TODO: Use better way to remove outlets?
+                let removed_outlet = node_manager.registry.outlets.remove(
+                    &alias,
+                );
+
+
+                if let Some(successfully_removed_outlet) = removed_outlet {
+                    Response::ok(req.id()).body(OutletStatus::new(
+                        addr.into_owned(),
+                        successfully_removed_outlet.worker_addr.to_string(),
+                        alias,
+                        None,
+                    ))
+                } else {
+                    Response::internal_error(req.id()).body(OutletStatus::new(
+                        addr.into_owned(),
+                        "",
+                        alias,
+                        None,
+                    ))
+                }
+
+            }
+            Err(e) => {
+                Response::bad_request(req.id()).body(OutletStatus::new(
+                    addr.into_owned(),
+                    "",
                     alias,
                     Some(e.to_string().into()),
                 ))

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -75,7 +75,7 @@ fn make_api_request<'a>(cmd: CreateCommand) -> crate::Result<RequestBuilder<'a, 
 
 fn alias_parser(arg: &str) -> Result<String> {
     if arg.contains(':') {
-        Err(anyhow!("an inlet alias must not contain ':' characters").into())
+        Err(anyhow!("an outlet alias must not contain ':' characters").into())
     } else {
         Ok(arg.to_string())
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -45,32 +45,17 @@ pub async fn run_impl(
     ctx: Context,
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    // let node = extract_address_value(&cmd.at/)?;
-    // let mut rpc = Rpc::background(&ctx, &options, &node)?;
+    let alias = cmd.alias.clone();
 
-    // let cmd = DeleteCommand {
-    //     from: extract_address_value(&cmd.from)?,
-    //     ..cmd
-    // };
-
-    // rpc.request(make_api_request(cmd)?).await?;
-    // let OutletStatus { worker_addr, .. } = rpc.parse_response()?;
-
-    // let addr = route_to_multiaddr(&route![worker_addr.to_string()])
-    //     .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
-    // println!("{addr}");
-
-    // TO-DO: here, a request has to be sent to API, using a DeleteOutlet structure containing node + alias
-    // This request will use the `.remove()` method from the registry's BTree. (See portals.rs AND portal.rs under ockam API)
     let node = extract_address_value(&cmd.node_opts.api_node)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
 
     let OutletStatus { worker_addr, .. } = rpc.parse_response()?;
-
     let addr = route_to_multiaddr(&route![worker_addr.to_string()])
         .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
-    println!("{addr}");
+
+    println!("Deleted TCP Outlet '{}' on node '{}'", alias, addr);
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,0 +1,92 @@
+use crate::node::NodeOpts;
+use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::{CommandGlobalOpts};
+use anyhow::ensure;
+use clap::Args;
+use ockam::Context;
+use ockam_api::{
+    error::ApiError,
+    nodes::models::portal::{DeleteOutlet, OutletStatus},
+    route_to_multiaddr,
+};
+use ockam_core::api::{Request, RequestBuilder};
+use ockam_core::route;
+
+/// Delete a TCP Outlet
+#[derive(Clone, Debug, Args)]
+#[command()]
+pub struct DeleteCommand {
+    /// Name assigned to outlet that will be deleted
+    #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]
+    alias: String,
+
+    /// Node on which to stop the tcp outlet. If none are provided, the default node will be used
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl DeleteCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
+    }
+
+    // pub fn check_credential(&self) -> Option<bool> {
+    //     if self.check_credential {
+    //         Some(true)
+    //     } else if self.disable_check_credential {
+    //         Some(false)
+    //     } else {
+    //         None
+    //     }
+    // }
+}
+
+pub async fn run_impl(
+    ctx: Context,
+    (options, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    // let node = extract_address_value(&cmd.at/)?;
+    // let mut rpc = Rpc::background(&ctx, &options, &node)?;
+
+    // let cmd = DeleteCommand {
+    //     from: extract_address_value(&cmd.from)?,
+    //     ..cmd
+    // };
+
+    // rpc.request(make_api_request(cmd)?).await?;
+    // let OutletStatus { worker_addr, .. } = rpc.parse_response()?;
+
+    // let addr = route_to_multiaddr(&route![worker_addr.to_string()])
+    //     .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
+    // println!("{addr}");
+
+    // TO-DO: here, a request has to be sent to API, using a DeleteOutlet structure containing node + alias
+    // This request will use the `.remove()` method from the registry's BTree. (See portals.rs AND portal.rs under ockam API)
+    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let mut rpc = Rpc::background(&ctx, &options, &node)?;
+    rpc.request(make_api_request(cmd)?).await?;
+
+    let OutletStatus { worker_addr, .. } = rpc.parse_response()?;
+
+    let addr = route_to_multiaddr(&route![worker_addr.to_string()])
+        .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
+    println!("{addr}");
+    Ok(())
+}
+
+/// Construct a request to delete a tcp outlet
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, DeleteOutlet<'a>>> {
+    // let alias = cmd.alias.map(|a| a.into());
+    let addr = extract_address_value(&cmd.node_opts.api_node)?;
+    let payload = DeleteOutlet::new(cmd.alias, addr);
+    let request = Request::delete("/node/outlet").body(payload);
+    Ok(request)
+}
+
+fn alias_parser(arg: &str) -> anyhow::Result<String> {
+    ensure! {
+        !arg.contains(':'),
+        "an outlet alias must not contain ':' characters"
+    }
+    Ok(arg.to_string())
+}

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -1,10 +1,13 @@
 mod create;
 mod list;
+mod delete;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
 use list::ListCommand;
+use delete::DeleteCommand;
+
 
 /// Manage TCP Outlets
 #[derive(Clone, Debug, Args)]
@@ -17,6 +20,7 @@ pub struct TcpOutletCommand {
 pub enum TcpOutletSubCommand {
     Create(CreateCommand),
     List(ListCommand),
+    Delete(DeleteCommand),
 }
 
 impl TcpOutletCommand {
@@ -24,6 +28,7 @@ impl TcpOutletCommand {
         match self.subcommand {
             TcpOutletSubCommand::Create(c) => c.run(options),
             TcpOutletSubCommand::List(c) => c.run(options),
+            TcpOutletSubCommand::Delete(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -1,13 +1,12 @@
 mod create;
-mod list;
 mod delete;
+mod list;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
-use list::ListCommand;
 use delete::DeleteCommand;
-
+use list::ListCommand;
 
 /// Manage TCP Outlets
 #[derive(Clone, Debug, Args)]

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -341,6 +341,23 @@ teardown() {
   assert_output --regexp "To Outlet Address: /service/.*/service/outlet"
 }
 
+@test "portals - delete a tcp outlet" {
+  port=5000
+  run --separate-stderr "$OCKAM" node create n1
+  assert_success
+
+  run $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to "127.0.0.1:$port" --alias "test-outlet"
+  assert_output --partial "/service/outlet"
+  assert_success
+
+  run $OCKAM tcp-outlet delete "test-outlet"
+  assert_success
+
+  # Test deletion of a previously deleted TCP outlet
+  run $OCKAM tcp-outlet delete "test-outlet"
+  assert_output --partial "NotFound"
+}
+
 @test "portals - create an inlet/outlet pair and move tcp traffic through it" {
   port=6000
   run --separate-stderr "$OCKAM" node create n1


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

There is no way to delete a tcp-outlet from a node directly.

## Proposed Changes

This PR resolves https://github.com/build-trust/ockam/issues/4268 by adding a `tcp-outlet delete` to `ockam::command`. 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
