### PR TITLE
docs(rust): improve command help

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -21,15 +21,13 @@ pub(crate) use show::ShowCommand;
 pub(crate) use store::StoreCommand;
 pub(crate) use verify::VerifyCommand;
 
-use crate::CommandGlobalOpts;
-use crate::{docs, Result};
+use crate::{docs, CommandGlobalOpts, Result};
 use clap::{Args, Subcommand};
 
 const HELP_DETAIL: &str = "";
 
 #[derive(Clone, Debug, Args)]
 #[command(
-    hide = docs::hide(),
     after_long_help = docs::after_help(HELP_DETAIL),
     arg_required_else_help = true,
     subcommand_required = true
@@ -41,6 +39,7 @@ pub struct CredentialCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum CredentialSubcommand {
+    #[command(display_order = 900)]
     Get(GetCommand),
     Issue(IssueCommand),
     List(ListCommand),

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -43,7 +43,7 @@ fn is_markdown() -> bool {
 }
 
 pub(crate) fn hide() -> bool {
-    get_env_with_default("OCKAM_HELP_SHOW_HIDDEN", false).unwrap_or(false)
+    get_env_with_default("OCKAM_HELP_SHOW_HIDDEN", true).unwrap_or(true)
 }
 
 pub(crate) fn about(body: &str) -> &'static str {
@@ -69,7 +69,7 @@ pub(crate) fn after_help(body: &str) -> &'static str {
 }
 
 /// Render the string if the document should be displayed in a terminal
-/// Otherwise, if it is a Mardown document just return a static string
+/// Otherwise, if it is a Markdown document just return a static string
 pub(crate) fn render(body: &str) -> &'static str {
     if is_markdown() {
         Box::leak(body.to_string().into_boxed_str())

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -190,58 +190,41 @@ impl CommandGlobalOpts {
 pub enum OckamSubcommand {
     #[command(display_order = 800)]
     Enroll(EnrollCommand),
-    #[command(display_order = 801)]
     Space(SpaceCommand),
-    #[command(display_order = 802)]
     Project(ProjectCommand),
-    #[command(display_order = 803)]
-    Status(StatusCommand),
-    #[command(display_order = 804)]
-    Reset(ResetCommand),
+    Admin(AdminCommand),
+    Subscription(SubscriptionCommand),
 
-    #[command(display_order = 810)]
-    Authority(AuthorityCommand),
-    #[command(display_order = 811)]
     Node(Box<NodeCommand>),
-    #[command(display_order = 812)]
-    Identity(IdentityCommand),
-    #[command(display_order = 813)]
-    TcpListener(TcpListenerCommand),
-    #[command(display_order = 814)]
-    TcpConnection(TcpConnectionCommand),
-    #[command(display_order = 815)]
-    TcpOutlet(TcpOutletCommand),
-    #[command(display_order = 816)]
-    TcpInlet(TcpInletCommand),
-    #[command(display_order = 817)]
-    SecureChannelListener(SecureChannelListenerCommand),
-    #[command(display_order = 818)]
-    SecureChannel(SecureChannelCommand),
-    #[command(display_order = 819)]
-    Forwarder(ForwarderCommand),
-    #[command(display_order = 820)]
-    Message(MessageCommand),
-    #[command(display_order = 821)]
-    Policy(PolicyCommand),
-    #[command(display_order = 821)]
     Worker(WorkerCommand),
+    Service(ServiceCommand),
+    Message(MessageCommand),
+    Forwarder(ForwarderCommand),
 
-    #[command(display_order = 900)]
-    Completion(CompletionCommand),
+    TcpListener(TcpListenerCommand),
+    TcpConnection(TcpConnectionCommand),
+    TcpOutlet(TcpOutletCommand),
+    TcpInlet(TcpInletCommand),
 
-    #[command(display_order = 901)]
+    SecureChannelListener(SecureChannelListenerCommand),
+    SecureChannel(SecureChannelCommand),
+
+    Vault(VaultCommand),
+    Identity(IdentityCommand),
+    Credential(CredentialCommand),
+    Authority(AuthorityCommand),
+    Policy(PolicyCommand),
+    Lease(LeaseCommand),
+
     Run(RunCommand),
-
+    Status(StatusCommand),
+    Reset(ResetCommand),
     Authenticated(AuthenticatedCommand),
     Configuration(ConfigurationCommand),
-    Credential(CredentialCommand),
-    Service(ServiceCommand),
-    Vault(VaultCommand),
-    Subscription(SubscriptionCommand),
-    Admin(AdminCommand),
-    Manpages(ManpagesCommand),
-    Lease(LeaseCommand),
+
+    Completion(CompletionCommand),
     Markdown(MarkdownCommand),
+    Manpages(ManpagesCommand),
 }
 
 pub fn run() {
@@ -279,36 +262,39 @@ impl OckamCommand {
             OckamSubcommand::Enroll(c) => c.run(options),
             OckamSubcommand::Space(c) => c.run(options),
             OckamSubcommand::Project(c) => c.run(options),
-            OckamSubcommand::Status(c) => c.run(options),
-            OckamSubcommand::Reset(c) => c.run(options),
+            OckamSubcommand::Admin(c) => c.run(options),
+            OckamSubcommand::Subscription(c) => c.run(options),
 
-            OckamSubcommand::Authority(c) => c.run(options),
             OckamSubcommand::Node(c) => c.run(options),
-            OckamSubcommand::Identity(c) => c.run(options),
+            OckamSubcommand::Worker(c) => c.run(options),
+            OckamSubcommand::Service(c) => c.run(options),
+            OckamSubcommand::Message(c) => c.run(options),
+            OckamSubcommand::Forwarder(c) => c.run(options),
+
             OckamSubcommand::TcpListener(c) => c.run(options),
             OckamSubcommand::TcpConnection(c) => c.run(options),
             OckamSubcommand::TcpOutlet(c) => c.run(options),
             OckamSubcommand::TcpInlet(c) => c.run(options),
+
             OckamSubcommand::SecureChannelListener(c) => c.run(options),
             OckamSubcommand::SecureChannel(c) => c.run(options),
-            OckamSubcommand::Forwarder(c) => c.run(options),
-            OckamSubcommand::Message(c) => c.run(options),
+
+            OckamSubcommand::Vault(c) => c.run(options),
+            OckamSubcommand::Identity(c) => c.run(options),
+            OckamSubcommand::Credential(c) => c.run(options),
+            OckamSubcommand::Authority(c) => c.run(options),
             OckamSubcommand::Policy(c) => c.run(options),
-            OckamSubcommand::Worker(c) => c.run(options),
+            OckamSubcommand::Lease(c) => c.run(options),
 
-            OckamSubcommand::Completion(c) => c.run(),
             OckamSubcommand::Run(c) => c.run(options),
-
+            OckamSubcommand::Status(c) => c.run(options),
+            OckamSubcommand::Reset(c) => c.run(options),
             OckamSubcommand::Authenticated(c) => c.run(),
             OckamSubcommand::Configuration(c) => c.run(options),
-            OckamSubcommand::Credential(c) => c.run(options),
-            OckamSubcommand::Service(c) => c.run(options),
-            OckamSubcommand::Vault(c) => c.run(options),
-            OckamSubcommand::Subscription(c) => c.run(options),
-            OckamSubcommand::Admin(c) => c.run(options),
-            OckamSubcommand::Manpages(c) => c.run(),
-            OckamSubcommand::Lease(c) => c.run(options),
+
+            OckamSubcommand::Completion(c) => c.run(),
             OckamSubcommand::Markdown(c) => c.run(),
+            OckamSubcommand::Manpages(c) => c.run(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -6,12 +6,11 @@ use crate::policy::create::CreateCommand;
 use crate::policy::delete::DeleteCommand;
 use crate::policy::list::ListCommand;
 use crate::policy::show::ShowCommand;
-use crate::{docs, CommandGlobalOpts};
+use crate::CommandGlobalOpts;
 use clap::{Args, Subcommand};
 use ockam_abac::{Action, Resource};
 
 #[derive(Clone, Debug, Args)]
-#[command(hide = docs::hide())]
 pub struct PolicyCommand {
     #[command(subcommand)]
     subcommand: PolicySubcommand,
@@ -19,6 +18,7 @@ pub struct PolicyCommand {
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum PolicySubcommand {
+    #[command(display_order = 900)]
     Create(CreateCommand),
     Show(ShowCommand),
     Delete(DeleteCommand),


### PR DESCRIPTION
1. make docs::hide() return true by default so it sets a command to hide
2. generate SUMMARY.md with markdown help
3. unhide policy and credential subcommands
4. change order of top level subcommands in help
