### PR TITLE
feat(rust):add tcp-outlet list subcommand

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,0 +1,45 @@
+use crate::node::NodeOpts;
+use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::{help, CommandGlobalOpts};
+use clap::Args;
+use ockam_api::nodes::models::portal::OutletList;
+use ockam_api::{error::ApiError, route_to_multiaddr};
+use ockam_core::api::Request;
+use ockam_core::route;
+const HELP_DETAIL: &str = include_str!("../../constants/tcp/outlet/help_detail.txt");
+
+/// List TCP Outlets
+#[derive(Clone, Debug, Args)]
+#[command(after_long_help = help::template(HELP_DETAIL))]
+
+pub struct ListCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ListCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (options, command): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let node_name = extract_address_value(&command.node_opts.api_node)?;
+    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    rpc.request(Request::get("/node/outlet")).await?;
+    let response = rpc.parse_response::<OutletList>()?;
+
+    println!("Outlet:");
+    for outlet in &response.list {
+        println!("    Alias: {}", outlet.alias);
+        let addr = route_to_multiaddr(&route![outlet.worker_addr.to_string()])
+            .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
+        println!("    From Outlet: {addr}");
+
+        println!("    To TCP: {}", outlet.tcp_addr);
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -1,8 +1,10 @@
 mod create;
+mod list;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
+use list::ListCommand;
 
 /// Manage TCP Outlets
 #[derive(Clone, Debug, Args)]
@@ -14,12 +16,14 @@ pub struct TcpOutletCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum TcpOutletSubCommand {
     Create(CreateCommand),
+    List(ListCommand),
 }
 
 impl TcpOutletCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             TcpOutletSubCommand::Create(c) => c.run(options),
+            TcpOutletSubCommand::List(c) => c.run(options),
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior
No Current subcommand exists to list all tcp outlets of a node
Closes #4228
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes
Added tcp-outlet list subcommand
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
