### PR TITLE
fix(rust): update stm32f4xx-hal on `example_projects` to fix resolution of `time` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c697cc33851b02ab0c26b2e8a211684fbe627ff1cc506131f35026dd7686dd"
+checksum = "1ba0b55c2201aa802adb684e7963ce2c3191675629e7df899774331e3ac747cf"
 
 [[package]]
 name = "anyhow"
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.9"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dcbed38184f9219183fcf38beb4cdbf5df7163a6d7cd227c6ac89b7966d6fe"
+checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -870,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "9a9d6ada83c1edcce028902ea27dd929069c70df4c7600b131b4d9a1ad2879cc"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -886,18 +886,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.1.4"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501ff0a401473ea1d4c3b125ff95506b62c5bc5768d818634195fbb7c4ad5ff4"
+checksum = "37686beaba5ac9f3ab01ee3172f792fc6ffdd685bfb9e63cfef02c0571a4e8e1"
 dependencies = [
- "clap 4.1.8",
+ "clap 4.1.9",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -908,20 +908,20 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0f09a0ca8f0dd8ac92c546b426f466ef19828185c6d504c80c48c9c2768ed9"
+checksum = "4237e29de9c6949982ba87d51709204504fb8ed2fd38232fcb1e5bf7d4ba48c8"
 dependencies = [
- "clap 4.1.8",
+ "clap 4.1.9",
  "roff",
 ]
 
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa-foundation"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+checksum = "931d3837c286f56e3c58423ce4eba12d08db2374461a785c86f672b08b5650d6"
 dependencies = [
  "bitflags",
  "block",
@@ -2493,10 +2493,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -3203,7 +3204,7 @@ dependencies = [
  "assert_cmd",
  "async-recursion",
  "async-trait",
- "clap 4.1.8",
+ "clap 4.1.9",
  "clap_complete",
  "clap_mangen",
  "cli-table",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -80,7 +80,7 @@ sysinfo = { version = "0.28", default-features = false }
 syntect = "5"
 tempfile = "3.4"
 thiserror = "1"
-tokio = { version="1", features = ["full"] }
+tokio = { version="1.25.0", features = ["full"] }
 tokio-retry = "0.3"
 tracing = { version = "0.1.31", features = ["attributes"] }
 tracing-error = "0.2"

--- a/implementations/rust/ockam/ockam_examples/example_projects/access_control/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/access_control/Cargo.toml
@@ -35,7 +35,7 @@ ockam = { path = "../../../ockam", default_features = false, features = [
 ockam_core = { path = "../../../ockam_core" } # for transport examples
 serde = { version = "1", default_features = false, features = ["derive"] }
 tracing = { version = "0.1", default_features = false }
-tokio = { version = "1.8", default_features = false } # for tokio::time::sleep
+tokio = { version = "1.25.0", default_features = false } # for tokio::time::sleep
 
 [dev-dependencies]
 example_test_helper = { path = "../../../../../../tools/docs/example_test_helper" }

--- a/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/channel/Cargo.toml
@@ -15,7 +15,7 @@ ockam_vault_sync_core = { path = "../../../ockam_vault_sync_core" }
 ockam_vault = { path = "../../../ockam_vault" }
 tracing = { version = "0.1", default-features = false }
 ockam_transport_tcp = { path = "../../../ockam_transport_tcp" }
-tokio = {version = "1.1.0", features = ["rt-multi-thread","sync","net","macros","time"]}
+tokio = {version = "1.25.0", features = ["rt-multi-thread","sync","net","macros","time"]}
 rand = "0.8.3"
 
 [[bin]]

--- a/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/no_std/Cargo.toml
@@ -62,7 +62,7 @@ panic-semihosting = { version = "0.5.6", optional = true }
 tracing = { version = "0.1", default-features = false }
 
 atsame54_xpro = { version = "0.4.0", optional = true }
-stm32f4xx-hal = { version = "0.14.0", features = ["rt", "stm32f407"], optional = true }
+stm32f4xx-hal = { version = "0.15.0", features = ["rt", "stm32f407"], optional = true }
 
 [profile.dev]
 debug = true

--- a/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
+++ b/implementations/rust/ockam/ockam_examples/example_projects/worker/Cargo.toml
@@ -13,4 +13,4 @@ ockam_node = { path = "../../../ockam_node" }
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = { version = "0.1", default-features = false }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.25.0", features = ["full"] }


### PR DESCRIPTION
Sometimes, when building the project I get the following error:

```bash
Execution failed (exit code 101).
/Users/adrian/.cargo/bin/cargo metadata --verbose --format-version 1 --all-features --filter-platform aarch64-apple-darwin
stdout :     Updating crates.io index
error: failed to select a version for `time`.
    ... required by package `ockam_identity v0.70.0 (/Users/adrian/projects/ockam/ockam/implementations/rust/ockam/ockam_identity)`
    ... which satisfies path dependency `ockam_identity` (locked to 0.70.0) of package `ockam v0.82.0 (/Users/adrian/projects/ockam/ockam/implementations/rust/ockam/ockam)`
    ... which satisfies path dependency `ockam` (locked to 0.82.0) of package `hello_ockam_no_std v0.1.0 (/Users/adrian/projects/ockam/ockam/implementations/rust/ockam/ockam_examples/example_projects/no_std)`
versions that meet the requirements `^0.3.20` are: 0.3.20

all possible versions conflict with previously selected packages.

  previously selected package `time v0.3.19`
    ... which satisfies dependency `time = "^0.3.14"` (locked to 0.3.19) of package `stm32f4xx-hal v0.14.0`
    ... which satisfies dependency `stm32f4xx-hal = "^0.14.0"` (locked to 0.14.0) of package `hello_ockam_no_std v0.1.0 (/Users/adrian/projects/ockam/ockam/implementations/rust/ockam/ockam_examples/example_projects/no_std)`

failed to select a version for `time` which could resolve this conflict
```

Looks like, depending on the order of how cargo resolves dependencies (??), building `stm32f4xx-hal` locks `time` to `0.3.19`, which conflicts with the requirement of other crates for `time` being `^0.3.20`.