### PR TITLE
feat(rust): move SocketAddrV4 parsing of TransportStatus as an intern…

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport.rs
@@ -1,6 +1,8 @@
 use minicbor::{Decode, Encode};
-use ockam_core::{CowStr, Result};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{CowStr, Error, Result};
 use std::fmt::{self, Display};
+use std::net::SocketAddrV4;
 
 use crate::cli_state::CliStateError;
 use crate::config::lookup::InternetAddress;
@@ -175,6 +177,12 @@ impl<'a> TransportStatus<'a> {
             worker_addr: worker_addr.into(),
             tid: tid.into(),
         }
+    }
+
+    pub fn socket_addr(&self) -> Result<SocketAddrV4> {
+        self.socket_addr
+            .parse::<SocketAddrV4>()
+            .map_err(|err| Error::new(Origin::Transport, Kind::Invalid, err))
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -9,7 +9,6 @@ use ockam_api::nodes::models;
 use ockam_multiaddr::proto::{DnsAddr, Tcp, Worker};
 use ockam_multiaddr::MultiAddr;
 use serde_json::json;
-use std::net::SocketAddrV4;
 
 #[derive(Clone, Debug, Args)]
 pub struct TcpConnectionNodeOpts {
@@ -44,8 +43,7 @@ impl CreateCommand {
         match opts.global_args.output_format {
             OutputFormat::Plain => {
                 let from = &self.node_opts.from;
-
-                let to = response.socket_addr.parse::<SocketAddrV4>()?;
+                let to = response.socket_addr()?;
                 if opts.global_args.no_color {
                     println!("\n  TCP Connection:");
                     println!("    ID: {}", response.tid);


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

In some commands, the TransportStatus socket_addr field is parsed manually.

## Proposed changes

Fixes https://github.com/build-trust/ockam/issues/4391

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Added a method to the TransportStatus struct to do that parsing.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
