### PR TITLE
fix(rust): allow ockam relay create at argument to be node name

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -37,7 +37,7 @@ pub struct CreateCommand {
     to: String,
 
     /// Route to the node at which to create the relay (optional)
-    #[arg(long, id = "ROUTE", display_order = 900, default_value_t = default_forwarder_at())]
+    #[arg(long, id = "ROUTE", display_order = 900, value_parser = parse_at, default_value_t = default_forwarder_at())]
     at: MultiAddr,
 
     /// Authorized identity for secure channel connection (optional)
@@ -49,6 +49,17 @@ impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         node_rpc(rpc, (options, self));
     }
+}
+
+fn parse_at(input: &str) -> Result<MultiAddr> {
+    let mut at = input.to_string();
+    if !input.contains('/') {
+        at = format!("/node/{}", input);
+    }
+
+    let ma = MultiAddr::from_str(&at)?;
+
+    Ok(ma)
 }
 
 pub fn default_forwarder_at() -> MultiAddr {


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior
```sh
ockam node create n1
ockam node create n2


ockam relay create my_relay --at /node/n1 --to n2
```

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes
```sh
ockam node create n1
ockam node create n2

ockam relay create my_relay --at n1 --to n2
```
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
