### PR TITLE
feat(rust): add rendezvous service for nat hole punching

### DIFF
--- a/implementations/rust/ockam/ockam_transport_udp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/lib.rs
@@ -1,6 +1,9 @@
 use ockam_core::TransportType;
+
+pub use rendezvous_service::{RendezvousRequest, RendezvousResponse, RendezvousWorker};
 pub use transport::*;
 
+mod rendezvous_service;
 mod router;
 mod transport;
 mod workers;

--- a/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/messages.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/messages.rs
@@ -1,0 +1,24 @@
+use std::net::SocketAddr;
+
+use ockam_core::{Message, Result};
+use serde::{Deserialize, Serialize};
+
+/// Request type for UDP Hole Punching Rendezvous service
+#[derive(Serialize, Deserialize, Debug, Message)]
+pub enum RendezvousRequest {
+    Update {
+        /// Name of sending node
+        node_name: String,
+    },
+    Query {
+        /// Name of node to lookup
+        node_name: String,
+    },
+}
+
+/// Response type for UDP Hole Punching Rendezvous service
+#[derive(Serialize, Deserialize, Debug, Message)]
+pub enum RendezvousResponse {
+    Update(Result<()>),
+    Query(Result<SocketAddr>),
+}

--- a/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/mod.rs
@@ -1,0 +1,5 @@
+pub use messages::{RendezvousRequest, RendezvousResponse};
+pub use rendezvous::RendezvousWorker;
+
+mod messages;
+mod rendezvous;

--- a/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/rendezvous.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/rendezvous.rs
@@ -1,0 +1,96 @@
+use crate::{
+    rendezvous_service::{RendezvousRequest, RendezvousResponse},
+    UDP,
+};
+use ockam_core::{async_trait, Address, Result, Route, Routed, Worker};
+use ockam_node::Context;
+use ockam_transport_core::TransportError;
+use std::{collections::BTreeMap, net::SocketAddr};
+use tracing::{debug, error, trace};
+
+/// Worker for the UDP NAT Hole Punching Rendezvous service
+///
+/// Maintains an internal map for remote nodes and the public IP address
+/// from which they send UDP datagrams.
+///
+/// Remote nodes can send requests to update and query the map.
+pub struct RendezvousWorker {
+    map: BTreeMap<String, SocketAddr>,
+}
+
+impl Default for RendezvousWorker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RendezvousWorker {
+    pub fn new() -> Self {
+        Self {
+            map: BTreeMap::new(),
+        }
+    }
+
+    /// Get address of next UDP hop
+    fn recent_udp_hop(route: &Route) -> Option<Address> {
+        route.iter().find(|x| x.transport_type() == UDP).cloned()
+    }
+
+    // Handle Update request
+    fn handle_update(&mut self, node_name: &str, return_route: &Route) -> Result<()> {
+        match Self::recent_udp_hop(return_route) {
+            Some(hop) => match hop.address().parse::<SocketAddr>() {
+                Ok(addr) => {
+                    self.map.insert(node_name.to_owned(), addr);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("Failed to parse '{:?}' into a socket address: {:?}", hop, e);
+                    Err(TransportError::InvalidAddress.into())
+                }
+            },
+            None => {
+                // This can happen, for example, if a client erroneously sends a request via TCP not UDP
+                error!("No UDP hop in message's return route: {:?}", return_route);
+                Err(TransportError::InvalidAddress.into())
+            }
+        }
+    }
+
+    // Handle Query request
+    fn handle_query(&self, node_name: &String) -> Result<SocketAddr> {
+        match self.map.get(node_name) {
+            Some(addr) => Ok(*addr),
+            None => Err(TransportError::PeerNotFound.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl Worker for RendezvousWorker {
+    type Message = RendezvousRequest;
+    type Context = Context;
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<Self::Message>,
+    ) -> Result<()> {
+        debug!("Received message: {:?}", msg);
+        let return_route = msg.return_route();
+        match msg.as_body() {
+            RendezvousRequest::Update { node_name } => {
+                let res = self.handle_update(node_name, &return_route);
+                ctx.send(return_route, RendezvousResponse::Update(res))
+                    .await?;
+            }
+            RendezvousRequest::Query { node_name } => {
+                let res = self.handle_query(node_name);
+                ctx.send(return_route, RendezvousResponse::Query(res))
+                    .await?;
+            }
+        }
+        trace!("Map: {:?}", self.map);
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_udp/tests/rendezvous_service.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/tests/rendezvous_service.rs
@@ -1,0 +1,104 @@
+use std::net::SocketAddr;
+
+use ockam_core::{route, AllowAll, Result, Route, Routed, Worker};
+use ockam_node::Context;
+use ockam_transport_udp::{
+    RendezvousRequest, RendezvousResponse, RendezvousWorker, UdpTransport, UDP,
+};
+use tracing::debug;
+
+mod utils;
+
+/// Test the Rendezvous service
+#[ockam_macros::test]
+async fn rendezvous_service(ctx: &mut Context) -> Result<()> {
+    // Find an available port
+    let bind_addr = *utils::available_local_ports(1).await?.first().unwrap();
+    debug!("bind_addr = {:?}", bind_addr);
+
+    // Create transport, start rendezvous service, start echo service and listen
+    let transport = UdpTransport::create(ctx).await?;
+    ctx.start_worker("rendezvous", RendezvousWorker::new(), AllowAll, AllowAll)
+        .await?;
+    let route_rendezvous = route![(UDP, bind_addr.to_string()), "rendezvous"];
+    ctx.start_worker("echo", EchoUDPAddress, AllowAll, AllowAll)
+        .await?;
+    let route_echo = route![(UDP, bind_addr.to_string()), "echo"];
+    transport.listen(bind_addr.to_string()).await?;
+
+    // Use echo service to find out our UDP sending address
+    let send_addr: String = ctx.send_and_receive(route_echo, String::new()).await?;
+    let send_addr = send_addr.parse::<SocketAddr>().unwrap();
+
+    // Send updates to service, should work
+    // Use Alice and Bob with the same address to check the service can
+    // handle multiple internal mappings and that map values can overlap
+    let res = update_operation("Alice", ctx, &route_rendezvous).await;
+    assert!(res.is_ok(), "Update operation should have been okay");
+    let res = update_operation("Bob", ctx, &route_rendezvous).await;
+    assert!(res.is_ok(), "Update operation should have been okay");
+
+    // Send queries to service, should work
+    let res = query_operation("Alice", ctx, &route_rendezvous).await;
+    assert_eq!(res.unwrap(), send_addr, "Unexpected response",);
+    let res = query_operation("Bob", ctx, &route_rendezvous).await;
+    assert_eq!(res.unwrap(), send_addr, "Unexpected response",);
+
+    // Send query to service, should error
+    let res = query_operation("DoesNotExist", ctx, &route_rendezvous).await;
+    assert!(res.is_err(), "Query operation should have failed");
+
+    // Shutdown
+    ctx.stop().await?;
+    Ok(())
+}
+
+/// Helper
+async fn update_operation(node_name: &str, ctx: &Context, route: &Route) -> Result<()> {
+    let msg = RendezvousRequest::Update {
+        node_name: String::from(node_name),
+    };
+    let res: RendezvousResponse = ctx.send_and_receive(route.clone(), msg).await?;
+    match res {
+        RendezvousResponse::Update(r) => r,
+        r => panic!("Invalid response: {:?}", r),
+    }
+}
+
+/// Helper
+async fn query_operation(node_name: &str, ctx: &Context, route: &Route) -> Result<SocketAddr> {
+    let msg = RendezvousRequest::Query {
+        node_name: String::from(node_name),
+    };
+    let res: RendezvousResponse = ctx.send_and_receive(route.clone(), msg).await?;
+    match res {
+        RendezvousResponse::Query(r) => r,
+        r => panic!("Invalid response: {:?}", r),
+    }
+}
+
+/// Echo service that allows us to find out the UDP address the tests are
+/// sending from
+pub struct EchoUDPAddress;
+
+#[ockam_core::worker]
+impl Worker for EchoUDPAddress {
+    type Message = String;
+    type Context = Context;
+
+    async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
+        // Get source UDP address
+        let src_addr = match msg
+            .return_route()
+            .iter()
+            .find(|x| x.transport_type() == UDP)
+        {
+            Some(addr) => String::from(addr.address()),
+            None => String::from("unknown"),
+        };
+
+        // Reply
+        debug!("Replying '{}' to {}", src_addr, &msg.return_route());
+        ctx.send(msg.return_route(), src_addr).await
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_udp/tests/utils.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/tests/utils.rs
@@ -1,0 +1,28 @@
+use ockam::{errcode::Origin, Error};
+use ockam_core::Result;
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+
+const AVAILABLE_LOCAL_PORTS_ADDR: &str = "127.0.0.1:0";
+
+/// Helper function. Try to find numbers of available local UDP ports.
+pub async fn available_local_ports(count: usize) -> Result<Vec<SocketAddr>> {
+    let mut sockets = Vec::new();
+    let mut addrs = Vec::new();
+
+    for _ in 0..count {
+        let s = UdpSocket::bind(AVAILABLE_LOCAL_PORTS_ADDR)
+            .await
+            .map_err(|e| Error::new_unknown(Origin::Unknown, e))?;
+        let a = s
+            .local_addr()
+            .map_err(|e| Error::new_unknown(Origin::Unknown, e))?;
+
+        addrs.push(a);
+
+        // Keep sockets open until we are done asking for available ports
+        sockets.push(s);
+    }
+
+    Ok(addrs)
+}


### PR DESCRIPTION
## Proposed changes

This is part of the prototype for UDP NAT Hole Punching (#3507).

- Add a 'Rendezvous service' to the UDP transport.
- Add tests to exercise new code.

Thanks!

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.