### PR TITLE
feat(rust): remove mutability of write methods on the `Terminal` abstraction

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -215,7 +215,7 @@ fn create_foreground_node(opts: &CommandGlobalOpts, cmd: &CreateCommand) -> crat
 
 async fn run_foreground_node(
     mut ctx: Context,
-    (mut opts, cmd, addr): (CommandGlobalOpts, CreateCommand, SocketAddr),
+    (opts, cmd, addr): (CommandGlobalOpts, CreateCommand, SocketAddr),
 ) -> crate::Result<()> {
     let cfg = &opts.config;
     let node_name = parse_node_name(&cmd.node_name)?;
@@ -357,7 +357,7 @@ async fn run_foreground_node(
 
     // Register a handler for SIGINT, SIGTERM, SIGHUP
     let tx_clone = tx.clone();
-    let mut opts_clone = opts.clone();
+    let opts_clone = opts.clone();
     ctrlc::set_handler(move || {
         let _ = tx_clone.blocking_send(());
         let _ = opts_clone
@@ -369,7 +369,7 @@ async fn run_foreground_node(
     // Spawn a thread to monitor STDIN for EOF
     if cmd.exit_on_eof {
         let tx_clone = tx.clone();
-        let mut opts_clone = opts.clone();
+        let opts_clone = opts.clone();
         std::thread::spawn(move || {
             let mut buffer = Vec::new();
             let mut handle = io::stdin().lock();

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -124,7 +124,7 @@ pub trait TerminalWriter: Clone {
 
     fn write(&mut self, s: &str) -> Result<()>;
     fn rewrite(&mut self, s: &str) -> Result<()>;
-    fn write_line(&mut self, s: &str) -> Result<()>;
+    fn write_line(&self, s: &str) -> Result<()>;
 }
 
 // Core functions
@@ -163,21 +163,21 @@ impl<W: TerminalWriter> Terminal<W> {
 
 // Logging mode
 impl<W: TerminalWriter> Terminal<W, Logging> {
-    pub fn write(&mut self, msg: &str) -> Result<()> {
+    pub fn write(&self, msg: &str) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
-        self.stderr.write(msg)
+        self.stderr.clone().write(msg)
     }
 
-    pub fn rewrite(&mut self, msg: &str) -> Result<()> {
+    pub fn rewrite(&self, msg: &str) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
-        self.stderr.rewrite(msg)
+        self.stderr.clone().rewrite(msg)
     }
 
-    pub fn write_line(&mut self, msg: &str) -> Result<()> {
+    pub fn write_line(&self, msg: &str) -> Result<()> {
         if self.quiet {
             return Ok(());
         }
@@ -215,7 +215,7 @@ impl<W: TerminalWriter> Terminal<W, Finished> {
         self
     }
 
-    pub fn write_line(mut self) -> Result<()> {
+    pub fn write_line(self) -> Result<()> {
         if self.quiet {
             return Ok(());
         }

--- a/implementations/rust/ockam/ockam_command/src/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/term.rs
@@ -38,7 +38,7 @@ impl TerminalWriter for TerminalStream<Term> {
         Ok(())
     }
 
-    fn write_line(&mut self, s: &str) -> Result<()> {
+    fn write_line(&self, s: &str) -> Result<()> {
         let s = self.prepare_msg(s)?;
         self.writer.write_line(&s)?;
         Ok(())
@@ -56,7 +56,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        let mut sut: Terminal<TerminalStream<Term>> =
+        let sut: Terminal<TerminalStream<Term>> =
             Terminal::new(false, false, false, OutputFormat::Plain);
         sut.write("1").unwrap();
         sut.rewrite("1-r\n").unwrap();


### PR DESCRIPTION
The streams used by `Terminal` must implement `Clone`. More specifically, the stream implementation we use (provided by the `term` crate), has an `Arc` around its internal buffer, so cloning is cheap.

We leverage that assumption to remove the mutability of write methods to reduce the complexity of the `Terminal` API.
