### PR TITLE
feat(rust): use async endpoints

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -45,6 +45,7 @@ impl From<ProjectLookup> for Project {
             confluent_config: None,
             version: None,
             running: None,
+            operation_id: None,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -66,6 +66,28 @@ impl ConfluentConfigResponse {
     }
 }
 
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DisableAddon<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))] pub tag: TypeTag<8677807>,
+
+    #[serde(borrow)]
+    #[cbor(b(1))] pub addon_id: CowStr<'a>,
+}
+
+impl<'a> DisableAddon<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(addon_id: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addon_id: addon_id.into(),
+        }
+    }
+}
+
 mod node {
     use minicbor::{Decode, Decoder, Encode};
     use tracing::trace;
@@ -74,7 +96,7 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::addon::ConfluentConfig;
+    use crate::cloud::addon::{ConfluentConfig, DisableAddon};
     use crate::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig};
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::error::ApiError;
@@ -173,15 +195,16 @@ mod node {
             ctx: &mut Context,
             dec: &mut Decoder<'_>,
             project_id: &str,
-            addon_id: &str,
         ) -> Result<Vec<u8>> {
-            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
-            let cloud_multiaddr = req_wrapper.multiaddr()?;
-
             let label = "disable_addon";
-            trace!(target: TARGET, project_id, addon_id, "disabling addon");
+            trace!(target: TARGET, project_id, "disabling addon");
 
-            let req_builder = Request::delete(format!("/v0/{project_id}/addons/{addon_id}"));
+            let req_wrapper: CloudRequestWrapper<DisableAddon> = dec.decode()?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
+            let req_body = req_wrapper.req;
+
+            let req_builder =
+                Request::post(format!("/v1/projects/{project_id}/disable_addon")).body(req_body);
 
             self.request_controller(
                 ctx,

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -67,8 +67,6 @@ impl ConfluentConfigResponse {
 }
 
 mod node {
-    use std::time::Duration;
-
     use minicbor::{Decode, Decoder, Encode};
     use tracing::trace;
 
@@ -78,9 +76,7 @@ mod node {
 
     use crate::cloud::addon::ConfluentConfig;
     use crate::cloud::project::{InfluxDBTokenLeaseManagerConfig, OktaConfig};
-    use crate::cloud::{
-        BareCloudRequestWrapper, CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT,
-    };
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::error::ApiError;
     use crate::nodes::NodeManagerWorker;
 
@@ -155,10 +151,12 @@ mod node {
             let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
 
-            let req_builder =
-                Request::put(format!("/v0/{project_id}/addons/{addon_id}")).body(req_body);
+            let req_builder = Request::post(format!(
+                "/v1/projects/{project_id}/configure_addon/{addon_id}"
+            ))
+            .body(req_body);
 
-            self.request_controller_with_timeout(
+            self.request_controller(
                 ctx,
                 label,
                 None,
@@ -166,7 +164,6 @@ mod node {
                 API_SERVICE,
                 req_builder,
                 None,
-                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -26,6 +26,9 @@ pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY
 /// A default timeout in seconds
 pub const ORCHESTRATOR_RESTART_TIMEOUT: u64 = 180;
 
+/// Total time in milliseconds to wait for Orchestrator long-running operations to complete
+pub const ORCHESTRATOR_AWAIT_TIMEOUT_MS: usize = 60 * 10 * 1000;
+
 pub type ProjectAddress = CowStr<'static>;
 
 /// A wrapper around a cloud request with extra fields.

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -11,6 +11,7 @@ use crate::error::ApiError;
 pub mod addon;
 pub mod enroll;
 pub mod lease_manager;
+pub mod operation;
 pub mod project;
 pub mod space;
 pub mod subscription;

--- a/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
@@ -1,0 +1,132 @@
+use minicbor::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use ockam_core::CowStr;
+#[cfg(feature = "tag")]
+use ockam_core::TypeTag;
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[cbor(map)]
+pub struct Operation<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))]
+    pub tag: TypeTag<2432199>,
+
+    #[cbor(b(1))]
+    #[serde(borrow)]
+    pub id: CowStr<'a>,
+
+    #[cbor(n(2))]
+    pub status: Status,
+}
+
+impl Clone for Operation<'_> {
+    fn clone(&self) -> Self {
+        self.to_owned()
+    }
+}
+
+impl Operation<'_> {
+    pub fn to_owned<'r>(&self) -> Operation<'r> {
+        Operation {
+            #[cfg(feature = "tag")]
+            tag: self.tag.to_owned(),
+            id: self.id.to_owned(),
+            status: self.status.clone(),
+        }
+    }
+
+    pub fn is_successful(&self) -> bool {
+        self.status == Status::Succeeded
+    }
+
+    pub fn is_failed(&self) -> bool {
+        self.status == Status::Failed
+    }
+
+    pub fn is_completed(&self) -> bool {
+        self.is_successful() || self.is_failed()
+    }
+}
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Default)]
+#[cbor(map)]
+pub struct CreateOperationResponse<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[cbor(n(0))]
+    pub tag: TypeTag<9056534>,
+
+    #[cbor(b(1))]
+    #[serde(borrow)]
+    pub operation_id: CowStr<'a>,
+}
+
+impl Clone for CreateOperationResponse<'_> {
+    fn clone(&self) -> Self {
+        self.to_owned()
+    }
+}
+
+impl CreateOperationResponse<'_> {
+    pub fn to_owned<'r>(&self) -> CreateOperationResponse<'r> {
+        CreateOperationResponse {
+            #[cfg(feature = "tag")]
+            tag: self.tag.to_owned(),
+            operation_id: self.operation_id.to_owned(),
+        }
+    }
+}
+
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[rustfmt::skip]
+#[cbor(index_only)]
+pub enum Status {
+    #[n(0)] Started,
+    #[n(1)] Succeeded,
+    #[n(2)] Failed,
+}
+
+mod node {
+    use minicbor::Decoder;
+    use tracing::trace;
+
+    use ockam_core::api::Request;
+    use ockam_core::{self, Result};
+    use ockam_node::Context;
+
+    use crate::cloud::BareCloudRequestWrapper;
+    use crate::nodes::NodeManagerWorker;
+
+    const TARGET: &str = "ockam_api::cloud::operation";
+    const API_SERVICE: &str = "projects";
+
+    impl NodeManagerWorker {
+        pub(crate) async fn get_operation(
+            &mut self,
+            ctx: &mut Context,
+            dec: &mut Decoder<'_>,
+            operation_id: &str,
+        ) -> Result<Vec<u8>> {
+            let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
+            let cloud_multiaddr = req_wrapper.multiaddr()?;
+
+            let label = "get_operation";
+            trace!(target: TARGET, operation_id, "getting operation");
+
+            let req_builder = Request::get(format!("/v1/operations/{operation_id}"));
+
+            self.request_controller(
+                ctx,
+                label,
+                None,
+                &cloud_multiaddr,
+                API_SERVICE,
+                req_builder,
+                None,
+            )
+            .await
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -65,6 +65,9 @@ pub struct Project {
 
     #[cbor(n(14))]
     pub running: Option<bool>,
+
+    #[cbor(n(15))]
+    pub operation_id: Option<String>,
 }
 
 impl Project {
@@ -258,8 +261,6 @@ impl<'a> CreateProject<'a> {
 }
 
 mod node {
-    use std::time::Duration;
-
     use minicbor::Decoder;
     use tracing::trace;
 
@@ -267,9 +268,7 @@ mod node {
     use ockam_core::{self, Result};
     use ockam_node::Context;
 
-    use crate::cloud::{
-        BareCloudRequestWrapper, CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT,
-    };
+    use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeManagerWorker;
 
     use super::*;
@@ -290,9 +289,10 @@ mod node {
             let label = "create_project";
             trace!(target: TARGET, %space_id, project_name = %req_body.name, "creating project");
 
-            let req_builder = Request::post(format!("/v0/{space_id}")).body(&req_body);
+            let req_builder =
+                Request::post(format!("/v1/spaces/{space_id}/projects")).body(&req_body);
 
-            self.request_controller_with_timeout(
+            self.request_controller(
                 ctx,
                 label,
                 "create_project",
@@ -300,7 +300,6 @@ mod node {
                 "projects",
                 req_builder,
                 req_wrapper.identity_name,
-                Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
             )
             .await
         }
@@ -415,6 +414,7 @@ mod tests {
                 confluent_config: None,
                 version: None,
                 running: None,
+                operation_id: None,
             })
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -799,11 +799,16 @@ impl NodeManagerWorker {
 
             // ==*== Addons ==*==
             (Get, [project_id, "addons"]) => self.list_addons(ctx, dec, project_id).await?,
-            (Put, [project_id, "addons", addon_id]) => {
+            (Post, ["v1", "projects", project_id, "configure_addon", addon_id]) => {
                 self.configure_addon(ctx, dec, project_id, addon_id).await?
             }
             (Delete, [project_id, "addons", addon_id]) => {
                 self.disable_addon(ctx, dec, project_id, addon_id).await?
+            }
+
+            // ==*== Operations ==*==
+            (Get, ["v1", "operations", operation_id]) => {
+                self.get_operation(ctx, dec, operation_id).await?
             }
 
             // ==*== Messages ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -771,7 +771,9 @@ impl NodeManagerWorker {
             (Delete, ["v0", "spaces", id]) => self.delete_space(ctx, dec, id).await?,
 
             // ==*== Projects ==*==
-            (Post, ["v0", "projects", space_id]) => self.create_project(ctx, dec, space_id).await?,
+            (Post, ["v1", "spaces", space_id, "projects"]) => {
+                self.create_project(ctx, dec, space_id).await?
+            }
             (Get, ["v0", "projects"]) => self.list_projects(ctx, dec).await?,
             (Get, ["v0", "projects", project_id]) => self.get_project(ctx, dec, project_id).await?,
             (Delete, ["v0", "projects", space_id, project_id]) => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -802,8 +802,8 @@ impl NodeManagerWorker {
             (Post, ["v1", "projects", project_id, "configure_addon", addon_id]) => {
                 self.configure_addon(ctx, dec, project_id, addon_id).await?
             }
-            (Delete, [project_id, "addons", addon_id]) => {
-                self.disable_addon(ctx, dec, project_id, addon_id).await?
+            (Post, ["v1", "projects", project_id, "disable_addon"]) => {
+                self.disable_addon(ctx, dec, project_id).await?
             }
 
             // ==*== Operations ==*==

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -23,6 +23,7 @@ mod manpages;
 mod markdown;
 mod message;
 mod node;
+mod operation;
 mod policy;
 mod project;
 mod relay;

--- a/implementations/rust/ockam/ockam_command/src/operation/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/mod.rs
@@ -1,0 +1,1 @@
+pub mod util;

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -20,7 +20,7 @@ pub async fn check_for_completion<'a>(
 
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {
-        spinner.set_message("Configuring project (this can take a few minutes)...");
+        spinner.set_message("Configuring project...");
     }
 
     let operation = Retry::spawn(retry_strategy.clone(), || async {

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -20,7 +20,7 @@ pub async fn check_for_completion<'a>(
 
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {
-        spinner.set_message("Configuring project (this can take a few minutes) ...");
+        spinner.set_message("Configuring project (this can take a few minutes)...");
     }
 
     let operation = Retry::spawn(retry_strategy.clone(), || async {

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -1,0 +1,54 @@
+use anyhow::anyhow;
+use tokio_retry::strategy::FixedInterval;
+use tokio_retry::Retry;
+
+use ockam_api::cloud::operation::Operation;
+
+use crate::util::api::CloudOpts;
+use crate::util::{api, RpcBuilder};
+use crate::{CommandGlobalOpts, Result};
+
+pub async fn check_for_completion<'a>(
+    ctx: &ockam::Context,
+    opts: &CommandGlobalOpts,
+    cloud_opts: &CloudOpts,
+    api_node: &str,
+    operation_id: &str,
+) -> Result<()> {
+    let total_sleep_time_ms = 10 * 60 * 1000;
+    let retry_strategy = FixedInterval::from_millis(5000).take(total_sleep_time_ms / 5000);
+
+    let spinner_option = opts.terminal.progress_spinner();
+    if let Some(spinner) = spinner_option.as_ref() {
+        spinner.set_message("Configuring project (this can take a few minutes) ...");
+    }
+
+    let operation = Retry::spawn(retry_strategy.clone(), || async {
+        let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
+
+        // Handle the operation show request result
+        // so we can provide better errors in the case orchestrator does not respond timely
+        if rpc
+            .request(api::operation::show(operation_id, &cloud_opts.route()))
+            .await
+            .is_ok()
+        {
+            let operation = rpc.parse_response::<Operation>()?;
+            if operation.is_completed() {
+                return Ok(operation.to_owned());
+            }
+        }
+        Err(anyhow!("Operation timed out. Please try again."))
+    })
+    .await?;
+
+    if let Some(spinner) = spinner_option.as_ref() {
+        spinner.finish_and_clear();
+    }
+
+    if operation.is_successful() {
+        Ok(())
+    } else {
+        Err(anyhow!("Operation failed. Please try again.").into())
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -3,6 +3,7 @@ use tokio_retry::strategy::FixedInterval;
 use tokio_retry::Retry;
 
 use ockam_api::cloud::operation::Operation;
+use ockam_api::cloud::ORCHESTRATOR_AWAIT_TIMEOUT_MS;
 
 use crate::util::api::CloudOpts;
 use crate::util::{api, RpcBuilder};
@@ -15,8 +16,8 @@ pub async fn check_for_completion<'a>(
     api_node: &str,
     operation_id: &str,
 ) -> Result<()> {
-    let total_sleep_time_ms = 10 * 60 * 1000;
-    let retry_strategy = FixedInterval::from_millis(5000).take(total_sleep_time_ms / 5000);
+    let retry_strategy =
+        FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
 
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -86,8 +86,6 @@ async fn run_impl(
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
-    println!("Confluent addon enabled");
-
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -1,5 +1,6 @@
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
+use colorful::Colorful;
 
 use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -17,7 +18,7 @@ use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 
 use crate::util::{api, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, fmt_ok, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/configure_confluent/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/configure_confluent/after_long_help.txt");
@@ -95,7 +96,8 @@ async fn run_impl(
     let project: Project = rpc.parse_response()?;
     check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
 
-    println!("Confluent addon configured successfully");
+    opts.terminal
+        .write_line(&fmt_ok!("Confluent addon configured successfully"))?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -187,11 +187,8 @@ async fn run_impl(
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
-    println!("InfluxDB addon enabled");
-
     // Wait until project is ready again
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
-    println!();
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let mut rpc = rpc.clone();
@@ -201,6 +198,7 @@ async fn run_impl(
     check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
 
     println!("InfluxDB addon configured successfully");
+
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
+use colorful::Colorful;
 
 use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -20,7 +21,7 @@ use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 
 use crate::util::{api, exitcode, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, fmt_ok, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/configure_influxdb/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/configure_influxdb/after_long_help.txt");
@@ -197,7 +198,8 @@ async fn run_impl(
     let project: Project = rpc.parse_response()?;
     check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
 
-    println!("InfluxDB addon configured successfully");
+    opts.terminal
+        .write_line(&fmt_ok!("InfluxDB addon configured successfully"))?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -7,13 +7,15 @@ use clap::Args;
 use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
+use ockam_api::cloud::operation::CreateOperationResponse;
 use ockam_api::cloud::project::{InfluxDBTokenLeaseManagerConfig, Project};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
 use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
-use crate::project::addon::base_endpoint;
+use crate::operation::util::check_for_completion;
+use crate::project::addon::configure_addon_endpoint;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 
@@ -172,40 +174,31 @@ async fn run_impl(
     let add_on_id = "influxdb_token_lease_manager";
     let endpoint = format!(
         "{}/{}",
-        base_endpoint(&opts.state, &project_name)?,
+        configure_addon_endpoint(&opts.state, &project_name)?,
         add_on_id
     );
-    let req = Request::put(endpoint).body(CloudRequestWrapper::new(
+    let req = Request::post(endpoint).body(CloudRequestWrapper::new(
         body,
         controller_route,
         None::<CowStr>,
     ));
 
     rpc.request(req).await?;
-    rpc.is_ok()?;
+    let res = rpc.parse_response::<CreateOperationResponse>()?;
+    let operation_id = res.operation_id;
+
     println!("InfluxDB addon enabled");
 
     // Wait until project is ready again
-    println!("Reconfiguring project (this can take a few minutes) ...");
-    tokio::time::sleep(std::time::Duration::from_secs(45)).await;
+    check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
+    let mut rpc = rpc.clone();
+    rpc.request(api::project::show(&project_id, controller_route))
+        .await?;
+    let project: Project = rpc.parse_response()?;
+    check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
 
-    // Give the sever ~20 seconds
-    // in intervals of 5s for the project to be available.
-    for _ in 0..4 {
-        rpc.request(api::project::show(&project_id, controller_route))
-            .await?;
-        let project: Project = match rpc.parse_response() {
-            Ok(p) => p,
-            Err(_) => {
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                continue;
-            }
-        };
-
-        check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
-    }
     println!("InfluxDB addon configured successfully");
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -191,6 +191,7 @@ async fn run_impl(
 
     // Wait until project is ready again
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
+    println!();
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let mut rpc = rpc.clone();

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
+use colorful::Colorful;
 use reqwest::Url;
 use rustls::{Certificate, ClientConfig, ClientConnection, Connection, RootCertStore, Stream};
 
@@ -25,7 +26,7 @@ use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 
 use crate::util::{api, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, fmt_ok, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/configure_influxdb/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/configure_influxdb/after_long_help.txt");
@@ -147,7 +148,8 @@ async fn run_impl(
     let project: Project = rpc.parse_response()?;
     check_project_readiness(&ctx, &opts, &cloud_opts, rpc.node_name(), None, project).await?;
 
-    println!("Okta addon configured successfully");
+    opts.terminal
+        .write_line(&fmt_ok!("Okta addon configured successfully"))?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -139,10 +139,7 @@ async fn run_impl(
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
-    println!("Okta addon enabled");
-
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
-    println!();
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     rpc.request(api::project::show(&project_id, controller_route))

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -142,6 +142,7 @@ async fn run_impl(
     println!("Okta addon enabled");
 
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
+    println!();
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     rpc.request(api::project::show(&project_id, controller_route))

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -1,5 +1,6 @@
 use clap::builder::NonEmptyStringValueParser;
 use clap::Args;
+use colorful::Colorful;
 
 use ockam::Context;
 
@@ -16,7 +17,7 @@ use crate::project::addon::disable_addon_endpoint;
 use crate::util::api::CloudOpts;
 
 use crate::util::{node_rpc, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use crate::{fmt_ok, CommandGlobalOpts, Result};
 
 /// Disable an addon for a project
 #[derive(Clone, Debug, Args)]
@@ -71,7 +72,8 @@ async fn run_impl(
 
     check_for_completion(&ctx, &opts, &cloud_opts, rpc.node_name(), &operation_id).await?;
 
-    println!("Addon disabled successfully");
+    opts.terminal
+        .write_line(&fmt_ok!("Addon disabled successfully"))?;
 
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -109,3 +109,16 @@ pub fn base_endpoint(cli_state: &CliState, project_name: &str) -> Result<String>
         .clone();
     Ok(format!("{project_id}/addons"))
 }
+
+pub fn configure_addon_endpoint(cli_state: &CliState, project_name: &str) -> Result<String> {
+    let project_id = cli_state
+        .projects
+        .get(project_name)
+        .context(format!(
+            "Failed to get project {project_name} from config lookup"
+        ))?
+        .config()
+        .id
+        .clone();
+    Ok(format!("v1/projects/{project_id}/configure_addon"))
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -122,3 +122,16 @@ pub fn configure_addon_endpoint(cli_state: &CliState, project_name: &str) -> Res
         .clone();
     Ok(format!("v1/projects/{project_id}/configure_addon"))
 }
+
+pub fn disable_addon_endpoint(cli_state: &CliState, project_name: &str) -> Result<String> {
+    let project_id = cli_state
+        .projects
+        .get(project_name)
+        .context(format!(
+            "Failed to get project {project_name} from config lookup"
+        ))?
+        .config()
+        .id
+        .clone();
+    Ok(format!("v1/projects/{project_id}/disable_addon"))
+}

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -1,7 +1,4 @@
-use std::time::Duration;
-
 use clap::Args;
-use ockam_api::cloud::ORCHESTRATOR_RESTART_TIMEOUT;
 use rand::prelude::random;
 
 use ockam::Context;
@@ -9,6 +6,7 @@ use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::cloud::project::Project;
 
 use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::operation::util::check_for_completion;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 use crate::util::{api, node_rpc, RpcBuilder};
@@ -62,12 +60,15 @@ async fn run_impl(
     let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
     let node_name = start_embedded_node(ctx, &opts, None).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
-    rpc.request_with_timeout(
-        api::project::create(&cmd.project_name, &space_id, &cmd.cloud_opts.route()),
-        Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
-    )
+    rpc.request(api::project::create(
+        &cmd.project_name,
+        &space_id,
+        &cmd.cloud_opts.route(),
+    ))
     .await?;
     let project = rpc.parse_response::<Project>()?;
+    let operation_id = project.operation_id.clone().unwrap();
+    check_for_completion(ctx, &opts, &cmd.cloud_opts, rpc.node_name(), &operation_id).await?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
     opts.state.projects.create(&project.name, project.clone())?;

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -180,6 +180,7 @@ pub async fn check_project_readiness(
     opts.state
         .projects
         .overwrite(&project.name, project.clone())?;
+
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {
         spinner.set_message("Waiting for project to be ready...");
@@ -209,7 +210,7 @@ pub async fn check_project_readiness(
         .await?;
     }
 
-    {
+        {
         if let Some(spinner) = spinner_option.as_ref() {
             spinner.set_message("Establishing connection to the project...");
         }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -210,7 +210,7 @@ pub async fn check_project_readiness(
         .await?;
     }
 
-        {
+    {
         if let Some(spinner) = spinner_option.as_ref() {
             spinner.set_message("Establishing connection to the project...");
         }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -9,6 +9,7 @@ use ockam::identity::IdentityIdentifier;
 use ockam::TcpTransport;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::cloud::project::Project;
+use ockam_api::cloud::ORCHESTRATOR_AWAIT_TIMEOUT_MS;
 use ockam_api::config::lookup::{LookupMeta, ProjectAuthority};
 use ockam_api::multiaddr_to_addr;
 use ockam_api::nodes::models::{self, secure_channel::*};
@@ -173,8 +174,8 @@ pub async fn check_project_readiness(
     mut project: Project,
 ) -> Result<Project> {
     // Total of 10 Mins sleep strategy with 5 second intervals between each retry
-    let total_sleep_time_ms = 10 * 60 * 1000;
-    let retry_strategy = FixedInterval::from_millis(5000).take(total_sleep_time_ms / 5000);
+    let retry_strategy =
+        FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
 
     // Persist project config prior to checking readiness which might take a while
     opts.state

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -331,6 +331,18 @@ pub(crate) mod project {
     }
 }
 
+/// Helpers to create operations API requests
+pub(crate) mod operation {
+    use super::*;
+
+    pub(crate) fn show<'a>(
+        id: &str,
+        cloud_route: &'a MultiAddr,
+    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        Request::get(format!("v1/operations/{id}")).body(CloudRequestWrapper::bare(cloud_route))
+    }
+}
+
 ////////////// !== parsers
 
 pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Result<Response> {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -303,7 +303,7 @@ pub(crate) mod project {
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
         let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
-        Request::post(format!("v0/projects/{space_id}")).body(CloudRequestWrapper::new(
+        Request::post(format!("v1/spaces/{space_id}/projects")).body(CloudRequestWrapper::new(
             b,
             cloud_route,
             None::<CowStr>,


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Creating projects:
- we're creating a project and then checking if it's ready by looking at access routes

Enabling addons:
- we're making a call to configure addon and waiting 45 seconds for the project to get configured

Disabling addons:
- we're making a call to disable addon and not wait for project to get reconfigured

## Proposed changes
Call async endpoints that will immediately return a response with long running operation id.
After that we can poll on a GET operation endpoint awaiting for the successful status indicating that the project is ready.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
