### PR TITLE
Add missing gitignore for ockam_typed_cbor package

### DIFF
--- a/implementations/elixir/ockam/ockam_typed_cbor/.gitignore
+++ b/implementations/elixir/ockam/ockam_typed_cbor/.gitignore
@@ -1,0 +1,2 @@
+_build
+deps


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Using Gradle tasks such as `elixir:build` produces non-committed non-ignored files in the traditional subdirectories used for Elixir build artifacts. Each other sibling package under `implementations/elixir/ockam` already includes a `.gitignore` file, most of them as minimal as this one.

## Proposed changes

Ignore these files so that they don't show up spuriously in `git status`, etc.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
