### PR TITLE
fix(rust): okta addon on new authority startup

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/node.rs
@@ -32,7 +32,9 @@ pub async fn start_node(ctx: &Context, configuration: &Configuration) -> Result<
         .await?;
 
     // start the Okta service (if the optional configuration has been provided)
-    authority.start_okta(ctx, configuration).await?;
+    authority
+        .start_okta(ctx, &sessions, &secure_channel_session_id, configuration)
+        .await?;
 
     // start an echo service so that the node can be queried as healthy
     authority.start_echo_service(ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -25,7 +25,6 @@ use tracing::error;
 /// Create a node
 #[derive(Clone, Debug, Args)]
 #[command(after_long_help = docs::after_help(HELP_DETAIL))]
-#[clap(group(ArgGroup::new("okta").args(&["tenant_base_url", "certificate", "attributes"])))]
 #[clap(group(ArgGroup::new("trusted").required(true).args(&["trusted_identities", "reload_from_trusted_identities_file"])))]
 pub struct CreateCommand {
     /// Name of the node
@@ -67,15 +66,15 @@ pub struct CreateCommand {
     reload_from_trusted_identities_file: Option<PathBuf>,
 
     /// Okta: URL used for accessing the Okta API (optional)
-    #[arg(long, group = "okta", value_name = "URL", default_value = None)]
+    #[arg(long, value_name = "URL", default_value = None)]
     tenant_base_url: Option<String>,
 
     /// Okta: pem certificate used to access the Okta server (optional)
-    #[arg(long, group = "okta", value_name = "STRING", default_value = None)]
+    #[arg(long, value_name = "STRING", default_value = None)]
     certificate: Option<String>,
 
     /// Okta: name of the attributes which can be retrieved from Okta (optional)
-    #[arg(long, group = "okta", value_name = "COMMA_SEPARATED_LIST", default_value = None)]
+    #[arg(long, value_name = "COMMA_SEPARATED_LIST", default_value = None)]
     attributes: Option<Vec<String>>,
 
     /// Run the node in foreground.

--- a/implementations/rust/ockam/ockam_command/src/project/auth.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/auth.rs
@@ -136,7 +136,9 @@ async fn authenticate_through_okta(
 
     // Return address to the "okta_authenticator" worker on the authority node through the secure channel
     let okta_authenticator_addr = {
-        let service = MultiAddr::try_from("/service/okta_authenticator")?;
+        let service = MultiAddr::try_from(
+            format!("/service/{}", DefaultAddress::OKTA_IDENTITY_PROVIDER).as_str(),
+        )?;
         let mut addr = secure_channel_addr.clone();
         for proto in service.iter() {
             addr.push_back_value(&proto)?;


### PR DESCRIPTION
* fix okta related arguments (the three where flagged as a group,  allowing only 1 of them to be specified.  In reality it should be either none,  or the three of them)
* add session' setup for okta worker,  otherwise messages are dropped by access control
* fix address used by client  (was  `#okta_authenticator`)

