### PR TITLE
tests(rust): remove automatically all the OCKAM_HOME created during a test after it's finished

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/BATS.md
+++ b/implementations/rust/ockam/ockam_command/tests/bats/BATS.md
@@ -16,6 +16,14 @@ Linux:
 npm install -g bats bats-support bats-assert
 ```
 
+### How to format the tests scripts
+
+We use the `shfmt` tool, which can be download from https://github.com/mvdan/sh.
+
+```bash
+shfmt -w ./implementations/rust/ockam/ockam_command/tests/bats/
+```
+
 ### Bats tests can also be run using our Builder Docker image
 
 docker run --rm -it -e HOST_USER_ID=$(id -u) --volume $(pwd):/work ghcr.io/build-trust/ockam-builder:latest bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "authority - standalone authority, enrollers, members" {
-  export PROJECT_JSON_PATH="$OCKAM_HOME/project-authority.json"
+  PROJECT_JSON_PATH="$OCKAM_HOME/project-authority.json"
 
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -90,10 +90,6 @@ teardown() {
   fwd=$(random_str)
   run "$OCKAM" forwarder create "$fwd"
   assert_success
-
-  teardown_home_dir
-  OCKAM_HOME=$ENROLLED_OCKAM_HOME
-  teardown_home_dir
 }
 
 @test "projects - send a message to a project node from an embedded node, enrolled member on different install" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -3,107 +3,107 @@
 # ===== SETUP
 
 setup() {
-    load load/base.bash
-    load load/orchestrator.bash
-    load_bats_ext
-    setup_home_dir
+  load load/base.bash
+  load load/orchestrator.bash
+  load_bats_ext
+  setup_home_dir
 }
 
 teardown() {
-    teardown_home_dir
+  teardown_home_dir
 }
 
 # ===== TESTS
 
 @test "trust context - no trust context; everything is accepted" {
-    run "$OCKAM" identity create m1
-    run "$OCKAM" node create n1 --identity m1
+  run "$OCKAM" identity create m1
+  run "$OCKAM" node create n1 --identity m1
 
-    run "$OCKAM" identity create m2
-    run "$OCKAM" node create n2 --identity m2
+  run "$OCKAM" identity create m2
+  run "$OCKAM" node create n2 --identity m2
 
-    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+  run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
         | $OCKAM message send hello --from /node/n1 --to -/service/echo"
-    assert_success
+  assert_success
 }
 
 @test "trust context - trust context with an id only; ABAC rules are applied" {
-    echo "{
+  echo "{
         \"id\": \"1\"
-    }" > ./trust_context.json
+    }" >./trust_context.json
 
-    run "$OCKAM" identity create m1
+  run "$OCKAM" identity create m1
 
-    m1_identifier=$(run "$OCKAM"  identity show m1)
-    trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\", \"project_id\" : \"1\", \"trust_context_id\" : \"1\"}}"
+  m1_identifier=$(run "$OCKAM" identity show m1)
+  trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\", \"project_id\" : \"1\", \"trust_context_id\" : \"1\"}}"
 
-    run "$OCKAM" node create n1 --identity m1
+  run "$OCKAM" node create n1 --identity m1
 
-    run "$OCKAM" node create n2  --trust-context ./trust_context.json --trusted-identities "$trusted"
+  run "$OCKAM" node create n2 --trust-context ./trust_context.json --trusted-identities "$trusted"
 
-    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+  run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
         | $OCKAM message send hello --from /node/n1 --to -/service/echo"
-    assert_success
+  assert_success
 
-    run "$OCKAM" message send hello --timeout 2 --from /node/n1 --to /node/n2/service/echo
-    assert_failure
+  run "$OCKAM" message send hello --timeout 2 --from /node/n1 --to /node/n2/service/echo
+  assert_failure
 }
 
 @test "trust context - trust context with an offline authority; Credential Exchange is performed" {
-    port=8005
-    # Create two identities
-    run "$OCKAM" identity create alice
-    alice_identity=$($OCKAM identity show alice --full --encoding hex)
+  port=8005
+  # Create two identities
+  run "$OCKAM" identity create alice
+  alice_identity=$($OCKAM identity show alice --full --encoding hex)
 
-    run "$OCKAM" identity create bob
-    bob_identity=$($OCKAM identity show bob --full --encoding hex)
+  run "$OCKAM" identity create bob
+  bob_identity=$($OCKAM identity show bob --full --encoding hex)
 
-    $OCKAM identity create attacker
+  $OCKAM identity create attacker
 
-    # Create an identity that both alice and bob will trust
-    run "$OCKAM" identity create authority
-    authority_identity=$($OCKAM identity show authority --full --encoding hex)
+  # Create an identity that both alice and bob will trust
+  run "$OCKAM" identity create authority
+  authority_identity=$($OCKAM identity show authority --full --encoding hex)
 
-    # issue and store credentials for alice
-    $OCKAM credential issue --as authority --for $alice_identity --attribute city="New York" --encoding hex > alice.cred
-    run "$OCKAM" credential store alice-cred --issuer $authority_identity --credential-path alice.cred
-    $OCKAM credential show alice-cred --as-trust-context > ./alice-trust-context.json
+  # issue and store credentials for alice
+  $OCKAM credential issue --as authority --for $alice_identity --attribute city="New York" --encoding hex >alice.cred
+  run "$OCKAM" credential store alice-cred --issuer $authority_identity --credential-path alice.cred
+  $OCKAM credential show alice-cred --as-trust-context >./alice-trust-context.json
 
-    # issue and store credential for bob
-    $OCKAM credential issue --as authority --for $bob_identity --attribute city="New York" --encoding hex > bob.cred
-    run "$OCKAM" credential store bob-cred --issuer $authority_identity --credential-path bob.cred
-    $OCKAM credential show bob-cred --as-trust-context > ./bob-trust-context.json
+  # issue and store credential for bob
+  $OCKAM credential issue --as authority --for $bob_identity --attribute city="New York" --encoding hex >bob.cred
+  run "$OCKAM" credential store bob-cred --issuer $authority_identity --credential-path bob.cred
+  $OCKAM credential show bob-cred --as-trust-context >./bob-trust-context.json
 
-    # Create a node for alice that trust authority as a credential authority
-    run "$OCKAM" node create alice --tcp-listener-address 127.0.0.1:$port  --identity alice --trust-context alice-trust-context.json
+  # Create a node for alice that trust authority as a credential authority
+  run "$OCKAM" node create alice --tcp-listener-address 127.0.0.1:$port --identity alice --trust-context alice-trust-context.json
 
-    msg=$(random_str)
+  msg=$(random_str)
 
-    # Fail, attacker won't present any credential
-    run $OCKAM message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  $msg
-    assert_failure
+  # Fail, attacker won't present any credential
+  run $OCKAM message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo $msg
+  assert_failure
 
-    # Fail, attacker will present an invalid credential (self signed rather than signed by authority)
-    $OCKAM credential issue --as attacker --for $($OCKAM identity show attacker --full --encoding hex) --encoding hex > "$OCKAM_HOME/attacker.cred"
-    $OCKAM credential store att-cred --issuer $authority_identity --credential-path $OCKAM_HOME/attacker.cred
-    $OCKAM credential show att-cred --as-trust-context > ./att-trust-context.json
-    run $OCKAM message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./att-trust-context.json  $msg
-    assert_failure
+  # Fail, attacker will present an invalid credential (self signed rather than signed by authority)
+  $OCKAM credential issue --as attacker --for $($OCKAM identity show attacker --full --encoding hex) --encoding hex >"$OCKAM_HOME/attacker.cred"
+  $OCKAM credential store att-cred --issuer $authority_identity --credential-path $OCKAM_HOME/attacker.cred
+  $OCKAM credential show att-cred --as-trust-context >./att-trust-context.json
+  run $OCKAM message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./att-trust-context.json $msg
+  assert_failure
 
-    # Fail, attacker will present an invalid credential (bob' credential, not own)
-    run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./bob-trust-context.json $msg
-    assert_failure
+  # Fail, attacker will present an invalid credential (bob' credential, not own)
+  run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./bob-trust-context.json $msg
+  assert_failure
 
-    run "$OCKAM" message send --timeout 2 --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./bob-trust-context.json $msg
-    assert_success
-    assert_output $msg
+  run "$OCKAM" message send --timeout 2 --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./bob-trust-context.json $msg
+  assert_success
+  assert_output $msg
 
-    $OCKAM node delete alice
-    echo "{\"id\": \"$authority_id\"}" > alice-trust-context.json
-    $OCKAM node create alice --tcp-listener-address 127.0.0.1:$port  --identity alice --trust-context ./alice-trust-context.json
+  $OCKAM node delete alice
+  echo "{\"id\": \"$authority_id\"}" >alice-trust-context.json
+  $OCKAM node create alice --tcp-listener-address 127.0.0.1:$port --identity alice --trust-context ./alice-trust-context.json
 
-    run "$OCKAM" message send --timeout 2 --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./bob-trust-context.json $msg
-    assert_failure
+  run "$OCKAM" message send --timeout 2 --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./bob-trust-context.json $msg
+  assert_failure
 }
 
 @test "trust context - trust context with an online authority; Credential Exchange is performed" {
@@ -114,7 +114,7 @@ teardown() {
   $OCKAM identity create authority
   bob_id=$($OCKAM identity show bob)
   alice_id=$($OCKAM identity show alice)
-  authority_identity=$($OCKAM identity show --full --encoding hex  authority)
+  authority_identity=$($OCKAM identity show --full --encoding hex authority)
 
   trusted="{\"$bob_id\": {}, \"$alice_id\": {}}"
   $OCKAM authority create --identity authority --tcp-listener-address=127.0.0.1:4200 --project-identifier "test-context" --trusted-identities "$trusted"
@@ -125,42 +125,42 @@ teardown() {
             \"own_credential\" :{
                 \"FromCredentialIssuer\" : {
                     \"identity\": \"$authority_identity\",
-                    \"maddr\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\" }}}}" > ./trust_context.json
+                    \"maddr\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\" }}}}" >./trust_context.json
 
   $OCKAM node create --identity alice --tcp-listener-address 127.0.0.1:$port --trust-context ./trust_context.json
 
   msg=$(random_str)
-  run "$OCKAM" message send --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./trust_context.json $msg
+  run "$OCKAM" message send --identity bob --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./trust_context.json $msg
   assert_success
   assert_output "$msg"
 
-  run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context ./trust_context.json $msg
+  run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context ./trust_context.json $msg
   assert_failure
-  run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo  --trust-context $msg
+  run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo --trust-context $msg
   assert_failure
 }
 
 @test "trust context - trust context with an id and authority using orchestrator; orchestrator enrollment and connection is performed, orchestrator" {
-    skip_if_orchestrator_tests_not_enabled
-    load_orchestrator_data
+  skip_if_orchestrator_tests_not_enabled
+  load_orchestrator_data
 
-    $OCKAM project information --as-trust-context > ./project_trust_context.json
+  $OCKAM project information --as-trust-context >./project_trust_context.json
 
-    run "$OCKAM" identity create m1
-    $OCKAM project enroll > m1.token
-    run "$OCKAM" project authenticate --identity m1 --trust-context ./project_trust_context.json --token $(cat m1.token)
+  run "$OCKAM" identity create m1
+  $OCKAM project enroll >m1.token
+  run "$OCKAM" project authenticate --identity m1 --trust-context ./project_trust_context.json --token $(cat m1.token)
 
-    run "$OCKAM" identity create m2
-    $OCKAM project enroll > m2.token
-    run "$OCKAM" project authenticate --identity m2 --trust-context ./project_trust_context.json --token $(cat m2.token)
+  run "$OCKAM" identity create m2
+  $OCKAM project enroll >m2.token
+  run "$OCKAM" project authenticate --identity m2 --trust-context ./project_trust_context.json --token $(cat m2.token)
 
-    run "$OCKAM" node create n1 --identity m1 --trust-context ./project_trust_context.json
-    assert_success
+  run "$OCKAM" node create n1 --identity m1 --trust-context ./project_trust_context.json
+  assert_success
 
-    run "$OCKAM" node create n2 --identity m2 --trust-context ./project_trust_context.json
-    assert_success
+  run "$OCKAM" node create n2 --identity m2 --trust-context ./project_trust_context.json
+  assert_success
 
-    run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
+  run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
         | $OCKAM message send hello --from /node/n1 --to -/service/echo"
-    assert_success
+  assert_success
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -350,7 +350,7 @@ teardown() {
   skip_if_orchestrator_tests_not_enabled
   load_orchestrator_data
 
-    port=7100
+  port=7100
 
   run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH"
   assert_success

--- a/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
@@ -116,11 +116,4 @@ teardown() {
   $OCKAM tcp-inlet create --at /node/x --from "127.0.0.1:$port_2" --to "/project/default/service/forward_to_$fwd/secure/api/service/outlet"
   run curl --fail --head --max-time 5 "127.0.0.1:$port_2"
   assert_failure 28 # timeout error
-
-  # Cleanup
-  teardown_home_dir # edge_plane
-  OCKAM_HOME=$CONTROL_OCKAM_HOME
-  teardown_home_dir # control_plane
-  OCKAM_HOME=$ADMIN_OCKAM_HOME
-  teardown_home_dir # admin
 }


### PR DESCRIPTION
Some bats tests use multiple $OCKAM_HOME to emulate scenarios where there are enrolled and non-enrolled identities.

When a test is finished (successfully or not), those OCKAM_HOME's should be removed using the `ockam reset` command to kill all the background processes generated in the tests. Not doing so can lead to tests blocking the CI (see details [here](https://bats-core.readthedocs.io/en/stable/gotchas.html#background-tasks-prevent-the-test-run-from-terminating-when-finished)).

In this PR, the `setup_home_dir` has been refactored so we keep a list of the OCKAM_HOME's created during a test. Then, on the teardown stage of the test, when running the `teardown_home_dir` function, we iterate through that list and remove all the resources automatically.

There is no need now to explicitly teardown OCKAM_HOME's.