### PR TITLE
fix(rust): Allow more than 2 hops when paring show secure channel rou…

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -57,20 +57,18 @@ impl ListCommand {
                 let show_route = show_response
                     .route
                     .ok_or("Failed to retrieve route from show channel response")?;
-                let parts: Vec<&str> = show_route.split(" => ").collect();
-                if parts.len() != 2 {
-                    return Err(format!(
-                        "Invalid route received from show channel response -- {show_route}"
-                    ));
-                }
-
-                let r1 = &route![*parts.first().unwrap()];
-                let r2 = &route![*parts.get(1).unwrap()];
-                let ma1 = route_to_multiaddr(r1)
-                    .ok_or(format!("Failed to convert route {r1} to multi-address"))?;
-                let ma2 = route_to_multiaddr(r2)
-                    .ok_or(format!("Failed to convert route {r2} to multi-address"))?;
-                format!("{ma1}{ma2}")
+                show_route
+                    .split(" => ")
+                    .map(|p| {
+                        let r = route![p];
+                        route_to_multiaddr(&r)
+                            .ok_or(format!("Failed to convert route {r} to multi-address"))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("")
             };
 
             // if stdout is not interactive/tty write the secure channel address to it

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -372,4 +372,8 @@ teardown() {
 
   run curl --fail --head --max-time 10 "127.0.0.1:$port"
   assert_success
+
+  run "$OCKAM" secure-channel list --at green
+  assert_success
+  assert_output --partial "/service"
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

After creating secure channel with a forwarder node, the `secure-channel list` command returns invalid route error message.

## Proposed Changes

When parsing the route returned in the `ShowSecureChannelResponse`, allow the route contains more than two parts.
Fix #3989 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository.

<!-- Looking forward to merging your contribution!! -->
