### PR TITLE
feat(rust): initialize the credential example with a change history and the latest key

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-alice.rs
@@ -11,13 +11,14 @@ async fn main(mut ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create an Identity representing Alice
-    // We preload Alice's vault with a secret key corresponding to the identity identifier
-    // P529d43ac7b01e23d3818d00e083508790bfe8825714644b98134db6c1a7a6602
+    // We preload Alice's vault with a change history and secret key corresponding to the identity identifier
+    // Pe92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638
     // which is an identifier known to the credential issuer, with some preset attributes
     let vault = Vault::create();
-    let key_id = "529d43ac7b01e23d3818d00e083508790bfe8825714644b98134db6c1a7a6602".to_string();
-    let secret = "acaf50c540be1494d67aaad78aca8d22ac62c4deb4fb113991a7b30a0bd0c757";
-    let alice = Identity::create_identity_with_secret(&ctx, vault, &key_id, secret).await?;
+
+    let identity_history = "01dcf392551f796ef1bcb368177e53f9a5875a962f67279259207d24a01e690721000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020a0d205f09cab9a9467591fcee560429aab1215d8136e5c985a6b7dc729e6f08203010140b098463a727454c0e5292390d8f4cbd4dd0cae5db95606832f3d0a138936487e1da1489c40d8a0995fce71cc1948c6bcfd67186467cdd78eab7e95c080141505";
+    let secret = "41b6873b20d95567bf958e6bab2808e9157720040882630b1bb37a72f4015cd2";
+    let alice = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
 
     // Create a client to the credential issuer
     let sessions = Sessions::default();

--- a/examples/rust/get_started/examples/06-credentials-exchange-bob.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-bob.rs
@@ -16,13 +16,13 @@ async fn main(ctx: Context) -> Result<()> {
     let tcp = TcpTransport::create(&ctx).await?;
 
     // Create an Identity representing Bob
-    // We preload Bob's vault with a secret key corresponding to the identity identifier
-    // P0189a2aec3799fe9d0dc0f982063022b697f18562a403eb46fa3d32be5bd31f8
+    // We preload Bob's vault with a change history and secret key corresponding to the identity identifier
+    // Pada09e0f96e56580f6a0cb54f55ecbde6c973db6732e30dfb39b178760aed041
     // which is an identifier known to the credential issuer, with some preset attributes
     let vault = Vault::create();
-    let key_id = "0189a2aec3799fe9d0dc0f982063022b697f18562a403eb46fa3d32be5bd31f8".to_string();
-    let secret = "08ddb4458a53d5493eac7e9941a1b0d06896efa2d1efac8cf225ee1ccb824458";
-    let bob = Identity::create_identity_with_secret(&ctx, vault, &key_id, secret).await?;
+    let identity_history = "01ed8a5b1303f975c1296c990d1bd3c1946cfef328de20531e3511ec5604ce0dd9000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020e8c328bc0cc07a374762091d037e69c36fdd4d2e1a651abd4d43a1362d3f800503010140a349968063d7337d0c965969fa9c640824c01a6d37fe130d4ab963b0271b9d5bbf0923faa5e27f15359554f94f08676df01b99d997944e4feaf0caaa1189480e";
+    let secret = "5b2b3f2abbd1787704d8f8b363529f8e2d8f423b6dd4b96a2c462e4f0e04ee18";
+    let bob = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
 
     // Create a client to a credential issuer
     let sessions = Sessions::default();

--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -10,15 +10,15 @@ async fn main(mut ctx: Context) -> Result<()> {
     // Initialize the TCP Transport
     let tcp = TcpTransport::create(&ctx).await?;
 
-    // Create an Identity representing Alice
-    // We preload Alice's vault with a change history and secret key corresponding to the identity identifier
+    // Create an Identity representing the client
+    // We preload the client vault with a change history and secret key corresponding to the identity identifier
     // Pe92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638
     // which is an identifier known to the credential issuer, with some preset attributes
     let vault = Vault::create();
 
     let identity_history = "01dcf392551f796ef1bcb368177e53f9a5875a962f67279259207d24a01e690721000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020a0d205f09cab9a9467591fcee560429aab1215d8136e5c985a6b7dc729e6f08203010140b098463a727454c0e5292390d8f4cbd4dd0cae5db95606832f3d0a138936487e1da1489c40d8a0995fce71cc1948c6bcfd67186467cdd78eab7e95c080141505";
     let secret = "41b6873b20d95567bf958e6bab2808e9157720040882630b1bb37a72f4015cd2";
-    let alice = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
+    let client = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
 
     // Create a client to the credential issuer
     let sessions = Sessions::default();
@@ -28,31 +28,31 @@ async fn main(mut ctx: Context) -> Result<()> {
     let issuer_trust_options = SecureChannelTrustOptions::new()
         .with_trust_policy(TrustEveryonePolicy)
         .with_ciphertext_session(&sessions, &issuer_session_id);
-    let issuer_channel = alice
+    let issuer_channel = client
         .create_secure_channel(route![issuer_connection, "issuer_listener"], issuer_trust_options)
         .await?;
     let issuer = CredentialIssuerClient::new(&ctx, route![issuer_channel]).await?;
 
-    // Get a credential for Alice (this is done via a secure channel)
-    let credential = issuer.get_credential(alice.identifier()).await?.unwrap();
+    // Get a credential for the client (this is done via a secure channel)
+    let credential = issuer.get_credential(client.identifier()).await?.unwrap();
     println!("got a credential from the issuer\n{credential}");
-    alice.set_credential(credential).await;
+    client.set_credential(credential).await;
 
-    // Create a secure channel to Bob's node
-    let bob_session_id = sessions.generate_session_id();
-    let bob_tcp_trust_options = TcpConnectionTrustOptions::new().with_session(&sessions, &bob_session_id);
-    let bob_connection = tcp.connect("127.0.0.1:4000", bob_tcp_trust_options).await?;
+    // Create a secure channel to the server node
+    let server_session_id = sessions.generate_session_id();
+    let server_tcp_trust_options = TcpConnectionTrustOptions::new().with_session(&sessions, &server_session_id);
+    let server_connection = tcp.connect("127.0.0.1:4000", server_tcp_trust_options).await?;
     let channel_trust_options = SecureChannelTrustOptions::new()
         .with_trust_policy(TrustEveryonePolicy)
-        .with_ciphertext_session(&sessions, &bob_session_id);
-    let channel = alice
-        .create_secure_channel(route![bob_connection, "bob_listener"], channel_trust_options)
+        .with_ciphertext_session(&sessions, &server_session_id);
+    let channel = client
+        .create_secure_channel(route![server_connection, "server_listener"], channel_trust_options)
         .await?;
     println!("created a secure channel at {channel:?}");
 
-    // Send Alice credentials over the secure channel
-    let storage = AuthenticatedAttributeStorage::new(alice.authenticated_storage().clone());
-    alice
+    // Send the client credentials over the secure channel
+    let storage = AuthenticatedAttributeStorage::new(client.authenticated_storage().clone());
+    client
         .present_credential_mutual(
             route![channel.clone(), "credential_exchange"],
             vec![&issuer.public_identity().await?],
@@ -62,8 +62,8 @@ async fn main(mut ctx: Context) -> Result<()> {
         .await?;
     println!("exchange done!");
 
-    // The echoer service should now be accessible to Alice because she
-    // presented the right credentials to Bob
+    // The echoer service should now be accessible to the client because she
+    // presented the right credentials to the server
     let received: String = ctx
         .send_and_receive(route![channel, "echoer"], "Hello!".to_string())
         .await?;

--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -22,9 +22,9 @@ async fn main(mut ctx: Context) -> Result<()> {
     //
     // We're hard coding this specific identity because its public identifier is known
     // to the credential issuer as a member of the production cluster.
-    let identity_history = "01dcf392551f796ef1bcb368177e53f9a5875a962f67279259207d24a01e690721000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020a0d205f09cab9a9467591fcee560429aab1215d8136e5c985a6b7dc729e6f08203010140b098463a727454c0e5292390d8f4cbd4dd0cae5db95606832f3d0a138936487e1da1489c40d8a0995fce71cc1948c6bcfd67186467cdd78eab7e95c080141505";
+    let change_history = "01dcf392551f796ef1bcb368177e53f9a5875a962f67279259207d24a01e690721000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020a0d205f09cab9a9467591fcee560429aab1215d8136e5c985a6b7dc729e6f08203010140b098463a727454c0e5292390d8f4cbd4dd0cae5db95606832f3d0a138936487e1da1489c40d8a0995fce71cc1948c6bcfd67186467cdd78eab7e95c080141505";
     let secret = "41b6873b20d95567bf958e6bab2808e9157720040882630b1bb37a72f4015cd2";
-    let client = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
+    let client = Identity::create_identity_with_change_history(&ctx, vault, change_history, secret).await?;
     let store = client.authenticated_storage();
 
     // Connect with the credential issuer and authenticate using the latest private

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -24,8 +24,8 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Create a CredentialIssuer which stores attributes for Alice and Bob, knowing their identity
     let issuer = CredentialIssuer::create(&ctx).await?;
-    let alice = "P529d43ac7b01e23d3818d00e083508790bfe8825714644b98134db6c1a7a6602".try_into()?;
-    let bob = "P0189a2aec3799fe9d0dc0f982063022b697f18562a403eb46fa3d32be5bd31f8".try_into()?;
+    let alice = "Pe92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638".try_into()?;
+    let bob = "Pada09e0f96e56580f6a0cb54f55ecbde6c973db6732e30dfb39b178760aed041".try_into()?;
 
     issuer.put_attribute_value(&alice, "name", "alice").await?;
     issuer.put_attribute_value(&bob, "name", "bob").await?;

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -4,16 +4,6 @@ use ockam::identity::credential_issuer::CredentialIssuer;
 use ockam::identity::TrustEveryonePolicy;
 use ockam::{Context, Result, TcpListenerTrustOptions, TcpTransport};
 
-/// This node starts a temporary credential issuer accessible via TCP on localhost:5000
-///
-/// In a real-life scenario this node would be an "Authority", a node holding
-/// attributes for a number of identities and able to issue credentials signed with its own key.
-///
-/// The process by which we declare to that Authority which identity holds which attributes is an
-/// enrollment process and would be driven by an "enroller node".
-/// For the simplicity of the example provided here we preload the credential issues node with some existing attributes
-/// for both Alice's and Bob's identities.
-///
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
     let issuer = CredentialIssuer::create(&ctx).await?;

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -14,17 +14,25 @@ use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, Tcp
 async fn main(ctx: Context) -> Result<()> {
     // Initialize the TCP Transport
     let tcp = TcpTransport::create(&ctx).await?;
+    let vault = Vault::create();
 
     // Create an Identity representing the server
-    // We preload the server vault with a change history and secret key corresponding to the identity identifier
-    // Pada09e0f96e56580f6a0cb54f55ecbde6c973db6732e30dfb39b178760aed041
-    // which is an identifier known to the credential issuer, with some preset attributes
-    let vault = Vault::create();
+    // Load an identity corresponding to the following public identifier
+    // Pe92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638
+    //
+    // We're hard coding this specific identity because its public identifier is known
+    // to the credential issuer as a member of the production cluster.
     let identity_history = "01ed8a5b1303f975c1296c990d1bd3c1946cfef328de20531e3511ec5604ce0dd9000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020e8c328bc0cc07a374762091d037e69c36fdd4d2e1a651abd4d43a1362d3f800503010140a349968063d7337d0c965969fa9c640824c01a6d37fe130d4ab963b0271b9d5bbf0923faa5e27f15359554f94f08676df01b99d997944e4feaf0caaa1189480e";
     let secret = "5b2b3f2abbd1787704d8f8b363529f8e2d8f423b6dd4b96a2c462e4f0e04ee18";
     let server = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
+    let store = server.authenticated_storage();
 
-    // Create a client to a credential issuer
+    // Connect with the credential issuer and authenticate using the latest private
+    // key of this program's hardcoded identity.
+    //
+    // The credential issuer already knows the public identifier of this identity
+    // as a member of the production cluster so it returns a signed credential
+    // attesting to that knowledge.
     let sessions = Sessions::default();
     let session_id = sessions.generate_session_id();
     let issuer_tcp_trust_options = TcpConnectionTrustOptions::new().with_session(&sessions, &session_id);
@@ -33,40 +41,38 @@ async fn main(ctx: Context) -> Result<()> {
         .with_trust_policy(TrustEveryonePolicy)
         .with_ciphertext_session(&sessions, &session_id);
     let issuer_channel = server
-        .create_secure_channel(route![issuer_connection, "issuer_listener"], issuer_trust_options)
+        .create_secure_channel(route![issuer_connection, "secure"], issuer_trust_options)
         .await?;
     let issuer = CredentialIssuerClient::new(&ctx, route![issuer_channel]).await?;
-
-    // Get a credential for the server (this is done via a secure channel)
     let credential = issuer.get_credential(server.identifier()).await?.unwrap();
-    println!("got a credential from the issuer\n{credential}");
+    println!("Credential:\n{credential}");
     server.set_credential(credential).await;
+
+    // Start an echoer worker that will only accept incoming requests from
+    // identities that have authenticated credentials issued by the above credential
+    // issuer. These credentials must also attest that requesting identity is
+    // a member of the production cluster.
+    let allow_production = AbacAccessControl::create(store.clone(), "cluster", "production");
+    ctx.start_worker("echoer", Echoer, allow_production, AllowAll).await?;
 
     // Start a worker which will receive credentials sent by the client and issued by the issuer node
     let issuer_identity = issuer.public_identity().await?;
-    let storage = AuthenticatedAttributeStorage::new(server.authenticated_storage().clone());
+    let storage = Arc::new(AuthenticatedAttributeStorage::new(store.clone()));
     server
-        .start_credential_exchange_worker(vec![issuer_identity], "credential_exchange", true, Arc::new(storage))
+        .start_credential_exchange_worker(vec![issuer_identity], "credentials", true, storage)
         .await?;
 
-    // Create a secure channel listener to allow the client to create a secure channel to the server node
+    // Start a secure channel listener that only allows channels with
+    // authenticated identities.
     let listener_session_id = sessions.generate_session_id();
-    let secure_channel_listener_trust_options = SecureChannelListenerTrustOptions::new()
+    let trust_options = SecureChannelListenerTrustOptions::new()
         .with_trust_policy(TrustEveryonePolicy)
         .with_session(&sessions, &listener_session_id);
-    server
-        .create_secure_channel_listener("server_listener", secure_channel_listener_trust_options)
-        .await?;
-    println!("created a secure channel listener");
-
-    // Start an echoer service which will only allow subjects with name = client
-    let client_only = AbacAccessControl::create(server.authenticated_storage().clone(), "name", "client");
-    ctx.start_worker("echoer", Echoer, client_only, AllowAll).await?;
+    server.create_secure_channel_listener("secure", trust_options).await?;
 
     // Create a TCP listener and wait for incoming connections
     let tcp_listener_trust_options = TcpListenerTrustOptions::new().with_session(&sessions, &listener_session_id);
     tcp.listen("127.0.0.1:4000", tcp_listener_trust_options).await?;
-    println!("created a TCP listener");
 
     // Don't call ctx.stop() here so this node runs forever.
     Ok(())

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -22,9 +22,9 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // We're hard coding this specific identity because its public identifier is known
     // to the credential issuer as a member of the production cluster.
-    let identity_history = "01ed8a5b1303f975c1296c990d1bd3c1946cfef328de20531e3511ec5604ce0dd9000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020e8c328bc0cc07a374762091d037e69c36fdd4d2e1a651abd4d43a1362d3f800503010140a349968063d7337d0c965969fa9c640824c01a6d37fe130d4ab963b0271b9d5bbf0923faa5e27f15359554f94f08676df01b99d997944e4feaf0caaa1189480e";
+    let change_history = "01ed8a5b1303f975c1296c990d1bd3c1946cfef328de20531e3511ec5604ce0dd9000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020e8c328bc0cc07a374762091d037e69c36fdd4d2e1a651abd4d43a1362d3f800503010140a349968063d7337d0c965969fa9c640824c01a6d37fe130d4ab963b0271b9d5bbf0923faa5e27f15359554f94f08676df01b99d997944e4feaf0caaa1189480e";
     let secret = "5b2b3f2abbd1787704d8f8b363529f8e2d8f423b6dd4b96a2c462e4f0e04ee18";
-    let server = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
+    let server = Identity::create_identity_with_change_history(&ctx, vault, change_history, secret).await?;
     let store = server.authenticated_storage();
 
     // Connect with the credential issuer and authenticate using the latest private

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 // This node starts a tcp listener, a secure channel listener, and an echoer worker.
 // It then runs forever waiting for messages.
 use hello_ockam::Echoer;
@@ -9,6 +8,7 @@ use ockam::identity::credential_issuer::{CredentialIssuerApi, CredentialIssuerCl
 use ockam::identity::{Identity, SecureChannelListenerTrustOptions, SecureChannelTrustOptions, TrustEveryonePolicy};
 use ockam::sessions::Sessions;
 use ockam::{route, vault::Vault, Context, Result, TcpConnectionTrustOptions, TcpListenerTrustOptions, TcpTransport};
+use std::sync::Arc;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -15,14 +15,14 @@ async fn main(ctx: Context) -> Result<()> {
     // Initialize the TCP Transport
     let tcp = TcpTransport::create(&ctx).await?;
 
-    // Create an Identity representing Bob
-    // We preload Bob's vault with a change history and secret key corresponding to the identity identifier
+    // Create an Identity representing the server
+    // We preload the server vault with a change history and secret key corresponding to the identity identifier
     // Pada09e0f96e56580f6a0cb54f55ecbde6c973db6732e30dfb39b178760aed041
     // which is an identifier known to the credential issuer, with some preset attributes
     let vault = Vault::create();
     let identity_history = "01ed8a5b1303f975c1296c990d1bd3c1946cfef328de20531e3511ec5604ce0dd9000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020e8c328bc0cc07a374762091d037e69c36fdd4d2e1a651abd4d43a1362d3f800503010140a349968063d7337d0c965969fa9c640824c01a6d37fe130d4ab963b0271b9d5bbf0923faa5e27f15359554f94f08676df01b99d997944e4feaf0caaa1189480e";
     let secret = "5b2b3f2abbd1787704d8f8b363529f8e2d8f423b6dd4b96a2c462e4f0e04ee18";
-    let bob = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
+    let server = Identity::create_identity_with_history(&ctx, vault, identity_history, secret).await?;
 
     // Create a client to a credential issuer
     let sessions = Sessions::default();
@@ -32,34 +32,36 @@ async fn main(ctx: Context) -> Result<()> {
     let issuer_trust_options = SecureChannelTrustOptions::new()
         .with_trust_policy(TrustEveryonePolicy)
         .with_ciphertext_session(&sessions, &session_id);
-    let issuer_channel = bob
+    let issuer_channel = server
         .create_secure_channel(route![issuer_connection, "issuer_listener"], issuer_trust_options)
         .await?;
     let issuer = CredentialIssuerClient::new(&ctx, route![issuer_channel]).await?;
 
-    // Get a credential for Bob (this is done via a secure channel)
-    let credential = issuer.get_credential(bob.identifier()).await?.unwrap();
+    // Get a credential for the server (this is done via a secure channel)
+    let credential = issuer.get_credential(server.identifier()).await?.unwrap();
     println!("got a credential from the issuer\n{credential}");
-    bob.set_credential(credential).await;
+    server.set_credential(credential).await;
 
-    // Start a worker which will receive credentials sent by Alice and issued by the issuer node
+    // Start a worker which will receive credentials sent by the client and issued by the issuer node
     let issuer_identity = issuer.public_identity().await?;
-    let storage = AuthenticatedAttributeStorage::new(bob.authenticated_storage().clone());
-    bob.start_credential_exchange_worker(vec![issuer_identity], "credential_exchange", true, Arc::new(storage))
+    let storage = AuthenticatedAttributeStorage::new(server.authenticated_storage().clone());
+    server
+        .start_credential_exchange_worker(vec![issuer_identity], "credential_exchange", true, Arc::new(storage))
         .await?;
 
-    // Create a secure channel listener to allow Alice to create a secure channel to Bob's node
+    // Create a secure channel listener to allow the client to create a secure channel to the server node
     let listener_session_id = sessions.generate_session_id();
     let secure_channel_listener_trust_options = SecureChannelListenerTrustOptions::new()
         .with_trust_policy(TrustEveryonePolicy)
         .with_session(&sessions, &listener_session_id);
-    bob.create_secure_channel_listener("bob_listener", secure_channel_listener_trust_options)
+    server
+        .create_secure_channel_listener("server_listener", secure_channel_listener_trust_options)
         .await?;
     println!("created a secure channel listener");
 
-    // Start an echoer service which will only allow subjects with name = alice
-    let alice_only = AbacAccessControl::create(bob.authenticated_storage().clone(), "name", "alice");
-    ctx.start_worker("echoer", Echoer, alice_only, AllowAll).await?;
+    // Start an echoer service which will only allow subjects with name = client
+    let client_only = AbacAccessControl::create(server.authenticated_storage().clone(), "name", "client");
+    ctx.start_worker("echoer", Echoer, client_only, AllowAll).await?;
 
     // Create a TCP listener and wait for incoming connections
     let tcp_listener_trust_options = TcpListenerTrustOptions::new().with_session(&sessions, &listener_session_id);

--- a/implementations/rust/ockam/ockam_identity/src/credential/worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/worker.rs
@@ -7,7 +7,7 @@ use ockam_core::async_trait;
 use ockam_core::compat::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use ockam_core::{Result, Routed, Worker};
 use ockam_node::Context;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 const TARGET: &str = "ockam::credential_exchange_worker::service";
 
@@ -133,11 +133,11 @@ impl CredentialExchangeWorker {
                     let credential = self.identity.credential.read().await;
                     match credential.as_ref() {
                         Some(p) if self.present_back => {
-                            warn!("Mutual credential presentation request processed successfully with {}. Responding with own credential...", sender);
+                            info!("Mutual credential presentation request processed successfully with {}. Responding with own credential...", sender);
                             Response::ok(req.id()).body(p).to_vec()?
                         }
                         _ => {
-                            warn!("Mutual credential presentation request processed successfully with {}. No credential to respond!", sender);
+                            info!("Mutual credential presentation request processed successfully with {}. No credential to respond!", sender);
                             Response::ok(req.id()).to_vec()?
                         }
                     }

--- a/implementations/rust/ockam/ockam_identity/src/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity.rs
@@ -257,7 +257,7 @@ impl Identity {
     /// encoded as a hex string.
     /// Such a key can be obtained by running vault.secret_export and then encoding
     /// the exported secret as a hex string
-    pub async fn create_identity_with_history(
+    pub async fn create_identity_with_change_history(
         ctx: &Context,
         vault: Arc<dyn IdentityVault>,
         identity_history: &str,


### PR DESCRIPTION
This PR initializes the credential exchange example with an exported key + change history for alice and bob.