### PR TITLE
refactor(rust): create abstraction for the cli state directories and applies it to the vaults state

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -1,0 +1,123 @@
+use crate::cli_state::{file_stem, CliState, CliStateError};
+use ockam_core::async_trait;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::Result;
+
+/// Represents the directory of a type of state and contains
+/// all the data related to that type.
+#[async_trait]
+pub trait StateTrait: Sized {
+    type ItemDir: StateItemDirTrait;
+    type ItemConfig: StateItemConfigTrait + Serialize + for<'a> Deserialize<'a>;
+
+    fn new(dir: PathBuf) -> Self;
+    fn default_filename() -> &'static str;
+    fn build_dir(root_path: &Path) -> PathBuf;
+    fn has_data_dir() -> bool;
+
+    #[allow(clippy::new_ret_no_self)]
+    fn load(root_path: &Path) -> Result<Self> {
+        let dir = Self::build_dir(root_path);
+        if Self::has_data_dir() {
+            std::fs::create_dir_all(dir.join("data"))?;
+        } else {
+            std::fs::create_dir_all(&dir)?;
+        }
+        Ok(Self::new(dir))
+    }
+
+    fn dir(&self) -> &PathBuf;
+    fn dir_as_string(&self) -> String {
+        self.dir().to_string_lossy().to_string()
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.dir().join(format!("{name}.json"))
+    }
+
+    async fn create(&self, name: &str, config: Self::ItemConfig) -> Result<Self::ItemDir>;
+
+    fn get(&self, name: &str) -> Result<Self::ItemDir> {
+        let path = {
+            let path = self.path(name);
+            if !path.exists() {
+                return Err(CliStateError::NotFound);
+            }
+            path
+        };
+        Self::ItemDir::load(path)
+    }
+
+    fn list(&self) -> Result<Vec<Self::ItemDir>> {
+        let mut items = Vec::default();
+        for entry in std::fs::read_dir(self.dir())? {
+            if let Ok(item) = self.get(&file_stem(&entry?.path())?) {
+                items.push(item);
+            }
+        }
+        Ok(items)
+    }
+
+    async fn delete(&self, name: &str) -> Result<()>;
+
+    fn default_path(&self) -> Result<PathBuf> {
+        let root_path = self.dir().parent().expect("Should have parent");
+        Ok(CliState::defaults_dir(root_path)?.join(Self::default_filename()))
+    }
+
+    fn default(&self) -> Result<Self::ItemDir> {
+        let path = std::fs::canonicalize(self.default_path()?)?;
+        Self::ItemDir::load(path)
+    }
+
+    fn set_default(&self, name: &str) -> Result<()> {
+        let original = {
+            let path = self.path(name);
+            if !path.exists() {
+                return Err(CliStateError::NotFound);
+            }
+            path
+        };
+        let link = self.default_path()?;
+        // Remove link if it exists
+        let _ = std::fs::remove_file(&link);
+        // Create link to the identity
+        std::os::unix::fs::symlink(original, link)?;
+        Ok(())
+    }
+
+    fn is_default(&self, name: &str) -> Result<bool> {
+        let _exists = self.get(name)?;
+        let default_name = {
+            let path = std::fs::canonicalize(self.default_path()?)?;
+            file_stem(&path)?
+        };
+        Ok(default_name.eq(name))
+    }
+
+    fn has_default(&self) -> Result<bool> {
+        Ok(self.default_path()?.exists())
+    }
+}
+
+/// This trait defines the methods to retrieve an item from a state directory.
+/// The details of the item are defined in the `Config` type.
+#[async_trait]
+pub trait StateItemDirTrait: Sized {
+    type Config: StateItemConfigTrait + Serialize + for<'a> Deserialize<'a>;
+
+    fn new(path: PathBuf, config: Self::Config) -> Result<Self>;
+    fn load(path: PathBuf) -> Result<Self>;
+    async fn delete(&self) -> Result<()>;
+    fn name(&self) -> &str;
+    fn path(&self) -> &PathBuf;
+    fn data_path(&self) -> Option<&PathBuf>;
+    fn config(&self) -> &Self::Config;
+}
+
+#[async_trait]
+pub trait StateItemConfigTrait {
+    async fn delete(&self) -> Result<()>;
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -1,0 +1,216 @@
+use super::Result;
+use crate::cli_state::traits::StateItemDirTrait;
+use ockam_identity::IdentitiesVault;
+use ockam_vault::storage::FileStorage;
+use ockam_vault::Vault;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VaultsState {
+    dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct VaultState {
+    name: String,
+    path: PathBuf,
+    /// The path to the vault's storage config file, contained in the data directory
+    data_path: PathBuf,
+    config: VaultConfig,
+}
+
+impl VaultState {
+    pub async fn get(&self) -> Result<Vault> {
+        let vault_storage = FileStorage::create(self.vault_file_path().clone()).await?;
+        let mut vault = Vault::new(Some(Arc::new(vault_storage)));
+        if self.config.aws_kms {
+            vault.enable_aws_kms().await?
+        }
+        Ok(vault)
+    }
+
+    fn build_data_path(name: &str, path: &Path) -> PathBuf {
+        path.parent()
+            .expect("Should have parent")
+            .join("data")
+            .join(format!("{name}-storage.json"))
+    }
+
+    pub fn vault_file_path(&self) -> &PathBuf {
+        self.data_path().expect("Should have data path")
+    }
+
+    pub async fn identities_vault(&self) -> Result<Arc<dyn IdentitiesVault>> {
+        let path = self.vault_file_path().clone();
+        Ok(Arc::new(Vault::new(Some(Arc::new(
+            FileStorage::create(path).await?,
+        )))))
+    }
+}
+
+impl Display for VaultState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Name: {}", self.name)?;
+        writeln!(
+            f,
+            "Type: {}",
+            match self.config.is_aws() {
+                true => "AWS KMS",
+                false => "OCKAM",
+            }
+        )?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+pub struct VaultConfig {
+    #[serde(default)]
+    aws_kms: bool,
+}
+
+impl VaultConfig {
+    pub fn new(aws_kms: bool) -> Result<Self> {
+        Ok(Self { aws_kms })
+    }
+
+    pub fn is_aws(&self) -> bool {
+        self.aws_kms
+    }
+}
+
+mod traits {
+    use super::*;
+    use crate::cli_state::traits::*;
+    use crate::cli_state::{file_stem, CliStateError};
+    use ockam_core::async_trait;
+    use std::path::Path;
+
+    #[async_trait]
+    impl StateTrait for VaultsState {
+        type ItemDir = VaultState;
+        type ItemConfig = VaultConfig;
+
+        fn new(dir: PathBuf) -> Self {
+            Self { dir }
+        }
+
+        fn default_filename() -> &'static str {
+            "vault"
+        }
+
+        fn build_dir(root_path: &Path) -> PathBuf {
+            root_path.join("vaults")
+        }
+
+        fn has_data_dir() -> bool {
+            true
+        }
+
+        fn dir(&self) -> &PathBuf {
+            &self.dir
+        }
+
+        async fn create(&self, name: &str, config: Self::ItemConfig) -> Result<Self::ItemDir> {
+            let path = {
+                let path = self.path(name);
+                if path.exists() {
+                    return Err(CliStateError::AlreadyExists);
+                }
+                path
+            };
+            let state = Self::ItemDir::new(path, config)?;
+            state.get().await?;
+            if !self.default_path()?.exists() {
+                self.set_default(name)?;
+            }
+            Ok(state)
+        }
+
+        async fn delete(&self, name: &str) -> Result<()> {
+            // Retrieve vault. If doesn't exist do nothing.
+            let vault = match self.get(name) {
+                Ok(v) => v,
+                Err(CliStateError::NotFound) => return Ok(()),
+                Err(e) => return Err(e),
+            };
+
+            // If it's the default, remove link
+            if let Ok(default) = self.default() {
+                if default.path == vault.path {
+                    let _ = std::fs::remove_file(self.default_path()?);
+                }
+            }
+
+            // Remove vault files
+            vault.delete().await?;
+
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl StateItemDirTrait for VaultState {
+        type Config = VaultConfig;
+
+        fn new(path: PathBuf, config: Self::Config) -> Result<Self> {
+            let contents = serde_json::to_string(&config)?;
+            std::fs::write(&path, contents)?;
+
+            let name = file_stem(&path)?;
+            let data_path = VaultState::build_data_path(&name, &path);
+            Ok(Self {
+                name,
+                path,
+                data_path,
+                config,
+            })
+        }
+
+        fn load(path: PathBuf) -> Result<Self> {
+            let name = file_stem(&path)?;
+            let contents = std::fs::read_to_string(&path)?;
+            let config = serde_json::from_str(&contents)?;
+            let data_path = VaultState::build_data_path(&name, &path);
+            Ok(Self {
+                name,
+                path,
+                data_path,
+                config,
+            })
+        }
+
+        async fn delete(&self) -> Result<()> {
+            std::fs::remove_file(&self.path)?;
+            std::fs::remove_file(&self.data_path)?;
+            std::fs::remove_file(self.data_path.with_extension("json.lock"))?;
+            Ok(())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn path(&self) -> &PathBuf {
+            &self.path
+        }
+
+        fn data_path(&self) -> Option<&PathBuf> {
+            Some(&self.data_path)
+        }
+
+        fn config(&self) -> &Self::Config {
+            &self.config
+        }
+    }
+
+    #[async_trait]
+    impl StateItemConfigTrait for VaultConfig {
+        async fn delete(&self) -> Result<()> {
+            unreachable!()
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -1,3 +1,4 @@
+use crate::cli_state::traits::StateTrait;
 use crate::error::ApiError;
 use crate::local_multiaddr_to_route;
 use crate::nodes::models::credentials::{GetCredentialRequest, PresentCredentialRequest};

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_identities.rs
@@ -1,3 +1,4 @@
+use crate::cli_state::traits::StateTrait;
 use crate::cli_state::CliState;
 use ockam::compat::sync::Arc;
 use ockam::identity::{Identities, IdentitiesCreation, IdentitiesKeys};

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -20,6 +20,7 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::{FlowControlId, FlowControlPolicy};
 use ockam_core::route;
 
+use crate::cli_state::traits::StateTrait;
 use crate::cli_state::CliStateError;
 use crate::kafka::KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS;
 use crate::nodes::service::NodeIdentities;
@@ -292,7 +293,7 @@ impl NodeManager {
             {
                 Ok(identity)
             } else {
-                Err(CliStateError::NotFound(format!("identity not found with name {name}")).into())
+                Err(CliStateError::NotFound.into())
             }
         } else {
             Ok(self.identity.clone())

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -255,7 +255,7 @@ pub fn is_local_node(ma: &MultiAddr) -> anyhow::Result<bool> {
 
 #[cfg(test)]
 pub mod test {
-    use crate::cli_state::{CliState, IdentityConfig, NodeConfig, VaultConfig};
+    use crate::cli_state::{traits::*, CliState, IdentityConfig, NodeConfig, VaultConfig};
     use crate::nodes::service::{
         ApiTransport, NodeManagerGeneralOptions, NodeManagerProjectsOptions,
         NodeManagerTransportOptions, NodeManagerTrustOptions,

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Context as _};
 use clap::{ArgGroup, Args};
 use ockam::Context;
 use ockam_api::bootstrapped_identities_store::PreTrustedIdentities;
+use ockam_api::cli_state::traits::StateTrait;
 use ockam_api::nodes::authority_node;
 use ockam_api::nodes::authority_node::{OktaConfiguration, TrustedIdentity};
 use ockam_api::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
@@ -304,7 +305,7 @@ async fn start_authority_node(
     let configuration = authority_node::Configuration {
         identity,
         storage_path: options.state.identities.identities_repository_path()?,
-        vault_path: options.state.vaults.default()?.vault_file_path()?,
+        vault_path: options.state.vaults.default()?.vault_file_path().clone(),
         project_identifier: command.project_identifier.clone(),
         trust_context_identifier: command.project_identifier,
         tcp_listener_address: command.tcp_listener_address.clone(),

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -11,6 +11,7 @@ use anyhow::{anyhow, Context as _};
 use clap::Args;
 use ockam::identity::CredentialData;
 use ockam::Context;
+use ockam_api::cli_state::traits::StateTrait;
 use ockam_identity::{identities, Identity};
 
 #[derive(Clone, Debug, Args)]

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use verify::VerifyCommand;
 
 use crate::{docs, CommandGlobalOpts, Result};
 use clap::{Args, Subcommand};
+use ockam_api::cli_state::traits::StateTrait;
 
 const HELP_DETAIL: &str = "";
 

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -3,6 +3,7 @@ use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam::identity::Identity;
 use ockam::Context;
+use ockam_api::cli_state::traits::{StateItemDirTrait, StateTrait};
 use rand::prelude::random;
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
@@ -44,7 +45,7 @@ impl CreateCommand {
         let vault_state = options.state.create_vault_state(self.vault.clone()).await?;
         let mut output = String::new();
         if default_vault_created {
-            output.push_str(&format!("Default vault created: {}\n", &vault_state.name));
+            output.push_str(&format!("Default vault created: {}\n", &vault_state.name()));
         }
 
         let identity_state = options
@@ -60,7 +61,7 @@ impl CreateCommand {
             .stdout()
             .plain(output)
             .machine(identity.identifier())
-            .json(&serde_json::json!({ "identity": { "identifier": &identity.identifier() } }))
+            .json(serde_json::json!({ "identity": { "identifier": &identity.identifier() } }))
             .write_line()?;
         Ok(identity)
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/default.rs
@@ -44,7 +44,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
             }
         }
         Err(err) => match err {
-            CliStateError::NotFound(_) => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
+            CliStateError::NotFound => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -41,7 +41,7 @@ async fn run_impl(
         }
         // Return the appropriate error
         Err(err) => match err {
-            CliStateError::NotFound(_) => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
+            CliStateError::NotFound => Err(anyhow!("Identity '{}' not found", &cmd.name).into()),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -26,6 +26,7 @@ use crate::{
 };
 use ockam::{Address, AsyncTryClone, TcpListenerOptions};
 use ockam::{Context, TcpTransport};
+use ockam_api::cli_state::traits::StateTrait;
 use ockam_api::nodes::authority_node;
 use ockam_api::nodes::models::transport::CreateTransportJson;
 use ockam_api::nodes::service::{ApiTransport, NodeManagerTrustOptions};
@@ -513,7 +514,7 @@ async fn start_authority_node(
         let configuration = authority_node::Configuration {
             identity,
             storage_path: options.state.identities.identities_repository_path()?,
-            vault_path: options.state.vaults.default()?.vault_file_path()?,
+            vault_path: options.state.vaults.default()?.vault_file_path().clone(),
             project_identifier: authenticator_config.project.clone(),
             trust_context_identifier: authenticator_config.project,
             tcp_listener_address: command.tcp_listener_address.clone(),

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -49,7 +49,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
                 &cmd.node_name
             ))
             .machine(&cmd.node_name)
-            .json(&serde_json::json!({ "node": { "name": &cmd.node_name } }))
+            .json(serde_json::json!({ "node": { "name": &cmd.node_name } }))
             .write_line()?;
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -2,7 +2,9 @@ use anyhow::{anyhow, Context as _};
 
 use ockam::{Context, TcpListenerOptions, TcpTransport};
 use ockam_api::cli_state;
+use ockam_api::cli_state::traits::StateItemDirTrait;
 use ockam_api::config::lookup::ProjectLookup;
+
 use ockam_api::nodes::models::transport::{TransportMode, TransportType};
 use ockam_api::nodes::service::{
     ApiTransport, NodeManagerGeneralOptions, NodeManagerProjectsOptions,
@@ -151,7 +153,7 @@ pub(crate) async fn init_node_state(
 
     // Create the node with the given vault and identity
     let node_config = cli_state::NodeConfigBuilder::default()
-        .vault(vault_state.path)
+        .vault(vault_state.path().clone())
         .identity(identity_state.path)
         .build(&opts.state)?;
     opts.state.nodes.create(node_name, node_config)?;

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -93,7 +93,7 @@ async fn run_impl(
             &cmd.project_name
         ))
         .machine(&cmd.project_name)
-        .json(&serde_json::json!({ "project": { "name": &cmd.project_name } }))
+        .json(serde_json::json!({ "project": { "name": &cmd.project_name } }))
         .write_line()?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -84,7 +84,7 @@ async fn run_impl(
             &cmd.name
         ))
         .machine(&cmd.name)
-        .json(&serde_json::json!({ "space": { "name": &cmd.name } }))
+        .json(serde_json::json!({ "space": { "name": &cmd.name } }))
         .write_line()?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -45,7 +45,7 @@ pub async fn run_impl(
             "✔︎".light_green(),
         ))
         .machine(&alias)
-        .json(&serde_json::json!({ "tcp-inlet": { "alias": alias, "node": node } }))
+        .json(serde_json::json!({ "tcp-inlet": { "alias": alias, "node": node } }))
         .write_line()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -43,7 +43,7 @@ async fn run_impl(
             &cmd.id
         ))
         .machine(&cmd.id)
-        .json(&serde_json::json!({ "tcp-listener": { "id": &cmd.id } }))
+        .json(serde_json::json!({ "tcp-listener": { "id": &cmd.id } }))
         .write_line()?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -46,7 +46,7 @@ pub async fn run_impl(
             "✔︎".light_green(),
         ))
         .machine(&alias)
-        .json(&serde_json::json!({ "tcp-outlet": { "alias": alias, "node": node } }))
+        .json(serde_json::json!({ "tcp-outlet": { "alias": alias, "node": node } }))
         .write_line()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -681,6 +681,7 @@ pub fn random_name() -> String {
 mod tests {
     use super::*;
     use ockam_api::cli_state;
+    use ockam_api::cli_state::traits::StateTrait;
     use ockam_api::cli_state::{IdentityConfig, NodeConfig, VaultConfig};
     use ockam_api::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
 

--- a/implementations/rust/ockam/ockam_command/src/vault/attach_key.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/attach_key.rs
@@ -3,6 +3,7 @@ use clap::Args;
 
 use ockam::Context;
 use ockam_api::cli_state;
+use ockam_api::cli_state::traits::{StateItemDirTrait, StateTrait};
 
 use ockam_core::vault::{Secret, SecretAttributes, SecretPersistence, SecretType, SecretVault};
 use ockam_identity::{IdentityChangeConstants, KeyAttributes};
@@ -35,7 +36,7 @@ async fn rpc(
 
 async fn run_impl(opts: CommandGlobalOpts, cmd: AttachKeyCommand) -> crate::Result<()> {
     let v_state = opts.state.vaults.get(&cmd.vault)?;
-    if !v_state.config.is_aws() {
+    if !v_state.config().is_aws() {
         return Err(anyhow!("Vault {} is not an AWS KMS vault", cmd.vault).into());
     }
     let vault = v_state.get().await?;

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -3,6 +3,7 @@ use rand::prelude::random;
 
 use ockam::Context;
 use ockam_api::cli_state;
+use ockam_api::cli_state::traits::StateTrait;
 
 use crate::util::node_rpc;
 use crate::CommandGlobalOpts;

--- a/implementations/rust/ockam/ockam_command/src/vault/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/default.rs
@@ -1,6 +1,7 @@
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
 use clap::Args;
+use ockam_api::cli_state::traits::{StateItemDirTrait, StateTrait};
 use ockam_api::cli_state::CliStateError;
 
 /// Set the default vault
@@ -25,18 +26,18 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
     match state.get(&cmd.name) {
         Ok(v) => {
             // If it exists, warn the user and exit
-            if state.is_default(&v.name)? {
+            if state.is_default(v.name())? {
                 Err(anyhow!("Vault '{}' is already the default", &cmd.name).into())
             }
             // Otherwise, set it as default
             else {
-                state.set_default(&v.name)?;
+                state.set_default(v.name())?;
                 println!("Vault '{}' is now the default", &cmd.name,);
                 Ok(())
             }
         }
         Err(err) => match err {
-            CliStateError::NotFound(_) => Err(anyhow!("Vault '{}' not found", &cmd.name).into()),
+            CliStateError::NotFound => Err(anyhow!("Vault '{}' not found", &cmd.name).into()),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
+use ockam_api::cli_state::traits::StateTrait;
 use ockam_api::cli_state::CliStateError;
 
 use crate::util::node_rpc;
@@ -49,14 +50,14 @@ async fn run_impl(
                     &name
                 ))
                 .machine(&name)
-                .json(&serde_json::json!({ "vault": { "name": &name } }))
+                .json(serde_json::json!({ "vault": { "name": &name } }))
                 .write_line()?;
 
             Ok(())
         }
         // Return the appropriate error
         Err(err) => match err {
-            CliStateError::NotFound(_) => Err(anyhow!("Vault '{name}' not found").into()),
+            CliStateError::NotFound => Err(anyhow!("Vault '{name}' not found").into()),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/vault/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/list.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use clap::Args;
+use ockam_api::cli_state::traits::StateTrait;
 
 use crate::CommandGlobalOpts;
 

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -15,6 +15,7 @@ use crate::vault::show::ShowCommand;
 use crate::CommandGlobalOpts;
 
 use clap::{Args, Subcommand};
+use ockam_api::cli_state::traits::{StateItemDirTrait, StateTrait};
 use ockam_api::cli_state::CliState;
 
 /// Manage vaults
@@ -70,5 +71,5 @@ pub fn default_vault_name() -> String {
     cli_state
         .vaults
         .default()
-        .map_or("default".to_string(), |v| v.name)
+        .map_or("default".to_string(), |v| v.name().to_string())
 }

--- a/implementations/rust/ockam/ockam_command/src/vault/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/show.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use ockam_api::cli_state::traits::{StateItemDirTrait, StateTrait};
 
 use crate::CommandGlobalOpts;
 
@@ -18,7 +19,9 @@ impl ShowCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
-    let name = cmd.name.unwrap_or(opts.state.vaults.default()?.name()?);
+    let name = cmd
+        .name
+        .unwrap_or(opts.state.vaults.default()?.name().to_string());
     let state = opts.state.vaults.get(&name)?;
     println!("Vault:");
     for line in state.to_string().lines() {


### PR DESCRIPTION
The `CliState` has similar logic for all the existing kinds of states (vaults, identities, nodes, projects, trust_contexts). The only differences among those states are how are they created/deleted. The rest can be abstracted away.

This PR introduces a set of traits that will abstract a good amount of code with only small changes in the client code. There is still room to abstract more common functions/boilerplate, but that can be done later without further altering the client code, probably through macros.