### PR TITLE
Authority node options

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -131,6 +131,10 @@ impl Authority {
         secure_channel_session_id: &SessionId,
         configuration: &Configuration,
     ) -> Result<()> {
+        if !configuration.direct_authentication {
+            return Ok(());
+        }
+
         let direct = crate::authenticator::direct::DirectAuthenticator::new(
             configuration.clone().project_identifier(),
             self.attributes_storage().clone(),
@@ -159,6 +163,10 @@ impl Authority {
         secure_channel_session_id: &SessionId,
         configuration: &Configuration,
     ) -> Result<()> {
+        if !configuration.token_enrollment {
+            return Ok(());
+        }
+
         let (issuer, acceptor) = EnrollmentTokenAuthenticator::new_worker_pair(
             configuration.project_identifier(),
             self.attributes_storage(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -39,6 +39,12 @@ pub struct Configuration {
     /// list of trusted identities (identities with the ockam-role: enroller)
     pub trusted_identities: PreTrustedIdentities,
 
+    /// If true start the direct authenticator service
+    pub direct_authentication: bool,
+
+    /// If true start the token enroller service
+    pub token_enrollment: bool,
+
     /// optional configuration for the okta service
     pub okta: Option<OktaConfiguration>,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
@@ -22,9 +22,11 @@ pub async fn start_node(ctx: &Context, configuration: &Configuration) -> Result<
     authority
         .start_direct_authenticator(ctx, &sessions, &secure_channel_session_id, configuration)
         .await?;
+
     authority
         .start_enrollment_services(ctx, &sessions, &secure_channel_session_id, configuration)
         .await?;
+
     authority
         .start_credential_issuer(ctx, &sessions, &secure_channel_session_id, configuration)
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -568,6 +568,8 @@ async fn start_authority_node(
             secure_channel_listener_name: Some(secure_channel_config.address),
             authenticator_name: Some(authenticator_config.address),
             trusted_identities,
+            direct_authentication: true,
+            token_enrollment: true,
             okta: None,
         };
         authority_node::start_node(&ctx, &configuration).await?;

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -29,7 +29,8 @@ teardown() {
   m2_identifier=$($OCKAM identity show m2)
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
-  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "[{\"identifier\": \"$m1_identifier\", \"attributes\": {\"sample_attr\" : \"sample_val\", \"project_id\" : \"1\"}}, {\"identifier\": \"$enroller_identifier\", \"attributes\": {\"project_id\": \"1\", \"ockam-role\": \"enroller\"}} ]"
+  trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\", \"project_id\" : \"1\"}, \"$enroller_identifier\": {\"project_id\": \"1\", \"ockam-role\": \"enroller\"}}"
+  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "$trusted"
   assert_success
 
   echo "{\"id\": \"1\",
@@ -44,7 +45,7 @@ teardown() {
   assert_success
   assert_output --partial "sample_val"
 
-  echo "{\"$m1_identifier\": {\"sample_attr\" : \"sample_val\", \"project_id\" : \"1\"}, \"$enroller_identifier\": {\"project_id\": \"1\", \"ockam-role\": \"enroller\"}}" > "$OCKAM_HOME/trusted-anchors.json"
+  echo "$trusted" > "$OCKAM_HOME/trusted-anchors.json"
   # Restart the authority node with a trusted identities file and check that m1 can still authenticate
   run "$OCKAM" node delete authority
   run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --reload-from-trusted-identities-file "$OCKAM_HOME/trusted-anchors.json"


### PR DESCRIPTION
This PR improves the options of the `ockam authority create` command:

 - it makes the trusted identities format consistant between the command line argument format and the file format
 - it adds 2 options to possibly disable the direct authentication and the token enrollment