### PR TITLE
refactor: removed type parameters exposing implementation details

### DIFF
--- a/examples/rust/file_transfer/examples/receiver.rs
+++ b/examples/rust/file_transfer/examples/receiver.rs
@@ -87,7 +87,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Receiver.
-    let receiver = Identity::create(&ctx, &vault).await?;
+    let receiver = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener for Receiver that will wait for requests to
     // initiate an Authenticated Key Exchange.

--- a/examples/rust/file_transfer/examples/sender.rs
+++ b/examples/rust/file_transfer/examples/sender.rs
@@ -43,7 +43,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Sender.
-    let sender = Identity::create(&ctx, &vault).await?;
+    let sender = Identity::create(&ctx, vault).await?;
 
     // This program expects that the receiver has setup a forwarding address,
     // for his secure channel listener, on the Ockam node at 1.node.ockam.network:4000.

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-initiator.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-initiator.rs
@@ -13,7 +13,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // Create a TCP connection to the middle node.
     let connection_to_middle_node = tcp.connect("localhost:3000", TcpConnectionTrustOptions::new()).await?;

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-responder.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-responder.rs
@@ -17,7 +17,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Bob.
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.

--- a/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
@@ -3,6 +3,7 @@ use ockam::identity::credential_issuer::{CredentialIssuerApi, CredentialIssuerCl
 use ockam::identity::{Identity, SecureChannelTrustOptions, TrustEveryonePolicy};
 use ockam::sessions::Sessions;
 use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
+use std::sync::Arc;
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -49,11 +50,12 @@ async fn main(mut ctx: Context) -> Result<()> {
     println!("created a secure channel at {channel:?}");
 
     // Send Alice credentials over the secure channel
+    let storage = AuthenticatedAttributeStorage::new(alice.authenticated_storage().clone());
     alice
         .present_credential_mutual(
             route![channel.clone(), "credential_exchange"],
             vec![&issuer.public_identity().await?],
-            &AuthenticatedAttributeStorage::new(alice.authenticated_storage().clone()),
+            Arc::new(storage),
             None,
         )
         .await?;

--- a/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
+++ b/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
@@ -15,7 +15,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // Create a stream client
     let (sender, _receiver) = Stream::new(&ctx)

--- a/examples/rust/get_started/examples/10-secure-channel-via-streams-responder.rs
+++ b/examples/rust/get_started/examples/10-secure-channel-via-streams-responder.rs
@@ -20,7 +20,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener at address "secure_channel_listener"
     bob.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -92,18 +92,18 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // store the credential and start a credential exchange worker which will be
     // later on to exchange credentials with the edge node
     control_plane.set_credential(credential).await;
-    let attributes_storage = AuthenticatedAttributeStorage::new(control_plane.authenticated_storage().clone());
+    let storage = AuthenticatedAttributeStorage::new(control_plane.authenticated_storage().clone());
     control_plane
         .start_credential_exchange_worker(
             vec![project.authority_public_identity()],
             "credential_exchange",
             true,
-            attributes_storage,
+            Arc::new(storage),
         )
         .await?;
 
     // 3. create an access control policy checking the value of the "component" attribute of the caller
-    let access_control = AbacAccessControl::create(control_plane.authenticated_storage(), "component", "edge");
+    let access_control = AbacAccessControl::create(control_plane.authenticated_storage().clone(), "component", "edge");
 
     // 4. create a tcp outlet with the above policy
     let outlet = tcp

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -51,13 +51,13 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
 
     // Create an Identity for the control node
     let vault = Vault::create();
-    let control_plane = Identity::create(&ctx, &vault).await?;
+    let control_plane = Identity::create(&ctx, vault.clone()).await?;
 
     // 2. create a secure channel to the authority
     //    to retrieve the node credential
 
     // Import the authority identity and route from the information file
-    let project = import_project(project_information_path, &vault).await?;
+    let project = import_project(project_information_path, vault).await?;
 
     let tcp_session = create_tcp_session(&project.authority_route(), &tcp).await.unwrap(); // FIXME: Handle error
     let trust_options = SecureChannelTrustOptions::new().with_trust_policy(TrustMultiIdentifiersPolicy::new(vec![

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -48,13 +48,13 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
 
     // Create an Identity for the edge plane
     let vault = Vault::create();
-    let edge_plane = Identity::create(&ctx, &vault).await?;
+    let edge_plane = Identity::create(&ctx, vault.clone()).await?;
 
     // 2. create a secure channel to the authority
     //    to retrieve the node credential
 
     // Import the authority identity and route from the information file
-    let project = import_project(project_information_path, &vault).await?;
+    let project = import_project(project_information_path, vault).await?;
 
     let tcp_authority_session = create_tcp_session(&project.authority_route(), &tcp).await.unwrap(); // FIXME: Handle error
     let authority_trust_options =

--- a/examples/rust/get_started/examples/alice.rs
+++ b/examples/rust/get_started/examples/alice.rs
@@ -11,7 +11,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // This program expects that Bob has setup a forwarding address,
     // for his secure channel listener, on the Ockam node at 1.node.ockam.network:4000.

--- a/examples/rust/get_started/examples/bob.rs
+++ b/examples/rust/get_started/examples/bob.rs
@@ -33,7 +33,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Bob.
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.

--- a/examples/rust/get_started/examples/hello.rs
+++ b/examples/rust/get_started/examples/hello.rs
@@ -11,14 +11,14 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Bob.
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault.clone()).await?;
 
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.
     bob.create_secure_channel_listener("bob", TrustEveryonePolicy).await?;
 
     // Create an entity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault.clone()).await?;
 
     // As Alice, connect to Bob's secure channel listener and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -1,6 +1,5 @@
 use anyhow::anyhow;
-use ockam::identity::{IdentityIdentifier, PublicIdentity};
-use ockam::vault::Vault;
+use ockam::identity::{IdentityIdentifier, IdentityVault, PublicIdentity};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{Error, Result};
 use ockam_multiaddr::MultiAddr;
@@ -8,6 +7,7 @@ use serde_json::{Map, Value};
 use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
+use std::sync::Arc;
 
 /// This struct contains the json data exported
 /// when running `ockam project information > project.json`
@@ -48,7 +48,7 @@ impl Project {
 
 /// Import a project identity into a Vault from a project.json path
 /// and return a Project struct
-pub async fn import_project(path: &str, vault: &Vault) -> Result<Project> {
+pub async fn import_project(path: &str, vault: Arc<dyn IdentityVault>) -> Result<Project> {
     match read_json(path)? {
         Value::Object(values) => {
             let project_identifier = IdentityIdentifier::from_str(get_field_as_str(&values, "identity")?.as_str())?;

--- a/examples/rust/ockam_kafka/examples/ockam_kafka_alice.rs
+++ b/examples/rust/ockam_kafka/examples/ockam_kafka_alice.rs
@@ -17,7 +17,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // This program expects that Bob has created two streams
     // bob_to_alice and alice_to_bob on the cloud node at 1.node.ockam.network:4000

--- a/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
+++ b/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
@@ -33,7 +33,7 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Bob.
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
@@ -18,7 +18,7 @@ async fn main(ctx: Context) -> Result<()> {
     // by a second command line argument.
 
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
+    let e = Identity::create(&ctx, vault).await?;
     let outlet_port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
     let outlet_connection = tcp
         .connect(&format!("127.0.0.1:{outlet_port}"), TcpConnectionTrustOptions::new())

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
@@ -14,7 +14,7 @@ async fn main(ctx: Context) -> Result<()> {
     //      that will wait for requests to start an Authenticated Key Exchange.
 
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
+    let e = Identity::create(&ctx, vault).await?;
     e.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)
         .await?;
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
@@ -15,7 +15,7 @@ async fn main(ctx: Context) -> Result<()> {
     // through a Remote Forwarder at "1.node.ockam.network:4000" and its forwarder address
     // points to secure channel listener.
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
+    let e = Identity::create(&ctx, vault).await?;
 
     // Expect second command line argument to be the Outlet node forwarder address
     let forwarding_address = std::env::args().nth(2).expect("no outlet forwarding address given");

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -12,7 +12,7 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
+    let e = Identity::create(&ctx, vault).await?;
     e.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)
         .await?;
 

--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -1,35 +1,54 @@
+use crate::traits::PolicyStorage;
+use crate::types::{Action, Resource};
+use crate::AbacAccessControl;
+use crate::{Env, Expr};
 use core::fmt;
+use core::fmt::{Debug, Formatter};
 use ockam_core::compat::boxed::Box;
+use ockam_core::compat::format;
+use ockam_core::compat::sync::Arc;
 use ockam_core::{async_trait, RelayMessage};
 use ockam_core::{IncomingAccessControl, Result};
 use ockam_identity::authenticated_storage::IdentityAttributeStorage;
 use tracing as log;
 
-use crate::traits::PolicyStorage;
-use crate::types::{Action, Resource};
-use crate::AbacAccessControl;
-use crate::{Env, Expr};
-
 /// Evaluates a policy expression against an environment of attributes.
 ///
 /// Attributes come from a pre-populated environment and are augmented
 /// by subject attributes from credential data.
-#[derive(Debug)]
-pub struct PolicyAccessControl<P, S> {
+pub struct PolicyAccessControl {
     resource: Resource,
     action: Action,
-    policies: P,
-    attributes: S,
+    policies: Arc<dyn PolicyStorage>,
+    attributes: Arc<dyn IdentityAttributeStorage>,
     environment: Env,
 }
 
-impl<P, S> PolicyAccessControl<P, S> {
+/// Debug implementation writing out the resource, action and initial environment
+impl Debug for PolicyAccessControl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let resource = &self.resource;
+        let action = &self.resource;
+        let environment = &self.environment;
+        f.write_str(format!("resource {resource:?}").as_str())?;
+        f.write_str(format!("action {action:?}").as_str())?;
+        f.write_str(format!("environment {environment:?}").as_str())
+    }
+}
+
+impl PolicyAccessControl {
     /// Create a new `PolicyAccessControl`.
     ///
     /// The policy expression is evaluated by getting subject attributes from
     /// the given authenticated storage, adding them the given environment,
     /// which may already contain other resource, action or subject attributes.
-    pub fn new(policies: P, store: S, r: Resource, a: Action, env: Env) -> Self {
+    pub fn new(
+        policies: Arc<dyn PolicyStorage>,
+        store: Arc<dyn IdentityAttributeStorage>,
+        r: Resource,
+        a: Action,
+        env: Env,
+    ) -> Self {
         Self {
             resource: r,
             action: a,
@@ -41,11 +60,7 @@ impl<P, S> PolicyAccessControl<P, S> {
 }
 
 #[async_trait]
-impl<P, S> IncomingAccessControl for PolicyAccessControl<P, S>
-where
-    S: IdentityAttributeStorage + fmt::Debug,
-    P: PolicyStorage + fmt::Debug,
-{
+impl IncomingAccessControl for PolicyAccessControl {
     async fn is_authorized(&self, msg: &RelayMessage) -> Result<bool> {
         // Load the policy expression for resource and action:
         let expr = if let Some(expr) = self
@@ -70,12 +85,8 @@ where
             return Ok(false);
         };
 
-        AbacAccessControl::new(
-            self.attributes.async_try_clone().await?,
-            expr,
-            self.environment.clone(),
-        )
-        .is_authorized(msg)
-        .await
+        AbacAccessControl::new(self.attributes.clone(), expr, self.environment.clone())
+            .is_authorized(msg)
+            .await
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/auth.rs
+++ b/implementations/rust/ockam/ockam_api/src/auth.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use minicbor::Decoder;
 use ockam_core::api::decode_option;
 use ockam_core::api::{Method, Request, Response};
+use ockam_core::compat::sync::Arc;
 use ockam_core::{self, Address, DenyAll, Result, Route, Routed, Worker};
 use ockam_identity::authenticated_storage::{AttributesEntry, IdentityAttributeStorageReader};
 use ockam_identity::IdentityIdentifier;
@@ -12,13 +13,12 @@ use ockam_node::Context;
 use tracing::trace;
 
 /// Auth API server.
-#[derive(Debug)]
-pub struct Server<S> {
-    store: S,
+pub struct Server {
+    store: Arc<dyn IdentityAttributeStorageReader>,
 }
 
 #[ockam_core::worker]
-impl<S: IdentityAttributeStorageReader> Worker for Server<S> {
+impl Worker for Server {
     type Context = Context;
     type Message = Vec<u8>;
 
@@ -32,8 +32,8 @@ impl<S: IdentityAttributeStorageReader> Worker for Server<S> {
     }
 }
 
-impl<S: IdentityAttributeStorageReader> Server<S> {
-    pub fn new(s: S) -> Self {
+impl Server {
+    pub fn new(s: Arc<dyn IdentityAttributeStorageReader>) -> Self {
         Server { store: s }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -79,7 +79,7 @@ impl AuthoritiesConfig {
     ) -> Result<Vec<PublicIdentity>> {
         let mut v = Vec::new();
         for a in self.authorities.values() {
-            v.push(PublicIdentity::import_arc(a.identity.as_slice(), vault.clone()).await?)
+            v.push(PublicIdentity::import(a.identity.as_slice(), vault.clone()).await?)
         }
         Ok(v)
     }

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -2,6 +2,7 @@
 
 use crate::config::{lookup::ConfigLookup, ConfigValues};
 use crate::{cli_state, HexByteVec};
+use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_identity::{IdentityIdentifier, IdentityVault, PublicIdentity};
 use ockam_multiaddr::MultiAddr;
@@ -72,13 +73,13 @@ impl AuthoritiesConfig {
         self.authorities.iter()
     }
 
-    pub async fn to_public_identities<V>(&self, vault: &V) -> Result<Vec<PublicIdentity>>
-    where
-        V: IdentityVault,
-    {
+    pub async fn to_public_identities(
+        &self,
+        vault: Arc<dyn IdentityVault>,
+    ) -> Result<Vec<PublicIdentity>> {
         let mut v = Vec::new();
         for a in self.authorities.values() {
-            v.push(PublicIdentity::import(a.identity.as_slice(), vault).await?)
+            v.push(PublicIdentity::import_arc(a.identity.as_slice(), vault.clone()).await?)
         }
         Ok(v)
     }

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -273,8 +273,7 @@ impl ProjectAuthority {
                 .ok_or_else(|| ApiError::generic("Identity is not set"))?;
             let a =
                 hex::decode(&**a).map_err(|_| ApiError::generic("Invalid project authority"))?;
-            let v = Vault::default();
-            let p = PublicIdentity::import(&a, &v).await?;
+            let p = PublicIdentity::import(&a, &Vault::default()).await?;
             Ok(Some(ProjectAuthority::new(p.identifier().clone(), rte, a)))
         } else {
             Ok(None)

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -273,7 +273,7 @@ impl ProjectAuthority {
                 .ok_or_else(|| ApiError::generic("Identity is not set"))?;
             let a =
                 hex::decode(&**a).map_err(|_| ApiError::generic("Invalid project authority"))?;
-            let p = PublicIdentity::import(&a, &Vault::default()).await?;
+            let p = PublicIdentity::import(&a, Vault::create()).await?;
             Ok(Some(ProjectAuthority::new(p.identifier().clone(), rte, a)))
         } else {
             Ok(None)

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -21,11 +21,11 @@ mod test {
     use ockam::compat::tokio::io::DuplexStream;
     use ockam::Context;
     use ockam_core::async_trait;
-    use ockam_core::{route, Address, AllowAll, AsyncTryClone, Route};
+    use ockam_core::compat::sync::Arc;
+    use ockam_core::{route, Address, AllowAll, Route};
     use ockam_identity::TrustEveryonePolicy;
     use ockam_node::compat::tokio;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -74,7 +74,7 @@ mod test {
         kind: KafkaServiceKind,
     ) -> ockam::Result<u16> {
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new_extended(
-            handle.identity.async_try_clone().await?,
+            handle.identity.clone(),
             route![],
             HopForwarderCreator {},
         );

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -586,7 +586,7 @@ mod test {
         let vault = Vault::create();
         let identity = Identity::create(context, &vault).await.unwrap();
         let secure_channel_controller =
-            KafkaSecureChannelControllerImpl::new(identity, route![]).into_trait();
+            KafkaSecureChannelControllerImpl::new(Arc::new(identity), route![]).into_trait();
 
         let portal_inlet_address = KafkaPortalWorker::start_kafka_portal(
             context,
@@ -638,7 +638,7 @@ mod test {
         let identity = Identity::create(context, &vault).await?;
 
         let secure_channel_controller =
-            KafkaSecureChannelControllerImpl::new(identity, route![]).into_trait();
+            KafkaSecureChannelControllerImpl::new(Arc::new(identity), route![]).into_trait();
 
         let inlet_map = KafkaInletMap::new(
             route![],

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -584,7 +584,7 @@ mod test {
         );
 
         let vault = Vault::create();
-        let identity = Identity::create(context, &vault).await.unwrap();
+        let identity = Identity::create(context, vault).await.unwrap();
         let secure_channel_controller =
             KafkaSecureChannelControllerImpl::new(Arc::new(identity), route![]).into_trait();
 
@@ -635,7 +635,7 @@ mod test {
         crate::test::start_manager_for_tests(context).await?;
 
         let vault = Vault::create();
-        let identity = Identity::create(context, &vault).await?;
+        let identity = Identity::create(context, vault).await?;
 
         let secure_channel_controller =
             KafkaSecureChannelControllerImpl::new(Arc::new(identity), route![]).into_trait();

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -318,7 +318,7 @@ impl NodeManager {
 
         for a in ac.authorities() {
             v.push(AuthorityInfo {
-                identity: PublicIdentity::import_arc(a.1.identity(), vault.clone()).await?,
+                identity: PublicIdentity::import(a.1.identity(), vault.clone()).await?,
                 addr: a.1.access_route().clone(),
             })
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
@@ -1,7 +1,7 @@
 use crate::nodes::models::policy::{Policy, PolicyList};
 use either::Either;
 use minicbor::Decoder;
-use ockam_abac::{Action, PolicyStorage, Resource};
+use ockam_abac::{Action, Resource};
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
 use ockam_core::Result;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -9,18 +9,18 @@ use crate::session::{util, Data, Replacer, Session};
 use crate::{actions, resources};
 use crate::{local_multiaddr_to_route, try_multiaddr_to_addr};
 use minicbor::Decoder;
-use ockam::compat::asynchronous::RwLock;
 use ockam::compat::tokio::time::timeout;
 use ockam::{Address, AsyncTryClone, Result};
 use ockam_abac::expr::{eq, ident, str};
-use ockam_abac::{Action, Env, PolicyAccessControl, PolicyStorage, Resource};
+use ockam_abac::{Action, Env, PolicyAccessControl, Resource};
 use ockam_core::api::{Request, Response, ResponseBuilder};
+use ockam_core::compat::sync::Arc;
 use ockam_core::{AllowAll, IncomingAccessControl};
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::proto::{Project, Secure, Service};
 use ockam_multiaddr::{MultiAddr, Protocol};
+use ockam_node::compat::asynchronous::RwLock;
 use ockam_node::Context;
-use std::sync::Arc;
 
 use super::{NodeManager, NodeManagerWorker};
 

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -4,6 +4,7 @@ use minicbor::Decoder;
 use ockam::identity::credential::Timestamp;
 use ockam_core::api;
 use ockam_core::api::{Method, Request, Response};
+use ockam_core::compat::sync::Arc;
 use ockam_core::{self, Result, Routed, Worker};
 use ockam_identity::authenticated_storage::{AttributesEntry, IdentityAttributeStorageWriter};
 use ockam_identity::{IdentityIdentifier, IdentitySecureChannelLocalInfo};
@@ -12,19 +13,16 @@ use reqwest::StatusCode;
 use std::collections::HashMap;
 use tracing::trace;
 
-pub struct Server<S> {
+pub struct Server {
     project: Vec<u8>,
-    store: S,
+    store: Arc<dyn IdentityAttributeStorageWriter>,
     tenant_base_url: String,
     certificate: reqwest::Certificate,
     attributes: Vec<String>,
 }
 
 #[ockam_core::worker]
-impl<S> Worker for Server<S>
-where
-    S: IdentityAttributeStorageWriter,
-{
+impl Worker for Server {
     type Context = Context;
     type Message = Vec<u8>;
 
@@ -41,13 +39,10 @@ where
     }
 }
 
-impl<S> Server<S>
-where
-    S: IdentityAttributeStorageWriter,
-{
+impl Server {
     pub fn new(
         project: Vec<u8>,
-        store: S,
+        store: Arc<dyn IdentityAttributeStorageWriter>,
         tenant_base_url: &str,
         certificate: &str,
         attributes: &[&str],

--- a/implementations/rust/ockam/ockam_api/src/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/vault.rs
@@ -6,24 +6,25 @@ use minicbor::encode::Write;
 use minicbor::{Decoder, Encode};
 use models::*;
 use ockam_core::api::{Error, Id, Method, Request, Response, Status};
-use ockam_core::vault::{
-    AsymmetricVault, Hasher, KeyId, SecretVault, Signature, Signer, SymmetricVault, Verifier,
-};
+use ockam_core::compat::sync::Arc;
+use ockam_core::vault::{KeyId, Signature};
 use ockam_core::CowStr;
 use ockam_core::{Result, Routed, Worker};
+use ockam_identity::IdentityVault;
 use ockam_node::Context;
-use ockam_vault::Vault;
 use tracing::trace;
 
 /// Vault Service Worker
 pub struct VaultService {
-    vault: Vault,
+    vault: Arc<dyn IdentityVault>,
 }
 
 impl VaultService {
     /// Constructor
-    pub fn new(vault: Vault) -> Self {
-        Self { vault }
+    pub fn new(vault: Arc<dyn IdentityVault>) -> Self {
+        Self {
+            vault: vault.clone(),
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier.rs
@@ -88,7 +88,7 @@ impl Verifier {
         let data = CredentialData::try_from(cre)?;
 
         let ident = if let Some(ident) = req.authority(data.unverified_issuer()) {
-            PublicIdentity::import_arc(ident, self.vault.clone()).await?
+            PublicIdentity::import(ident, self.vault.clone()).await?
         } else {
             let err = Error::new("/verify").with_message("unauthorised issuer");
             return Ok(Either::Left(Response::unauthorized(id).body(err)));

--- a/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
@@ -1,7 +1,9 @@
 use ockam_api::auth;
 use ockam_api::bootstrapped_identities_store::PreTrustedIdentities;
 use ockam_core::{AllowAll, Result};
+use ockam_identity::authenticated_storage::IdentityAttributeStorageReader;
 use ockam_node::Context;
+use std::sync::Arc;
 
 #[ockam_macros::test]
 async fn auth_smoke(ctx: &mut Context) -> Result<()> {
@@ -10,6 +12,7 @@ async fn auth_smoke(ctx: &mut Context) -> Result<()> {
             "P624ed0b2e5a2be82e267ead6b3279f683616b66de9537a23e45343c95cbb357b":{"attr":"value2"}
            }"#,
     )?;
+    let s: Arc<dyn IdentityAttributeStorageReader> = Arc::new(s);
     ctx.start_worker("auth", auth::Server::new(s), AllowAll, AllowAll)
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -18,8 +18,8 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     let api_worker_addr = random_string();
     let auth_worker_addr = random_string();
 
-    let auth_identity = Arc::new(Identity::create(ctx, &Vault::create()).await?);
-    let member_identity = Arc::new(Identity::create(ctx, &Vault::create()).await?);
+    let auth_identity = Arc::new(Identity::create(ctx, Vault::create()).await?);
+    let member_identity = Arc::new(Identity::create(ctx, Vault::create()).await?);
     let now = Timestamp::now().unwrap();
     let pre_trusted = HashMap::from([(
         member_identity.identifier().clone(),
@@ -57,9 +57,9 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     // Get a fresh member credential and verify its validity:
     let cred = c.credential().await?;
     let exported = auth_identity.export().await?;
-    let vault = Arc::new(Vault::create());
+    let vault = Vault::create();
 
-    let pkey = PublicIdentity::import(&exported, &Vault::create())
+    let pkey = PublicIdentity::import(&exported, Vault::create())
         .await
         .unwrap();
     let data = pkey

--- a/implementations/rust/ockam/ockam_api/tests/identity.rs
+++ b/implementations/rust/ockam/ockam_api/tests/identity.rs
@@ -5,10 +5,11 @@ use ockam_api::identity::IdentityService;
 use ockam_core::api::{Request, Response, Status};
 use ockam_core::compat::rand::random;
 use ockam_core::errcode::{Kind, Origin};
-use ockam_core::{route, AsyncTryClone, Error, LocalOnwardOnly, LocalSourceOnly, Result};
+use ockam_core::{route, Error, LocalOnwardOnly, LocalSourceOnly, Result};
 use ockam_identity::change_history::IdentityHistoryComparison;
 use ockam_node::Context;
 use ockam_vault::Vault;
+use std::sync::Arc;
 
 async fn create_identity(ctx: &mut Context, service_address: &str) -> Result<(Vec<u8>, String)> {
     let req = Request::post("").to_vec()?;
@@ -161,14 +162,14 @@ async fn full_flow(ctx: &mut Context) -> Result<()> {
     // Start services
     ctx.start_worker(
         "1",
-        IdentityService::new(ctx, vault1.async_try_clone().await?, cli_state.clone()).await?,
+        IdentityService::new(ctx, Arc::new(vault1), cli_state.clone()).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )
     .await?;
     ctx.start_worker(
         "2",
-        IdentityService::new(ctx, vault2.async_try_clone().await?, cli_state).await?,
+        IdentityService::new(ctx, Arc::new(vault2), cli_state).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )

--- a/implementations/rust/ockam/ockam_api/tests/identity.rs
+++ b/implementations/rust/ockam/ockam_api/tests/identity.rs
@@ -9,7 +9,6 @@ use ockam_core::{route, Error, LocalOnwardOnly, LocalSourceOnly, Result};
 use ockam_identity::change_history::IdentityHistoryComparison;
 use ockam_node::Context;
 use ockam_vault::Vault;
-use std::sync::Arc;
 
 async fn create_identity(ctx: &mut Context, service_address: &str) -> Result<(Vec<u8>, String)> {
     let req = Request::post("").to_vec()?;
@@ -162,14 +161,14 @@ async fn full_flow(ctx: &mut Context) -> Result<()> {
     // Start services
     ctx.start_worker(
         "1",
-        IdentityService::new(ctx, Arc::new(vault1), cli_state.clone()).await?,
+        IdentityService::new(ctx, vault1, cli_state.clone()).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )
     .await?;
     ctx.start_worker(
         "2",
-        IdentityService::new(ctx, Arc::new(vault2), cli_state).await?,
+        IdentityService::new(ctx, vault2, cli_state).await?,
         LocalSourceOnly,
         LocalOnwardOnly,
     )

--- a/implementations/rust/ockam/ockam_api/tests/vault.rs
+++ b/implementations/rust/ockam/ockam_api/tests/vault.rs
@@ -9,13 +9,12 @@ use ockam_core::vault::{SecretAttributes, SecretPersistence, SecretType};
 use ockam_core::{route, AllowAll, Result};
 use ockam_node::Context;
 use ockam_vault::Vault;
-use std::sync::Arc;
 
 #[ockam_macros::test]
 async fn full_flow(ctx: &mut Context) -> Result<()> {
     // Start service
     let vault = Vault::create();
-    let service = VaultService::new(Arc::new(vault));
+    let service = VaultService::new(vault);
 
     ctx.start_worker("vault_service", service, AllowAll, AllowAll)
         .await?;

--- a/implementations/rust/ockam/ockam_api/tests/vault.rs
+++ b/implementations/rust/ockam/ockam_api/tests/vault.rs
@@ -9,11 +9,13 @@ use ockam_core::vault::{SecretAttributes, SecretPersistence, SecretType};
 use ockam_core::{route, AllowAll, Result};
 use ockam_node::Context;
 use ockam_vault::Vault;
+use std::sync::Arc;
 
 #[ockam_macros::test]
 async fn full_flow(ctx: &mut Context) -> Result<()> {
     // Start service
-    let service = VaultService::new(Vault::create());
+    let vault = Vault::create();
+    let service = VaultService::new(Arc::new(vault));
 
     ctx.start_worker("vault_service", service, AllowAll, AllowAll)
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,4 +1,5 @@
 use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::Arc;
 
 use crate::{
     identity::default_identity_name,
@@ -58,7 +59,7 @@ async fn run_impl(
     let vault = opts.state.vaults.get(&cmd.vault)?.get().await?;
     let ident_state = opts.state.identities.get(&cmd.as_identity)?;
 
-    let ident = ident_state.get(&ctx, &vault).await?;
+    let ident = ident_state.get(&ctx, Arc::new(vault)).await?;
 
     let credential = ident.issue_credential(cred_builder).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -3,6 +3,7 @@ use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_api::cli_state::{self, VaultConfig};
+use ockam_core::compat::sync::Arc;
 use ockam_identity::Identity;
 use rand::prelude::random;
 
@@ -43,8 +44,8 @@ async fn run_impl(
     let vault = vault_state.get().await?;
     let identity = Identity::create_ext(
         &ctx,
-        &options.state.identities.authenticated_storage().await?,
-        &vault,
+        options.state.identities.authenticated_storage().await?,
+        Arc::new(vault),
     )
     .await?;
     let identity_config = cli_state::IdentityConfig::new(&identity).await;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -228,8 +228,8 @@ async fn run_foreground_node(
 
     if let Some(authority_identities) = cmd.authority_identities {
         for auth in authority_identities.into_iter() {
-            let vault = Vault::default();
-            let i = PublicIdentity::import(auth.identity(), &vault).await?;
+            let vault = Vault::create();
+            let i = PublicIdentity::import(auth.identity(), vault).await?;
             cfg.authorities(&node_name)?
                 .add_authority(i.identifier().clone(), auth)?;
         }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -16,6 +16,7 @@ use ockam_api::nodes::service::{
     NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
 };
 use ockam_api::nodes::{NodeManager, NodeManagerWorker, NODEMANAGER_ADDR};
+use ockam_core::compat::sync::Arc;
 use ockam_core::AllowAll;
 use ockam_multiaddr::MultiAddr;
 use ockam_vault::Vault;
@@ -179,8 +180,8 @@ pub(super) async fn init_node_state(
         let identity_name = hex::encode(random::<[u8; 4]>());
         let identity = Identity::create_ext(
             ctx,
-            &opts.state.identities.authenticated_storage().await?,
-            &vault,
+            opts.state.identities.authenticated_storage().await?,
+            Arc::new(vault),
         )
         .await?;
         let identity_config = cli_state::IdentityConfig::new(&identity).await;
@@ -205,8 +206,7 @@ pub(super) async fn add_project_authority(
     node: &str,
     cfg: &OckamConfig,
 ) -> Result<()> {
-    let v = Vault::default();
-    let i = PublicIdentity::import(&authority_identity, &v).await?;
+    let i = PublicIdentity::import(&authority_identity, &Vault::default()).await?;
     let a = cli::Authority::new(authority_identity, authority_access_route);
     cfg.authorities(node)?
         .add_authority(i.identifier().clone(), a)

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -206,7 +206,7 @@ pub(super) async fn add_project_authority(
     node: &str,
     cfg: &OckamConfig,
 ) -> Result<()> {
-    let i = PublicIdentity::import(&authority_identity, &Vault::default()).await?;
+    let i = PublicIdentity::import(&authority_identity, Vault::create()).await?;
     let a = cli::Authority::new(authority_identity, authority_access_route);
     cfg.authorities(node)?
         .add_authority(i.identifier().clone(), a)

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -5,10 +5,8 @@ use anyhow::anyhow;
 use clap::Args;
 use ockam::{Context, TcpTransport};
 use ockam_api::cli_state::{IdentityState, NodeState};
-use ockam_api::lmdb::LmdbStorage;
 use ockam_api::nodes::models::base::NodeStatus;
 use ockam_identity::Identity;
-use ockam_vault::Vault;
 use std::time::Duration;
 
 /// Display Ockam Status
@@ -20,7 +18,7 @@ pub struct StatusCommand {
 }
 
 struct NodeDetails {
-    identity: Identity<Vault, LmdbStorage>,
+    identity: Identity,
     state: NodeState,
     status: String,
 }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -659,6 +659,7 @@ mod tests {
     use ockam_api::cli_state;
     use ockam_api::cli_state::{IdentityConfig, NodeConfig, VaultConfig};
     use ockam_api::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
+    use ockam_core::compat::sync::Arc;
     use ockam_identity::Identity;
 
     #[test]
@@ -695,11 +696,10 @@ mod tests {
         let v_config = VaultConfig::default();
         cli_state.vaults.create(&v_name, v_config).await?;
         let v = cli_state.vaults.get(&v_name)?.get().await?;
-
         let idt = Identity::create_ext(
             ctx,
-            &cli_state.identities.authenticated_storage().await?,
-            &v,
+            cli_state.identities.authenticated_storage().await?,
+            Arc::new(v),
         )
         .await?;
         let idt_config = IdentityConfig::new(&idt).await;

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -8,6 +8,7 @@ use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use ockam::Context;
 use ockam_api::cli_state::{self, CliState, CliStateError};
+use ockam_core::compat::sync::Arc;
 use ockam_core::vault::{Secret, SecretAttributes, SecretPersistence, SecretType, SecretVault};
 use ockam_identity::{Identity, IdentityStateConst, KeyAttributes};
 use rand::prelude::random;
@@ -95,8 +96,8 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
                 let attrs = KeyAttributes::new(IdentityStateConst::ROOT_LABEL.to_string(), attrs);
                 Identity::create_with_external_key_ext(
                     &ctx,
-                    &opts.state.identities.authenticated_storage().await?,
-                    &v,
+                    opts.state.identities.authenticated_storage().await?,
+                    Arc::new(v),
                     &kid,
                     attrs,
                 )

--- a/implementations/rust/ockam/ockam_core/src/key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_core/src/key_exchanger.rs
@@ -21,7 +21,7 @@ pub trait KeyExchanger {
     /// Returns true if the key exchange process is complete.
     async fn is_complete(&self) -> Result<bool>;
     /// Return the data and keys needed for channels. Key exchange must be completed prior to calling this function.
-    async fn finalize(self) -> Result<CompletedKeyExchange>;
+    async fn finalize(&mut self) -> Result<CompletedKeyExchange>;
 }
 
 /// A creator of both initiator and responder peers of a key exchange.
@@ -39,7 +39,7 @@ pub trait NewKeyExchanger {
 }
 
 /// The state of a completed key exchange.
-#[derive(Debug, Zeroize)]
+#[derive(Debug, Clone, Zeroize)]
 #[zeroize(drop)]
 pub struct CompletedKeyExchange {
     h: [u8; 32],

--- a/implementations/rust/ockam/ockam_core/src/key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_core/src/key_exchanger.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroize;
 
 /// A trait implemented by both Initiator and Responder peers.
 #[async_trait]
-pub trait KeyExchanger {
+pub trait KeyExchanger: Send + Sync + 'static {
     /// Return key exchange unique name.
     async fn name(&self) -> Result<String>;
     /// Generate request that should be sent to the other party.
@@ -28,9 +28,9 @@ pub trait KeyExchanger {
 #[async_trait]
 pub trait NewKeyExchanger {
     /// Initiator
-    type Initiator: KeyExchanger + Send + Sync + 'static;
+    type Initiator: KeyExchanger;
     /// Responder
-    type Responder: KeyExchanger + Send + Sync + 'static;
+    type Responder: KeyExchanger;
 
     /// Create a new Key Exchanger with the initiator role
     async fn initiator(&self) -> Result<Self::Initiator>;

--- a/implementations/rust/ockam/ockam_core/src/vault/hasher.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/hasher.rs
@@ -4,7 +4,7 @@ use crate::{async_trait, compat::boxed::Box};
 
 /// A trait for hashing input data into a fixed length output.
 #[async_trait]
-pub trait Hasher {
+pub trait Hasher: Sync + Send {
     /// Compute the SHA-256 digest given input `data`.
     async fn sha256(&self, data: &[u8]) -> Result<[u8; 32]>;
     /// Derive multiple output [`super::Secret`]s with given attributes using

--- a/implementations/rust/ockam/ockam_core/src/vault/secret_vault.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/secret_vault.rs
@@ -11,7 +11,7 @@ use super::Secret;
 /// See `ockam_vault::vault::Vault` for a usage example.
 ///
 #[async_trait]
-pub trait SecretVault {
+pub trait SecretVault: Sync + Send {
     /// Generate a fresh secret with the given attributes.
     async fn secret_generate(&self, attributes: SecretAttributes) -> Result<KeyId>;
     /// Import a secret with the given attributes from binary form into the vault.

--- a/implementations/rust/ockam/ockam_core/src/vault/symmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/symmetric_vault.rs
@@ -4,7 +4,7 @@ use crate::{async_trait, compat::boxed::Box};
 
 /// Defines the Vault interface for symmetric encryption.
 #[async_trait]
-pub trait SymmetricVault {
+pub trait SymmetricVault: Send + Sync {
     /// Encrypt a payload using AES-GCM.
     async fn aead_aes_gcm_encrypt(
         &self,

--- a/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/07-inlet.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/07-inlet.rs
@@ -19,11 +19,18 @@ async fn main(ctx: Context) -> Result<()> {
     // by a second command line argument.
 
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
-    let outlet_port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
-    let r = route![(TCP, &format!("127.0.0.1:{outlet_port}")), "secure_channel_listener"];
+    let e = Identity::create(&ctx, vault).await?;
+    let outlet_port = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "4000".to_string());
+    let r = route![
+        (TCP, &format!("127.0.0.1:{outlet_port}")),
+        "secure_channel_listener"
+    ];
     let storage = InMemoryStorage::new();
-    let channel = e.create_secure_channel(r, TrustEveryonePolicy, &storage).await?;
+    let channel = e
+        .create_secure_channel(r, TrustEveryonePolicy, &storage)
+        .await?;
 
     // We know Secure Channel address that tunnels messages to the node with an Outlet,
     // we also now that Outlet lives at "outlet" address at that node.

--- a/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/07-outlet.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/07-outlet.rs
@@ -15,7 +15,7 @@ async fn main(ctx: Context) -> Result<()> {
     //      that will wait for requests to start an Authenticated Key Exchange.
 
     let vault = Vault::create();
-    let e = Identity::create(&ctx, &vault).await?;
+    let e = Identity::create(&ctx, vault).await?;
     let storage = InMemoryStorage::new();
     e.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy, &storage)
         .await?;
@@ -43,7 +43,9 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // Use port 4000, unless otherwise specified by second command line argument.
 
-    let port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
+    let port = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "4000".to_string());
     tcp.listen(format!("127.0.0.1:{port}")).await?;
 
     #[cfg(feature = "debugger")]

--- a/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/src/main.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/hub_inlet/src/main.rs
@@ -188,7 +188,7 @@ async fn main(ctx: Context) -> Result<()> {
     let config = Config::new();
 
     let vault = Vault::create(&ctx).await?;
-    let mut hub = Identity::create(&ctx, &vault)?;
+    let mut hub = Identity::create(&ctx, vault)?;
 
     hub.create_secure_channel_listener("secure_channel_listener_service", TrustEveryonePolicy)?;
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/examples/hello.rs
@@ -75,7 +75,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Identity to represent Bob.
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     // Create a secure channel listener for Bob that will wait for requests to
     // initiate an Authenticated Key Exchange.
@@ -83,7 +83,7 @@ async fn main(mut ctx: Context) -> Result<()> {
         .await?;
 
     // Create an Identity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // As Alice, connect to Bob's secure channel listener and perform an
     // Authenticated Key Exchange to establish an encrypted secure channel with Bob.

--- a/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/inlet_hub.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/inlet_hub.rs
@@ -65,7 +65,7 @@ impl Worker for InletCreatorWorker {
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create(&ctx).await?;
-    let mut hub = Identity::create(&ctx, &vault)?;
+    let mut hub = Identity::create(&ctx, vault)?;
 
     hub.create_secure_channel_listener("secure_channel_listener", TrustEveryonePolicy)?;
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/main.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/main.rs
@@ -6,7 +6,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create(&ctx).await?;
 
     // Create an Identity to represent this machine
-    let mut fabric_machine = Identity::create(&ctx, &vault)?;
+    let mut fabric_machine = Identity::create(&ctx, vault)?;
 
     // Initialize the TCP Transport
     let tcp = TcpTransport::create(&ctx).await?;

--- a/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/outlet_hub.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ports/src/bin/outlet_hub.rs
@@ -3,7 +3,7 @@ use ockam::{route, Context, Identity, Result, TcpTransport, TrustEveryonePolicy,
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create(&ctx).await?;
-    let mut fabric_machine = Identity::create(&ctx, &vault)?;
+    let mut fabric_machine = Identity::create(&ctx, vault)?;
 
     let tcp = TcpTransport::create(&ctx).await?;
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/alice.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/alice.rs
@@ -9,7 +9,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let _tcp = TcpTransport::create(&ctx).await?;
 
     let vault = Vault::create();
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     let secret_key_path = env::var("SECRET_KEY_PATH").unwrap();
     let secret_key = fs::read_to_string(secret_key_path).unwrap();

--- a/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/ssh_credentials/src/bin/bob.rs
@@ -30,7 +30,7 @@ async fn main(ctx: Context) -> Result<()> {
         .start(ctx)
         .await?;
 
-    let bob = Identity::create(&ctx, &vault).await?;
+    let bob = Identity::create(&ctx, vault).await?;
 
     let public_key_path = env::var("PUBLIC_KEY_PATH").unwrap();
     let public_key = fs::read_to_string(public_key_path).unwrap();

--- a/implementations/rust/ockam/ockam_examples/example_projects/tunnel/src/bin/client.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tunnel/src/bin/client.rs
@@ -18,7 +18,7 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // create secure channel to the server
     let vault = Vault::create(&ctx).await?;
-    let mut me = Identity::create(&ctx, &vault)?;
+    let mut me = Identity::create(&ctx, vault)?;
     let route = route![(TCP, "127.0.0.1:8000"), "secure_listener"];
     let secure_channel = me.create_secure_channel(route, TrustEveryonePolicy)?;
 

--- a/implementations/rust/ockam/ockam_examples/example_projects/tunnel/src/bin/server.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/tunnel/src/bin/server.rs
@@ -63,7 +63,7 @@ impl Worker for ConnectionBrokerWorker {
 async fn main(ctx: Context) -> Result<()> {
     // create a secure listening channel
     let vault = Vault::create(&ctx).await?;
-    let mut me = Identity::create(&ctx, &vault)?;
+    let mut me = Identity::create(&ctx, vault)?;
     me.create_secure_channel_listener("secure_listener", TrustEveryonePolicy)?;
 
     // start listening over TCP and start worker

--- a/implementations/rust/ockam/ockam_identity/src/change/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_identity/src/change/rotate_key.rs
@@ -1,7 +1,6 @@
-use crate::authenticated_storage::AuthenticatedStorage;
 use crate::change::{IdentityChange, IdentitySignedChange, Signature, SignatureType};
 use crate::change_history::IdentityChangeHistory;
-use crate::{ChangeIdentifier, Identity, IdentityError, IdentityVault, KeyAttributes};
+use crate::{ChangeIdentifier, Identity, IdentityError, KeyAttributes};
 use core::fmt;
 use ockam_core::vault::PublicKey;
 use ockam_core::{Encodable, Result};
@@ -57,7 +56,7 @@ impl fmt::Display for RotateKeyChangeData {
     }
 }
 
-impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
+impl Identity {
     /// Rotate key change
     pub(crate) async fn make_rotate_key_change(
         &self,
@@ -72,8 +71,9 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
         )?
         .clone();
 
-        let last_key_in_chain =
-            Self::get_secret_key_from_change(&last_change_in_chain, &self.vault).await?;
+        let last_key_in_chain = self
+            .get_secret_key_from_change(&last_change_in_chain)
+            .await?;
 
         let secret_attributes = key_attributes.secret_attributes();
 

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -24,15 +24,14 @@ pub mod access_control;
 /// SecureChannel API
 pub mod api;
 
-use crate::authenticated_storage::AuthenticatedStorage;
 use crate::channel::decryptor_worker::DecryptorWorker;
 use crate::channel::listener::IdentityChannelListener;
 use crate::error::IdentityError;
-use crate::{Identity, IdentityVault};
+use crate::Identity;
 use core::time::Duration;
 use ockam_core::{Address, AsyncTryClone, Result, Route};
 
-impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
+impl Identity {
     /// Spawns a SecureChannel listener at given `Address` with given [`SecureChannelListenerTrustOptions`]
     pub async fn create_secure_channel_listener(
         &self,

--- a/implementations/rust/ockam/ockam_identity/src/channel/common.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/common.rs
@@ -1,8 +1,14 @@
+use crate::IdentityVault;
+use ockam_core::async_trait;
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
-use ockam_core::vault::SymmetricVault;
-use ockam_core::AsyncTryClone;
+use ockam_core::vault::{
+    AsymmetricVault, Buffer, Hasher, KeyId, PublicKey, Secret, SecretAttributes, SecretVault,
+    SmallBuffer, SymmetricVault,
+};
 use ockam_core::Message;
-use ockam_core::{KeyExchanger, NewKeyExchanger};
+use ockam_core::{KeyExchanger, NewKeyExchanger, Result};
 use ockam_key_exchange_xx::XXVault;
 use serde::{Deserialize, Serialize};
 
@@ -32,15 +38,9 @@ impl Role {
 }
 
 /// Vault with XX required functionality
-pub trait SecureChannelVault:
-    SymmetricVault + XXVault + AsyncTryClone + Send + Sync + 'static
-{
-}
+pub trait SecureChannelVault: SymmetricVault + XXVault + Send + Sync + 'static {}
 
-impl<D> SecureChannelVault for D where
-    D: SymmetricVault + XXVault + AsyncTryClone + Send + Sync + 'static
-{
-}
+impl<D> SecureChannelVault for D where D: SymmetricVault + XXVault + Send + Sync + 'static {}
 
 /// KeyExchanger with extra constraints
 pub trait SecureChannelKeyExchanger: KeyExchanger + Send + Sync + 'static {}
@@ -78,4 +78,127 @@ impl CreateResponderChannelMessage {
             custom_payload,
         }
     }
+}
+
+/// This struct is used to compensate for the lack of non-experimental trait upcasting in Rust
+/// We encapsulate an IdentityVault and delegate the implementation of all the functions of
+/// the various traits inherited by IdentityVault: SymmetricVault, SecretVault, etc...
+struct CoercedIdentityVault {
+    vault: Arc<dyn IdentityVault>,
+}
+
+#[async_trait]
+impl SymmetricVault for CoercedIdentityVault {
+    async fn aead_aes_gcm_encrypt(
+        &self,
+        key_id: &KeyId,
+        plaintext: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Buffer<u8>> {
+        self.vault
+            .aead_aes_gcm_encrypt(key_id, plaintext, nonce, aad)
+            .await
+    }
+
+    async fn aead_aes_gcm_decrypt(
+        &self,
+        key_id: &KeyId,
+        cipher_text: &[u8],
+        nonce: &[u8],
+        aad: &[u8],
+    ) -> Result<Buffer<u8>> {
+        self.vault
+            .aead_aes_gcm_decrypt(key_id, cipher_text, nonce, aad)
+            .await
+    }
+}
+
+#[async_trait]
+impl SecretVault for CoercedIdentityVault {
+    async fn secret_generate(&self, attributes: SecretAttributes) -> Result<KeyId> {
+        self.vault.secret_generate(attributes).await
+    }
+
+    async fn secret_import(&self, secret: Secret, attributes: SecretAttributes) -> Result<KeyId> {
+        self.vault.secret_import(secret, attributes).await
+    }
+
+    async fn secret_export(&self, key_id: &KeyId) -> Result<Secret> {
+        self.vault.secret_export(key_id).await
+    }
+
+    async fn secret_attributes_get(&self, key_id: &KeyId) -> Result<SecretAttributes> {
+        self.vault.secret_attributes_get(key_id).await
+    }
+
+    async fn secret_public_key_get(&self, key_id: &KeyId) -> Result<PublicKey> {
+        self.vault.secret_public_key_get(key_id).await
+    }
+
+    async fn secret_destroy(&self, key_id: KeyId) -> Result<()> {
+        self.vault.secret_destroy(key_id).await
+    }
+}
+
+#[async_trait]
+impl Hasher for CoercedIdentityVault {
+    async fn sha256(&self, data: &[u8]) -> Result<[u8; 32]> {
+        self.vault.sha256(data).await
+    }
+
+    async fn hkdf_sha256(
+        &self,
+        salt: &KeyId,
+        info: &[u8],
+        ikm: Option<&KeyId>,
+        output_attributes: SmallBuffer<SecretAttributes>,
+    ) -> Result<SmallBuffer<KeyId>> {
+        self.vault
+            .hkdf_sha256(salt, info, ikm, output_attributes)
+            .await
+    }
+}
+
+#[async_trait]
+impl AsymmetricVault for CoercedIdentityVault {
+    async fn ec_diffie_hellman(
+        &self,
+        secret: &KeyId,
+        peer_public_key: &PublicKey,
+    ) -> Result<KeyId> {
+        self.vault.ec_diffie_hellman(secret, peer_public_key).await
+    }
+
+    async fn compute_key_id_for_public_key(&self, public_key: &PublicKey) -> Result<KeyId> {
+        self.vault.compute_key_id_for_public_key(public_key).await
+    }
+}
+
+/// Return this vault as a symmetric vault
+pub fn to_symmetric_vault(vault: Arc<dyn IdentityVault>) -> Arc<dyn SymmetricVault> {
+    Arc::new(CoercedIdentityVault {
+        vault: vault.clone(),
+    })
+}
+
+/// Return this vault as a XX vault
+pub fn to_xx_vault(vault: Arc<dyn IdentityVault>) -> Arc<dyn XXVault> {
+    Arc::new(CoercedIdentityVault {
+        vault: vault.clone(),
+    })
+}
+
+/// Return this vault as a secret vault
+pub fn to_secret_vault(vault: Arc<dyn IdentityVault>) -> Arc<dyn SecretVault> {
+    Arc::new(CoercedIdentityVault {
+        vault: vault.clone(),
+    })
+}
+
+/// Return this vault as a hasher
+pub fn to_hasher(vault: Arc<dyn IdentityVault>) -> Arc<dyn Hasher> {
+    Arc::new(CoercedIdentityVault {
+        vault: vault.clone(),
+    })
 }

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
@@ -1,22 +1,24 @@
-use crate::channel::common::SecureChannelKeyExchanger;
 use crate::channel::decryptor::Decryptor;
 use crate::channel::encryptor::Encryptor;
-use crate::{IdentityIdentifier, IdentityVault};
+use crate::IdentityIdentifier;
+use ockam_core::compat::sync::Arc;
+use ockam_core::KeyExchanger;
+use ockam_node::compat::asynchronous::RwLock;
 
-pub(crate) struct KeyExchange<K: SecureChannelKeyExchanger> {
-    pub key_exchanger: K,
+pub(crate) struct KeyExchange {
+    pub key_exchanger: Arc<RwLock<dyn KeyExchanger + Send + Sync>>,
 }
 
-pub(crate) struct ExchangeIdentity<V: IdentityVault> {
-    pub encryptor: Encryptor<V>,
-    pub decryptor: Decryptor<V>,
+pub(crate) struct ExchangeIdentity {
+    pub encryptor: Encryptor,
+    pub decryptor: Decryptor,
     pub auth_hash: [u8; 32],
     pub identity_sent: bool,
     pub received_identity_id: Option<IdentityIdentifier>,
 }
 
-pub(crate) struct Initialized<V: IdentityVault> {
-    pub decryptor: Decryptor<V>,
+pub(crate) struct Initialized {
+    pub decryptor: Decryptor,
     pub their_identity_id: IdentityIdentifier,
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
@@ -1,12 +1,11 @@
 use crate::channel::decryptor::Decryptor;
 use crate::channel::encryptor::Encryptor;
 use crate::IdentityIdentifier;
-use ockam_core::compat::sync::Arc;
+use ockam_core::compat::boxed::Box;
 use ockam_core::KeyExchanger;
-use ockam_node::compat::asynchronous::RwLock;
 
 pub(crate) struct KeyExchange {
-    pub key_exchanger: Arc<RwLock<dyn KeyExchanger + Send + Sync>>,
+    pub key_exchanger: Box<dyn KeyExchanger>,
 }
 
 pub(crate) struct ExchangeIdentity {

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_worker.rs
@@ -370,7 +370,7 @@ impl DecryptorWorker {
             );
 
             let their_identity =
-                PublicIdentity::import_arc(&identity, self.identity.vault.clone()).await?;
+                PublicIdentity::import(&identity, self.identity.vault.clone()).await?;
             let their_identity_id = their_identity.identifier();
 
             // Verify responder posses their Identity key

--- a/implementations/rust/ockam/ockam_identity/src/channel/encryptor.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/encryptor.rs
@@ -1,15 +1,16 @@
 use crate::error::IdentityError;
+use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::vault::{KeyId, SymmetricVault};
 use ockam_core::Result;
 
-pub(crate) struct Encryptor<V: SymmetricVault> {
+pub(crate) struct Encryptor {
     key: KeyId,
     nonce: u64,
-    vault: V,
+    vault: Arc<dyn SymmetricVault>,
 }
 
-impl<V: SymmetricVault> Encryptor<V> {
+impl Encryptor {
     /// We use u64 nonce since it's convenient to work with it (e.g. increment)
     /// But we use 8-byte be format to send it over to the other side (according to noise spec)
     /// And we use 12-byte be format for encryption, since AES-GCM wants 12 bytes
@@ -44,7 +45,7 @@ impl<V: SymmetricVault> Encryptor<V> {
         Ok(res)
     }
 
-    pub fn new(key: KeyId, nonce: u64, vault: V) -> Self {
+    pub fn new(key: KeyId, nonce: u64, vault: Arc<dyn SymmetricVault>) -> Self {
         Self { key, nonce, vault }
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/channel/encryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/encryptor_worker.rs
@@ -1,6 +1,5 @@
 use crate::api::{EncryptionRequest, EncryptionResponse};
 use crate::channel::addresses::Addresses;
-use crate::channel::common::SecureChannelVault;
 use crate::channel::encryptor::Encryptor;
 use crate::channel::Role;
 use crate::error::IdentityError;
@@ -10,21 +9,21 @@ use ockam_core::{Any, Result, Routed, TransportMessage, Worker};
 use ockam_node::Context;
 use tracing::debug;
 
-pub(crate) struct EncryptorWorker<V: SecureChannelVault> {
+pub(crate) struct EncryptorWorker {
     role: Role,
     addresses: Addresses,
     remote_route: Route,
     remote_backwards_compatibility_address: Address,
-    encryptor: Encryptor<V>,
+    encryptor: Encryptor,
 }
 
-impl<V: SecureChannelVault> EncryptorWorker<V> {
+impl EncryptorWorker {
     pub fn new(
         role: Role,
         addresses: Addresses,
         remote_route: Route,
         remote_backwards_compatibility_address: Address,
-        encryptor: Encryptor<V>,
+        encryptor: Encryptor,
     ) -> Self {
         Self {
             role,
@@ -111,7 +110,7 @@ impl<V: SecureChannelVault> EncryptorWorker<V> {
 }
 
 #[async_trait]
-impl<V: SecureChannelVault> Worker for EncryptorWorker<V> {
+impl Worker for EncryptorWorker {
     type Message = Any;
     type Context = Context;
 

--- a/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
@@ -1,19 +1,18 @@
-use crate::authenticated_storage::AuthenticatedStorage;
 use crate::channel::common::CreateResponderChannelMessage;
 use crate::channel::decryptor_worker::DecryptorWorker;
-use crate::{Identity, IdentityVault, SecureChannelListenerTrustOptions};
+use crate::{Identity, SecureChannelListenerTrustOptions};
 use ockam_core::compat::boxed::Box;
 use ockam_core::sessions::SessionIdLocalInfo;
 use ockam_core::{Address, AllowAll, AsyncTryClone, DenyAll, Result, Routed, Worker};
 use ockam_node::Context;
 
-pub(crate) struct IdentityChannelListener<V: IdentityVault, S: AuthenticatedStorage> {
+pub(crate) struct IdentityChannelListener {
     trust_options: SecureChannelListenerTrustOptions,
-    identity: Identity<V, S>,
+    identity: Identity,
 }
 
-impl<V: IdentityVault, S: AuthenticatedStorage> IdentityChannelListener<V, S> {
-    pub fn new(trust_options: SecureChannelListenerTrustOptions, identity: Identity<V, S>) -> Self {
+impl IdentityChannelListener {
+    pub fn new(trust_options: SecureChannelListenerTrustOptions, identity: Identity) -> Self {
         Self {
             trust_options,
             identity,
@@ -24,7 +23,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> IdentityChannelListener<V, S> {
         ctx: &Context,
         address: Address,
         trust_options: SecureChannelListenerTrustOptions,
-        identity: Identity<V, S>,
+        identity: Identity,
     ) -> Result<()> {
         if let Some((sessions, session_id)) = &trust_options.session {
             sessions.set_listener_session_id(&address, session_id);
@@ -43,7 +42,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> IdentityChannelListener<V, S> {
 }
 
 #[ockam_core::worker]
-impl<V: IdentityVault, S: AuthenticatedStorage> Worker for IdentityChannelListener<V, S> {
+impl Worker for IdentityChannelListener {
     type Message = CreateResponderChannelMessage;
     type Context = Context;
 

--- a/implementations/rust/ockam/ockam_identity/src/channel/trust_policy/trust_public_key_policy.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/trust_policy/trust_public_key_policy.rs
@@ -1,5 +1,4 @@
-use crate::authenticated_storage::AuthenticatedStorage;
-use crate::{Identity, IdentityVault, SecureChannelTrustInfo, TrustPolicy};
+use crate::{Identity, SecureChannelTrustInfo, TrustPolicy};
 use ockam_core::compat::string::String;
 use ockam_core::vault::PublicKey;
 use ockam_core::{async_trait, compat::boxed::Box};
@@ -8,18 +7,18 @@ use ockam_core::{AsyncTryClone, Result};
 /// `TrustPolicy` based on pre-known `PublicKey` of the other participant
 #[derive(AsyncTryClone)]
 #[async_try_clone(crate = "ockam_core")]
-pub struct TrustPublicKeyPolicy<V: IdentityVault, S: AuthenticatedStorage> {
+pub struct TrustPublicKeyPolicy {
     public_key: PublicKey,
     public_key_label: String,
-    identity: Identity<V, S>,
+    identity: Identity,
 }
 
-impl<V: IdentityVault, S: AuthenticatedStorage> TrustPublicKeyPolicy<V, S> {
+impl TrustPublicKeyPolicy {
     /// Constructor
     pub fn new(
         public_key: PublicKey,
         public_key_label: impl Into<String>,
-        identity: Identity<V, S>,
+        identity: Identity,
     ) -> Self {
         Self {
             public_key,
@@ -30,7 +29,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> TrustPublicKeyPolicy<V, S> {
 }
 
 #[async_trait]
-impl<V: IdentityVault, S: AuthenticatedStorage> TrustPolicy for TrustPublicKeyPolicy<V, S> {
+impl TrustPolicy for TrustPublicKeyPolicy {
     async fn check(&self, trust_info: &SecureChannelTrustInfo) -> Result<bool> {
         let their_identity = match self
             .identity

--- a/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/access_control/credential_access_control.rs
@@ -2,26 +2,29 @@ use crate::authenticated_storage::IdentityAttributeStorage;
 use crate::IdentitySecureChannelLocalInfo;
 use core::fmt::{Debug, Formatter};
 use ockam_core::access_control::IncomingAccessControl;
-use ockam_core::compat::{string::String, vec::Vec};
+use ockam_core::compat::{string::String, sync::Arc, vec::Vec};
 use ockam_core::Result;
 use ockam_core::{async_trait, compat::boxed::Box, RelayMessage};
 
 #[derive(Clone)]
-pub struct CredentialAccessControl<S: IdentityAttributeStorage> {
+pub struct CredentialAccessControl {
     required_attributes: Vec<(String, Vec<u8>)>,
-    storage: S,
+    storage: Arc<dyn IdentityAttributeStorage>,
 }
 
-impl<S: IdentityAttributeStorage> CredentialAccessControl<S> {
-    pub fn new(required_attributes: &[(String, Vec<u8>)], storage: S) -> Self {
+impl CredentialAccessControl {
+    pub fn new(
+        required_attributes: &[(String, Vec<u8>)],
+        storage: impl IdentityAttributeStorage,
+    ) -> Self {
         Self {
             required_attributes: required_attributes.to_vec(),
-            storage,
+            storage: Arc::new(storage),
         }
     }
 }
 
-impl<S: IdentityAttributeStorage> Debug for CredentialAccessControl<S> {
+impl Debug for CredentialAccessControl {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         let attributes = format!("{:?}", self.required_attributes.iter().map(|x| &x.0));
 
@@ -32,7 +35,7 @@ impl<S: IdentityAttributeStorage> Debug for CredentialAccessControl<S> {
 }
 
 #[async_trait]
-impl<S: IdentityAttributeStorage> IncomingAccessControl for CredentialAccessControl<S> {
+impl IncomingAccessControl for CredentialAccessControl {
     async fn is_authorized(&self, relay_message: &RelayMessage) -> Result<bool> {
         if let Ok(msg_identity_id) =
             IdentitySecureChannelLocalInfo::find_info(relay_message.local_message())

--- a/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
@@ -4,7 +4,7 @@ use crate::credential::{Credential, CredentialData, Timestamp, Verified};
 use crate::PublicIdentity;
 use crate::{IdentityIdentifier, IdentityStateConst, IdentityVault};
 use ockam_core::compat::collections::BTreeMap;
-use ockam_core::compat::{string::String, vec::Vec};
+use ockam_core::compat::{string::String, sync::Arc, vec::Vec};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::vault::Signature;
 use ockam_core::{Error, Result};
@@ -17,7 +17,7 @@ impl PublicIdentity {
         &self,
         credential: &Credential,
         subject: &IdentityIdentifier,
-        vault: &impl IdentityVault,
+        vault: Arc<dyn IdentityVault>,
     ) -> Result<CredentialData<Verified>> {
         let dat = CredentialData::try_from(credential)?;
         if dat.unverified_key_label() != IdentityStateConst::ROOT_LABEL {

--- a/implementations/rust/ockam/ockam_identity/src/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential_issuer.rs
@@ -38,7 +38,7 @@ pub struct CredentialIssuer {
 impl CredentialIssuer {
     /// Create a fully in-memory issuer for testing
     pub async fn create(ctx: &Context) -> Result<CredentialIssuer> {
-        let identity = Identity::create(ctx, &Vault::create()).await?;
+        let identity = Identity::create(ctx, Vault::create()).await?;
         Ok(CredentialIssuer { identity })
     }
 

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -5,6 +5,7 @@ use minicbor::decode::{self, Decoder};
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
 use ockam_core::compat::string::{String, ToString};
+use ockam_core::compat::sync::Arc;
 use ockam_core::vault::{Hasher, KeyId};
 use ockam_core::{Error, Result};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -125,7 +126,7 @@ impl AsRef<[u8]> for ChangeIdentifier {
 
 impl ChangeIdentifier {
     /// Initial `ChangeIdentifier` that is used as a previous_identifier of the first change
-    pub async fn initial(hasher: &(impl Hasher + Sync)) -> Self {
+    pub async fn initial(hasher: Arc<dyn Hasher>) -> Self {
         let h = match hasher.sha256(IdentityStateConst::INITIAL_CHANGE).await {
             Ok(hash) => hash,
             Err(_) => panic!("failed to hash initial change"),

--- a/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
@@ -28,7 +28,7 @@ impl IdentityBuilder {
 
     /// Build an `Identity`
     pub async fn build(self) -> Result<Identity> {
-        Identity::create_arc(&self.ctx, self.vault).await
+        Identity::create(&self.ctx, self.vault).await
     }
 }
 
@@ -42,7 +42,7 @@ mod test {
 
     #[ockam_macros::test]
     async fn test_builder(ctx: &mut Context) -> Result<()> {
-        let vault: Arc<dyn IdentityVault> = Arc::new(Vault::create());
+        let vault: Arc<dyn IdentityVault> = Vault::create();
         let builder = IdentityBuilder::new(ctx, vault).await.unwrap();
         let _ = builder.build().await.unwrap();
 

--- a/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity_builder.rs
@@ -1,17 +1,17 @@
-use crate::authenticated_storage::mem::InMemoryStorage;
 use crate::{Identity, IdentityVault};
+use ockam_core::compat::sync::Arc;
 use ockam_core::{Address, DenyAll, Result};
 use ockam_node::Context;
 
 /// Builder for `Identity`
-pub struct IdentityBuilder<V: IdentityVault> {
+pub struct IdentityBuilder {
     ctx: Context,
-    vault: V,
+    vault: Arc<dyn IdentityVault>,
 }
 
-impl<V: IdentityVault> IdentityBuilder<V> {
+impl IdentityBuilder {
     /// Constructor
-    pub async fn new(ctx: &Context, vault: &V) -> Result<Self> {
+    pub async fn new(ctx: &Context, vault: Arc<dyn IdentityVault>) -> Result<Self> {
         let child_ctx = ctx
             .new_detached(
                 Address::random_tagged("IdentityBuilder.detached"),
@@ -22,27 +22,28 @@ impl<V: IdentityVault> IdentityBuilder<V> {
 
         Ok(Self {
             ctx: child_ctx,
-            vault: vault.async_try_clone().await?,
+            vault: vault.clone(),
         })
     }
 
     /// Build an `Identity`
-    pub async fn build(self) -> Result<Identity<V, InMemoryStorage>> {
-        Identity::create(&self.ctx, &self.vault).await
+    pub async fn build(self) -> Result<Identity> {
+        Identity::create_arc(&self.ctx, self.vault).await
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::IdentityBuilder;
+    use crate::{IdentityBuilder, IdentityVault};
     use ockam_core::Result;
     use ockam_node::Context;
     use ockam_vault::Vault;
+    use std::sync::Arc;
 
     #[ockam_macros::test]
     async fn test_builder(ctx: &mut Context) -> Result<()> {
-        let vault = Vault::create();
-        let builder = IdentityBuilder::new(ctx, &vault).await.unwrap();
+        let vault: Arc<dyn IdentityVault> = Arc::new(Vault::create());
+        let builder = IdentityBuilder::new(ctx, vault).await.unwrap();
         let _ = builder.build().await.unwrap();
 
         ctx.stop().await

--- a/implementations/rust/ockam/ockam_identity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_identity/src/lib.rs
@@ -18,7 +18,6 @@ extern crate core;
 #[macro_use]
 extern crate alloc;
 
-use ockam_core::AsyncTryClone;
 use ockam_vault::{Hasher, SecretVault, Signer, Verifier};
 
 use crate::IdentityError;
@@ -64,18 +63,11 @@ mod invalid_signatures_tests;
 
 /// Traits required for a Vault implementation suitable for use in an Identity
 pub trait IdentityVault:
-    SecretVault + SecureChannelVault + Hasher + Signer + Verifier + AsyncTryClone + Send + 'static
+    SecretVault + SecureChannelVault + Hasher + Signer + Verifier + Send + Sync + 'static
 {
 }
 
 impl<D> IdentityVault for D where
-    D: SecretVault
-        + SecureChannelVault
-        + Hasher
-        + Signer
-        + Verifier
-        + AsyncTryClone
-        + Send
-        + 'static
+    D: SecretVault + SecureChannelVault + Hasher + Signer + Verifier + Send + Sync + 'static
 {
 }

--- a/implementations/rust/ockam/ockam_identity/src/public_identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/public_identity.rs
@@ -4,7 +4,7 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::vault::Signature;
 use ockam_core::Result;
-use ockam_vault::{PublicKey, Vault};
+use ockam_vault::PublicKey;
 use serde::{Deserialize, Serialize};
 
 /// Public part of an `Identity`
@@ -25,14 +25,7 @@ impl PublicIdentity {
     }
 
     /// Import from the binary format
-    pub async fn import(data: &[u8], vault: &Vault) -> Result<Self> {
-        let vault: Arc<dyn IdentityVault> = Arc::new(vault.clone());
-        let result = PublicIdentity::import_arc(data, vault).await?;
-        Ok(result)
-    }
-
-    /// Import from the binary format
-    pub async fn import_arc(data: &[u8], vault: Arc<dyn IdentityVault>) -> Result<Self> {
+    pub async fn import(data: &[u8], vault: Arc<dyn IdentityVault>) -> Result<Self> {
         let change_history = IdentityChangeHistory::import(data)?;
         if !change_history
             .verify_all_existing_changes(vault.clone())

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -16,8 +16,8 @@ async fn test_channel(ctx: &mut Context) -> Result<()> {
     let alice_vault = Vault::create();
     let bob_vault = Vault::create();
 
-    let alice = Identity::create(ctx, &alice_vault).await?;
-    let bob = Identity::create(ctx, &bob_vault).await?;
+    let alice = Identity::create(ctx, alice_vault).await?;
+    let bob = Identity::create(ctx, bob_vault).await?;
 
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
     let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
@@ -71,8 +71,8 @@ async fn test_channel_registry(ctx: &mut Context) -> Result<()> {
     let alice_vault = Vault::create();
     let bob_vault = Vault::create();
 
-    let alice = Identity::create(ctx, &alice_vault).await?;
-    let bob = Identity::create(ctx, &bob_vault).await?;
+    let alice = Identity::create(ctx, alice_vault).await?;
+    let bob = Identity::create(ctx, bob_vault).await?;
 
     bob.create_secure_channel_listener("bob_listener", TrustEveryonePolicy)
         .await?;
@@ -128,8 +128,8 @@ async fn test_channel_api(ctx: &mut Context) -> Result<()> {
     let alice_vault = Vault::create();
     let bob_vault = Vault::create();
 
-    let alice = Identity::create(ctx, &alice_vault).await?;
-    let bob = Identity::create(ctx, &bob_vault).await?;
+    let alice = Identity::create(ctx, alice_vault).await?;
+    let bob = Identity::create(ctx, bob_vault).await?;
 
     bob.create_secure_channel_listener("bob_listener", TrustEveryonePolicy)
         .await?;
@@ -223,8 +223,8 @@ async fn test_channel_api(ctx: &mut Context) -> Result<()> {
 async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     let vault = Vault::create();
 
-    let alice = Identity::create(ctx, &vault).await?;
-    let bob = Identity::create(ctx, &vault).await?;
+    let alice = Identity::create(ctx, vault.clone()).await?;
+    let bob = Identity::create(ctx, vault.clone()).await?;
 
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
     let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
@@ -279,8 +279,8 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
 async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     let vault = Vault::create();
 
-    let alice = Identity::create(ctx, &vault).await?;
-    let bob = Identity::create(ctx, &vault).await?;
+    let alice = Identity::create(ctx, vault.clone()).await?;
+    let bob = Identity::create(ctx, vault.clone()).await?;
 
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
     let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
@@ -345,8 +345,8 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
 async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     let vault = Vault::create();
 
-    let alice = Identity::create(ctx, &vault).await?;
-    let bob = Identity::create(ctx, &vault).await?;
+    let alice = Identity::create(ctx, vault.clone()).await?;
+    let bob = Identity::create(ctx, vault.clone()).await?;
 
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier().clone());
     let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier().clone());
@@ -426,8 +426,8 @@ async fn access_control__known_participant__should_pass_messages(ctx: &mut Conte
 
     let vault = Vault::create();
 
-    let alice = Identity::create(ctx, &vault).await?;
-    let bob = Identity::create(ctx, &vault).await?;
+    let alice = Identity::create(ctx, vault.clone()).await?;
+    let bob = Identity::create(ctx, vault.clone()).await?;
 
     let access_control = IdentityAccessControlBuilder::new_with_id(alice.identifier().clone());
     WorkerBuilder::with_access_control(
@@ -477,8 +477,8 @@ async fn access_control__unknown_participant__should_not_pass_messages(
 
     let vault = Vault::create();
 
-    let alice = Identity::create(ctx, &vault).await?;
-    let bob = Identity::create(ctx, &vault).await?;
+    let alice = Identity::create(ctx, vault.clone()).await?;
+    let bob = Identity::create(ctx, vault.clone()).await?;
 
     let access_control = IdentityAccessControlBuilder::new_with_id(bob.identifier().clone());
     WorkerBuilder::with_access_control(

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -21,9 +21,8 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
     let authenticated_attribute_storage =
         AuthenticatedAttributeStorage::new(Arc::new(InMemoryStorage::new()));
 
-    let authority = Identity::create(ctx, &vault).await?;
-
-    let server = Identity::create(ctx, &vault).await?;
+    let authority = Identity::create(ctx, vault.clone()).await?;
+    let server = Identity::create(ctx, vault.clone()).await?;
 
     server
         .create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -39,7 +38,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
         )
         .await?;
 
-    let client = Identity::create(ctx, &vault).await?;
+    let client = Identity::create(ctx, vault).await?;
     let channel = client
         .create_secure_channel(
             route!["listener"],
@@ -79,9 +78,8 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
     let authenticated_attribute_storage_client_2 =
         AuthenticatedAttributeStorage::new(storage2.clone());
 
-    let authority = Identity::create(ctx, &vault).await?;
-
-    let client2 = Identity::create(ctx, &vault).await?;
+    let authority = Identity::create(ctx, vault.clone()).await?;
+    let client2 = Identity::create(ctx, vault.clone()).await?;
 
     let credential2 =
         Credential::builder(client2.identifier().clone()).with_attribute("is_admin", b"true");
@@ -103,7 +101,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         )
         .await?;
 
-    let client1 = Identity::create(ctx, &vault).await?;
+    let client1 = Identity::create(ctx, vault).await?;
 
     let credential1 =
         Credential::builder(client1.identifier().clone()).with_attribute("is_user", b"true");
@@ -167,8 +165,8 @@ impl Worker for CountingWorker {
 async fn access_control(ctx: &mut Context) -> Result<()> {
     let vault = Vault::create();
     let storage = Arc::new(InMemoryStorage::new());
-    let authority = Identity::create(ctx, &vault).await?;
-    let server = Identity::create(ctx, &vault).await?;
+    let authority = Identity::create(ctx, vault.clone()).await?;
+    let server = Identity::create(ctx, vault.clone()).await?;
 
     server
         .create_secure_channel_listener("listener", TrustEveryonePolicy)
@@ -185,7 +183,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
         )
         .await?;
 
-    let client = Identity::create(ctx, &vault).await?;
+    let client = Identity::create(ctx, vault.clone()).await?;
     let channel = client
         .create_secure_channel(
             route!["listener"],

--- a/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
@@ -281,7 +281,7 @@ async fn create_secure_channel_listener(
     ctx: &Context,
     session: &Option<(Sessions, SessionId)>,
 ) -> Result<SecureChannelListenerInfo> {
-    let identity = Identity::create(ctx, &Vault::create()).await?;
+    let identity = Identity::create(ctx, Vault::create()).await?;
 
     let trust_options =
         SecureChannelListenerTrustOptions::new().with_trust_policy(TrustEveryonePolicy);
@@ -309,7 +309,7 @@ async fn create_secure_channel(
     ctx: &Context,
     connection: &TcpConnectionInfo,
 ) -> Result<SecureChannelInfo> {
-    let identity = Identity::create(ctx, &Vault::create()).await?;
+    let identity = Identity::create(ctx, Vault::create()).await?;
 
     let trust_options = SecureChannelTrustOptions::new();
     let trust_options = if let Some((sessions, session_id)) = &connection.session {

--- a/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
@@ -2,7 +2,6 @@ use core::time::Duration;
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::sessions::{SessionId, Sessions};
 use ockam_core::{route, Address, AllowAll, Result, Route};
-use ockam_identity::authenticated_storage::mem::InMemoryStorage;
 use ockam_identity::{
     Identity, SecureChannelListenerTrustOptions, SecureChannelTrustOptions, TrustEveryonePolicy,
 };
@@ -263,7 +262,7 @@ async fn create_tcp_connection(
 }
 
 struct SecureChannelListenerInfo {
-    identity: Identity<Vault, InMemoryStorage>,
+    identity: Identity,
 }
 
 impl SecureChannelListenerInfo {
@@ -302,7 +301,7 @@ async fn create_secure_channel_listener(
 }
 
 struct SecureChannelInfo {
-    identity: Identity<Vault, InMemoryStorage>,
+    identity: Identity,
     address: Address,
 }
 

--- a/implementations/rust/ockam/ockam_identity/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/tests.rs
@@ -5,6 +5,7 @@ use ockam_identity::Identity;
 use ockam_node::Context;
 use ockam_vault::Vault;
 use rand::{thread_rng, RngCore};
+use std::sync::Arc;
 
 fn test_error<S: Into<String>>(error: S) -> Result<()> {
     Err(Error::new_without_cause(Origin::Identity, Kind::Unknown).context("msg", error.into()))
@@ -39,7 +40,7 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
 
     let known_bob = alice.get_known_identity(bob.identifier()).await?.unwrap();
     if !known_bob
-        .verify_signature(&bob_proof, &state, None, &alice_vault)
+        .verify_signature(&bob_proof, &state, None, Arc::new(alice_vault))
         .await?
     {
         return test_error("bob's proof was invalid");
@@ -47,7 +48,7 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
 
     let known_alice = bob.get_known_identity(alice.identifier()).await?.unwrap();
     if !known_alice
-        .verify_signature(&alice_proof, &state, None, &bob_vault)
+        .verify_signature(&alice_proof, &state, None, Arc::new(bob_vault))
         .await?
     {
         return test_error("alice's proof was invalid");
@@ -122,7 +123,7 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
 
     let known_bob = alice.get_known_identity(bob.identifier()).await?.unwrap();
     if !known_bob
-        .verify_signature(&bob_proof, &state, None, &alice_vault)
+        .verify_signature(&bob_proof, &state, None, Arc::new(alice_vault))
         .await?
     {
         return test_error("bob's proof was invalid");
@@ -130,7 +131,7 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
 
     let known_alice = bob.get_known_identity(alice.identifier()).await?.unwrap();
     if !known_alice
-        .verify_signature(&alice_proof, &state, None, &bob_vault)
+        .verify_signature(&alice_proof, &state, None, Arc::new(bob_vault))
         .await?
     {
         return test_error("alice's proof was invalid");

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -63,12 +63,11 @@ mod tests {
     use ockam_core::{KeyExchanger, NewKeyExchanger};
     use ockam_node::Context;
     use ockam_vault::Vault;
-    use std::sync::Arc;
 
     #[allow(non_snake_case)]
     #[ockam_macros::test]
     async fn full_flow__correct_credential__keys_should_match(ctx: &mut Context) -> Result<()> {
-        let vault = Arc::new(Vault::create());
+        let vault = Vault::create();
 
         let key_exchanger = XXNewKeyExchanger::new(vault.clone());
 

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -25,7 +25,6 @@ extern crate alloc;
 mod error;
 
 pub use error::*;
-use ockam_core::AsyncTryClone;
 
 /// The number of bytes in a SHA256 digest
 pub const SHA256_SIZE_U32: u32 = 32;
@@ -39,19 +38,12 @@ pub const AES_GCM_TAGSIZE_USIZE: usize = 16;
 
 /// Vault with XX required functionality
 pub trait XXVault:
-    SecretVault + Hasher + AsymmetricVault + SymmetricVault + AsyncTryClone + Send + Sync + 'static
+    SecretVault + Hasher + AsymmetricVault + SymmetricVault + Send + Sync + 'static
 {
 }
 
 impl<D> XXVault for D where
-    D: SecretVault
-        + Hasher
-        + AsymmetricVault
-        + SymmetricVault
-        + AsyncTryClone
-        + Send
-        + Sync
-        + 'static
+    D: SecretVault + Hasher + AsymmetricVault + SymmetricVault + Send + Sync + 'static
 {
 }
 
@@ -71,13 +63,14 @@ mod tests {
     use ockam_core::{KeyExchanger, NewKeyExchanger};
     use ockam_node::Context;
     use ockam_vault::Vault;
+    use std::sync::Arc;
 
     #[allow(non_snake_case)]
     #[ockam_macros::test]
     async fn full_flow__correct_credential__keys_should_match(ctx: &mut Context) -> Result<()> {
-        let vault = Vault::create();
+        let vault = Arc::new(Vault::create());
 
-        let key_exchanger = XXNewKeyExchanger::new(vault.async_try_clone().await.unwrap());
+        let key_exchanger = XXNewKeyExchanger::new(vault.clone());
 
         let mut initiator = key_exchanger.initiator().await.unwrap();
         let mut responder = key_exchanger.responder().await.unwrap();

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/new_key_exchanger.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/new_key_exchanger.rs
@@ -1,37 +1,36 @@
 use crate::state::State;
 use crate::{Initiator, Responder, XXVault};
-use ockam_core::{async_trait, compat::boxed::Box, AsyncTryClone, Result};
+use ockam_core::compat::sync::Arc;
+use ockam_core::{async_trait, compat::boxed::Box, Result};
 
 use ockam_core::NewKeyExchanger;
 
 /// Represents an XX NewKeyExchanger
-#[derive(AsyncTryClone)]
-#[async_try_clone(crate = "ockam_core")]
-pub struct XXNewKeyExchanger<V: XXVault> {
-    vault: V,
+pub struct XXNewKeyExchanger {
+    vault: Arc<dyn XXVault>,
 }
 
-impl<V: XXVault> XXNewKeyExchanger<V> {
+impl XXNewKeyExchanger {
     /// Create a new XXNewKeyExchanger
-    pub fn new(vault: V) -> Self {
+    pub fn new(vault: Arc<dyn XXVault>) -> Self {
         Self { vault }
     }
 }
 
 #[async_trait]
-impl<V: XXVault> NewKeyExchanger for XXNewKeyExchanger<V> {
-    type Initiator = Initiator<V>;
-    type Responder = Responder<V>;
+impl NewKeyExchanger for XXNewKeyExchanger {
+    type Initiator = Initiator;
+    type Responder = Responder;
 
     /// Create a new initiator using the provided backing vault
-    async fn initiator(&self) -> Result<Initiator<V>> {
-        let ss = State::new(&self.vault).await?;
+    async fn initiator(&self) -> Result<Initiator> {
+        let ss = State::new(self.vault.clone()).await?;
         Ok(Initiator::new(ss))
     }
 
     /// Create a new responder using the provided backing vault
-    async fn responder(&self) -> Result<Responder<V>> {
-        let ss = State::new(&self.vault).await?;
+    async fn responder(&self) -> Result<Responder> {
+        let ss = State::new(self.vault.clone()).await?;
         Ok(Responder::new(ss))
     }
 }

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/state.rs
@@ -406,7 +406,7 @@ mod tests {
             100, 252, 104, 43, 230, 163, 171, 75, 104, 44, 141, 182, 75,
         ];
 
-        let vault: Arc<dyn XXVault> = Arc::new(vault);
+        let vault: Arc<dyn XXVault> = vault;
         let mut state = State::new(vault.clone()).await.unwrap();
         let res = state.prologue().await;
         assert!(res.is_ok());
@@ -442,7 +442,7 @@ mod tests {
         const MSG_3_CIPHERTEXT: &str = "e610eadc4b00c17708bf223f29a66f02342fbedf6c0044736544b9271821ae40e70144cecd9d265dffdc5bb8e051c3f83db32a425e04d8f510c58a43325fbc56";
         const MSG_3_PAYLOAD: &str = "";
 
-        let vault: Arc<dyn XXVault> = Arc::new(Vault::create());
+        let vault: Arc<dyn XXVault> = Vault::create();
 
         mock_handshake(
             vault,
@@ -530,7 +530,7 @@ mod tests {
         const MSG_3_PAYLOAD: &str = "746573745f6d73675f32";
         const MSG_3_CIPHERTEXT: &str = "e610eadc4b00c17708bf223f29a66f02342fbedf6c0044736544b9271821ae40232c55cd96d1350af861f6a04978f7d5e070c07602c6b84d25a331242a71c50ae31dd4c164267fd48bd2";
 
-        let vault: Arc<dyn XXVault> = Arc::new(Vault::create());
+        let vault: Arc<dyn XXVault> = Vault::create();
 
         mock_handshake(
             vault,
@@ -566,7 +566,7 @@ mod tests {
         const MSG_3_CIPHERTEXT: &str = "e610eadc4b00c17708bf223f29a66f02342fbedf6c0044736544b9271821ae40e70144cecd9d265dffdc5bb8e051c3f83db32a425e04d8f510c58a43325fbc56";
         const MSG_3_PAYLOAD: &str = "";
 
-        let vault: Arc<dyn XXVault> = Arc::new(Vault::create());
+        let vault: Arc<dyn XXVault> = Vault::create();
 
         let initiator = mock_prologue(vault.clone(), INIT_STATIC, INIT_EPH).await;
         let responder = mock_prologue(vault.clone(), RESP_STATIC, RESP_EPH).await;

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/state/dh_state.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/state/dh_state.rs
@@ -1,18 +1,20 @@
 use crate::{XXError, XXVault, SHA256_SIZE_U32};
+use ockam_core::compat::sync::Arc;
 use ockam_core::vault::{
     KeyId, PublicKey, Secret, SecretAttributes, SecretKey, SecretPersistence, SecretType,
     AES256_SECRET_LENGTH_U32,
 };
 use ockam_core::Result;
 
-pub(crate) struct DhState<V: XXVault> {
+#[derive(Clone)]
+pub(crate) struct DhState {
     pub(crate) key: Option<KeyId>,
     pub(crate) ck: Option<KeyId>,
-    pub(crate) vault: V,
+    pub(crate) vault: Arc<dyn XXVault>,
 }
 
-impl<V: XXVault> DhState<V> {
-    pub(crate) fn empty(vault: V) -> Self {
+impl DhState {
+    pub(crate) fn empty(vault: Arc<dyn XXVault>) -> Self {
         Self {
             key: None,
             ck: None,
@@ -20,7 +22,7 @@ impl<V: XXVault> DhState<V> {
         }
     }
 
-    pub(crate) async fn new(protocol_name: &[u8; 32], vault: V) -> Result<Self> {
+    pub(crate) async fn new(protocol_name: &[u8; 32], vault: Arc<dyn XXVault>) -> Result<Self> {
         let attributes = SecretAttributes::new(
             SecretType::Buffer,
             SecretPersistence::Ephemeral,
@@ -38,7 +40,7 @@ impl<V: XXVault> DhState<V> {
     }
 }
 
-impl<V: XXVault> DhState<V> {
+impl DhState {
     pub(crate) fn key(&self) -> Option<&KeyId> {
         self.key.as_ref()
     }
@@ -47,7 +49,7 @@ impl<V: XXVault> DhState<V> {
     }
 }
 
-impl<V: XXVault> DhState<V> {
+impl DhState {
     pub(crate) fn get_symmetric_key_type_and_length(&self) -> (SecretType, u32) {
         (SecretType::Aes, AES256_SECRET_LENGTH_U32)
     }

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -30,7 +30,7 @@ async fn async_main(mut ctx: Context) -> Result<()> {
     let vault = Vault::create();
 
     // Create an Entity to represent Alice.
-    let alice = Identity::create(&ctx, &vault).await?;
+    let alice = Identity::create(&ctx, vault).await?;
 
     // Connect to BLE Server
     ble.connect(ble_client, "ockam_ble_1".to_string()).await?;

--- a/implementations/rust/ockam/ockam_vault/src/vault.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault.rs
@@ -56,8 +56,8 @@ impl Vault {
     }
 
     /// Same as ```Vault::new()```
-    pub fn create() -> Self {
-        Self::new(None)
+    pub fn create() -> Arc<Vault> {
+        Arc::new(Self::new(None))
     }
 
     /// Enable AWS KMS.


### PR DESCRIPTION
The main objective of this PR is to simplify the code using `Identity` by removing its type parameters. 
Those type parameters specify which `IdentityVault` and which `AuthenticatedStorage` are used to implement an `Identity` and don't have to be known by the users of `Identity`. The benefits are:

 - a simpler rust entity to manipulate
 - an isolation of the rest of the code from changes in the `Identity` implementation
 - a removal of the same same type parameters which had to be set on other structs using `Identity`

Removing these type parameters consists in using `Arc<dyn Trait>` (for example `Arc<dyn IdentityVault>`) in the implementation of `Identity`. This removal has a number of knock-on effects on other structs and functions which also had to be parameterized by the type parameters used by `Identity` hence the unfortunately large PR.

I left some comments on the PR itself to help the reviewers, please tell me if I have introduced any possible regression or broken a rust idiom.
