### PR TITLE
fix(rust): when deleting the default vault/identity/project the data and the link are deleted

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,6 +62,10 @@ async fn run_impl(
     let project = rpc.parse_response::<Project>()?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
+    opts.state
+        .projects
+        .create(&project.name, project.clone())
+        .await?;
     rpc.print_response(project)?;
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -80,6 +80,7 @@ async fn run_impl(
 
     // Try to remove from config again, in case it was re-added after the refresh.
     let _ = config::remove_project(&opts.config, &cmd.project_name);
+    opts.state.projects.delete(&cmd.project_name)?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
 

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -61,6 +61,8 @@ async fn run_impl(
 
     // Try to remove from config again, in case it was re-added after the refresh.
     let _ = config::remove_space(&opts.config, &cmd.name);
+    // Delete all projects data from the state.
+    opts.state.projects.delete_all()?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
 


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/4541 as well as other related issues:
- When deleting the default vault/identity/project the link under `$OCKAM_HOME/defaults` is also deleted.
- When a space is deleted via `ockam space delete` the stored projects in `$OCKAM_HOME/projects` are deleted as well
- When a project is created via `ockam project create` it will be stored in `$OCKAM_HOME/projects`. Previously, projects were stored in the state only when creating the default project in `ockam enroll`
- When a project is deleted via `ockam project delete` it will be deleted from `$OCKAM_HOME/projects`