### PR TITLE
fix(rust): make the authority_node field optional

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -1034,8 +1034,9 @@ pub struct NodeSetupConfig {
     pub verbose: u8,
 
     /// This flag is used to determine how the node status should be
-    /// displayed in print_query_status
-    pub authority_node: bool,
+    /// displayed in print_query_status.
+    /// The field might be missing in previous configuration files, hence it is an Option
+    pub authority_node: Option<bool>,
 
     transports: Vec<CreateTransportJson>,
     // TODO
@@ -1052,7 +1053,7 @@ impl NodeSetupConfig {
     }
 
     pub fn set_authority_node(mut self) -> Self {
-        self.authority_node = true;
+        self.authority_node = Some(true);
         self
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -171,7 +171,7 @@ pub async fn print_query_status(
         let is_authority_node = node_state
             .setup()
             .ok()
-            .map(|setup| setup.authority_node)
+            .map(|setup| setup.authority_node.unwrap_or(false))
             .unwrap_or_default();
         print_node_info(
             node_port,


### PR DESCRIPTION
That field did not exist in previous configuration files.