### PR TITLE
refactor(rust): cli docs to handle fourth level markdown headers

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -27,11 +27,15 @@ use crate::util::output::Output;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts, Result};
 
-const HELP_DETAIL: &str = "";
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
 
 /// Enroll with Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[command(after_long_help = docs::after_help(HELP_DETAIL))]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct EnrollCommand {
     #[command(flatten)]
     pub cloud_opts: CloudOpts,

--- a/implementations/rust/ockam/ockam_command/src/enroll/static/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/enroll/static/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam enroll
+```

--- a/implementations/rust/ockam/ockam_command/src/enroll/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/enroll/static/long_about.txt
@@ -1,0 +1,3 @@
+When you run this command for the first time, it creates a space for you to host your projects, as well as a default project for you within this space.
+
+It also generates a unique cryptographically provable identity and saves the corresponding key in a vault. This identity is issued a membership credential that will be used to manage the resources in your project. Optionally, you can pass an existing identity.

--- a/implementations/rust/ockam/ockam_command/src/static/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/static/after_long_help.txt
@@ -15,7 +15,7 @@ $ ockam enroll
 You can also create encrypted relays outside the orchestrator.
 See `ockam forwarder --help`.
 
-Application Service:
+#### Application Service
 
 Next let's prepare the service side of our application.
 
@@ -35,7 +35,7 @@ $ ockam tcp-outlet create --at /node/blue --from /service/outlet --to 127.0.0.1:
 $ ockam relay create blue --at /project/default --to /node/blue
 ```
 
-Application Client:
+#### Application Client
 
 Now on the client side
 


### PR DESCRIPTION
- Terminal docs will show the header as underlined text; markdown docs will show them as `#### {header}`. An example of this can be seen in the output of the `ockam --help` command.
- Fix `ockam` docs and add documentation o `ockam enroll` command

