### PR TITLE
fix(rust): resolve transport addresses as a separate step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,6 +3520,7 @@ dependencies = [
  "ockam_core",
  "ockam_executor",
  "ockam_macros",
+ "ockam_transport_core",
  "once_cell",
  "serde",
  "serde_bare",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -29,11 +29,20 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "tokio", "tracing-subscriber", "tracing-error", "alloc", "futures/std", "minicbor/std"]
+std = [
+  "ockam_core/std",
+  "ockam_transport_core/std",
+  "tokio",
+  "tracing-subscriber",
+  "tracing-error",
+  "alloc",
+  "futures/std",
+  "minicbor/std",
+]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
-no_std = ["ockam_core/no_std", "heapless"]
+no_std = ["ockam_core/no_std", "ockam_transport_core/no_std", "heapless"]
 
 # Feature: "alloc" enables support for heap allocation (implied by `feature = "std"`)
 alloc = ["ockam_core/alloc", "ockam_executor/alloc", "futures/alloc", "minicbor/alloc"]
@@ -58,6 +67,7 @@ minicbor = { version = "0.19.0", features = ["derive"] }
 ockam_core = { path = "../ockam_core", version = "^0.78.0", default_features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.46.0", default-features = false, optional = true }
 ockam_macros = { path = "../ockam_macros", version = "^0.28.0" }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.51.0", default-features = false, optional = true }
 once_cell = { version = "1", optional = true, default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_bare = { version = "0.5.0", default-features = false }

--- a/implementations/rust/ockam/ockam_node/src/context/transports.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/transports.rs
@@ -1,0 +1,66 @@
+use crate::Context;
+use ockam_core::compat::sync::Arc;
+use ockam_core::flow_control::FlowControls;
+use ockam_core::{Result, Route, TransportType};
+use ockam_transport_core::Transport;
+
+impl Context {
+    /// Return the list of supported transports
+    pub fn register_transport(&self, transport: Arc<dyn Transport>) {
+        let mut transports = self.transports.lock().unwrap();
+        transports.insert(transport.transport_type(), transport);
+    }
+
+    /// Return true if a given transport has already been registered
+    pub fn is_transport_registered(&self, transport_type: TransportType) -> bool {
+        let transports = self.transports.lock().unwrap();
+        transports.contains_key(&transport_type)
+    }
+
+    /// For each address handled by a given transport in a route, for example, (TCP, "127.0.0.1:4000")
+    /// Create a worker supporting the routing of messages for this transport and replace the address
+    /// in the route with the worker address
+    pub async fn resolve_transport_route(
+        &self,
+        flow_controls: &FlowControls,
+        route: Route,
+    ) -> Result<Route> {
+        let transports = self.transports.lock().unwrap().clone();
+        let mut resolved = route;
+        for transport in transports.values() {
+            resolved = transport.resolve_route(flow_controls, resolved).await?;
+        }
+        Ok(resolved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_core::async_trait;
+
+    #[ockam_macros::test(crate = "crate")]
+    async fn test_transports(ctx: &mut Context) -> Result<()> {
+        let transport = Arc::new(SomeTransport());
+        ctx.register_transport(transport.clone());
+        assert!(ctx.is_transport_registered(transport.transport_type()));
+        ctx.stop().await
+    }
+
+    struct SomeTransport();
+
+    #[async_trait]
+    impl Transport for SomeTransport {
+        fn transport_type(&self) -> TransportType {
+            TransportType::new(0)
+        }
+
+        async fn resolve_route(
+            &self,
+            _flow_controls: &FlowControls,
+            route: Route,
+        ) -> Result<Route> {
+            Ok(route)
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -1,5 +1,7 @@
 use crate::{debugger, Context, Executor};
+use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::sync::Arc;
+use ockam_core::compat::sync::Mutex;
 use ockam_core::{Address, AllowAll, Mailbox, Mailboxes};
 
 /// A minimal worker implementation that does nothing
@@ -58,6 +60,7 @@ impl NodeBuilder {
                 vec![],
             ),
             None,
+            Arc::new(Mutex::new(HashMap::new())),
         );
 
         debugger::log_inherit_context("NODE", &ctx, &ctx);

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -76,12 +76,7 @@ where
         let main_address = mailboxes.main_address().clone();
 
         // Pass it to the context
-        let (ctx, sender, ctrl_rx) = Context::new(
-            context.runtime().clone(),
-            context.sender().clone(),
-            mailboxes,
-            None,
-        );
+        let (ctx, sender, ctrl_rx) = context.copy_with_mailboxes(mailboxes);
 
         debugger::log_inherit_context("PROCESSOR", context, &ctx);
 

--- a/implementations/rust/ockam/ockam_node/src/worker_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/worker_builder.rs
@@ -73,12 +73,7 @@ where
         let main_address = mailboxes.main_address().clone();
 
         // Pass it to the context
-        let (ctx, sender, ctrl_rx) = Context::new(
-            context.runtime().clone(),
-            context.sender().clone(),
-            mailboxes,
-            None,
-        );
+        let (ctx, sender, ctrl_rx) = context.copy_with_mailboxes(mailboxes);
 
         debugger::log_inherit_context("WORKER", context, &ctx);
 

--- a/implementations/rust/ockam/ockam_transport_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub use error::TransportError;
-
 mod error;
+mod transport;
+
+pub use error::TransportError;
+pub use transport::*;

--- a/implementations/rust/ockam/ockam_transport_core/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/transport.rs
@@ -1,0 +1,17 @@
+use ockam_core::compat::boxed::Box;
+use ockam_core::flow_control::FlowControls;
+use ockam_core::{async_trait, Result, Route, TransportType};
+
+/// Generic representation of a Transport
+/// At minimum, a Transport must be able
+///  - return its type
+///  - instantiate workers for all the addresses with that transport type in a Route
+#[async_trait]
+pub trait Transport: Send + Sync + 'static {
+    /// Return the type of the Transport
+    fn transport_type(&self) -> TransportType;
+
+    /// Instantiate transport workers for each address in the route with the transport type
+    /// and replace the transport address with the local address of the transport worker
+    async fn resolve_route(&self, flow_controls: &FlowControls, route: Route) -> Result<Route>;
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -24,7 +24,8 @@ TCP Transport for the Ockam Routing Protocol.
 
 [features]
 default = ["std"]
-std = ["ockam_macros/std"]
+std = ["ockam_macros/std", "ockam_transport_core/std"]
+no_std = ["ockam_macros/no_std", "ockam_transport_core/no_std"]
 alloc = []
 
 [dependencies]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -30,6 +30,7 @@ mod portal;
 mod registry;
 mod transport;
 
+use ockam_core::TransportType;
 pub use options::*;
 pub use portal::*;
 pub use registry::*;
@@ -39,3 +40,6 @@ mod workers;
 pub(crate) use workers::*;
 
 pub(crate) const CLUSTER_NAME: &str = "_internals.transport.tcp";
+
+/// Transport type for TCP addresses
+pub const TCP: TransportType = TransportType::new(1);

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
@@ -1,6 +1,13 @@
-use crate::{TcpRegistry, TcpTransport};
-use ockam_core::{AsyncTryClone, Result};
+use crate::{TcpConnectionOptions, TcpRegistry, TcpTransport, TCP};
+use core::str::FromStr;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::flow_control::FlowControls;
+use ockam_core::{async_trait, AsyncTryClone, Error, Result, Route, TransportType};
 use ockam_node::Context;
+use ockam_transport_core::Transport;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tracing::debug;
 
 impl TcpTransport {
     /// Create a TCP transport
@@ -14,10 +21,15 @@ impl TcpTransport {
     /// # Ok(()) }
     /// ```
     pub async fn create(ctx: &Context) -> Result<Self> {
-        Ok(Self {
+        let tcp = Self {
             ctx: ctx.async_try_clone().await?,
             registry: TcpRegistry::default(),
-        })
+        };
+        // make the TCP transport available in the list of supported transports for
+        // later address resolution when socket addresses will need to be instantiated as TCP
+        // worker addresses
+        ctx.register_transport(Arc::new(tcp.async_try_clone().await?));
+        Ok(tcp)
     }
 }
 
@@ -29,5 +41,140 @@ impl TcpTransport {
     /// Registry of all active connections
     pub fn registry(&self) -> &TcpRegistry {
         &self.registry
+    }
+}
+
+#[async_trait]
+impl Transport for TcpTransport {
+    fn transport_type(&self) -> TransportType {
+        TCP
+    }
+
+    async fn resolve_route(&self, flow_controls: &FlowControls, route: Route) -> Result<Route> {
+        let mut result = Route::new();
+        let mut number_of_tcp_hops = 0;
+
+        for address in route.iter() {
+            if address.transport_type() == TCP {
+                if number_of_tcp_hops >= 1 {
+                    return Err(Error::new(
+                        Origin::Transport,
+                        Kind::Invalid,
+                        "only one TCP hop is allowed in a route",
+                    ));
+                }
+
+                let options = if SocketAddr::from_str(address.address())
+                    .map(|socket_addr| socket_addr.ip().is_loopback())
+                    .is_ok()
+                {
+                    // TODO: Enable FlowControl for loopback addresses as well
+                    TcpConnectionOptions::insecure()
+                } else {
+                    let id = flow_controls.generate_id();
+                    TcpConnectionOptions::as_producer(flow_controls, &id)
+                };
+
+                number_of_tcp_hops += 1;
+                let addr = self.connect(address.address().to_string(), options).await?;
+                result = result.append(addr)
+            } else {
+                result = result.append(address.clone());
+            }
+        }
+
+        let resolved = result.into();
+        debug!("resolved route {} to {}", route, resolved);
+        Ok(resolved)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_core::{route, TransportType, LOCAL};
+    use ockam_transport_core::TransportError;
+    use std::net::TcpListener;
+
+    #[ockam_macros::test]
+    async fn test_resolve_route(ctx: &mut Context) -> Result<()> {
+        let tcp = TcpTransport::create(ctx).await?;
+        let tcp_address = "127.0.0.1:5001";
+        let _listener = TcpListener::bind(tcp_address).map_err(TransportError::from)?;
+        let initial_workers = ctx.list_workers().await?;
+
+        let other_transport_type = TransportType::new(10);
+        let other_address = (other_transport_type, "other_address");
+        let route = tcp
+            .resolve_route(
+                &FlowControls::default(),
+                route![(TCP, tcp_address), other_address],
+            )
+            .await?;
+
+        // there are 2 additional workers
+        let mut additional_workers = ctx.list_workers().await?;
+        additional_workers.retain(|w| !initial_workers.contains(w));
+        assert_eq!(additional_workers.len(), 2);
+
+        // the TCP address is replaced with the TCP sender worker address
+        // the other address is left unchanged
+        assert_eq!(
+            route.iter().map(|a| a.transport_type()).collect::<Vec<_>>(),
+            vec![LOCAL, other_transport_type]
+        );
+
+        let first_address = route.next()?;
+        assert!(additional_workers.contains(first_address));
+
+        // trying to resolve the address a second time should still work
+        let _route = tcp
+            .resolve_route(
+                &FlowControls::default(),
+                route![(TCP, tcp_address), other_address],
+            )
+            .await?;
+
+        ctx.stop().await
+    }
+
+    #[ockam_macros::test]
+    async fn test_resolve_route_only_single_hop_is_allowed(ctx: &mut Context) -> Result<()> {
+        let tcp = TcpTransport::create(ctx).await?;
+        let tcp_address = "127.0.0.1:5002";
+        let _listener = TcpListener::bind(tcp_address).map_err(TransportError::from)?;
+
+        let result = tcp
+            .resolve_route(
+                &FlowControls::default(),
+                route![
+                    (TCP, tcp_address),
+                    (TransportType::new(10), "other_address"),
+                    (TCP, tcp_address)
+                ],
+            )
+            .await
+            .err();
+
+        assert_eq!(
+            result.unwrap().to_string(),
+            "only one TCP hop is allowed in a route"
+        );
+        ctx.stop().await
+    }
+
+    #[ockam_macros::test]
+    async fn test_resolve_route_with_dns_address(ctx: &mut Context) -> Result<()> {
+        let tcp = TcpTransport::create(ctx).await?;
+        let result = tcp
+            .resolve_route(
+                &FlowControls::default(),
+                route![(TCP, "www.google.com:80"),],
+            )
+            .await
+            .is_ok();
+
+        assert!(result);
+        ctx.stop().await
     }
 }


### PR DESCRIPTION
This fixes a connection issue with the `CredentialRetriever` where the route that is configured to retrieve credentials must be resolved to actual TCP workers when the route is accessed.

The `CredentialRetriever` is now configured with a route which has been resolved from the original multiaddr configuration.

However, instead of creating TCP workers during the multiaddr conversion, IP addresses are replaced with `TCP` transport addresses. Then, on credential retrieval, the TCP addresses are used to create a TCP connection and TCP addresses are replaced with the local workers addresses (what was done during multiaddr resolution before).

I went the extra-step of making this kind of resolution generic across transports so that resolving `UDP` addresses into local UDP workers should be easy to do in the future (whereas the current multiaddr resolution does not support UDP).


