### PR TITLE
fix(rust): do not recreate an identity state if it already exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,7 @@ dependencies = [
  "thiserror",
  "time",
  "tinyvec",
+ "tokio",
  "tokio-retry",
  "tracing",
  "uuid",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -100,4 +100,5 @@ ockam_api = { path = ".", features = ["std", "authenticators"] }
 ockam_macros = { version = "0.28.0", path = "../ockam_macros", features = ["std"] }
 ockam_transport_tcp = { version = "0.79.0", path = "../ockam_transport_tcp" }
 quickcheck = "1.0.1"
+tokio = { version = "1.27.0", features = ["full"] }
 uuid = "1.3.1"


### PR DESCRIPTION
This issue was likely caused by an incorrect rebase. I still need to do some follow-up to understand why we could not see this during bats tests.