### PR TITLE
feat(rust): remove the vault service endpoint for getting secret data

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/vault.rs
+++ b/implementations/rust/ockam/ockam_api/src/vault.rs
@@ -104,30 +104,6 @@ impl VaultService {
 
         match method {
             Get => match req.path_segments::<3>().as_slice() {
-                ["secrets", key_id] => {
-                    if !req.has_body() {
-                        return Self::response_for_bad_request(req, "empty body", enc);
-                    }
-
-                    let args = dec.decode::<GetSecretRequest>()?;
-
-                    let key_id: KeyId = key_id.to_string();
-
-                    match args.operation() {
-                        GetSecretRequestOperation::GetAttributes => {
-                            let resp = self.vault.secret_attributes_get(&key_id).await?;
-                            let body = GetSecretAttributesResponse::new(resp);
-
-                            Self::ok_response(req, Some(body), enc)
-                        }
-                        GetSecretRequestOperation::GetSecretBytes => {
-                            let resp = self.vault.secret_export(&key_id).await?;
-                            let body = ExportSecretResponse::new(resp);
-
-                            Self::ok_response(req, Some(body), enc)
-                        }
-                    }
-                }
                 ["secrets", key_id, "public_key"] => {
                     let key_id: KeyId = key_id.to_string();
 

--- a/implementations/rust/ockam/ockam_api/src/vault/models/secret_request.rs
+++ b/implementations/rust/ockam/ockam_api/src/vault/models/secret_request.rs
@@ -47,34 +47,3 @@ impl CreateSecretRequest {
         }
     }
 }
-
-#[derive(Debug, Copy, Clone, Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[non_exhaustive]
-#[rustfmt::skip]
-#[cbor(index_only)]
-pub enum GetSecretRequestOperation {
-    #[n(1)] GetAttributes,
-    #[n(2)] GetSecretBytes,
-}
-
-#[derive(Debug, Clone, Encode, Decode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct GetSecretRequest {
-    #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<4500806>,
-    #[n(1)] operation: GetSecretRequestOperation,
-}
-
-impl GetSecretRequest {
-    pub fn new(operation: GetSecretRequestOperation) -> Self {
-        Self {
-            #[cfg(feature = "tag")]
-            tag: TypeTag,
-            operation,
-        }
-    }
-    pub fn operation(&self) -> GetSecretRequestOperation {
-        self.operation
-    }
-}


### PR DESCRIPTION
A node currently exposes an operation to export secret data. This creates a risk of exposing sensitive data to the outside world. That risk is currently being mitigated by controlling the flow of messages between workers in a node but the best defense is simply to stop exposing this endpoint.
