### PR TITLE
fix(rust): move the multiaddr resolution for a credential retriever

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3442,6 +3442,7 @@ dependencies = [
  "ockam_core",
  "ockam_key_exchange_xx",
  "ockam_macros",
+ "ockam_multiaddr",
  "ockam_node",
  "ockam_transport_tcp",
  "ockam_vault",
@@ -3500,12 +3501,15 @@ dependencies = [
  "multiaddr",
  "ockam_core",
  "ockam_multiaddr",
+ "ockam_node",
+ "ockam_transport_tcp",
  "once_cell",
  "quickcheck",
  "rand",
  "serde",
  "serde_json",
  "tinyvec",
+ "tracing",
  "unsigned-varint",
 ]
 

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -89,10 +89,6 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     );
     token_acceptor.present_token(&token).await?;
 
-    let tcp_project_session = multiaddr_to_route(&project.authority_route(), &tcp, &flow_controls)
-        .await
-        .unwrap(); // FIXME: Handle error
-
     // Create a trust context that will be used to authenticate credential exchanges
     let trust_context = TrustContext::new(
         "trust_context_id".to_string(),
@@ -103,7 +99,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
                 node.secure_channels(),
                 RemoteCredentialsRetrieverInfo::new(
                     project.authority_identity(),
-                    tcp_project_session.route,
+                    project.authority_route.clone(),
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 ),
                 flow_controls.clone(),

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -96,10 +96,6 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     token_acceptor.present_token(&token).await?;
 
     // Create a trust context that will be used to authenticate credential exchanges
-    let tcp_project_session = multiaddr_to_route(&project.route(), &tcp, &flow_controls)
-        .await
-        .unwrap(); // FIXME: Handle error
-
     let trust_context = TrustContext::new(
         "trust_context_id".to_string(),
         Some(AuthorityService::new(
@@ -109,7 +105,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
                 node.secure_channels(),
                 RemoteCredentialsRetrieverInfo::new(
                     project.authority_identity(),
-                    tcp_project_session.route,
+                    project.route(),
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 ),
                 flow_controls.clone(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -389,16 +389,8 @@ impl NodeManager {
     }
 
     async fn configure_trust_context(&mut self, tc: &TrustContextConfig) -> Result<()> {
-        self.trust_context = Some(
-            tc.to_trust_context(
-                self.secure_channels.clone(),
-                Some(self.tcp_transport.async_try_clone().await?),
-            )
-            .await?,
-        );
-
+        self.trust_context = Some(tc.to_trust_context(self.secure_channels.clone()).await?);
         info!("NodeManager::configure_trust_context: trust context configured");
-
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -31,6 +31,7 @@ std = [
   "ockam_core/std",
   "ockam_macros/std",
   "ockam_key_exchange_xx/std",
+  "ockam_multiaddr/std",
   "ockam_node/std",
   "ockam_vault/std",
   "hex/std",
@@ -74,6 +75,7 @@ minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
 ockam_core = { path = "../ockam_core", version = "^0.78.0", default-features = false }
 ockam_key_exchange_xx = { path = "../ockam_key_exchange_xx", version = "^0.74.0", default-features = false, optional = true }
 ockam_macros = { path = "../ockam_macros", version = "^0.28.0", default-features = false }
+ockam_multiaddr = { path = "../ockam_multiaddr", version = "^0.18.0", default-features = false, optional = true }
 ockam_node = { path = "../ockam_node", version = "^0.81.0", default-features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.74.0", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false }
@@ -88,7 +90,7 @@ tokio-retry = { version = "0.3.0", default-features = false, optional = true }
 tracing = { version = "0.1", default_features = false }
 
 [dev-dependencies]
-ockam_transport_tcp = { path = "../ockam_transport_tcp" }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.79.0" }
 ockam_vault = { path = "../ockam_vault", version = "^0.74.0" }
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_remote_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_remote_retriever.rs
@@ -1,0 +1,104 @@
+#![cfg(feature = "std")]
+use crate::{
+    Credential, CredentialsIssuerClient, CredentialsRetriever, Identity, SecureChannelOptions,
+    SecureChannels, TrustMultiIdentifiersPolicy,
+};
+use core::time::Duration;
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::sync::Arc;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::flow_control::FlowControls;
+use ockam_core::{async_trait, route, Address, Result, Route};
+use ockam_multiaddr::MultiAddr;
+use ockam_node::Context;
+use tracing::{debug, error};
+
+/// Credentials retriever for credentials located on a different node
+pub struct RemoteCredentialsRetriever {
+    secure_channels: Arc<SecureChannels>,
+    issuer: RemoteCredentialsRetrieverInfo,
+    flow_controls: FlowControls,
+}
+
+impl RemoteCredentialsRetriever {
+    /// Create a new remote credential retriever
+    pub fn new(
+        secure_channels: Arc<SecureChannels>,
+        issuer: RemoteCredentialsRetrieverInfo,
+        flow_controls: FlowControls,
+    ) -> Self {
+        Self {
+            secure_channels,
+            issuer,
+            flow_controls,
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialsRetriever for RemoteCredentialsRetriever {
+    async fn retrieve(&self, ctx: &Context, for_identity: &Identity) -> Result<Credential> {
+        debug!("Getting credential from : {}", &self.issuer.multiaddr);
+        let route = self.issuer.resolve_route(ctx, &self.flow_controls).await?;
+
+        let allowed = vec![self.issuer.identity.identifier()];
+        debug!("Create secure channel to authority");
+
+        let flow_control_id = self.flow_controls.generate_id();
+        let options = SecureChannelOptions::as_producer(&self.flow_controls, &flow_control_id)
+            .as_consumer(&self.flow_controls)
+            .with_trust_policy(TrustMultiIdentifiersPolicy::new(allowed));
+
+        let sc = self
+            .secure_channels
+            .create_secure_channel_extended(
+                ctx,
+                for_identity,
+                route,
+                options,
+                Duration::from_secs(120),
+            )
+            .await?;
+
+        debug!("Created secure channel to project authority");
+
+        let client =
+            CredentialsIssuerClient::new(route![sc, self.issuer.service_address.clone()], ctx)
+                .await?
+                .with_flow_controls(&self.flow_controls);
+
+        let credential = client.credential().await?;
+        Ok(credential)
+    }
+}
+
+/// Information necessary to connect to a remote credential retriever
+#[derive(Debug, Clone)]
+pub struct RemoteCredentialsRetrieverInfo {
+    /// Issuer identity, used to validate retrieved credentials
+    pub identity: Identity,
+    /// Multiaddr used to establish a secure channel to the remote node
+    pub multiaddr: MultiAddr,
+    /// Address of the credentials service on the remote node
+    pub service_address: Address,
+}
+
+impl RemoteCredentialsRetrieverInfo {
+    /// Create new information for a credential retriever
+    pub fn new(identity: Identity, multiaddr: MultiAddr, service_address: Address) -> Self {
+        Self {
+            identity,
+            multiaddr,
+            service_address,
+        }
+    }
+
+    async fn resolve_route(&self, ctx: &Context, flow_controls: &FlowControls) -> Result<Route> {
+        let Some(authority_tcp_session) = self.multiaddr.to_route(ctx, flow_controls).await else {
+            let err_msg = format!("Invalid route within trust context: {}", &self.multiaddr);
+            error!("{err_msg}");
+            return Err(ockam_core::Error::new(Origin::Application, Kind::Unknown, err_msg));
+        };
+        Ok(authority_tcp_session.route)
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
@@ -1,15 +1,7 @@
-use crate::{
-    Credential, CredentialsIssuerClient, Identity, SecureChannelOptions, SecureChannels,
-    TrustMultiIdentifiersPolicy,
-};
-use core::time::Duration;
+use crate::{Credential, Identity};
 use ockam_core::compat::boxed::Box;
-use ockam_core::compat::sync::Arc;
-use ockam_core::flow_control::FlowControls;
-use ockam_core::{async_trait, route, Address, Result, Route};
+use ockam_core::{async_trait, Result};
 use ockam_node::Context;
-use serde::{Deserialize, Serialize};
-use tracing::debug;
 
 /// Trait for retrieving a credential for a given identity
 #[async_trait]
@@ -35,85 +27,5 @@ impl CredentialsRetriever for CredentialsMemoryRetriever {
     /// Retrieve a credential stored in memory
     async fn retrieve(&self, _ctx: &Context, _for_identity: &Identity) -> Result<Credential> {
         Ok(self.credential.clone())
-    }
-}
-
-/// Credentials retriever for credentials located on a different node
-pub struct RemoteCredentialsRetriever {
-    secure_channels: Arc<SecureChannels>,
-    issuer: RemoteCredentialsRetrieverInfo,
-    flow_controls: FlowControls,
-}
-
-impl RemoteCredentialsRetriever {
-    /// Create a new remote credential retriever
-    pub fn new(
-        secure_channels: Arc<SecureChannels>,
-        issuer: RemoteCredentialsRetrieverInfo,
-        flow_controls: FlowControls,
-    ) -> Self {
-        Self {
-            secure_channels,
-            issuer,
-            flow_controls,
-        }
-    }
-}
-
-#[async_trait]
-impl CredentialsRetriever for RemoteCredentialsRetriever {
-    async fn retrieve(&self, ctx: &Context, for_identity: &Identity) -> Result<Credential> {
-        debug!("Getting credential from : {}", &self.issuer.route);
-
-        let allowed = vec![self.issuer.identity.identifier()];
-        debug!("Create secure channel to authority");
-
-        let flow_control_id = self.flow_controls.generate_id();
-        let options = SecureChannelOptions::as_producer(&self.flow_controls, &flow_control_id)
-            .as_consumer(&self.flow_controls)
-            .with_trust_policy(TrustMultiIdentifiersPolicy::new(allowed));
-
-        let sc = self
-            .secure_channels
-            .create_secure_channel_extended(
-                ctx,
-                for_identity,
-                self.issuer.route.clone(),
-                options,
-                Duration::from_secs(120),
-            )
-            .await?;
-
-        debug!("Created secure channel to project authority");
-
-        let client =
-            CredentialsIssuerClient::new(route![sc, self.issuer.service_address.clone()], ctx)
-                .await?
-                .with_flow_controls(&self.flow_controls);
-
-        let credential = client.credential().await?;
-        Ok(credential)
-    }
-}
-
-/// Information necessary to connect to a remote credential retriever
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteCredentialsRetrieverInfo {
-    /// Issuer identity, used to validate retrieved credentials
-    pub identity: Identity,
-    /// Route used to establish a secure channel to the remote node
-    pub route: Route,
-    /// Address of the credentials service on the remote node
-    pub service_address: Address,
-}
-
-impl RemoteCredentialsRetrieverInfo {
-    /// Create new information for a credential retriever
-    pub fn new(identity: Identity, route: Route, service_address: Address) -> Self {
-        Self {
-            identity,
-            route,
-            service_address,
-        }
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/credentials/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/mod.rs
@@ -2,6 +2,8 @@ mod authority_service;
 #[allow(clippy::module_inception)]
 mod credentials;
 mod credentials_issuer;
+#[cfg(feature = "std")]
+mod credentials_remote_retriever;
 mod credentials_retriever;
 mod credentials_server;
 mod credentials_server_worker;
@@ -10,6 +12,8 @@ mod trust_context;
 pub use authority_service::*;
 pub use credentials::*;
 pub use credentials_issuer::*;
+#[cfg(feature = "std")]
+pub use credentials_remote_retriever::*;
 pub use credentials_retriever::*;
 pub use credentials_server::*;
 pub use trust_context::*;

--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -10,14 +10,17 @@ repository = "https://github.com/ockam-network/ockam"
 description = "An implementation of multiformats.io/multiaddr"
 
 [features]
-std = ["ockam_core/std", "unsigned-varint/std", "serde?/std"]
+std = ["ockam_core/std", "ockam_transport_tcp/std", "unsigned-varint/std", "serde?/std"]
+no_std = ["ockam_core/no_std"]
 cbor = ["minicbor"]
+alloc = ["ockam_transport_tcp/alloc"]
 
 [dependencies]
 minicbor = { version = "0.19.0", default-features = false, features = ["alloc"], optional = true }
 once_cell = { version = "1.17.1", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.160", default-features = false, optional = true }
 tinyvec = { version = "1.5.1", features = ["alloc"] }
+tracing = { version = "0.1", default-features = false }
 unsigned-varint = "0.7.1"
 
 [dependencies.ockam_core]
@@ -25,6 +28,18 @@ version = "0.78.0"
 path = "../ockam_core"
 default-features = false
 features = ["no_std", "alloc"]
+
+[dependencies.ockam_node]
+version = "0.81.0"
+path = "../ockam_node"
+default-features = false
+features = ["std", "no_std"]
+
+[dependencies.ockam_transport_tcp]
+version = "0.79.0"
+path = "../ockam_transport_tcp"
+default-features = false
+features = ["std", "alloc"]
 
 [dev-dependencies]
 bincode = "1.1.3"

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -16,6 +16,7 @@ mod registry;
 
 pub mod codec;
 pub mod iter;
+pub mod multiaddr_to_route;
 pub mod proto;
 
 use alloc::vec::Vec;
@@ -29,6 +30,8 @@ use tinyvec::{Array, ArrayVec, TinyVec};
 
 use crate::proto::{DnsAddr, Ip4, Ip6, Tcp};
 pub use error::Error;
+pub use multiaddr_to_route::*;
+use ockam_core::compat::string::String;
 use ockam_core::env::FromString;
 pub use registry::{Registry, RegistryBuilder};
 

--- a/implementations/rust/ockam/ockam_multiaddr/src/multiaddr_to_route.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/multiaddr_to_route.rs
@@ -1,0 +1,124 @@
+use crate::proto::{DnsAddr, Ip4, Ip6, Secure, Service, Tcp, Worker};
+use crate::{MultiAddr, Protocol};
+use ockam_core::flow_control::{FlowControlId, FlowControls};
+use ockam_core::{Address, Route, LOCAL};
+use ockam_node::Context;
+use ockam_transport_tcp::{TcpConnectionOptions, TcpTransport};
+use std::net::{SocketAddrV4, SocketAddrV6};
+use tracing::error;
+
+impl MultiAddr {
+    pub async fn to_route(
+        &self,
+        ctx: &Context,
+        flow_controls: &FlowControls,
+    ) -> Option<MultiAddrToRouteResult> {
+        let tcp = TcpTransport::create(ctx).await.unwrap();
+
+        let mut rb = Route::new();
+        let mut it = self.iter().peekable();
+
+        let mut flow_control_id = None;
+        let mut number_of_tcp_hops = 0;
+
+        while let Some(p) = it.next() {
+            match p.code() {
+                Ip4::CODE => {
+                    if number_of_tcp_hops >= 1 {
+                        return None; // Only 1 TCP hop is allowed
+                    }
+
+                    let ip4 = p.cast::<Ip4>()?;
+                    let port = it.next()?.cast::<Tcp>()?;
+                    let socket_addr = SocketAddrV4::new(*ip4, *port);
+
+                    let options = if socket_addr.ip().is_loopback() {
+                        // TODO: Enable FlowControl for loopback addresses as well
+                        TcpConnectionOptions::insecure()
+                    } else {
+                        let id = flow_controls.generate_id();
+                        flow_control_id = Some(id.clone());
+                        TcpConnectionOptions::as_producer(flow_controls, &id)
+                    };
+
+                    let addr = tcp.connect(socket_addr.to_string(), options).await.ok()?;
+                    number_of_tcp_hops += 1;
+                    rb = rb.append(addr)
+                }
+                Ip6::CODE => {
+                    if number_of_tcp_hops >= 1 {
+                        return None; // Only 1 TCP hop is allowed
+                    }
+
+                    let ip6 = p.cast::<Ip6>()?;
+                    let port = it.next()?.cast::<Tcp>()?;
+                    let socket_addr = SocketAddrV6::new(*ip6, *port, 0, 0);
+
+                    let options = if socket_addr.ip().is_loopback() {
+                        // TODO: Enable FlowControl for loopback addresses as well
+                        TcpConnectionOptions::insecure()
+                    } else {
+                        let id = flow_controls.generate_id();
+                        flow_control_id = Some(id.clone());
+                        TcpConnectionOptions::as_producer(flow_controls, &id)
+                    };
+
+                    let addr = tcp.connect(socket_addr.to_string(), options).await.ok()?;
+                    number_of_tcp_hops += 1;
+                    rb = rb.append(addr)
+                }
+                DnsAddr::CODE => {
+                    if number_of_tcp_hops >= 1 {
+                        return None; // Only 1 TCP hop is allowed
+                    }
+
+                    let host = p.cast::<DnsAddr>()?;
+                    if let Some(p) = it.peek() {
+                        if p.code() == Tcp::CODE {
+                            let port = p.cast::<Tcp>()?;
+
+                            let id = flow_controls.generate_id();
+                            flow_control_id = Some(id.clone());
+                            let options = TcpConnectionOptions::as_producer(flow_controls, &id);
+
+                            let addr = tcp
+                                .connect(format!("{}:{}", &*host, *port), options)
+                                .await
+                                .ok()?;
+                            number_of_tcp_hops += 1;
+                            rb = rb.append(addr);
+                            let _ = it.next();
+                            continue;
+                        }
+                    }
+                }
+                Worker::CODE => {
+                    let local = p.cast::<Worker>()?;
+                    rb = rb.append(Address::new(LOCAL, &*local))
+                }
+                Service::CODE => {
+                    let local = p.cast::<Service>()?;
+                    rb = rb.append(Address::new(LOCAL, &*local))
+                }
+                Secure::CODE => {
+                    let local = p.cast::<Secure>()?;
+                    rb = rb.append(Address::new(LOCAL, &*local))
+                }
+                other => {
+                    error!(target: "ockam_api", code = %other, "unsupported protocol");
+                    return None;
+                }
+            }
+        }
+
+        Some(MultiAddrToRouteResult {
+            flow_control_id,
+            route: rb.into(),
+        })
+    }
+}
+
+pub struct MultiAddrToRouteResult {
+    pub flow_control_id: Option<FlowControlId>,
+    pub route: Route,
+}


### PR DESCRIPTION
**UPDATE** This PR is now closed in favor of https://github.com/build-trust/ockam/pull/4752

This is a proposal of a fix for the broken bats portals tests.

# Diagnostic

 - the previous version had a `CredentialRetriever` possibly configured with a `Route` to the authority
 - the code was moved from the `ockam_api` crate to the `ockam_identity` along with other `TrustContext` and `Credential` concerns (this allowed to remove some redundant code around `CredentialIssuer`)
 - in order to do the move the multiaddr in the original configuration of a `CredentialRetriever` was resolved to a `Route` and that route used as the configuration for the `CredentialRetriever`

My understanding of the current issue is that: 

 - unfortunately that route is not "stable". It contains the addresses of some TCP workers which might be dropped, and then the authority can not be contacted anymore in a portals via Orchestrator case

# Fix

The fix applied here consists in keeping the `MultiAddr` configuration on the `CredentialRetriever` and do the resolution inside the `ockam_identity` crate. This now passes all the tests.

Unfortunately this changes the dependencies of the crates and now we have a dependency between `ockam_identity` and `ockam_multiaddr` and this may not be what we want.
 