### PR TITLE
fix(rust): set node pid when initiating its state

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -196,7 +196,11 @@ pub(crate) async fn init_node_state(
         .vault(vault_state.path)
         .identity(identity_state.path)
         .build(&opts.state)?;
-    opts.state.nodes.create(node_name, node_config)?;
+    let node_state = opts.state.nodes.create(node_name, node_config)?;
+
+    // Set PID using the current process. If this node is then spawned in a subprocess
+    // the PID will be updated to the new process ID.
+    node_state.set_pid(std::process::id() as i32)?;
 
     Ok(())
 }


### PR DESCRIPTION
Current status: this has some side effects I need to investigate further. Let's keep it on hold for now.

## Problem
Embedded nodes were not being affected by `ockam reset` command, forcing the user to manually stop stale ockam processes caused by this kind of nodes.

## Proposed changes
Currently, only spawned nodes (background or foreground) were storing their PID in their state. Now, embedded nodes will also store their PID so they can be killed via the `reset` command.