### PR TITLE
chore(rust): add more bats test

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -4,7 +4,7 @@ use crate::node::util::run_ockam;
 use crate::util::node_rpc;
 use crate::util::{embedded_node_that_is_not_stopped, exitcode};
 use crate::{docs, identity, CommandGlobalOpts, Result};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use clap::{ArgGroup, Args};
 use ockam::AsyncTryClone;
 use ockam::Context;
@@ -80,6 +80,14 @@ pub struct CreateCommand {
     /// Run the node in foreground.
     #[arg(long, short, value_name = "BOOL", default_value_t = false)]
     foreground: bool,
+
+    /// Vault that authority will use
+    #[arg(long = "vault", value_name = "VAULT")]
+    vault: Option<String>,
+
+    /// Authority Identity
+    #[arg(long = "identity", value_name = "IDENTITY")]
+    identity: Option<String>,
 }
 
 /// Start an authority node by calling the `ockam` executable with the current command-line
@@ -90,7 +98,14 @@ async fn spawn_background_node(
     cmd: &CreateCommand,
 ) -> crate::Result<()> {
     // Create node state, including the vault and identity if they don't exist
-    init_node_state(ctx, opts, &cmd.node_name, None, None).await?;
+    init_node_state(
+        ctx,
+        opts,
+        &cmd.node_name,
+        cmd.vault.as_ref(),
+        cmd.identity.as_ref(),
+    )
+    .await?;
 
     // Construct the arguments list and re-execute the ockam
     // CLI in foreground mode to start the newly created node
@@ -139,6 +154,16 @@ async fn spawn_background_node(
     if let Some(attributes) = &cmd.attributes {
         args.push("--attributes".to_string());
         args.push(attributes.join(","));
+    }
+
+    if let Some(vault) = &cmd.vault {
+        args.push("--vault".to_string());
+        args.push(vault.clone());
+    }
+
+    if let Some(identity) = &cmd.identity {
+        args.push("--identity".to_string());
+        args.push(identity.clone());
     }
     args.push(cmd.node_name.to_string());
 
@@ -213,18 +238,35 @@ async fn start_authority_node(
         .get_node_path(&command.node_name)
         .exists()
     {
-        init_node_state(&ctx, &options, &command.node_name, None, None).await?;
+        init_node_state(
+            &ctx,
+            &options,
+            &command.node_name,
+            cmd.vault.as_ref(),
+            cmd.identity.as_ref(),
+        )
+        .await?;
     };
 
     // retrieve the authority identity if it has been created before
     // otherwise create a new one
-    let public_identity = match options.state.identities.default().ok() {
-        Some(state) => state.config.public_identity(),
-        None => {
-            let cmd = identity::CreateCommand::new("authority".into(), None);
-            cmd.create_identity(ctx.async_try_clone().await?, options.clone())
-                .await?
-        }
+    let public_identity = match cmd.identity {
+        Some(identity_name) => options
+            .state
+            .identities
+            .get(&identity_name)
+            .context("Identity not found")
+            .unwrap()
+            .config
+            .public_identity(),
+        None => match options.state.identities.default().ok() {
+            Some(state) => state.config.public_identity(),
+            None => {
+                let cmd = identity::CreateCommand::new("authority".into(), None);
+                cmd.create_identity(ctx.async_try_clone().await?, options.clone())
+                    .await?
+            }
+        },
     };
 
     let okta_configuration = match (

--- a/implementations/rust/ockam/ockam_command/tests/bats/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message.bats
@@ -50,13 +50,13 @@ teardown() {
 
   # m1 is a member,  must be able to contact the project' service
   msg=$(random_str)
-  run "$OCKAM" message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --timeout 5 --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
   assert_success
   assert_output "$msg"
 
   # m2 is not a member, must not be able to contact the project' service
   run "$OCKAM" identity create m2
   assert_success
-  run "$OCKAM" message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --timeout 5 --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
   assert_failure
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -136,12 +136,12 @@ teardown() {
   run $OCKAM project authenticate --identity m1 --project-path "$PROJECT_JSON_PATH"
 
   # m1 is a member,  must be able to contact the project' service
-  run $OCKAM message send --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
+  run $OCKAM message send --timeout 5 --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
   assert_success
   assert_output "hello"
 
   # m2 is not a member,  must not be able to contact the project' service
-  run $OCKAM message send --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
+  run $OCKAM message send --timeout 5 --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo hello
   assert_failure
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -269,7 +269,7 @@ teardown() {
   run "$OCKAM" node create n1
   assert_success
   msg=$(random_str)
-  run "$OCKAM" message send "$msg" --to /node/n1/service/uppercase
+  run "$OCKAM" message send "$msg" --timeout 5 --to /node/n1/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
@@ -277,13 +277,13 @@ teardown() {
   run "$OCKAM" node create n2
   assert_success
   msg=$(random_str)
-  run "$OCKAM" message send "$msg" --from n1 --to /node/n2/service/uppercase
+  run "$OCKAM" message send "$msg" --timeout 5 --from n1 --to /node/n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
   # Same, but using the `/node/` prefix in the `--from` argument
   msg=$(random_str)
-  run "$OCKAM" message send "$msg" --from /node/n1 --to /node/n2/service/uppercase
+  run "$OCKAM" message send "$msg" --timeout 5 --from /node/n1 --to /node/n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 }
@@ -325,7 +325,7 @@ teardown() {
   # In two separate commands
   msg=$(random_str)
   output=$($OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api)
-  run "$OCKAM" message send "$msg" --from /node/n1 --to "$output/service/uppercase"
+  run "$OCKAM" message send "$msg" --timeout 5 --from /node/n1 --to "$output/service/uppercase"
   assert_success
   assert_output "$(to_uppercase "$msg")"
 
@@ -354,7 +354,7 @@ teardown() {
   # In two separate commands
   $OCKAM forwarder create n2 --at /node/n1 --to /node/n2
   msg=$(random_str)
-  run "$OCKAM" message send "$msg" --to /node/n1/service/hop/service/forward_to_n2/service/uppercase
+  run "$OCKAM" message send --timeout 5 "$msg" --to /node/n1/service/hop/service/forward_to_n2/service/uppercase
   assert_success
   assert_output "$(to_uppercase "$msg")"
 


### PR DESCRIPTION
add more bats test,  mainly 
* standalone authority case
* ensure ABAC rules/credentials are enforced

and small tweaks to make that possible
* let create authority with a specific identity and vault
* let specify a timeout in `message send`  overriding the default one  (just to make tests doesn't take that long when testing the failure cases)