### PR TITLE
feat(rust): Create clap command to delete an existing secure-channel listener on a node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -125,6 +125,46 @@ impl<'a> CreateSecureChannelListenerRequest<'a> {
     }
 }
 
+/// Request body when deleting a Secure Channel Listener
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteSecureChannelListenerRequest<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<8293631>,
+    #[b(1)] pub addr: Cow<'a, str>,
+}
+
+impl<'a> DeleteSecureChannelListenerRequest<'a> {
+    pub fn new(addr: &Address) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addr: addr.to_string().into(),
+        }
+    }
+}
+
+/// Response body when deleting a Secure Channel Listener
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteSecureChannelListenerResponse<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<8642885>,
+    #[b(1)] pub addr: Option<Cow<'a, str>>,
+}
+
+impl<'a> DeleteSecureChannelListenerResponse<'a> {
+    pub fn new(addr: Option<Address>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addr: addr.map(|ch| ch.to_string().into()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -604,6 +604,10 @@ impl NodeManagerWorker {
                 .create_secure_channel_listener(req, dec, ctx)
                 .await?
                 .to_vec()?,
+            (Delete, ["node", "secure_channel_listener"]) => self
+                .delete_secure_channel_listener(req, dec)
+                .await?
+                .to_vec()?,
 
             // ==*== Services ==*==
             (Post, ["node", "services", DefaultAddress::VAULT_SERVICE]) => {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/common.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/common.rs
@@ -1,0 +1,10 @@
+use clap::Args;
+
+use crate::node::default_node_name;
+
+#[derive(Clone, Debug, Args)]
+pub struct SecureChannelListenerNodeOpts {
+    /// Node at which to create the listener
+    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
+    pub at: String,
+}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
-use crate::node::default_node_name;
+use super::common::SecureChannelListenerNodeOpts;
 use crate::secure_channel::HELP_DETAIL;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{help, CommandGlobalOpts, Result};
@@ -32,13 +32,6 @@ pub struct CreateCommand {
 
     #[arg(value_name = "IDENTITY", long)]
     identity: Option<String>,
-}
-
-#[derive(Clone, Debug, Args)]
-pub struct SecureChannelListenerNodeOpts {
-    /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
-    pub at: String,
 }
 
 impl CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -1,0 +1,49 @@
+use clap::Args;
+
+use ockam::Context;
+use ockam_core::Address;
+
+use super::common::SecureChannelListenerNodeOpts;
+use crate::secure_channel::HELP_DETAIL;
+use crate::util::{api, extract_address_value, node_rpc, Rpc};
+use crate::{help, CommandGlobalOpts};
+
+/// Delete Secure Channel Listeners
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, after_long_help = help::template(HELP_DETAIL))]
+pub struct DeleteCommand {
+    /// Address at which the channel listener to be deleted is running (required)
+    address: Address,
+
+    #[command(flatten)]
+    node_opts: SecureChannelListenerNodeOpts,
+}
+
+impl DeleteCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(rpc, (opts, self));
+    }
+}
+
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> crate::Result<()> {
+    run_impl(&ctx, (opts, cmd)).await
+}
+
+async fn run_impl(
+    ctx: &Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    let at = &cmd.node_opts.at;
+
+    let node = extract_address_value(at)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node)?;
+    let req = api::delete_secure_channel_listener(&cmd.address);
+    rpc.request(req).await?;
+    rpc.is_ok()?;
+
+    println!(
+        "Deleted secure-channel listener with address '/service/{}' on node '{node}'",
+        cmd.address.address()
+    );
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
@@ -1,7 +1,10 @@
+mod common;
 pub mod create;
+pub mod delete;
 pub mod list;
 
 pub(crate) use create::CreateCommand;
+pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 
 use crate::secure_channel::HELP_DETAIL;
@@ -25,6 +28,8 @@ pub enum SecureChannelListenerSubcommand {
     #[command(display_order = 800)]
     Create(CreateCommand),
     #[command(display_order = 800)]
+    Delete(DeleteCommand),
+    #[command(display_order = 800)]
     List(ListCommand),
 }
 
@@ -32,6 +37,7 @@ impl SecureChannelListenerCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             SecureChannelListenerSubcommand::Create(c) => c.run(options),
+            SecureChannelListenerSubcommand::Delete(c) => c.run(options),
             SecureChannelListenerSubcommand::List(c) => c.run(options),
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -116,6 +116,13 @@ pub(crate) fn list_secure_channel_listener() -> RequestBuilder<'static, ()> {
     Request::get("/node/secure_channel_listener")
 }
 
+pub(crate) fn delete_secure_channel_listener(
+    addr: &Address,
+) -> RequestBuilder<'static, models::secure_channel::DeleteSecureChannelListenerRequest<'static>> {
+    let payload = models::secure_channel::DeleteSecureChannelListenerRequest::new(addr);
+    Request::delete("/node/secure_channel_listener").body(payload)
+}
+
 /// Construct a request to start a Vault Service
 pub(crate) fn start_vault_service(addr: &str) -> RequestBuilder<'static, StartVaultServiceRequest> {
     let payload = StartVaultServiceRequest::new(addr);


### PR DESCRIPTION
## Current behaviour

Currently cannot delete a secure-channel listener

## Proposed changes

```
ockam secure-channel-listener delete [address] --at [node-name]
```

Required args:
- address: the listener's address

Optional args:
- at: defaults to the default node

Output: show a message to confirm the deletion of the listener.

```
Deleted secure-channel listener with address '/service/<service_name>' on node 'node-name'
```