### PR TITLE
Improve the credential exchange example

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
@@ -1,8 +1,8 @@
 use ockam::authenticated_storage::AuthenticatedAttributeStorage;
 use ockam::identity::credential_issuer::{CredentialIssuerApi, CredentialIssuerClient};
 use ockam::identity::{Identity, SecureChannelTrustOptions, TrustEveryonePolicy};
+use ockam::sessions::Sessions;
 use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpTransport};
-use ockam_core::sessions::Sessions;
 
 #[ockam::node]
 async fn main(mut ctx: Context) -> Result<()> {

--- a/examples/rust/get_started/examples/06-credentials-exchange-bob.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-bob.rs
@@ -6,9 +6,8 @@ use ockam::access_control::AllowAll;
 use ockam::authenticated_storage::AuthenticatedAttributeStorage;
 use ockam::identity::credential_issuer::{CredentialIssuerApi, CredentialIssuerClient};
 use ockam::identity::{Identity, SecureChannelListenerTrustOptions, SecureChannelTrustOptions, TrustEveryonePolicy};
-use ockam::{vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
-use ockam_core::route;
-use ockam_core::sessions::Sessions;
+use ockam::sessions::Sessions;
+use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -1,8 +1,8 @@
+use ockam::access_control::AllowAll;
 use ockam::access_control::IdentityIdAccessControl;
 use ockam::identity::credential_issuer::CredentialIssuer;
 use ockam::identity::TrustEveryonePolicy;
-use ockam::{Context, TcpListenerTrustOptions, TcpTransport};
-use ockam_core::{AllowAll, Result};
+use ockam::{Context, Result, TcpListenerTrustOptions, TcpTransport};
 
 /// This node starts a temporary credential issuer accessible via TCP on localhost:5000
 ///

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -4,11 +4,11 @@ use ockam::identity::credential::OneTimeCode;
 use ockam::identity::{Identity, SecureChannelTrustOptions, TrustEveryonePolicy, TrustMultiIdentifiersPolicy};
 
 use ockam::abac::AbacAccessControl;
+use ockam::access_control::AllowAll;
 use ockam::remote::RemoteForwarder;
 use ockam::{route, vault::Vault, Context, Result, TcpTransport};
 use ockam_api::authenticator::direct::{CredentialIssuerClient, RpcClient, TokenAcceptorClient};
 use ockam_api::{create_tcp_session, DefaultAddress};
-use ockam_core::AllowAll;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -67,6 +67,11 @@ pub mod access_control {
     pub use ockam_identity::access_control::*;
 }
 
+/// Sessions
+pub mod sessions {
+    pub use ockam_core::sessions::*;
+}
+
 /// Mark an Ockam Worker implementation.
 ///
 /// This is currently implemented as a re-export of the `async_trait` macro, but

--- a/implementations/rust/ockam/ockam_node/src/async_drop.rs
+++ b/implementations/rust/ockam/ockam_node/src/async_drop.rs
@@ -45,12 +45,12 @@ impl AsyncDrop {
 
             let (msg, mut reply) = NodeMessage::stop_worker(addr, true);
             if let Err(e) = self.sender.send(msg).await {
-                warn!("Failed sending AsyncDrop request to router: {}", e);
+                debug!("Failed sending AsyncDrop request to router: {}", e);
             }
 
             // Then check that address was properly shut down
             if reply.recv().await.is_none() {
-                warn!("AsyncDrop router reply was None");
+                debug!("AsyncDrop router reply was None");
             }
         }
     }

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -311,7 +311,7 @@ impl Router {
                     }
                 }
                 Err(err) => {
-                    warn!("Router error: {} while handling {}", err, msg_str);
+                    debug!("Router error: {} while handling {}", err, msg_str);
                 }
             }
         }


### PR DESCRIPTION
This PR removes the dependency on `ockam_core` (and replaces it with a dependency of `ockam`) + changes a log level to clean the execution trace of nodes when stopping the context.
