### PR TITLE
`TCP` <-> `SecureChannel` Message Flow Auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4416,9 +4416,9 @@ checksum = "5a9f47faea3cad316faa914d013d24f471cd90bfca1a0c70f05a3f42c6441e99"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
 dependencies = [
  "serde_derive",
 ]
@@ -4465,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/rust/file_transfer/examples/receiver.rs
+++ b/examples/rust/file_transfer/examples/receiver.rs
@@ -7,7 +7,7 @@ use ockam::{
     identity::{Identity, TrustEveryonePolicy},
     remote::RemoteForwarder,
     vault::Vault,
-    Context, Error, Result, Routed, TcpTransport, Worker,
+    Context, Error, Result, Routed, TcpConnectionTrustOptions, TcpTransport, Worker,
 };
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -104,7 +104,9 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub, AllowAll).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Receiver is:");

--- a/examples/rust/file_transfer/examples/sender.rs
+++ b/examples/rust/file_transfer/examples/sender.rs
@@ -1,13 +1,13 @@
 // examples/sender.rs
 
 use file_transfer::{FileData, FileDescription};
-use ockam::TcpTransport;
 use ockam::{
     identity::{Identity, TrustEveryonePolicy},
     route,
     vault::Vault,
     Context,
 };
+use ockam::{TcpConnectionTrustOptions, TcpTransport};
 
 use std::path::PathBuf;
 
@@ -52,7 +52,9 @@ async fn main(ctx: Context) -> Result<()> {
     let forwarding_address = opt.address.trim();
 
     // Connect to the cloud node over TCP
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
 
     // Combine the tcp address of the cloud node and the forwarding_address to get a route
     // to Receiver's secure channel listener.

--- a/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-initiator.rs
@@ -1,6 +1,6 @@
 // This node routes a message, to a worker on a different node, over the tcp transport.
 
-use ockam::{route, Context, Result, TcpTransport};
+use ockam::{route, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -8,7 +8,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP connection to a different node.
-    let connection_to_responder = tcp.connect("localhost:4000").await?;
+    let connection_to_responder = tcp.connect("localhost:4000", TcpConnectionTrustOptions::new()).await?;
 
     // Send a message to the "echoer" worker on a different node, over a tcp transport.
     let r = route![connection_to_responder, "echoer"];

--- a/examples/rust/get_started/examples/04-routing-over-transport-responder.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-responder.rs
@@ -3,7 +3,7 @@
 
 use hello_ockam::Echoer;
 use ockam::access_control::AllowAll;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -14,7 +14,7 @@ async fn main(ctx: Context) -> Result<()> {
     ctx.start_worker("echoer", Echoer, AllowAll, AllowAll).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    tcp.listen("127.0.0.1:4000", TcpListenerTrustOptions::new()).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-initiator.rs
@@ -1,6 +1,6 @@
 // This node routes a message, to a worker on a different node, over two tcp transport hops.
 
-use ockam::{route, Context, Result, TcpTransport};
+use ockam::{route, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -8,7 +8,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP connection to the middle node.
-    let connection_to_middle_node = tcp.connect("localhost:3000").await?;
+    let connection_to_middle_node = tcp.connect("localhost:3000", TcpConnectionTrustOptions::new()).await?;
 
     // Send a message to the "echoer" worker, on a different node, over two tcp hops.
     let r = route![connection_to_middle_node, "forward_to_responder", "echoer"];

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
@@ -4,7 +4,7 @@
 
 use hello_ockam::Forwarder;
 use ockam::access_control::AllowAll;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, Result, TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -12,7 +12,7 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP connection to the responder node.
-    let connection_to_responder = tcp.connect("127.0.0.1:4000").await?;
+    let connection_to_responder = tcp.connect("127.0.0.1:4000", TcpConnectionTrustOptions::new()).await?;
 
     // Create a Forwarder worker
     ctx.start_worker(
@@ -24,7 +24,7 @@ async fn main(ctx: Context) -> Result<()> {
     .await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:3000").await?;
+    tcp.listen("127.0.0.1:3000", TcpListenerTrustOptions::new()).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-responder.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-responder.rs
@@ -3,7 +3,7 @@
 
 use hello_ockam::Echoer;
 use ockam::access_control::AllowAll;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -14,7 +14,7 @@ async fn main(ctx: Context) -> Result<()> {
     ctx.start_worker("echoer", Echoer, AllowAll, AllowAll).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    tcp.listen("127.0.0.1:4000", TcpListenerTrustOptions::new()).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-initiator.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-initiator.rs
@@ -2,7 +2,7 @@
 // It then routes a message, to a worker on a different node, through this encrypted channel.
 
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport};
+use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -16,7 +16,7 @@ async fn main(mut ctx: Context) -> Result<()> {
     let alice = Identity::create(&ctx, &vault).await?;
 
     // Create a TCP connection to the middle node.
-    let connection_to_middle_node = tcp.connect("localhost:3000").await?;
+    let connection_to_middle_node = tcp.connect("localhost:3000", TcpConnectionTrustOptions::new()).await?;
 
     // Connect to a secure channel listener and perform a handshake.
     let r = route![connection_to_middle_node, "forward_to_bob", "bob_listener"];

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-middle.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-middle.rs
@@ -4,7 +4,7 @@
 
 use hello_ockam::Forwarder;
 use ockam::access_control::AllowAll;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, Result, TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -12,14 +12,14 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP connection to Bob.
-    let connection_to_bob = tcp.connect("127.0.0.1:4000").await?;
+    let connection_to_bob = tcp.connect("127.0.0.1:4000", TcpConnectionTrustOptions::new()).await?;
 
     // Start a Forwarder to forward messages to Bob using the TCP connection.
     ctx.start_worker("forward_to_bob", Forwarder(connection_to_bob), AllowAll, AllowAll)
         .await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:3000").await?;
+    tcp.listen("127.0.0.1:3000", TcpListenerTrustOptions::new()).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-responder.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-responder.rs
@@ -4,7 +4,7 @@
 use hello_ockam::Echoer;
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{vault::Vault, Context, Result, TcpTransport};
+use ockam::{vault::Vault, Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -25,7 +25,7 @@ async fn main(ctx: Context) -> Result<()> {
         .await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:4000").await?;
+    tcp.listen("127.0.0.1:4000", TcpListenerTrustOptions::new()).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -1,7 +1,7 @@
 use ockam::access_control::IdentityIdAccessControl;
 use ockam::identity::credential_issuer::CredentialIssuer;
 use ockam::identity::TrustEveryonePolicy;
-use ockam::{Context, TcpTransport};
+use ockam::{Context, TcpListenerTrustOptions, TcpTransport};
 use ockam_core::{AllowAll, Result};
 
 /// This node starts a temporary credential issuer accessible via TCP on localhost:5000
@@ -20,7 +20,7 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create a TCP listener and wait for incoming connections.
-    tcp.listen("127.0.0.1:5000").await?;
+    tcp.listen("127.0.0.1:5000", TcpListenerTrustOptions::new()).await?;
 
     // Create a CredentialIssuer which stores attributes for Alice and Bob, knowing their identity
     let issuer = CredentialIssuer::create(&ctx).await?;

--- a/examples/rust/get_started/examples/09-streams-initiator.rs
+++ b/examples/rust/get_started/examples/09-streams-initiator.rs
@@ -1,4 +1,4 @@
-use ockam::{route, stream::Stream, Context, Result, TcpTransport};
+use ockam::{route, stream::Stream, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -6,7 +6,9 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
     let hub_node_tcp_address = "<Your node Address copied from hub.ockam.network>";
-    let node_in_hub = tcp.connect(hub_node_tcp_address).await?;
+    let node_in_hub = tcp
+        .connect(hub_node_tcp_address, TcpConnectionTrustOptions::new())
+        .await?;
 
     // Create a stream client
     let (sender, _receiver) = Stream::new(&ctx)

--- a/examples/rust/get_started/examples/09-streams-responder.rs
+++ b/examples/rust/get_started/examples/09-streams-responder.rs
@@ -1,6 +1,6 @@
 use hello_ockam::Echoer;
 use ockam::access_control::AllowAll;
-use ockam::{route, stream::Stream, Context, Result, TcpTransport};
+use ockam::{route, stream::Stream, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -11,7 +11,9 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
     let hub_node_tcp_address = "<Your node Address copied from hub.ockam.network>";
-    let node_in_hub = tcp.connect(hub_node_tcp_address).await?;
+    let node_in_hub = tcp
+        .connect(hub_node_tcp_address, TcpConnectionTrustOptions::new())
+        .await?;
 
     // Create a stream client
     Stream::new(&ctx)

--- a/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
+++ b/examples/rust/get_started/examples/10-secure-channel-via-streams-initiator.rs
@@ -1,5 +1,5 @@
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, stream::Stream, vault::Vault, Context, Result, TcpTransport};
+use ockam::{route, stream::Stream, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {
@@ -7,7 +7,9 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
     let hub_node_tcp_address = "<Your node Address copied from hub.ockam.network>";
-    let node_in_hub = tcp.connect(hub_node_tcp_address).await?;
+    let node_in_hub = tcp
+        .connect(hub_node_tcp_address, TcpConnectionTrustOptions::new())
+        .await?;
 
     // Create a vault
     let vault = Vault::create();

--- a/examples/rust/get_started/examples/10-secure-channel-via-streams-responder.rs
+++ b/examples/rust/get_started/examples/10-secure-channel-via-streams-responder.rs
@@ -1,7 +1,7 @@
 use hello_ockam::Echoer;
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, stream::Stream, vault::Vault, Context, Result, TcpTransport};
+use ockam::{route, stream::Stream, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -12,7 +12,9 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Set the address of the Kafka node you created here. (e.g. "192.0.2.1:4000")
     let hub_node_tcp_address = "<Your node Address copied from hub.ockam.network>";
-    let node_in_hub = tcp.connect(hub_node_tcp_address).await?;
+    let node_in_hub = tcp
+        .connect(hub_node_tcp_address, TcpConnectionTrustOptions::new())
+        .await?;
 
     // Create a vault
     let vault = Vault::create();

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -71,7 +71,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // create a secure channel to the authority
     // when creating the channel we check that the opposite side is indeed presenting the authority identity
     let secure_channel = control_plane
-        .create_secure_channel_extended_trust(tcp_session.route, trust_options, Duration::from_secs(120))
+        .create_secure_channel_extended(tcp_session.route, trust_options, Duration::from_secs(120))
         .await?;
 
     let token_acceptor = TokenAcceptorClient::new(
@@ -125,7 +125,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // create a secure channel to the project first
     // we make sure that we indeed connect to the correct project on the Orchestrator
     let secure_channel_address = control_plane
-        .create_secure_channel_extended_trust(
+        .create_secure_channel_extended(
             tcp_project_session.route,
             project_trust_options,
             Duration::from_secs(120),

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -125,7 +125,11 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // create a secure channel to the project first
     // we make sure that we indeed connect to the correct project on the Orchestrator
     let secure_channel_address = control_plane
-        .create_secure_channel_extended_trust(project.route(), project_trust_options, Duration::from_secs(120))
+        .create_secure_channel_extended_trust(
+            tcp_project_session.route,
+            project_trust_options,
+            Duration::from_secs(120),
+        )
         .await?;
     println!("secure channel to project: {secure_channel_address:?}");
 

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -70,7 +70,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // create a secure channel to the authority
     // when creating the channel we check that the opposite side is indeed presenting the authority identity
     let secure_channel = edge_plane
-        .create_secure_channel_extended_trust(tcp_authority_session.route, trust_options, Duration::from_secs(120))
+        .create_secure_channel_extended(tcp_authority_session.route, trust_options, Duration::from_secs(120))
         .await?;
 
     let token_acceptor = TokenAcceptorClient::new(
@@ -118,7 +118,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
 
     // 4.1 first created a secure channel to the project
     let secure_channel_address = edge_plane
-        .create_secure_channel_extended_trust(
+        .create_secure_channel_extended(
             tcp_project_session.route,
             project_trust_options,
             Duration::from_secs(120),

--- a/examples/rust/get_started/examples/alice.rs
+++ b/examples/rust/get_started/examples/alice.rs
@@ -1,5 +1,5 @@
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport};
+use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 use std::io;
 
 #[ockam::node]
@@ -24,7 +24,9 @@ async fn main(mut ctx: Context) -> Result<()> {
 
     // Combine the tcp address of the node and the forwarding_address to get a route
     // to Bob's secure channel listener.
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let route_to_bob_listener = route![node_in_hub, forwarding_address, "listener"];
 
     // As Alice, connect to Bob's secure channel listener, and perform an

--- a/examples/rust/get_started/examples/bob.rs
+++ b/examples/rust/get_started/examples/bob.rs
@@ -1,6 +1,6 @@
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{remote::RemoteForwarder, Routed, TcpTransport, Worker};
+use ockam::{remote::RemoteForwarder, Routed, TcpConnectionTrustOptions, TcpTransport, Worker};
 use ockam::{vault::Vault, Context, Result};
 
 struct Echoer;
@@ -49,7 +49,9 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub, AllowAll).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Bob is:");

--- a/examples/rust/ockam_kafka/examples/ockam_kafka_alice.rs
+++ b/examples/rust/ockam_kafka/examples/ockam_kafka_alice.rs
@@ -4,7 +4,7 @@ use ockam::{
     stream::Stream,
     unique_with_prefix,
     vault::Vault,
-    Context, Result, TcpTransport,
+    Context, Result, TcpConnectionTrustOptions, TcpTransport,
 };
 use std::io;
 
@@ -42,7 +42,9 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Starts a sender (producer) for the alice_to_bob stream and a receiver (consumer)
     // for the `bob_to_alice` stream to get two-way communication.
 
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let (sender, _receiver) = Stream::new(&ctx)
         .await?
         .stream_service("stream_kafka")

--- a/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
+++ b/examples/rust/ockam_kafka/examples/ockam_kafka_bob.rs
@@ -4,7 +4,7 @@ use ockam::{
     route,
     stream::Stream,
     vault::Vault,
-    Context, Result, Routed, TcpTransport, Worker,
+    Context, Result, Routed, TcpConnectionTrustOptions, TcpTransport, Worker,
 };
 
 struct Echoer;
@@ -48,7 +48,9 @@ async fn main(ctx: Context) -> Result<()> {
     // - a receiver (consumer) for the `alice_to_bob` stream
     // - a sender (producer) for the `bob_to_alice` stream.
 
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let b_to_a_stream_address = ockam::unique_with_prefix("bob_to_alice");
     let a_to_b_stream_address = ockam::unique_with_prefix("alice_to_bob");
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-inlet.rs
@@ -1,5 +1,5 @@
 use ockam::access_control::AllowAll;
-use ockam::{route, Context, Result, TcpTransport};
+use ockam::{route, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -13,7 +13,9 @@ async fn main(ctx: Context) -> Result<()> {
     // by a second command line argument.
 
     let outlet_port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
-    let outlet_connection = tcp.connect(&format!("127.0.0.1:{outlet_port}")).await?;
+    let outlet_connection = tcp
+        .connect(&format!("127.0.0.1:{outlet_port}"), TcpConnectionTrustOptions::new())
+        .await?;
     let route_to_outlet = route![outlet_connection, "outlet"];
 
     // Expect first command line argument to be the TCP address on which to start an Inlet

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
@@ -1,5 +1,5 @@
 use ockam::access_control::AllowAll;
-use ockam::{Context, Result, TcpTransport};
+use ockam::{Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -30,7 +30,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Use port 4000, unless otherwise specified by second command line argument.
 
     let port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
-    tcp.listen(format!("127.0.0.1:{port}")).await?;
+    tcp.listen(format!("127.0.0.1:{port}"), TcpListenerTrustOptions::new())
+        .await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-inlet.rs
@@ -1,6 +1,6 @@
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, TcpTransport};
+use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -20,7 +20,9 @@ async fn main(ctx: Context) -> Result<()> {
     let vault = Vault::create();
     let e = Identity::create(&ctx, &vault).await?;
     let outlet_port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
-    let outlet_connection = tcp.connect(&format!("127.0.0.1:{outlet_port}")).await?;
+    let outlet_connection = tcp
+        .connect(&format!("127.0.0.1:{outlet_port}"), TcpConnectionTrustOptions::new())
+        .await?;
     let r = route![outlet_connection, "secure_channel_listener"];
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
@@ -1,6 +1,6 @@
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{vault::Vault, Context, Result, TcpTransport};
+use ockam::{vault::Vault, Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -42,7 +42,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Use port 4000, unless otherwise specified by second command line argument.
 
     let port = std::env::args().nth(2).unwrap_or_else(|| "4000".to_string());
-    tcp.listen(format!("127.0.0.1:{port}")).await?;
+    tcp.listen(format!("127.0.0.1:{port}"), TcpListenerTrustOptions::new())
+        .await?;
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
@@ -1,6 +1,6 @@
 use ockam::access_control::AllowAll;
 use ockam::identity::{Identity, TrustEveryonePolicy};
-use ockam::{route, vault::Vault, Context, Result, Route, TcpTransport};
+use ockam::{route, vault::Vault, Context, Result, Route, TcpConnectionTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -19,7 +19,9 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Expect second command line argument to be the Outlet node forwarder address
     let forwarding_address = std::env::args().nth(2).expect("no outlet forwarding address given");
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let r = route![node_in_hub, forwarding_address, "secure_channel_listener"];
     let channel = e.create_secure_channel(r, TrustEveryonePolicy).await?;
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -3,7 +3,7 @@ use ockam::{
     identity::{Identity, TrustEveryonePolicy},
     remote::RemoteForwarder,
     vault::Vault,
-    Context, Result, TcpTransport,
+    Context, Result, TcpConnectionTrustOptions, TcpTransport,
 };
 
 #[ockam::node]
@@ -41,7 +41,9 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
-    let node_in_hub = tcp.connect("1.node.ockam.network:4000").await?;
+    let node_in_hub = tcp
+        .connect("1.node.ockam.network:4000", TcpConnectionTrustOptions::new())
+        .await?;
     let forwarder = RemoteForwarder::create(&ctx, node_in_hub, AllowAll).await?;
     println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address in Hub is:");

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -121,4 +121,4 @@ pub mod authenticated_storage {
 }
 
 #[cfg(feature = "ockam_transport_tcp")]
-pub use ockam_transport_tcp::TcpTransport;
+pub use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};

--- a/implementations/rust/ockam/ockam/src/remote.rs
+++ b/implementations/rust/ockam/ockam/src/remote.rs
@@ -362,7 +362,7 @@ mod test {
     use super::*;
     use crate::workers::Echoer;
     use ockam_core::route;
-    use ockam_transport_tcp::TcpTransport;
+    use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpTransport};
     use std::env;
 
     fn get_cloud_address() -> Option<String> {
@@ -391,7 +391,9 @@ mod test {
             .await?;
 
         let tcp = TcpTransport::create(ctx).await?;
-        let node_in_hub = tcp.connect(cloud_address).await?;
+        let node_in_hub = tcp
+            .connect(cloud_address, TcpConnectionTrustOptions::new())
+            .await?;
 
         let remote_info = RemoteForwarder::create(ctx, node_in_hub.clone(), AllowAll).await?;
 
@@ -422,7 +424,9 @@ mod test {
 
         let tcp = TcpTransport::create(ctx).await?;
 
-        let node_in_hub = tcp.connect(cloud_address).await?;
+        let node_in_hub = tcp
+            .connect(cloud_address, TcpConnectionTrustOptions::new())
+            .await?;
         let _ = RemoteForwarder::create_static(ctx, node_in_hub.clone(), "alias", AllowAll).await?;
 
         let resp = ctx

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -81,7 +81,6 @@ mod node {
     use std::time::Duration;
 
     use minicbor::{Decode, Decoder, Encode};
-    use ockam::AsyncTryClone;
     use tracing::trace;
 
     use ockam_core::api::Request;
@@ -107,28 +106,21 @@ mod node {
             project_id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "list_addons";
             trace!(target: TARGET, project_id, "listing addons");
 
             let req_builder = Request::get(format!("/v0/{project_id}/addons"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -167,21 +159,11 @@ mod node {
             project_id: &str,
             addon_id: &str,
         ) -> Result<Vec<u8>> {
-            let ident = self
-                .get()
-                .read()
-                .await
-                .identity()?
-                .async_try_clone()
-                .await?;
-
             let label = "configure_addon";
             trace!(target: TARGET, project_id, addon_id, "configuring addon");
 
             let req_wrapper: CloudRequestWrapper<T> = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
             let req_builder =
@@ -191,10 +173,10 @@ mod node {
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
                 Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
@@ -208,28 +190,21 @@ mod node {
             addon_id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "disable_addon";
             trace!(target: TARGET, project_id, addon_id, "disabling addon");
 
             let req_builder = Request::delete(format!("/v0/{project_id}/addons/{addon_id}"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -199,7 +199,7 @@ mod node {
                     trust_options
                 };
                 identity
-                    .create_secure_channel_trust(cloud_session.route, trust_options)
+                    .create_secure_channel(cloud_session.route, trust_options)
                     .await?
             };
             let route = route![&sc.to_string(), api_service];

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -187,7 +187,7 @@ mod node {
             let sc = {
                 let node_manager = self.get().read().await;
                 let cloud_session =
-                    crate::create_tcp_session(&cloud_multiaddr, &node_manager.tcp_transport)
+                    crate::create_tcp_session(cloud_multiaddr, &node_manager.tcp_transport)
                         .await
                         .ok_or_else(|| ApiError::generic("Invalid Multiaddr"))?;
                 let trust_options = SecureChannelTrustOptions::new().with_trust_policy(

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -62,7 +62,6 @@ mod node {
     use tracing::trace;
 
     use ockam_core::api::Request;
-    use ockam_core::AsyncTryClone;
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
@@ -79,9 +78,7 @@ mod node {
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<CreateSpace> = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
             let label = "create_space";
@@ -89,19 +86,14 @@ mod node {
 
             let req_builder = Request::post("/v0/").body(req_body);
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 "create_space",
-                cloud_route,
+                &cloud_multiaddr,
                 "spaces",
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -112,22 +104,23 @@ mod node {
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "list_spaces";
             trace!(target: TARGET, "listing spaces");
 
             let req_builder = Request::get("/v0/");
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                &cloud_multiaddr,
+                "spaces",
+                req_builder,
+                None,
+            )
+            .await
         }
 
         pub(crate) async fn get_space(
@@ -137,22 +130,23 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "get_space";
             trace!(target: TARGET, space = %id, space = %id, "getting space");
 
             let req_builder = Request::get(format!("/v0/{id}"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                &cloud_multiaddr,
+                "spaces",
+                req_builder,
+                None,
+            )
+            .await
         }
 
         pub(crate) async fn delete_space(
@@ -162,22 +156,23 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "delete_space";
             trace!(target: TARGET, space = %id, "deleting space");
 
             let req_builder = Request::delete(format!("/v0/{id}"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
-            self.request_controller(ctx, label, None, cloud_route, "spaces", req_builder, ident)
-                .await
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                &cloud_multiaddr,
+                "spaces",
+                req_builder,
+                None,
+            )
+            .await
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -1,7 +1,6 @@
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use ockam_core::AsyncTryClone;
 use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -110,28 +109,21 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "unsubscribe";
             trace!(target: TARGET, subscription = %id, "unsubscribing");
 
             let req_builder = Request::put(format!("/v0/{id}/unsubscribe"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -143,9 +135,7 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
             let label = "list_sbuscriptions";
@@ -153,19 +143,14 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{id}/space_id")).body(req_body);
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -176,9 +161,7 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<String> = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
             let label = "update_subscription_contact_info";
@@ -186,19 +169,14 @@ mod node {
 
             let req_builder = Request::put(format!("/v0/{id}/contact_info")).body(req_body);
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -208,28 +186,21 @@ mod node {
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "list_subscriptions";
             trace!(target: TARGET, "listing subscriptions");
 
             let req_builder = Request::get("/v0/");
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -240,28 +211,21 @@ mod node {
             id: &str,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
 
             let label = "get_subscription";
             trace!(target: TARGET, subscription = %id, "getting subscription");
 
             let req_builder = Request::get(format!("/v0/{id}"));
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 None,
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }
@@ -271,9 +235,7 @@ mod node {
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<ActivateSubscription> = dec.decode()?;
-            let cloud_route = req_wrapper
-                .route(&self.get().read().await.tcp_transport)
-                .await?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
             let label = "activate_subscription";
@@ -281,19 +243,14 @@ mod node {
 
             let req_builder = Request::post("/v0/activate").body(req_body);
 
-            let ident = {
-                let inner = self.get().read().await;
-                inner.identity()?.async_try_clone().await?
-            };
-
             self.request_controller(
                 ctx,
                 label,
                 "activate_request",
-                cloud_route,
+                &cloud_multiaddr,
                 API_SERVICE,
                 req_builder,
-                ident,
+                None,
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -258,6 +258,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage, F: ForwarderCreator>
             } else {
                 trace!("creating new secure channel to {topic_partition_address}");
 
+                // TODO: Figure out if session should be used
                 let encryptor_address = inner
                     .identity
                     .create_secure_channel(

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -267,7 +267,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage, F: ForwarderCreator>
                     SecureChannelTrustOptions::new().with_trust_policy(TrustEveryonePolicy);
                 let encryptor_address = inner
                     .identity
-                    .create_secure_channel_trust(
+                    .create_secure_channel(
                         route![
                             inner.project_route.clone(),
                             topic_partition_address.clone(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection.rs
@@ -2,23 +2,20 @@ use ockam_core::CowStr;
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
-use ockam_transport_tcp::TcpTransport;
 use std::time::Duration;
 
-pub struct Connection<'a, T> {
-    pub transport: &'a T,
+pub struct Connection<'a> {
     pub ctx: &'a Context,
     pub addr: &'a MultiAddr,
     pub identity_name: Option<CowStr<'a>>,
     pub credential_name: Option<CowStr<'a>>,
-    pub authorized_identities: Option<IdentityIdentifier>,
+    pub authorized_identities: Option<Vec<IdentityIdentifier>>,
     pub timeout: Option<Duration>,
 }
 
-impl<'a> Connection<'a, TcpTransport> {
-    pub fn new(transport: &'a TcpTransport, ctx: &'a Context, addr: &'a MultiAddr) -> Self {
+impl<'a> Connection<'a> {
+    pub fn new(ctx: &'a Context, addr: &'a MultiAddr) -> Self {
         Self {
-            transport,
             ctx,
             addr,
             identity_name: None,
@@ -28,22 +25,17 @@ impl<'a> Connection<'a, TcpTransport> {
         }
     }
 
-    pub fn with_identity_name<T: Into<Option<CowStr<'a>>>>(mut self, identity_name: T) -> Self {
-        self.identity_name = identity_name.into();
-        self
-    }
-
     #[allow(unused)]
     pub fn with_credential_name<T: Into<Option<CowStr<'a>>>>(mut self, credential_name: T) -> Self {
         self.credential_name = credential_name.into();
         self
     }
 
-    pub fn with_authorized_identities<T: Into<Option<IdentityIdentifier>>>(
+    pub fn with_authorized_identity<T: Into<Option<IdentityIdentifier>>>(
         mut self,
-        authorized_identities: T,
+        authorized_identity: T,
     ) -> Self {
-        self.authorized_identities = authorized_identities.into();
+        self.authorized_identities = authorized_identity.into().map(|x| vec![x]);
         self
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection.rs
@@ -1,0 +1,54 @@
+use ockam_core::CowStr;
+use ockam_identity::IdentityIdentifier;
+use ockam_multiaddr::MultiAddr;
+use ockam_node::Context;
+use ockam_transport_tcp::TcpTransport;
+use std::time::Duration;
+
+pub struct Connection<'a, T> {
+    pub transport: &'a T,
+    pub ctx: &'a Context,
+    pub addr: &'a MultiAddr,
+    pub identity_name: Option<CowStr<'a>>,
+    pub credential_name: Option<CowStr<'a>>,
+    pub authorized_identities: Option<IdentityIdentifier>,
+    pub timeout: Option<Duration>,
+}
+
+impl<'a> Connection<'a, TcpTransport> {
+    pub fn new(transport: &'a TcpTransport, ctx: &'a Context, addr: &'a MultiAddr) -> Self {
+        Self {
+            transport,
+            ctx,
+            addr,
+            identity_name: None,
+            credential_name: None,
+            authorized_identities: None,
+            timeout: None,
+        }
+    }
+
+    pub fn with_identity_name<T: Into<Option<CowStr<'a>>>>(mut self, identity_name: T) -> Self {
+        self.identity_name = identity_name.into();
+        self
+    }
+
+    #[allow(unused)]
+    pub fn with_credential_name<T: Into<Option<CowStr<'a>>>>(mut self, credential_name: T) -> Self {
+        self.credential_name = credential_name.into();
+        self
+    }
+
+    pub fn with_authorized_identities<T: Into<Option<IdentityIdentifier>>>(
+        mut self,
+        authorized_identities: T,
+    ) -> Self {
+        self.authorized_identities = authorized_identities.into();
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/mod.rs
@@ -3,6 +3,7 @@ pub mod registry;
 
 pub mod service;
 
+pub(crate) mod connection;
 pub mod models;
 
 /// A const address to bind and send messages to

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -441,7 +441,7 @@ impl NodeManager {
                 }
                 None => {
                     // We don't use a secure channel here, should be safe without sessions
-                    let route = multiaddr_to_route(&addr, transport)
+                    let route = multiaddr_to_route(addr, transport)
                         .await
                         .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
                     Ok((

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -34,9 +34,8 @@ impl NodeManagerWorker {
 
         debug!(addr = %req.address(), alias = ?req.alias(), "Handling CreateForwarder request");
 
-        let tcp_transport = node_manager.tcp_transport.async_try_clone().await?;
-        let connection = Connection::new(&tcp_transport, ctx, req.address())
-            .with_authorized_identities(req.authorized());
+        let connection =
+            Connection::new(ctx, req.address()).with_authorized_identity(req.authorized());
 
         let (sec_chan, suffix) = node_manager.connect(connection).await?;
 
@@ -119,9 +118,8 @@ fn replacer(
                 let prev = try_multiaddr_to_addr(&prev)?;
                 let mut this = manager.write().await;
                 let _ = this.delete_secure_channel(&prev).await;
-                let tcp_transport = this.tcp_transport.async_try_clone().await?;
-                let connection = Connection::new(&tcp_transport, ctx.as_ref(), &addr)
-                    .with_authorized_identities(auth)
+                let connection = Connection::new(ctx.as_ref(), &addr)
+                    .with_authorized_identity(auth)
                     .with_timeout(util::MAX_CONNECT_TIME);
                 let (sec, rest) = this.connect(connection).await?;
                 let a = sec.clone().try_with(&rest)?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -42,10 +42,10 @@ mod node {
     use tracing::trace;
 
     use crate::error::ApiError;
+    use crate::local_multiaddr_to_route;
     use crate::nodes::connection::Connection;
-    use crate::{local_multiaddr_to_route, multiaddr_to_route};
     use ockam_core::api::{Request, Response, Status};
-    use ockam_core::{self, route, AsyncTryClone, Result};
+    use ockam_core::{self, Result};
     use ockam_node::Context;
 
     use crate::nodes::NodeManagerWorker;
@@ -65,8 +65,7 @@ mod node {
             let msg_length = msg.len();
 
             let mut node_manager = self.node_manager.write().await;
-            let tcp_transport = node_manager.tcp_transport.async_try_clone().await?;
-            let connection = Connection::new(&tcp_transport, ctx, &multiaddr);
+            let connection = Connection::new(ctx, &multiaddr);
             let (sc, suffix) = node_manager.connect(connection).await?;
             let full = sc.try_with(&suffix)?;
             let route =

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -15,6 +15,7 @@ use minicbor::Decoder;
 use ockam::identity::TrustEveryonePolicy;
 use ockam::{Address, Result, Route};
 use ockam_core::api::{Request, Response, ResponseBuilder};
+use ockam_core::sessions::{SessionId, Sessions};
 use ockam_core::{route, AsyncTryClone, CowStr};
 use ockam_identity::authenticated_storage::AuthenticatedStorage;
 
@@ -95,6 +96,7 @@ impl NodeManager {
         identity_name: Option<CowStr<'_>>,
         ctx: &Context,
         credential_name: Option<CowStr<'_>>,
+        session: Option<(Sessions, SessionId)>,
     ) -> Result<Address> {
         let identity = if let Some(identity) = identity_name {
             let idt_state = self.cli_state.identities.get(&identity)?;
@@ -313,6 +315,7 @@ impl NodeManagerWorker {
                 identity,
                 ctx,
                 credential_name,
+                None,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -81,7 +81,7 @@ impl NodeManager {
         };
 
         let sc_addr = identity
-            .create_secure_channel_extended_trust(sc_route.clone(), trust_options, timeout)
+            .create_secure_channel_extended(sc_route.clone(), trust_options, timeout)
             .await?;
 
         debug!(%sc_route, %sc_addr, "Created secure channel");
@@ -226,7 +226,7 @@ impl NodeManager {
         };
 
         identity
-            .create_secure_channel_listener_trust(addr.clone(), trust_options)
+            .create_secure_channel_listener(addr.clone(), trust_options)
             .await?;
 
         self.registry

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
@@ -5,6 +5,7 @@ use crate::nodes::service::{random_alias, Alias, Transports};
 use minicbor::Decoder;
 use ockam::Result;
 use ockam_core::api::{Request, Response, ResponseBuilder};
+use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpListenerTrustOptions};
 
 use super::NodeManagerWorker;
 
@@ -53,14 +54,14 @@ impl NodeManagerWorker {
                 .tcp_transport
                 // We don't use Sessions for listeners and connections created manually
                 // TODO: Add that functionality
-                .listen(&addr)
+                .listen(&addr, TcpListenerTrustOptions::new())
                 .await
                 .map(|(socket, worker_address)| (socket.to_string(), worker_address)),
             (Tcp, Connect) => node_manager
                 .tcp_transport
                 // We don't use Sessions for listeners and connections created manually
                 // TODO: Add that functionality
-                .connect(&socket_addr)
+                .connect(&socket_addr, TcpConnectionTrustOptions::new())
                 .await
                 .map(|worker_address| (socket_addr, worker_address)),
             _ => unimplemented!(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
@@ -51,11 +51,15 @@ impl NodeManagerWorker {
         let res = match (tt, tm) {
             (Tcp, Listen) => node_manager
                 .tcp_transport
+                // We don't use Sessions for listeners and connections created manually
+                // TODO: Add that functionality
                 .listen(&addr)
                 .await
                 .map(|(socket, worker_address)| (socket.to_string(), worker_address)),
             (Tcp, Connect) => node_manager
                 .tcp_transport
+                // We don't use Sessions for listeners and connections created manually
+                // TODO: Add that functionality
                 .connect(&socket_addr)
                 .await
                 .map(|worker_address| (socket_addr, worker_address)),

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -177,7 +177,6 @@ pub async fn create_tcp_session(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Tc
 }
 
 /// Try to convert a multi-address to an Ockam route.
-#[deprecated]
 pub async fn multiaddr_to_route(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Route> {
     // Guaranteed to be called when we use Tcp connection without a secure channel
     let trust_options = TcpConnectionTrustOptions::new();

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -103,7 +103,7 @@ pub async fn create_tcp_session(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Tc
                 };
 
                 let addr = tcp
-                    .connect_trust(socket_addr.to_string(), trust_options)
+                    .connect(socket_addr.to_string(), trust_options)
                     .await
                     .ok()?;
                 rb = rb.append(addr)
@@ -119,7 +119,7 @@ pub async fn create_tcp_session(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Tc
                 };
 
                 let addr = tcp
-                    .connect_trust(socket_addr.to_string(), trust_options)
+                    .connect(socket_addr.to_string(), trust_options)
                     .await
                     .ok()?;
                 rb = rb.append(addr)
@@ -136,7 +136,7 @@ pub async fn create_tcp_session(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Tc
                         };
 
                         let addr = tcp
-                            .connect_trust(format!("{}:{}", &*host, *port), trust_options)
+                            .connect(format!("{}:{}", &*host, *port), trust_options)
                             .await
                             .ok()?;
                         rb = rb.append(addr);
@@ -190,7 +190,7 @@ pub async fn multiaddr_to_route(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Ro
                 let port = it.next()?.cast::<Tcp>()?;
                 let socket_addr = SocketAddrV4::new(*ip4, *port);
                 let addr = tcp
-                    .connect_trust(socket_addr.to_string(), trust_options.clone())
+                    .connect(socket_addr.to_string(), trust_options.clone())
                     .await
                     .ok()?;
                 rb = rb.append(addr)
@@ -200,7 +200,7 @@ pub async fn multiaddr_to_route(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Ro
                 let port = it.next()?.cast::<Tcp>()?;
                 let socket_addr = SocketAddrV6::new(*ip6, *port, 0, 0);
                 let addr = tcp
-                    .connect_trust(socket_addr.to_string(), trust_options.clone())
+                    .connect(socket_addr.to_string(), trust_options.clone())
                     .await
                     .ok()?;
                 rb = rb.append(addr)
@@ -211,7 +211,7 @@ pub async fn multiaddr_to_route(ma: &MultiAddr, tcp: &TcpTransport) -> Option<Ro
                     if p.code() == Tcp::CODE {
                         let port = p.cast::<Tcp>()?;
                         let addr = tcp
-                            .connect_trust(format!("{}:{}", &*host, *port), trust_options.clone())
+                            .connect(format!("{}:{}", &*host, *port), trust_options.clone())
                             .await
                             .ok()?;
                         rb = rb.append(addr);

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -269,7 +269,7 @@ pub mod test {
     /// things *will* break.
     // #[must_use] make sense to enable only on rust 1.67+
     pub async fn start_manager_for_tests(context: &mut Context) -> Result<NodeManagerHandle> {
-        let tcp = TcpTransport::create(&context).await?;
+        let tcp = TcpTransport::create(context).await?;
         let cli_state = CliState::test()?;
 
         let vault_name = hex::encode(rand::random::<[u8; 4]>());
@@ -296,7 +296,7 @@ pub mod test {
         cli_state.nodes.create(&node_name, node_config)?;
 
         let node_manager = NodeManager::create(
-            &context,
+            context,
             NodeManagerGeneralOptions::new(cli_state.clone(), node_name, true, None),
             NodeManagerProjectsOptions::new(None, None, Default::default(), None),
             NodeManagerTransportOptions::new(

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -1,13 +1,13 @@
 use crate::help;
 use crate::util::embedded_node;
 use crate::Result;
-use anyhow::{anyhow, ensure, Context as _};
+use anyhow::{anyhow, Context as _};
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
 use ockam::compat::collections::HashMap;
 use ockam::{Context, TcpTransport};
+use ockam_api::auth;
 use ockam_api::is_local_node;
-use ockam_api::{auth, create_tcp_session};
 use ockam_identity::authenticated_storage::AttributesEntry;
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -29,7 +29,7 @@ use crate::{
     node::util::{add_project_authority_from_project_info, init_node_state},
     util::RpcBuilder,
 };
-use ockam::{Address, AsyncTryClone};
+use ockam::{Address, AsyncTryClone, TcpConnectionTrustOptions, TcpListenerTrustOptions};
 use ockam::{Context, TcpTransport};
 use ockam_api::{
     bootstrapped_identities_store::PreTrustedIdentities,
@@ -253,7 +253,7 @@ async fn run_foreground_node(
     // This listener gives exclusive access to our node, make sure this is intended
     // + make sure this tcp address is only reachable from the local loopback and/or intended
     // network
-    let (socket_addr, listener_addr) = tcp.listen(&bind).await?;
+    let (socket_addr, listener_addr) = tcp.listen(&bind, TcpListenerTrustOptions::new()).await?;
 
     let node_state = opts.state.nodes.get(&node_name)?;
     let setup_config = node_state.setup()?;
@@ -395,7 +395,9 @@ async fn start_services(
     // Checking if node accepts connections
     // Connection without a Session gives exclusive access to the node
     // that runs that connection, make sure it's intended
-    let addr = tcp.connect(addr.to_string()).await?;
+    let addr = tcp
+        .connect(addr.to_string(), TcpConnectionTrustOptions::new())
+        .await?;
 
     if let Some(cfg) = config.vault {
         if !cfg.disabled {

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -389,7 +389,7 @@ async fn start_services(
     };
 
     // Checking if node accepts connections
-    let addr = tcp.connect_socket(addr).await?;
+    let addr = tcp.connect(addr.to_string()).await?;
 
     if let Some(cfg) = config.vault {
         if !cfg.disabled {

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -249,6 +249,10 @@ async fn run_foreground_node(
 
     let tcp = TcpTransport::create(&ctx).await?;
     let bind = cmd.tcp_listener_address;
+
+    // This listener gives exclusive access to our node, make sure this is intended
+    // + make sure this tcp address is only reachable from the local loopback and/or intended
+    // network
     let (socket_addr, listener_addr) = tcp.listen(&bind).await?;
 
     let node_state = opts.state.nodes.get(&node_name)?;
@@ -389,6 +393,8 @@ async fn start_services(
     };
 
     // Checking if node accepts connections
+    // Connection without a Session gives exclusive access to the node
+    // that runs that connection, make sure it's intended
     let addr = tcp.connect(addr.to_string()).await?;
 
     if let Some(cfg) = config.vault {

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use ockam::identity::{Identity, PublicIdentity};
-use ockam::{Context, TcpTransport};
+use ockam::{Context, TcpListenerTrustOptions, TcpTransport};
 use ockam_api::cli_state;
 use ockam_api::config::cli::{self, Authority};
 use ockam_api::nodes::models::transport::{TransportMode, TransportType};
@@ -69,7 +69,8 @@ pub async fn start_embedded_node_with_vault_and_identity(
     // This listener gives exclusive access to our node, make sure this is intended
     // + make sure this tcp address is only reachable from the local loopback and/or intended
     // network
-    let (socket_addr, listened_worker_address) = tcp.listen(&bind).await?;
+    let (socket_addr, listened_worker_address) =
+        tcp.listen(&bind, TcpListenerTrustOptions::new()).await?;
 
     let projects = cfg.inner().lookup().projects().collect();
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -66,6 +66,9 @@ pub async fn start_embedded_node_with_vault_and_identity(
 
     let tcp = TcpTransport::create(ctx).await?;
     let bind = cmd.tcp_listener_address;
+    // This listener gives exclusive access to our node, make sure this is intended
+    // + make sure this tcp address is only reachable from the local loopback and/or intended
+    // network
     let (socket_addr, listened_worker_address) = tcp.listen(&bind).await?;
 
     let projects = cfg.inner().lookup().projects().collect();

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -194,11 +194,15 @@ impl<'a> Rpc<'a> {
                 let addr = match tcp {
                     None => {
                         let tcp = TcpTransport::create(ctx).await?;
+                        // Connection without a Session gives exclusive access to the node
+                        // that runs that connection, make sure it's intended
                         tcp.connect(addr_str).await?
                     }
                     Some(tcp) => {
                         // Create a new connection anyway
                         tcp.connect(addr_str).await?
+                        // Connection without a Session gives exclusive access to the node
+                        // that runs that connection, make sure it's intended
                     }
                 };
                 to.modify().prepend(addr);

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
 
 pub use config::*;
-use ockam::{Address, Context, NodeBuilder, Route, TcpTransport};
+use ockam::{Address, Context, NodeBuilder, Route, TcpConnectionTrustOptions, TcpTransport};
 use ockam_api::cli_state::{CliState, NodeState};
 use ockam_api::config::lookup::{InternetAddress, LookupMeta};
 use ockam_api::nodes::NODEMANAGER_ADDR;
@@ -196,11 +196,13 @@ impl<'a> Rpc<'a> {
                         let tcp = TcpTransport::create(ctx).await?;
                         // Connection without a Session gives exclusive access to the node
                         // that runs that connection, make sure it's intended
-                        tcp.connect(addr_str).await?
+                        tcp.connect(addr_str, TcpConnectionTrustOptions::new())
+                            .await?
                     }
                     Some(tcp) => {
                         // Create a new connection anyway
-                        tcp.connect(addr_str).await?
+                        tcp.connect(addr_str, TcpConnectionTrustOptions::new())
+                            .await?
                         // Connection without a Session gives exclusive access to the node
                         // that runs that connection, make sure it's intended
                     }

--- a/implementations/rust/ockam/ockam_core/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control.rs
@@ -28,6 +28,7 @@ use core::fmt::Debug;
 #[async_trait]
 #[allow(clippy::wrong_self_convention)]
 pub trait IncomingAccessControl: Debug + Send + Sync + 'static {
+    // TODO: Consider &mut self
     /// Return true if the message is allowed to pass, and false if not.
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool>;
 }
@@ -58,6 +59,7 @@ pub trait IncomingAccessControl: Debug + Send + Sync + 'static {
 #[async_trait]
 #[allow(clippy::wrong_self_convention)]
 pub trait OutgoingAccessControl: Debug + Send + Sync + 'static {
+    // TODO: Consider &mut self
     /// Return true if the message is allowed to pass, and false if not.
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool>;
 }

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -227,6 +227,7 @@ pub mod sync {
     pub use alloc::sync::Arc;
 
     /// Wrap `spin::RwLock` as it does not return LockResult<Guard> like `std::sync::Mutex`.
+    #[derive(Debug)]
     pub struct RwLock<T>(spin::RwLock<T>);
     impl<T> RwLock<T> {
         /// Creates a new spinlock wrapping the supplied data.

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod api;
 pub mod compat;
 /// Debugger
 pub mod debugger;
+pub mod sessions;
 pub mod vault;
 
 mod cbor_utils;

--- a/implementations/rust/ockam/ockam_core/src/sessions.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions.rs
@@ -41,7 +41,7 @@ impl Sessions {
 
     /// Get [`SessionId`] for given [`Address`]
     pub fn get_session_id(&self, address: &Address) -> Option<SessionId> {
-        match self.internal.write().unwrap().get_info(address) {
+        match self.internal.read().unwrap().get_info(address) {
             Some(address_info) => address_info.session_id.clone(),
             None => None,
         }
@@ -57,7 +57,7 @@ impl Sessions {
 
     /// Get listener [`SessionId`] for given [`Address`]
     pub fn get_listener_session_id(&self, address: &Address) -> Option<SessionId> {
-        match self.internal.write().unwrap().get_info(address) {
+        match self.internal.read().unwrap().get_info(address) {
             Some(address_info) => address_info.listener_session_id.clone(),
             None => None,
         }
@@ -103,7 +103,7 @@ impl SessionsInternal {
             .unwrap()
     }
 
-    fn get_info(&mut self, address: &Address) -> Option<&AddressInfo> {
+    fn get_info(&self, address: &Address) -> Option<&AddressInfo> {
         self.data.iter().find(|&x| &x.address == address)
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/sessions.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions.rs
@@ -1,0 +1,109 @@
+//! Sessions
+//!
+//! Allows to setup Message Flow Authorization between two workers (in this case
+//! SecureChannel Decryptor and Tcp Receiver) to limit their interaction with other workers
+//! for security reasons.
+
+use crate::compat::rand::random;
+use crate::compat::sync::{Arc, RwLock};
+use crate::compat::vec::Vec;
+use crate::Address;
+
+mod access_control;
+mod local_info;
+mod session_id;
+
+pub use access_control::*;
+pub use local_info::*;
+pub use session_id::*;
+
+// TODO: Consider integrating this into Routing for better UX + to allow removing
+// entries from that storage
+/// Storage for Session-related data tied to an [`Address`]
+#[derive(Clone, Debug, Default)]
+pub struct Sessions {
+    internal: Arc<RwLock<SessionsInternal>>,
+}
+
+impl Sessions {
+    /// Generate a fresh random [`SessionId`]
+    pub fn generate_session_id(&self) -> SessionId {
+        random()
+    }
+
+    /// Mark that given [`Address`] belongs to the given [`SessionId`]
+    pub fn set_session_id(&self, address: &Address, session_id: &SessionId) {
+        let mut lock = self.internal.write().unwrap();
+        let address_info = lock.get_info_mut(address);
+
+        address_info.session_id = Some(session_id.clone());
+    }
+
+    /// Get [`SessionId`] for given [`Address`]
+    pub fn get_session_id(&self, address: &Address) -> Option<SessionId> {
+        match self.internal.write().unwrap().get_info(address) {
+            Some(address_info) => address_info.session_id.clone(),
+            None => None,
+        }
+    }
+
+    /// Mark that given [`Address`] belongs to the given listener [`SessionId`]
+    pub fn set_listener_session_id(&self, address: &Address, session_id: &SessionId) {
+        let mut lock = self.internal.write().unwrap();
+        let address_info = lock.get_info_mut(address);
+
+        address_info.listener_session_id = Some(session_id.clone());
+    }
+
+    /// Get listener [`SessionId`] for given [`Address`]
+    pub fn get_listener_session_id(&self, address: &Address) -> Option<SessionId> {
+        match self.internal.write().unwrap().get_info(address) {
+            Some(address_info) => address_info.listener_session_id.clone(),
+            None => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AddressInfo {
+    address: Address,
+    session_id: Option<SessionId>,
+    listener_session_id: Option<SessionId>,
+}
+
+impl AddressInfo {
+    fn new(
+        address: Address,
+        session_id: Option<SessionId>,
+        listener_session_id: Option<SessionId>,
+    ) -> Self {
+        Self {
+            address,
+            session_id,
+            listener_session_id,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct SessionsInternal {
+    data: Vec<AddressInfo>,
+}
+
+impl SessionsInternal {
+    fn get_info_mut(&mut self, address: &Address) -> &mut AddressInfo {
+        if !self.data.iter().any(|x| &x.address == address) {
+            let info = AddressInfo::new(address.clone(), None, None);
+            self.data.push(info);
+        }
+
+        self.data
+            .iter_mut()
+            .find(|x| &x.address == address)
+            .unwrap()
+    }
+
+    fn get_info(&mut self, address: &Address) -> Option<&AddressInfo> {
+        self.data.iter().find(|&x| &x.address == address)
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/sessions/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions/access_control.rs
@@ -1,0 +1,112 @@
+use crate::compat::boxed::Box;
+use crate::compat::sync::RwLock;
+use crate::sessions::{SessionId, Sessions};
+use crate::Result;
+use crate::{OutgoingAccessControl, RelayMessage};
+
+/// Builder for [`SessionOutgoingAccessControl`]
+pub struct SessionOutgoingAccessControlBuilder {
+    session_id: SessionId,
+    listener_session_id: Option<SessionId>,
+    allow_only_1_message_to_the_listener: bool,
+    sessions: Sessions,
+}
+
+impl SessionOutgoingAccessControlBuilder {
+    /// Constructor
+    pub fn new(session_id: SessionId, sessions: Sessions) -> Self {
+        Self {
+            session_id,
+            listener_session_id: None,
+            allow_only_1_message_to_the_listener: true,
+            sessions,
+        }
+    }
+
+    /// Consume the builder and build [`SessionOutgoingAccessControl`]
+    pub fn build(self) -> SessionOutgoingAccessControl {
+        SessionOutgoingAccessControl::new(
+            self.session_id,
+            self.listener_session_id,
+            self.allow_only_1_message_to_the_listener,
+            self.sessions,
+        )
+    }
+
+    /// Allow one message to the listener with given listener session id (this will
+    /// make listener to spawn a new session)
+    pub fn allow_one_message_to_the_listener(mut self, listener_session_id: SessionId) -> Self {
+        self.listener_session_id = Some(listener_session_id);
+        self.allow_only_1_message_to_the_listener = true;
+
+        self
+    }
+}
+
+/// Session Outgoing Access Control
+///
+/// Allows to send messages only to members of the given [`SessionId`] or message listener
+/// with given [`SessionId`]. Optionally, only 1 message can be passed to the listener.
+#[derive(Debug)]
+pub struct SessionOutgoingAccessControl {
+    session_id: SessionId,
+    listener_session_id: Option<SessionId>,
+    allow_only_1_message_to_the_listener: bool,
+    message_was_sent_to_the_listener: RwLock<bool>,
+    sessions: Sessions,
+}
+
+impl SessionOutgoingAccessControl {
+    /// Constructor
+    pub fn new(
+        session_id: SessionId,
+        listener_session_id: Option<SessionId>,
+        allow_only_1_message_to_the_listener: bool,
+        sessions: Sessions,
+    ) -> Self {
+        Self {
+            session_id,
+            listener_session_id,
+            allow_only_1_message_to_the_listener,
+            message_was_sent_to_the_listener: RwLock::new(false),
+            sessions,
+        }
+    }
+}
+
+#[async_trait]
+impl OutgoingAccessControl for SessionOutgoingAccessControl {
+    async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool> {
+        let onward_route = relay_msg.onward_route();
+
+        let next = onward_route.next()?;
+
+        // Allow messages to workers with the same session id
+        if let Some(address_session_id) = self.sessions.get_session_id(next) {
+            if address_session_id == self.session_id {
+                return crate::allow();
+            }
+        }
+
+        // Allow messages to the corresponding listener
+        if let (Some(listener_session_id), Some(address_listener_session_id)) = (
+            &self.listener_session_id,
+            self.sessions.get_listener_session_id(next),
+        ) {
+            // This is the intended listener
+            #[allow(clippy::collapsible_if)]
+            if listener_session_id == &address_listener_session_id {
+                // We haven't yet sent a message to it
+                if !self.allow_only_1_message_to_the_listener
+                    || !*self.message_was_sent_to_the_listener.read().unwrap()
+                {
+                    // Prevent further message to it
+                    *self.message_was_sent_to_the_listener.write().unwrap() = true;
+                    return crate::allow();
+                }
+            }
+        }
+
+        crate::deny()
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/sessions/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions/access_control.rs
@@ -8,7 +8,7 @@ use crate::{OutgoingAccessControl, RelayMessage};
 pub struct SessionOutgoingAccessControlBuilder {
     session_id: SessionId,
     listener_session_id: Option<SessionId>,
-    allow_only_1_message_to_the_listener: bool,
+    allow_one_message_to_the_listener: bool,
     sessions: Sessions,
 }
 
@@ -18,7 +18,7 @@ impl SessionOutgoingAccessControlBuilder {
         Self {
             session_id,
             listener_session_id: None,
-            allow_only_1_message_to_the_listener: true,
+            allow_one_message_to_the_listener: true,
             sessions,
         }
     }
@@ -28,7 +28,7 @@ impl SessionOutgoingAccessControlBuilder {
         SessionOutgoingAccessControl::new(
             self.session_id,
             self.listener_session_id,
-            self.allow_only_1_message_to_the_listener,
+            self.allow_one_message_to_the_listener,
             self.sessions,
         )
     }
@@ -37,7 +37,7 @@ impl SessionOutgoingAccessControlBuilder {
     /// make listener to spawn a new session)
     pub fn allow_one_message_to_the_listener(mut self, listener_session_id: SessionId) -> Self {
         self.listener_session_id = Some(listener_session_id);
-        self.allow_only_1_message_to_the_listener = true;
+        self.allow_one_message_to_the_listener = true;
 
         self
     }

--- a/implementations/rust/ockam/ockam_core/src/sessions/local_info.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions/local_info.rs
@@ -1,0 +1,74 @@
+use crate::errcode::{Kind, Origin};
+use crate::sessions::SessionId;
+use crate::{Decodable, Encodable, Error, LocalInfo, LocalMessage, Result};
+use serde::{Deserialize, Serialize};
+
+/// SessionId LocalInfo unique Identifier
+pub const SESSION_ID_IDENTIFIER: &str = "SESSION_ID_IDENTIFIER";
+
+/// Session LocalInfo used for LocalMessage
+#[derive(Serialize, Deserialize)]
+pub struct SessionIdLocalInfo {
+    session_id: SessionId,
+}
+
+impl SessionIdLocalInfo {
+    /// Try to decode `SessionIdLocalInfo` from general `LocalInfo`
+    pub fn from_local_info(value: &LocalInfo) -> Result<Self> {
+        if value.type_identifier() != SESSION_ID_IDENTIFIER {
+            return Err(Error::new(
+                Origin::Core,
+                Kind::Invalid,
+                "LocalInfoId doesn't match",
+            ));
+        }
+
+        if let Ok(info) = SessionIdLocalInfo::decode(value.data()) {
+            return Ok(info);
+        }
+
+        Err(Error::new(
+            Origin::Core,
+            Kind::Invalid,
+            "LocalInfoId doesn't match",
+        ))
+    }
+
+    /// Encode `SessionIdLocalInfo` to general `LocalInfo`
+    pub fn to_local_info(&self) -> Result<LocalInfo> {
+        Ok(LocalInfo::new(SESSION_ID_IDENTIFIER.into(), self.encode()?))
+    }
+
+    /// Find `SessionIdLocalInfo` in a list of general `LocalInfo` of that `LocalMessage`
+    pub fn find_info(local_msg: &LocalMessage) -> Result<Self> {
+        Self::find_info_from_list(local_msg.local_info())
+    }
+
+    /// Find `SessionIdLocalInfo` in a list of general `LocalInfo`
+    pub fn find_info_from_list(local_info: &[LocalInfo]) -> Result<Self> {
+        if let Some(local_info) = local_info
+            .iter()
+            .find(|x| x.type_identifier() == SESSION_ID_IDENTIFIER)
+        {
+            Self::from_local_info(local_info)
+        } else {
+            Err(Error::new(
+                Origin::Core,
+                Kind::Invalid,
+                "LocalInfoId doesn't match",
+            ))
+        }
+    }
+
+    /// Constructor
+    pub fn new(session_id: SessionId) -> Self {
+        Self { session_id }
+    }
+}
+
+impl SessionIdLocalInfo {
+    /// [`SessionId`]
+    pub fn session_id(&self) -> &SessionId {
+        &self.session_id
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/sessions/session_id.rs
+++ b/implementations/rust/ockam/ockam_core/src/sessions/session_id.rs
@@ -1,0 +1,15 @@
+use crate::compat::rand::distributions::{Distribution, Standard};
+use crate::compat::rand::Rng;
+use crate::compat::string::String;
+use serde::{Deserialize, Serialize};
+
+/// Unique random identifier of a session
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct SessionId(String);
+
+impl Distribution<SessionId> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> SessionId {
+        let address: [u8; 16] = rng.gen();
+        SessionId(hex::encode(address))
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -20,12 +20,14 @@ default = ["std", "software_vault", "noise_xx"]
 noise_xx = ["ockam_key_exchange_xx"]
 software_vault = [
     "ockam_vault",
+    "ockam_vault/rustcrypto"
 ]
 lease_proto_json = ["serde_json"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
 std = [
+    "alloc",
     "ockam_core/std",
     "ockam_macros/std",
     "ockam_key_exchange_xx/std",

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -33,52 +33,30 @@ use core::time::Duration;
 use ockam_core::{Address, AsyncTryClone, Result, Route};
 
 impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
-    /// Spawns a SecureChannel listener at given `Address`
+    /// Spawns a SecureChannel listener at given `Address` with given [`SecureChannelListenerTrustOptions`]
     pub async fn create_secure_channel_listener(
         &self,
         address: impl Into<Address>,
-        trust_policy: impl TrustPolicy,
-    ) -> Result<()> {
-        self.create_secure_channel_listener_trust(
-            address,
-            SecureChannelListenerTrustOptions::new().with_trust_policy(trust_policy),
-        )
-        .await
-    }
-
-    /// Spawns a SecureChannel listener at given `Address` with given [`SecureChannelListenerTrustOptions`]
-    pub async fn create_secure_channel_listener_trust(
-        &self,
-        address: impl Into<Address>,
-        trust_options: SecureChannelListenerTrustOptions,
+        trust_options: impl Into<SecureChannelListenerTrustOptions>,
     ) -> Result<()> {
         let identity_clone = self.async_try_clone().await?;
 
-        IdentityChannelListener::create(&self.ctx, address.into(), trust_options, identity_clone)
-            .await?;
+        IdentityChannelListener::create(
+            &self.ctx,
+            address.into(),
+            trust_options.into(),
+            identity_clone,
+        )
+        .await?;
 
         Ok(())
     }
 
-    /// Initiate a SecureChannel using [`Route`] to the SecureChannel listener
-    #[deprecated]
+    /// Initiate a SecureChannel using `Route` to the SecureChannel listener and [`SecureChannelTrustOptions`]
     pub async fn create_secure_channel(
         &self,
         route: impl Into<Route>,
-        trust_policy: impl TrustPolicy,
-    ) -> Result<Address> {
-        self.create_secure_channel_trust(
-            route,
-            SecureChannelTrustOptions::new().with_trust_policy(trust_policy),
-        )
-        .await
-    }
-
-    /// Initiate a SecureChannel using `Route` to the SecureChannel listener and [`SecureChannelTrustOptions`]
-    pub async fn create_secure_channel_trust(
-        &self,
-        route: impl Into<Route>,
-        trust_options: SecureChannelTrustOptions,
+        trust_options: impl Into<SecureChannelTrustOptions>,
     ) -> Result<Address> {
         let identity_clone = self.async_try_clone().await?;
 
@@ -86,33 +64,17 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
             &self.ctx,
             route.into(),
             identity_clone,
-            trust_options,
+            trust_options.into(),
             Duration::from_secs(120),
         )
         .await
     }
 
-    /// Extended function to create a SecureChannel
-    #[deprecated]
+    /// Extended function to create a SecureChannel with [`SecureChannelTrustOptions`]
     pub async fn create_secure_channel_extended(
         &self,
         route: impl Into<Route>,
-        trust_policy: impl TrustPolicy,
-        timeout: Duration,
-    ) -> Result<Address> {
-        self.create_secure_channel_extended_trust(
-            route,
-            SecureChannelTrustOptions::new().with_trust_policy(trust_policy),
-            timeout,
-        )
-        .await
-    }
-
-    /// Extended function to create a SecureChannel with [`SecureChannelTrustOptions`]
-    pub async fn create_secure_channel_extended_trust(
-        &self,
-        route: impl Into<Route>,
-        trust_options: SecureChannelTrustOptions,
+        trust_options: impl Into<SecureChannelTrustOptions>,
         timeout: Duration,
     ) -> Result<Address> {
         let identity_clone = self.async_try_clone().await?;
@@ -121,7 +83,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
             &self.ctx,
             route.into(),
             identity_clone,
-            trust_options,
+            trust_options.into(),
             timeout,
         )
         .await

--- a/implementations/rust/ockam/ockam_identity/src/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel.rs
@@ -61,6 +61,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
     }
 
     /// Initiate a SecureChannel using [`Route`] to the SecureChannel listener
+    #[deprecated]
     pub async fn create_secure_channel(
         &self,
         route: impl Into<Route>,
@@ -92,6 +93,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Identity<V, S> {
     }
 
     /// Extended function to create a SecureChannel
+    #[deprecated]
     pub async fn create_secure_channel_extended(
         &self,
         route: impl Into<Route>,

--- a/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
@@ -1,22 +1,44 @@
 use crate::authenticated_storage::AuthenticatedStorage;
 use crate::channel::common::CreateResponderChannelMessage;
 use crate::channel::decryptor_worker::DecryptorWorker;
-use crate::{Identity, IdentityVault, TrustPolicy};
-use ockam_core::compat::{boxed::Box, sync::Arc};
-use ockam_core::{AsyncTryClone, Result, Routed, Worker};
+use crate::{Identity, IdentityVault, SecureChannelListenerTrustOptions};
+use ockam_core::compat::boxed::Box;
+use ockam_core::sessions::SessionIdLocalInfo;
+use ockam_core::{Address, AllowAll, AsyncTryClone, DenyAll, Result, Routed, Worker};
 use ockam_node::Context;
 
 pub(crate) struct IdentityChannelListener<V: IdentityVault, S: AuthenticatedStorage> {
-    trust_policy: Arc<dyn TrustPolicy>,
+    trust_options: SecureChannelListenerTrustOptions,
     identity: Identity<V, S>,
 }
 
 impl<V: IdentityVault, S: AuthenticatedStorage> IdentityChannelListener<V, S> {
-    pub fn new(trust_policy: impl TrustPolicy, identity: Identity<V, S>) -> Self {
-        IdentityChannelListener {
-            trust_policy: Arc::new(trust_policy),
+    pub fn new(trust_options: SecureChannelListenerTrustOptions, identity: Identity<V, S>) -> Self {
+        Self {
+            trust_options,
             identity,
         }
+    }
+
+    pub async fn create(
+        ctx: &Context,
+        address: Address,
+        trust_options: SecureChannelListenerTrustOptions,
+        identity: Identity<V, S>,
+    ) -> Result<()> {
+        if let Some((sessions, session_id)) = &trust_options.session {
+            sessions.set_listener_session_id(&address, session_id);
+        }
+
+        let listener = Self::new(trust_options, identity);
+
+        ctx.start_worker(
+            address, listener, AllowAll, // TODO: @ac allow to customize
+            DenyAll,
+        )
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -30,8 +52,16 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Worker for IdentityChannelListen
         ctx: &mut Self::Context,
         msg: Routed<Self::Message>,
     ) -> Result<()> {
-        let trust_policy = Arc::clone(&self.trust_policy);
         let identity = self.identity.async_try_clone().await?;
-        DecryptorWorker::create_responder(ctx, identity, trust_policy, msg).await
+
+        // Check if there is a session that connection worker added to LocalInfo
+        // If yet - decryptor will be added to that session to be able to receive further messages
+        // from the transport connection
+        let session_id = SessionIdLocalInfo::find_info(msg.local_message())
+            .ok()
+            .map(|x| x.session_id().clone());
+        let trust_options = self.trust_options.secure_channel_trust_options(session_id);
+
+        DecryptorWorker::create_responder(ctx, identity, trust_options, msg).await
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/listener.rs
@@ -55,7 +55,7 @@ impl<V: IdentityVault, S: AuthenticatedStorage> Worker for IdentityChannelListen
         let identity = self.identity.async_try_clone().await?;
 
         // Check if there is a session that connection worker added to LocalInfo
-        // If yet - decryptor will be added to that session to be able to receive further messages
+        // If yes - decryptor will be added to that session to be able to receive further messages
         // from the transport connection
         let session_id = SessionIdLocalInfo::find_info(msg.local_message())
             .ok()

--- a/implementations/rust/ockam/ockam_identity/src/channel/trust_options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/trust_options.rs
@@ -1,0 +1,90 @@
+use crate::{TrustEveryonePolicy, TrustPolicy};
+use ockam_core::compat::sync::Arc;
+use ockam_core::sessions::{SessionId, Sessions};
+
+/// Trust options for a Secure Channel
+pub struct SecureChannelTrustOptions {
+    pub(crate) ciphertext_session: Option<(Sessions, SessionId)>,
+    pub(crate) _plaintext_session: Option<(Sessions, SessionId)>,
+    pub(crate) trust_policy: Arc<dyn TrustPolicy>,
+}
+
+impl Default for SecureChannelTrustOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecureChannelTrustOptions {
+    /// Constructor
+    pub fn new() -> Self {
+        Self {
+            ciphertext_session: None,
+            _plaintext_session: None,
+            trust_policy: Arc::new(TrustEveryonePolicy),
+        }
+    }
+
+    /// Set session for ciphertext part of the Secure Channel
+    pub fn with_ciphertext_session(mut self, sessions: &Sessions, session_id: &SessionId) -> Self {
+        self.ciphertext_session = Some((sessions.clone(), session_id.clone()));
+        self
+    }
+
+    /// Set Trust Policy
+    pub fn with_trust_policy(mut self, trust_policy: impl TrustPolicy) -> Self {
+        self.trust_policy = Arc::new(trust_policy);
+        self
+    }
+}
+
+/// Trust options for a Secure Channel Listener
+pub struct SecureChannelListenerTrustOptions {
+    pub(crate) session: Option<(Sessions, SessionId)>,
+    pub(crate) trust_policy: Arc<dyn TrustPolicy>,
+}
+
+impl Default for SecureChannelListenerTrustOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SecureChannelListenerTrustOptions {
+    /// Constructor
+    pub fn new() -> Self {
+        Self {
+            session: None,
+            trust_policy: Arc::new(TrustEveryonePolicy),
+        }
+    }
+
+    /// Set session for this listener
+    pub fn with_session(mut self, sessions: &Sessions, listener_session_id: &SessionId) -> Self {
+        self.session = Some((sessions.clone(), listener_session_id.clone()));
+        self
+    }
+
+    /// Set trust policy
+    pub fn with_trust_policy(mut self, trust_policy: impl TrustPolicy) -> Self {
+        self.trust_policy = Arc::new(trust_policy);
+        self
+    }
+
+    pub(crate) fn secure_channel_trust_options(
+        &self,
+        session_id: Option<SessionId>,
+    ) -> SecureChannelTrustOptions {
+        let trust_options =
+            SecureChannelTrustOptions::new().with_trust_policy(self.trust_policy.clone());
+
+        match (&self.session, session_id) {
+            // Ignore listener_session_id, since we're spawning dedicated decryptor after
+            // listener received the message
+            (Some((sessions, _listener_session_id)), Some(session_id)) => {
+                trust_options.with_ciphertext_session(sessions, &session_id)
+            }
+            _ => trust_options,
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/channel/trust_options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/trust_options.rs
@@ -88,3 +88,25 @@ impl SecureChannelListenerTrustOptions {
         }
     }
 }
+
+// Keeps backwards compatibility to allow creating secure channel by only specifying a TrustPolicy
+// TODO: remove in the future to make API safer
+impl<T> From<T> for SecureChannelTrustOptions
+where
+    T: TrustPolicy,
+{
+    fn from(trust_policy: T) -> Self {
+        Self::new().with_trust_policy(trust_policy)
+    }
+}
+
+// Keeps backwards compatibility to allow creating secure channel by only specifying a TrustPolicy
+// TODO: remove in the future to make API safer
+impl<T> From<T> for SecureChannelListenerTrustOptions
+where
+    T: TrustPolicy,
+{
+    fn from(trust_policy: T) -> Self {
+        Self::new().with_trust_policy(trust_policy)
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential_issuer.rs
@@ -204,6 +204,7 @@ impl CredentialIssuerClient {
 #[ockam_core::async_trait]
 impl CredentialIssuerApi for CredentialIssuerClient {
     async fn public_identity(&self) -> Result<PublicIdentity> {
+        // TODO: Create a tcp connection here + use sessions
         let channel = self
             .identity
             .create_secure_channel(self.credential_issuer_route.clone(), TrustEveryonePolicy)
@@ -220,6 +221,7 @@ impl CredentialIssuerApi for CredentialIssuerClient {
     }
 
     async fn get_credential(&self, subject: &IdentityIdentifier) -> Result<Option<Credential>> {
+        // TODO: Create a tcp connection here + use sessions
         let channel = self
             .identity
             .create_secure_channel(self.credential_issuer_route.clone(), TrustEveryonePolicy)

--- a/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/message_flow_auth.rs
@@ -1,0 +1,318 @@
+use core::time::Duration;
+use ockam_core::compat::net::SocketAddr;
+use ockam_core::sessions::{SessionId, Sessions};
+use ockam_core::{route, Address, AllowAll, Result, Route};
+use ockam_identity::authenticated_storage::mem::InMemoryStorage;
+use ockam_identity::{
+    Identity, SecureChannelListenerTrustOptions, SecureChannelTrustOptions, TrustEveryonePolicy,
+};
+use ockam_node::Context;
+use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
+use ockam_vault::Vault;
+use rand::random;
+
+async fn check_message_flow(ctx: &Context, route: Route, should_pass: bool) -> Result<()> {
+    let address = Address::random_local();
+    let mut receiving_ctx = ctx
+        .new_detached(address.clone(), AllowAll, AllowAll)
+        .await?;
+
+    let msg: [u8; 4] = random();
+    let msg = hex::encode(&msg);
+    ctx.send(route![route, address], msg.clone()).await?;
+
+    if should_pass {
+        let msg_received = receiving_ctx.receive::<String>().await?.take().body();
+        assert_eq!(msg_received, msg);
+    } else {
+        let res = receiving_ctx.receive_timeout::<String>(1).await;
+        assert!(res.is_err(), "Messages should not pass for given route");
+    }
+
+    Ok(())
+}
+
+struct TcpListenerInfo {
+    tcp: TcpTransport,
+    socket_addr: SocketAddr,
+    session: Option<(Sessions, SessionId)>,
+}
+
+impl TcpListenerInfo {
+    fn get_connection(&self) -> Address {
+        self.tcp
+            .registry()
+            .get_all_sender_workers()
+            .first()
+            .unwrap()
+            .clone()
+    }
+}
+
+async fn create_tcp_listener(ctx: &Context, with_session: bool) -> Result<TcpListenerInfo> {
+    let tcp = TcpTransport::create(ctx).await?;
+    let (socket_addr, session) = if with_session {
+        let sessions = Sessions::default();
+        let session_id = sessions.generate_session_id();
+        let trust_options = TcpListenerTrustOptions::new().with_session(&sessions, &session_id);
+        let (socket_addr, _) = tcp.listen_trust("127.0.0.1:0", trust_options).await?;
+        (socket_addr, Some((sessions, session_id)))
+    } else {
+        let (socket_addr, _) = tcp.listen("127.0.0.1:0").await?;
+        (socket_addr, None)
+    };
+
+    let info = TcpListenerInfo {
+        tcp,
+        socket_addr,
+        session,
+    };
+
+    Ok(info)
+}
+
+struct TcpConnectionInfo {
+    address: Address,
+    session: Option<(Sessions, SessionId)>,
+}
+
+async fn create_connection(
+    ctx: &Context,
+    socket_addr: &SocketAddr,
+    with_session: bool,
+) -> Result<TcpConnectionInfo> {
+    let tcp = TcpTransport::create(ctx).await?;
+    let (address, session) = if with_session {
+        let sessions = Sessions::default();
+        let session_id = sessions.generate_session_id();
+        let trust_options = TcpConnectionTrustOptions::new().with_session(&sessions, &session_id);
+        let address = tcp
+            .connect_trust(socket_addr.to_string(), trust_options)
+            .await?;
+        (address, Some((sessions, session_id)))
+    } else {
+        let address = tcp.connect(socket_addr.to_string()).await?;
+        (address, None)
+    };
+
+    let info = TcpConnectionInfo { address, session };
+
+    Ok(info)
+}
+
+struct SecureChannelListenerInfo {
+    identity: Identity<Vault, InMemoryStorage>,
+}
+
+impl SecureChannelListenerInfo {
+    fn get_channel(&self) -> Address {
+        self.identity
+            .secure_channel_registry()
+            .get_channel_list()
+            .first()
+            .unwrap()
+            .encryptor_messaging_address()
+            .clone()
+    }
+}
+
+async fn create_secure_channel_listener(
+    ctx: &Context,
+    session: &Option<(Sessions, SessionId)>,
+) -> Result<SecureChannelListenerInfo> {
+    let identity = Identity::create(ctx, &Vault::create()).await?;
+
+    if let Some((sessions, session_id)) = session {
+        let trust_options =
+            SecureChannelListenerTrustOptions::new().with_session(sessions, session_id);
+        identity
+            .create_secure_channel_listener_trust("listener", trust_options)
+            .await?;
+    } else {
+        identity
+            .create_secure_channel_listener("listener", TrustEveryonePolicy)
+            .await?;
+    }
+
+    let info = SecureChannelListenerInfo { identity };
+
+    Ok(info)
+}
+
+struct SecureChannelInfo {
+    identity: Identity<Vault, InMemoryStorage>,
+    address: Address,
+}
+
+async fn create_secure_channel(
+    ctx: &Context,
+    connection: &TcpConnectionInfo,
+) -> Result<SecureChannelInfo> {
+    let identity = Identity::create(ctx, &Vault::create()).await?;
+
+    let address = if let Some((sessions, session_id)) = &connection.session {
+        let trust_options =
+            SecureChannelTrustOptions::new().with_ciphertext_session(sessions, session_id);
+        identity
+            .create_secure_channel_trust(
+                route![connection.address.clone(), "listener"],
+                trust_options,
+            )
+            .await?
+    } else {
+        identity
+            .create_secure_channel(
+                route![connection.address.clone(), "listener"],
+                TrustEveryonePolicy,
+            )
+            .await?
+    };
+
+    let info = SecureChannelInfo { identity, address };
+
+    Ok(info)
+}
+
+#[allow(non_snake_case)]
+#[ockam_macros::test]
+async fn sessions__secure_channel_over_tcp_without_session__should_pass_messages(
+    ctx: &mut Context,
+) -> Result<()> {
+    let bob_tcp_info = create_tcp_listener(ctx, false).await?;
+
+    let bob_listener_info = create_secure_channel_listener(ctx, &bob_tcp_info.session).await?;
+
+    let connection_to_bob = create_connection(ctx, &bob_tcp_info.socket_addr, false).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let connection_to_alice = bob_tcp_info.get_connection();
+
+    check_message_flow(ctx, route![connection_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![connection_to_alice.clone()], true).await?;
+
+    let channel_to_bob = create_secure_channel(ctx, &connection_to_bob).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let channel_to_alice = bob_listener_info.get_channel();
+
+    check_message_flow(ctx, route![channel_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![channel_to_alice.clone()], true).await?;
+
+    ctx.stop().await
+}
+
+#[allow(non_snake_case)]
+#[ockam_macros::test]
+async fn sessions__secure_channel_over_tcp_with_alice_session__should_not_pass_messages(
+    ctx: &mut Context,
+) -> Result<()> {
+    let bob_tcp_info = create_tcp_listener(ctx, false).await?;
+
+    let connection_to_bob = create_connection(ctx, &bob_tcp_info.socket_addr, true).await?;
+
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let connection_to_alice = bob_tcp_info.get_connection();
+
+    check_message_flow(ctx, route![connection_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![connection_to_alice.clone()], false).await?;
+
+    let bob_listener_info = create_secure_channel_listener(ctx, &bob_tcp_info.session).await?;
+
+    let channel_to_bob = create_secure_channel(ctx, &connection_to_bob).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let channel_to_alice = bob_listener_info.get_channel();
+
+    check_message_flow(ctx, route![channel_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![channel_to_alice.clone()], true).await?;
+
+    let res = channel_to_bob
+        .identity
+        .create_secure_channel_extended(
+            route![connection_to_bob.address.clone(), "listener"],
+            TrustEveryonePolicy,
+            Duration::from_secs(1),
+        )
+        .await;
+    assert!(
+        res.is_err(),
+        "We can only create 1 secure channel with that connection"
+    );
+
+    ctx.stop().await
+}
+
+#[allow(non_snake_case)]
+#[ockam_macros::test]
+async fn sessions__secure_channel_over_tcp_with_bob_session__should_not_pass_messages(
+    ctx: &mut Context,
+) -> Result<()> {
+    let bob_tcp_info = create_tcp_listener(&ctx, true).await?;
+
+    let connection_to_bob = create_connection(ctx, &bob_tcp_info.socket_addr, false).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let connection_to_alice = bob_tcp_info.get_connection();
+
+    check_message_flow(ctx, route![connection_to_bob.address.clone()], false).await?;
+    check_message_flow(ctx, route![connection_to_alice.clone()], true).await?;
+
+    let bob_listener_info = create_secure_channel_listener(ctx, &bob_tcp_info.session).await?;
+
+    let channel_to_bob = create_secure_channel(ctx, &connection_to_bob).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let channel_to_alice = bob_listener_info.get_channel();
+
+    check_message_flow(ctx, route![channel_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![channel_to_alice.clone()], true).await?;
+
+    let res = channel_to_bob
+        .identity
+        .create_secure_channel_extended(
+            route![connection_to_bob.address.clone(), "listener"],
+            TrustEveryonePolicy,
+            Duration::from_secs(1),
+        )
+        .await;
+    assert!(
+        res.is_err(),
+        "We can only create 1 secure channel with that connection"
+    );
+
+    ctx.stop().await
+}
+
+#[allow(non_snake_case)]
+#[ockam_macros::test]
+async fn sessions__secure_channel_over_tcp_with_both_sides_session__should_not_pass_messages(
+    ctx: &mut Context,
+) -> Result<()> {
+    let bob_tcp_info = create_tcp_listener(ctx, true).await?;
+
+    let connection_to_bob = create_connection(ctx, &bob_tcp_info.socket_addr, true).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let connection_to_alice = bob_tcp_info.get_connection();
+
+    check_message_flow(ctx, route![connection_to_bob.address.clone()], false).await?;
+    check_message_flow(ctx, route![connection_to_alice.clone()], false).await?;
+
+    let bob_listener_info = create_secure_channel_listener(ctx, &bob_tcp_info.session).await?;
+
+    let channel_to_bob = create_secure_channel(ctx, &connection_to_bob).await?;
+    ctx.sleep(Duration::from_millis(50)).await; // Wait for workers to add themselves to the registry
+    let channel_to_alice = bob_listener_info.get_channel();
+
+    check_message_flow(ctx, route![channel_to_bob.address.clone()], true).await?;
+    check_message_flow(ctx, route![channel_to_alice.clone()], true).await?;
+
+    let res = channel_to_bob
+        .identity
+        .create_secure_channel_extended(
+            route![connection_to_bob.address.clone(), "listener"],
+            TrustEveryonePolicy,
+            Duration::from_secs(1),
+        )
+        .await;
+    assert!(
+        res.is_err(),
+        "We can only create 1 secure channel with that connection"
+    );
+
+    ctx.stop().await
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -28,10 +28,12 @@ extern crate alloc;
 mod portal;
 mod registry;
 mod transport;
+mod trust_options;
 
 pub use portal::*;
 pub use registry::*;
 pub use transport::*;
+pub use trust_options::*;
 
 mod workers;
 pub(crate) use workers::*;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/registry.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/registry.rs
@@ -80,6 +80,13 @@ impl TcpRegistry {
     }
 }
 
+impl TcpRegistry {
+    /// Return [`Address`]es of all active sender workers
+    pub fn get_all_sender_workers(&self) -> Vec<Address> {
+        self.registry.read().unwrap().sender_workers.clone()
+    }
+}
+
 #[derive(Default)]
 struct InternalRegistry {
     portal_workers: Vec<Address>,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -125,6 +125,7 @@ impl TcpTransport {
     /// let addr = tcp.connect("127.0.0.1:5000").await?; // and connect to port 5000
     /// # Ok(()) }
     /// ```
+    #[deprecated]
     pub async fn connect(&self, peer: impl Into<String>) -> Result<Address> {
         self.connect_trust(peer, TcpConnectionTrustOptions::new())
             .await
@@ -184,6 +185,7 @@ impl TcpTransport {
     /// let tcp = TcpTransport::create(&ctx).await?;
     /// tcp.listen("127.0.0.1:8000").await?;
     /// # Ok(()) }
+    #[deprecated]
     pub async fn listen(&self, bind_addr: impl AsRef<str>) -> Result<(SocketAddr, Address)> {
         self.listen_trust(bind_addr, TcpListenerTrustOptions::new())
             .await

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -31,26 +31,26 @@ pub(crate) const CLUSTER_NAME: &str = "_internals.transport.tcp";
 /// establishing a connection upon arrival of an initial message.
 ///
 /// ```rust
-/// use ockam_transport_tcp::TcpTransport;
+/// use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
 /// # use ockam_node::Context;
 /// # use ockam_core::Result;
 /// # async fn test(ctx: Context) -> Result<()> {
 /// let tcp = TcpTransport::create(&ctx).await?;
-/// tcp.listen("127.0.0.1:8000").await?; // Listen on port 8000
-/// tcp.connect("127.0.0.1:5000").await?; // And connect to port 5000
+/// tcp.listen("127.0.0.1:8000", TcpListenerTrustOptions::new()).await?; // Listen on port 8000
+/// tcp.connect("127.0.0.1:5000", TcpConnectionTrustOptions::new()).await?; // And connect to port 5000
 /// # Ok(()) }
 /// ```
 ///
 /// The same `TcpTransport` can also bind to multiple ports.
 ///
 /// ```rust
-/// use ockam_transport_tcp::TcpTransport;
+/// use ockam_transport_tcp::{TcpListenerTrustOptions, TcpTransport};
 /// # use ockam_node::Context;
 /// # use ockam_core::Result;
 /// # async fn test(ctx: Context) -> Result<()> {
 /// let tcp = TcpTransport::create(&ctx).await?;
-/// tcp.listen("127.0.0.1:8000").await?; // Listen on port 8000
-/// tcp.listen("127.0.0.1:9000").await?; // Listen on port 9000
+/// tcp.listen("127.0.0.1:8000", TcpListenerTrustOptions::new()).await?; // Listen on port 8000
+/// tcp.listen("127.0.0.1:9000", TcpListenerTrustOptions::new()).await?; // Listen on port 9000
 /// # Ok(()) }
 /// ```
 #[derive(AsyncTryClone)]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -116,23 +116,16 @@ impl TcpTransport {
     /// Establish an outgoing TCP connection.
     ///
     /// ```rust
-    /// use ockam_transport_tcp::TcpTransport;
+    /// use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
     /// # use ockam_node::Context;
     /// # use ockam_core::Result;
     /// # async fn test(ctx: Context) -> Result<()> {
     /// let tcp = TcpTransport::create(&ctx).await?;
-    /// tcp.listen("127.0.0.1:8000").await?; // Listen on port 8000
-    /// let addr = tcp.connect("127.0.0.1:5000").await?; // and connect to port 5000
+    /// tcp.listen("127.0.0.1:8000", TcpListenerTrustOptions::new()).await?; // Listen on port 8000
+    /// let addr = tcp.connect("127.0.0.1:5000", TcpConnectionTrustOptions::new()).await?; // and connect to port 5000
     /// # Ok(()) }
     /// ```
-    #[deprecated]
-    pub async fn connect(&self, peer: impl Into<String>) -> Result<Address> {
-        self.connect_trust(peer, TcpConnectionTrustOptions::new())
-            .await
-    }
-
-    /// Connect with trust options
-    pub async fn connect_trust(
+    pub async fn connect(
         &self,
         peer: impl Into<String>,
         trust_options: TcpConnectionTrustOptions,
@@ -178,21 +171,14 @@ impl TcpTransport {
     /// which port was actually bound.
     ///
     /// ```rust
-    /// use ockam_transport_tcp::TcpTransport;
+    /// use ockam_transport_tcp::{TcpListenerTrustOptions, TcpTransport};
     /// # use ockam_node::Context;
     /// # use ockam_core::Result;
     /// # async fn test(ctx: Context) -> Result<()> {
     /// let tcp = TcpTransport::create(&ctx).await?;
-    /// tcp.listen("127.0.0.1:8000").await?;
+    /// tcp.listen("127.0.0.1:8000", TcpListenerTrustOptions::new()).await?;
     /// # Ok(()) }
-    #[deprecated]
-    pub async fn listen(&self, bind_addr: impl AsRef<str>) -> Result<(SocketAddr, Address)> {
-        self.listen_trust(bind_addr, TcpListenerTrustOptions::new())
-            .await
-    }
-
-    /// Start a listener with trust options
-    pub async fn listen_trust(
+    pub async fn listen(
         &self,
         bind_addr: impl AsRef<str>,
         trust_options: TcpListenerTrustOptions,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport.rs
@@ -156,7 +156,7 @@ impl TcpTransport {
             &addresses,
             socket,
             access_control.receiver_outgoing_access_control,
-            access_control.fresh_session_id,
+            access_control.session_id,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/trust_options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/trust_options.rs
@@ -9,7 +9,7 @@ pub(crate) struct TcpConnectionAccessControl {
 }
 
 /// Trust Options for a TCP connection
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct TcpConnectionTrustOptions {
     pub(crate) session: Option<(Sessions, SessionId)>,
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/trust_options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/trust_options.rs
@@ -1,0 +1,103 @@
+use ockam_core::compat::sync::Arc;
+use ockam_core::sessions::{SessionId, SessionOutgoingAccessControlBuilder, Sessions};
+use ockam_core::{IncomingAccessControl, LocalOnwardOnly, LocalSourceOnly, OutgoingAccessControl};
+
+pub(crate) struct TcpConnectionAccessControl {
+    pub fresh_session_id: Option<SessionId>,
+    pub sender_incoming_access_control: Arc<dyn IncomingAccessControl>,
+    pub receiver_outgoing_access_control: Arc<dyn OutgoingAccessControl>,
+}
+
+/// Trust Options for a TCP connection
+#[derive(Default, Debug)]
+pub struct TcpConnectionTrustOptions {
+    pub(crate) session: Option<(Sessions, SessionId)>,
+}
+
+impl TcpConnectionTrustOptions {
+    /// Constructor
+    pub fn new() -> Self {
+        Self { session: None }
+    }
+
+    /// Set session for this connection, in this case messages from that connection
+    /// will be only allowed to go to the [`Address`]es with the same [`SessionId`].
+    /// Information of [`Address`]' [`SessionId`] is stored in [`Sessions`] struct.
+    ///
+    /// Also this [`SessionId`] will be added to [`LocalInfo`] of the messages from that
+    /// connection
+    pub fn with_session(mut self, sessions: &Sessions, session_id: &SessionId) -> Self {
+        self.session = Some((sessions.clone(), session_id.clone()));
+        self
+    }
+
+    pub(crate) fn access_control(self) -> TcpConnectionAccessControl {
+        match self.session {
+            Some((sessions, session_id)) => TcpConnectionAccessControl {
+                fresh_session_id: Some(session_id.clone()),
+                sender_incoming_access_control: Arc::new(LocalSourceOnly),
+                receiver_outgoing_access_control: Arc::new(
+                    SessionOutgoingAccessControlBuilder::new(session_id, sessions).build(),
+                ),
+            },
+            None => TcpConnectionAccessControl {
+                fresh_session_id: None,
+                sender_incoming_access_control: Arc::new(LocalSourceOnly),
+                receiver_outgoing_access_control: Arc::new(LocalOnwardOnly),
+            },
+        }
+    }
+}
+
+/// Trust Options for a TCP listener
+#[derive(Default, Debug)]
+pub struct TcpListenerTrustOptions {
+    pub(crate) session: Option<(Sessions, SessionId)>,
+}
+
+impl TcpListenerTrustOptions {
+    /// Constructor
+    pub fn new() -> Self {
+        Self { session: None }
+    }
+
+    /// Set session for this listener, in this case messages from connections have following
+    /// outgoing access control:
+    ///  - 1 message is allowed to the [`Address`]
+    ///     with the same listener [`SessionId`] (e.g., SecureChannel listener)
+    /// - fresh [`SessionId`] is generated for each spawned connection
+    /// - messages are allowed to the [`Address`]es with the same fresh [`SessionId`]
+    /// - fresh [`SessionId`] is added to the [`LocalInfo`] of messages
+    ///     received by this TCP connection
+    ///
+    /// Information of [`Address`]' [`SessionId`] is stored in [`Sessions`] struct.
+    pub fn with_session(mut self, sessions: &Sessions, listener_session_id: &SessionId) -> Self {
+        self.session = Some((sessions.clone(), listener_session_id.clone()));
+        self
+    }
+
+    pub(crate) fn access_control(&self) -> TcpConnectionAccessControl {
+        match &self.session {
+            Some((sessions, listener_session_id)) => {
+                let fresh_session_id = sessions.generate_session_id();
+                TcpConnectionAccessControl {
+                    fresh_session_id: Some(fresh_session_id.clone()),
+                    sender_incoming_access_control: Arc::new(LocalSourceOnly),
+                    receiver_outgoing_access_control: Arc::new(
+                        SessionOutgoingAccessControlBuilder::new(
+                            fresh_session_id,
+                            sessions.clone(),
+                        )
+                        .allow_one_message_to_the_listener(listener_session_id.clone())
+                        .build(),
+                    ),
+                }
+            }
+            None => TcpConnectionAccessControl {
+                fresh_session_id: None,
+                sender_incoming_access_control: Arc::new(LocalSourceOnly),
+                receiver_outgoing_access_control: Arc::new(LocalOnwardOnly),
+            },
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/addresses.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/addresses.rs
@@ -1,0 +1,38 @@
+use crate::workers::ConnectionRole;
+use ockam_core::Address;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Addresses {
+    /// Sender internal address to receive messages from the Receiver (about the connection drop)
+    sender_internal_addr: Address,
+    /// Used to receive messages from other workers which are then serialized and sent over the wire
+    sender_address: Address,
+    /// Receiver Processor Address
+    receiver_address: Address,
+}
+
+impl Addresses {
+    pub(crate) fn generate(role: ConnectionRole) -> Self {
+        let role_str = role.str();
+
+        let sender_address = Address::random_tagged(&format!("TcpSendWorker_tx_addr_{}", role_str));
+        let sender_internal_addr =
+            Address::random_tagged(&format!("TcpSendWorker_int_addr_{}", role_str));
+        let receiver_address = Address::random_tagged(&format!("TcpRecvProcessor_{}", role_str));
+
+        Self {
+            sender_address,
+            sender_internal_addr,
+            receiver_address,
+        }
+    }
+    pub fn sender_internal_addr(&self) -> &Address {
+        &self.sender_internal_addr
+    }
+    pub fn sender_address(&self) -> &Address {
+        &self.sender_address
+    }
+    pub fn receiver_address(&self) -> &Address {
+        &self.receiver_address
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
@@ -95,7 +95,7 @@ impl Processor for TcpListenProcessor {
             peer,
             access_control.receiver_outgoing_access_control,
             // This session_id (if present) will be added to messages' LocalInfo
-            access_control.fresh_session_id,
+            access_control.session_id,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/mod.rs
@@ -1,7 +1,9 @@
+mod addresses;
 mod listener;
 mod receiver;
 mod sender;
 
+pub(crate) use addresses::*;
 pub(crate) use listener::*;
 pub(crate) use receiver::*;
 pub(crate) use sender::*;

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/keepalive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/keepalive.rs
@@ -1,7 +1,7 @@
 use ockam_core::compat::rand::{self, Rng};
 use ockam_core::{route, Result};
 use ockam_node::Context;
-use ockam_transport_tcp::TcpTransport;
+use ockam_transport_tcp::{TcpConnectionTrustOptions, TcpTransport};
 use std::time::Duration;
 use tracing::info;
 
@@ -16,7 +16,12 @@ async fn tcp_keepalive_test(ctx: &mut Context) -> Result<()> {
         .map(char::from)
         .collect();
 
-    let cloud = tcp.connect("1.node.ockam.network:4000").await?;
+    let cloud = tcp
+        .connect(
+            "1.node.ockam.network:4000",
+            TcpConnectionTrustOptions::new(),
+        )
+        .await?;
 
     // Send the message to the cloud node echoer
     // Wait to receive an echo and print it.


### PR DESCRIPTION
Implement Sessions that allow creating boundaries around individual TCP connections and SecureChannels which will make TcpReceiver send messages to this Secure Channel's Decryptor and no other Address