### PR TITLE
fix(rust): use the same criteria for checking if a node exists

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -691,7 +691,7 @@ impl NodesState {
         config.name = name.to_string();
 
         // check if node name already exists
-        if self.dir.join(name).exists() {
+        if self.get_node_path(name).exists() {
             return Err(CliStateError::AlreadyExists(format!("node `{name}`")));
         }
 
@@ -739,16 +739,17 @@ impl NodesState {
     }
 
     pub fn get(&self, name: &str) -> Result<NodeState> {
-        let path = {
-            let mut path = self.dir.clone();
-            path.push(name);
-            if !path.exists() {
-                return Err(CliStateError::NotFound(format!("node `{name}`")));
-            }
-            path
-        };
+        let path = self.get_node_path(name);
+        if !path.exists() {
+            return Err(CliStateError::NotFound(format!("node `{name}`")));
+        }
+
         let config = NodeConfig::try_from(&path)?;
         Ok(NodeState::new(path, config))
+    }
+
+    pub fn get_node_path(&self, name: &str) -> PathBuf {
+        self.dir.join(name)
     }
 
     pub fn delete(&self, name: &str, sigkill: bool) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -208,7 +208,12 @@ async fn start_authority_node(
     let command = cmd.clone();
 
     // Create node state, including the vault and identity if they don't exist
-    if options.state.nodes.get(&command.node_name).is_err() {
+    if !options
+        .state
+        .nodes
+        .get_node_path(&command.node_name)
+        .exists()
+    {
         init_node_state(&ctx, &options, &command.node_name, None, None).await?;
     };
 


### PR DESCRIPTION
when creating the authority node and when creating the initial state.
This _could_ fix the restart issue on the Orchestrator, at least we should not get the same error. We can possibly get another one if the existing data cannot be read for some yet unknown reason.
