### PR TITLE
Add an `ockam authority create` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,7 @@ dependencies = [
  "thiserror",
  "time",
  "tinyvec",
+ "tokio-retry",
  "tracing",
  "uuid",
 ]

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -44,6 +44,7 @@ serde_json      = "1.0.93"
 time            = { version = "0.3.20", default-features = false }
 tempfile        = "3.4.0"
 tinyvec         = { version = "1.6.0", features = ["rustc_1_57"] }
+tokio-retry     = "0.3.0"
 tracing         = { version = "0.1.34", default-features = false }
 lmdb-rkv        = { version = "0.14.0", optional = true }
 lru             = "0.10.0"

--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -9,6 +9,7 @@ use ockam_identity::authenticated_storage::{
 };
 use ockam_identity::credential::Timestamp;
 use ockam_identity::IdentityIdentifier;
+use serde::{Deserialize, Serialize};
 use serde_json as json;
 use std::path::PathBuf;
 use tracing::trace;
@@ -101,7 +102,7 @@ impl IdentityAttributeStorage for BootstrapedIdentityStore {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PreTrustedIdentities {
     Fixed(HashMap<IdentityIdentifier, AttributesEntry>),
     ReloadFrom(PathBuf),

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -467,15 +467,7 @@ impl IdentitiesState {
     }
 
     pub fn authenticated_storage_path(&self) -> Result<PathBuf> {
-        //TODO: remove this once we don't need to convert from old location anymore
-        //      there is probably a better place for this than here, but this code
-        //      is going to be short-lived and authenticated_storage/1 is anyway
-        //      called once at node startup by node_manager, so it's good enough.
-        let legacy_location = self.dir.join("authenticated_storage.lmdb");
         let lmdb_path = self.dir.join("data").join("authenticated_storage.lmdb");
-        if legacy_location.exists() {
-            std::fs::rename(&legacy_location, &lmdb_path)?;
-        }
         Ok(lmdb_path)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -1034,6 +1034,11 @@ impl FromStr for NodeConfigVersion {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
 pub struct NodeSetupConfig {
     pub verbose: u8,
+
+    /// This flag is used to determine how the node status should be
+    /// displayed in print_query_status
+    pub authority_node: bool,
+
     transports: Vec<CreateTransportJson>,
     // TODO
     // secure_channels: ?,
@@ -1045,6 +1050,11 @@ pub struct NodeSetupConfig {
 impl NodeSetupConfig {
     pub fn set_verbose(mut self, verbose: u8) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    pub fn set_authority_node(mut self) -> Self {
+        self.authority_node = true;
         self
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -1,5 +1,6 @@
 use crate::authenticator::direct::{CredentialIssuer, EnrollmentTokenAuthenticator};
 use crate::bootstrapped_identities_store::{BootstrapedIdentityStore, PreTrustedIdentities};
+use crate::echoer::Echoer;
 use crate::lmdb::LmdbStorage;
 use crate::nodes::authority_node::authority::EnrollerCheck::{AnyMember, EnrollerOnly};
 use crate::nodes::authority_node::{Configuration, TrustedIdentity};
@@ -262,6 +263,12 @@ impl Authority {
             .await?;
         }
         Ok(())
+    }
+
+    /// Start an echo service
+    pub async fn start_echo_service(&self, ctx: &Context) -> Result<()> {
+        ctx.start_worker(DefaultAddress::ECHO_SERVICE, Echoer, AllowAll, AllowAll)
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -134,7 +134,6 @@ impl Authority {
         let direct = crate::authenticator::direct::DirectAuthenticator::new(
             configuration.clone().project_identifier(),
             self.attributes_storage().clone(),
-            self.identity.authenticated_storage().clone(),
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -1,5 +1,7 @@
 use crate::DefaultAddress;
 use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::fmt;
+use ockam_core::compat::fmt::{Display, Formatter};
 use ockam_identity::authenticated_storage::AttributesEntry;
 use ockam_identity::credential::Timestamp;
 use ockam_identity::{IdentityIdentifier, PublicIdentity};
@@ -101,6 +103,16 @@ impl OktaConfiguration {
 pub struct TrustedIdentity {
     identifier: IdentityIdentifier,
     attributes: HashMap<String, String>,
+}
+
+impl Display for TrustedIdentity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(
+            serde_json::to_string(self)
+                .map_err(|_| fmt::Error)?
+                .as_str(),
+        )
+    }
 }
 
 impl TrustedIdentity {

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -1,3 +1,4 @@
+use crate::bootstrapped_identities_store::PreTrustedIdentities;
 use crate::DefaultAddress;
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::fmt;
@@ -36,7 +37,7 @@ pub struct Configuration {
     pub authenticator_name: Option<String>,
 
     /// list of trusted identities (identities with the ockam-role: enroller)
-    pub trusted_identities: Vec<TrustedIdentity>,
+    pub trusted_identities: PreTrustedIdentities,
 
     /// optional configuration for the okta service
     pub okta: Option<OktaConfiguration>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
@@ -32,6 +32,9 @@ pub async fn start_node(ctx: &Context, configuration: &Configuration) -> Result<
     // start the Okta service (if the optional configuration has been provided)
     authority.start_okta(ctx, configuration).await?;
 
+    // start an echo service so that the node can be queried as healthy
+    authority.start_echo_service(ctx).await?;
+
     info!(
         "Authority node started with identity\n{}",
         authority.public_identity().await?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -826,8 +826,8 @@ impl Worker for NodeManagerWorker {
                     cause  = ?err.source(),
                     "failed to handle request"
                 }
-                let err =
-                    Error::new(req.path()).with_message(format!("failed to handle request: {err}"));
+                let err = Error::new(req.path())
+                    .with_message(format!("failed to handle request: {err} {req:?}"));
                 Response::builder(req.id(), Status::InternalServerError)
                     .body(err)
                     .to_vec()?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -312,7 +312,6 @@ impl NodeManager {
         let direct = crate::authenticator::direct::DirectAuthenticator::new(
             proj.to_vec(),
             self.attributes_storage.clone(),
-            self.identity.authenticated_storage().clone(),
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -79,6 +79,7 @@ impl CreateCommand {
     }
 }
 
+/// Given a Context start a node in a new OS process
 async fn create_background_node(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
@@ -87,6 +88,8 @@ async fn create_background_node(
     spawn_background_node(&ctx, &opts, &cmd).await
 }
 
+/// Start an authority node by calling the `ockam` executable with the current command-line
+/// arguments
 async fn spawn_background_node(
     ctx: &Context,
     opts: &CommandGlobalOpts,
@@ -128,6 +131,10 @@ async fn spawn_background_node(
     run_ockam(opts, &cmd.node_name, args)
 }
 
+/// Start an authority node:
+///   - retrieve the node identity if the authority identity has been created before
+///   - persist the node state
+///   - start the node services
 async fn start_authority_node(
     ctx: Context,
     opts: (CommandGlobalOpts, CreateCommand),
@@ -193,6 +200,7 @@ async fn start_authority_node(
     Ok(())
 }
 
+/// Return a list of trusted identities passed as a JSON string on the command line
 fn parse_trusted_identities(values: &str) -> Result<TrustedIdentities> {
     serde_json::from_str::<TrustedIdentities>(values).map_err(|e| {
         crate::Error::new(

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -27,7 +27,7 @@ use tracing::error;
 #[derive(Clone, Debug, Args)]
 #[command(after_long_help = help::template(HELP_DETAIL))]
 #[clap(group(ArgGroup::new("okta").args(&["tenant_base_url", "certificate", "attributes"])))]
-#[clap(group(ArgGroup::new("trusted").args(&["trusted_identities", "reload_from_trusted_identities_file"])))]
+#[clap(group(ArgGroup::new("trusted").required(true).args(&["trusted_identities", "reload_from_trusted_identities_file"])))]
 pub struct CreateCommand {
     /// Name of the node
     #[arg(default_value = "authority")]

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -131,7 +131,7 @@ async fn spawn_background_node(
     opts: &CommandGlobalOpts,
     cmd: &CreateCommand,
 ) -> crate::Result<()> {
-    // Create node state, including the vault and identity if don't exist
+    // Create node state, including the vault and identity if they don't exist
     init_node_state(ctx, opts, &cmd.node_name, None, None).await?;
 
     // Construct the arguments list and re-execute the ockam
@@ -189,6 +189,11 @@ async fn start_authority_node(
 ) -> crate::Result<()> {
     let (options, cmd) = opts;
     let command = cmd.clone();
+
+    // Create node state, including the vault and identity if they don't exist
+    if options.state.nodes.get(&command.node_name).is_err() {
+        init_node_state(&ctx, &options, &command.node_name, None, None).await?;
+    };
 
     // retrieve the authority identity if it has been created before
     // otherwise create a new one

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -1,0 +1,234 @@
+use crate::authority::HELP_DETAIL;
+use crate::help;
+use crate::node::util::init_node_state;
+use crate::node::util::run_ockam;
+use crate::util::node_rpc;
+use crate::util::{embedded_node_that_is_not_stopped, exitcode};
+use crate::{identity, CommandGlobalOpts, Result};
+use anyhow::anyhow;
+use clap::{ArgGroup, Args};
+use ockam::AsyncTryClone;
+use ockam::Context;
+use ockam_api::nodes::authority_node;
+use ockam_api::nodes::authority_node::{OktaConfiguration, TrustedIdentity};
+use ockam_api::DefaultAddress;
+use ockam_core::compat::fmt;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use tracing::error;
+
+/// Create a node
+#[derive(Clone, Debug, Args)]
+#[command(after_long_help = help::template(HELP_DETAIL))]
+#[clap(group(ArgGroup::new("okta").args(&["tenant_base_url", "certificate", "attributes"])))]
+pub struct CreateCommand {
+    /// Name of the node
+    #[arg(default_value = "authority")]
+    node_name: String,
+
+    /// Identifier of the project associated to this authority node on the Orchestrator
+    #[arg(long, value_name = "PROJECT_IDENTIFIER")]
+    project_identifier: String,
+
+    /// TCP listener address
+    #[arg(
+        display_order = 900,
+        long,
+        short,
+        id = "SOCKET_ADDRESS",
+        default_value = "127.0.0.1:4000"
+    )]
+    tcp_listener_address: String,
+
+    /// List of the trusted identities, and corresponding attributes to be preload in the attributes storage
+    #[arg(long, value_name = "JSON_ARRAY", value_parser=parse_trusted_identities)]
+    trusted_identities: TrustedIdentities,
+
+    /// Okta: URL used for accessing the Okta API (optional)
+    #[arg(long, group = "okta", value_name = "URL", default_value = None)]
+    tenant_base_url: Option<String>,
+
+    /// Okta: pem certificate used to access the Okta server (optional)
+    #[arg(long, group = "okta", value_name = "STRING", default_value = None)]
+    certificate: Option<String>,
+
+    /// Okta: name of the attributes which can be retrieved from Okta (optional)
+    #[arg(long, group = "okta", value_name = "COMMA_SEPARATED_LIST", default_value = None)]
+    attributes: Option<Vec<String>>,
+
+    /// Run the node in foreground.
+    #[arg(long, short, value_name = "BOOL", default_value_t = false)]
+    foreground: bool,
+}
+
+impl CreateCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        if self.foreground {
+            // Create a new node in the foreground (i.e. in this OS process)
+            if let Err(e) = embedded_node_that_is_not_stopped(start_authority_node, (options, self))
+            {
+                error!(%e);
+                eprintln!("{e:?}");
+                std::process::exit(e.code());
+            }
+        } else {
+            // Create a new node running in the background (i.e. another, new OS process)
+            node_rpc(create_background_node, (options, self))
+        }
+    }
+}
+
+async fn create_background_node(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+) -> crate::Result<()> {
+    // Spawn node in another, new process
+    spawn_background_node(&ctx, &opts, &cmd).await
+}
+
+async fn spawn_background_node(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    cmd: &CreateCommand,
+) -> crate::Result<()> {
+    // Create node state, including the vault and identity if don't exist
+    init_node_state(ctx, opts, &cmd.node_name, None, None).await?;
+
+    // Construct the arguments list and re-execute the ockam
+    // CLI in foreground mode to start the newly created node
+    let mut args = vec![
+        "authority".to_string(),
+        "create".to_string(),
+        "--project-identifier".to_string(),
+        cmd.project_identifier.clone(),
+        "--tcp-listener-address".to_string(),
+        cmd.tcp_listener_address.clone(),
+        "--trusted-identities".to_string(),
+        cmd.trusted_identities.to_string(),
+        "--foreground".to_string(),
+    ];
+
+    if let Some(tenant_base_url) = &cmd.tenant_base_url {
+        args.push("--tenant-base-url".to_string());
+        args.push(tenant_base_url.clone());
+    }
+
+    if let Some(certificate) = &cmd.certificate {
+        args.push("--certificate".to_string());
+        args.push(certificate.clone());
+    }
+
+    if let Some(attributes) = &cmd.attributes {
+        args.push("--attributes".to_string());
+        args.push(attributes.join(","));
+    }
+
+    run_ockam(opts, &cmd.node_name, args)
+}
+
+async fn start_authority_node(
+    ctx: Context,
+    opts: (CommandGlobalOpts, CreateCommand),
+) -> crate::Result<()> {
+    let (options, cmd) = opts;
+    let command = cmd.clone();
+
+    // retrieve the authority identity if it has been created before
+    // otherwise create a new one
+    let public_identity = match options.state.identities.default().ok() {
+        Some(state) => state.config.public_identity(),
+        None => {
+            let cmd = identity::CreateCommand::new("authority".into(), None);
+            cmd.create_identity(ctx.async_try_clone().await?, options.clone())
+                .await?
+        }
+    };
+
+    let okta_configuration = match (
+        command.tenant_base_url,
+        command.certificate,
+        command.attributes,
+    ) {
+        (Some(tenant_base_url), Some(certificate), Some(attributes)) => Some(OktaConfiguration {
+            address: DefaultAddress::OKTA_IDENTITY_PROVIDER.to_string(),
+            tenant_base_url,
+            certificate,
+            attributes,
+        }),
+        _ => None,
+    };
+
+    let configuration = authority_node::Configuration {
+        identity: public_identity,
+        storage_path: options.state.identities.authenticated_storage_path()?,
+        vault_path: options.state.vaults.default()?.vault_file_path()?,
+        project_identifier: command.project_identifier,
+        tcp_listener_address: command.tcp_listener_address.clone(),
+        secure_channel_listener_name: None,
+        authenticator_name: None,
+        trusted_identities: command.trusted_identities.0,
+        okta: okta_configuration,
+    };
+    authority_node::start_node(&ctx, &configuration).await?;
+
+    Ok(())
+}
+
+fn parse_trusted_identities(values: &str) -> Result<TrustedIdentities> {
+    serde_json::from_str::<TrustedIdentities>(values).map_err(|e| {
+        crate::Error::new(
+            exitcode::CONFIG,
+            anyhow!("Cannot parse the trusted identities: {e}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_core::compat::collections::HashMap;
+    use ockam_identity::IdentityIdentifier;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_parse_trusted_identities() {
+        let identity1 = IdentityIdentifier::from_str(
+            "Pe86be15e83d1c93e24dd1967010b01b6df491b459725fd9ae0bebfd7c1bf8ea3",
+        )
+        .unwrap();
+        let identity2 = IdentityIdentifier::from_str(
+            "P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94",
+        )
+        .unwrap();
+
+        let trusted = format!("[{{\"identifier\":\"{identity1}\", \"attributes\": {{\"name\" : \"value\", \"project_id\" : \"1\"}}}}, {{\"identifier\":\"{identity2}\", \"attributes\": {{\"project_id\" : \"1\", \"ockam-role\" : \"enroller\"}}}}]");
+        let actual = parse_trusted_identities(&trusted.as_str()).unwrap();
+
+        let attributes1 = HashMap::from([
+            ("name".into(), "value".into()),
+            ("project_id".into(), "1".into()),
+        ]);
+        let attributes2 = HashMap::from([
+            ("project_id".into(), "1".into()),
+            ("ockam-role".into(), "enroller".into()),
+        ]);
+        let expected = vec![
+            TrustedIdentity::new(&identity1, &attributes1),
+            TrustedIdentity::new(&identity2, &attributes2),
+        ];
+        assert_eq!(actual.0, expected);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+struct TrustedIdentities(Vec<TrustedIdentity>);
+
+impl Display for TrustedIdentities {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            serde_json::to_string(self)
+                .map_err(|_| fmt::Error)?
+                .as_str(),
+        )
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -122,6 +122,7 @@ async fn spawn_background_node(
         args.push("--attributes".to_string());
         args.push(attributes.join(","));
     }
+    args.push(cmd.node_name.to_string());
 
     run_ockam(opts, &cmd.node_name, args)
 }

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -229,7 +229,7 @@ mod tests {
         .unwrap();
 
         let trusted = format!("[{{\"identifier\":\"{identity1}\", \"attributes\": {{\"name\" : \"value\", \"project_id\" : \"1\"}}}}, {{\"identifier\":\"{identity2}\", \"attributes\": {{\"project_id\" : \"1\", \"ockam-role\" : \"enroller\"}}}}]");
-        let actual = parse_trusted_identities(&trusted.as_str()).unwrap();
+        let actual = parse_trusted_identities(trusted.as_str()).unwrap();
 
         let attributes1 = HashMap::from([
             ("name".into(), "value".into()),

--- a/implementations/rust/ockam/ockam_command/src/authority/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/mod.rs
@@ -1,0 +1,33 @@
+use crate::authority::create::CreateCommand;
+use crate::{help, CommandGlobalOpts};
+use clap::Args;
+use clap::Subcommand;
+mod create;
+
+const HELP_DETAIL: &str = include_str!("../constants/authority/help_detail.txt");
+
+/// Create an Authority node
+#[derive(Clone, Debug, Args)]
+#[command(
+arg_required_else_help = true,
+subcommand_required = true,
+after_long_help = help::template(HELP_DETAIL)
+)]
+pub struct AuthorityCommand {
+    #[command(subcommand)]
+    subcommand: AuthoritySubcommand,
+}
+
+impl AuthorityCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            AuthoritySubcommand::Create(c) => c.run(options),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum AuthoritySubcommand {
+    #[command(display_order = 800)]
+    Create(CreateCommand),
+}

--- a/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
+++ b/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
@@ -12,16 +12,16 @@ Examples:
     # Create an authority node which can be accessed by users of project 93c6455c5f
     # The default node name is 'authority'.
     $ ockam authority create \
-          --tcp-listener-address=127.0.0.1:4200 \
+          --tcp-listener-address 127.0.0.1:4200 \
           --project-identifier 93c6455c5f \
           --trusted-identities "[{\"identifier\": \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\", \"attributes\": {\"ockam-role\": \"enroller\"}}]"
 
     # Create an authority node which can be accessed by users of project 93c6455c5f
     # Trusted identities come from a file which is always reloaded where searching for an identity attribute
     $ ockam authority create \
-          --tcp-listener-address=127.0.0.1:4200 \
+          --tcp-listener-address 127.0.0.1:4200 \
           --project-identifier 93c6455c5f \
-          --reload-from-trusted-identities-file=/mnt/storage/trust-anchors.json
+          --reload-from-trusted-identities-file trust-anchors.json
 
     # Delete an authority node
     $ ockam node delete authority

--- a/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
+++ b/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
@@ -10,11 +10,18 @@ About:
 Examples:
 ```sh
     # Create an authority node which can be accessed by users of project 93c6455c5f
-    # The default node name is 'authority'
+    # The default node name is 'authority'.
     $ ockam authority create \
           --tcp-listener-address=127.0.0.1:4200 \
           --project-identifier 93c6455c5f \
           --trusted-identities "[{\"identifier\": \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\", \"attributes\": {\"ockam-role\": \"enroller\"}}]"
+
+    # Create an authority node which can be accessed by users of project 93c6455c5f
+    # Trusted identities come from a file which is always reloaded where searching for an identity attribute
+    $ ockam authority create \
+          --tcp-listener-address=127.0.0.1:4200 \
+          --project-identifier 93c6455c5f \
+          --reload-from-trusted-identities-file=/mnt/storage/trust-anchors.json
 
     # Delete an authority node
     $ ockam node delete authority

--- a/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
+++ b/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
@@ -1,0 +1,22 @@
+About:
+    An Ockam Authority node is an Ockam node running a limited set of services used by other nodes to:
+
+     - issue credentials
+     - create enrollment tokens
+     - accept enrollment tokens
+     - authenticate identities as project members
+
+    Those services are accessible by creating a secure channel over a TCP connection at `tcp-listener-address`.
+
+Examples:
+```sh
+    # Create an authority node which can be accessed by users of project 93c6455c5f
+    # The default node name is 'authority'
+    $ ockam authority create \
+         --tcp-listener-address=127.0.0.1:4200 \
+         --project-identifier 93c6455c5f \
+         --trusted-identities "[{\"identifier\": \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\", \"attributes\": {\"ockam-role\": \"enroller\"}}]"
+
+    # Delete an authority node
+    $ ockam node delete authority
+```

--- a/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
+++ b/implementations/rust/ockam/ockam_command/src/constants/authority/help_detail.txt
@@ -1,10 +1,9 @@
 About:
     An Ockam Authority node is an Ockam node running a limited set of services used by other nodes to:
-
-     - issue credentials
-     - create enrollment tokens
-     - accept enrollment tokens
-     - authenticate identities as project members
+        - issue credentials
+        - create enrollment tokens
+        - accept enrollment tokens
+        - authenticate identities as project members
 
     Those services are accessible by creating a secure channel over a TCP connection at `tcp-listener-address`.
 
@@ -13,9 +12,9 @@ Examples:
     # Create an authority node which can be accessed by users of project 93c6455c5f
     # The default node name is 'authority'
     $ ockam authority create \
-         --tcp-listener-address=127.0.0.1:4200 \
-         --project-identifier 93c6455c5f \
-         --trusted-identities "[{\"identifier\": \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\", \"attributes\": {\"ockam-role\": \"enroller\"}}]"
+          --tcp-listener-address=127.0.0.1:4200 \
+          --project-identifier 93c6455c5f \
+          --trusted-identities "[{\"identifier\": \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\", \"attributes\": {\"ockam-role\": \"enroller\"}}]"
 
     # Delete an authority node
     $ ockam node delete authority

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod admin;
 mod authenticated;
+mod authority;
 mod completion;
 mod configuration;
 mod credential;
@@ -62,6 +63,7 @@ use version::Version;
 use worker::WorkerCommand;
 
 use crate::admin::AdminCommand;
+use crate::authority::AuthorityCommand;
 use crate::subscription::SubscriptionCommand;
 use crate::terminal::{Terminal, TerminalStream};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
@@ -194,6 +196,8 @@ pub enum OckamSubcommand {
     #[command(display_order = 804)]
     Reset(ResetCommand),
 
+    #[command(display_order = 810)]
+    Authority(AuthorityCommand),
     #[command(display_order = 811)]
     Node(NodeCommand),
     #[command(display_order = 812)]
@@ -272,6 +276,7 @@ impl OckamCommand {
             OckamSubcommand::Status(c) => c.run(options),
             OckamSubcommand::Reset(c) => c.run(options),
 
+            OckamSubcommand::Authority(c) => c.run(options),
             OckamSubcommand::Node(c) => c.run(options),
             OckamSubcommand::Identity(c) => c.run(options),
             OckamSubcommand::TcpListener(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -162,7 +162,7 @@ impl CreateCommand {
     }
 }
 
-fn parse_launch_config(config_or_path: &str) -> Result<Config> {
+pub fn parse_launch_config(config_or_path: &str) -> Result<Config> {
     match serde_json::from_str::<Config>(config_or_path) {
         Ok(c) => Ok(c),
         Err(_) => {
@@ -354,7 +354,7 @@ async fn run_foreground_node(
     Ok(())
 }
 
-fn load_pre_trusted_identities(cmd: &CreateCommand) -> Result<Option<PreTrustedIdentities>> {
+pub fn load_pre_trusted_identities(cmd: &CreateCommand) -> Result<Option<PreTrustedIdentities>> {
     let command = cmd.clone();
     let pre_trusted_identities = match (
         command.trusted_identities,
@@ -517,7 +517,7 @@ async fn spawn_background_node(
     Ok(())
 }
 
-fn parse_identity_authority(identity: &str) -> Result<Authority> {
+pub fn parse_identity_authority(identity: &str) -> Result<Authority> {
     let identity_as_bytes = match hex::decode(identity) {
         Ok(b) => b,
         Err(e) => return Err(anyhow!(e).into()),

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -217,6 +217,8 @@ async fn run_foreground_node(
     let cfg = &opts.config;
     let node_name = parse_node_name(&cmd.node_name)?;
 
+    // TODO: remove this special case once the Orchestrator has migrated to the
+    // new ockam authority create command
     if node_name == "authority" && cmd.launch_config.is_some() {
         return start_authority_node(ctx, (opts, cmd)).await;
     };

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -21,6 +21,7 @@ mod show;
 mod start;
 mod stop;
 pub mod util;
+pub use create::*;
 
 const HELP_DETAIL: &str = include_str!("../constants/node/help_detail.txt");
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -165,8 +165,24 @@ pub async fn print_query_status(
                 .ok()
                 .map(|listener| listener.addr.port())
         });
+
+        // it is expected to not be able to open an arbitrary TCP connection on an authority node
+        // so in that case we display an UP status
+        let is_authority_node = node_state
+            .setup()
+            .ok()
+            .map(|setup| setup.authority_node)
+            .unwrap_or_default();
         print_node_info(
-            node_port, node_name, is_default, false, None, None, None, None, None,
+            node_port,
+            node_name,
+            is_default,
+            is_authority_node,
+            None,
+            None,
+            None,
+            None,
+            None,
         );
     } else {
         // Get short id for the node

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -420,7 +420,7 @@ where
     Fut: core::future::Future<Output = crate::Result<T>> + Send + 'static,
     T: Send + 'static,
 {
-    let (ctx, mut executor) = NodeBuilder::new().no_logging().build();
+    let (mut ctx, mut executor) = NodeBuilder::new().no_logging().build();
     executor.execute(async move {
         let child_ctx = ctx
             .new_detached(
@@ -430,7 +430,13 @@ where
             )
             .await
             .expect("Embedded node child ctx can't be created");
-        f(child_ctx, a).await
+        let result = f(child_ctx, a).await;
+        if result.is_err() {
+            ctx.stop().await?;
+            result
+        } else {
+            result
+        }
     })?
 }
 
@@ -749,5 +755,32 @@ mod tests {
 
         ctx.stop().await?;
         Ok(())
+    }
+
+    #[test]
+    fn test_execute_error() {
+        let result = embedded_node_that_is_not_stopped(function_returning_an_error, 1);
+        assert!(result.is_err());
+
+        async fn function_returning_an_error(_ctx: Context, _parameter: u8) -> crate::Result<()> {
+            Err(crate::Error::new(exitcode::CONFIG, anyhow!("boom")))
+        }
+    }
+
+    #[test]
+    fn test_execute_error_() {
+        let result = embedded_node_that_is_not_stopped(
+            function_returning_an_error_and_stopping_the_context,
+            1,
+        );
+        assert!(result.is_err());
+
+        async fn function_returning_an_error_and_stopping_the_context(
+            mut ctx: Context,
+            _parameter: u8,
+        ) -> crate::Result<()> {
+            ctx.stop().await?;
+            Err(crate::Error::new(exitcode::CONFIG, anyhow!("boom")))
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -26,12 +26,8 @@ teardown() {
   m1_identifier=$($OCKAM identity show m1)
   m2_identifier=$($OCKAM identity show m2)
 
-  # Create a launch configuration json file,  to be used to start the authority node
-  echo '{"startup_services" : {"authenticator" : {"project" : "1"}, "secure_channel_listener": {}}}' >"$OCKAM_HOME/auth_launch_config.json"
-
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
-
-  run "$OCKAM" node create --tcp-listener-address=127.0.0.1:4200 --identity authority --launch-config "$OCKAM_HOME/auth_launch_config.json" --trusted-identities "{\"$m1_identifier\": {\"sample_attr\" : \"sample_val\", \"project_id\" : \"1\"}, \"$enroller_identifier\" : {\"project_id\" : \"1\", \"ockam-role\" : \"enroller\"}}" authority
+  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "[{\"identifier\": \"$m1_identifier\", \"attributes\": {\"sample_attr\" : \"sample_val\", \"project_id\" : \"1\"}}, {\"identifier\": \"$enroller_identifier\", \"attributes\": {\"project_id\": \"1\", \"ockam-role\": \"enroller\"}} ]"
   assert_success
 
   echo "{\"id\": \"1\",

--- a/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
+++ b/implementations/rust/ockam/ockam_identity/src/authenticated_storage.rs
@@ -8,6 +8,7 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::compat::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Result;
+use serde::{Deserialize, Serialize};
 
 /// Storage for Authenticated data
 #[async_trait]
@@ -27,7 +28,7 @@ pub trait AuthenticatedStorage: Send + Sync + 'static {
 }
 
 /// An entry on the AuthenticatedIdentities table.
-#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Serialize, Deserialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct AttributesEntry {

--- a/implementations/rust/ockam/ockam_identity/src/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential.rs
@@ -292,7 +292,9 @@ impl Attributes {
 }
 
 /// A Unix timestamp (seconds since 1970-01-01 00:00:00 UTC)
-#[derive(Debug, Clone, Copy, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, Copy, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 #[cbor(transparent)]
 pub struct Timestamp(#[n(0)] u64);
 


### PR DESCRIPTION
This PR adds a new command `ockam authority create` to create an Authority node.

An authority node is a node which only starts authentication services (credentials, enrollment tokens, authentification).
Those services are only accessible by first creating a secure channel.

When the Orchestrator has migrated to this command it will be possible to remove the [special casing of the current `ockam node create` command for authority nodes](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_command/src/node/create.rs#L220).