### PR TITLE
fix: make install.sh continue to the next rcfile when adding to path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -271,7 +271,7 @@ add_to_path() {
     local _contents
     _contents=$(cat "$_rcpath")
     if [[ "$_contents" == *"$_source_cmd"* ]]; then
-      break
+      continue
     fi
 
     info "Adding source command to $_rcpath"


### PR DESCRIPTION
This makes install.sh continue to the next rcfile even if one of them is already sourcing the ockam env file.

I noticed that if my ~/.profile file had the entry, it would not add it to ~/.zshenv even though that didn't have the entry. 

This PR fixes that.
