### PR TITLE
docs(rust): improve documentation of `node` subcommands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -1,6 +1,7 @@
 use crate::terminal::TerminalBackground;
 use colorful::Colorful;
 use once_cell::sync::Lazy;
+use std::io::{Read, Write};
 use syntect::highlighting::Theme;
 use syntect::{
     easy::HighlightLines,
@@ -9,6 +10,7 @@ use syntect::{
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},
 };
+use termcolor::WriteColor;
 
 const FOOTER: &str = "
 Learn More:
@@ -123,4 +125,18 @@ fn highlight_syntax(input: String) -> String {
     } else {
         input
     }
+}
+
+#[allow(unused)]
+fn to_bold_and_underline(mut b: String, s: &str) -> String {
+    let mut buffer = termcolor::Buffer::ansi();
+    let mut color = termcolor::ColorSpec::new();
+    color.set_bold(true);
+    color.set_underline(true);
+    let err_msg = "Failed to create styled text";
+    buffer.set_color(&color).expect(err_msg);
+    buffer.write_all(s.as_bytes()).expect(err_msg);
+    buffer.reset().expect(err_msg);
+    buffer.as_slice().read_to_string(&mut b).expect(err_msg);
+    b
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -1,5 +1,5 @@
 use crate::util::node_rpc;
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam::Context;
 use ockam_api::cli_state::{self, VaultConfig};
@@ -7,7 +7,15 @@ use ockam_core::compat::sync::Arc;
 use ockam_identity::{Identity, PublicIdentity};
 use rand::prelude::random;
 
+const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
+/// Create a new identity
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct CreateCommand {
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/identity/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/default.rs
@@ -1,10 +1,18 @@
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam_api::cli_state::CliStateError;
 
-/// Set the default identity
+const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt");
+
+/// Change the default identity
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DefaultCommand {
     /// Name of the identity to be set as default
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,12 +1,20 @@
 use crate::util::node_rpc;
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam::Context;
 use ockam_api::cli_state::CliStateError;
 
+const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
 /// Delete an identity
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DeleteCommand {
     /// Name of the identity to be deleted
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -1,12 +1,19 @@
 use crate::util::exitcode;
 use crate::util::output::Output;
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};
 
-/// List nodes
+const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
+/// List identities
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ListCommand {
     #[arg(short, long)]
     full: bool,

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -10,12 +10,21 @@ pub(crate) use list::ListCommand;
 use ockam_api::cli_state::CliState;
 pub(crate) use show::ShowCommand;
 
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use crate::{error::Error, identity::default::DefaultCommand};
 use clap::{Args, Subcommand};
 
-/// Manage Identities
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
+
+/// Manage identities
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct IdentityCommand {
     #[command(subcommand)]
     subcommand: IdentitySubcommand,
@@ -23,15 +32,10 @@ pub struct IdentityCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum IdentitySubcommand {
-    /// Create Identity
     Create(CreateCommand),
-    /// Print short existing identity, `--full` for long identity
     Show(ShowCommand),
-    /// Print all existing identities, `--full` for long identities
     List(ListCommand),
-    /// Set the default identity
     Default(DefaultCommand),
-    /// Delete an identity
     Delete(DeleteCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,8 +1,6 @@
 use crate::util::output::Output;
 use crate::util::print_output;
-use crate::{
-    EncodeFormat, {CommandGlobalOpts, Result},
-};
+use crate::{docs, CommandGlobalOpts, EncodeFormat, Result};
 use anyhow::anyhow;
 use clap::Args;
 use core::fmt::Write;
@@ -10,7 +8,15 @@ use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};
 use ockam_identity::change_history::IdentityChangeHistory;
 
+const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
+
+/// Show the details of a node
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ShowCommand {
     #[arg(default_value_t = default_identity_name())]
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/identity/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/create/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# To create a new identity with a random name
+$ ockam identity create
+
+# To create a new identity with a specific name
+$ ockam identity create i
+
+# To create a new identity for a specific vault
+$ ockam identity create --vault v
+```

--- a/implementations/rust/ockam/ockam_command/src/identity/static/create/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/create/long_about.txt
@@ -1,0 +1,2 @@
+This command will create a new identity. It will create a vault if none exists and will be assigned as the default for the system.
+

--- a/implementations/rust/ockam/ockam_command/src/identity/static/default/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/default/after_long_help.txt
@@ -1,0 +1,8 @@
+```sh
+# The first created identity will be set as the default identity
+$ ockam identity create i1
+
+# Let's create a second identity and assign it as default
+$ ockam identity create i2
+$ ockam identity default i2
+```

--- a/implementations/rust/ockam/ockam_command/src/identity/static/default/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/default/long_about.txt
@@ -1,0 +1,1 @@
+This command will change the default identity. The default identity is used when creating a node if not specified otherwise.

--- a/implementations/rust/ockam/ockam_command/src/identity/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/delete/after_long_help.txt
@@ -1,0 +1,4 @@
+```sh
+# To delete an identity given its name
+$ ockam identity delete i
+```

--- a/implementations/rust/ockam/ockam_command/src/identity/static/delete/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/delete/long_about.txt
@@ -1,0 +1,1 @@
+This command will delete the specified identity. If a running node is using that identity, it won't be deleted and an error will be raised.

--- a/implementations/rust/ockam/ockam_command/src/identity/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/list/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam identity list
+```

--- a/implementations/rust/ockam/ockam_command/src/identity/static/list/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/list/long_about.txt
@@ -1,0 +1,1 @@
+This command will show the details of all the available identities.

--- a/implementations/rust/ockam/ockam_command/src/identity/static/show/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/show/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# To show the default identity
+$ ockam identity show
+
+# To show a specific identity
+$ ockam identity show i
+
+# To show the full details
+$ ockam identity show --full
+```

--- a/implementations/rust/ockam/ockam_command/src/identity/static/show/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/identity/static/show/long_about.txt
@@ -1,0 +1,1 @@
+This command will show by default the identifier of a given identity. If the `--full` flag is passed, it will show the change history of the identity.

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -21,7 +21,7 @@ use crate::service::start;
 use crate::util::node_rpc;
 use crate::util::{bind_to_port_check, embedded_node_that_is_not_stopped, exitcode};
 use crate::{
-    identity, node::show::print_query_status, project, util::find_available_port,
+    docs, identity, node::show::print_query_status, project, util::find_available_port,
     CommandGlobalOpts, Result,
 };
 use crate::{node::util::spawn_node, util::parse_node_name};
@@ -47,8 +47,15 @@ use ockam_api::{
 use ockam_api::{config::cli, nodes::models::transport::CreateTransportJson};
 use ockam_core::{AllowAll, LOCAL};
 
-/// Create a node
+const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
+/// Create a new node
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct CreateCommand {
     /// Name of the node (Optional).
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,10 +1,17 @@
 use crate::node::default_node_name;
 use crate::node::util::{check_default, set_default_node};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
-/// Changes default node
+const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt");
+
+/// Change the default node
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DefaultCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name())]

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,12 +1,18 @@
 use crate::node::default_node_name;
 use crate::node::util::{delete_all_nodes, delete_node};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 
-/// Delete a node
+const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
+/// Delete nodes
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DeleteCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name(), group = "nodes")]

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,13 +1,20 @@
 use crate::util::{api, exitcode, node_rpc, RpcBuilder};
-use crate::{node::show::print_query_status, CommandGlobalOpts};
+use crate::{docs, node::show::print_query_status, CommandGlobalOpts};
 use anyhow::{anyhow, Context as _};
 use clap::Args;
 use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::base::NodeStatus;
 use std::time::Duration;
 
+const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
 /// List nodes
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ListCommand {}
 
 impl ListCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -1,10 +1,17 @@
 use crate::node::default_node_name;
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use std::path::PathBuf;
 
+const LONG_ABOUT: &str = include_str!("./static/logs/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/logs/after_long_help.txt");
+
 /// Get the stdout/stderr log file of a node
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct LogCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name())]

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -24,9 +24,9 @@ pub mod util;
 pub use create::*;
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
-const AFTER_LONG_HELP: &str = include_str!("../static/after_long_help.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
 
-/// Manage Nodes
+/// Manage nodes
 #[derive(Clone, Debug, Args)]
 #[command(
     arg_required_else_help = true,

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,6 +1,6 @@
 use crate::node::default_node_name;
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
-use crate::{CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
 use colorful::Colorful;
 use ockam::TcpTransport;
@@ -14,12 +14,18 @@ use ockam_multiaddr::MultiAddr;
 use tokio_retry::strategy::FixedInterval;
 use tracing::debug;
 
+const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
+
 const IS_NODE_UP_TIME_BETWEEN_CHECKS_MS: usize = 50;
 const IS_NODE_UP_MAX_ATTEMPTS: usize = 20; // 1 second
 
-/// Show node details
+/// Show the details of a node
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ShowCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name())]

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -6,10 +6,18 @@ use crate::node::default_node_name;
 use crate::node::show::print_query_status;
 use crate::node::util::spawn_node;
 use crate::util::{node_rpc, RpcBuilder};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
-/// Start a node
+const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/start/after_long_help.txt");
+
+/// Start a node that was previously stopped
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct StartCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name())]

--- a/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To create a new node with a random name
+$ ockam node create
+
+# To create a new node with a specific name
+$ ockam node create n
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/create/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/create/long_about.txt
@@ -1,0 +1,1 @@
+This command will create a new node. It will create a vault and identity if none exist and will be assigned as the default for the system.

--- a/implementations/rust/ockam/ockam_command/src/node/static/default/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/default/after_long_help.txt
@@ -1,0 +1,8 @@
+```sh
+# The first created node will be set as the default node
+$ ockam node create n1
+
+# Let's create a second node and assign it as default
+$ ockam node create n2
+$ ockam node default n2
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/default/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/default/long_about.txt
@@ -1,0 +1,1 @@
+This command will change the default node. The default node is used by most of the commands when none is specified.

--- a/implementations/rust/ockam/ockam_command/src/node/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/delete/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# To delete the default node
+$ ockam node delete
+
+# To delete a node given its name
+$ ockam node delete n
+
+# To delete all existing nodes
+$ ockam node delete --all
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/delete/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/delete/long_about.txt
@@ -1,0 +1,1 @@
+This command will delete the specified node or all the available nodes if the `--all` flag is used. Deleting a node implies killing the process and removing its data directory. To temporary pause a node use `ockam node stop` instead.

--- a/implementations/rust/ockam/ockam_command/src/node/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/list/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam node list
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/list/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/list/long_about.txt
@@ -1,0 +1,1 @@
+This command will show the details of all the nodes registered in the system.

--- a/implementations/rust/ockam/ockam_command/src/node/static/logs/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/logs/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# Return the path to the stdout log file of the default node
+$ ockam node logs
+
+# Return the path to the stderr log file of the given node
+$ ockam node logs n --err
+
+# Pipe the logs to a file into another tool to process it
+$ cat < $(ockam node logs n)
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/logs/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/logs/long_about.txt
@@ -1,0 +1,1 @@
+This command will return the path to the node's log file. The user can select whether to return the stdout or the stderr log file. The default is to return the stdout log file.

--- a/implementations/rust/ockam/ockam_command/src/node/static/show/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/show/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To show the default node
+$ ockam node show
+
+# To show a node with a specific name
+$ ockam node show n
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/show/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/show/long_about.txt
@@ -1,0 +1,1 @@
+This command will show all the details of a node such as its name, route, default identity, and the services running on it.

--- a/implementations/rust/ockam/ockam_command/src/node/static/start/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/start/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To start the default node
+$ ockam node start
+
+# To start a node with a specific name
+$ ockam node start n
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/start/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/start/long_about.txt
@@ -1,0 +1,1 @@
+This command will start a node as a background process that was previously stopped via the command `ockam node stop`. The node will be started with the same configuration as when it was created.

--- a/implementations/rust/ockam/ockam_command/src/node/static/stop/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/stop/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To stop the default node sending a SIGTERM signal
+$ ockam node stop
+
+# To stop the given node sending a SIGKILL signal
+$ ockam node stop n --force
+```

--- a/implementations/rust/ockam/ockam_command/src/node/static/stop/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/stop/long_about.txt
@@ -1,0 +1,1 @@
+This command will a running node, killing the associated background process. This operation will keep the node state in the `$OCKAM_HOME` directory, so it can be restarted with `ockam node start`.

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,9 +1,17 @@
 use crate::node::default_node_name;
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
-/// Stop a node
+const LONG_ABOUT: &str = include_str!("./static/stop/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/stop/after_long_help.txt");
+
+/// Stop a running node
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct StopCommand {
     /// Name of the node.
     #[arg(default_value_t = default_node_name())]

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -7,10 +7,18 @@ use crate::node::util::delete_embedded_node;
 use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use colorful::Colorful;
 
+const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
+/// Create a new space
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct CreateCommand {
     /// Name of the space.
     #[arg(display_order = 1001, default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true, value_parser = validate_space_name)]

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -7,9 +7,18 @@ use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, RpcBuilder};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
+const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
+/// Delete a space
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DeleteCommand {
     /// Name of the space.
     #[arg(display_order = 1001)]

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -7,9 +7,17 @@ use crate::node::util::delete_embedded_node;
 use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
+const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
+/// List spaces
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ListCommand {
     #[command(flatten)]
     pub cloud_opts: CloudOpts,

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -6,7 +6,7 @@ pub use list::ListCommand;
 pub use show::ShowCommand;
 pub use util::config;
 
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
 mod create;
 mod delete;
@@ -14,9 +14,17 @@ mod list;
 mod show;
 pub mod util;
 
-/// Manage Spaces in Ockam Orchestrator
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
+
+/// Manage spaces in Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, subcommand_required = true)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct SpaceCommand {
     #[command(subcommand)]
     subcommand: SpaceSubcommand,
@@ -24,19 +32,12 @@ pub struct SpaceCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum SpaceSubcommand {
-    /// Create spaces
     #[command(display_order = 800)]
     Create(CreateCommand),
-
-    /// Delete spaces
     #[command(display_order = 800)]
     Delete(DeleteCommand),
-
-    /// List spaces
     #[command(display_order = 800)]
     List(ListCommand),
-
-    /// Show spaces
     #[command(display_order = 800)]
     Show(ShowCommand),
 }

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -7,9 +7,18 @@ use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::space::util::config;
 use crate::util::api::{self, CloudOpts};
 use crate::util::{node_rpc, RpcBuilder};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
+const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
+
+/// Show the details of a space
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ShowCommand {
     /// Name of the space.
     #[arg(display_order = 1001)]

--- a/implementations/rust/ockam/ockam_command/src/space/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/create/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To create a new space with a random name
+$ ockam space create
+
+# To create a new space with a specific name
+$ ockam space create s
+```

--- a/implementations/rust/ockam/ockam_command/src/space/static/create/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/create/long_about.txt
@@ -1,0 +1,1 @@
+This command will create a new space. If the space already exists, it will just fetch it and show its details.

--- a/implementations/rust/ockam/ockam_command/src/space/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/delete/after_long_help.txt
@@ -1,0 +1,4 @@
+```sh
+# To delete a space given its name
+$ ockam space delete s
+```

--- a/implementations/rust/ockam/ockam_command/src/space/static/delete/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/delete/long_about.txt
@@ -1,0 +1,1 @@
+This command will delete the specified space. Deleting a space implies deleting all the projects associated with it.

--- a/implementations/rust/ockam/ockam_command/src/space/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/list/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam space list
+```

--- a/implementations/rust/ockam/ockam_command/src/space/static/list/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/list/long_about.txt
@@ -1,0 +1,1 @@
+This command will show the details of all the available spaces.

--- a/implementations/rust/ockam/ockam_command/src/space/static/show/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/show/after_long_help.txt
@@ -1,0 +1,4 @@
+```sh
+# To show a space with a specific name
+$ ockam space show s
+```

--- a/implementations/rust/ockam/ockam_command/src/space/static/show/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/space/static/show/long_about.txt
@@ -1,0 +1,1 @@
+This command will show all the details of a space such as its name, ID, and users that have access to it.


### PR DESCRIPTION
You can quickly change how the output looks with:

- `ockam node`, `ockam forwarder`,  `ockam node create --help`

- `ockam markdown` -> and open the markdown files