### PR TITLE
Enable Git CLI based fetching of RUSTSEC advisors in cargo-deny

### DIFF
--- a/tools/cargo-deny/deny.toml
+++ b/tools/cargo-deny/deny.toml
@@ -62,3 +62,12 @@ ignore = [
     # (https://rustsec.org/advisories/RUSTSEC-2022-0048.html)
     "RUSTSEC-2022-0048",
 ]
+# Users who require or prefer Git to use SSH cloning instead of HTTPS,
+# such as implemented via "insteadOf" rules in Git config, can still
+# successfully fetch advisories with this enabled.
+#
+# See also:
+# https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-git-fetch-with-cli-field-optional
+# https://github.com/EmbarkStudios/cargo-deny/pull/420
+git-fetch-with-cli = true


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Users with non-default Git configs such as [url.*.insteadOf](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) to force Git cloning to occur over SSH might experience failures like so:


```
> Task :rust:lint_cargo_deny FAILED
[Gradle] Command: cargo deny --all-features --manifest-path=../../Cargo.toml check --config=tools/cargo-deny/deny.toml licenses advisories
2023-04-04 20:37:50 [ERROR] failed to fetch advisory database https://github.com/RustSec/advisory-db: failed to authenticate when downloading repository
attempted ssh-agent authentication, but none of the usernames `git` succeeded
```

For example, the following Git config stanza can trigger this, which I mostly include here for search-keyword benefits:
```ini
[url "ssh://git@github.com/"]
	insteadOf = "https://github.com/"
```

## Proposed changes

Cargo by default uses a Rust implementation of Git, but has already accomodated this scenario with an [opt-in config setting](https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli) called `net.git-fetch-with-cli`. Later on, cargo-deny [implemented their own version of the same setting](https://github.com/EmbarkStudios/cargo-deny/pull/420).

At the time of writing, `cargo-deny` does not permit any kind of layered configuration, configuration inheritance, or environment variables to tune this behavior in a way that does not require changes in-repo to enable. In practice this would switch all users to use the `git` CLI directly any time `cargo-deny advisories fetch` is implicitly or explicitly run, while not affecting other `cargo` usage. This shouldn't have negative implications, other than the very slight overhead of shelling out to a new command as a separate subprocess.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
