### PR TITLE
fix(rust): keep migrating legacy storage data but not on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,6 +3553,7 @@ dependencies = [
  "ockam_core",
  "ockam_macros",
  "ockam_node",
+ "openssl",
  "p256",
  "rand",
  "rand_pcg",
@@ -3611,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -3643,9 +3644,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -467,7 +467,15 @@ impl IdentitiesState {
     }
 
     pub fn authenticated_storage_path(&self) -> Result<PathBuf> {
+        //TODO: remove this once we don't need to convert from old location anymore
+        //      there is probably a better place for this than here, but this code
+        //      is going to be short-lived and authenticated_storage/1 is anyway
+        //      called once at node startup by node_manager, so it's good enough.
+        let legacy_location = self.dir.join("authenticated_storage.lmdb");
         let lmdb_path = self.dir.join("data").join("authenticated_storage.lmdb");
+        if legacy_location.exists() {
+            std::fs::rename(&legacy_location, &lmdb_path)?;
+        }
         Ok(lmdb_path)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -138,6 +138,7 @@ impl Authority {
         let direct = crate::authenticator::direct::DirectAuthenticator::new(
             configuration.clone().project_identifier(),
             self.attributes_storage().clone(),
+            self.identity.authenticated_storage().clone(),
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/services.rs
@@ -312,6 +312,7 @@ impl NodeManager {
         let direct = crate::authenticator::direct::DirectAuthenticator::new(
             proj.to_vec(),
             self.attributes_storage.clone(),
+            self.identity.authenticated_storage().clone(),
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -91,6 +91,7 @@ aws-sdk-kms = { version = "0.24.0", default-features = false, features = ["nativ
 thiserror   = { version = "1.0.38", optional = true }
 # ECDSA providers:
 p256 = { version = "0.12.0", default_features = false }
+openssl = "0.10.48"
 
 [dev-dependencies]
 tokio = { version = "1.25", features = ["full"] }


### PR DESCRIPTION
This is an attempt to fix some restart issues that we observed with Ockam Orchestrator. In this PR:

 - the code for migrating legacy data has been put back
 - however it is only activated once when we enroll a member and not at start-up in order to avoid triggering a LMDB exception

