### PR TITLE
ci : added default shell in create-release-pull-request

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -31,6 +31,10 @@ on:
         - major
         - minor
         - patch
+# runs every command in bash (for every job in the workflow)
+defaults:
+  run:
+    shell: bash
 
 jobs:
   bump_crates:
@@ -70,7 +74,6 @@ jobs:
           gpg_email: '${{ secrets.GPG_EMAIL }}'
 
       - name: Bump Ockam
-        shell: bash
         env:
           OCKAM_BUMP_RELEASE_VERSION: '${{ github.event.inputs.ockam_bump_release_version }}'
           OCKAM_BUMP_MODIFIED_RELEASE: '${{ github.event.inputs.ockam_bump_modified_release }}'
@@ -79,13 +82,11 @@ jobs:
         run: bash -ex ./tools/scripts/release/crate-bump.sh
 
       - name: Generate Changelogs
-        shell: bash
         env:
           GIT_TAG: '${{ github.event.inputs.git_tag }}'
         run: bash -ex ./tools/scripts/release/changelog.sh
 
       - name: Push Update
-        shell: bash
         run: |
           # Squash commits
           git reset ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

This issue solves the problem in https://github.com/build-trust/ockam/issues/3995 the problem was , in every job or run command there was a need for mentioning which shell do we need to run the command in .

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

To solve this issue , I used a default to create a map of the settings that will apply to every job in the workflow and gave a default value for shell as bash since every run command in the workflow runs in bash

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
