### PR TITLE
fix(rust): fix okta addon attributes argument on authority command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -96,11 +96,11 @@ impl Server {
                                             crate::authenticator::direct::LEGACY_ID.to_owned(),
                                             self.project.clone(),
                                         ),
-                                        ((
+                                        (
                                             crate::authenticator::direct::TRUST_CONTEXT_ID
                                                 .to_owned(),
                                             self.project.clone(),
-                                        )),
+                                        ),
                                     ]
                                     .into_iter(),
                                 )

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -91,10 +91,17 @@ impl Server {
                                 .into_iter()
                                 .map(|(k, v)| (k, v.as_bytes().to_vec()))
                                 .chain(
-                                    [(
-                                        crate::authenticator::direct::LEGACY_ID.to_owned(),
-                                        self.project.clone(),
-                                    )]
+                                    [
+                                        (
+                                            crate::authenticator::direct::LEGACY_ID.to_owned(),
+                                            self.project.clone(),
+                                        ),
+                                        ((
+                                            crate::authenticator::direct::TRUST_CONTEXT_ID
+                                                .to_owned(),
+                                            self.project.clone(),
+                                        )),
+                                    ]
                                     .into_iter(),
                                 )
                                 .collect(),

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -74,7 +74,7 @@ pub struct CreateCommand {
     certificate: Option<String>,
 
     /// Okta: name of the attributes which can be retrieved from Okta (optional)
-    #[arg(long, value_name = "COMMA_SEPARATED_LIST", default_value = None)]
+    #[arg(long, value_name = "ATTRIBUTE_NAMES", default_value = None)]
     attributes: Option<Vec<String>>,
 
     /// Run the node in foreground.
@@ -156,8 +156,10 @@ async fn spawn_background_node(
     }
 
     if let Some(attributes) = &cmd.attributes {
-        args.push("--attributes".to_string());
-        args.push(attributes.join(","));
+        attributes.iter().for_each(|attr| {
+            args.push("--attributes".to_string());
+            args.push(attr.clone());
+        });
     }
 
     if let Some(vault) = &cmd.vault {


### PR DESCRIPTION
clap parses Vec<_> as multiple --ARG  rather than comma separate list of things.

Also small addition on okta' authenticator to include appropriate attribute. 
