### PR TITLE
feat(rust): added `tcp-outlet` and `tcp-inlet` `show` commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -128,6 +128,7 @@ impl<'a> CreateOutlet<'a> {
     }
 }
 
+// TO-DO use PortalAlias struct instead of this
 /// Request body to delete an outlet
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
@@ -275,6 +276,28 @@ impl<'a> OutletList<'a> {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             list,
+        }
+    }
+}
+
+/// Response body to access an Inlet or Outlet by its alias
+// TO-DO: reuse this struct for `tcp-outlet delete`, and `tcp-inlet delete` as well
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct PortalAlias<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<1193889>,
+    /// The alias of the TCP outlet to be deleted
+    #[b(1)] pub alias: CowStr<'a>,
+}
+
+impl<'a> PortalAlias<'a> {
+    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            alias: alias.into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -76,27 +76,6 @@ impl<'a> CreateInlet<'a> {
     }
 }
 
-/// Request body to delete an inlet
-#[derive(Clone, Debug, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct DeleteInlet<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<4775492>,
-    /// The alias of the TCP inlet to be deleted
-    #[b(1)] pub alias: CowStr<'a>,
-}
-
-impl<'a> DeleteInlet<'a> {
-    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            alias: alias.into(),
-        }
-    }
-}
-
 /// Request body to create an outlet
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
@@ -123,28 +102,6 @@ impl<'a> CreateOutlet<'a> {
             tag: TypeTag,
             tcp_addr: tcp_addr.into(),
             worker_addr: worker_addr.into(),
-            alias: alias.into(),
-        }
-    }
-}
-
-// TO-DO use PortalAlias struct instead of this
-/// Request body to delete an outlet
-#[derive(Clone, Debug, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct DeleteOutlet<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<1193889>,
-    /// The alias of the TCP outlet to be deleted
-    #[b(1)] pub alias: CowStr<'a>,
-}
-
-impl<'a> DeleteOutlet<'a> {
-    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
             alias: alias.into(),
         }
     }
@@ -281,14 +238,13 @@ impl<'a> OutletList<'a> {
 }
 
 /// Response body to access an Inlet or Outlet by its alias
-// TO-DO: reuse this struct for `tcp-outlet delete`, and `tcp-inlet delete` as well
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct PortalAlias<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<1193889>,
-    /// The alias of the TCP outlet to be deleted
+    /// The alias of the TCP inlet/outlet to be accessed
     #[b(1)] pub alias: CowStr<'a>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -236,24 +236,3 @@ impl<'a> OutletList<'a> {
         }
     }
 }
-
-/// Response body to access an Inlet or Outlet by its alias
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct PortalAlias<'a> {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<1193889>,
-    /// The alias of the TCP inlet/outlet to be accessed
-    #[b(1)] pub alias: CowStr<'a>,
-}
-
-impl<'a> PortalAlias<'a> {
-    pub fn new(alias: impl Into<CowStr<'a>>) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            alias: alias.into(),
-        }
-    }
-}

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -122,7 +122,7 @@ impl KafkaServiceInfo {
         &self.kind
     }
 }
-
+#[derive(Clone)]
 pub(crate) struct InletInfo {
     pub(crate) bind_addr: String,
     pub(crate) worker_addr: Address,
@@ -147,6 +147,7 @@ impl InletInfo {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct OutletInfo {
     pub(crate) tcp_addr: String,
     pub(crate) worker_addr: Address,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -657,25 +657,19 @@ impl NodeManagerWorker {
 
             // ==*== Inlets & Outlets ==*==
             (Get, ["node", "inlet"]) => {
-                if req.has_body() {
-                    self.show_inlet(req, dec).await?.to_vec()?
-                } else {
-                    let node_manager = self.node_manager.read().await;
-                    self.get_inlets(req, &node_manager.registry).to_vec()?
-                }
+                let node_manager = self.node_manager.read().await;
+                self.get_inlets(req, &node_manager.registry).to_vec()?
             }
+            (Get, ["node", "inlet", alias]) => self.show_inlet(req, alias).await?.to_vec()?,
             (Get, ["node", "outlet"]) => {
-                if req.has_body() {
-                    self.show_outlet(req, dec).await?.to_vec()?
-                } else {
-                    let node_manager = self.node_manager.read().await;
-                    self.get_outlets(req, &node_manager.registry).to_vec()?
-                }
+                let node_manager = self.node_manager.read().await;
+                self.get_outlets(req, &node_manager.registry).to_vec()?
             }
+            (Get, ["node", "outlet", alias]) => self.show_outlet(req, alias).await?.to_vec()?,
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
-            (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
-            (Delete, ["node", "inlet"]) => self.delete_inlet(req, dec).await?.to_vec()?,
+            (Delete, ["node", "outlet", alias]) => self.delete_outlet(req, alias).await?.to_vec()?,
+            (Delete, ["node", "inlet", alias]) => self.delete_inlet(req, alias).await?.to_vec()?,
             (Delete, ["node", "portal"]) => todo!(),
 
             // ==*== Workers ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -657,13 +657,19 @@ impl NodeManagerWorker {
 
             // ==*== Inlets & Outlets ==*==
             (Get, ["node", "inlet"]) => {
-                let node_manager = self.node_manager.read().await;
-                self.get_inlets(req, &node_manager.registry).to_vec()?
+                let inlet_registry = {
+                    let node_manager = self.node_manager.read().await;
+                    &node_manager.registry.inlets.clone()
+                };
+                self.get_inlets(req, inlet_registry).to_vec()?
             }
             (Get, ["node", "inlet", alias]) => self.show_inlet(req, alias).await?.to_vec()?,
             (Get, ["node", "outlet"]) => {
-                let node_manager = self.node_manager.read().await;
-                self.get_outlets(req, &node_manager.registry).to_vec()?
+                let outlet_registry = {
+                    let node_manager = self.node_manager.read().await;
+                    &node_manager.registry.outlets.clone()
+                };
+                self.get_outlets(req, outlet_registry).to_vec()?
             }
             (Get, ["node", "outlet", alias]) => self.show_outlet(req, alias).await?.to_vec()?,
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -668,6 +668,8 @@ impl NodeManagerWorker {
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "inlet"]) => self.delete_inlet(req, dec).await?.to_vec()?,
+            //TO-DO Move show parameter to node/outlet endpoint, make it conditionak
+            (Get, ["node", "outlet", "show"]) => self.show_outlet(req, dec).await?.to_vec()?,
 
             (Delete, ["node", "portal"]) => todo!(),
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -668,7 +668,9 @@ impl NodeManagerWorker {
             (Get, ["node", "outlet", alias]) => self.show_outlet(req, alias).await?.to_vec()?,
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
-            (Delete, ["node", "outlet", alias]) => self.delete_outlet(req, alias).await?.to_vec()?,
+            (Delete, ["node", "outlet", alias]) => {
+                self.delete_outlet(req, alias).await?.to_vec()?
+            }
             (Delete, ["node", "inlet", alias]) => self.delete_inlet(req, alias).await?.to_vec()?,
             (Delete, ["node", "portal"]) => todo!(),
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -657,20 +657,25 @@ impl NodeManagerWorker {
 
             // ==*== Inlets & Outlets ==*==
             (Get, ["node", "inlet"]) => {
-                let node_manager = self.node_manager.read().await;
-                self.get_inlets(req, &node_manager.registry).to_vec()?
+                if req.has_body() {
+                    self.show_inlet(req, dec).await?.to_vec()?
+                } else {
+                    let node_manager = self.node_manager.read().await;
+                    self.get_inlets(req, &node_manager.registry).to_vec()?
+                }
             }
             (Get, ["node", "outlet"]) => {
-                let node_manager = self.node_manager.read().await;
-                self.get_outlets(req, &node_manager.registry).to_vec()?
+                if req.has_body() {
+                    self.show_outlet(req, dec).await?.to_vec()?
+                } else {
+                    let node_manager = self.node_manager.read().await;
+                    self.get_outlets(req, &node_manager.registry).to_vec()?
+                }
             }
             (Post, ["node", "inlet"]) => self.create_inlet(req, dec, ctx).await?.to_vec()?,
             (Post, ["node", "outlet"]) => self.create_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "outlet"]) => self.delete_outlet(req, dec).await?.to_vec()?,
             (Delete, ["node", "inlet"]) => self.delete_inlet(req, dec).await?.to_vec()?,
-            //TO-DO Move show parameter to node/outlet endpoint, make it conditionak
-            (Get, ["node", "outlet", "show"]) => self.show_outlet(req, dec).await?.to_vec()?,
-
             (Delete, ["node", "portal"]) => todo!(),
 
             // ==*== Workers ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -274,7 +274,7 @@ impl NodeManagerWorker {
                 Ok(Response::internal_error(req.id()).body(InletStatus::new(
                     inlet_to_delete.bind_addr,
                     inlet_to_delete.worker_addr.to_string(),
-                    alias.clone(),
+                    alias,
                     Some(format!("Failed to remove inlet with alias {alias}").into()),
                     inlet_to_delete.outlet_route.to_string(),
                 )))
@@ -284,7 +284,7 @@ impl NodeManagerWorker {
             Ok(Response::not_found(req.id()).body(InletStatus::new(
                 "".to_string(),
                 "".to_string(),
-                alias.clone(),
+                alias,
                 Some(format!("Inlet with alias {alias} not found").into()),
                 "".to_string(),
             )))
@@ -313,7 +313,7 @@ impl NodeManagerWorker {
             Ok(Response::not_found(req.id()).body(InletStatus::new(
                 "".to_string(),
                 "".to_string(),
-                alias.clone(),
+                alias,
                 Some(format!("Inlet with alias {alias} not found").into()),
                 "".to_string(),
             )))
@@ -418,7 +418,7 @@ impl NodeManagerWorker {
                 Ok(Response::internal_error(req.id()).body(OutletStatus::new(
                     outlet_to_delete.tcp_addr,
                     outlet_to_delete.worker_addr.to_string(),
-                    alias.clone(),
+                    alias,
                     Some(format!("Failed to remove outlet with alias {alias}").into()),
                 )))
             }
@@ -427,7 +427,7 @@ impl NodeManagerWorker {
             Ok(Response::not_found(req.id()).body(OutletStatus::new(
                 "".to_string(),
                 "".to_string(),
-                alias.clone(),
+                alias,
                 Some(format!("Outlet with alias {alias} not found").into()),
             )))
         }
@@ -454,7 +454,7 @@ impl NodeManagerWorker {
             Ok(Response::not_found(req.id()).body(OutletStatus::new(
                 "".to_string(),
                 "".to_string(),
-                alias.clone(),
+                alias,
                 Some(format!("Outlet with alias {alias} not found").into()),
             )))
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -1,7 +1,7 @@
 use crate::error::ApiError;
 use crate::nodes::connection::Connection;
 use crate::nodes::models::portal::{
-    CreateInlet, CreateOutlet, InletList, InletStatus, OutletList, OutletStatus, PortalAlias,
+    CreateInlet, CreateOutlet, InletList, InletStatus, OutletList, OutletStatus,
 };
 use crate::nodes::registry::{InletInfo, OutletInfo, Registry};
 use crate::nodes::service::random_alias;
@@ -248,15 +248,12 @@ impl NodeManagerWorker {
     pub(super) async fn delete_inlet<'a>(
         &mut self,
         req: &Request<'_>,
-        dec: &mut Decoder<'_>,
+        alias: &'a str,
     ) -> Result<ResponseBuilder<InletStatus<'a>>> {
         let mut node_manager = self.node_manager.write().await;
-        let PortalAlias { alias, .. } = dec.decode()?;
-
-        let alias = alias.into_owned();
 
         info!(%alias, "Handling request to delete inlet portal");
-        if let Some(inlet_to_delete) = node_manager.registry.inlets.remove(&alias) {
+        if let Some(inlet_to_delete) = node_manager.registry.inlets.remove(alias) {
             debug!(%alias, "Sucessfully removed inlet from node registry");
             let was_stopped = node_manager
                 .tcp_transport
@@ -297,15 +294,12 @@ impl NodeManagerWorker {
     pub(super) async fn show_inlet<'a>(
         &mut self,
         req: &Request<'_>,
-        dec: &mut Decoder<'_>,
+        alias: &'a str,
     ) -> Result<ResponseBuilder<InletStatus<'a>>> {
         let node_manager = self.node_manager.write().await;
-        let PortalAlias { alias, .. } = dec.decode()?;
-
-        let alias = alias.into_owned();
 
         info!(%alias, "Handling request to show inlet portal");
-        if let Some(inlet_to_show) = node_manager.registry.inlets.get(&alias) {
+        if let Some(inlet_to_show) = node_manager.registry.inlets.get(alias) {
             debug!(%alias, "Inlet not found in node registry");
             Ok(Response::ok(req.id()).body(InletStatus::new(
                 inlet_to_show.bind_addr.to_string(),
@@ -399,15 +393,12 @@ impl NodeManagerWorker {
     pub(super) async fn delete_outlet<'a>(
         &mut self,
         req: &Request<'_>,
-        dec: &mut Decoder<'_>,
+        alias: &'a str,
     ) -> Result<ResponseBuilder<OutletStatus<'a>>> {
         let mut node_manager = self.node_manager.write().await;
-        let PortalAlias { alias, .. } = dec.decode()?;
-
-        let alias = alias.into_owned();
 
         info!(%alias, "Handling request to delete outlet portal");
-        if let Some(outlet_to_delete) = node_manager.registry.outlets.remove(&alias) {
+        if let Some(outlet_to_delete) = node_manager.registry.outlets.remove(alias) {
             debug!(%alias, "Successfully removed outlet from node registry");
             let was_stopped = node_manager
                 .tcp_transport
@@ -445,15 +436,12 @@ impl NodeManagerWorker {
     pub(super) async fn show_outlet<'a>(
         &mut self,
         req: &Request<'_>,
-        dec: &mut Decoder<'_>,
+        alias: &'a str,
     ) -> Result<ResponseBuilder<OutletStatus<'a>>> {
         let node_manager = self.node_manager.write().await;
-        let PortalAlias { alias, .. } = dec.decode()?;
-
-        let alias = alias.into_owned();
 
         info!(%alias, "Handling request to show outlet portal");
-        if let Some(outlet_to_show) = node_manager.registry.outlets.get(&alias) {
+        if let Some(outlet_to_show) = node_manager.registry.outlets.get(alias) {
             debug!(%alias, "Outlet not found in node registry");
             Ok(Response::ok(req.id()).body(OutletStatus::new(
                 outlet_to_show.tcp_addr.to_string(),

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -4,7 +4,6 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::models::portal::PortalAlias;
 use ockam_core::api::{Request, RequestBuilder};
 
 /// Delete a TCP Outlet
@@ -42,8 +41,8 @@ pub async fn run_impl(
 }
 
 /// Construct a request to delete a tcp inlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
-    let payload = PortalAlias::new(cmd.alias);
-    let request = Request::delete("/node/inlet").body(payload);
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
+    let alias = cmd.alias.clone();
+    let request = Request::delete(format!("/node/inlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -2,6 +2,7 @@ use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use crate::Result;
 use clap::Args;
 use ockam::Context;
 use ockam_core::api::{Request, RequestBuilder};
@@ -41,7 +42,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to delete a tcp inlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
+fn make_api_request<'a>(cmd: DeleteCommand) -> Result<RequestBuilder<'a>> {
     let alias = cmd.alias;
     let request = Request::delete(format!("/node/inlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -42,7 +42,7 @@ pub async fn run_impl(
 
 /// Construct a request to delete a tcp inlet
 fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
-    let alias = cmd.alias.clone();
+    let alias = cmd.alias;
     let request = Request::delete(format!("/node/inlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -4,7 +4,7 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::models::portal::DeleteInlet;
+use ockam_api::nodes::models::portal::PortalAlias;
 use ockam_core::api::{Request, RequestBuilder};
 
 /// Delete a TCP Outlet
@@ -41,9 +41,9 @@ pub async fn run_impl(
     Ok(())
 }
 
-/// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, DeleteInlet<'a>>> {
-    let payload = DeleteInlet::new(cmd.alias);
+/// Construct a request to delete a tcp inlet
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
+    let payload = PortalAlias::new(cmd.alias);
     let request = Request::delete("/node/inlet").body(payload);
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
@@ -1,12 +1,14 @@
 mod create;
 mod delete;
 mod list;
+mod show;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
 use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
+pub(crate) use show::ShowCommand;
 
 /// Manage TCP Inlets
 #[derive(Clone, Debug, Args)]
@@ -20,6 +22,7 @@ pub enum TcpInletSubCommand {
     Create(CreateCommand),
     Delete(DeleteCommand),
     List(ListCommand),
+    Show(ShowCommand),
 }
 
 impl TcpInletCommand {
@@ -28,6 +31,7 @@ impl TcpInletCommand {
             TcpInletSubCommand::Create(c) => c.run(options),
             TcpInletSubCommand::Delete(c) => c.run(options),
             TcpInletSubCommand::List(c) => c.run(options),
+            TcpInletSubCommand::Show(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -4,7 +4,7 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{Context, Route};
-use ockam_api::nodes::models::portal::{InletStatus, PortalAlias};
+use ockam_api::nodes::models::portal::{InletStatus};
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
@@ -49,9 +49,9 @@ pub async fn run_impl(
     Ok(())
 }
 
-/// Construct a request to delete a tcp Inlet
-fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
-    let payload = PortalAlias::new(cmd.alias);
-    let request = Request::get("/node/inlet").body(payload);
+/// Construct a request to show a tcp inlet
+fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
+    let alias = cmd.alias.clone();
+    let request = Request::get(format!("/node/inlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -2,6 +2,7 @@ use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use crate::Result;
 use clap::Args;
 use ockam::{Context, Route};
 use ockam_api::nodes::models::portal::InletStatus;
@@ -50,7 +51,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to show a tcp inlet
-fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
+fn make_api_request<'a>(cmd: ShowCommand) -> Result<RequestBuilder<'a>> {
     let alias = cmd.alias;
     let request = Request::get(format!("/node/inlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -3,21 +3,20 @@ use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
-use ockam::{route, Context};
-use ockam_api::error::ApiError;
-use ockam_api::nodes::models::portal::{OutletStatus, PortalAlias};
+use ockam::{Context, Route};
+use ockam_api::nodes::models::portal::{InletStatus, PortalAlias};
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
-/// Delete a TCP Outlet
+/// Delete a TCP Inlet
 #[derive(Clone, Debug, Args)]
 #[command()]
 pub struct ShowCommand {
-    /// Name assigned to outlet that will be shown
+    /// Name assigned to inlet that will be shown
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]
     alias: String,
 
-    /// Node from the outlet that is to be shown. If none are provided, the default node will be used
+    /// Node from the inlet that is to be shown. If none are provided, the default node will be used
     #[command(flatten)]
     node_opts: NodeOpts,
 }
@@ -37,20 +36,22 @@ pub async fn run_impl(
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;
 
-    let outlet_to_show = rpc.parse_response::<OutletStatus>()?;
+    let inlet_to_show = rpc.parse_response::<InletStatus>()?;
 
-    println!("Outlet:");
-    println!("  Alias: {}", outlet_to_show.alias);
-    let addr = route_to_multiaddr(&route![outlet_to_show.worker_addr.to_string()])
-        .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
-    println!("  From Outlet: {addr}");
-    println!("  To TCP: {}", outlet_to_show.tcp_addr);
+    println!("Inlet:");
+    println!("  Alias: {}", inlet_to_show.alias);
+    println!("  TCP Address: {}", inlet_to_show.bind_addr);
+    if let Some(r) = Route::parse(inlet_to_show.outlet_route.as_ref()) {
+        if let Some(ma) = route_to_multiaddr(&r) {
+            println!("  To Outlet Address: {ma}");
+        }
+    }
     Ok(())
 }
 
-/// Construct a request to delete a tcp outlet
+/// Construct a request to delete a tcp Inlet
 fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
     let payload = PortalAlias::new(cmd.alias);
-    let request = Request::get("/node/outlet").body(payload);
+    let request = Request::get("/node/inlet").body(payload);
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -4,7 +4,7 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{Context, Route};
-use ockam_api::nodes::models::portal::{InletStatus};
+use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
@@ -51,7 +51,7 @@ pub async fn run_impl(
 
 /// Construct a request to show a tcp inlet
 fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
-    let alias = cmd.alias.clone();
+    let alias = cmd.alias;
     let request = Request::get(format!("/node/inlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -4,7 +4,7 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::models::portal::DeleteOutlet;
+use ockam_api::nodes::models::portal::PortalAlias;
 use ockam_core::api::{Request, RequestBuilder};
 
 /// Delete a TCP Outlet
@@ -43,8 +43,8 @@ pub async fn run_impl(
 }
 
 /// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, DeleteOutlet<'a>>> {
-    let payload = DeleteOutlet::new(cmd.alias);
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
+    let payload = PortalAlias::new(cmd.alias);
     let request = Request::delete("/node/outlet").body(payload);
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -4,7 +4,6 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
-use ockam_api::nodes::models::portal::PortalAlias;
 use ockam_core::api::{Request, RequestBuilder};
 
 /// Delete a TCP Outlet
@@ -43,8 +42,8 @@ pub async fn run_impl(
 }
 
 /// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
-    let payload = PortalAlias::new(cmd.alias);
-    let request = Request::delete("/node/outlet").body(payload);
+fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
+    let alias = cmd.alias.clone();
+    let request = Request::delete(format!("/node/outlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -43,7 +43,7 @@ pub async fn run_impl(
 
 /// Construct a request to delete a tcp outlet
 fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
-    let alias = cmd.alias.clone();
+    let alias = cmd.alias;
     let request = Request::delete(format!("/node/outlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -2,6 +2,7 @@ use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use crate::Result;
 use clap::Args;
 use ockam::Context;
 use ockam_core::api::{Request, RequestBuilder};
@@ -42,7 +43,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: DeleteCommand) -> crate::Result<RequestBuilder<'a>> {
+fn make_api_request<'a>(cmd: DeleteCommand) -> Result<RequestBuilder<'a>> {
     let alias = cmd.alias;
     let request = Request::delete(format!("/node/outlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -1,12 +1,14 @@
 mod create;
 mod delete;
 mod list;
+mod show;
 
 use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use create::CreateCommand;
 use delete::DeleteCommand;
 use list::ListCommand;
+use show::ShowCommand;
 
 /// Manage TCP Outlets
 #[derive(Clone, Debug, Args)]
@@ -18,16 +20,18 @@ pub struct TcpOutletCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum TcpOutletSubCommand {
     Create(CreateCommand),
-    List(ListCommand),
     Delete(DeleteCommand),
+    Show(ShowCommand),
+    List(ListCommand),
 }
 
 impl TcpOutletCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             TcpOutletSubCommand::Create(c) => c.run(options),
-            TcpOutletSubCommand::List(c) => c.run(options),
             TcpOutletSubCommand::Delete(c) => c.run(options),
+            TcpOutletSubCommand::Show(c) => c.run(options),
+            TcpOutletSubCommand::List(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -21,8 +21,8 @@ pub struct TcpOutletCommand {
 pub enum TcpOutletSubCommand {
     Create(CreateCommand),
     Delete(DeleteCommand),
-    Show(ShowCommand),
     List(ListCommand),
+    Show(ShowCommand),
 }
 
 impl TcpOutletCommand {
@@ -30,8 +30,8 @@ impl TcpOutletCommand {
         match self.subcommand {
             TcpOutletSubCommand::Create(c) => c.run(options),
             TcpOutletSubCommand::Delete(c) => c.run(options),
-            TcpOutletSubCommand::Show(c) => c.run(options),
             TcpOutletSubCommand::List(c) => c.run(options),
+            TcpOutletSubCommand::Show(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -5,7 +5,7 @@ use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{route, Context};
 use ockam_api::error::ApiError;
-use ockam_api::nodes::models::portal::{OutletStatus, PortalAlias};
+use ockam_api::nodes::models::portal::{OutletStatus};
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
@@ -48,9 +48,9 @@ pub async fn run_impl(
     Ok(())
 }
 
-/// Construct a request to delete a tcp outlet
-fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
-    let payload = PortalAlias::new(cmd.alias);
-    let request = Request::get("/node/outlet").body(payload);
+/// Construct a request to show a tcp outlet
+fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
+    let alias = cmd.alias.clone();
+    let request = Request::get(format!("/node/outlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -2,6 +2,7 @@ use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
+use crate::Result;
 use clap::Args;
 use ockam::{route, Context};
 use ockam_api::error::ApiError;
@@ -49,7 +50,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to show a tcp outlet
-fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
+fn make_api_request<'a>(cmd: ShowCommand) -> Result<RequestBuilder<'a>> {
     let alias = cmd.alias;
     let request = Request::get(format!("/node/outlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -5,7 +5,7 @@ use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::{route, Context};
 use ockam_api::error::ApiError;
-use ockam_api::nodes::models::portal::{OutletStatus};
+use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
@@ -50,7 +50,7 @@ pub async fn run_impl(
 
 /// Construct a request to show a tcp outlet
 fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a>> {
-    let alias = cmd.alias.clone();
+    let alias = cmd.alias;
     let request = Request::get(format!("/node/outlet/{alias}"));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,0 +1,66 @@
+use crate::node::NodeOpts;
+use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::CommandGlobalOpts;
+use crate::Result;
+use anyhow::anyhow;
+use clap::Args;
+use ockam::{route, Context};
+use ockam_api::error::ApiError;
+use ockam_api::nodes::models::portal::{OutletStatus, PortalAlias};
+use ockam_api::route_to_multiaddr;
+use ockam_core::api::{Request, RequestBuilder};
+
+/// Delete a TCP Outlet
+#[derive(Clone, Debug, Args)]
+#[command()]
+pub struct ShowCommand {
+    /// Name assigned to outlet that will be shown
+    #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]
+    alias: String,
+
+    /// Node from the outlet that is to be shown. If none are provided, the default node will be used
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ShowCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
+    }
+}
+
+pub async fn run_impl(
+    ctx: Context,
+    (options, cmd): (CommandGlobalOpts, ShowCommand),
+) -> crate::Result<()> {
+    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let mut rpc = Rpc::background(&ctx, &options, &node)?;
+    rpc.request(make_api_request(cmd)?).await?;
+    rpc.is_ok()?;
+
+    let outlet_to_show = rpc.parse_response::<OutletStatus>()?;
+
+    println!("Outlet:");
+    println!("  Alias: {}", outlet_to_show.alias);
+    let addr = route_to_multiaddr(&route![outlet_to_show.worker_addr.to_string()])
+        .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
+    println!("  From Outlet: {addr}");
+    println!("  To TCP: {}", outlet_to_show.tcp_addr);
+    Ok(())
+}
+
+/// Construct a request to delete a tcp outlet
+fn make_api_request<'a>(cmd: ShowCommand) -> crate::Result<RequestBuilder<'a, PortalAlias<'a>>> {
+    // let alias = cmd.alias.map(|a| a.into());
+    let payload = PortalAlias::new(cmd.alias);
+    let request = Request::get("/node/outlet/show").body(payload);
+    Ok(request)
+}
+
+fn alias_parser(arg: &str) -> Result<String> {
+    if arg.contains(':') {
+        Err(anyhow!("an outlet alias must not contain ':' characters").into())
+    } else {
+        Ok(arg.to_string())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -360,7 +360,7 @@ teardown() {
   assert_success
 
   # Test deletion of a previously deleted TCP inlet
-  run $OCKAM tcp-inlet delete "test-inlet"
+  run $OCKAM tcp-inlet delete "test-inlet" --node /node/n2
   assert_output --partial "NotFound"
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -391,6 +391,24 @@ teardown() {
   assert_output --partial "NotFound"
 }
 
+@test "portals - show a tcp outlet" {
+  port=5100
+  run --separate-stderr "$OCKAM" node create n1
+  assert_success
+
+  run $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to "127.0.0.1:$port" --alias "test-outlet"
+  assert_output --partial "/service/outlet"
+  assert_success
+
+  run $OCKAM tcp-outlet show "test-outlet"
+  assert_success
+
+  # Test if non-existing TCP outlet returns NotFound
+  run $OCKAM tcp-outlet show "non-existing-outlet"
+  assert_output --partial "NotFound"
+}
+
+
 @test "portals - create an inlet/outlet pair and move tcp traffic through it" {
   port=6000
   run --separate-stderr "$OCKAM" node create n1


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

There is no way to directly show a TCP Outlet or Inlet by its `alias` and `node`.

## Proposed changes

- Solves https://github.com/build-trust/ockam/issues/4421 and https://github.com/build-trust/ockam/issues/4435 by introducing the `tcp-outlet show` and `tcp-inlet show` commands

- Adds corresponding bats tests

- Refactored `DeleteInlet` and `DeleteOutlet` into an in-route `alias` param

- Adjusted previous `tcp-inlet`/`tcp-outlet` CRUD tests to use output from `tcp-inlet`/`tcp-outlet` `show` commands in assertions

- Added missing `tcp-outlet list` test

- Fixed a bug where the `tcp-inlet CRUD` test would fail to properly assert the deletion of a non existing inlet


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
