### PR TITLE
Add the credentials example to the test suite

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[test-groups]
+sequential = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(hello_ockam)'
+test-group = 'sequential'
+
+[[profile.default.overrides]]
+filter = 'package(tcp_inlet_and_outlet)'
+test-group = 'sequential'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -60,7 +60,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
  "version_check",
 ]
@@ -597,7 +597,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -899,6 +899,12 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1018,6 +1024,15 @@ dependencies = [
  "error-code",
  "str-buf 1.0.6",
  "winapi",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1242,7 +1257,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1257,7 +1272,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -1271,7 +1286,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1281,7 +1296,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1293,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.8.0",
  "scopeguard",
@@ -1305,7 +1320,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1315,7 +1330,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1328,7 +1343,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1494,11 +1509,11 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
- "lock_api",
+ "lock_api 0.4.9",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -1656,7 +1671,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -1841,7 +1856,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1931,7 +1946,7 @@ version = "0.1.0"
 name = "example_test_helper"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "duct",
  "libc",
  "regex",
@@ -1968,7 +1983,7 @@ version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9799aefb4a2e4a01cc47610b1dd47c18ab13d991f27bbcaed9296f5a53d5cbad"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "rustix",
  "windows-sys 0.45.0",
 ]
@@ -2230,7 +2245,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2241,7 +2256,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -2376,6 +2391,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]
@@ -2574,7 +2590,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2766,6 +2782,15 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
@@ -2780,7 +2805,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2948,7 +2973,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -2963,7 +2988,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3094,7 +3119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -3361,7 +3386,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "cddl-cat",
- "cfg-if",
+ "cfg-if 1.0.0",
  "core2",
  "futures-util",
  "hashbrown 0.13.2",
@@ -3406,7 +3431,7 @@ name = "ockam_identity"
 version = "0.71.0"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "group",
  "heapless",
  "hex",
@@ -3540,7 +3565,7 @@ dependencies = [
 name = "ockam_transport_tcp"
 version = "0.78.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.13.2",
  "ockam_core",
  "ockam_macros",
@@ -3610,7 +3635,7 @@ dependencies = [
  "arrayref",
  "aws-config",
  "aws-sdk-kms",
- "cfg-if",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "data-encoding",
  "ed25519-dalek",
@@ -3683,7 +3708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3756,12 +3781,36 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.3",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.4.9",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi",
+ "libc",
+ "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3770,7 +3819,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
@@ -3897,7 +3946,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -4137,6 +4186,12 @@ dependencies = [
  "crossbeam-utils",
  "num_cpus",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -4420,7 +4475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clipboard-win",
  "dirs-next",
  "fd-lock",
@@ -4654,12 +4709,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.10.2",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4677,7 +4754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -4689,7 +4766,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4828,7 +4905,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.9",
 ]
 
 [[package]]
@@ -5071,7 +5148,7 @@ version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -5094,7 +5171,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
@@ -5175,7 +5252,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -5232,7 +5309,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.4.9",
@@ -5375,7 +5452,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -5725,7 +5802,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -5750,7 +5827,7 @@ version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -47,3 +47,4 @@ serde_json = { version = "1.0", default_features = false }
 [dev-dependencies]
 example_test_helper = { path = "../../../tools/docs/example_test_helper" }
 rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
+serial_test = "0.4.0"

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -73,5 +73,6 @@ async fn main(ctx: Context) -> Result<()> {
     .await?;
 
     // Don't call ctx.stop() here so this node runs forever.
+    println!("issuer started");
     Ok(())
 }

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -114,5 +114,6 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.listen("127.0.0.1:4000", tcp_listener_options).await?;
 
     // Don't call ctx.stop() here so this node runs forever.
+    println!("server started");
     Ok(())
 }

--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -1,7 +1,8 @@
 use example_test_helper::{CmdBuilder, Error};
-use rand::Rng;
+use serial_test::serial;
 
 #[test]
+#[serial]
 fn run_01_node() -> Result<(), Error> {
     // Run 01-node to completion
     let (exitcode, stdout) = CmdBuilder::new("cargo run --example 01-node").run()?;
@@ -11,6 +12,7 @@ fn run_01_node() -> Result<(), Error> {
 }
 
 #[test]
+#[serial]
 fn run_02_worker() -> Result<(), Error> {
     // Run to completion
     let (exitcode, stdout) = CmdBuilder::new("cargo run --example 02-worker").run()?;
@@ -20,6 +22,7 @@ fn run_02_worker() -> Result<(), Error> {
 }
 
 #[test]
+#[serial]
 fn run_03_routing() -> Result<(), Error> {
     // Run to completion
     let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing").run()?;
@@ -29,6 +32,7 @@ fn run_03_routing() -> Result<(), Error> {
 }
 
 #[test]
+#[serial]
 fn run_03_routing_many_hops() -> Result<(), Error> {
     // Run to completion
     let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing-many-hops").run()?;
@@ -37,52 +41,36 @@ fn run_03_routing_many_hops() -> Result<(), Error> {
     Ok(())
 }
 
-// TODO: Uncomment me when we manage to solve ports collision problems during CI runs
-// #[test]
-// fn run_04_routing_over_transport() -> Result<(), Error> {
-//     let rand_port = rand::thread_rng().gen_range(10000..65535);
-//     // Launch responder, wait for it to start up
-//     let resp = CmdBuilder::new(&format!(
-//         "cargo run --example 04-routing-over-transport-responder {rand_port}"
-//     ))
-//     .spawn()?;
-//     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
-//
-//     // Run initiator to completion
-//     let (exitcode, stdout) = CmdBuilder::new(&format!(
-//         "cargo run --example 04-routing-over-transport-initiator {rand_port}",
-//     ))
-//     .run()?;
-//
-//     // Assert successful run conditions
-//     assert_eq!(Some(0), exitcode);
-//     assert!(stdout.to_lowercase().contains("goodbye"));
-//     Ok(())
-// }
+#[test]
+#[serial]
+fn run_04_routing_over_transport() -> Result<(), Error> {
+    // Launch responder, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-responder").spawn()?;
+    resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Run initiator to completion
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-routing-over-transport-initiator").run()?;
+
+    // Assert successful run conditions
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.to_lowercase().contains("goodbye"));
+    Ok(())
+}
 
 #[test]
+#[serial]
 fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
-    let rand_port_responder = rand::thread_rng().gen_range(10000..65535);
-    let rand_port_middle = rand::thread_rng().gen_range(10000..65535);
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new(&format!(
-        "cargo run --example 04-routing-over-transport-two-hops-responder {rand_port_responder}"
-    ))
-    .spawn()?;
+    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-responder").spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Launch middle, wait for it to start up
-    let mid = CmdBuilder::new(&format!(
-        "cargo run --example 04-routing-over-transport-two-hops-middle {rand_port_middle}"
-    ))
-    .spawn()?;
+    let mid = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-middle").spawn()?;
     mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Run initiator to completion
-    let (exitcode, stdout) = CmdBuilder::new(&format!(
-        "cargo run --example 04-routing-over-transport-two-hops-initiator {rand_port_middle} {rand_port_responder}"
-    ))
-    .run()?;
+    let (exitcode, stdout) =
+        CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -91,53 +79,63 @@ fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
 }
 
 #[test]
+#[serial]
 fn run_04_udp() -> Result<(), Error> {
-    let rand_port = rand::thread_rng().gen_range(10000..65535);
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new(&format!("cargo run --example 04-udp-transport-responder {rand_port}")).spawn()?;
+    let resp = CmdBuilder::new("cargo run --example 04-udp-transport-responder").spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming UDP datagram")?;
 
     // Run initiator to completion
-    let (exitcode, stdout) =
-        CmdBuilder::new(&format!("cargo run --example 04-udp-transport-initiator {rand_port}",)).run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-udp-transport-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
     assert!(stdout.to_lowercase().contains("goodbye"));
     Ok(())
 }
-// TODO: Uncomment me when we manage to solve ports collision problems during CI runs
-// #[test]
-// fn run_05_secure_channel_over_two_transport_hops() -> Result<(), Error> {
-//     let rand_port_responder = rand::thread_rng().gen_range(10000..65535);
-//     let rand_port_middle = rand::thread_rng().gen_range(10000..65535);
-//     // Launch responder, wait for it to start up
-//     let resp = CmdBuilder::new(&format!(
-//         "cargo run --example 05-secure-channel-over-two-transport-hops-responder {rand_port_responder}"
-//     ))
-//     .spawn()?;
-//     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
-//
-//     // Launch middle, wait for it to start up
-//     let mid = CmdBuilder::new(&format!(
-//         "cargo run --example 05-secure-channel-over-two-transport-hops-middle {rand_port_middle}"
-//     ))
-//     .spawn()?;
-//     mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
-//
-//     // Run initiator to completion
-//     let (exitcode, stdout) = CmdBuilder::new(&format!(
-//         "cargo run --example 05-secure-channel-over-two-transport-hops-initiator {rand_port_middle} {rand_port_responder}"
-//     ))
-//     .run()?;
-//
-//     // Assert successful run conditions
-//     assert_eq!(Some(0), exitcode);
-//     assert!(stdout.to_lowercase().contains("goodbye"));
-//     Ok(())
-// }
 
 #[test]
+#[serial]
+fn run_05_secure_channel_over_two_transport_hops() -> Result<(), Error> {
+    // Launch responder, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-responder").spawn()?;
+    resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Launch middle, wait for it to start up
+    let mid = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-middle").spawn()?;
+    mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+
+    // Run initiator to completion
+    let (exitcode, stdout) =
+        CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-initiator").run()?;
+
+    // Assert successful run conditions
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.to_lowercase().contains("goodbye"));
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn run_06_credentials_exchange() -> Result<(), Error> {
+    // Launch the issuer, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 06-credentials-exchange-issuer").spawn()?;
+    resp.match_stdout("issuer started")?;
+
+    // Launch the server, wait for it to start up
+    let resp = CmdBuilder::new("cargo run --example 06-credentials-exchange-server").spawn()?;
+    resp.match_stdout("server started")?;
+
+    // Launch the client, wait for the message to be sent and received
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 06-credentials-exchange-client").run()?;
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.to_lowercase().contains("received"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn run_hello() -> Result<(), Error> {
     let (exitcode, stdout) = CmdBuilder::new("cargo run --example hello").run()?;
 

--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
@@ -95,6 +95,13 @@ fn output(mut cont: Container) -> TokenStream {
             use core::time::Duration;
             use ockam_core::{Error, errcode::{Origin, Kind}};
             use #ockam_crate::{NodeBuilder, compat::{tokio::time::timeout, futures::FutureExt}};
+            // don't enable logs in tests by default
+            use ockam_core::env::get_env;
+
+            match get_env::<String>("OCKAM_LOG").unwrap() {
+               None => std::env::set_var("OCKAM_LOG", "none"),
+               Some(_) => (),
+            };
 
             let (mut #ctx_ident, mut executor) = NodeBuilder::new().build();
             executor


### PR DESCRIPTION
This PR:

 - adds the credentials exchange example to the examples tests suite
 - makes sure that the examples are run sequentially to avoid port clashes
 - removes the writing of logs when running `cargo test`
