### PR TITLE
test(rust): cleanup unused variables from bats tests

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -169,8 +169,8 @@ teardown() {
 
   fwd="$(random_str)"
   run "$OCKAM" forwarder create "$fwd" --at /project/default --to /node/blue
-  assert_output --partial "forward_to_$fwd"
   assert_success
+  assert_output --partial "forward_to_$fwd"
 
   run bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$fwd/service/api \
               | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -51,8 +51,6 @@ teardown() {
   blue_token=$($OCKAM project enroll --attribute role=member)
   OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
 
-  echo "OCKAM_HOME=$OCKAM_HOME;PROJECT=$(project_json_path)"
-
   # Green' identity was added by enroller
   run "$OCKAM" project authenticate --identity green --project-path "$PROJECT_JSON_PATH"
   assert_success
@@ -86,7 +84,6 @@ teardown() {
   run "$OCKAM" identity create green
   run "$OCKAM" identity create blue
   green_identifier=$($OCKAM identity show green)
-  blue_identifier=$($OCKAM identity show blue)
 
   # Create nodes for the non-enrolled identities using the exported project information
   run "$OCKAM" node create green --project "$ENROLLED_OCKAM_HOME/${project_name}_project.json" --identity green
@@ -116,6 +113,9 @@ teardown() {
   assert_success
   run "$OCKAM" space delete "${space_name}"
   assert_success
+
+  OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
+  teardown_home_dir
 }
 
 @test "projects - send a message to a project node from an embedded node, enrolled member on different install" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
@@ -46,7 +46,7 @@ teardown() {
               | $OCKAM tcp-inlet create --at /node/client_sidecar --from 127.0.0.1:$port --to -/service/outlet"
   assert_success
 
-  curl --head --max-time 10 "127.0.0.1:$port"
+  run curl --head --max-time 10 "127.0.0.1:$port"
   assert_success
 }
 
@@ -70,7 +70,7 @@ teardown() {
               | $OCKAM tcp-inlet create --at /node/c --from 127.0.0.1:$port --to -/service/outlet"
   assert_success
 
-  curl --head --max-time 10 "127.0.0.1:$port"
+  run curl --head --max-time 10 "127.0.0.1:$port"
   assert_success
 }
 


### PR DESCRIPTION
This [section here](https://github.com/build-trust/ockam/pull/4430/files#diff-7b9e7353cc1d5bad26ceadd80529b67b6b6585cde34ff581e4789f6bbff687ecR117-R118) also fixes a problem that was causing the bats tests to hang right before exiting even though all the tests where successful.