### PR TITLE
chore(rust): various small changes to udp transport

### DIFF
--- a/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_udp/Cargo.toml
@@ -10,16 +10,17 @@ categories = [
   "network-programming",
   "embedded",
 ]
+
 edition = "2021"
 homepage = "https://github.com/ockam-network/ockam"
-keywords = ["ockam", "crypto", "network", "networking", "tcp"]
+keywords = ["ockam", "crypto", "network", "networking", "udp"]
 license = "Apache-2.0"
 publish = false
 readme = "README.md"
-repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_tcp"
+repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/ockam_transport_udp"
 rust-version = "1.56.0"
 description = """
-TCP Transport for the Ockam Routing Protocol.
+UDP Transport for the Ockam Routing Protocol.
 """
 
 [features]

--- a/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/messages.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/messages.rs
@@ -1,20 +1,22 @@
 use ockam_core::{Message, Result, Route};
 use serde::{Deserialize, Serialize};
 
+// TODO: Change this Request/Response protocol to use CBOR encoding for messages.
+
 /// Request type for UDP Hole Punching Rendezvous service
 #[derive(Serialize, Deserialize, Debug, Message)]
 pub enum RendezvousRequest {
     /// Update service's internal table with the
-    /// return route of the sending node.
+    /// details of the sending node.
     Update {
-        /// Name of sending node
-        node_name: String,
+        /// Name of sending node's puncher
+        puncher_name: String,
     },
     /// Query service's internal table for the public
     /// route to the named node.
     Query {
-        /// Name of node to lookup
-        node_name: String,
+        /// Name of puncher to lookup
+        puncher_name: String,
     },
     /// Ping service to see if it is reachable and working.
     Ping,
@@ -23,7 +25,6 @@ pub enum RendezvousRequest {
 /// Response type for UDP Hole Punching Rendezvous service
 #[derive(Serialize, Deserialize, Debug, Message)]
 pub enum RendezvousResponse {
-    Update(Result<Route>),
     Query(Result<Route>),
     Pong,
 }

--- a/implementations/rust/ockam/ockam_transport_udp/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/workers/listener.rs
@@ -5,7 +5,7 @@ use futures_util::StreamExt;
 use ockam_core::{async_trait, route, Address, AllowAll, LocalMessage, Processor, Result};
 use ockam_node::Context;
 use tokio_util::udp::UdpFramed;
-use tracing::{debug, error, info};
+use tracing::{debug, warn};
 
 /// A listener for the UDP transport
 ///
@@ -56,7 +56,7 @@ impl Processor for UdpListenProcessor {
             Some(res) => match res {
                 Ok((msg, addr)) => (msg, addr),
                 Err(e) => {
-                    error!(
+                    warn!(
                         "Failed to read message, will wait for next message: {:?}",
                         e
                     );
@@ -64,7 +64,7 @@ impl Processor for UdpListenProcessor {
                 }
             },
             None => {
-                info!("No message read, will wait for next message.");
+                debug!("No message read, will wait for next message.");
                 return Ok(true);
             }
         };


### PR DESCRIPTION

## Proposed changes

This PR contains various small changes to `ockam_transport_udp`. 
It is part of the ongoing work for a UDP NAT Hole Puncher prototype (#3507).

`Cargo.toml`...
- Update metadata to be for UDP, not TCP

Rendezvous service...
- Rename `node_name` to `puncher_name` as a node can have more than one Hole Puncher
- Remove reply for Update message as Hole Puncher will not use it
- Use `Error::new_without_cause()` instead of `TransportError` as the error relates to the service, not the UDP transport 
- Add 'TODO' comment that messages should use CBOR encoding
- Add test(s)

UDP transport listener...
- Minor changes to logging

Thanks! :smile:

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.
