### PR TITLE
fix(rust): add `verbose` argument when creating an authority node

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -117,6 +117,10 @@ async fn spawn_background_node(
         "--tcp-listener-address".to_string(),
         cmd.tcp_listener_address.clone(),
         "--foreground".to_string(),
+        match opts.global_args.verbose {
+            0 => "-vv".to_string(),
+            v => format!("-{}", "v".repeat(v as usize)),
+        },
     ];
 
     if cmd.no_direct_authentication {

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "authority - standalone authority, enrollers, members" {
-  export PROJECT_JSON_PATH="$OCKAM_HOME/project.json"
+  export PROJECT_JSON_PATH="$OCKAM_HOME/project-authority.json"
 
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller


### PR DESCRIPTION
Nodes crated with the `ockam authority create` command were not passing the `verbose` argument to the subprocess, creating a node with no logs.