### PR TITLE
Permit noreply outcomes from API Endpoint callback modules

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/api/endpoint.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api/endpoint.ex
@@ -125,6 +125,12 @@ defmodule Ockam.Services.API.Endpoint do
           {:ok, body, new_endpoint_state} ->
             {:reply, :ok, body, %{state | endpoint_state: new_endpoint_state}}
 
+          :noreply ->
+            {:noreply, state}
+
+          {:noreply, new_endpoint_state} ->
+            {:noreply, %{state | endpoint_state: new_endpoint_state}}
+
           {:error, reason} ->
             {:error, reason}
         end


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Elixir modules that `use Ockam.Services.API.Endpoint` currently must return an ok-tuple or error-tuple from their request handler functions in order to satisfy the `case` statement of `dispatch/5` [here](https://github.com/build-trust/ockam/blob/47a03863942682b24a1d47e8f4e7862c21a7ffde/implementations/elixir/ockam/ockam_services/lib/services/api/endpoint.ex#L120).

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

In order to allow such downstream modules to perform asynchronous replies out-of-band, it must be allowed to return `:noreply` or `{:noreply, new_state}`. Implementation details to conduct those replies in practice are not included here, though they would likely be built atop `Ockam.Services.API.reply` and `reply_error`.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
