### PR TITLE
refactor(rust): refactored channel decryptor state to the most normal…

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/channel/common.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/common.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Message)]
 pub(crate) struct AuthenticationConfirmation;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) enum Role {
     Initiator,
     Responder,

--- a/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/decryptor_state.rs
@@ -1,28 +1,113 @@
+use crate::channel::addresses::Addresses;
 use crate::channel::decryptor::Decryptor;
 use crate::channel::encryptor::Encryptor;
-use crate::IdentityIdentifier;
+use crate::channel::Role;
+use crate::{Identity, IdentityIdentifier, TrustPolicy};
+use alloc::vec::Vec;
 use ockam_core::compat::boxed::Box;
-use ockam_core::KeyExchanger;
+use ockam_core::compat::sync::Arc;
+use ockam_core::{Address, KeyExchanger, Route};
 
-pub(crate) struct KeyExchange {
-    pub key_exchanger: Box<dyn KeyExchanger>,
+pub(crate) struct KeyExchangeState {
+    pub(crate) role: Role,
+    pub(crate) identity: Identity,
+    pub(crate) addresses: Addresses,
+    pub(crate) remote_route: Route,
+    pub(crate) key_exchanger: Box<dyn KeyExchanger>,
+    pub(crate) initial_responder_payload: Option<Vec<u8>>,
+    pub(crate) initialization_run: bool,
+
+    remote_backwards_compatibility_address: Option<Address>,
+    trust_policy: Arc<dyn TrustPolicy>,
 }
 
-pub(crate) struct ExchangeIdentity {
-    pub encryptor: Encryptor,
-    pub decryptor: Decryptor,
-    pub auth_hash: [u8; 32],
-    pub identity_sent: bool,
-    pub received_identity_id: Option<IdentityIdentifier>,
+pub(crate) struct IdentityExchangeState {
+    pub(crate) role: Role,
+    pub(crate) identity: Identity,
+    pub(crate) encryptor: Option<Encryptor>,
+    pub(crate) addresses: Addresses,
+    pub(crate) remote_route: Route,
+    pub(crate) decryptor: Decryptor,
+    pub(crate) auth_hash: [u8; 32],
+    pub(crate) identity_sent: bool,
+    pub(crate) trust_policy: Arc<dyn TrustPolicy>,
+    pub(crate) remote_backwards_compatibility_address: Option<Address>,
 }
 
-pub(crate) struct Initialized {
-    pub decryptor: Decryptor,
-    pub their_identity_id: IdentityIdentifier,
+pub(crate) struct InitializedState {
+    //for debug purposes only
+    pub(crate) role: &'static str,
+    pub(crate) addresses: Addresses,
+    pub(crate) decryptor: Decryptor,
+    pub(crate) their_identity_id: IdentityIdentifier,
 }
 
+impl KeyExchangeState {
+    pub(crate) fn into_identity_exchange(
+        self,
+        encryptor: Encryptor,
+        decryptor: Decryptor,
+        auth_hash: [u8; 32],
+    ) -> IdentityExchangeState {
+        IdentityExchangeState {
+            role: self.role,
+            identity: self.identity,
+            remote_route: self.remote_route,
+            addresses: self.addresses,
+            trust_policy: self.trust_policy,
+            remote_backwards_compatibility_address: self.remote_backwards_compatibility_address,
+            encryptor: Some(encryptor),
+            decryptor,
+            auth_hash,
+            identity_sent: false,
+        }
+    }
+}
+
+impl IdentityExchangeState {
+    pub(crate) fn into_initialized(
+        self,
+        their_identity_id: IdentityIdentifier,
+    ) -> InitializedState {
+        InitializedState {
+            role: self.role.str(),
+            addresses: self.addresses,
+            decryptor: self.decryptor,
+            their_identity_id,
+        }
+    }
+}
+
+// false positive: https://github.com/rust-lang/rust-clippy/issues/9798
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum State {
-    KeyExchange,
-    ExchangeIdentity,
-    Initialized,
+    KeyExchange(KeyExchangeState),
+    IdentityExchange(IdentityExchangeState),
+    Initialized(InitializedState),
+}
+
+impl State {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        role: Role,
+        identity: Identity,
+        addresses: Addresses,
+        key_exchanger: Box<dyn KeyExchanger>,
+        remote_route: Route,
+        trust_policy: Arc<dyn TrustPolicy>,
+        remote_backwards_compatibility_address: Option<Address>,
+        initial_responder_payload: Option<Vec<u8>>,
+    ) -> Self {
+        Self::KeyExchange(KeyExchangeState {
+            role,
+            identity,
+            addresses,
+            remote_route,
+            key_exchanger,
+            trust_policy,
+            remote_backwards_compatibility_address,
+            initial_responder_payload,
+            initialization_run: true,
+        })
+    }
 }

--- a/implementations/rust/ockam/ockam_identity/src/channel/encryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/channel/encryptor_worker.rs
@@ -1,7 +1,6 @@
 use crate::api::{EncryptionRequest, EncryptionResponse};
 use crate::channel::addresses::Addresses;
 use crate::channel::encryptor::Encryptor;
-use crate::channel::Role;
 use crate::error::IdentityError;
 use ockam_core::compat::boxed::Box;
 use ockam_core::{async_trait, Address, Decodable, Encodable, Route};
@@ -10,7 +9,8 @@ use ockam_node::Context;
 use tracing::debug;
 
 pub(crate) struct EncryptorWorker {
-    role: Role,
+    //for debug purposes only
+    role: &'static str,
     addresses: Addresses,
     remote_route: Route,
     remote_backwards_compatibility_address: Address,
@@ -19,7 +19,7 @@ pub(crate) struct EncryptorWorker {
 
 impl EncryptorWorker {
     pub fn new(
-        role: Role,
+        role: &'static str,
         addresses: Addresses,
         remote_route: Route,
         remote_backwards_compatibility_address: Address,
@@ -41,8 +41,7 @@ impl EncryptorWorker {
     ) -> Result<()> {
         debug!(
             "SecureChannel {} received Encrypt API {}",
-            self.role.str(),
-            &self.addresses.encryptor
+            self.role, &self.addresses.encryptor
         );
 
         let return_route = msg.return_route();
@@ -72,8 +71,7 @@ impl EncryptorWorker {
     ) -> Result<()> {
         debug!(
             "SecureChannel {} received Encrypt {}",
-            self.role.str(),
-            &self.addresses.encryptor
+            self.role, &self.addresses.encryptor
         );
 
         let mut onward_route = msg.onward_route();


### PR DESCRIPTION
## Current behavior

From the decryptor state, it isn't clear which fields are used in which phase. If an error occurs during secure channel construction, a half-modified state is kept.

## Proposed changes

Every step has explicit field dependencies expressed in the structures, if an error occurs during secure channel construction, the worker state is lost, becoming inoperable.
Some of the logic was also made more explicit by splitting the identity exchange.