### PR TITLE
Expand Credential Commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -1327,6 +1327,7 @@ mod tests {
             format!("nodes/{node_name}"),
             "projects".to_string(),
             "projects/data".to_string(),
+            "credentials".to_string(),
             "defaults".to_string(),
             "defaults/vault".to_string(),
             "defaults/identity".to_string(),
@@ -1413,6 +1414,10 @@ mod tests {
                         let file_name = entry.file_name().into_string().unwrap();
                         found_entries.push(format!("{dir_name}/{file_name}"));
                     });
+                }
+                "credentials" => {
+                    assert!(entry.path().is_dir());
+                    found_entries.push(dir_name.clone());
                 }
                 _ => panic!("unexpected file"),
             }

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -3,6 +3,7 @@ use crate::nodes::models::transport::{CreateTransportJson, TransportMode, Transp
 use nix::errno::Errno;
 use ockam_identity::change_history::{IdentityChangeHistory, IdentityHistoryComparison};
 use ockam_identity::{Identity, IdentityIdentifier, SecureChannelRegistry};
+use ockam_node::tokio;
 use ockam_vault::{storage::FileStorage, Vault};
 use rand::random;
 use serde::{Deserialize, Serialize};
@@ -58,6 +59,7 @@ pub struct CliState {
     pub identities: IdentitiesState,
     pub nodes: NodesState,
     pub projects: ProjectsState,
+    pub credentials: CredentialsState,
     pub dir: PathBuf,
 }
 
@@ -74,6 +76,7 @@ impl CliState {
             identities: IdentitiesState::new(dir)?,
             nodes: NodesState::new(dir)?,
             projects: ProjectsState::new(dir)?,
+            credentials: CredentialsState::new(&dir)?,
             dir: dir.to_path_buf(),
         })
     }
@@ -359,6 +362,21 @@ impl IdentitiesState {
             path
         };
         IdentityState::try_from(&path)
+    }
+
+    pub fn get_by_identifier(&self, identifier: &IdentityIdentifier) -> Result<IdentityState> {
+        let identities = self.list()?;
+
+        let identity_state = identities
+            .into_iter()
+            .find(|ident_state| &ident_state.config.identifier == identifier);
+
+        match identity_state {
+            Some(is) => Ok(is),
+            None => Err(CliStateError::NotFound(format!(
+                "identity with identifier `{identifier}`"
+            ))),
+        }
     }
 
     pub fn list(&self) -> Result<Vec<IdentityState>> {
@@ -1100,6 +1118,125 @@ impl ProjectState {
                 CliStateError::Io(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     "failed to parse the project name",
+                ))
+            })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialConfig {
+    pub issuer: String,
+    pub encoded_credential: String,
+}
+
+impl CredentialConfig {
+    pub fn new(issuer: String, encoded_credential: String) -> Result<Self> {
+        Ok(Self {
+            issuer,
+            encoded_credential,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CredentialsState {
+    dir: PathBuf,
+}
+
+impl CredentialsState {
+    fn new(cli_path: &Path) -> Result<Self> {
+        let dir = cli_path.join("credentials");
+        std::fs::create_dir_all(dir.join("data"))?;
+        Ok(Self { dir })
+    }
+
+    pub async fn create(&self, name: &str, cred: CredentialConfig) -> Result<CredentialState> {
+        let path = {
+            let mut path = self.dir.clone();
+            path.push(format!("{name}.json"));
+            if path.exists() {
+                return Err(CliStateError::AlreadyExists(format!("credential `{name}`")));
+            }
+            path
+        };
+        let contents = serde_json::to_string(&cred)?;
+        std::fs::write(&path, contents)?;
+        if !self.default_path()?.exists() {
+            self.set_default(name)?;
+        }
+
+        Ok(CredentialState { path })
+    }
+
+    pub fn get(&self, name: &str) -> Result<CredentialState> {
+        let path = {
+            let mut path = self.dir.clone();
+            path.push(format!("{name}.json"));
+            if !path.exists() {
+                return Err(CliStateError::NotFound(format!("credential `{name}`")));
+            }
+            path
+        };
+        Ok(CredentialState { path })
+    }
+
+    pub fn list(&self) -> Result<Vec<CredentialState>> {
+        let mut creds = vec![];
+        for entry in std::fs::read_dir(&self.dir)? {
+            if let Ok(cred) = self.get(&file_stem(&entry?.path())?) {
+                creds.push(cred);
+            }
+        }
+
+        Ok(creds)
+    }
+
+    pub fn default_path(&self) -> Result<PathBuf> {
+        Ok(
+            CliState::defaults_dir(self.dir.parent().expect("Should have parent"))?
+                .join("credential"),
+        )
+    }
+
+    pub fn default(&self) -> Result<CredentialState> {
+        let path = std::fs::canonicalize(self.default_path()?)?;
+        Ok(CredentialState { path })
+    }
+
+    pub fn set_default(&self, name: &str) -> Result<CredentialState> {
+        let original = {
+            let mut path = self.dir.clone();
+            path.push(format!("{name}.json"));
+            if !path.exists() {
+                return Err(CliStateError::NotFound(format!("credential `{name}`")));
+            }
+            path
+        };
+        let link = self.default_path()?;
+        std::os::unix::fs::symlink(original, link)?;
+        self.get(name)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CredentialState {
+    pub path: PathBuf,
+}
+
+impl CredentialState {
+    pub async fn config(&self) -> Result<CredentialConfig> {
+        let string_config = tokio::fs::read_to_string(&self.path).await?;
+        Ok(serde_json::from_str(&string_config)?)
+    }
+
+    pub fn name(&self) -> Result<String> {
+        self.path
+            .file_stem()
+            .and_then(|s| s.to_os_string().into_string().ok())
+            .ok_or_else(|| {
+                CliStateError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "failed to parse the credentials name",
                 ))
             })
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -3,7 +3,7 @@ use crate::nodes::models::transport::{CreateTransportJson, TransportMode, Transp
 use nix::errno::Errno;
 use ockam_identity::change_history::{IdentityChangeHistory, IdentityHistoryComparison};
 use ockam_identity::{Identity, IdentityIdentifier, SecureChannelRegistry};
-use ockam_node::tokio;
+
 use ockam_vault::{storage::FileStorage, Vault};
 use rand::random;
 use serde::{Deserialize, Serialize};
@@ -1225,7 +1225,7 @@ pub struct CredentialState {
 
 impl CredentialState {
     pub async fn config(&self) -> Result<CredentialConfig> {
-        let string_config = tokio::fs::read_to_string(&self.path).await?;
+        let string_config = std::fs::read_to_string(&self.path)?;
         Ok(serde_json::from_str(&string_config)?)
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -76,7 +76,7 @@ impl CliState {
             identities: IdentitiesState::new(dir)?,
             nodes: NodesState::new(dir)?,
             projects: ProjectsState::new(dir)?,
-            credentials: CredentialsState::new(&dir)?,
+            credentials: CredentialsState::new(dir)?,
             dir: dir.to_path_buf(),
         })
     }

--- a/implementations/rust/ockam/ockam_api/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier.rs
@@ -93,7 +93,7 @@ where
     ) -> Result<Either<ResponseBuilder<Error<'_>>, CredentialData<Verified>>> {
         let data = CredentialData::try_from(cre)?;
 
-        let ident = if let Some(ident) = req.authority(data.unverfied_issuer()) {
+        let ident = if let Some(ident) = req.authority(data.unverified_issuer()) {
             PublicIdentity::import(ident, &self.vault).await?
         } else {
             let err = Error::new("/verify").with_message("unauthorised issuer");

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -7,7 +7,7 @@ use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
-pub struct GetCredentialCommand {
+pub struct GetCommand {
     #[command(flatten)]
     pub node_opts: NodeOpts,
 
@@ -18,23 +18,20 @@ pub struct GetCredentialCommand {
     identity: Option<String>,
 }
 
-impl GetCredentialCommand {
+impl GetCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         node_rpc(rpc, (options, self));
     }
 }
 
-async fn rpc(
-    mut ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, GetCredentialCommand),
-) -> crate::Result<()> {
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, GetCommand)) -> crate::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
 async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
-    cmd: GetCredentialCommand,
+    cmd: GetCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::credentials::get_credential(

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use crate::{
+    identity::default_identity_name,
+    util::{node_rpc, print_output},
+    vault::default_vault_name,
+    CommandGlobalOpts, Result,
+};
+use anyhow::Context as _;
+use clap::Args;
+use ockam::Context;
+use ockam_identity::{credential::Credential, IdentityIdentifier};
+
+#[derive(Clone, Debug, Args)]
+pub struct IssueCommand {
+    #[arg(long = "as", default_value_t = default_identity_name())]
+    pub as_identity: String,
+
+    #[arg(long = "for", value_name = "IDENTITY_ID")]
+    pub for_identity: IdentityIdentifier,
+
+    /// Attributes in `key=value` format to be attached to the member
+    #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
+    pub attributes: Vec<String>,
+
+    #[arg(default_value_t = default_vault_name())]
+    pub vault: String,
+}
+
+impl IssueCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+
+    fn attributes(&self) -> Result<HashMap<String, String>> {
+        let mut attributes = HashMap::new();
+        for attr in &self.attributes {
+            let mut parts = attr.splitn(2, '=');
+            let key = parts.next().context("key expected")?;
+            let value = parts.next().context("value expected)")?;
+            attributes.insert(key.to_string(), value.to_string());
+        }
+        Ok(attributes)
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, IssueCommand),
+) -> crate::Result<()> {
+    let attrs = cmd.attributes()?;
+    let cred_builder = attrs.iter().fold(
+        Credential::builder(cmd.for_identity.clone()),
+        |crd, (k, v)| crd.with_attribute(k, v.as_bytes()),
+    );
+
+    let vault = opts.state.vaults.get(&cmd.vault)?.get().await?;
+    let ident_state = opts.state.identities.get(&cmd.as_identity)?;
+
+    let ident = ident_state.get(&ctx, &vault).await?;
+
+    let credential = ident.issue_credential(cred_builder).await?;
+
+    print_output(credential, &opts.global_args.output_format)?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ockam_core::compat::collections::HashMap;
 
 use crate::{
     identity::default_identity_name,
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::Context as _;
 use clap::Args;
 use ockam::Context;
-use ockam_identity::{credential::Credential, IdentityIdentifier};
+use ockam_identity::{credential::CredentialBuilder, IdentityIdentifier};
 
 #[derive(Clone, Debug, Args)]
 pub struct IssueCommand {
@@ -53,10 +53,7 @@ async fn run_impl(
     (opts, cmd): (CommandGlobalOpts, IssueCommand),
 ) -> crate::Result<()> {
     let attrs = cmd.attributes()?;
-    let cred_builder = attrs.iter().fold(
-        Credential::builder(cmd.for_identity.clone()),
-        |crd, (k, v)| crd.with_attribute(k, v.as_bytes()),
-    );
+    let cred_builder = CredentialBuilder::from_attributes(cmd.for_identity.clone(), attrs);
 
     let vault = opts.state.vaults.get(&cmd.vault)?.get().await?;
     let ident_state = opts.state.identities.get(&cmd.as_identity)?;

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use crate::{
     identity::default_identity_name,
-    util::{node_rpc, print_output},
+    util::{node_rpc, print_encodable},
     vault::default_vault_name,
-    CommandGlobalOpts, Result,
+    CommandGlobalOpts, EncodeFormat, Result,
 };
 use anyhow::Context as _;
 use clap::Args;
@@ -25,6 +25,10 @@ pub struct IssueCommand {
 
     #[arg(default_value_t = default_vault_name())]
     pub vault: String,
+
+    /// Encoding Format
+    #[arg(long = "encoding", value_enum, default_value = "plain")]
+    encode_format: EncodeFormat,
 }
 
 impl IssueCommand {
@@ -61,7 +65,7 @@ async fn run_impl(
 
     let credential = ident.issue_credential(cred_builder).await?;
 
-    print_output(credential, &opts.global_args.output_format)?;
+    print_encodable(credential, &cmd.encode_format)?;
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -1,4 +1,5 @@
 use clap::{arg, Args};
+use colorful::Colorful;
 use ockam::Context;
 use ockam_identity::{credential::Credential, IdentityIdentifier};
 
@@ -47,8 +48,8 @@ async fn run_impl(
         )
         .await
         {
-            Ok(_) => "✅",
-            Err(_) => "❌",
+            Ok(_) => "✔︎".light_green(),
+            Err(_) => "✕".light_red(),
         };
 
         println!("Credential: {cred_name} {is_verified}");

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -48,8 +48,8 @@ async fn run_impl(
         )
         .await
         {
-            Ok(_) => "✔︎".light_green(),
-            Err(_) => "✕".light_red(),
+            Ok(_) => format!("Verified({})", "✔︎".light_green()),
+            Err(_) => format!("Unverified({})", "✕".light_red()),
         };
 
         println!("Credential: {cred_name} {is_verified}");

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -1,0 +1,59 @@
+use clap::{arg, Args};
+use ockam::Context;
+use ockam_identity::{credential::Credential, IdentityIdentifier};
+
+use crate::{
+    credential::validate_encoded_cred, util::node_rpc, vault::default_vault_name, CommandGlobalOpts,
+};
+use anyhow::anyhow;
+
+#[derive(Clone, Debug, Args)]
+pub struct ListCommand {
+    #[arg(default_value_t = default_vault_name())]
+    pub vault: String,
+}
+
+impl ListCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let cred_states = opts.state.credentials.list()?;
+
+    for cred_state in cred_states {
+        let cred_name = cred_state.name()?;
+        opts.state.credentials.get(&cred_name)?;
+
+        let config = cred_state.config().await?;
+
+        let bytes = match hex::decode(&config.encoded_credential) {
+            Ok(b) => b,
+            Err(e) => return Err(anyhow!(e).into()),
+        };
+
+        let cred: Credential = minicbor::decode(&bytes)?;
+        let issuer = IdentityIdentifier::try_from(config.issuer)?;
+        let is_verified = match validate_encoded_cred(
+            &config.encoded_credential,
+            &issuer,
+            &cmd.vault,
+            &opts,
+            &ctx,
+        )
+        .await
+        {
+            Ok(_) => "✅",
+            Err(_) => "❌",
+        };
+
+        println!("Credential: {cred_name} {is_verified}");
+        println!("{cred}");
+    }
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -1,11 +1,27 @@
-pub(crate) mod get_credential;
-pub(crate) mod present_credential;
+pub(crate) mod get;
+pub(crate) mod issue;
+pub(crate) mod list;
+pub(crate) mod present;
+pub(crate) mod show;
+pub(crate) mod store;
+pub(crate) mod verify;
 
-pub(crate) use get_credential::GetCredentialCommand;
-pub(crate) use present_credential::PresentCredentialCommand;
+use anyhow::anyhow;
+pub(crate) use get::GetCommand;
+pub(crate) use issue::IssueCommand;
+pub(crate) use list::ListCommand;
+use ockam::Context;
+use ockam_identity::credential::Credential;
+use ockam_identity::credential::CredentialData;
+use ockam_identity::credential::Unverified;
+use ockam_identity::IdentityIdentifier;
+pub(crate) use present::PresentCommand;
+pub(crate) use show::ShowCommand;
+pub(crate) use store::StoreCommand;
+pub(crate) use verify::VerifyCommand;
 
-use crate::help;
 use crate::CommandGlobalOpts;
+use crate::{help, Result};
 use clap::{Args, Subcommand};
 
 const HELP_DETAIL: &str = "";
@@ -24,15 +40,56 @@ pub struct CredentialCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum CredentialSubcommand {
-    Get(GetCredentialCommand),
-    Present(PresentCredentialCommand),
+    Get(GetCommand),
+    Issue(IssueCommand),
+    List(ListCommand),
+    Present(PresentCommand),
+    Show(ShowCommand),
+    Store(StoreCommand),
+    Verify(VerifyCommand),
 }
 
 impl CredentialCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             CredentialSubcommand::Get(c) => c.run(options),
+            CredentialSubcommand::Issue(c) => c.run(options),
+            CredentialSubcommand::List(c) => c.run(options),
             CredentialSubcommand::Present(c) => c.run(options),
+            CredentialSubcommand::Show(c) => c.run(options),
+            CredentialSubcommand::Store(c) => c.run(options),
+            CredentialSubcommand::Verify(c) => c.run(options),
         }
     }
+}
+
+pub async fn validate_encoded_cred(
+    encoded_cred: &str,
+    issuer: &IdentityIdentifier,
+    vault: &str,
+    opts: &CommandGlobalOpts,
+    ctx: &Context,
+) -> Result<()> {
+    let vault = opts.state.vaults.get(vault)?.get().await?;
+
+    let bytes = match hex::decode(encoded_cred) {
+        Ok(b) => b,
+        Err(e) => return Err(anyhow!(e).into()),
+    };
+
+    let cred: Credential = minicbor::decode(&bytes)?;
+
+    let cred_data: CredentialData<Unverified> = minicbor::decode(cred.unverified_data())?;
+
+    let ident_state = opts.state.identities.get_by_identifier(issuer)?;
+
+    let ident = ident_state.get(ctx, &vault).await?;
+
+    ident
+        .to_public()
+        .await?
+        .verify_credential(&cred, cred_data.unverfied_subject(), &vault)
+        .await?;
+
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -88,7 +88,7 @@ pub async fn validate_encoded_cred(
     ident
         .to_public()
         .await?
-        .verify_credential(&cred, cred_data.unverfied_subject(), &vault)
+        .verify_credential(&cred, cred_data.unverified_subject(), &vault)
         .await?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -9,7 +9,7 @@ use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
-pub struct PresentCredentialCommand {
+pub struct PresentCommand {
     #[command(flatten)]
     pub node_opts: NodeOpts,
 
@@ -20,7 +20,7 @@ pub struct PresentCredentialCommand {
     pub oneway: bool,
 }
 
-impl PresentCredentialCommand {
+impl PresentCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         node_rpc(rpc, (options, self));
     }
@@ -28,7 +28,7 @@ impl PresentCredentialCommand {
 
 async fn rpc(
     mut ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, PresentCredentialCommand),
+    (opts, cmd): (CommandGlobalOpts, PresentCommand),
 ) -> crate::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
@@ -36,7 +36,7 @@ async fn rpc(
 async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
-    cmd: PresentCredentialCommand,
+    cmd: PresentCommand,
 ) -> crate::Result<()> {
     let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
     rpc.request(api::credentials::present_credential(&cmd.to, cmd.oneway))

--- a/implementations/rust/ockam/ockam_command/src/credential/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/show.rs
@@ -1,0 +1,53 @@
+use clap::{arg, Args};
+use ockam::Context;
+use ockam_identity::{credential::Credential, IdentityIdentifier};
+
+use crate::{
+    credential::validate_encoded_cred, util::node_rpc, vault::default_vault_name, CommandGlobalOpts,
+};
+use anyhow::anyhow;
+
+#[derive(Clone, Debug, Args)]
+pub struct ShowCommand {
+    #[arg()]
+    pub credential_name: String,
+
+    #[arg(default_value_t = default_vault_name())]
+    pub vault: String,
+}
+
+impl ShowCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+) -> crate::Result<()> {
+    let cred_state = opts.state.credentials.get(&cmd.credential_name)?;
+    let cred_name = cred_state.name()?;
+
+    let config = cred_state.config().await?;
+
+    let bytes = match hex::decode(&config.encoded_credential) {
+        Ok(b) => b,
+        Err(e) => return Err(anyhow!(e).into()),
+    };
+
+    let cred: Credential = minicbor::decode(&bytes)?;
+    let issuer = IdentityIdentifier::try_from(config.issuer)?;
+    let is_verified =
+        match validate_encoded_cred(&config.encoded_credential, &issuer, &cmd.vault, &opts, &ctx)
+            .await
+        {
+            Ok(_) => "✅",
+            Err(_) => "❌",
+        };
+
+    println!("Credential: {cred_name} {is_verified}");
+    println!("{cred}");
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/credential/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/show.rs
@@ -1,4 +1,5 @@
 use clap::{arg, Args};
+use colorful::Colorful;
 use ockam::Context;
 use ockam_identity::{credential::Credential, IdentityIdentifier};
 
@@ -42,8 +43,8 @@ async fn run_impl(
         match validate_encoded_cred(&config.encoded_credential, &issuer, &cmd.vault, &opts, &ctx)
             .await
         {
-            Ok(_) => "✅",
-            Err(_) => "❌",
+            Ok(_) => "✔︎".light_green(),
+            Err(_) => "✕".light_red(),
         };
 
     println!("Credential: {cred_name} {is_verified}");

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -20,9 +20,6 @@ pub struct StoreCommand {
     #[arg(long = "issuer")]
     pub issuer: IdentityIdentifier,
 
-    #[arg(long = "subject")]
-    pub subject: IdentityIdentifier,
-
     #[arg(group = "credential_value", value_name = "CREDENTIAL_STRING", long)]
     pub credential: Option<String>,
 

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use crate::{
+    util::{node_rpc, random_name},
+    vault::default_vault_name,
+    CommandGlobalOpts,
+};
+use anyhow::anyhow;
+
+use clap::Args;
+use ockam::Context;
+use ockam_api::cli_state::CredentialConfig;
+use ockam_identity::IdentityIdentifier;
+
+#[derive(Clone, Debug, Args)]
+pub struct StoreCommand {
+    #[arg(hide_default_value = true, default_value_t = random_name())]
+    pub credential_name: String,
+
+    #[arg(long = "issuer")]
+    pub issuer: IdentityIdentifier,
+
+    #[arg(long = "subject")]
+    pub subject: IdentityIdentifier,
+
+    #[arg(group = "credential_value", value_name = "CREDENTIAL_STRING", long)]
+    pub credential: Option<String>,
+
+    #[arg(group = "credential_value", value_name = "CREDENTIAL_FILE", long)]
+    pub credential_path: Option<PathBuf>,
+
+    #[arg(default_value_t = default_vault_name())]
+    pub vault: String,
+}
+
+impl StoreCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, StoreCommand),
+) -> crate::Result<()> {
+    let cred_as_str = match (cmd.credential, cmd.credential_path) {
+        (_, Some(credential_path)) => tokio::fs::read_to_string(credential_path).await?,
+        (Some(credential), _) => credential,
+        _ => return Err(anyhow!("Credential or Credential Path argument must be provided").into()),
+    };
+
+    // store
+    opts.state
+        .credentials
+        .create(
+            &cmd.credential_name,
+            CredentialConfig::new(cmd.issuer.to_string(), cred_as_str)?,
+        )
+        .await?;
+
+    println!("Credential {} stored", &cmd.credential_name);
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+
+use crate::{util::node_rpc, vault::default_vault_name, CommandGlobalOpts};
+use anyhow::anyhow;
+
+use clap::Args;
+use ockam::Context;
+
+use ockam_identity::IdentityIdentifier;
+
+use super::validate_encoded_cred;
+
+#[derive(Clone, Debug, Args)]
+pub struct VerifyCommand {
+    #[arg(long = "issuer")]
+    pub issuer: IdentityIdentifier,
+
+    #[arg(group = "credential_value", value_name = "CREDENTIAL_STRING", long)]
+    pub credential: Option<String>,
+
+    #[arg(group = "credential_value", value_name = "CREDENTIAL_FILE", long)]
+    pub credential_path: Option<PathBuf>,
+
+    #[arg(default_value_t = default_vault_name())]
+    pub vault: String,
+}
+
+impl VerifyCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, self));
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, VerifyCommand),
+) -> crate::Result<()> {
+    let cred_as_str = match (cmd.credential, cmd.credential_path) {
+        (_, Some(credential_path)) => tokio::fs::read_to_string(credential_path).await?,
+        (Some(credential), _) => credential,
+        _ => return Err(anyhow!("Credential or Credential Path argument must be provided").into()),
+    };
+
+    match validate_encoded_cred(&cred_as_str, &cmd.issuer, &cmd.vault, &opts, &ctx).await {
+        Ok(_) => {
+            println!("✅ Verified Credential");
+        }
+        Err(e) => {
+            println!("❌ Credential is not valid!\n\n{e}");
+        }
+    };
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -4,6 +4,7 @@ use crate::{util::node_rpc, vault::default_vault_name, CommandGlobalOpts};
 use anyhow::anyhow;
 
 use clap::Args;
+use colorful::Colorful;
 use ockam::Context;
 
 use ockam_identity::IdentityIdentifier;
@@ -43,10 +44,10 @@ async fn run_impl(
 
     match validate_encoded_cred(&cred_as_str, &cmd.issuer, &cmd.vault, &opts, &ctx).await {
         Ok(_) => {
-            println!("✅ Verified Credential");
+            println!("{} Verified Credential", "✔︎".light_green());
         }
         Err(e) => {
-            println!("❌ Credential is not valid!\n\n{e}");
+            println!("{} Credential is not valid!\n\n{e}", "✕".light_red());
         }
     };
 

--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -99,7 +99,7 @@ async fn default_space<'a>(
     let default_space = if available_spaces.is_empty() {
         let cmd = crate::space::CreateCommand {
             cloud_opts: cloud_opts.clone(),
-            name: crate::space::random_name(),
+            name: crate::util::random_name(),
             admins: vec![],
         };
         println!(

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -59,10 +59,8 @@ pub fn default_identity_name() -> String {
         }
     };
 
-    let default_name = cli_state.identities.default().map(|i| i.name);
-
-    match default_name {
-        Ok(name) => name,
-        Err(_) => "default".to_string(),
-    }
+    cli_state
+        .identities
+        .default()
+        .map_or("default".to_string(), |i| i.name)
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -7,10 +7,11 @@ mod show;
 pub(crate) use create::CreateCommand;
 pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
+use ockam_api::cli_state::CliState;
 pub(crate) use show::ShowCommand;
 
-use crate::identity::default::DefaultCommand;
 use crate::CommandGlobalOpts;
+use crate::{error::Error, identity::default::DefaultCommand};
 use clap::{Args, Subcommand};
 
 /// Manage Identities
@@ -43,5 +44,25 @@ impl IdentityCommand {
             IdentitySubcommand::Delete(c) => c.run(options),
             IdentitySubcommand::Default(c) => c.run(options),
         }
+    }
+}
+
+pub fn default_identity_name() -> String {
+    let res_cli = CliState::try_default();
+
+    let cli_state = match res_cli {
+        Ok(cli_state) => cli_state,
+        Err(err) => {
+            eprintln!("Error initializing command state. \n\n {err:?}");
+            let command_err: Error = err.into();
+            std::process::exit(command_err.code());
+        }
+    };
+
+    let default_name = cli_state.identities.default().map(|i| i.name);
+
+    match default_name {
+        Ok(name) => name,
+        Err(_) => "default".to_string(),
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,17 +1,14 @@
 use crate::util::output::Output;
 use crate::util::print_output;
-use crate::{CommandGlobalOpts, Result};
+use crate::{
+    EncodeFormat, {CommandGlobalOpts, Result},
+};
 use anyhow::anyhow;
 use clap::{Args, ValueEnum};
 use core::fmt::Write;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};
 use ockam_identity::change_history::IdentityChangeHistory;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-enum Encoding {
-    Hex,
-}
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -26,7 +23,7 @@ pub struct ShowCommand {
     //      authority' identity change history to be in hex format.  This only applies
     //      for `full` (change history) identity.
     #[arg(long, value_enum, requires = "full")]
-    encoding: Option<Encoding>,
+    encoding: Option<EncodeFormat>,
 }
 
 impl ShowCommand {
@@ -47,7 +44,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
     let state = opts.state.identities.get(&cmd.name)?;
     if cmd.full {
         let identity = state.config.change_history.export()?;
-        if Some(Encoding::Hex) == cmd.encoding {
+        if Some(EncodeFormat::Hex) == cmd.encoding {
             print_output(identity, &opts.global_args.output_format)?;
         } else {
             let output = LongIdentityResponse::new(identity);

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -4,7 +4,7 @@ use crate::{
     EncodeFormat, {CommandGlobalOpts, Result},
 };
 use anyhow::anyhow;
-use clap::{Args, ValueEnum};
+use clap::Args;
 use core::fmt::Write;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -143,6 +143,12 @@ pub enum OutputFormat {
     Json,
 }
 
+#[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
+pub enum EncodeFormat {
+    Plain,
+    Hex,
+}
+
 #[derive(Clone)]
 pub struct CommandGlobalOpts {
     pub global_args: GlobalArgs,

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -13,7 +13,7 @@ pub use util::config;
 
 use clap::{Args, Subcommand};
 
-pub use crate::credential::get_credential::GetCredentialCommand;
+pub use crate::credential::get::GetCommand;
 pub use addon::AddonCommand;
 pub use create::CreateCommand;
 pub use delete::DeleteCommand;

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -51,7 +51,3 @@ impl SpaceCommand {
         }
     }
 }
-
-pub fn random_name() -> String {
-    hex::encode(rand::random::<[u8; 4]>())
-}

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -610,6 +610,10 @@ pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {
     s.is_terminal()
 }
 
+pub fn random_name() -> String {
+    hex::encode(rand::random::<[u8; 4]>())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -297,24 +297,39 @@ impl<'a> Rpc<'a> {
     where
         T: Output + serde::Serialize,
     {
-        let r = print_output(b, &self.opts.global_args.output_format)?;
-        println!();
-        Ok(r)
+        println_output(b, &self.opts.global_args.output_format)
     }
+}
+
+pub fn println_output<T>(b: T, output_format: &OutputFormat) -> Result<T>
+where
+    T: Output + serde::Serialize,
+{
+    let o = get_output(&b, output_format)?;
+    println!("{o}");
+    Ok(b)
 }
 
 pub fn print_output<T>(b: T, output_format: &OutputFormat) -> Result<T>
 where
     T: Output + serde::Serialize,
 {
-    let o = match output_format {
-        OutputFormat::Plain => b.output().context("Failed to serialize output")?,
-        OutputFormat::Json => {
-            serde_json::to_string_pretty(&b).context("Failed to serialize output")?
-        }
-    };
+    let o = get_output(&b, output_format)?;
     print!("{o}");
     Ok(b)
+}
+
+fn get_output<T>(b: &T, output_format: &OutputFormat) -> Result<String>
+where
+    T: Output + serde::Serialize,
+{
+    let output = match output_format {
+        OutputFormat::Plain => b.output().context("Failed to serialize output")?,
+        OutputFormat::Json => {
+            serde_json::to_string_pretty(b).context("Failed to serialize output")?
+        }
+    };
+    Ok(output)
 }
 
 pub fn print_encodable<T>(e: T, encode_format: &EncodeFormat) -> Result<()>

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -161,10 +161,8 @@ pub fn default_vault_name() -> String {
         }
     };
 
-    let default_name = cli_state.vaults.default().map(|v| v.name);
-
-    match default_name {
-        Ok(name) => name,
-        Err(_) => "default".to_string(),
-    }
+    cli_state
+        .vaults
+        .default()
+        .map_or("default".to_string(), |v| v.name)
 }

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -1,13 +1,13 @@
 mod default;
 
+use crate::error::Error;
 use crate::util::node_rpc;
 use crate::vault::default::DefaultCommand;
 use crate::{help, CommandGlobalOpts, Result};
 use anyhow::anyhow;
 use clap::{Args, Subcommand};
 use ockam::Context;
-use ockam_api::cli_state;
-use ockam_api::cli_state::CliStateError;
+use ockam_api::cli_state::{self, CliState, CliStateError};
 use ockam_core::vault::{Secret, SecretAttributes, SecretPersistence, SecretType, SecretVault};
 use ockam_identity::{Identity, IdentityStateConst, KeyAttributes};
 use rand::prelude::random;
@@ -147,4 +147,24 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, VaultCommand)) 
         VaultSubcommand::Default(cmd) => cmd.run(opts),
     }
     Ok(())
+}
+
+pub fn default_vault_name() -> String {
+    let res_cli = CliState::try_default();
+
+    let cli_state = match res_cli {
+        Ok(cli_state) => cli_state,
+        Err(err) => {
+            eprintln!("Error initializing command state. \n\n {err:?}");
+            let command_err: Error = err.into();
+            std::process::exit(command_err.code());
+        }
+    };
+
+    let default_name = cli_state.vaults.default().map(|v| v.name);
+
+    match default_name {
+        Ok(name) => name,
+        Err(_) => "default".to_string(),
+    }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/credentials.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/credentials.bats
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load load/base.bash
+  load_bats_ext
+  setup_home_dir
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "credentials - issue, verify, store, show and list" {
+  run "$OCKAM" identity create i1
+  assert_success
+  idt1=$($OCKAM identity show i1)
+
+  run "$OCKAM" identity create i2
+  assert_success
+  idt2=$($OCKAM identity show i2)
+
+  # No "run" here since it won't redirect the output to a file if we do so.
+  "$OCKAM" credential issue --as i1 --for "$idt2" --attribute application="Smart Factory" --attribute city="New York" --encoding hex > "$OCKAM_HOME/credential"
+
+  run "$OCKAM" credential verify --issuer "$idt1" --credential-path "$OCKAM_HOME/credential"
+  assert_success
+  assert_output --partial "Verified Credential"
+
+  run "$OCKAM" credential store smart_nyc_cred --issuer "$idt1" --credential-path "$OCKAM_HOME/credential"
+  assert_success
+  assert_output --partial "Credential smart_nyc_cred stored"
+
+  run "$OCKAM" credential show smart_nyc_cred
+  assert_success
+  assert_output --partial "Credential: smart_nyc_cred"
+  assert_output --partial "Attributes: {\"application\": \"Smart Factory\", \"city\": \"New York\"}"
+
+  run "$OCKAM" credential list
+  assert_success
+  assert_output --partial "Credential: smart_nyc_cred"
+  assert_output --partial "Attributes: {\"application\": \"Smart Factory\", \"city\": \"New York\"}"
+}
+

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -192,6 +192,9 @@ impl CredentialData<Unverified> {
     pub fn unverfied_key_label(&self) -> &str {
         &self.issuer_key_label
     }
+    pub fn unverfied_subject(&self) -> &IdentityIdentifier {
+        &self.subject
+    }
 }
 
 impl TryFrom<&Credential> for CredentialData<Unverified> {

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -7,6 +7,7 @@ mod worker;
 pub mod access_control;
 pub mod one_time_code;
 
+use ockam_core::compat::collections::HashMap;
 pub use one_time_code::*;
 
 use crate::IdentityIdentifier;
@@ -186,13 +187,13 @@ impl CredentialData<Verified> {
 }
 
 impl CredentialData<Unverified> {
-    pub fn unverfied_issuer(&self) -> &IdentityIdentifier {
+    pub fn unverified_issuer(&self) -> &IdentityIdentifier {
         &self.issuer
     }
-    pub fn unverfied_key_label(&self) -> &str {
+    pub fn unverified_key_label(&self) -> &str {
         &self.issuer_key_label
     }
-    pub fn unverfied_subject(&self) -> &IdentityIdentifier {
+    pub fn unverified_subject(&self) -> &IdentityIdentifier {
         &self.subject
     }
 }
@@ -305,6 +306,13 @@ pub struct CredentialBuilder {
 }
 
 impl CredentialBuilder {
+    pub fn from_attributes(identity: IdentityIdentifier, attrs: HashMap<String, String>) -> Self {
+        attrs
+            .iter()
+            .fold(Credential::builder(identity), |crd, (k, v)| {
+                crd.with_attribute(k, v.as_bytes())
+            })
+    }
     /// Add some key-value pair as credential attribute.
     pub fn with_attribute(mut self, k: &str, v: &[u8]) -> Self {
         self.attrs.put(k, v);

--- a/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/public_identity.rs
@@ -20,7 +20,7 @@ impl PublicIdentity {
         vault: &impl IdentityVault,
     ) -> Result<CredentialData<Verified>> {
         let dat = CredentialData::try_from(credential)?;
-        if dat.unverfied_key_label() != IdentityStateConst::ROOT_LABEL {
+        if dat.unverified_key_label() != IdentityStateConst::ROOT_LABEL {
             return Err(Error::new(
                 Origin::Application,
                 Kind::Invalid,
@@ -60,7 +60,7 @@ impl PublicIdentity {
             .verify_signature(
                 &sig,
                 credential.unverified_data(),
-                Some(dat.unverfied_key_label()),
+                Some(dat.unverified_key_label()),
                 vault,
             )
             .await?


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed Changes

```sh
o identity create i1

o identity create i2

#  --as can use a default identity
o credential issue --as i1 --for [i2 IdentityIdentifier] --attribute application="Smart Factory" --attribute city="New York" --encoding hex > credential

# can use credential path or credential as a string
o credential verify --issuer [i1 IdentityIdentifier] --credential-path credential

o credential store smart_nyc_cred  --issuer [i1 IdentityIdentifier] --credential-path credential

o credential show smart_nyc_cred

o credential list
```

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
