### PR TITLE
fix(rust): fixed compatibility with older kafka protocol versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,12 +3571,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
+checksum = "21ecf2487e799604735754d2c5896106785987b441b5aee58f242e4d4963179a"
 dependencies = [
  "pathdiff",
- "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
@@ -1,6 +1,6 @@
+use crate::kafka::secure_channel_map::{KafkaSecureChannelController, UniqueSecureChannelId};
 use kafka_protocol::messages::ApiKey;
 use minicbor::{Decode, Encode};
-
 use ockam_core::compat::{
     collections::HashMap,
     fmt::Debug,
@@ -10,11 +10,10 @@ use ockam_core::AsyncTryClone;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
-use crate::kafka::secure_channel_map::{KafkaSecureChannelController, UniqueSecureChannelId};
-
 mod request;
 mod response;
-mod utils;
+mod tests;
+pub(super) mod utils;
 
 #[derive(Clone, Debug)]
 struct RequestInfo {

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -1,0 +1,203 @@
+#[cfg(test)]
+mod test {
+    use crate::kafka::inlet_map::KafkaInletMap;
+    use crate::kafka::protocol_aware::utils::{encode_request, encode_response};
+    use crate::kafka::protocol_aware::{Interceptor, UniqueSecureChannelId};
+    use crate::kafka::secure_channel_map::{KafkaEncryptedContent, KafkaSecureChannelController};
+    use crate::port_range::PortRange;
+    use kafka_protocol::messages::ApiKey;
+    use kafka_protocol::messages::BrokerId;
+    use kafka_protocol::messages::{ApiVersionsRequest, MetadataRequest, MetadataResponse};
+    use kafka_protocol::messages::{ApiVersionsResponse, RequestHeader, ResponseHeader};
+    use kafka_protocol::protocol::{Builder, StrBytes};
+    use ockam_core::compat::sync::Arc;
+    use ockam_core::{async_trait, route};
+    use ockam_node::Context;
+
+    struct DummySecureChannelController;
+
+    #[async_trait]
+    impl KafkaSecureChannelController for DummySecureChannelController {
+        async fn encrypt_content_for(
+            &self,
+            _context: &mut Context,
+            _topic_name: &str,
+            _partition_id: i32,
+            content: Vec<u8>,
+        ) -> ockam_core::Result<KafkaEncryptedContent> {
+            Ok(KafkaEncryptedContent {
+                content,
+                secure_channel_id: 0,
+            })
+        }
+
+        async fn decrypt_content_for(
+            &self,
+            _context: &mut Context,
+            _secure_channel_id: UniqueSecureChannelId,
+            encrypted_content: Vec<u8>,
+        ) -> ockam_core::Result<Vec<u8>> {
+            Ok(encrypted_content)
+        }
+
+        async fn start_forwarders_for(
+            &self,
+            _context: &mut Context,
+            _topic_id: &str,
+            _partitions: Vec<i32>,
+        ) -> ockam_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[allow(non_snake_case)]
+    #[ockam_macros::test(timeout = 5_000)]
+    async fn interceptor__basic_messages_with_several_api_versions__parsed_correctly(
+        context: &mut Context,
+    ) -> ockam::Result<()> {
+        let interceptor = Interceptor::new(
+            Arc::new(DummySecureChannelController {}),
+            Default::default(),
+        );
+
+        let inlet_map = KafkaInletMap::new(
+            route![],
+            "invalid-address".to_string(),
+            PortRange::new(0, 0).unwrap(),
+        );
+
+        let mut correlation_id = 0;
+
+        for api_version in 0..14 {
+            let result = interceptor
+                .intercept_request(
+                    context,
+                    encode_request(
+                        &RequestHeader::builder()
+                            .request_api_version(api_version)
+                            .correlation_id(correlation_id)
+                            .request_api_key(ApiKey::ApiVersionsKey as i16)
+                            .unknown_tagged_fields(Default::default())
+                            .client_id(None)
+                            .build()
+                            .unwrap(),
+                        &ApiVersionsRequest::builder()
+                            .client_software_name(StrBytes::from_str("mr. software"))
+                            .client_software_version(StrBytes::from_str("1.0.0"))
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        api_version,
+                        ApiKey::ApiVersionsKey,
+                    )
+                    .unwrap(),
+                )
+                .await;
+
+            if let Err(error) = result {
+                panic!("unexpected error: {error:?}");
+            }
+
+            let result = interceptor
+                .intercept_response(
+                    context,
+                    encode_response(
+                        &ResponseHeader::builder()
+                            .correlation_id(correlation_id)
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        &ApiVersionsResponse::builder()
+                            .error_code(0)
+                            .api_keys(Default::default())
+                            .throttle_time_ms(0)
+                            .supported_features(Default::default())
+                            .finalized_features_epoch(0)
+                            .finalized_features(Default::default())
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        api_version,
+                        ApiKey::ApiVersionsKey,
+                    )
+                    .unwrap(),
+                    &inlet_map,
+                )
+                .await;
+
+            if let Err(error) = result {
+                panic!("unexpected error: {error:?}");
+            }
+
+            correlation_id += 1;
+        }
+
+        for api_version in 0..14 {
+            let result = interceptor
+                .intercept_request(
+                    context,
+                    encode_request(
+                        &RequestHeader::builder()
+                            .request_api_version(api_version)
+                            .correlation_id(correlation_id)
+                            .request_api_key(ApiKey::MetadataKey as i16)
+                            .unknown_tagged_fields(Default::default())
+                            .client_id(None)
+                            .build()
+                            .unwrap(),
+                        &MetadataRequest::builder()
+                            .topics(None)
+                            .allow_auto_topic_creation(true)
+                            .include_cluster_authorized_operations(false)
+                            .include_topic_authorized_operations(false)
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        api_version,
+                        ApiKey::MetadataKey,
+                    )
+                    .unwrap(),
+                )
+                .await;
+
+            if let Err(error) = result {
+                panic!("unexpected error: {error:?}");
+            }
+
+            let result = interceptor
+                .intercept_response(
+                    context,
+                    encode_response(
+                        &ResponseHeader::builder()
+                            .correlation_id(correlation_id)
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        &MetadataResponse::builder()
+                            .throttle_time_ms(0)
+                            .brokers(Default::default())
+                            .cluster_id(None)
+                            .controller_id(BrokerId::from(0 as i32))
+                            .cluster_authorized_operations(-2147483648)
+                            .topics(Default::default())
+                            .unknown_tagged_fields(Default::default())
+                            .build()
+                            .unwrap(),
+                        api_version,
+                        ApiKey::MetadataKey,
+                    )
+                    .unwrap(),
+                    &inlet_map,
+                )
+                .await;
+
+            if let Err(error) = result {
+                panic!("unexpected error: {error:?}");
+            }
+
+            correlation_id += 1;
+        }
+
+        context.stop().await
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
@@ -1,10 +1,11 @@
 use crate::kafka::portal_worker::InterceptError;
 use bytes::BytesMut;
+use kafka_protocol::messages::ApiKey;
 use kafka_protocol::protocol::buf::ByteBuf;
 use kafka_protocol::protocol::{Decodable, Encodable, StrBytes};
 use std::io::{Error, ErrorKind};
 
-pub(super) fn decode<T, B>(buffer: &mut B, api_version: i16) -> Result<T, InterceptError>
+pub(crate) fn decode_body<T, B>(buffer: &mut B, api_version: i16) -> Result<T, InterceptError>
 where
     T: Decodable,
     B: ByteBuf,
@@ -19,15 +20,33 @@ where
     Ok(response)
 }
 
-pub(super) fn encode<H: Encodable, T: Encodable>(
+pub(crate) fn encode_request<H: Encodable, T: Encodable>(
     header: &H,
     body: &T,
     api_version: i16,
+    api_key: ApiKey,
 ) -> Result<BytesMut, InterceptError> {
     let mut buffer = BytesMut::new();
 
     header
-        .encode(&mut buffer, api_version)
+        .encode(&mut buffer, api_key.request_header_version(api_version))
+        .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
+    body.encode(&mut buffer, api_version)
+        .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
+
+    Ok(buffer)
+}
+
+pub(crate) fn encode_response<H: Encodable, T: Encodable>(
+    header: &H,
+    body: &T,
+    api_version: i16,
+    api_key: ApiKey,
+) -> Result<BytesMut, InterceptError> {
+    let mut buffer = BytesMut::new();
+
+    header
+        .encode(&mut buffer, api_key.response_header_version(api_version))
         .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
     body.encode(&mut buffer, api_version)
         .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;


### PR DESCRIPTION
## Current behavior

When older Kafka clients are used, the decoding of Kafka packets breaks, closing the connection.

## Proposed changes

Fixed a bug during encoding and decoding of request and response headers.
The header version doesn't depend solely on the API version, but it also depends on the type of message and whether it's a request or a response.

