### PR TITLE
refactor(rust): refactor `CliState` so it can be built using an explicit directory

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -46,7 +46,7 @@ impl ConfigValues for OckamConfig {
 impl OckamConfig {
     /// Determine the default storage location for the ockam config
     pub fn dir() -> PathBuf {
-        cli_state::CliState::dir().unwrap()
+        cli_state::CliState::default_dir().unwrap()
     }
 
     /// This function could be zero-copy if we kept the lock on the

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -73,7 +73,7 @@ impl NodeManager {
         }
 
         let vault = self.vault()?.async_try_clone().await?;
-        let service = IdentityService::new(ctx, vault).await?;
+        let service = IdentityService::new(ctx, vault, self.cli_state.clone()).await?;
 
         ctx.start_worker(
             addr.clone(),

--- a/implementations/rust/ockam/ockam_api/tests/identity.rs
+++ b/implementations/rust/ockam/ockam_api/tests/identity.rs
@@ -1,4 +1,5 @@
 use minicbor::Decoder;
+use ockam_api::cli_state::CliState;
 use ockam_api::identity::models::*;
 use ockam_api::identity::IdentityService;
 use ockam_core::api::{Request, Response, Status};
@@ -153,20 +154,21 @@ async fn verify_signature(
 
 #[ockam_macros::test]
 async fn full_flow(ctx: &mut Context) -> Result<()> {
+    let cli_state = CliState::test().unwrap();
     let vault1 = Vault::create();
     let vault2 = Vault::create();
 
     // Start services
     ctx.start_worker(
         "1",
-        IdentityService::new(ctx, vault1.async_try_clone().await?).await?,
+        IdentityService::new(ctx, vault1.async_try_clone().await?, cli_state.clone()).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )
     .await?;
     ctx.start_worker(
         "2",
-        IdentityService::new(ctx, vault2.async_try_clone().await?).await?,
+        IdentityService::new(ctx, vault2.async_try_clone().await?, cli_state).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -26,22 +26,21 @@ async fn run_impl(
     ctx: Context,
     (options, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let vault_config = if let Some(vault_name) = cmd.vault {
-        options.state.vaults.get(&vault_name)?.config
+    let vault_state = if let Some(vault_name) = cmd.vault {
+        options.state.vaults.get(&vault_name)?
     } else if options.state.vaults.default().is_err() {
         let vault_name = hex::encode(random::<[u8; 4]>());
-        let config = options
+        let state = options
             .state
             .vaults
-            .create(&vault_name, VaultConfig::from_name(&vault_name)?)
-            .await?
-            .config;
+            .create(&vault_name, VaultConfig::default())
+            .await?;
         println!("Default vault created: {}", &vault_name);
-        config
+        state
     } else {
-        options.state.vaults.default()?.config
+        options.state.vaults.default()?
     };
-    let vault = vault_config.get().await?;
+    let vault = vault_state.get().await?;
     let identity = Identity::create_ext(
         &ctx,
         &options.state.identities.authenticated_storage().await?,

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -78,7 +78,8 @@ impl Output for ShortIdentityResponse<'_> {
 }
 
 fn default_identity_name() -> String {
-    let state = CliState::new().expect("Failed to load CLI state. Try running 'ockam reset'");
+    let state =
+        CliState::try_default().expect("Failed to load CLI state. Try running 'ockam reset'");
     state
         .identities
         .default()

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -153,7 +153,7 @@ impl CommandGlobalOpts {
         Self {
             global_args,
             config,
-            state: CliState::new().expect("Failed to load CLI state"),
+            state: CliState::try_default().expect("Failed to load CLI state"),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -281,6 +281,7 @@ async fn run_foreground_node(
     let node_man = NodeManager::create(
         &ctx,
         NodeManagerGeneralOptions::new(
+            opts.state.clone(),
             cmd.node_name.clone(),
             cmd.launch_config.is_some(),
             pre_trusted_identities,

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -85,7 +85,7 @@ pub struct NodeOpts {
 }
 
 pub fn default_node_name() -> String {
-    CliState::new()
+    CliState::try_default()
         .unwrap()
         .nodes
         .default()

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -155,7 +155,7 @@ pub async fn print_query_status(
     wait_until_ready: bool,
     is_default: bool,
 ) -> Result<()> {
-    let cli_state = cli_state::CliState::new()?;
+    let cli_state = cli_state::CliState::try_default()?;
     let node_state = cli_state.nodes.get(node_name)?;
     if !is_node_up(rpc, wait_until_ready).await? {
         let node_port = node_state.setup().ok().and_then(|setup| {
@@ -239,7 +239,7 @@ async fn is_node_up(rpc: &mut Rpc<'_>, wait_until_ready: bool) -> Result<bool> {
     let timeout =
         FixedInterval::from_millis(IS_NODE_UP_TIME_BETWEEN_CHECKS_MS as u64).take(attempts);
 
-    let cli_state = cli_state::CliState::new()?;
+    let cli_state = cli_state::CliState::try_default()?;
     let now = std::time::Instant::now();
     for t in timeout {
         // The node is down if it has not stored its default tcp listener in its state file.

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -73,7 +73,12 @@ pub async fn start_embedded_node_with_vault_and_identity(
 
     let node_man = NodeManager::create(
         ctx,
-        NodeManagerGeneralOptions::new(cmd.node_name.clone(), cmd.launch_config.is_some(), None),
+        NodeManagerGeneralOptions::new(
+            opts.state.clone(),
+            cmd.node_name.clone(),
+            cmd.launch_config.is_some(),
+            None,
+        ),
         NodeManagerProjectsOptions::new(
             Some(&cfg.authorities(&cmd.node_name)?.snapshot()),
             project_id,
@@ -147,7 +152,7 @@ pub(super) async fn init_node_state(
         v
     } else {
         let n = hex::encode(random::<[u8; 4]>());
-        let c = cli_state::VaultConfig::from_name(&n)?;
+        let c = cli_state::VaultConfig::default();
         opts.state.vaults.create(&n, c).await?
     };
 
@@ -159,7 +164,7 @@ pub(super) async fn init_node_state(
     else if let Ok(idt) = opts.state.identities.default() {
         idt
     } else {
-        let vault = vault_state.config.get().await?;
+        let vault = vault_state.get().await?;
         let identity_name = hex::encode(random::<[u8; 4]>());
         let identity = Identity::create_ext(
             ctx,

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -44,7 +44,7 @@ impl OckamConfig {
     }
 
     pub fn authorities(&self, node: &str) -> Result<AuthoritiesConfig> {
-        let path = cli_state::CliState::new()?.nodes.dir.join(node);
+        let path = cli_state::CliState::try_default()?.nodes.dir.join(node);
         AuthoritiesConfig::load(path)
     }
 


### PR DESCRIPTION
It also refactors the `NodeManager` so it includes a `CliState` instance instead of building a new default instance every time it needs it.

Tries to fix https://github.com/build-trust/ockam/issues/4345
