### PR TITLE
refactor(rust): simplify the has context signature

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -34,8 +34,7 @@ async fn main(ctx: Context) -> Result<()> {
         )
         .await?;
 
-    let issuer_client =
-        CredentialsIssuerClient::new(route![issuer_channel, "issuer"], &node.get_context().await?).await?;
+    let issuer_client = CredentialsIssuerClient::new(route![issuer_channel, "issuer"], node.context()).await?;
     let credential = issuer_client.credential().await?;
     println!("Credential:\n{credential}");
 
@@ -62,7 +61,7 @@ async fn main(ctx: Context) -> Result<()> {
     let r = route![channel.clone(), "credentials"];
     node.credentials_server()
         .present_credential_mutual(
-            &node.get_context().await?,
+            node.context(),
             r,
             &[issuer],
             credential,

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -43,8 +43,7 @@ async fn main(ctx: Context) -> Result<()> {
         )
         .await?;
 
-    let issuer_client =
-        CredentialsIssuerClient::new(route![issuer_channel, "issuer"], &node.get_context().await?).await?;
+    let issuer_client = CredentialsIssuerClient::new(route![issuer_channel, "issuer"], node.context()).await?;
     let credential = issuer_client.credential().await?;
     println!("Credential:\n{credential}");
 
@@ -77,7 +76,7 @@ async fn main(ctx: Context) -> Result<()> {
     // Start a worker which will receive credentials sent by the client and issued by the issuer node
     node.credentials_server()
         .start(
-            &node.get_context().await?,
+            node.context(),
             trust_context,
             server.clone(),
             "credentials".into(),

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -83,7 +83,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     let token_acceptor = TokenAcceptorClient::new(
         RpcClient::new(
             route![secure_channel.clone(), DefaultAddress::ENROLLMENT_TOKEN_ACCEPTOR],
-            &node.get_context().await?,
+            node.context(),
         )
         .await?,
     );
@@ -113,7 +113,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
 
     let credential = trust_context
         .authority()?
-        .credential(&node.get_context().await?, &control_plane)
+        .credential(node.context(), &control_plane)
         .await?;
 
     println!("{credential}");
@@ -122,7 +122,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // later on to exchange credentials with the edge node
     node.credentials_server()
         .start(
-            &node.get_context().await?,
+            node.context(),
             trust_context,
             project.authority_identity(),
             "credential_exchange".into(),
@@ -169,7 +169,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // present this node credential to the project
     node.credentials_server()
         .present_credential(
-            &node.get_context().await?,
+            node.context(),
             route![secure_channel_address.clone(), DefaultAddress::CREDENTIALS_SERVICE],
             credential,
             MessageSendReceiveOptions::new().with_flow_control(&flow_controls),

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -89,7 +89,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     let token_acceptor = TokenAcceptorClient::new(
         RpcClient::new(
             route![secure_channel.clone(), DefaultAddress::ENROLLMENT_TOKEN_ACCEPTOR],
-            &node.get_context().await?,
+            node.context(),
         )
         .await?,
     );
@@ -119,7 +119,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
 
     let credential = trust_context
         .authority()?
-        .credential(&node.get_context().await?, &edge_plane)
+        .credential(node.context(), &edge_plane)
         .await?;
 
     println!("{credential}");
@@ -128,7 +128,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // later on to exchange credentials with the control node
     node.credentials_server()
         .start(
-            &node.get_context().await?,
+            node.context(),
             trust_context,
             project.authority_identity(),
             "credential_exchange".into(),
@@ -166,7 +166,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 4.2 and send this node credential to the project
     node.credentials_server()
         .present_credential(
-            &node.get_context().await?,
+            node.context(),
             route![secure_channel_address.clone(), DefaultAddress::CREDENTIALS_SERVICE],
             credential.clone(),
             MessageSendReceiveOptions::new().with_flow_control(&flow_controls),
@@ -189,7 +189,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 4.4 exchange credential with the control node
     node.credentials_server()
         .present_credential_mutual(
-            &node.get_context().await?,
+            node.context(),
             route![secure_channel_to_control.clone(), "credential_exchange"],
             &[project.authority_identity()],
             credential,

--- a/examples/rust/get_started/examples/old/08-routing-over-many-transports-many-hops-middle.rs
+++ b/examples/rust/get_started/examples/old/08-routing-over-many-transports-many-hops-middle.rs
@@ -15,7 +15,7 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.connect("127.0.0.1:4000").await?;
 
     // Initialize the WS Transport.
-    let ws = WebSocketTransport::create(&node.get_context().await?).await?;
+    let ws = WebSocketTransport::create(node.context()).await?;
 
     // Create a WS listener and wait for incoming connections.
     ws.listen("127.0.0.1:3000").await?;

--- a/examples/rust/get_started/examples/old/09-secure-channel-over-many-transports-many-hops-middle.rs
+++ b/examples/rust/get_started/examples/old/09-secure-channel-over-many-transports-many-hops-middle.rs
@@ -15,7 +15,7 @@ async fn main(ctx: Context) -> Result<()> {
     tcp.connect("127.0.0.1:4000").await?;
 
     // Initialize the WS Transport.
-    let ws = WebSocketTransport::create(&node.get_context().await?).await?;
+    let ws = WebSocketTransport::create(node.context()).await?;
 
     // Create a WS listener and wait for incoming connections.
     ws.listen("127.0.0.1:3000").await?;

--- a/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/01-access-control-for-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_examples/example_projects/access_control/examples/01-access-control-for-transport-initiator.rs
@@ -10,7 +10,11 @@ async fn main(mut ctx: Context) -> Result<()> {
     let tcp = node.create_tcp_transport().await?;
 
     // A repeater Context is needed because the node Context has LocalOriginOnly AccessControl.
-    let mut repeater_ctx = node.get_context().await?.new_repeater(AllowedTransport::single(TCP)).await?;
+    let mut repeater_ctx = node
+        .context()
+        .await?
+        .new_repeater(AllowedTransport::single(TCP))
+        .await?;
 
     // Send a message to the "echoer" worker, on a different node, over a tcp transport.
     let r = route![(TCP, "localhost:4000"), "echoer"];

--- a/implementations/rust/ockam/ockam_node/src/context/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/mod.rs
@@ -16,9 +16,8 @@ use crate::channel_types::{SmallReceiver, SmallSender};
 use crate::tokio::runtime::Handle;
 use crate::{error::*, NodeMessage};
 use core::sync::atomic::AtomicUsize;
-use ockam_core::compat::boxed::Box;
 use ockam_core::compat::{string::String, sync::Arc, vec::Vec};
-use ockam_core::{async_trait, Address, Mailboxes, RelayMessage, Result};
+use ockam_core::{Address, Mailboxes, RelayMessage, Result};
 
 #[cfg(feature = "std")]
 use core::fmt::{Debug, Formatter};
@@ -37,10 +36,9 @@ pub struct Context {
 }
 
 /// This trait can be used to integrate transports into a node
-#[async_trait]
 pub trait HasContext {
     /// Return a cloned context
-    async fn context(&self) -> Result<Context>;
+    fn get_context(&self) -> &Context;
 }
 
 #[cfg(feature = "std")]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
@@ -61,7 +61,7 @@ pub struct TcpTransport {
 pub trait TcpTransportExtension: HasContext {
     /// Create a TCP transport
     async fn create_tcp_transport(&self) -> Result<TcpTransport> {
-        TcpTransport::create(&self.context().await?).await
+        TcpTransport::create(self.get_context()).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_udp/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/transport.rs
@@ -35,7 +35,7 @@ impl UdpTransport {
 pub trait UdpTransportExtension: HasContext {
     /// Create a UDP transport
     async fn create_udp_transport(&self) -> Result<UdpTransport> {
-        UdpTransport::create(&self.context().await?).await
+        UdpTransport::create(self.get_context()).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_uds/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/transport.rs
@@ -117,7 +117,7 @@ impl UdsTransport {
 pub trait UdsTransportExtension: HasContext {
     /// Create a UDS transport
     async fn create_uds_transport(&self) -> Result<UdsTransport> {
-        UdsTransport::create(&self.context().await?).await
+        UdsTransport::create(self.get_context()).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_websocket/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/transport.rs
@@ -108,7 +108,7 @@ impl WebSocketTransport {
 pub trait WebSocketTransportExtension: HasContext {
     /// Create a WebSocket transport
     async fn create_web_socket_transport(&self) -> Result<WebSocketTransport> {
-        WebSocketTransport::create(&self.context().await?).await
+        WebSocketTransport::create(self.get_context()).await
     }
 }
 


### PR DESCRIPTION
The `HasContext` trait has been introduced to allow transports to be seamlessly integrated into a `Node` interface. 
However the method provided on the trait doesn't need to force a node to make an async clone of its `Context`, returning a reference to the `Context` is enough. So this PR simplifies the trait.