### PR TITLE
docs(rust): fix `cargo doc` warnings

### DIFF
--- a/implementations/rust/ockam/ockam/src/remote/options.rs
+++ b/implementations/rust/ockam/ockam/src/remote/options.rs
@@ -5,7 +5,7 @@ use ockam_core::flow_control::{
 };
 use ockam_core::{Address, AllowAll, OutgoingAccessControl};
 
-/// Trust options for [`RemoteForwarder`]
+/// Trust options for [`RemoteForwarder`](super::RemoteForwarder)
 pub struct RemoteForwarderOptions {
     pub(super) flow_controls: Option<FlowControls>,
 }
@@ -27,6 +27,8 @@ impl RemoteForwarderOptions {
     /// context, it's just a Message Routing helper. Therefore, workers that are allowed to receive
     /// messages from the corresponding Secure Channel should as well be allowed to receive messages
     /// through the [`RemoteForwarder`] through the same Secure Channel.
+    ///
+    /// [`RemoteForwarder`]: super::RemoteForwarder
     pub fn as_consumer_and_producer(flow_controls: &FlowControls) -> Self {
         Self {
             flow_controls: Some(flow_controls.clone()),

--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -3,12 +3,12 @@
 //!
 //! When importing from the standard library:
 //!
-//!   1. always prefer core::<mod> over std::<mod> where it's
-//!      available. (e.g. std::fmt::Result -> core::fmt::Result)
-//!   2. use ockam_core::compat::<mod> equivalents where
-//!      possible. (e.g. std::sync::Arc -> ockam_core::compat::sync::Arc)
+//!   1. always prefer `core::<mod>` over `std::<mod>` where it's
+//!      available. (e.g. `std::fmt::Result` -> `core::fmt::Result`)
+//!   2. use `ockam_core::compat::<mod>` equivalents where
+//!      possible. (e.g. `std::sync::Arc` -> `ockam_core::compat::sync::Arc`)
 //!   3. if you need to add new items to compat, follow the originating
-//!      namespace. (e.g. compat::vec::Vec and not compat::Vec)
+//!      namespace. (e.g. `compat::vec::Vec` and not `compat::Vec`)
 
 /// Provides `std::borrow` for `alloc` targets.
 #[cfg(feature = "alloc")]

--- a/implementations/rust/ockam/ockam_core/src/env.rs
+++ b/implementations/rust/ockam/ockam_core/src/env.rs
@@ -11,13 +11,13 @@ use std::env::VarError;
 #[cfg(feature = "std")]
 use std::path::PathBuf;
 
-/// Get environmental value [var_name]. If value is not found returns Ok(None)
+/// Get environmental value `var_name`. If value is not found returns Ok(None)
 #[cfg(feature = "std")]
 pub fn get_env<T: FromString>(var_name: &str) -> Result<Option<T>> {
     get_env_impl::<Option<T>>(var_name, None)
 }
 
-/// Get environmental value [var_name]. If value is not found returns [default_value]
+/// Get environmental value `var_name`. If value is not found returns `default_value`
 #[cfg(feature = "std")]
 pub fn get_env_with_default<T: FromString>(var_name: &str, default_value: T) -> Result<T> {
     get_env_impl::<T>(var_name, default_value)

--- a/implementations/rust/ockam/ockam_core/src/flow_control/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/mod.rs
@@ -14,7 +14,7 @@
 //!     Secure Channel Listener is an example of Spawner that spawns both Producers and Consumers.
 //!
 //! Each Flow Control is identified by a unique random [`FlowControlId`].
-//! Producers, Consumers and Spawners are identified by their messaging [`Address`].
+//! Producers, Consumers and Spawners are identified by their messaging [`Address`](crate::Address).
 //! [`FlowControls`] object is used to store all Flow Control-related data, as well as setup interactions
 //! between Producers, Consumers and Spawners.
 

--- a/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
@@ -5,7 +5,7 @@ use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 
 /// A `Mailbox` controls the dispatch of incoming messages for a particular [`Address`]
-/// Note that [`Worker`], [`Processor`] and `Context` may have multiple Mailboxes (with different
+/// Note that [`Worker`](crate::Worker), [`Processor`](crate::Processor) and `Context` may have multiple Mailboxes (with different
 /// addresses), but they always have exactly one mpsc receiver (message queue)
 #[derive(Clone)]
 pub struct Mailbox {
@@ -83,7 +83,7 @@ impl Mailbox {
     }
 }
 
-/// A collection of [`Mailbox`]es for a specific [`Worker`], [`Processor`] or `Context`
+/// A collection of [`Mailbox`]es for a specific [`Worker`](crate::Worker), [`Processor`](crate::Processor) or `Context`
 #[derive(Clone)]
 pub struct Mailboxes {
     main_mailbox: Mailbox,

--- a/implementations/rust/ockam/ockam_core/src/routing/transport_type.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/transport_type.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug, Display};
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-/// The transport type of an [`Address`].
+/// The transport type of an [`Address`](crate::Address).
 #[derive(
     Serialize, Deserialize, Decode, Encode, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]

--- a/implementations/rust/ockam/ockam_identity/src/credential/credential_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/credential_builder.rs
@@ -14,7 +14,7 @@ use crate::identity::IdentityIdentifier;
 #[cfg(feature = "tag")]
 use crate::TypeTag;
 
-/// Convenience structure to create [`Credential`]s.
+/// Convenience structure to create [`Credential`](crate::Credential)s.
 pub struct CredentialBuilder {
     pub(crate) schema: Option<SchemaId>,
     pub(crate) attrs: Attributes,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change/change_identifier.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change/change_identifier.rs
@@ -2,7 +2,7 @@ use core::fmt::{Display, Formatter};
 use ockam_core::compat::string::String;
 use serde::{Deserialize, Serialize};
 
-/// Unique [`crate::change::IdentityChange`] identifier, computed as SHA256 of the change data
+/// Unique [`IdentityChange`](crate::IdentityChange) identifier, computed as SHA256 of the change data
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ChangeIdentifier([u8; 32]);
 

--- a/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
@@ -1,10 +1,12 @@
+use core::sync::atomic::Ordering;
+use core::time::Duration;
+
+use ockam_core::{Message, RelayMessage, Result, Routed};
+
 use crate::debugger;
 use crate::tokio::time::timeout;
 use crate::{error::*, parser};
 use crate::{Context, DEFAULT_TIMEOUT};
-use core::sync::atomic::Ordering;
-use core::time::Duration;
-use ockam_core::{Message, RelayMessage, Result, Routed};
 
 pub(super) enum MessageWait {
     Timeout(Duration),
@@ -115,9 +117,9 @@ impl Context {
     ///
     /// This function may return a `Err(FailedLoadData)` if the
     /// underlying worker was shut down, or `Err(Timeout)` if the call
-    /// was waiting for longer than the `default timeout`.  Use
-    /// [`receive_timeout`](Context::receive_timeout) to adjust the
-    /// timeout period.
+    /// was waiting for longer than the `default timeout`.
+    ///
+    /// Use [`receive_extended()`](Self::receive_extended) to use a specific timeout period.
     ///
     /// Will return `None` if the corresponding worker has been
     /// stopped, or the underlying Node has shut down.

--- a/implementations/rust/ockam/ockam_transport_tcp/src/options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/options.rs
@@ -17,7 +17,7 @@ pub struct TcpConnectionOptions {
 
 impl TcpConnectionOptions {
     /// This constructor is insecure, because outgoing messages from such connections will not be
-    /// restricted and can reach any [`Address`] on this node.
+    /// restricted and can reach any [`Address`](ockam_core::Address) on this node.
     /// Should only be used for testing purposes
     pub fn insecure() -> Self {
         Self {
@@ -26,7 +26,7 @@ impl TcpConnectionOptions {
     }
 
     /// This constructor is insecure, because outgoing messages from such connection will not be
-    /// restricted and can reach any [`Address`] on this node.
+    /// restricted and can reach any [`Address`](ockam_core::Address) on this node.
     /// Should only be used for testing purposes
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
@@ -79,7 +79,7 @@ pub struct TcpListenerOptions {
 
 impl TcpListenerOptions {
     /// This constructor is insecure, because outgoing messages from such connections will not be
-    /// restricted and can reach any [`Address`] on this node.
+    /// restricted and can reach any [`Address`](ockam_core::Address) on this node.
     /// Should only be used for testing purposes
     pub fn insecure() -> Self {
         Self {
@@ -88,7 +88,7 @@ impl TcpListenerOptions {
     }
 
     /// This constructor is insecure, because outgoing messages from such connections will not be
-    /// restricted and can reach any [`Address`] on this node.
+    /// restricted and can reach any [`Address`](ockam_core::Address) on this node.
     /// Should only be used for testing purposes
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {


### PR DESCRIPTION
## Current behavior

Warnings are issued by `cargo doc`.

<details>
<summary>Warnings...</summary>

```shell
warning: output filename collision.
The lib target `webpki` in package `webpki v0.22.0` has the same output filename as the lib target `webpki` in package `rustls-webpki v0.100.1`.
Colliding filename is: /Users/neil/dev/ockam/target/doc/webpki/index.html
The targets should have unique names.
This is a known bug where multiple crates with the same name use
the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: unresolved link to `Address`
  --> implementations/rust/ockam/ockam_core/src/flow_control/mod.rs:17:75
   |
17 | //! Producers, Consumers and Spawners are identified by their messaging [`Address`].
   |                                                                           ^^^^^^^ no item named `Address` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `var_name`
  --> implementations/rust/ockam/ockam_core/src/env.rs:14:30
   |
14 | /// Get environmental value [var_name]. If value is not found returns Ok(None)
   |                              ^^^^^^^^ no item named `var_name` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `var_name`
  --> implementations/rust/ockam/ockam_core/src/env.rs:20:30
   |
20 | /// Get environmental value [var_name]. If value is not found returns [default_value]
   |                              ^^^^^^^^ no item named `var_name` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `default_value`
  --> implementations/rust/ockam/ockam_core/src/env.rs:20:72
   |
20 | /// Get environmental value [var_name]. If value is not found returns [default_value]
   |                                                                        ^^^^^^^^^^^^^ no item named `default_value` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Worker`
 --> implementations/rust/ockam/ockam_core/src/routing/mailbox.rs:8:17
  |
8 | /// Note that [`Worker`], [`Processor`] and `Context` may have multiple Mailboxes (with different
  |                 ^^^^^^ no item named `Worker` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Processor`
 --> implementations/rust/ockam/ockam_core/src/routing/mailbox.rs:8:29
  |
8 | /// Note that [`Worker`], [`Processor`] and `Context` may have multiple Mailboxes (with different
  |                             ^^^^^^^^^ no item named `Processor` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Worker`
  --> implementations/rust/ockam/ockam_core/src/routing/mailbox.rs:86:52
   |
86 | /// A collection of [`Mailbox`]es for a specific [`Worker`], [`Processor`] or `Context`
   |                                                    ^^^^^^ no item named `Worker` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Processor`
  --> implementations/rust/ockam/ockam_core/src/routing/mailbox.rs:86:64
   |
86 | /// A collection of [`Mailbox`]es for a specific [`Worker`], [`Processor`] or `Context`
   |                                                                ^^^^^^^^^ no item named `Processor` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Address`
 --> implementations/rust/ockam/ockam_core/src/routing/transport_type.rs:5:32
  |
5 | /// The transport type of an [`Address`].
  |                                ^^^^^^^ no item named `Address` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unclosed HTML tag `mod`
 --> implementations/rust/ockam/ockam_core/src/compat.rs:6:30
  |
6 | //!   1. always prefer core::<mod> over std::<mod> where it's
  |                              ^^^^^
  |
  = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
help: try marking as source code
  |
6 | //!   1. always prefer `core::<mod>` over std::<mod> where it's
  |                        +           +

warning: unclosed HTML tag `mod`
 --> implementations/rust/ockam/ockam_core/src/compat.rs:6:46
  |
6 | //!   1. always prefer core::<mod> over std::<mod> where it's
  |                                              ^^^^^
  |
help: try marking as source code
  |
6 | //!   1. always prefer core::<mod> over `std::<mod>` where it's
  |                                         +          +

warning: unclosed HTML tag `mod`
 --> implementations/rust/ockam/ockam_core/src/compat.rs:8:34
  |
8 | //!   2. use ockam_core::compat::<mod> equivalents where
  |                                  ^^^^^
  |
help: try marking as source code
  |
8 | //!   2. use `ockam_core::compat::<mod>` equivalents where
  |              +                         +

warning: `ockam_core` (lib doc) generated 12 warnings
warning: unresolved link to `Context::receive_timeout`
   --> implementations/rust/ockam/ockam_node/src/context/receive_message.rs:119:29
    |
119 |     /// [`receive_timeout`](Context::receive_timeout) to adjust the
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^ the struct `Context` has no field or associated item named `receive_timeout`
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `ockam_node` (lib doc) generated 1 warning
warning: unresolved link to `Credential`
  --> implementations/rust/ockam/ockam_identity/src/credential/credential_builder.rs:17:39
   |
17 | /// Convenience structure to create [`Credential`]s.
   |                                       ^^^^^^^^^^ no item named `Credential` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `crate::change::IdentityChange`
 --> implementations/rust/ockam/ockam_identity/src/identity/identity_change/change_identifier.rs:5:14
  |
5 | /// Unique [`crate::change::IdentityChange`] identifier, computed as SHA256 of the change data
  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `change` in module `ockam_identity`

warning: `ockam_identity` (lib doc) generated 2 warnings
warning: unresolved link to `Address`
  --> implementations/rust/ockam/ockam_transport_tcp/src/options.rs:20:40
   |
20 |     /// restricted and can reach any [`Address`] on this node.
   |                                        ^^^^^^^ no item named `Address` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `Address`
  --> implementations/rust/ockam/ockam_transport_tcp/src/options.rs:29:40
   |
29 |     /// restricted and can reach any [`Address`] on this node.
   |                                        ^^^^^^^ no item named `Address` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Address`
  --> implementations/rust/ockam/ockam_transport_tcp/src/options.rs:82:40
   |
82 |     /// restricted and can reach any [`Address`] on this node.
   |                                        ^^^^^^^ no item named `Address` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `Address`
  --> implementations/rust/ockam/ockam_transport_tcp/src/options.rs:91:40
   |
91 |     /// restricted and can reach any [`Address`] on this node.
   |                                        ^^^^^^^ no item named `Address` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `ockam_transport_tcp` (lib doc) generated 4 warnings
warning: unresolved link to `RemoteForwarder`
 --> implementations/rust/ockam/ockam/src/remote/options.rs:8:25
  |
8 | /// Trust options for [`RemoteForwarder`]
  |                         ^^^^^^^^^^^^^^^ no item named `RemoteForwarder` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: unresolved link to `RemoteForwarder`
  --> implementations/rust/ockam/ockam/src/remote/options.rs:24:21
   |
24 |     /// Mark this [`RemoteForwarder`] as a Producer and Consumer for a given [`FlowControlId`]
   |                     ^^^^^^^^^^^^^^^ no item named `RemoteForwarder` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `RemoteForwarder`
  --> implementations/rust/ockam/ockam/src/remote/options.rs:26:54
   |
26 |     /// forwarder (probably Secure Channel), since [`RemoteForwarder`] doesn't imply any new "trust"
   |                                                      ^^^^^^^^^^^^^^^ no item named `RemoteForwarder` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `RemoteForwarder`
  --> implementations/rust/ockam/ockam/src/remote/options.rs:29:23
   |
29 |     /// through the [`RemoteForwarder`] through the same Secure Channel.
   |                       ^^^^^^^^^^^^^^^ no item named `RemoteForwarder` in scope
   |
   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `ockam` (lib doc) generated 4 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.56s

```

</details>

## Proposed changes

Fix `cargo doc` warnings.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.
