### PR TITLE
Fix merge queue race issue

### DIFF
--- a/.github/workflows/rust-lint-cargo-lock-ignored.yml
+++ b/.github/workflows/rust-lint-cargo-lock-ignored.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust Cargo Lock Lint
 
 permissions:
   contents: read
@@ -6,7 +6,7 @@ permissions:
 on:
   pull_request:
     paths-ignore:
-      - ".github/workflows/rust-link-cargo-lock.yml"
+      - ".github/workflows/rust-lint-cargo-lock.yml"
       - ".github/actions/**"
       - "**.toml"
       - "**/Cargo.lock"

--- a/.github/workflows/rust-lint-cargo-lock.yml
+++ b/.github/workflows/rust-lint-cargo-lock.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust Cargo Lock Lint
 
 permissions:
   contents: read
@@ -7,13 +7,13 @@ on:
   merge_group:
   pull_request:
     paths:
-      - ".github/workflows/rust-link-cargo-lock.yml"
+      - ".github/workflows/rust-lint-cargo-lock.yml"
       - ".github/actions/**"
       - "**.toml"
       - "**/Cargo.lock"
   push:
     paths:
-      - ".github/workflows/rust-link-cargo-lock.yml"
+      - ".github/workflows/rust-lint-cargo-lock.yml"
       - ".github/actions/**"
       - "**.toml"
       - "**/Cargo.lock"


### PR DESCRIPTION
To ensure only one CI workflow run per pull request, we add a concurrency rule as follow 
`workflow_name`-`commit sha of pull request`-`event that kickstarted the workflow e.g. pull_request, merge_queue, push event`

We currently have two workflows with same name, [Rust workflow](https://github.com/build-trust/ockam/blob/d18fd79ee98c7ca8dde161695a67dc516b1898fe/.github/workflows/rust.yml#L1) which is named as `Rust` and [Cargo lock lint workflow](https://github.com/build-trust/ockam/blob/d18fd79ee98c7ca8dde161695a67dc516b1898fe/.github/workflows/rust-lint-cargo-lock.yml#L1) which is also named as `Rust`. 

Having two workflow with same name clashes with our concurrency rule and causes a race issue where either rust test or cargo lock lint test has to fail, if Rust test fails, merge group blocks. 

This PR renames cargo lock lint workflow appropriately