### PR TITLE
Improve GitHub merge queue workflow

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get commit information from Github (Pull Request)
         if: github.event_name == 'pull_request'
-        run: gh api repos/build-trust/ockam/pulls/${{ github.event.number }}/commits > commits.json
+        run: gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/commits > commits.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -9,6 +9,14 @@ on:
     inputs:
       commit_sha:
         description: SHA to test workflow
+  merge_group:
+    paths:
+      - ".github/workflows/ockam_command.yml"
+      - "**.rs"
+      - "**.toml"
+      - "**/Cargo.lock"
+      - "implementations/rust/ockam/ockam_command/tests/commands.bats"
+      - ".github/actions/**"
   pull_request:
     paths:
       - ".github/workflows/ockam_command.yml"

--- a/.github/workflows/ockam_command.yml
+++ b/.github/workflows/ockam_command.yml
@@ -10,13 +10,6 @@ on:
       commit_sha:
         description: SHA to test workflow
   merge_group:
-    paths:
-      - ".github/workflows/ockam_command.yml"
-      - "**.rs"
-      - "**.toml"
-      - "**/Cargo.lock"
-      - "implementations/rust/ockam/ockam_command/tests/commands.bats"
-      - ".github/actions/**"
   pull_request:
     paths:
       - ".github/workflows/ockam_command.yml"

--- a/.github/workflows/pr_ci_watcher.yml
+++ b/.github/workflows/pr_ci_watcher.yml
@@ -1,0 +1,43 @@
+name: PR CI Watcher
+
+permissions:
+  contents: read
+
+on:
+  merge_group:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  done:
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    permissions:
+      actions: read
+      pull-requests: read
+
+    name: PR CI Watcher
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Ockam
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          fetch-depth: 0
+
+      - name: Check Running Actions For PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -ex
+
+          pr_number="${{ github.ref_name }}"
+          branch_name="${{ github.head_ref }}"
+
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            PR_NUMBER="${{ github.head_ref || github.ref_name }}" ORGANIZATION="${{ github.repository_owner }}" bash tools/scripts/pr_ci_watcher/pr_ci_watcher.sh
+          elif [[ ${{ github.event_name }} == 'merge_group' ]]; then
+            BRANCH_NAME="${{ github.head_ref || github.ref_name }}" ORGANIZATION="${{ github.repository_owner }}" bash tools/scripts/pr_ci_watcher/ci_watcher.sh
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,13 +20,6 @@ on:
       - "gradlew"
       - "gradlew.bat"
       - ".github/actions/**"
-      # This is a temporary fix.
-      # To allow merge queue to merge PRs, we need Rust and Elixir
-      # workflows to pass successfully. This PR ensures we also
-      # run Rust workflows on update to Elixir code.
-      - '**.ex'
-      - '**.exs'
-      - '**/mix.lock'
   push:
     paths:
       - ".github/workflows/rust.yml"
@@ -38,13 +31,6 @@ on:
       - "gradlew"
       - "gradlew.bat"
       - ".github/actions/**"
-      # This is a temporary fix.
-      # To allow merge queue to merge PRs, we need Rust and Elixir
-      # workflows to pass successfully. This PR ensures we also
-      # run Rust workflows on update to Elixir code.
-      - '**.ex'
-      - '**.exs'
-      - '**/mix.lock'
     branches:
       - develop
   schedule:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,6 +13,7 @@ on:
       commit_sha:
         description: SHA to test workflow
   pull_request:
+  merge_group:
   push:
     branches:
       - develop

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,12 +13,12 @@ on:
       commit_sha:
         description: SHA to test workflow
   merge_group:
-    paths:
-      - "**.sh"
   pull_request:
     paths:
       - "**.sh"
   push:
+    paths:
+      - "**.sh"
     branches:
       - develop
   schedule:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,12 +12,13 @@ on:
     inputs:
       commit_sha:
         description: SHA to test workflow
+  merge_group:
+    paths:
+      - "**.sh"
   pull_request:
     paths:
       - "**.sh"
   push:
-    paths:
-      - "**.sh"
     branches:
       - develop
   schedule:

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -13,6 +13,7 @@ on:
       commit_sha:
         description: SHA to test workflow
   pull_request:
+  merge_group:
   push:
     branches:
       - develop

--- a/tools/scripts/pr_ci_watcher/ci_watcher.sh
+++ b/tools/scripts/pr_ci_watcher/ci_watcher.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# This Script watches actions on a defined branch.
+# It differs with the pr_ci_watcher.sh script as it tracks
+# workflow run for a branch (instead of a PR). It is used
+# to track progress of merge_group workflow run.
+# This script is limited with the amount of workflow run it
+# can track and should only be used for merge_group workflows
+# as new branches are created for every merge group initiated.
+if [[ -z $BRANCH_NAME ]]; then
+  echo "Please set BRANCH_NAME variable"
+  exit 1
+fi
+
+if [[ -z $ORGANIZATION ]]; then
+  echo "Please set ORGANIZATION variable"
+  exit 1
+fi
+
+set -ex
+
+while true; do
+  runs=$(gh run list -b $BRANCH_NAME -L 50 --json status,conclusion,name,url,startedAt -R ${ORGANIZATION}/ockam)
+  if [[ $(jq -r '.|type' <<<$runs) != 'array' ]]; then
+    echo "Invalid return type... Exiting now."
+    exit 1
+  fi
+
+  run_length=$(jq '.|length' <<<$runs)
+
+  if [[ $run_length == 0 ]]; then
+    echo "No run detected, retrying...."
+    sleep 10
+    continue
+  fi
+
+  new_map="{}"
+
+  # Compare time stamp and get the latest run
+  for ((c = 0; c < $run_length; c++)); do
+    workflow_name=$(jq -r ".[$c].name" <<<$runs)
+    run_timestamp=$(jq -r ".[$c].startedAt" <<<$runs)
+    conclusion=$(jq -r ".[$c].conclusion" <<<$runs)
+    status=$(jq -r ".[$c].status" <<<$runs)
+    url=$(jq -r ".[$c].url" <<<$runs)
+
+    if [[ $(jq "has(\"$workflow_name\")" <<<$new_map) == 'false' ]]; then
+      new_map=$(jq ".\"${workflow_name}\" += {\"startedAt\":\"$run_timestamp\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"status\":\"$status\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"conclusion\":\"$conclusion\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"url\":\"$conclusion\"}" <<<$new_map)
+
+      continue
+    fi
+
+    mapped_workflow=$(jq -r ".\"${workflow_name}\"" <<<$new_map)
+    mapped_timestamp=$(jq -r ".\"${workflow_name}\".startedAt" <<<$new_map)
+
+    if [[ $run_timestamp > $mapped_timestamp ]]; then
+      url=$(jq -r ".[$c].url" <<<$runs)
+      echo "Changing data of run to $run_timestamp $url"
+
+      new_map=$(jq ".\"${workflow_name}\" += {\"startedAt\":\"$run_timestamp\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"status\":\"$status\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"conclusion\":\"$conclusion\"}" <<<$new_map)
+    fi
+  done
+
+  jq '.' <<<$new_map
+
+  # Exit if any of the latest run failed or was cancelled
+  if [[ $new_map == *"\"conclusion\": \"failure\""* || $new_map == *"\"conclusion\": \"cancelled\""* ]]; then
+    jq '.' <<<$new_map
+    echo "A workflow failed ❌"
+    exit 1
+  fi
+
+  echo "No workflow failed. Checking if all succeeded"
+
+  # Check individual workflow (Omitting the master workflow) ensuring they all succeeded
+  keys=$(jq 'keys' <<<$new_map)
+
+  all_workflow_succeded='true'
+  for ((c = 0; c < $(jq '.|length' <<<$keys); c++)); do
+    key=$(jq -r ".[$c]" <<<$keys)
+
+    if [[ $key == "PR CI Watcher" ]]; then
+      echo "\"PR CI Watcher\" is the parent workflow and the status will always be inconclusive, skipping now"
+      continue
+    fi
+
+    if [[ $(jq -r ".\"${key}\".conclusion" <<<$new_map) == "" ]]; then
+      echo "\"$key\" workflow inconclusive, retrying....."
+      all_workflow_succeded='false'
+      sleep 10
+      break
+    fi
+  done
+
+  if [[ $all_workflow_succeded == 'true' ]]; then
+    echo "All workflows succeeded ✅✅✅"
+    break
+  fi
+done

--- a/tools/scripts/pr_ci_watcher/pr_ci_watcher.sh
+++ b/tools/scripts/pr_ci_watcher/pr_ci_watcher.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# This script tracks all workflow run made a PR, it is more
+# detailed as it retrieves jobs state in a workflow.
+if [[ -z $PR_NUMBER ]]; then
+  echo "Please set PR_NUMBER variable"
+  exit 1
+fi
+
+if [[ -z $ORGANIZATION ]]; then
+  echo "Please set ORGANIZATION variable"
+  exit 1
+fi
+
+set -ex
+
+while true; do
+  # Get the last time a PR was updated with a commit and then compare it with
+  # all workflow run ensuring we don't check old workflows.
+  run_details=$(gh pr view ${PR_NUMBER} --json statusCheckRollup,updatedAt,createdAt -R ${ORGANIZATION}/ockam)
+  runs=$(jq '.statusCheckRollup' <<<$run_details)
+  pr_updated_date=$(jq '.updatedAt' <<<$run_details)
+  pr_creation_date=$(jq '.createdAt' <<<$run_details)
+
+  if [[ $(jq '.|type' <<<$runs) == '' ]]; then
+    echo "Invalid return type... Exiting now."
+    exit 1
+  fi
+
+  run_length=$(jq '.|length' <<<$runs)
+
+  if [[ $run_length == 0 ]]; then
+    echo "No run detected, retrying...."
+    sleep 10
+    continue
+  fi
+
+  new_map="{}"
+
+  # Compare time stamp and get the latest run.
+  for ((c = 0; c < $run_length; c++)); do
+    workflow_name=$(jq -r ".[$c].name" <<<$runs)
+    run_timestamp=$(jq -r ".[$c].startedAt" <<<$runs)
+    conclusion=$(jq -r ".[$c].conclusion" <<<$runs)
+    status=$(jq -r ".[$c].status" <<<$runs)
+
+    # Check workflow state if recent.
+    if [[ $(jq "has(\"$workflow_name\")" <<<$new_map) == 'false' ]]; then
+
+      if [[ $pr_updated_date > $run_timestamp || $pr_creation_date > $run_timestamp ]]; then
+        echo "Workflow run is of a recent commit, skipping..."
+        continue
+      fi
+
+      new_map=$(jq ".\"${workflow_name}\" += {\"startedAt\":\"$run_timestamp\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"status\":\"$status\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"conclusion\":\"$conclusion\"}" <<<$new_map)
+
+      continue
+    fi
+
+    mapped_workflow=$(jq -r ".\"${workflow_name}\"" <<<$new_map)
+    mapped_timestamp=$(jq -r ".\"${workflow_name}\".startedAt" <<<$new_map)
+
+    # If workflow name exists, then compare timestamps
+    if [[ $run_timestamp > $mapped_timestamp ]]; then
+      url=$(jq -r ".[$c].detailsUrl" <<<$runs)
+      echo "Changing data of run to $run_timestamp $url"
+
+      new_map=$(jq ".\"${workflow_name}\" += {\"startedAt\":\"$run_timestamp\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"status\":\"$status\"}" <<<$new_map)
+      new_map=$(jq ".\"${workflow_name}\" += {\"conclusion\":\"$conclusion\"}" <<<$new_map)
+    fi
+  done
+
+  jq '.' <<<$new_map
+
+  # Exit if any of the latest run failed or was cancelled
+  if [[ $new_map == *"\"conclusion\": \"FAILURE\""* || $new_map == *"\"conclusion\": \"CANCELLED\""* ]]; then
+    echo "A workflow failed"
+    exit 1
+  fi
+
+  echo "No workflow failed. Checking if all succeeded"
+
+  # Check individual workflow (Omitting the master workflow) ensuring they all succeeded
+  keys=$(jq 'keys' <<<$new_map)
+
+  all_workflow_succeded='true'
+  for ((c = 0; c < $(jq '.|length' <<<$keys); c++)); do
+    key=$(jq -r ".[$c]" <<<$keys)
+
+    if [[ $key == "PR CI Watcher" ]]; then
+      echo "\"PR CI Watcher\" is the parent workflow and the status will always be inconclusive, skipping now"
+      continue
+    fi
+
+    if [[ $(jq -r ".\"${key}\".conclusion" <<<$new_map) == "" ]]; then
+      echo "\"$key\" workflow inconclusive, retrying....."
+      all_workflow_succeded='false'
+      sleep 10
+      break
+    fi
+  done
+
+  if [[ $all_workflow_succeded == 'true' ]]; then
+    echo "All workflows succeeded ✅✅✅"
+    break
+  fi
+done


### PR DESCRIPTION
This PR update merge queue rule...
Merge queue rule requires that `Rust`, `Elixir` and `Commit - Check` workflows `Must` pass before merge queue merges a PR. This causes some unprecedented issues as some PR make changes that don't run Elixir or Rust workflows, this causes merge queue to block PRs from being merged.
This PR updates the merge queue to only require one workflow for merge queue to merge a PR, this `parent` workflow checks other workflow run on a pull request ensuring that all workflows passes, if a workflow fails, the `parent workflow will fail` leading to the PR to not be mergeable.

For a parent workflow (pr_ci_watcher) to track a PR workflow run, we use the GitHub `gh pr view ${PR_NUMBER} --json statusCheckRollup` command where `PR_NUMBER` is the pull request number to watch the workflow number, this command watches all the latest workflow run on the pull request and check if any run was `cancelled`, `failed` or `inconclusive`. If a workflow fails or is cancelled, the parent workflow fails automatically, if all workflow run passes, then parent workflow goes green ✅ and becomes mergeable(we still haven't treated merge queue run yet).

When a PR is added to the merge queue, the PR is rebased and a [temporary branch is created](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#about-merge-queues) `where on merge_group workflow` is started on, this will kickstart  [workflows that indicate merge_group action](https://github.com/build-trust/ockam/blob/74b779d7d31564b1cb093bbe10faef23d00ec874/.github/workflows/elixir.yml#L8) thereby running CI over the rebased PR. The parent workflow also keep watch over workflows that run on `merge_queue` and fails if a workflow fails after being rebased with the default branch or passes if all workflow passes on merge queue.

To track workflows run on the `merge queue temporary branch`, we use the GitHub CLI run list command `gh run list -b $BRANCH_NAME --json status,conclusion,name,url,startedAt` which will retrieve the workflow runs for a particular branch.

We need to add `only` the `PR CI Checker` workflow as a required status check in branch protection rule.