### PR TITLE
feat(rust): serialize keys using hex while keeping back-compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,6 +3588,7 @@ dependencies = [
  "aws-sdk-kms",
  "cfg-if",
  "curve25519-dalek",
+ "data-encoding",
  "ed25519-dalek",
  "fs2",
  "hex",

--- a/implementations/rust/ockam/ockam_core/src/hex_encoding.rs
+++ b/implementations/rust/ockam/ockam_core/src/hex_encoding.rs
@@ -1,0 +1,57 @@
+use alloc::vec::Vec;
+use core::fmt;
+use serde::de::{SeqAccess, Unexpected};
+use serde::{Deserializer, Serializer};
+
+/// By default, serde serializes using a sequence of integers.
+/// We rather serialize a using hex string.
+pub fn serialize<S: Serializer>(value: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&hex::encode(value.as_slice()))
+}
+
+/// To keep back-compatibility we parse both sequence of integer or a hex string
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> serde::de::Visitor<'de> for Visitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("secret key")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            match hex::decode(value.as_bytes()) {
+                Ok(decoded) => Ok(decoded),
+                Err(_) => {
+                    return Err(serde::de::Error::invalid_value(
+                        Unexpected::Other("invalid hex"),
+                        &self,
+                    ))
+                }
+            }
+        }
+
+        // legacy format was a sequence of integers
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut buffer = Vec::with_capacity(32);
+            while let Some(value) = seq.next_element()? {
+                buffer.push(value);
+            }
+            Ok(buffer)
+        }
+    }
+    deserializer.deserialize_any(Visitor {})
+}

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -52,10 +52,14 @@ extern crate futures_util;
 pub mod access_control;
 pub mod api;
 pub mod compat;
+
 /// Debugger
 pub mod debugger;
 pub mod sessions;
 pub mod vault;
+
+/// Encoding
+pub mod hex_encoding;
 
 mod cbor_utils;
 mod error;

--- a/implementations/rust/ockam/ockam_core/src/vault/types.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/types.rs
@@ -1,6 +1,6 @@
 use crate::{
     errcode::{Kind, Origin},
-    Error,
+    hex_encoding, Error,
 };
 use cfg_if::cfg_if;
 use core::fmt;
@@ -74,7 +74,11 @@ cfg_if! {
 #[derive(Serialize, Deserialize, Clone, Zeroize, Encode, Decode)]
 #[zeroize(drop)]
 #[cbor(transparent)]
-pub struct SecretKey(#[n(0)] SecretKeyVec);
+pub struct SecretKey(
+    #[serde(with = "hex_encoding")]
+    #[n(0)]
+    SecretKeyVec,
+);
 
 impl SecretKey {
     /// Create a new secret key.
@@ -83,8 +87,8 @@ impl SecretKey {
     }
 }
 
-impl core::fmt::Debug for SecretKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+impl fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("<secret key omitted>")
     }
 }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -95,3 +95,5 @@ p256 = { version = "0.13.0", default_features = false }
 [dev-dependencies]
 tokio = { version = "1.27", features = ["full"] }
 trybuild = { version = "1.0", features = ["diff"] }
+data-encoding = { version = "2.3.3", features = ["alloc"] }
+


### PR DESCRIPTION
## Current behavior

Keys within vaults are stored as a list of integers: 
```
"Key":[23,251,34,116,121,124,85,11,253,75,129,109,88,235,189,88,226,150,43,55,187,149,247,137,163,166,131,44,126,133,229,139]
```

## Proposed changes

Keys are stored in hex while keeping back-compatibility for the list of integers.

```
"Key":"17fb2274797c550bfd4b816d58ebbd58e2962b37bb95f789a3a6832c7e85e58b"
```
No explicit migration is present, at the first edit the new hex serialization will be used.
