### PR TITLE
fix(rust): fix the setting of boolean flags

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -131,7 +131,7 @@ impl Authority {
         secure_channel_session_id: &SessionId,
         configuration: &Configuration,
     ) -> Result<()> {
-        if !configuration.direct_authentication {
+        if configuration.no_direct_authentication {
             return Ok(());
         }
 
@@ -163,7 +163,7 @@ impl Authority {
         secure_channel_session_id: &SessionId,
         configuration: &Configuration,
     ) -> Result<()> {
-        if !configuration.token_enrollment {
+        if configuration.no_token_enrollment {
             return Ok(());
         }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -39,11 +39,11 @@ pub struct Configuration {
     /// list of trusted identities (identities with the ockam-role: enroller)
     pub trusted_identities: PreTrustedIdentities,
 
-    /// If true start the direct authenticator service
-    pub direct_authentication: bool,
+    /// If true don't start the direct authenticator service
+    pub no_direct_authentication: bool,
 
-    /// If true start the token enroller service
-    pub token_enrollment: bool,
+    /// If true don't start the token enroller service
+    pub no_token_enrollment: bool,
 
     /// optional configuration for the okta service
     pub okta: Option<OktaConfiguration>,

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -46,15 +46,15 @@ pub struct CreateCommand {
     )]
     tcp_listener_address: String,
 
-    /// Set this option to false if the authority node should not support the enrollment
+    /// Set this option if the authority node should not support the enrollment
     /// of new project members
-    #[arg(long, value_name = "BOOL", default_value_t = true)]
-    direct_authentication: bool,
+    #[arg(long, value_name = "BOOL", default_value_t = false)]
+    no_direct_authentication: bool,
 
-    /// Set this option to false if the authority node should not support
+    /// Set this option if the authority node should not support
     /// the issuing of enrollment tokens
-    #[arg(long, value_name = "BOOL", default_value_t = true)]
-    token_enrollment: bool,
+    #[arg(long, value_name = "BOOL", default_value_t = false)]
+    no_token_enrollment: bool,
 
     /// List of the trusted identities, and corresponding attributes to be preload in the attributes storage.
     /// Format: {"identifier1": {"attribute1": "value1", "attribute2": "value12"}, ...}
@@ -105,12 +105,12 @@ async fn spawn_background_node(
         "--foreground".to_string(),
     ];
 
-    if cmd.direct_authentication {
-        args.push("--direct-authentication".to_string());
+    if cmd.no_direct_authentication {
+        args.push("--no-direct-authentication".to_string());
     }
 
-    if cmd.token_enrollment {
-        args.push("--token-enrollment".to_string());
+    if cmd.no_token_enrollment {
+        args.push("--no-token-enrollment".to_string());
     }
 
     if let Some(trusted_identities) = &cmd.trusted_identities {
@@ -268,8 +268,8 @@ async fn start_authority_node(
         secure_channel_listener_name: None,
         authenticator_name: None,
         trusted_identities: trusted_identities.clone(),
-        direct_authentication: command.direct_authentication,
-        token_enrollment: command.token_enrollment,
+        no_direct_authentication: command.no_direct_authentication,
+        no_token_enrollment: command.no_token_enrollment,
         okta: okta_configuration,
     };
     authority_node::start_node(&ctx, &configuration).await?;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -567,8 +567,8 @@ async fn start_authority_node(
             secure_channel_listener_name: Some(secure_channel_config.address),
             authenticator_name: Some(authenticator_config.address),
             trusted_identities,
-            direct_authentication: true,
-            token_enrollment: true,
+            no_direct_authentication: true,
+            no_token_enrollment: true,
             okta: None,
         };
         authority_node::start_node(&ctx, &configuration).await?;

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -29,8 +29,10 @@ teardown() {
   m2_identifier=$($OCKAM identity show m2)
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
+  # For the first test we start the node with no direct authentication service nor token enrollment
   trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\", \"project_id\" : \"1\"}, \"$enroller_identifier\": {\"project_id\": \"1\", \"ockam-role\": \"enroller\"}}"
-  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "$trusted"
+  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --no-token-enrollment
+
   assert_success
 
   echo "{\"id\": \"1\",


### PR DESCRIPTION
 for no direct authentication and/or no token enrollment with the authority node.

The previous 2 flags `--direct-authentication` and `--token-enrollment` were not effective. 

This PR:

 - changes the flags to `--direct-authentication` and `--token-enrollment` with `false` as default value
 - adds some usage for those flags in the bats test
