### PR TITLE
feat(rust): first draft of auto-reconnect for kafka service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,8 @@ dependencies = [
  "dirs",
  "either",
  "fake",
+ "futures 0.3.26",
+ "futures-util",
  "hex",
  "indexmap",
  "kafka-protocol",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -55,6 +55,8 @@ once_cell       = { version = "1", optional = true, default-features = false }
 reqwest         = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 sysinfo         = "0.28"
 kafka-protocol  = "0.5.1"
+futures         = { version = "0.3.26", default-features = true }
+futures-util    = { version = "0.3.26", default-features = true }
 
 ockam               = { path = "../ockam", version = "^0.81.0", features = ["software_vault"] }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.76.0" }

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_map.rs
@@ -1,53 +1,59 @@
-use core::str::FromStr;
-use minicbor::Decoder;
-
 use ockam::compat::tokio::sync::Mutex;
-use ockam_core::api::{Request, Response, Status};
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::compat::sync::Arc;
 use ockam_core::errcode::{Kind, Origin};
-use ockam_core::{route, Address, Error, Route};
+use ockam_core::{route, Address, AllowAll, Error, IncomingAccessControl, Route};
+use ockam_node::tokio::sync::MutexGuard;
 use ockam_node::Context;
+use ockam_transport_tcp::TcpTransport;
 
 use crate::kafka::kafka_outlet_address;
-use crate::nodes::models::portal::{CreateInlet, InletStatus};
-use crate::nodes::NODEMANAGER_ADDR;
+use crate::kafka::ORCHESTRATOR_KAFKA_BOOTSTRAP_ADDRESS;
 use crate::port_range::PortRange;
-use crate::route_to_multiaddr;
 
 type BrokerId = i32;
 
 /// Shared structure for every kafka worker to keep track of which brokers are being proxied
 /// with the relative inlet listener socket address.
 /// Also takes care of creating inlets dynamically when they are not present yet.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct KafkaInletMap {
     inner: Arc<Mutex<KafkaInletMapInner>>,
 }
 
-#[derive(Debug)]
 struct KafkaInletMapInner {
-    broker_map: HashMap<BrokerId, SocketAddr>,
+    broker_map: HashMap<BrokerId, (Address, SocketAddr)>,
     port_range: PortRange,
     current_port: u16,
     bind_host: String,
     interceptor_route: Route,
+    tcp_transport: TcpTransport,
+    bootstrap_port: u16,
+    bootstrap_worker: Option<Address>,
+    access_control: Arc<dyn IncomingAccessControl>,
 }
 
 impl KafkaInletMap {
     pub(crate) fn new(
+        tcp_transport: TcpTransport,
+        access_control: Arc<dyn IncomingAccessControl>,
         interceptor_route: Route,
         bind_address: String,
+        bootstrap_port: u16,
         port_range: PortRange,
     ) -> KafkaInletMap {
         Self {
             inner: Arc::new(Mutex::new(KafkaInletMapInner {
+                tcp_transport,
                 interceptor_route,
                 broker_map: HashMap::new(),
                 current_port: port_range.start(),
                 port_range,
+                bootstrap_port,
                 bind_host: bind_address,
+                bootstrap_worker: None,
+                access_control,
             })),
         }
     }
@@ -55,7 +61,88 @@ impl KafkaInletMap {
     #[cfg(test)]
     pub(crate) async fn retrieve_inlet(&self, broker_id: BrokerId) -> Option<SocketAddr> {
         let self_guard = self.inner.lock().await;
-        self_guard.broker_map.get(&broker_id).map(|x| x.clone())
+        self_guard
+            .broker_map
+            .get(&broker_id)
+            .map(|(_worker_address, socket_address)| socket_address.clone())
+    }
+
+    /// When the underlying route changes we need to rebuild every existing inlet using the
+    /// new route. This method stop existing inlets and create new ones.
+    pub(crate) async fn change_route(
+        &self,
+        context: &Context,
+        new_route: Route,
+    ) -> ockam::Result<()> {
+        let mut new_map = HashMap::new();
+
+        let mut inner = self.inner.lock().await;
+        inner.interceptor_route = new_route;
+
+        if let Some(bootstrap_worker_address) = &inner.bootstrap_worker {
+            inner
+                .tcp_transport
+                .stop_inlet(bootstrap_worker_address.clone())
+                .await?;
+            inner.bootstrap_worker = None;
+        }
+        self.create_bootstrap_inlet_impl(&mut inner).await?;
+
+        for (broker_id, (worker_address, socket_address)) in &inner.broker_map {
+            inner
+                .tcp_transport
+                .stop_inlet(worker_address.clone())
+                .await?;
+
+            let to = route![
+                inner.interceptor_route.clone(),
+                kafka_outlet_address(*broker_id)
+            ];
+
+            let (worker_address, socket_address) = inner
+                .tcp_transport
+                .create_inlet_impl(socket_address.to_string(), to, inner.access_control.clone())
+                .await?;
+            new_map.insert(*broker_id, (worker_address, socket_address));
+        }
+
+        inner.broker_map = new_map;
+        Ok(())
+    }
+
+    // pub(crate) async fn create_bootstrap_inlet(&self) -> ockam_core::Result<SocketAddr> {
+    //     let mut inner = self.inner.lock().await;
+    //     self.create_bootstrap_inlet_impl(&mut inner).await
+    // }
+
+    async fn create_bootstrap_inlet_impl<'a>(
+        &'a self,
+        inner: &mut MutexGuard<'a, KafkaInletMapInner>,
+    ) -> ockam_core::Result<SocketAddr> {
+        if inner.bootstrap_worker.is_some() {
+            return Err(Error::new(
+                Origin::Transport,
+                Kind::AlreadyExists,
+                "bootstrap inlet already exists",
+            ));
+        }
+
+        let to = route![
+            inner.interceptor_route.clone(),
+            ORCHESTRATOR_KAFKA_BOOTSTRAP_ADDRESS
+        ];
+
+        let (worker_address, socket_address) = inner
+            .tcp_transport
+            .create_inlet_impl(
+                format!("{}:{}", &inner.bind_host, inner.bootstrap_port),
+                to,
+                inner.access_control.clone(),
+            )
+            .await?;
+
+        inner.bootstrap_worker = Some(worker_address);
+        Ok(socket_address)
     }
 
     /// Asserts the presence of an inlet for a broker
@@ -63,14 +150,13 @@ impl KafkaInletMap {
     /// on the second one it'll just return the address
     pub(crate) async fn assert_inlet_for_broker(
         &self,
-        context: &mut Context,
         broker_id: BrokerId,
     ) -> ockam_core::Result<SocketAddr> {
-        let mut self_guard = self.inner.lock().await;
-        if let Some(address) = self_guard.broker_map.get(&broker_id) {
-            Ok(*address)
+        let mut inner = self.inner.lock().await;
+        if let Some((_worker_address, socket_address)) = inner.broker_map.get(&broker_id) {
+            Ok(*socket_address)
         } else {
-            if self_guard.current_port >= self_guard.port_range.end() {
+            if inner.current_port >= inner.port_range.end() {
                 //we don't have any port left for the broker!
                 return Err(Error::new(
                     Origin::Transport,
@@ -79,61 +165,24 @@ impl KafkaInletMap {
                 ));
             }
 
-            let socket_address = SocketAddr::from_str(&format!(
-                "{}:{}",
-                self_guard.bind_host, self_guard.current_port
-            ))
-            .map_err(|err| Error::new(Origin::Transport, Kind::Invalid, err))?;
+            let to = route![
+                inner.interceptor_route.clone(),
+                kafka_outlet_address(broker_id)
+            ];
 
-            let to = route_to_multiaddr(
-                &self_guard
-                    .interceptor_route
-                    .clone()
-                    .modify()
-                    .append(kafka_outlet_address(broker_id))
-                    .into(),
-            )
-            .ok_or_else(|| {
-                Error::new(
-                    Origin::Transport,
-                    Kind::Invalid,
-                    "cannot convert route to multiaddr",
-                )
-            })?;
-
-            let buffer: Vec<u8> = context
-                .send_and_receive(
-                    route![NODEMANAGER_ADDR],
-                    Request::post("/node/inlet")
-                        .body(CreateInlet::to_node(socket_address, to, None, None))
-                        .to_vec()?,
+            let (worker_address, socket_address) = inner
+                .tcp_transport
+                .create_inlet_impl(
+                    format!("{}:{}", inner.bind_host, inner.current_port),
+                    to,
+                    inner.access_control.clone(),
                 )
                 .await?;
 
-            let mut decoder = Decoder::new(&buffer);
-            let response: Response = decoder.decode()?;
-
-            let status = response.status().unwrap_or(Status::InternalServerError);
-            if status != Status::Ok {
-                return Err(Error::new(
-                    Origin::Transport,
-                    Kind::Invalid,
-                    format!("cannot create inlet: {}", status),
-                ));
-            }
-            let _inlet_address = if !response.has_body() {
-                return Err(Error::new(
-                    Origin::Transport,
-                    Kind::Unknown,
-                    "invalid create inlet response",
-                ));
-            } else {
-                let status: InletStatus = decoder.decode()?;
-                Address::from(status.worker_addr.to_string())
-            };
-
-            self_guard.current_port += 1;
-            self_guard.broker_map.insert(broker_id, socket_address);
+            inner.current_port += 1;
+            inner
+                .broker_map
+                .insert(broker_id, (worker_address, socket_address));
 
             Ok(socket_address)
         }

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -104,6 +104,7 @@ mod test {
 
         KafkaPortalListener::create(
             context,
+            handle.tcp.async_try_clone().await?,
             secure_channel_controller.into_trait(),
             outlet_route,
             listener_address,

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -9,8 +9,10 @@ mod portal_worker;
 mod protocol_aware;
 mod secure_channel_map;
 
+pub(crate) use inlet_map::KafkaInletMap;
 use ockam_core::Address;
 pub(crate) use portal_listener::KafkaPortalListener;
+pub(crate) use secure_channel_map::KafkaSecureChannelController;
 pub(crate) use secure_channel_map::KafkaSecureChannelControllerImpl;
 
 pub const ORCHESTRATOR_KAFKA_CONSUMERS: &str = "kafka_consumers";

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
@@ -1,9 +1,8 @@
 use ockam_core::compat::sync::Arc;
-use tracing::trace;
-
 use ockam_core::{Address, AllowAll, Any, Route, Routed, Worker};
-
 use ockam_node::Context;
+use ockam_transport_tcp::TcpTransport;
+use tracing::trace;
 
 use crate::kafka::inlet_map::KafkaInletMap;
 use crate::kafka::portal_worker::KafkaPortalWorker;
@@ -64,16 +63,14 @@ impl KafkaPortalListener {
     pub(crate) async fn create(
         context: &Context,
         secure_channel_controller: Arc<dyn KafkaSecureChannelController>,
-        interceptor_route: Route,
         listener_address: Address,
-        bind_host: String,
-        port_range: PortRange,
+        inlet_map: KafkaInletMap,
     ) -> ockam_core::Result<()> {
         context
             .start_worker(
                 listener_address,
                 Self {
-                    inlet_map: KafkaInletMap::new(interceptor_route, bind_host, port_range),
+                    inlet_map,
                     secure_channel_controller,
                     uuid_to_name: Default::default(),
                 },

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
@@ -73,7 +73,6 @@ impl Interceptor {
                 ApiKey::FindCoordinatorKey => {
                     return self
                         .handle_find_coordinator_response(
-                            context,
                             &mut buffer,
                             inlet_map,
                             &request_info,
@@ -84,13 +83,7 @@ impl Interceptor {
 
                 ApiKey::MetadataKey => {
                     return self
-                        .handle_metadata_response(
-                            context,
-                            &mut buffer,
-                            inlet_map,
-                            request_info,
-                            &header,
-                        )
+                        .handle_metadata_response(&mut buffer, inlet_map, request_info, &header)
                         .await;
                 }
                 _ => {}
@@ -110,7 +103,6 @@ impl Interceptor {
     // to dedicated tcp inlet ports
     async fn handle_metadata_response(
         &self,
-        context: &mut Context,
         buffer: &mut Bytes,
         inlet_map: &KafkaInletMap,
         request_info: RequestInfo,
@@ -137,7 +129,7 @@ impl Interceptor {
 
         for (broker_id, info) in response.brokers.iter_mut() {
             let inlet_address: SocketAddr = inlet_map
-                .assert_inlet_for_broker(context, broker_id.0)
+                .assert_inlet_for_broker(broker_id.0)
                 .await
                 .map_err(InterceptError::Ockam)?;
 
@@ -158,7 +150,6 @@ impl Interceptor {
 
     async fn handle_find_coordinator_response(
         &self,
-        context: &mut Context,
         buffer: &mut Bytes,
         inlet_map: &KafkaInletMap,
         request_info: &RequestInfo,
@@ -173,7 +164,7 @@ impl Interceptor {
         if request_info.request_api_version >= 4 {
             for coordinator in response.coordinators.iter_mut() {
                 let inlet_address: SocketAddr = inlet_map
-                    .assert_inlet_for_broker(context, coordinator.node_id.0)
+                    .assert_inlet_for_broker(coordinator.node_id.0)
                     .await
                     .map_err(InterceptError::Ockam)?;
 
@@ -183,7 +174,7 @@ impl Interceptor {
             }
         } else {
             let inlet_address: SocketAddr = inlet_map
-                .assert_inlet_for_broker(context, response.node_id.0)
+                .assert_inlet_for_broker(response.node_id.0)
                 .await
                 .map_err(InterceptError::Ockam)?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -111,6 +111,10 @@ impl NodeManager {
             .create_secure_channel_internal(&identity, sc_route, authorized_identifiers, timeout)
             .await?;
 
+        warn!(
+            "WTF: self.enable_credential_checks: {}",
+            self.enable_credential_checks
+        );
         let actual_exchange_mode = if self.enable_credential_checks {
             credential_exchange_mode
         } else {

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -15,7 +15,7 @@
 pub use alloc::borrow;
 
 #[doc(hidden)]
-pub use futures_util::{join, try_join};
+pub use futures_util::{future::join_all, join, try_join};
 
 /// Provides `std::boxed` for `alloc` targets.
 pub mod boxed {


### PR DESCRIPTION
## Current Behavior

Currently, whenever a project is relocated, or a connection simply goes down, there is no recovery of any kind and consumer and producer remain broken indefinitely.

## Proposed Changes

The proposal is simple:
  - avoid using `node manager` APIs and witch to direct creation of `inlets`, `forwarders` and `secure channels`
  - add a session specific for the `kafka service` <--> `orchestrator` monitoring
