### PR TITLE
feat(rust): add a limited version of the `ockam run` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c10657158e12163d6b3fb1e0c9154e43656843794a3071d9ee63ec82a4de2d"
+checksum = "aad0ad03c4ba802906340847aaea796d4158317864276864acbb281155bdcf4d"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a308b7277ac9aac78ab37933509659c6f978a8473e95d8e7a8103093133c3"
+checksum = "2493efc64aa1c6469a252c221c335ccdcebfcc556c81b1efaee051c6ddc3dd99"
 dependencies = [
  "aws-credential-types",
  "aws-endpoint",
@@ -692,9 +692,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
 
 [[package]]
 name = "block"
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+checksum = "19c5cb402c5c958281c7c0702edea7b780d03b86b606497ca3a10fcd3fc393ac"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1621,6 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1724,14 +1725,15 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+checksum = "106401dadc137d05cb0d4ab4d42be089746aefdfe8992df4d0edcf351c16ddca"
 dependencies = [
  "der",
+ "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
- "signature 2.0.0",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -1763,9 +1765,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -3302,6 +3304,7 @@ dependencies = [
  "dialoguer",
  "directories",
  "dirs",
+ "duct",
  "flate2",
  "hex",
  "indicatif",
@@ -3329,6 +3332,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "serde_json",
+ "serde_yaml",
  "strip-ansi-escapes",
  "syntect",
  "sysinfo",
@@ -3853,9 +3857,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -4330,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.6"
+version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d097081ed288dfe45699b72f5b5d648e5f15d64d900c7080273baa20c16a6849"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -4631,6 +4635,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,9 +4761,9 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",
@@ -4810,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
  "der",
@@ -4893,7 +4910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe4a709ccbccd9994d2363e27104933561ef170f892c950ffe939546c2ece1d"
 dependencies = [
  "bare-metal 1.0.0",
- "bitflags 2.0.2",
+ "bitflags 2.1.0",
  "cast",
  "cortex-m 0.7.7",
  "embedded-dma",
@@ -5514,6 +5531,12 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "unsigned-varint"

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -778,6 +778,14 @@ impl NodesState {
         Ok(nodes)
     }
 
+    pub fn exists(&self, name: &str) -> Result<bool> {
+        match self.get(name) {
+            Ok(_) => Ok(true),
+            Err(CliStateError::NotFound(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     pub fn get(&self, name: &str) -> Result<NodeState> {
         let path = self.get_node_path(name);
         if !path.exists() {

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -67,6 +67,7 @@ ctrlc = { version = "3.2.5", features = ["termination"] }
 dialoguer = "0.10"
 directories = "5"
 dirs = "5.0.0"
+duct = "0.13"
 flate2 = "1.0.25"
 hex = "0.4"
 indicatif = "0.17.3"
@@ -93,6 +94,7 @@ rustls-native-certs = "0.6.2"
 serde = { version = "1", features = ["derive"] }
 serde_bare = { version = "0.5.0", default-features = false, features = ["alloc"] }
 serde_json = "1"
+serde_yaml = "0.9"
 strip-ansi-escapes = "0.1.1"
 syntect = "5"
 sysinfo = { version = "0.28", default-features = false }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -63,6 +63,7 @@ gen_from_impl!(std::net::AddrParseError, DATAERR);
 gen_from_impl!(hex::FromHexError, DATAERR);
 gen_from_impl!(serde_bare::error::Error, DATAERR);
 gen_from_impl!(serde_json::Error, DATAERR);
+gen_from_impl!(serde_yaml::Error, DATAERR);
 gen_from_impl!(minicbor::encode::Error<std::convert::Infallible>, DATAERR);
 gen_from_impl!(minicbor::decode::Error, DATAERR);
 gen_from_impl!(ockam::Error, SOFTWARE);

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -20,6 +20,7 @@ mod node;
 mod policy;
 mod project;
 mod reset;
+mod run;
 mod secure_channel;
 mod service;
 mod space;
@@ -64,6 +65,7 @@ use worker::WorkerCommand;
 
 use crate::admin::AdminCommand;
 use crate::authority::AuthorityCommand;
+use crate::run::RunCommand;
 use crate::subscription::SubscriptionCommand;
 use crate::terminal::{Terminal, TerminalStream};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
@@ -227,6 +229,9 @@ pub enum OckamSubcommand {
     #[command(display_order = 900)]
     Completion(CompletionCommand),
 
+    #[command(display_order = 901)]
+    Run(RunCommand),
+
     Authenticated(AuthenticatedCommand),
     Configuration(ConfigurationCommand),
     Credential(CredentialCommand),
@@ -292,6 +297,7 @@ impl OckamCommand {
             OckamSubcommand::Worker(c) => c.run(options),
 
             OckamSubcommand::Completion(c) => c.run(),
+            OckamSubcommand::Run(c) => c.run(options),
 
             OckamSubcommand::Authenticated(c) => c.run(),
             OckamSubcommand::Configuration(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -1,0 +1,55 @@
+mod parser;
+
+use crate::util::node_rpc;
+use crate::{CommandGlobalOpts, Result};
+use anyhow::{anyhow, Context as _};
+use clap::Args;
+use ockam::Context;
+use std::path::PathBuf;
+
+/// Create nodes given a declarative configuration file
+#[derive(Clone, Debug, Args)]
+pub struct RunCommand {
+    /// Path to the configuration file
+    #[arg(long)]
+    pub config_path: Option<PathBuf>,
+}
+
+impl RunCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(rpc, (opts, self));
+    }
+}
+
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, RunCommand)) -> Result<()> {
+    run_impl(&ctx, opts, cmd).await
+}
+
+async fn run_impl(_ctx: &Context, opts: CommandGlobalOpts, cmd: RunCommand) -> Result<()> {
+    let path = match cmd.config_path {
+        Some(path) => path,
+        None => {
+            let mut path = std::env::current_dir().context("Failed to get current directory")?;
+            let default_file_names = ["ockam.yml", "ockam.yaml"];
+            let mut found = false;
+            for file_name in default_file_names.iter() {
+                path.push(file_name);
+                if path.exists() {
+                    found = true;
+                    break;
+                }
+                path.pop();
+            }
+            if !found {
+                return Err(anyhow!(
+                    "No default configuration file found in current directory.\n\
+                    Try passing the path to the config file with the --config-path flag."
+                )
+                .into());
+            }
+            path
+        }
+    };
+    parser::ConfigRunner::go(&opts.state, &path)?;
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/run/parser.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser.rs
@@ -1,0 +1,418 @@
+use crate::Result;
+use duct::Expression;
+use ockam_api::cli_state::CliState;
+use ockam_core::compat::collections::HashMap;
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::fmt::Debug;
+use std::path::Path;
+use tracing::debug;
+
+pub struct ConfigRunner {
+    commands_sorted: Vec<ParsedCommand>,
+    commands_index: BTreeMap<String, usize>,
+}
+
+#[derive(Clone)]
+pub struct ParsedCommand {
+    pub id: String,
+    pub depends_on: Option<String>,
+    pub cmd: Expression,
+}
+
+impl ConfigRunner {
+    fn new() -> Self {
+        Self {
+            commands_sorted: vec![],
+            commands_index: Default::default(),
+        }
+    }
+
+    pub fn go(cli_state: &CliState, path: &Path) -> Result<()> {
+        let mut cr = Self::new();
+        cr.parse(cli_state, path)?;
+        cr.run()?;
+        Ok(())
+    }
+
+    fn parse(&mut self, cli_state: &CliState, path: &Path) -> Result<()> {
+        let config = std::fs::read_to_string(path)?;
+        let config: Config = serde_yaml::from_str(&config)?;
+        let mut visited = HashSet::new();
+        let mut nodes = VecDeque::new();
+        for (name, node) in config.nodes {
+            nodes.push_back((name, node));
+        }
+        while let Some((name, node)) = nodes.pop_front() {
+            // If the node depends on another node, check if that node has been parsed.
+            if let Some(depends_on) = &node.depends_on {
+                // If the dependency has been visited already but not
+                // parsed, we have a circular dependency.
+                if visited.contains(depends_on) {
+                    return Err(anyhow::anyhow!(
+                        "Circular dependency detected: {} -> {}",
+                        depends_on,
+                        name
+                    )
+                    .into());
+                }
+                // If the dependency has been parsed, remove it from the control
+                // vector and proceed with the current node.
+                if self
+                    .commands_index
+                    .contains_key(&format!("node/{depends_on}"))
+                {
+                    visited.remove(depends_on);
+                }
+                // If the dependency has not been parsed, push the current
+                // node back to the queue and continue with the next one.
+                if !self
+                    .commands_index
+                    .contains_key(&format!("node/{depends_on}"))
+                {
+                    visited.insert(name.clone());
+                    nodes.push_back((name, node));
+                    continue;
+                }
+            }
+            // Remove it from the control vector and parse it.
+            visited.remove(&name);
+            node.parse(cli_state, &name, self)?;
+        }
+        Ok(())
+    }
+
+    fn run(self) -> Result<()> {
+        for c in self.commands_sorted.into_iter() {
+            debug!("Running command: {}", c.id);
+            // If a command fails it will show the appropriate error in its subshell.
+            // No need to return an error here.
+            if c.cmd.run().is_err() {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The config structure will be a yml file with the following structure:
+/// ```yml
+/// nodes:
+///   telegraf:
+///     enrollment-token: $OCKAM_TELEGRAF_TOKEN
+///     tcp-inlets:
+///       telegraf:
+///         from: '127.0.0.1:8087'
+///         to: /project/default/service/forward_to_influxdb/secure/api/service/outlet
+///         access_control: '(= subject.component "influxdb")'
+///
+///   influxdb:
+///     enrollment-token: $OCKAM_INFLUXDB_TOKEN
+///     tcp-outlets:
+///       influxdb:
+///         from: /service/outlet
+///         to: '127.0.0.1:8086'
+///         access_control: '(= subject.component "telegraf")'
+///     forwarders:
+///       influxdb:
+///         at: /project/default
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub nodes: HashMap<String, NodeConfig>,
+}
+
+/// Defines the structure of a node in the config file.
+#[derive(Debug, Deserialize)]
+pub struct NodeConfig {
+    #[serde(rename(deserialize = "depends-on"))]
+    pub depends_on: Option<String>,
+    pub enrollment_token: Option<String>,
+    #[serde(rename(deserialize = "tcp-inlets"))]
+    pub tcp_inlets: Option<HashMap<String, InletConfig>>,
+    #[serde(rename(deserialize = "tcp-outlets"))]
+    pub tcp_outlets: Option<HashMap<String, OutletConfig>>,
+    pub forwarders: Option<HashMap<String, ForwarderConfig>>,
+}
+
+impl NodeConfig {
+    fn parse(self, cli_state: &CliState, node_name: &str, cmds: &mut ConfigRunner) -> Result<()> {
+        let mut insert_command = |subject: &str, name: &str, depends_on, args: &[&str]| {
+            debug!("Parsed command: {} {}", binary_path(), args.join(" "));
+            let cmd = duct::cmd(binary_path(), args);
+            let id = format!("{subject}/{name}");
+            if cmds.commands_index.contains_key(&id) {
+                return Err(anyhow::anyhow!(
+                    "There can't be {subject}s with the same name: {name}"
+                ));
+            }
+            cmds.commands_index
+                .insert(id.clone(), cmds.commands_sorted.len());
+            cmds.commands_sorted.push(ParsedCommand {
+                id,
+                depends_on,
+                cmd,
+            });
+            Ok(())
+        };
+
+        // Check if the node already exists. If it doesn't, create it.
+        if !cli_state.nodes.exists(node_name)? {
+            let args = {
+                let mut args = vec!["node", "create", node_name];
+                if let Some(enrollment_token) = &self.enrollment_token {
+                    args.push("--enrollment-token");
+                    args.push(enrollment_token);
+                }
+                args
+            };
+            insert_command(
+                "node",
+                node_name,
+                self.depends_on.map(|s| format!("node/{s}")),
+                args.as_slice(),
+            )?;
+        }
+
+        // TODO: all commands should support both `/node/{name}` and `{name}` formats.
+        let node_name_formatted = format!("/node/{node_name}");
+
+        if let Some(tcp_inlets) = &self.tcp_inlets {
+            for (name, inlet) in tcp_inlets {
+                // TODO: store inlets in CliState; Then check if the inlet already exists. If it doesn't, create it.
+                if let Some(exp) = &inlet.access_control {
+                    let args = &[
+                        "policy",
+                        "set",
+                        "--at",
+                        &node_name_formatted,
+                        "--resource",
+                        "tcp-inlet",
+                        "--expression",
+                        exp,
+                    ];
+                    insert_command("policy", name, None, args)?;
+                }
+                let args = &[
+                    "tcp-inlet",
+                    "create",
+                    "--at",
+                    &node_name_formatted,
+                    "--from",
+                    &inlet.from,
+                    "--to",
+                    &inlet.to,
+                    "--alias",
+                    name,
+                ];
+                insert_command("inlet", name, None, args)?;
+            }
+        }
+
+        if let Some(tcp_outlets) = &self.tcp_outlets {
+            for (name, outlet) in tcp_outlets {
+                // TODO: store outlets in CliState; Then check if the outlet already exists. If it doesn't, create it.
+                if let Some(exp) = &outlet.access_control {
+                    let args = &[
+                        "policy",
+                        "set",
+                        "--at",
+                        &node_name_formatted,
+                        "--resource",
+                        "tcp-outlet",
+                        "--expression",
+                        exp,
+                    ];
+                    insert_command("policy", name, None, args)?;
+                }
+                let args = &[
+                    "tcp-outlet",
+                    "create",
+                    "--at",
+                    &node_name_formatted,
+                    "--from",
+                    &outlet.from,
+                    "--to",
+                    &outlet.to,
+                    "--alias",
+                    name,
+                ];
+                insert_command("outlet", name, None, args)?;
+            }
+        }
+
+        if let Some(forwarders) = &self.forwarders {
+            for (name, forwarder) in forwarders {
+                // TODO: store forwarders in CliState; Then check if the forwarder already exists. If it doesn't, create it.
+                let args = &[
+                    "forwarder",
+                    "create",
+                    name,
+                    "--to",
+                    &node_name_formatted,
+                    "--at",
+                    &forwarder.at,
+                ];
+                insert_command("forwarder", name, None, args)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Defines the structure of a tcp inlet in the config file.
+#[derive(Debug, Deserialize)]
+pub struct InletConfig {
+    pub from: String,
+    pub to: String,
+    pub access_control: Option<String>,
+}
+
+/// Defines the structure of a tcp outlet in the config file.
+#[derive(Debug, Deserialize)]
+pub struct OutletConfig {
+    pub from: String,
+    pub to: String,
+    pub access_control: Option<String>,
+}
+
+/// Defines the structure of a forwarder in the config file.
+#[derive(Debug, Deserialize)]
+pub struct ForwarderConfig {
+    pub at: String,
+}
+
+static BINARY_PATH: Lazy<String> = Lazy::new(|| {
+    std::env::args()
+        .next()
+        .expect("Failed to get the binary path")
+});
+
+fn binary_path() -> &'static str {
+    &BINARY_PATH
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_config_with_depends_on() {
+        let config = r#"
+            nodes:
+              influxdb:
+                tcp-outlets:
+                  influxdb:
+                    from: /service/outlet
+                    to: '127.0.0.1:8086'
+                    access_control: '(= subject.component "telegraf")'
+                forwarders:
+                  influxdb:
+                    at: /project/default
+
+              telegraf:
+                depends-on: influxdb
+                tcp-inlets:
+                  telegraf:
+                    from: '127.0.0.1:8087'
+                    to: /project/default/service/forward_to_influxdb/secure/api/service/outlet
+                    access_control: '(= subject.component "influxdb")'
+        "#;
+        let tmp_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp_file.path(), config).unwrap();
+
+        let mut sut = ConfigRunner::new();
+        let cli_state = CliState::test().unwrap();
+        sut.parse(&cli_state, tmp_file.path()).unwrap();
+
+        assert_eq!(sut.commands_sorted.len(), 7);
+        assert_eq!(sut.commands_sorted[0].id, "node/influxdb");
+        assert_eq!(sut.commands_sorted[1].id, "policy/influxdb");
+        assert_eq!(sut.commands_sorted[2].id, "outlet/influxdb");
+        assert_eq!(sut.commands_sorted[3].id, "forwarder/influxdb");
+        assert_eq!(sut.commands_sorted[4].id, "node/telegraf");
+        assert_eq!(
+            sut.commands_sorted[4].depends_on.as_ref().unwrap(),
+            "node/influxdb"
+        );
+        assert_eq!(sut.commands_sorted[5].id, "policy/telegraf");
+        assert_eq!(sut.commands_sorted[6].id, "inlet/telegraf");
+    }
+
+    #[test]
+    fn detect_circular_dependency() {
+        let cases = vec![
+            (
+                r#"
+                    nodes:
+                      node1:
+                        depends-on: node2
+                      node2:
+                        depends-on: node1
+                "#,
+                Err(()),
+            ),
+            (
+                r#"
+                    nodes:
+                      node1:
+                        depends-on: node2
+                      node2:
+                        depends-on: node3
+                      node3:
+                        depends-on: node1
+                "#,
+                Err(()),
+            ),
+            (
+                r#"
+                    nodes:
+                      node1:
+                        depends-on: node2
+                      node2:
+                        depends-on: node1
+                      node3:
+                "#,
+                Err(()),
+            ),
+            (
+                r#"
+                    nodes:
+                      node1:
+                        depends-on: node3
+                      node2:
+                        depends-on: node3
+                      node3:
+                "#,
+                Ok(()),
+            ),
+            (
+                r#"
+                    nodes:
+                      node1:
+                      node2:
+                "#,
+                Ok(()),
+            ),
+        ];
+        let tmp_file = tempfile::NamedTempFile::new().unwrap();
+        for (config, expected) in cases {
+            std::fs::write(tmp_file.path(), config).unwrap();
+            let mut sut = ConfigRunner::new();
+            let cli_state = CliState::test().unwrap();
+            let result = sut.parse(&cli_state, tmp_file.path());
+            match expected {
+                Ok(_) => assert!(result.is_ok()),
+                Err(_) => {
+                    assert!(result.is_err());
+                    assert!(result
+                        .unwrap_err()
+                        .to_string()
+                        .contains("Circular dependency detected"));
+                }
+            }
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -265,13 +265,20 @@ impl<W: TerminalWriter> Terminal<W, Finished> {
             OutputFormat::Plain => {
                 if self.stdout.is_tty() {
                     // If not set, fallback with the following priority: Machine -> JSON
-                    plain.unwrap_or(
-                        machine.unwrap_or(json.context("JSON output should be defined")?),
-                    )
+                    match (plain, machine, json) {
+                        (Some(plain), _, _) => plain,
+                        (None, Some(machine), _) => machine,
+                        (None, None, Some(json)) => json,
+                        _ => unreachable!(),
+                    }
                 } else {
                     // If not set, fallback with the following priority: JSON -> Plain
-                    machine
-                        .unwrap_or(json.unwrap_or(plain.context("Plain output should be defined")?))
+                    match (machine, json, plain) {
+                        (Some(machine), _, _) => machine,
+                        (None, Some(json), _) => json,
+                        (None, None, Some(plain)) => plain,
+                        _ => unreachable!(),
+                    }
                 }
             }
             // If not set, no fallback is provided and returns an error


### PR DESCRIPTION
Ref: https://github.com/build-trust/ockam/issues/4479

Limitations:
- Supports creation of nodes, tcp-inlets/outlets, policies on tcp-inlets/outlets, and forwarders
- Supports dependencies only between nodes
- The config file is mapped to a Hashmap, which doesn't keep the file's explicit structure. We'd like to honor the explicit order of the commands
- Assumes `enroll` is done and the needed projects/spaces exist