### PR TITLE
Update Dockerfiles to use SHA256 for InfluxDB and Telegraf images

### DIFF
--- a/demos/influxdb-telegraf/influxdb/Dockerfile
+++ b/demos/influxdb-telegraf/influxdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM influxdb:2.6
+FROM influxdb@sha256:1db410a831ae62beaf59f2d8f6176a37cdd54cd3ffa12d6afc4e86fac8c4aa12
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/ockam_v0.82.0/install.sh | sh
 RUN mv ockam /usr/local/bin
 RUN chmod +x /usr/local/bin/ockam

--- a/demos/influxdb-telegraf/telegraf/Dockerfile
+++ b/demos/influxdb-telegraf/telegraf/Dockerfile
@@ -1,4 +1,4 @@
-FROM telegraf:1.25
+FROM telegraf@sha256:9e25b937a8d5ff968d84906587095b188fc489458df9e56f0885bb6f67b55f18
 RUN curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/build-trust/ockam/ockam_v0.82.0/install.sh | sh
 RUN mv ockam /usr/local/bin
 RUN chmod +x /usr/local/bin/ockam


### PR DESCRIPTION
It resolves issues #4521 #4523 