### PR TITLE
fix(rust): flow control fixes

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
@@ -3,7 +3,7 @@ use tracing::trace;
 
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::FlowControls;
-use ockam_core::{Address, AllowAll, Any, Error, Route, Routed, Worker};
+use ockam_core::{route, Address, AllowAll, Any, Error, Route, Routed, Worker};
 use ockam_node::Context;
 
 use crate::kafka::inlet_controller::KafkaInletController;
@@ -55,6 +55,8 @@ impl Worker for KafkaPortalListener {
             ));
         }
 
+        let inlet_responder_address = message.return_route().next().cloned()?;
+
         let worker_address = KafkaPortalWorker::start_kafka_portal(
             context,
             self.secure_channel_controller.clone(),
@@ -62,6 +64,7 @@ impl Worker for KafkaPortalListener {
             self.inlet_controller.clone(),
             None,
             Some(&(self.flow_controls.clone(), flow_control_id)),
+            route![inlet_responder_address],
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/mod.rs
@@ -236,15 +236,6 @@ impl ConnectionInstanceBuilder {
                     }
 
                     if changes.flow_control_id.is_some() {
-                        if self.flow_control_id.is_some()
-                            && self.flow_control_id != changes.flow_control_id
-                        {
-                            return Err(ockam_core::Error::new(
-                                Origin::Transport,
-                                Kind::Unsupported,
-                                "multiple flow controls created in a `MultiAddr`",
-                            ));
-                        }
                         self.flow_control_id = changes.flow_control_id;
                     }
                     self.transport_route = self.recalculate_transport_route()?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -54,10 +54,6 @@ impl Instantiator for ProjectInstantiator {
         let (_before, project_piece, after) =
             ConnectionInstanceBuilder::extract(&builder.current_multiaddr, match_start, 1);
 
-        if builder.flow_control_id.is_some() {
-            return Err(ApiError::message("invalid multiple TCP hops"));
-        }
-
         let project_protocol_value = project_piece
             .first()
             .ok_or_else(|| ApiError::message("missing project protocol in multiaddr"))?;
@@ -87,7 +83,6 @@ impl Instantiator for ProjectInstantiator {
                 self.identity_name.clone(),
                 &self.context,
                 self.credential_name.clone(),
-                tcp.flow_control_id,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
@@ -69,7 +69,6 @@ impl Instantiator for SecureChannelInstantiator {
                 None,
                 &self.context,
                 None,
-                builder.flow_control_id.clone(),
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -40,7 +40,6 @@ impl NodeManager {
         sc_route: Route,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
         timeout: Option<Duration>,
-        flow_control_id: Option<FlowControlId>,
     ) -> Result<(Address, FlowControlId)> {
         // If channel was already created, do nothing.
         if let Some(channel) = self.registry.secure_channels.get_by_route(&sc_route) {
@@ -54,8 +53,7 @@ impl NodeManager {
 
         debug!(%sc_route, "Creating secure channel");
         let timeout = timeout.unwrap_or(Duration::from_secs(120));
-        let sc_flow_control_id =
-            flow_control_id.unwrap_or_else(|| self.flow_controls.generate_id());
+        let sc_flow_control_id = self.flow_controls.generate_id();
         let options = SecureChannelOptions::as_producer(&self.flow_controls, &sc_flow_control_id);
 
         // Just add ourself as consumer for the next hop if it's a producer
@@ -100,7 +98,6 @@ impl NodeManager {
         identity_name: Option<String>,
         ctx: &Context,
         credential_name: Option<String>,
-        flow_control_id: Option<FlowControlId>,
     ) -> Result<(Address, FlowControlId)> {
         let identity = self.get_identity(None, identity_name.clone()).await?;
         let provided_credential = if let Some(credential_name) = credential_name {
@@ -122,7 +119,6 @@ impl NodeManager {
                 sc_route,
                 authorized_identifiers,
                 timeout,
-                flow_control_id,
             )
             .await?;
 
@@ -440,7 +436,6 @@ impl NodeManagerWorker {
                 identity.map(|i| i.to_string()),
                 ctx,
                 credential_name.map(|c| c.to_string()),
-                None,
             )
             .await?;
 


### PR DESCRIPTION
    Avoid sharing the same flow control id which must be regenerated to provide proper isolation.
    Fixes missing validation of kafka worker onward route.