### PR TITLE
refactor(rust): implement custom get_env

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -18,6 +18,7 @@ use std::time::SystemTime;
 use sysinfo::{Pid, System, SystemExt};
 
 use crate::lmdb::LmdbStorage;
+use ockam_core::env::get_env_with_default;
 use ockam_identity::authenticated_storage::AuthenticatedStorage;
 use ockam_identity::credential::Credential;
 use thiserror::Error;
@@ -130,12 +131,12 @@ impl CliState {
 
     /// Returns the default directory for the CLI state.
     pub fn default_dir() -> Result<PathBuf> {
-        Ok(match std::env::var("OCKAM_HOME") {
-            Ok(dir) => PathBuf::from(&dir),
-            Err(_) => dirs::home_dir()
+        Ok(get_env_with_default::<PathBuf>(
+            "OCKAM_HOME",
+            dirs::home_dir()
                 .ok_or_else(|| CliStateError::NotFound("home dir".to_string()))?
                 .join(".ockam"),
-        })
+        )?)
     }
 
     /// Returns the directory where the default objects are stored.

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -73,7 +73,6 @@ impl<'a> BareCloudRequestWrapper<'a> {
 }
 
 mod node {
-    use std::env;
     use std::str::FromStr;
     use std::sync::Arc;
     use std::time::Duration;
@@ -82,6 +81,7 @@ mod node {
     use rust_embed::EmbeddedFile;
 
     use ockam_core::api::RequestBuilder;
+    use ockam_core::env::get_env;
     use ockam_core::{self, route, CowStr, Result};
     use ockam_identity::{IdentityIdentifier, SecureChannelTrustOptions, TrustIdentifierPolicy};
     use ockam_multiaddr::MultiAddr;
@@ -99,9 +99,9 @@ mod node {
         /// If the env var `OCKAM_CONTROLLER_IDENTITY_ID` is set, that will be used to
         /// load the identity instead of the file.
         pub(crate) fn load_controller_identity_id() -> Result<IdentityIdentifier> {
-            if let Ok(s) = env::var(OCKAM_CONTROLLER_IDENTITY_ID) {
-                trace!(idt = %s, "Read controller identity id from env");
-                return IdentityIdentifier::from_str(&s);
+            if let Ok(Some(idt)) = get_env::<IdentityIdentifier>(OCKAM_CONTROLLER_IDENTITY_ID) {
+                trace!(idt = %idt, "Read controller identity id from env");
+                return Ok(idt);
             }
             match StaticFiles::get("controller.id") {
                 Some(EmbeddedFile { data, .. }) => {

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -1,5 +1,6 @@
 use crate::terminal::TerminalBackground;
 use colorful::Colorful;
+use ockam_core::env::get_env_with_default;
 use once_cell::sync::Lazy;
 use std::io::{Read, Write};
 use syntect::highlighting::Theme;
@@ -38,17 +39,11 @@ static THEME: Lazy<Option<Theme>> = Lazy::new(|| {
 });
 
 fn is_markdown() -> bool {
-    match std::env::var("OCKAM_HELP_RENDER_MARKDOWN") {
-        Ok(v) => v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("1"),
-        Err(_e) => false,
-    }
+    get_env_with_default("OCKAM_HELP_RENDER_MARKDOWN", false).unwrap_or(false)
 }
 
 pub(crate) fn hide() -> bool {
-    match std::env::var("OCKAM_HELP_SHOW_HIDDEN") {
-        Ok(v) => !v.eq_ignore_ascii_case("true") || !v.eq_ignore_ascii_case("1"),
-        Err(_e) => true,
-    }
+    get_env_with_default("OCKAM_HELP_SHOW_HIDDEN", false).unwrap_or(false)
 }
 
 pub(crate) fn about(body: &str) -> &'static str {

--- a/implementations/rust/ockam/ockam_command/src/upgrade.rs
+++ b/implementations/rust/ockam/ockam_command/src/upgrade.rs
@@ -1,5 +1,6 @@
 use clap::crate_version;
 use colorful::Colorful;
+use ockam_core::env::get_env_with_default;
 use serde::Deserialize;
 use std::env;
 use tokio::runtime::Builder;
@@ -46,11 +47,5 @@ async fn check() {
 }
 
 fn upgrade_check_is_disabled() -> bool {
-    match env::var("OCKAM_DISABLE_UPGRADE_CHECK") {
-        Ok(v) => {
-            let disable = v.trim().to_lowercase();
-            disable == "1" || disable == "true" || disable == "yes"
-        }
-        Err(_e) => false,
-    }
+    get_env_with_default("OCKAM_DISABLE_UPGRADE_CHECK", false).unwrap_or(false)
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -2,7 +2,6 @@
 
 use regex::Regex;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use anyhow::{anyhow, Context};
 use clap::Args;
@@ -20,6 +19,7 @@ use ockam_api::nodes::*;
 use ockam_api::DefaultAddress;
 use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
+use ockam_core::env::{get_env_with_default, FromString};
 use ockam_core::{Address, CowStr};
 use ockam_multiaddr::MultiAddr;
 
@@ -328,15 +328,16 @@ pub struct ProjectOpts {
 
 impl CloudOpts {
     pub fn route(&self) -> MultiAddr {
-        let route = if let Ok(s) = std::env::var(OCKAM_CONTROLLER_ADDR) {
-            s
-        } else {
-            DEFAULT_CONTROLLER_ADDRESS.to_string()
-        };
+        let default_addr = MultiAddr::from_string(DEFAULT_CONTROLLER_ADDRESS)
+            .context(format!(
+                "invalid Controller route: {DEFAULT_CONTROLLER_ADDRESS}"
+            ))
+            .unwrap();
+
+        let route = get_env_with_default::<MultiAddr>(OCKAM_CONTROLLER_ADDR, default_addr).unwrap();
         trace!(%route, "Controller route");
-        MultiAddr::from_str(&route)
-            .context(format!("invalid Controller route: {route}"))
-            .unwrap()
+
+        route
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,6 +1,5 @@
 use core::time::Duration;
 use std::{
-    env,
     net::{SocketAddr, TcpListener},
     path::Path,
     str::FromStr,
@@ -21,6 +20,7 @@ use ockam_api::cli_state::{CliState, NodeState};
 use ockam_api::config::lookup::{InternetAddress, LookupMeta};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{RequestBuilder, Response, Status};
+use ockam_core::env::get_env;
 use ockam_core::DenyAll;
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Project, Service, Space, Tcp};
 use ockam_multiaddr::{
@@ -467,8 +467,8 @@ pub fn setup_logging(verbose: u8, no_color: bool) {
     // If both `verbose` and OCKAM_LOG are not set, logging will not be enabled.
     // Otherwise, use `verbose` to define the log level.
     let filter = match verbose {
-        0 => match env::var("OCKAM_LOG") {
-            Ok(s) if !s.is_empty() => builder.with_env_var("OCKAM_LOG").from_env_lossy(),
+        0 => match get_env::<String>("OCKAM_LOG") {
+            Ok(Some(s)) if !s.is_empty() => builder.with_env_var("OCKAM_LOG").from_env_lossy(),
             _ => return,
         },
         1 => builder

--- a/implementations/rust/ockam/ockam_core/src/env.rs
+++ b/implementations/rust/ockam/ockam_core/src/env.rs
@@ -1,19 +1,29 @@
+use crate::alloc::borrow::ToOwned;
+use crate::alloc::string::ToString;
+use crate::compat::fmt::Vec;
+use crate::compat::string::String;
 use crate::errcode::{Kind, Origin};
 use crate::{Error, Result};
+#[cfg(feature = "std")]
 use std::env;
+#[cfg(feature = "std")]
 use std::env::VarError;
+#[cfg(feature = "std")]
 use std::path::PathBuf;
 
 /// Get environmental value [var_name]. If value is not found returns Ok(None)
+#[cfg(feature = "std")]
 pub fn get_env<T: FromString>(var_name: &str) -> Result<Option<T>> {
     get_env_impl::<Option<T>>(var_name, None)
 }
 
 /// Get environmental value [var_name]. If value is not found returns [default_value]
+#[cfg(feature = "std")]
 pub fn get_env_with_default<T: FromString>(var_name: &str, default_value: T) -> Result<T> {
     get_env_impl::<T>(var_name, default_value)
 }
 
+#[cfg(feature = "std")]
 fn get_env_impl<T: FromString>(var_name: &str, default_value: T) -> Result<T> {
     match env::var(var_name) {
         Ok(val) => Ok(T::from_string(&val)?),
@@ -102,6 +112,7 @@ impl FromString for u64 {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromString for PathBuf {
     fn from_string(s: &str) -> Result<Self> {
         Ok(PathBuf::from(&s))

--- a/implementations/rust/ockam/ockam_core/src/env.rs
+++ b/implementations/rust/ockam/ockam_core/src/env.rs
@@ -1,0 +1,185 @@
+use crate::errcode::{Kind, Origin};
+use crate::{Error, Result};
+use std::env;
+use std::env::VarError;
+use std::path::PathBuf;
+
+/// Get environmental value [var_name]. If value is not found returns Ok(None)
+pub fn get_env<T: FromString>(var_name: &str) -> Result<Option<T>> {
+    get_env_impl::<Option<T>>(var_name, None)
+}
+
+/// Get environmental value [var_name]. If value is not found returns [default_value]
+pub fn get_env_with_default<T: FromString>(var_name: &str, default_value: T) -> Result<T> {
+    get_env_impl::<T>(var_name, default_value)
+}
+
+fn get_env_impl<T: FromString>(var_name: &str, default_value: T) -> Result<T> {
+    match env::var(var_name) {
+        Ok(val) => Ok(T::from_string(&val)?),
+        Err(e) => match e {
+            VarError::NotPresent => Ok(default_value),
+            VarError::NotUnicode(_) => Err(error("get_env error: not unicode".to_owned())),
+        },
+    }
+}
+
+/// For-internal-use trait for types that can be parsed from string
+pub trait FromString: Sized {
+    /// Parses string and gives the result. Can return an error in case
+    /// of parsing error.
+    fn from_string(s: &str) -> Result<Self>;
+}
+
+impl<T: FromString> FromString for Option<T> {
+    fn from_string(s: &str) -> Result<Self> {
+        let result = T::from_string(s);
+        if let Ok(val) = result {
+            return Ok(Some(val));
+        }
+        Err(result.err().unwrap())
+    }
+}
+
+impl FromString for bool {
+    fn from_string(s: &str) -> Result<Self> {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "true" | "1" | "yes" => Ok(true),
+            "false" | "0" | "no" => Ok(false),
+            _ => Err(error(format!("bool parsing error: {}", s))),
+        }
+    }
+}
+
+impl FromString for char {
+    fn from_string(s: &str) -> Result<Self> {
+        if s.len() != 1 {
+            return Err(error("char parsing error: length != 1".to_owned()));
+        }
+
+        Ok(s.chars().next().unwrap())
+    }
+}
+
+impl FromString for String {
+    fn from_string(s: &str) -> Result<Self> {
+        Ok(s.to_owned())
+    }
+}
+
+impl<T: FromString> FromString for Vec<T> {
+    fn from_string(s: &str) -> Result<Self> {
+        s.split(',').map(|x| T::from_string(x)).collect()
+    }
+}
+
+impl FromString for u8 {
+    fn from_string(s: &str) -> Result<Self> {
+        s.parse::<u8>()
+            .map_err(|_| error("u8 parsing error".to_string()))
+    }
+}
+
+impl FromString for u16 {
+    fn from_string(s: &str) -> Result<Self> {
+        s.parse::<u16>()
+            .map_err(|_| error("u16 parsing error".to_string()))
+    }
+}
+
+impl FromString for u32 {
+    fn from_string(s: &str) -> Result<Self> {
+        s.parse::<u32>()
+            .map_err(|_| error("u32 parsing error".to_string()))
+    }
+}
+
+impl FromString for u64 {
+    fn from_string(s: &str) -> Result<Self> {
+        s.parse::<u64>()
+            .map_err(|_| error("u64 parsing error".to_string()))
+    }
+}
+
+impl FromString for PathBuf {
+    fn from_string(s: &str) -> Result<Self> {
+        Ok(PathBuf::from(&s))
+    }
+}
+
+fn error(msg: String) -> Error {
+    Error::new(Origin::Core, Kind::Internal, msg)
+}
+
+#[cfg(test)]
+mod tests_from_string_trait {
+    use super::*;
+
+    #[test]
+    fn test_bool_ok() {
+        bool::from_string("true").unwrap();
+        bool::from_string("false").unwrap();
+        bool::from_string("TRUE").unwrap();
+        bool::from_string("FALSE").unwrap();
+        bool::from_string("tRuE").unwrap();
+        bool::from_string("fAlSe").unwrap();
+        bool::from_string("0").unwrap();
+        bool::from_string("1").unwrap();
+        bool::from_string("yes").unwrap();
+        bool::from_string("no").unwrap();
+    }
+
+    #[test]
+    fn test_bool_err() {
+        assert!(bool::from_string("something").is_err());
+        assert!(bool::from_string("").is_err());
+    }
+
+    #[test]
+    fn test_string_ok() {
+        assert_eq!(
+            "something".to_owned(),
+            String::from_string("something").unwrap()
+        );
+        assert_eq!("".to_owned(), String::from_string("").unwrap());
+    }
+
+    #[test]
+    fn test_vec_ok() {
+        Vec::<bool>::from_string("1,0,TRUE,FALSE,true,fAlSe").unwrap();
+        Vec::<char>::from_string("a,b,c,d,e").unwrap();
+        Vec::<String>::from_string("hello,world").unwrap();
+    }
+
+    #[test]
+    fn test_vec_err() {
+        assert!(Vec::<bool>::from_string("").is_err());
+        assert!(Vec::<u8>::from_string("1,2,3,100000").is_err());
+        assert!(Vec::<u8>::from_string("1, 2").is_err());
+        assert!(Vec::<u8>::from_string("1,").is_err())
+    }
+
+    #[test]
+    fn test_ints_ok() {
+        u8::from_string("1").unwrap();
+        u16::from_string("65535").unwrap();
+        u32::from_string("4294967295").unwrap();
+        u64::from_string("18446744073709551615").unwrap();
+    }
+
+    #[test]
+    fn test_ints_err() {
+        assert!(u8::from_string("-1").is_err());
+        assert!(u8::from_string("256").is_err());
+        assert!(u16::from_string("65536").is_err());
+        assert!(u32::from_string("4294967296").is_err());
+        assert!(u64::from_string("18446744073709551616").is_err());
+    }
+
+    #[test]
+    fn test_option_ok() {
+        let result = Option::<u8>::from_string("1");
+        assert_eq!(result.unwrap(), Some(1));
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -61,6 +61,9 @@ pub mod vault;
 /// Encoding
 pub mod hex_encoding;
 
+/// Environmental variables
+pub mod env;
+
 mod cbor_utils;
 mod error;
 mod key_exchanger;

--- a/implementations/rust/ockam/ockam_identity/src/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identifiers.rs
@@ -6,6 +6,7 @@ use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::Cow;
 use ockam_core::compat::string::{String, ToString};
 use ockam_core::compat::sync::Arc;
+use ockam_core::env::FromString;
 use ockam_core::vault::{Hasher, KeyId};
 use ockam_core::{Error, Result};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -105,6 +106,12 @@ impl FromStr for IdentityIdentifier {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl FromString for IdentityIdentifier {
+    fn from_string(s: &str) -> Result<Self> {
         s.try_into()
     }
 }

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -29,6 +29,7 @@ use tinyvec::{Array, ArrayVec, TinyVec};
 
 use crate::proto::{DnsAddr, Ip4, Ip6, Tcp};
 pub use error::Error;
+use ockam_core::env::FromString;
 pub use registry::{Registry, RegistryBuilder};
 
 /// Global default registry of known protocols.
@@ -284,6 +285,18 @@ impl Clone for MultiAddr {
                 reg: self.reg.clone(),
             }
         }
+    }
+}
+
+impl FromString for MultiAddr {
+    fn from_string(s: &str) -> ockam_core::Result<Self> {
+        Self::from_str(s).map_err(|_| {
+            ockam_core::Error::new(
+                ockam_core::errcode::Origin::Core,
+                ockam_core::errcode::Kind::Internal,
+                "MultiAddr parse error",
+            )
+        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/metrics.rs
+++ b/implementations/rust/ockam/ockam_node/src/metrics.rs
@@ -4,6 +4,7 @@ use core::{
     time::Duration,
 };
 use ockam_core::compat::{collections::BTreeMap, sync::Arc};
+use ockam_core::env::get_env;
 use std::{fs::OpenOptions, io::Write};
 
 pub struct Metrics {
@@ -25,9 +26,9 @@ impl Metrics {
 
     /// Spawned by the Executor to periodically collect metrics
     pub(crate) async fn run(self: Arc<Self>, alive: Arc<AtomicBool>) {
-        let path = match std::env::var("OCKAM_METRICS_PATH") {
-            Ok(path) => path,
-            Err(_) => {
+        let path = match get_env::<String>("OCKAM_METRICS_PATH") {
+            Ok(Some(path)) => path,
+            _ => {
                 debug!("Metrics collection disabled, set `OCKAM_METRICS_PATH` to collect metrics");
                 return;
             }

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{NodeError, NodeReason},
     NodeReplyResult, RouterReply,
 };
+use ockam_core::env::get_env;
 use ockam_core::{compat::sync::Arc, Address, Result};
 
 /// Execute a `StartWorker` command
@@ -52,8 +53,10 @@ async fn start(
     router.map.internal.insert(addr.clone(), record);
 
     #[cfg(feature = "std")]
-    if std::env::var("OCKAM_DUMP_INTERNALS").is_ok() {
-        trace!("{:#?}", router.map.internal);
+    if let Ok(Some(dump_internals)) = get_env::<bool>("OCKAM_DUMP_INTERNALS") {
+        if dump_internals {
+            trace!("{:#?}", router.map.internal);
+        }
     }
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]
     trace!("{:#?}", router.map.internal);

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{NodeError, NodeReason},
     NodeReplyResult, RouterReply,
 };
+#[cfg(feature = "std")]
 use ockam_core::env::get_env;
 use ockam_core::{compat::sync::Arc, Address, Result};
 

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -7,6 +7,7 @@ use crate::{
 use core::sync::atomic::AtomicUsize;
 use ockam_core::{
     compat::{sync::Arc, vec::Vec},
+    env::get_env,
     Address, Result,
 };
 
@@ -65,7 +66,7 @@ async fn start(
         .insert(primary_addr.clone(), address_record);
 
     #[cfg(feature = "std")]
-    if std::env::var("OCKAM_DUMP_INTERNALS").is_ok() {
+    if let Ok(Some(_)) = get_env::<String>("OCKAM_DUMP_INTERNALS") {
         trace!("{:#?}", router.map.internal);
     }
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -5,9 +5,10 @@ use crate::{
     NodeReplyResult, RouterReason, RouterReply,
 };
 use core::sync::atomic::AtomicUsize;
+#[cfg(feature = "std")]
+use ockam_core::env::get_env;
 use ockam_core::{
     compat::{sync::Arc, vec::Vec},
-    env::get_env,
     Address, Result,
 };
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Environment variables are used everywhere and being parsed in different manners. This requires boilerplate code to handle them.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes
Implement convinient custom `get_env` and `get_env_with_default` which are going to parse env variables and give the results right away.

fixes https://github.com/build-trust/ockam/issues/4549
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
