### PR TITLE
feat(rust): added `tcp-inlet delete` command, hotfix to `tcp-outlet list` bug

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -76,6 +76,27 @@ impl<'a> CreateInlet<'a> {
     }
 }
 
+/// Request body to delete an inlet
+#[derive(Clone, Debug, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteInlet<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<4775492>,
+    /// The alias of the TCP inlet to be deleted
+    #[b(1)] pub alias: CowStr<'a>,
+}
+
+impl<'a> DeleteInlet<'a> {
+    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            alias: alias.into(),
+        }
+    }
+}
+
 /// Request body to create an outlet
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -667,6 +667,7 @@ impl NodeManagerWorker {
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
+            (Delete, ["node", "inlet"]) => self.delete_inlet(req, dec).await?.to_vec()?,
 
             (Delete, ["node", "portal"]) => todo!(),
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -258,14 +258,14 @@ impl NodeManagerWorker {
 
         info!(%alias, "Handling request to delete inlet portal");
         if let Some(inlet_to_delete) = node_manager.registry.inlets.remove(&alias) {
-            info!(%alias, "Sucessfully removed inlet from node registry");
+            debug!(%alias, "Sucessfully removed inlet from node registry");
             let was_stopped = node_manager
                 .tcp_transport
                 .stop_inlet(inlet_to_delete.worker_addr.clone())
                 .await
                 .is_ok();
             if was_stopped {
-                info!(%alias, "Successfully stopped inlet");
+                debug!(%alias, "Successfully stopped inlet");
                 Ok(Response::ok(req.id()).body(InletStatus::new(
                     inlet_to_delete.bind_addr,
                     inlet_to_delete.worker_addr.to_string(),
@@ -377,14 +377,14 @@ impl NodeManagerWorker {
 
         info!(%alias, "Handling request to delete outlet portal");
         if let Some(outlet_to_delete) = node_manager.registry.outlets.remove(&alias) {
-            info!(%alias, "Successfully removed outlet from node registry");
+            debug!(%alias, "Successfully removed outlet from node registry");
             let was_stopped = node_manager
                 .tcp_transport
                 .stop_outlet(outlet_to_delete.worker_addr.clone())
                 .await
                 .is_ok();
             if was_stopped {
-                info!(%alias, "Successfully stopped outlet");
+                debug!(%alias, "Successfully stopped outlet");
                 Ok(Response::ok(req.id()).body(OutletStatus::new(
                     outlet_to_delete.tcp_addr,
                     outlet_to_delete.worker_addr.to_string(),

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,10 +1,11 @@
 use crate::node::default_node_name;
+use crate::tcp::util::alias_parser;
 use crate::util::{
     bind_to_port_check, exitcode, extract_address_value, node_rpc, process_nodes_multiaddr,
     RpcBuilder,
 };
-use crate::Result;
-use crate::{help, CommandGlobalOpts};
+use crate::{help, CommandGlobalOpts, Result};
+
 use anyhow::anyhow;
 use clap::Args;
 use ockam::identity::IdentityIdentifier;
@@ -83,12 +84,4 @@ async fn rpc(ctx: Context, (opts, mut cmd): (CommandGlobalOpts, CreateCommand)) 
     rpc.parse_response::<InletStatus>()?;
 
     Ok(())
-}
-
-fn alias_parser(arg: &str) -> Result<String> {
-    if arg.contains(':') {
-        Err(anyhow!("an inlet alias must not contain ':' characters").into())
-    } else {
-        Ok(arg.to_string())
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -5,18 +5,18 @@ use crate::Result;
 use anyhow::anyhow;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::models::portal::DeleteOutlet;
+use ockam_api::nodes::models::portal::DeleteInlet;
 use ockam_core::api::{Request, RequestBuilder};
 
 /// Delete a TCP Outlet
 #[derive(Clone, Debug, Args)]
 #[command()]
 pub struct DeleteCommand {
-    /// Name assigned to outlet that will be deleted
+    /// Name assigned to inlet that will be deleted
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]
     alias: String,
 
-    /// Node on which to stop the tcp outlet. If none are provided, the default node will be used
+    /// Node on which to stop the tcp inlet. If none are provided, the default node will be used
     #[command(flatten)]
     node_opts: NodeOpts,
 }
@@ -39,20 +39,20 @@ pub async fn run_impl(
 
     rpc.is_ok()?;
 
-    println!("Deleted TCP Outlet '{alias}' on node '{node}'");
+    println!("Deleted TCP Inlet '{alias}' on node '{node}'");
     Ok(())
 }
 
 /// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, DeleteOutlet<'a>>> {
-    let payload = DeleteOutlet::new(cmd.alias);
-    let request = Request::delete("/node/outlet").body(payload);
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, DeleteInlet<'a>>> {
+    let payload = DeleteInlet::new(cmd.alias);
+    let request = Request::delete("/node/inlet").body(payload);
     Ok(request)
 }
 
 fn alias_parser(arg: &str) -> Result<String> {
     if arg.contains(':') {
-        Err(anyhow!("an outlet alias must not contain ':' characters").into())
+        Err(anyhow!("an inlet alias must not contain ':' characters").into())
     } else {
         Ok(arg.to_string())
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,8 +1,7 @@
 use crate::node::NodeOpts;
+use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
-use crate::Result;
-use anyhow::anyhow;
 use clap::Args;
 use ockam::Context;
 use ockam_api::nodes::models::portal::DeleteInlet;
@@ -32,7 +31,6 @@ pub async fn run_impl(
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let alias = cmd.alias.clone();
-
     let node = extract_address_value(&cmd.node_opts.api_node)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
@@ -48,12 +46,4 @@ fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, 
     let payload = DeleteInlet::new(cmd.alias);
     let request = Request::delete("/node/inlet").body(payload);
     Ok(request)
-}
-
-fn alias_parser(arg: &str) -> Result<String> {
-    if arg.contains(':') {
-        Err(anyhow!("an inlet alias must not contain ':' characters").into())
-    } else {
-        Ok(arg.to_string())
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,6 +1,7 @@
 use crate::node::NodeOpts;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use anyhow::anyhow;
 use clap::Args;
 use ockam_api::nodes::models;
 use ockam_api::route_to_multiaddr;
@@ -28,6 +29,13 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(Request::get("/node/inlet")).await?;
     let response = rpc.parse_response::<models::portal::InletList>()?;
+
+    if response.list.is_empty() {
+        return Err(crate::Error::new(
+            exitcode::IOERR,
+            anyhow!("No Inlets found on this system!"),
+        ));
+    }
 
     for inlet_infor in response.list.iter() {
         println!("Inlet:");

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -29,8 +29,6 @@ async fn run_impl(
     rpc.request(Request::get("/node/inlet")).await?;
     let response = rpc.parse_response::<models::portal::InletList>()?;
 
-    // let mut inlet_infor = response.list.iter();
-
     for inlet_infor in response.list.iter() {
         println!("Inlet:");
         println!("  Alias: {}", inlet_infor.alias);

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
@@ -1,9 +1,11 @@
 mod create;
+mod delete;
 mod list;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
+use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 
 /// Manage TCP Inlets
@@ -16,6 +18,7 @@ pub struct TcpInletCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum TcpInletSubCommand {
     Create(CreateCommand),
+    Delete(DeleteCommand),
     List(ListCommand),
 }
 
@@ -23,6 +26,7 @@ impl TcpInletCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             TcpInletSubCommand::Create(c) => c.run(options),
+            TcpInletSubCommand::Delete(c) => c.run(options),
             TcpInletSubCommand::List(c) => c.run(options),
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod connection;
 pub(crate) mod inlet;
 pub(crate) mod listener;
 pub(crate) mod outlet;
+pub(crate) mod util;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,7 +1,7 @@
 use crate::node::default_node_name;
+use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{help, CommandGlobalOpts, Result};
-use anyhow::anyhow;
+use crate::{help, CommandGlobalOpts};
 use clap::Args;
 use ockam::Context;
 use ockam_api::{
@@ -72,12 +72,4 @@ fn make_api_request<'a>(cmd: CreateCommand) -> crate::Result<RequestBuilder<'a, 
     let payload = CreateOutlet::new(tcp_addr, worker_addr, alias);
     let request = Request::post("/node/outlet").body(payload);
     Ok(request)
-}
-
-fn alias_parser(arg: &str) -> Result<String> {
-    if arg.contains(':') {
-        Err(anyhow!("an outlet alias must not contain ':' characters").into())
-    } else {
-        Ok(arg.to_string())
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,8 +1,7 @@
 use crate::node::NodeOpts;
+use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
-use crate::Result;
-use anyhow::anyhow;
 use clap::Args;
 use ockam::Context;
 use ockam_api::nodes::models::portal::DeleteOutlet;
@@ -48,12 +47,4 @@ fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, 
     let payload = DeleteOutlet::new(cmd.alias);
     let request = Request::delete("/node/outlet").body(payload);
     Ok(request)
-}
-
-fn alias_parser(arg: &str) -> Result<String> {
-    if arg.contains(':') {
-        Err(anyhow!("an outlet alias must not contain ':' characters").into())
-    } else {
-        Ok(arg.to_string())
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -32,14 +32,14 @@ async fn run_impl(
     rpc.request(Request::get("/node/outlet")).await?;
     let response = rpc.parse_response::<OutletList>()?;
 
-    println!("Outlet:");
     for outlet in &response.list {
-        println!("    Alias: {}", outlet.alias);
+        println!("Outlet:");
+
+        println!("  Alias: {}", outlet.alias);
         let addr = route_to_multiaddr(&route![outlet.worker_addr.to_string()])
             .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
-        println!("    From Outlet: {addr}");
-
-        println!("    To TCP: {}", outlet.tcp_addr);
+        println!("  From Outlet: {addr}");
+        println!("  To TCP: {}", outlet.tcp_addr);
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/util.rs
@@ -1,0 +1,10 @@
+use crate::Result;
+use anyhow::anyhow;
+
+pub fn alias_parser(arg: &str) -> Result<String> {
+    if arg.contains(':') {
+        Err(anyhow!("an alias must not contain ':' characters").into())
+    } else {
+        Ok(arg.to_string())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -341,8 +341,8 @@ teardown() {
   assert_output --regexp "To Outlet Address: /service/.*/service/outlet"
 }
 
-@test "portals - delete a tcp outlet" {
-  port=5000
+@test "portals - tcp outlet CRUD" {
+  port=9000
   run --separate-stderr "$OCKAM" node create n1
   assert_success
 
@@ -358,9 +358,9 @@ teardown() {
   assert_output --partial "NotFound"
 }
 
-@test "portals - delete a tcp inlet" {
-  outlet_port=5000
-  inlet_port=6000
+@test "portals - tcp inlet CRUD" {
+  outlet_port=7000
+  inlet_port=8000
 
   # Create nodes for inlet/outlet pair
   run --separate-stderr "$OCKAM" node create n1

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -218,7 +218,7 @@ teardown() {
   refute_output --partial "127.0.0.1:5000"
 }
 
-@test "tcp - create a tcp connection and then delete it " {
+@test "tcp - create a tcp connection and then delete it" {
   run "$OCKAM" node create n1
   run "$OCKAM" tcp-connection create --from n1 --to 127.0.0.1:5000 --output json
   assert_success
@@ -331,18 +331,19 @@ teardown() {
 # ===== PORTALS (INLET/OUTLET)
 
 @test "portals - list inlets on a node" {
+  port=6002
   $OCKAM node create n1
   $OCKAM node create n2
-  $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:6000 --to /node/n1/service/outlet --alias tcp-inlet-2
+  $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:$port --to /node/n1/service/outlet --alias tcp-inlet-2
   run $OCKAM tcp-inlet list --node /node/n2
 
   assert_output --partial "Alias: tcp-inlet-2"
-  assert_output --partial "TCP Address: 127.0.0.1:6000"
+  assert_output --partial "TCP Address: 127.0.0.1:$port"
   assert_output --regexp "To Outlet Address: /service/.*/service/outlet"
 }
 
 @test "portals - tcp outlet CRUD" {
-  port=9000
+  port=6003
   run --separate-stderr "$OCKAM" node create n1
   assert_success
 
@@ -359,8 +360,8 @@ teardown() {
 }
 
 @test "portals - tcp inlet CRUD" {
-  outlet_port=7000
-  inlet_port=8000
+  outlet_port=6004
+  inlet_port=6005
 
   # Create nodes for inlet/outlet pair
   run --separate-stderr "$OCKAM" node create n1


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

There is no current way to delete a `tcp-inlet` by its  `alias` and `node`.

## Proposed changes

This PR solves https://github.com/build-trust/ockam/issues/4269 by adding the `ockam tcp-inlet delete` subcommand.
Minor changes also included in this PR:
- Bats test for inlet deletion;
- Fixed a bug where `tcp-outlet list` would format outlets in an incorrect manner;
- Additional logging in `delete_outlet` and `delete_inlet` routines located in `ockam_api/src/nodes/service/portals.rs`; 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
