### PR TITLE
feat(rust): worker address as output of `tcp-connection create`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,4 +1,5 @@
 use crate::node::default_node_name;
+use crate::util::is_tty;
 use crate::{
     util::{api, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
@@ -42,6 +43,14 @@ impl CreateCommand {
         // if output format is json, write json to stdout.
         match opts.global_args.output_format {
             OutputFormat::Plain => {
+                if !is_tty(std::io::stdout()) {
+                    let worker_addr = response
+                        .worker_addr
+                        .strip_prefix("0#")
+                        .unwrap_or(response.worker_addr.as_ref());
+                    println!("/service/{worker_addr}");
+                    return Ok(());
+                }
                 let from = &self.node_opts.from;
                 let to = response.socket_addr()?;
                 if opts.global_args.no_color {


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/4600