### PR TITLE
fix(elixir): add target_name tag to healthcheck error metris

### DIFF
--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/metrics.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/metrics.ex
@@ -27,7 +27,14 @@ defmodule Ockam.Healthcheck.Metrics do
         measurement: :duration,
         unit: {:native, :millisecond},
         reporter_options: [buckets: [1, 10, 50, 100, 1000]],
-        tags: [:target_host, :target_port, :api_worker, :healthcheck_worker, :reason],
+        tags: [
+          :target_name,
+          :target_host,
+          :target_port,
+          :api_worker,
+          :healthcheck_worker,
+          :reason
+        ],
         tag_values: fn meta ->
           meta = expand_target(meta)
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently healthcheck metrics for OK and status are reporting `target_name` tag, but error metric is missing this tag

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Add missing tag to the metric.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
