### PR TITLE
fix: ockam_vault requires rustcrypto feature for p256

### DIFF
--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -40,6 +40,8 @@ std = [
   "x25519-dalek/std",
   "x25519-dalek/u64_backend",
   "alloc",
+  # required for p256
+  "rustcrypto",
   "p256/std",
   "fs2",
 ]


### PR DESCRIPTION
Related issue & comment: https://github.com/build-trust/ockam/issues/3661#issuecomment-1508089713

## Current behavior

ockam_abac fails to build docs.

There's currently a FIXIME for this feature and when `default-features=false` is enabled or only `std` is enabled it fails to build the `ockam_abac` crate.

https://github.com/build-trust/ockam/blob/6d5799608ac5ce2e039db6411e7c2f5280f44df6/implementations/rust/ockam/ockam_vault/Cargo.toml#L66-L67

## Proposed changes

enable `rustcrypto` features for `std` by default in ockam_vault

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
