### PR TITLE
fixes from running bats test

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -148,10 +148,15 @@ impl NodeManager {
                     Some(e) => e.clone(),
                     None => and([
                         eq([ident("resource.project_id"), ident("subject.project_id")]), // TODO: DEPRECATE - Removing PROJECT_ID attribute in favor of TRUST_CONTEXT_ID
-                        eq([
-                            ident("resource.trust_context_id"),
-                            ident("subject.trust_context_id"),
-                        ]),
+                                                                                         /*
+                                                                                         * TODO: replace the project_id check for trust_context_id.  For now the
+                                                                                         * existing authority deployed doesn't know about trust_context so this is to
+                                                                                         * be done after updating deployed authorities.
+                                                                                         eq([
+                                                                                             ident("resource.trust_context_id"),
+                                                                                             ident("subject.trust_context_id"),
+                                                                                         ]),
+                                                                                         */
                     ]),
                 };
                 self.policies.set_policy(r, a, &fallback).await?

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -13,18 +13,18 @@ use std::{
 };
 use tracing::error;
 
+use crate::node::util::{add_project_info_to_node_state, init_node_state, spawn_node};
 use crate::secure_channel::listener::create as secure_channel_listener;
 use crate::service::config::Config;
 use crate::service::start;
 use crate::util::api::{TrustContextConfigBuilder, TrustContextOpts};
 use crate::util::node_rpc;
 use crate::util::{bind_to_port_check, embedded_node_that_is_not_stopped, exitcode};
+use crate::util::{parse_node_name, RpcBuilder};
 use crate::{
     docs, identity, node::show::print_query_status, util::find_available_port, CommandGlobalOpts,
     Result,
 };
-use crate::{node::util::init_node_state, util::RpcBuilder};
-use crate::{node::util::spawn_node, util::parse_node_name};
 use ockam::{Address, AsyncTryClone, TcpConnectionTrustOptions, TcpListenerTrustOptions};
 use ockam::{Context, TcpTransport};
 use ockam_api::nodes::authority_node;
@@ -232,6 +232,8 @@ async fn run_foreground_node(
         )
         .await?;
     }
+
+    add_project_info_to_node_state(&opts, cfg, &cmd.trust_context_opts).await?;
 
     let trust_context_config = TrustContextConfigBuilder::new(&cmd.trust_context_opts)
         .with_authority_identity(cmd.authority_identity.as_ref())

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -381,14 +381,18 @@ impl TrustContextConfigBuilder {
     pub fn build(&self) -> Option<TrustContextConfig> {
         self.trust_context
             .clone()
-            .or_else(|| self.get_from_project_path())
+            .or_else(|| self.get_from_project_path(self.project_path.as_ref()?))
             .or_else(|| self.get_from_project_name())
             .or_else(|| self.get_from_authority_identity())
             .or_else(|| self.get_from_credential())
+            .or_else(|| {
+                self.default_proj
+                    .as_ref()
+                    .and_then(|path| self.get_from_project_path(path))
+            })
     }
 
-    fn get_from_project_path(&self) -> Option<TrustContextConfig> {
-        let path = self.project_path.as_ref()?;
+    fn get_from_project_path(&self, path: &PathBuf) -> Option<TrustContextConfig> {
         let s = std::fs::read_to_string(path).unwrap();
         let proj_info: ProjectInfo = serde_json::from_str(&s).unwrap();
         TrustContextConfig::from_project(&(&proj_info).into()).ok()

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -22,8 +22,8 @@ teardown() {
     run "$OCKAM" identity create m2
     run "$OCKAM" node create n2 --identity m2
 
-    run "$OCKAM" secure-channel create --from /node/n1 --to /node/n2/service/api \
-        | "$OCKAM" message send hello --from /node/n1 --to -/service/echo
+    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+        | $OCKAM message send hello --from /node/n1 --to -/service/echo"
     assert_success
 }
 
@@ -41,8 +41,8 @@ teardown() {
 
     run "$OCKAM" node create n2  --trust-context ./trust_context.json --trusted-identities "$trusted"
 
-    run "$OCKAM" secure-channel create --from /node/n1 --to /node/n2/service/api \
-        | "$OCKAM" message send hello --from /node/n1 --to -/service/echo
+    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+        | $OCKAM message send hello --from /node/n1 --to -/service/echo"
     assert_success
 
     run "$OCKAM" message send hello --from /node/n1 --to /node/n2/service/echo
@@ -77,28 +77,32 @@ teardown() {
     # Create a node for i2 that trust identity_authority as a credential authority
     run "$OCKAM" node create n2 --identity i2 --trust-context i2-trust-context.json
 
-    run "$OCKAM" secure-channel create --from /node/n1 --to /node/n2/service/api
+    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+        | $OCKAM message send hello --from /node/n1 --to -/service/echo"
     assert_success
 }
 
 @test "trust context - trust context with an id and authority using orchestrator; orchestrator enrollment and connection is performed, orchestrator" {
     skip_if_orchestrator_tests_not_enabled
     load_orchestrator_data
-    $OCKAM project information --as-trust-context > trust_context.json
+
+    $OCKAM project information --as-trust-context > ./project_trust_context.json
 
     run "$OCKAM" identity create m1
     $OCKAM project enroll > m1.token
-    run "$OCKAM" project authenticate --identity m1 --trust-context ./trust_context.json --token $(cat m1.token)
+    run "$OCKAM" project authenticate --identity m1 --trust-context ./project_trust_context.json --token $(cat m1.token)
 
     run "$OCKAM" identity create m2
     $OCKAM project enroll > m2.token
-    run "$OCKAM" project authenticate --identity m2 --trust-context ./trust_context.json --token $(cat m2.token)
+    run "$OCKAM" project authenticate --identity m2 --trust-context ./project_trust_context.json --token $(cat m2.token)
 
-    run "$OCKAM" node create n1 --identity m1 --trust-context ./trust_context.json
+    run "$OCKAM" node create n1 --identity m1 --trust-context ./project_trust_context.json
+    assert_success
 
-    run "$OCKAM" node create n2 --identity m2 --trust-context ./trust_context.json
+    run "$OCKAM" node create n2 --identity m2 --trust-context ./project_trust_context.json
+    assert_success
 
-    run "$OCKAM" secure-channel create --from /node/n1 --to /node/n2/service/api \
-        | "$OCKAM" message send hello --from /node/n1 --to -/service/echo
+    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+        | $OCKAM message send hello --from /node/n1 --to -/service/echo"
     assert_success
 }


### PR DESCRIPTION
bats tests on `message`,  `portals`,  `projects` ,  `trust_context` and `use-cases` suites where broken,  this fix them.  

* Use the default project configured on the `TrustContextConfigBuilder` , if no other was given.
* Do not enforce  `trust_context_id`  on abac rules  _yet_   , as that requires coordination to update existing authorities that don't return that until this get merged
*  `/project/name`  multiaddresses are  resolved from some lookup mechanism.    This data must be obtained from the project.json file  (it won't be there on  OCKAM_HOME   if the node is started on a different OCKAM_HOME,  or different machine than the one where the project was created)


TODO:
one trust_context case nees :eyes:  as it's not fixed.