### PR TITLE
tests(rust): generate the project.json file before every test instead of reusing it

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll.rs
@@ -167,10 +167,7 @@ async fn default_project<'a>(
         check_project_readiness(ctx, opts, cloud_opts, node_name, None, default_project).await?;
     println!("{}", project.output()?);
 
-    opts.state
-        .projects
-        .create(&project.name, project.clone())
-        .await?;
+    opts.state.projects.create(&project.name, project.clone())?;
     Ok(project)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,10 +62,7 @@ async fn run_impl(
     let project = rpc.parse_response::<Project>()?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
-    opts.state
-        .projects
-        .create(&project.name, project.clone())
-        .await?;
+    opts.state.projects.create(&project.name, project.clone())?;
     rpc.print_response(project)?;
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -70,8 +70,8 @@ async fn run_impl(
 
     // Try to remove from config again, in case it was re-added after the refresh.
     let _ = config::remove_space(&opts.config, &cmd.name);
-    // Delete all projects data from the state.
-    opts.state.projects.delete_all()?;
+    // TODO: remove projects associated to the space.
+    //  Currently we are not storing that association in the project config file.
 
     delete_embedded_node(&opts, rpc.node_name()).await;
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -15,6 +15,8 @@ teardown() {
 # ===== TESTS
 
 @test "authority - standalone authority, enrollers, members" {
+  export PROJECT_JSON_PATH="$OCKAM_HOME/project.json"
+
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller
   # m1 will be pre-authenticated on authority.  m2 will be added directly, m3 will be added through enrollment token
@@ -40,10 +42,10 @@ teardown() {
   \"identity\" : \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\",
   \"access_route\" : \"/dnsaddr/127.0.0.1/tcp/4000/service/api\",
   \"authority_access_route\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\",
-  \"authority_identity\" : \"$authority_identity_full\"}" >"$OCKAM_HOME/project.json"
+  \"authority_identity\" : \"$authority_identity_full\"}" >"$PROJECT_JSON_PATH"
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
-  run "$OCKAM" project authenticate --project-path "$OCKAM_HOME/project.json" --identity m1
+  run "$OCKAM" project authenticate --project-path "$PROJECT_JSON_PATH" --identity m1
   assert_success
   assert_output --partial "sample_val"
 
@@ -53,15 +55,15 @@ teardown() {
   run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --reload-from-trusted-identities-file "$OCKAM_HOME/trusted-anchors.json"
   assert_success
 
-  run "$OCKAM" project enroll --identity enroller --project-path "$OCKAM_HOME/project.json" --member $m2_identifier --attribute sample_attr=m2_member
+  run "$OCKAM" project enroll --identity enroller --project-path "$PROJECT_JSON_PATH" --member $m2_identifier --attribute sample_attr=m2_member
   assert_success
 
-  run "$OCKAM" project authenticate --project-path "$OCKAM_HOME/project.json" --identity m2
+  run "$OCKAM" project authenticate --project-path "$PROJECT_JSON_PATH" --identity m2
   assert_success
   assert_output --partial "m2_member"
 
-  token=$($OCKAM project enroll --identity enroller --project-path "$OCKAM_HOME/project.json" --attribute sample_attr=m3_member)
-  run "$OCKAM" project authenticate --project-path "$OCKAM_HOME/project.json" --identity m3 --token "$token"
+  token=$($OCKAM project enroll --identity enroller --project-path "$PROJECT_JSON_PATH" --attribute sample_attr=m3_member)
+  run "$OCKAM" project authenticate --project-path "$PROJECT_JSON_PATH" --identity m3 --token "$token"
   assert_success
   assert_output --partial "m3_member"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -22,15 +22,8 @@ function skip_if_long_tests_not_enabled() {
 
 function load_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
-    if [ ! -f "$OCKAM_HOME_BASE/project.json" ]; then
-      OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM project information --output json >"$OCKAM_HOME_BASE/project.json"
-    fi
-    export PROJECT_JSON_PATH="$OCKAM_HOME_BASE/project.json"
-  fi
-}
-
-function copy_orchestrator_data() {
-  if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     cp -a $OCKAM_HOME_BASE $OCKAM_HOME
+    export PROJECT_JSON_PATH="$OCKAM_HOME/project.json"
+    $OCKAM project information --output json >"$PROJECT_JSON_PATH"
   fi
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message.bats
@@ -4,8 +4,6 @@
 
 setup_file() {
   load load/base.bash
-  load load/orchestrator.bash
-  load_orchestrator_data
 }
 
 setup() {
@@ -14,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 }
 
 teardown() {
@@ -25,23 +23,23 @@ teardown() {
 
 @test "message - send a message to a project node from an embedded node" {
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --to /project/default/service/echo
+  run "$OCKAM" message send "$msg" --to /project/default/service/echo
   assert_success
   assert_output "$msg"
 }
 
 @test "message - send a message to a project node from a background node" {
-  run --separate-stderr "$OCKAM" node create blue
+  run "$OCKAM" node create blue
   assert_success
 
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --from /node/blue --to /project/default/service/echo
+  run "$OCKAM" message send "$msg" --from /node/blue --to /project/default/service/echo
   assert_success
   assert_output "$msg"
 }
 
 @test "message - send a message to a project node from an embedded node, passing identity" {
-  run --separate-stderr "$OCKAM" identity create m1
+  run "$OCKAM" identity create m1
   assert_success
   m1_identifier=$($OCKAM identity show m1)
 
@@ -52,13 +50,13 @@ teardown() {
 
   # m1 is a member,  must be able to contact the project' service
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
   assert_success
   assert_output "$msg"
 
   # m2 is not a member, must not be able to contact the project' service
-  run --separate-stderr "$OCKAM" identity create m2
+  run "$OCKAM" identity create m2
   assert_success
-  run --separate-stderr "$OCKAM" message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
   assert_failure
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -4,8 +4,6 @@
 
 setup_file() {
   load load/base.bash
-  load load/orchestrator.bash
-  load_orchestrator_data
 }
 
 setup() {
@@ -14,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 }
 
 teardown() {
@@ -26,14 +24,14 @@ teardown() {
 @test "portals - create an inlet/outlet pair with relay through a forwarder in an orchestrator project and move tcp traffic through it" {
   port=7100
 
-  run --separate-stderr "$OCKAM" node create blue
+  run "$OCKAM" node create blue
   assert_success
   $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
 
   fwd="$(random_str)"
   $OCKAM forwarder create "$fwd" --at /project/default --to /node/blue
 
-  run --separate-stderr "$OCKAM" node create green
+  run "$OCKAM" node create green
   assert_success
   $OCKAM secure-channel create --from /node/green --to "/project/default/service/forward_to_$fwd/service/api" |
     $OCKAM tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to -/service/outlet
@@ -45,14 +43,14 @@ teardown() {
 @test "portals - create an inlet (with implicit secure channel creation) / outlet pair with relay through a forwarder in an orchestrator project and move tcp traffic through it" {
   port=7101
 
-  run --separate-stderr "$OCKAM" node create blue
+  run "$OCKAM" node create blue
   assert_success
   $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
 
   fwd="$(random_str)"
   $OCKAM forwarder create "$fwd" --at /project/default --to /node/blue
 
-  run --separate-stderr "$OCKAM" node create green
+  run "$OCKAM" node create green
   assert_success
   $OCKAM tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to "/project/default/service/forward_to_$fwd/secure/api/service/outlet"
 
@@ -63,12 +61,14 @@ teardown() {
 @test "portals - inlet/outlet example with credential, not provided" {
   port=7102
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
+
+  # Setup nodes from a non-enrolled environment
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  run --separate-stderr "$OCKAM" identity create green
+  run "$OCKAM" identity create green
   assert_success
-  run --separate-stderr "$OCKAM" identity create blue
+  run "$OCKAM" identity create blue
   assert_success
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
@@ -107,9 +107,9 @@ teardown() {
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  run --separate-stderr "$OCKAM" identity create green
+  run "$OCKAM" identity create green
   assert_success
-  run --separate-stderr "$OCKAM" identity create blue
+  run "$OCKAM" identity create blue
   assert_success
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
@@ -145,9 +145,9 @@ teardown() {
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  run --separate-stderr "$OCKAM" identity create green
+  run "$OCKAM" identity create green
   assert_success
-  run --separate-stderr "$OCKAM" identity create blue
+  run "$OCKAM" identity create blue
   assert_success
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
@@ -190,9 +190,9 @@ teardown() {
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  run --separate-stderr "$OCKAM" identity create green
+  run "$OCKAM" identity create green
   assert_success
-  run --separate-stderr "$OCKAM" identity create blue
+  run "$OCKAM" identity create blue
   assert_success
 
   run "$OCKAM" project authenticate --project-path "$PROJECT_JSON_PATH" --identity green --token $green_token

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -4,8 +4,6 @@
 
 setup_file() {
   load load/base.bash
-  load load/orchestrator.bash
-  load_orchestrator_data
 }
 
 setup() {
@@ -14,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 }
 
 teardown() {
@@ -34,11 +32,11 @@ teardown() {
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  run --separate-stderr "$OCKAM" identity create green
+  run "$OCKAM" identity create green
   assert_success
   green_identifier=$($OCKAM identity show green)
 
-  run --separate-stderr "$OCKAM" identity create blue
+  run "$OCKAM" identity create blue
   assert_success
   blue_identifier=$($OCKAM identity show blue)
 
@@ -138,17 +136,17 @@ teardown() {
   run $OCKAM project authenticate --identity m1 --project-path "$PROJECT_JSON_PATH"
 
   # m1 is a member,  must be able to contact the project' service
-  run --separate-stderr $OCKAM message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
+  run $OCKAM message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
   assert_success
   assert_output "hello"
 
   # m2 is not a member,  must not be able to contact the project' service
-  run --separate-stderr $OCKAM message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
+  run $OCKAM message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
   assert_failure
 }
 
 @test "projects - list addons" {
-  run --separate-stderr "$OCKAM" project addon list --project default
+  run "$OCKAM" project addon list --project default
   assert_success
   assert_output --partial "Id: okta"
 }
@@ -156,26 +154,26 @@ teardown() {
 @test "projects - enable and disable addons" {
   skip # TODO: wait until cloud has the influxdb and confluent addons enabled
 
-  run --separate-stderr "$OCKAM" project addon list --project default
+  run "$OCKAM" project addon list --project default
   assert_success
   assert_output --partial --regex "Id: okta\n +Enabled: false"
   assert_output --partial --regex "Id: confluent\n +Enabled: false"
 
-  run --separate-stderr "$OCKAM" project addon enable okta --project default --tenant tenant --client-id client_id --cert cert
+  run "$OCKAM" project addon enable okta --project default --tenant tenant --client-id client_id --cert cert
   assert_success
-  run --separate-stderr "$OCKAM" project addon enable confluent --project default --bootstrap-server bootstrap-server.confluent:9092 --api-key ApIkEy --api-secret ApIsEcrEt
+  run "$OCKAM" project addon enable confluent --project default --bootstrap-server bootstrap-server.confluent:9092 --api-key ApIkEy --api-secret ApIsEcrEt
   assert_success
 
-  run --separate-stderr "$OCKAM" project addon list --project default
+  run "$OCKAM" project addon list --project default
   assert_success
   assert_output --partial --regex "Id: okta\n +Enabled: true"
   assert_output --partial --regex "Id: confluent\n +Enabled: true"
 
-  run --separate-stderr "$OCKAM" project addon disable --addon okta --project default
-  run --separate-stderr "$OCKAM" project addon disable --addon --project default
-  run --separate-stderr "$OCKAM" project addon disable --addon confluent --project default
+  run "$OCKAM" project addon disable --addon okta --project default
+  run "$OCKAM" project addon disable --addon --project default
+  run "$OCKAM" project addon disable --addon confluent --project default
 
-  run --separate-stderr "$OCKAM" project addon list --project default
+  run "$OCKAM" project addon list --project default
   assert_success
   assert_output --partial --regex "Id: okta\n +Enabled: false"
   assert_output --partial --regex "Id: confluent\n +Enabled: false"

--- a/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
@@ -4,8 +4,6 @@
 
 setup_file() {
   load load/base.bash
-  load load/orchestrator.bash
-  load_orchestrator_data
 }
 
 setup() {
@@ -14,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 }
 
 teardown() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -32,7 +32,7 @@ teardown() {
 }
 
 @test "node - start services" {
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
 
   # Check we can start service, but only once with the same name
@@ -194,7 +194,7 @@ teardown() {
 # ===== TCP
 
 @test "tcp connection - CRUD" {
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
 
   # Create tcp-connection and check output
@@ -266,24 +266,24 @@ teardown() {
 
 @test "message - send messages between local nodes" {
   # Send from a temporary node to a background node
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --to /node/n1/service/uppercase
+  run "$OCKAM" message send "$msg" --to /node/n1/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
   # Send between two background nodes
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --from n1 --to /node/n2/service/uppercase
+  run "$OCKAM" message send "$msg" --from n1 --to /node/n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
   # Same, but using the `/node/` prefix in the `--from` argument
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --from /node/n1 --to /node/n2/service/uppercase
+  run "$OCKAM" message send "$msg" --from /node/n1 --to /node/n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 }
@@ -317,15 +317,15 @@ teardown() {
 # ===== SECURE CHANNEL
 
 @test "secure channel - create secure channel and send message through it" {
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   # In two separate commands
   msg=$(random_str)
   output=$($OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api)
-  run --separate-stderr "$OCKAM" message send "$msg" --from /node/n1 --to "$output/service/uppercase"
+  run "$OCKAM" message send "$msg" --from /node/n1 --to "$output/service/uppercase"
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
@@ -346,15 +346,15 @@ teardown() {
 # ===== FORWARDER
 
 @test "forwarder - create forwarder and send message through it" {
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   # In two separate commands
   $OCKAM forwarder create n2 --at /node/n1 --to /node/n2
   msg=$(random_str)
-  run --separate-stderr "$OCKAM" message send "$msg" --to /node/n1/service/hop/service/forward_to_n2/service/uppercase
+  run "$OCKAM" message send "$msg" --to /node/n1/service/hop/service/forward_to_n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
@@ -372,9 +372,9 @@ teardown() {
   inlet_port=6101
 
   # Create nodes for inlet/outlet pair
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   # Create inlet/outlet pair
@@ -403,7 +403,7 @@ teardown() {
 
 @test "portals - tcp outlet CRUD" {
   port=6103
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to "127.0.0.1:$port" --alias "test-outlet"
@@ -426,9 +426,9 @@ teardown() {
 
 @test "portals - list inlets on a node" {
   port=6104
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   run $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:$port --to /node/n1/service/outlet --alias tcp-inlet-2
@@ -442,7 +442,7 @@ teardown() {
 
 @test "portals - list outlets on a node" {
   port=6105
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
 
   run $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to "127.0.0.1:$port" --alias "test-outlet"
   assert_output --partial "/service/outlet"
@@ -457,9 +457,9 @@ teardown() {
 
 @test "portals - show a tcp inlet" {
   port=6106
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   run $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:$port --to /node/n1/service/outlet --alias "test-inlet"
@@ -475,7 +475,7 @@ teardown() {
 
 @test "portals - show a tcp outlet" {
   port=6107
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
 
   run $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to "127.0.0.1:$port" --alias "test-outlet"
@@ -492,9 +492,9 @@ teardown() {
 
 @test "portals - create an inlet/outlet pair and move tcp traffic through it" {
   port=6000
-  run --separate-stderr "$OCKAM" node create n1
+  run "$OCKAM" node create n1
   assert_success
-  run --separate-stderr "$OCKAM" node create n2
+  run "$OCKAM" node create n2
   assert_success
 
   $OCKAM tcp-outlet create --at /node/n1 --from /service/outlet --to 127.0.0.1:5000
@@ -506,15 +506,15 @@ teardown() {
 
 @test "portals - create an inlet/outlet pair with relay through a forwarder and move tcp traffic through it" {
   port=6001
-  run --separate-stderr "$OCKAM" node create relay
+  run "$OCKAM" node create relay
   assert_success
-  run --separate-stderr "$OCKAM" node create blue
+  run "$OCKAM" node create blue
   assert_success
 
   $OCKAM tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:5000
   $OCKAM forwarder create blue --at /node/relay --to /node/blue
 
-  run --separate-stderr "$OCKAM" node create green
+  run "$OCKAM" node create green
   assert_success
   $OCKAM secure-channel create --from /node/green --to /node/relay/service/hop/service/forward_to_blue/service/api |
     $OCKAM tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to -/service/outlet

--- a/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
@@ -6,8 +6,6 @@
 
 setup_file() {
   load load/base.bash
-  load load/orchestrator.bash
-  load_orchestrator_data
 }
 
 setup() {
@@ -26,11 +24,11 @@ teardown() {
 # https://docs.ockam.io/guides/use-cases/add-end-to-end-encryption-to-any-client-and-server-application-with-no-code-change
 @test "use-case - end-to-end encryption, local" {
   port=9000
-  run --separate-stderr "$OCKAM" node create relay
+  run "$OCKAM" node create relay
   assert_success
 
   # Service
-  run --separate-stderr "$OCKAM" node create server_sidecar
+  run "$OCKAM" node create server_sidecar
   assert_success
 
   run "$OCKAM" tcp-outlet create --at /node/server_sidecar --from /service/outlet --to 127.0.0.1:5000
@@ -40,7 +38,7 @@ teardown() {
   assert_success
 
   # Client
-  run --separate-stderr "$OCKAM" node create client_sidecar
+  run "$OCKAM" node create client_sidecar
   assert_success
   run bash -c "$OCKAM secure-channel create --from /node/client_sidecar --to /node/relay/service/hop/service/forward_to_server_sidecar/service/api \
               | $OCKAM tcp-inlet create --at /node/client_sidecar --from 127.0.0.1:$port --to -/service/outlet"
@@ -53,7 +51,7 @@ teardown() {
 # https://docs.ockam.io/
 @test "use-case - end-to-end encryption, orchestrator" {
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 
   port=9001
 
@@ -77,7 +75,7 @@ teardown() {
 # https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac
 @test "use-case - abac" {
   skip_if_orchestrator_tests_not_enabled
-  copy_orchestrator_data
+  load_orchestrator_data
 
   port_1=9002
   port_2=9003


### PR DESCRIPTION
Fixes the following problems

### bats tests setup

Currently, the `project.json` file is generated once before running the first test and then it's shared among the other tests. This can cause problems if one of the tests modifies that file (deleting the default project for example). 

This PR changes that strategy and generates/stores the file in the test environment before running it. This will make orchestrator-based tests a little bit slower but more robust.

### project deletion from CliState

Two different fixes have been applied here:
- `ockam space delete` no longer deletes the projects from the CliState. Details [here](https://github.com/build-trust/ockam/pull/4552/files#diff-cc6c2d924ad6a110a7e92821050d827ba16ca0a5eb742b314d3a72ffee4a06d4R73)
- deleting a project from CliState now works as expected: the `ProjectState` is just a json file with the project details and we were trying to delete it as a directory, causing an error. Details [here](https://github.com/build-trust/ockam/pull/4552/files#diff-a17a5a1da1448cd1d92017a87dd5cd59c347565441dea82b61b4903d814776d7R1187) and [here](https://github.com/build-trust/ockam/pull/4552/files#diff-a17a5a1da1448cd1d92017a87dd5cd59c347565441dea82b61b4903d814776d7L1250)
