### PR TITLE
Fix links and missing sections in READMEs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8

--- a/.github/actions/cargo_home_cache/action.yml
+++ b/.github/actions/cargo_home_cache/action.yml
@@ -10,6 +10,6 @@ runs:
           /usr/rust/cargo/registry/index
           /usr/rust/cargo/registry/cache
           /usr/rust/cargo/git/db
-        key: cache-cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+        key: cache-cargo-home-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
 
 # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -8,7 +8,7 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: target
-        key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('./rustc_version.txt') }}
-        restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c-
+        key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('./rustc_version.txt') }}
+        restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8-
 
 # https://doc.rust-lang.org/cargo/guide/build-cache.html

--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -7,6 +7,6 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: '**/deps'
-        key: cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c-${{ hashFiles('**/mix.lock') }}
+        key: cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c-
+          cache-elixir-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8-

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -6,9 +6,9 @@ runs:
     - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
       with:
         path: /root/.gradle/wrapper/dists
-        key: cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+        key: cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
         restore-keys: |
-          cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+          cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
           cache-gradle-${{ github.workflow }}-${{ github.job }}-
           cache-gradle-${{ github.workflow }}-
           cache-gradle-

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -60,7 +60,7 @@ jobs:
     name: Elixir - lint_ockam_vault_software
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -73,7 +73,7 @@ jobs:
     name: Elixir - lint_ockam
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -86,7 +86,7 @@ jobs:
     name: Elixir - lint_ockam_kafka
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -99,7 +99,7 @@ jobs:
     name: Elixir - lint_ockam_services
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -112,7 +112,7 @@ jobs:
     name: Elixir - lint_ockam_metrics
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -125,7 +125,7 @@ jobs:
     name: Elixir - lint_ockam_healthcheck
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -138,7 +138,7 @@ jobs:
     name: Elixir - lint_ockam_cloud_node
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -151,7 +151,7 @@ jobs:
     name: Elixir - build_ockam_vault_software
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -164,7 +164,7 @@ jobs:
     name: Elixir - build_ockam
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -177,7 +177,7 @@ jobs:
     name: Elixir - build_ockam_kafka
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -190,7 +190,7 @@ jobs:
     name: Elixir - build_ockam_services
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -203,7 +203,7 @@ jobs:
     name: Elixir - build_ockam_metrics
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -216,7 +216,7 @@ jobs:
     name: Elixir - build_ockam_healthcheck
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -229,7 +229,7 @@ jobs:
     name: Elixir - build_ockam_cloud_node
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -242,7 +242,7 @@ jobs:
     name: Elixir - test_ockam_vault_software
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -258,7 +258,7 @@ jobs:
     name: Elixir - test_ockam
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -271,7 +271,7 @@ jobs:
     name: Elixir - test_ockam_kafka
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -284,7 +284,7 @@ jobs:
     name: Elixir - test_ockam_services
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -297,7 +297,7 @@ jobs:
     name: Elixir - test_ockam_metrics
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -310,7 +310,7 @@ jobs:
     name: Elixir - test_ockam_healthcheck
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:e43dd94652096b03cc472a3c709c7335e8b166cab77b7a7b56f88fa38f3d24cc
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -323,7 +323,7 @@ jobs:
     name: Elixir - test_ockam_cloud_node
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,7 +43,7 @@ jobs:
     name: Gradle - full_build_in_release_mode
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -15,7 +15,7 @@ on:
       ockam_publish_recent_failure:
         description: Indicate A Recent Failure
         type: choice
-        default: false
+        default: 'false'
         options:
         - false
         - true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,20 @@ jobs:
           rustc --version
           cd implementations/rust && ../../gradlew lint_cargo_fmt_check
 
+  lint_cargo_readme:
+    name: Rust - lint_cargo_readme
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: ${{ github.event.inputs.commit_sha }}
+      - uses: ./.github/actions/gradle_cache
+      - run: |
+          rustc --version
+          cd implementations/rust && ../../gradlew lint_cargo_readme
+
   lint_cargo_clippy:
     name: Rust - lint_cargo_clippy
     runs-on: ubuntu-20.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     name: Rust - lint_cargo_fmt_check
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -79,7 +79,7 @@ jobs:
     name: Rust - lint_cargo_readme
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -93,7 +93,7 @@ jobs:
     name: Rust - lint_cargo_clippy
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -110,7 +110,7 @@ jobs:
     name: Rust - lint_cargo_clippy
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -124,7 +124,7 @@ jobs:
     name: Rust - build_docs
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -141,7 +141,7 @@ jobs:
     name: Rust - build
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -158,7 +158,7 @@ jobs:
     name: Rust - build_examples
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -175,7 +175,7 @@ jobs:
     name: Rust - test
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     services:
       ockam_cloud:
         image: ghcr.io/build-trust/ockam-cloud-node@sha256:518314876a5b07c263b88995792335c4426d940c10e5e638a60e66776d86cff5
@@ -197,7 +197,7 @@ jobs:
     name: Rust - check_no_std
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -226,7 +226,7 @@ jobs:
     name: Rust - check_tag
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -243,7 +243,7 @@ jobs:
     name: Rust - check_cargo_update
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -263,7 +263,7 @@ jobs:
     name: Rust - check_nightly
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -282,7 +282,7 @@ jobs:
     name: Rust - build_nightly
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -301,7 +301,7 @@ jobs:
     name: Rust - test_nightly
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
@@ -329,7 +329,7 @@ jobs:
           os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-gnu
-          container: "ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c"
+          container: "ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -49,7 +49,7 @@ jobs:
     name: Shell - lint_shfmt
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/examples/rust/ockam_kafka/Dockerfile
+++ b/examples/rust/ockam_kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c AS builder
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8 AS builder
 
 WORKDIR /build
 

--- a/examples/rust/tcp_inlet_and_outlet/Dockerfile
+++ b/examples/rust/tcp_inlet_and_outlet/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c as builder
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8 as builder
 COPY . .
 RUN set -xe; cd examples/rust/tcp_inlet_and_outlet; cargo build --release --examples
 

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -54,6 +54,32 @@ task lint_cargo_fmt_check {
   }
 }
 
+task lint_cargo_readme {
+  doLast {
+    new File("ockam").eachDir { directory ->
+      def crate = "ockam/${directory.name}"
+      // recreate the README files
+      exec {
+        environment environmentVars()
+        commandLine cargo('readme', '--project-root', crate, '--template', '../README.tpl', '-o', 'README-updated.md')
+      }
+
+      // check if any README file has changed and throw an exception if this is the case
+      exec {
+        def expected = file("$crate/README-updated.md")
+        def actual = file("$crate/README.md")
+
+        if (actual.text != expected.text) {
+          throw new GradleException("the README.md file in $crate needs to be updated. Please run the command `gradle update_readmes` from the `implementations/rust` directory")
+        } else {
+          commandLine 'rm', expected
+        }
+      }
+    }
+  }
+}
+
+
 task lint_cargo_clippy {
   doLast {
     exec {
@@ -93,7 +119,7 @@ task lint {
   group project.name
   description 'Lint the project.'
 
-  dependsOn lint_cargo_fmt_check, lint_cargo_clippy, lint_cargo_deny, lint_environment_variables
+  dependsOn lint_cargo_fmt_check, lint_cargo_clippy, lint_cargo_deny, lint_environment_variables, lint_cargo_readme
 }
 
 task build_docs {

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -133,6 +133,20 @@ task build_examples {
   }
 }
 
+// This task needs to be executed in the `implementations/rust` directory
+// It collects the names of all the crates and runs the cargo readme task to update
+// the crate README file according to a common template and to the top-level documentation of the src/lib.rs file
+task update_readmes {
+  doLast {
+    new File("ockam").eachDir { directory ->
+      exec {
+        environment environmentVars()
+        commandLine cargo('readme', '--project-root', "ockam/${directory.name}", '--template', '../README.tpl', '-o', "README.md")
+      }
+    }
+  }
+}
+
 task test {
   group project.name
   description 'Test the project.'

--- a/implementations/rust/ockam/README.tpl
+++ b/implementations/rust/ockam/README.tpl
@@ -1,4 +1,4 @@
-# ockam
+# {{crate}}
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
@@ -8,8 +8,7 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-The ockam_abac crate is responsible for performing attribute based authorization
-control on messages within an Ockam worker system.
+{{readme}}
 
 ## Usage
 
@@ -17,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_abac = "0.19.0"
+{{crate}} = "{{version}}"
 ```
 
 ## License
@@ -26,11 +25,11 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
 
-[crate-image]: https://img.shields.io/crates/v/ockam_abac.svg
-[crate-link]: https://crates.io/crates/ockam_abac
+[crate-image]: https://img.shields.io/crates/v/{{crate}}.svg
+[crate-link]: https://crates.io/crates/{{crate}}
 
-[docs-image]: https://docs.rs/ockam_abac/badge.svg
-[docs-link]: https://docs.rs/ockam_abac
+[docs-image]: https://docs.rs/{{crate}}/badge.svg
+[docs-link]: https://docs.rs/{{crate}}
 
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
 [license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -3,8 +3,10 @@
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
 [![license][license-image]][license-link]
-[![status][status-image]][status-link]
 [![discuss][discuss-image]][discuss-link]
+
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
 
 End-to-end encrypted, mutually authenticated, secure communication.
 
@@ -26,7 +28,7 @@ to be vulnerable at every point, along their journey, where a transport connecti
 Instead, our application can have a strikingly smaller vulnerability surface and easily make
 _granular authorization decisions about all incoming information and commands._
 
-## Features
+### Features
 
 * End-to-end encrypted, mutually authenticated _secure channels_.
 * Multi-hop, multi-transport, application layer routing.
@@ -35,9 +37,11 @@ _granular authorization decisions about all incoming information and commands._
 * Attribute-based Access Control - credentials with _selective disclosure_.
 * Add-ons for a variety of operating environments, transport protocols, and _cryptographic hardware_.
 
-## Documentation
+### Documentation
 
 Tutorials, examples and reference guides are available at [docs.ockam.io](https://docs.ockam.io).
+
+[e2ee-rust-guide]: https://docs.ockam.io/reference/libraries/rust
 
 ## Usage
 
@@ -60,13 +64,8 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 [docs-image]: https://docs.rs/ockam/badge.svg
 [docs-link]: https://docs.rs/ockam
 
-[status-image]: https://img.shields.io/badge/Status-Preview-58E0C9.svg
-[status-link]: https://github.com/build-trust/ockam/blob/develop/SECURITY.md
-
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
 [license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE
 
-[discuss-image]: https://img.shields.io/badge/Discuss-On%20Github-ff70b4.svg
+[discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
 [discuss-link]: https://github.com/build-trust/ockam/discussions
-
-[e2ee-rust-guide]: https://docs.ockam.io/reference/libraries/rust

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -35,32 +35,9 @@ _granular authorization decisions about all incoming information and commands._
 * Attribute-based Access Control - credentials with _selective disclosure_.
 * Add-ons for a variety of operating environments, transport protocols, and _cryptographic hardware_.
 
-## Get Started
+## Documentation
 
-* [__End-to-End Encryption with Rust__][e2ee-rust-guide]:
-In this guide, we create two small Rust programs called Alice and Bob. Alice and Bob send each other
-messages, over the network, via a cloud service. They mutually authenticate each other and have a cryptographic
-guarantee that the integrity, authenticity, and confidentiality of their messages is protected end-to-end.
-[👉][e2ee-rust-guide]
-
-* [__Step-by-Step Deep Dive__][step-by-step-rust-guide]:
-In this step-by-step guide we write many small rust programs to understand the various building blocks
-that make up Ockam. We dive into Node, Workers, Routing, Transport, Secure Channels and more.
-[👉][step-by-step-rust-guide]
-
-* [__End-to-End Encryption through Kafka__][e2ee-kafka-guide]:
-In this guide, we show two programs called Alice and Bob. Alice and Bob send each other messages, over
-the network, via a cloud service, _through Kafka_. They mutually authenticate each other and have a
-cryptographic guarantee that the integrity, authenticity, and confidentiality of their messages is protected
-end-to-end. The Kafka instance, the intermediary cloud service and attackers on the network are not be able
-to see or change the contents of en-route messages. The application data in Kafka is encrypted.
-[👉][e2ee-kafka-guide]
-
-* [__Build Secure Remote Access Tunnels__][secure-remote-access-tunnels]:
-In this guide, we'll write a few simple Rust programs to programmatically create secure access tunnels to remote
-services and devices that are running in a private network, behind a NAT. We'll then tunnel arbitrary communication
-protocols through these secure tunnels.
-[👉][secure-remote-access-tunnels]
+Tutorials, examples and reference guides are available at [docs.ockam.io](https://docs.ockam.io).
 
 ## Usage
 
@@ -92,7 +69,4 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 [discuss-image]: https://img.shields.io/badge/Discuss-On%20Github-ff70b4.svg
 [discuss-link]: https://github.com/build-trust/ockam/discussions
 
-[e2ee-rust-guide]: https://github.com/build-trust/ockam/tree/develop/documentation/use-cases/end-to-end-encryption-with-rust#readme
-[e2ee-kafka-guide]: https://github.com/build-trust/ockam/tree/develop/documentation/use-cases/end-to-end-encryption-through-kafka#readme
-[step-by-step-rust-guide]: https://github.com/build-trust/ockam/tree/develop/documentation/guides/rust#readme
-[secure-remote-access-tunnels]: https://github.com/build-trust/ockam/tree/develop/documentation/use-cases/secure-remote-access-tunnels
+[e2ee-rust-guide]: https://docs.ockam.io/reference/libraries/rust

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -1,4 +1,37 @@
-//! End-to-end encryption and mutual authentication for distributed applications.
+//! End-to-end encrypted, mutually authenticated, secure communication.
+//!
+//! _[A hands-on guide 👉][e2ee-rust-guide]_.
+//!
+//! Data, within modern distributed applications, are rarely exchanged over a single point-to-point
+//! transport connection. Application messages routinely flow over complex, multi-hop, multi-protocol
+//! routes — _across data centers, through queues and caches, via gateways and brokers_ — before reaching
+//! their end destination.
+//!
+//! Transport layer security protocols are unable to protect application messages because their protection
+//! is constrained by the length and duration of the underlying transport connection.
+//!
+//! Ockam makes it simple for our applications to guarantee end-to-end integrity, authenticity,
+//! and confidentiality of data. We no longer have to implicitly depend on the defenses of every machine
+//! or application within the same, usually porous, network boundary. Our application's messages don't have
+//! to be vulnerable at every point, along their journey, where a transport connection terminates.
+//!
+//! Instead, our application can have a strikingly smaller vulnerability surface and easily make
+//! _granular authorization decisions about all incoming information and commands._
+//!
+//! ## Features
+//!
+//! * End-to-end encrypted, mutually authenticated _secure channels_.
+//! * Multi-hop, multi-transport, application layer routing.
+//! * Key establishment, rotation, and revocation - _for fleets, at scale_.
+//! * Lightweight, Concurrent, Stateful Workers that enable _simple APIs_.
+//! * Attribute-based Access Control - credentials with _selective disclosure_.
+//! * Add-ons for a variety of operating environments, transport protocols, and _cryptographic hardware_.
+//!
+//! ## Documentation
+//!
+//! Tutorials, examples and reference guides are available at [docs.ockam.io](https://docs.ockam.io).
+//!
+//! [e2ee-rust-guide]: https://docs.ockam.io/reference/libraries/rust
 
 #![deny(unsafe_code)]
 #![warn(

--- a/implementations/rust/ockam/ockam_abac/Cargo.toml
+++ b/implementations/rust/ockam/ockam_abac/Cargo.toml
@@ -56,4 +56,4 @@ rand = "0.8.5"
 name = "repl"
 test = true
 required-features = ["repl"]
-path = "."
+path = "src/bin/repl.rs"

--- a/implementations/rust/ockam/ockam_abac/Cargo.toml
+++ b/implementations/rust/ockam/ockam_abac/Cargo.toml
@@ -56,3 +56,4 @@ rand = "0.8.5"
 name = "repl"
 test = true
 required-features = ["repl"]
+path = "."

--- a/implementations/rust/ockam/ockam_abac/README.md
+++ b/implementations/rust/ockam/ockam_abac/README.md
@@ -1,4 +1,4 @@
-# ockam
+# ockam_abac
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -1,3 +1,6 @@
+//! The ockam_abac crate is responsible for performing attribute based authorization
+//! control on messages within an Ockam worker system.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/implementations/rust/ockam/ockam_api/README.md
+++ b/implementations/rust/ockam/ockam_api/README.md
@@ -8,7 +8,9 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-This crate supports the creation of a fully-featured Ockam Node (see [`NodeManager`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L87) in [`src/nodes/service.rs`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs)).
+This crate supports the creation of a fully-featured Ockam Node
+(see [`NodeManager`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L87) in [`src/nodes/service.rs`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs)).
+
 
 ## Usage
 

--- a/implementations/rust/ockam/ockam_api/README.md
+++ b/implementations/rust/ockam/ockam_api/README.md
@@ -8,6 +8,17 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
+This crate supports the creation of a fully-featured Ockam Node (see [`NodeManager`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L87) in [`src/nodes/service.rs`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs)).
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```
+[dependencies]
+ockam_api = "0.28.0"
+```
+
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -1,3 +1,6 @@
+//! This crate supports the creation of a fully-featured Ockam Node
+//! (see [`NodeManager`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs#L87) in [`src/nodes/service.rs`](https://github.com/build-trust/ockam/blob/2fc6d7714a4e54f8734c172ad6480fedc6e3629c/implementations/rust/ockam/ockam_api/src/nodes/service.rs)).
+//!
 pub mod auth;
 pub mod authenticator;
 pub mod bootstrapped_identities_store;

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -49,6 +49,7 @@ dockerfile = "../../../../tools/cross/Cross.Dockerfile.armv7"
 name = "ockam"
 doc = false
 test = false
+path = "src/bin/ockam.rs"
 
 [dependencies]
 anyhow = "1"

--- a/implementations/rust/ockam/ockam_command/README.md
+++ b/implementations/rust/ockam/ockam_command/README.md
@@ -8,7 +8,7 @@
 Orchestrate end-to-end encryption, mutual authentication, key management,
 credential management, and authorization policy enforcement — at scale.
 
-This crates provides the `ockam` command line application to start Ockam nodes and interact with them.
+This crate provides the `ockam` command line application to start Ockam nodes and interact with them.
 
 ## Usage
 

--- a/implementations/rust/ockam/ockam_command/README.md
+++ b/implementations/rust/ockam/ockam_command/README.md
@@ -8,6 +8,8 @@
 Orchestrate end-to-end encryption, mutual authentication, key management,
 credential management, and authorization policy enforcement — at scale.
 
+This crates provides the `ockam` command line application to start Ockam nodes and interact with them.
+
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/implementations/rust/ockam/ockam_command/README.md
+++ b/implementations/rust/ockam/ockam_command/README.md
@@ -5,10 +5,14 @@
 [![license][license-image]][license-link]
 [![discuss][discuss-image]][discuss-link]
 
-Orchestrate end-to-end encryption, mutual authentication, key management,
-credential management, and authorization policy enforcement — at scale.
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
 
-This crate provides the `ockam` command line application to start Ockam nodes and interact with them.
+This crate provides the ockam command line application to:
+ - start Ockam nodes and interact with them
+ - manage projects and spaces hosted within the Ockam Orchestrator
+
+For more information please visit the [command guide](https://docs.ockam.io/reference/command)
 
 ## Usage
 
@@ -16,12 +20,14 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_core = "0.85.0"
+ockam_command = "0.85.0"
 ```
 
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 
 [crate-image]: https://img.shields.io/crates/v/ockam_command.svg
 [crate-link]: https://crates.io/crates/ockam_command

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -1,4 +1,8 @@
-//! This crates provides the ockam command line application to start Ockam nodes and interact with them.
+//! This crate provides the ockam command line application to:
+//!  - start Ockam nodes and interact with them
+//!  - manage projects and spaces hosted within the Ockam Orchestrator
+//!
+//! For more information please visit the [command guide](https://docs.ockam.io/reference/command)
 
 mod admin;
 mod authenticated;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -1,5 +1,4 @@
-//! Orchestrate end-to-end encryption, mutual authentication, key management,
-//! credential management, and authorization policy enforcement — at scale.
+//! This crates provides the ockam command line application to start Ockam nodes and interact with them.
 
 mod admin;
 mod authenticated;

--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -15,6 +15,24 @@ to the main [Ockam][main-ockam-crate-link] library.
 The main [Ockam][main-ockam-crate-link] crate re-exports types defined in
 this crate.
 
+### Crate Features
+
+The `ockam_core` crate has a Cargo feature named `"std"` that is enabled by
+default. In order to use this crate in a `no_std` context this feature can
+be disabled as follows
+
+```toml
+[dependencies]
+ockam_core = { version = "<current version>" , default-features = false }
+```
+
+Please note that Cargo features are unioned across the entire dependency
+graph of a project. If any other crate you depend on has not opted out of
+`ockam_core` default features, Cargo will build `ockam_core` with the std
+feature enabled whether or not your direct dependency on `ockam_core`
+has `default-features = false`.
+
+
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -23,23 +41,6 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ockam_core = "0.79.0"
 ```
-
-## Crate Features
-
-The `ockam_core` crate has a Cargo feature named `"std"` that is enabled by
-default. In order to use this crate in a `no_std` context this feature can
-be disabled as follows
-
-```
-[dependencies]
-ockam_core = { version = "0.79.0" , default-features = false }
-```
-
-Please note that Cargo features are unioned across the entire dependency
-graph of a project. If any other crate you depend on has not opted out of
-`ockam_core` default features, Cargo will build `ockam_core` with the std
-feature enabled whether or not your direct dependency on `ockam_core`
-has `default-features = false`.
 
 ## License
 

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -1,10 +1,9 @@
-//! Core types of the Ockam library.
+//! This crate contains the core types of the [Ockam][main-ockam-crate-link]
+//! library and is intended for use by crates that provide features and add-ons
+//! to the main [Ockam][main-ockam-crate-link] library.
 //!
-//! This crate contains the core types of the Ockam library and is intended
-//! for use by other crates that provide features and add-ons to the main
-//! Ockam library.
-//!
-//! The main Ockam crate re-exports types defined in this crate.
+//! The main [Ockam][main-ockam-crate-link] crate re-exports types defined in
+//! this crate.
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_core/src/lib.rs
@@ -4,6 +4,24 @@
 //!
 //! The main [Ockam][main-ockam-crate-link] crate re-exports types defined in
 //! this crate.
+//!
+//! ## Crate Features
+//!
+//! The `ockam_core` crate has a Cargo feature named `"std"` that is enabled by
+//! default. In order to use this crate in a `no_std` context this feature can
+//! be disabled as follows
+//!
+//! ```toml
+//! [dependencies]
+//! ockam_core = { version = "<current version>" , default-features = false }
+//! ```
+//!
+//! Please note that Cargo features are unioned across the entire dependency
+//! graph of a project. If any other crate you depend on has not opted out of
+//! `ockam_core` default features, Cargo will build `ockam_core` with the std
+//! feature enabled whether or not your direct dependency on `ockam_core`
+//! has `default-features = false`.
+//!
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_executor/README.md
+++ b/implementations/rust/ockam/ockam_executor/README.md
@@ -30,13 +30,12 @@ ockam_executor = "0.47.0"
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
-[ockam-node-crate-link]: https://crates.io/crates/ockam_node
 
 [crate-image]: https://img.shields.io/crates/v/ockam_executor.svg
 [crate-link]: https://crates.io/crates/ockam_executor
 
-[docs-image]: https://docs.rs/ockam_node/badge.svg
-[docs-link]: https://docs.rs/ockam_node
+[docs-image]: https://docs.rs/ockam_executor/badge.svg
+[docs-link]: https://docs.rs/ockam_executor
 
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
 [license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE

--- a/implementations/rust/ockam/ockam_executor/src/lib.rs
+++ b/implementations/rust/ockam/ockam_executor/src/lib.rs
@@ -1,11 +1,10 @@
-//! Async executor for the Ockam library.
-//!
 //! This crate provides an implementation of an async executor for
 //! `no_std` environments and is intended for use by crates that provide
-//! features and add-ons to the main Ockam library.
+//! features and add-ons to the main [Ockam][main-ockam-crate-link]
+//! library.
 //!
-//! The ockam_node crate re-exports types defined in this crate when the 'std'
-//! feature is not enabled.
+//! The [ockam-node][ockam-node-crate-link] crate re-exports types defined in
+//! this crate when the `"std"` feature is disabled.
 #![warn(
     //missing_docs,
     trivial_casts,

--- a/implementations/rust/ockam/ockam_ffi/Cargo.toml
+++ b/implementations/rust/ockam/ockam_ffi/Cargo.toml
@@ -22,6 +22,7 @@ description = """FFI layer for ockam_vault.
 
 [lib]
 crate-type = ["staticlib"]
+path = "src/lib.rs"
 
 [features]
 default = []

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -28,7 +28,6 @@ ockam-ffi = "0.71.0"
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
-[ockam-ffi-crate-link]: https://crates.io/crates/ockam-ffi
 
 [crate-image]: https://img.shields.io/crates/v/ockam-ffi.svg
 [crate-link]: https://crates.io/crates/ockam-ffi

--- a/implementations/rust/ockam/ockam_ffi/src/lib.rs
+++ b/implementations/rust/ockam/ockam_ffi/src/lib.rs
@@ -1,4 +1,8 @@
-//! Ockam Vault Foreign Function Interface (FFI) for library integration.
+//! In order to support a variety of cryptographically capable hardware we maintain loose coupling between our protocols and how a specific building block is invoked in a specific hardware. This is achieved using an abstract Vault trait.
+//!
+//! A concrete implementation of the Vault trait is called an Ockam Vault. Over time, and with help from the Ockam open source community, we plan to add vaults for several TEEs, TPMs, HSMs, and Secure Enclaves.
+//!
+//! This crate provides the Vault FFI bindings following the  "C" calling convention, and generates static and dynamic C linkable libraries.
 #![warn(
     missing_docs,
     trivial_casts,

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -1,4 +1,4 @@
-# ockam_identity
+# ockam
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
@@ -8,13 +8,22 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-Identity is an abstraction easing use of authentication and authorization APIs.
+This crate supports the domain of "identities", which is required to create secure channels:
 
-## Crate Features
+ - the `identity` module describes an entity as a set of verified key changes and an identifier
+   uniquely representing those changes
 
-Features of the `ockam_identity` crate:
-- `noise_xx` - Enable Noise Protocol XX key agreement dependency.
-- `software_vault` - Enable Software Vault dependency.
+ - the `identities` module provides services to create, update, and import identities
+
+ - the `credential` module describes sets of attributes describing a given identity and signed by
+   another identity
+
+ - the `credentials` module provides services to create, import and verify credentials
+
+ - the `secure_channel` module describes the steps required to establish a secure channel
+   between 2 identities
+
+ - the `secure_channels` module provides services to create a secure channel between 2 identities
 
 ## Usage
 
@@ -30,7 +39,6 @@ ockam_identity = "0.73.0"
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
-[ockam-entity-crate-link]: https://crates.io/crates/ockam_identity
 
 [crate-image]: https://img.shields.io/crates/v/ockam_identity.svg
 [crate-link]: https://crates.io/crates/ockam_identity

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -1,4 +1,4 @@
-# ockam
+# ockam_identity
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -11,6 +11,7 @@ and trustfully with cloud services and other devices.
 In order to support a variety of key exchange protocols [Ockam][main-ockam-crate-link] crate uses an abstract Key Exchange trait.
 
 This crate provides an implementation of Key Exchange using [Noise][noise-protocol-framework] protocol with XX pattern.
+[noise-protocol-framework]: http://www.noiseprotocol.org/noise.html
 
 The main [Ockam][main-ockam-crate-link] has optional dependency on this crate.
 
@@ -28,7 +29,6 @@ ockam_key_exchange_xx = "0.75.0"
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
-[ockam-vault-crate-link]: https://crates.io/crates/ockam_key_exchange_xx
 
 [crate-image]: https://img.shields.io/crates/v/ockam_key_exchange_xx.svg
 [crate-link]: https://crates.io/crates/ockam_key_exchange_xx
@@ -41,5 +41,3 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
 [discuss-link]: https://github.com/build-trust/ockam/discussions
-
-[noise-protocol-framework]: http://www.noiseprotocol.org/noise.html

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -1,10 +1,8 @@
-//! XX (Noise Protocol) implementation of an Ockam Key Exchanger.
+//! In order to support a variety of key exchange protocols [Ockam][main-ockam-crate-link] crate uses an abstract Key Exchange trait.
 //!
-//! This crate contains the key exchange types of the Ockam library and is intended
-//! for use by other crates that provide features and add-ons to the main
-//! Ockam library.
+//! This crate provides an implementation of Key Exchange using [Noise][noise-protocol-framework] protocol with XX pattern.
 //!
-//! The main Ockam crate re-exports types defined in this crate.
+//! The main [Ockam][main-ockam-crate-link] has optional dependency on this crate.
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/src/lib.rs
@@ -1,6 +1,7 @@
 //! In order to support a variety of key exchange protocols [Ockam][main-ockam-crate-link] crate uses an abstract Key Exchange trait.
 //!
 //! This crate provides an implementation of Key Exchange using [Noise][noise-protocol-framework] protocol with XX pattern.
+//! [noise-protocol-framework]: http://www.noiseprotocol.org/noise.html
 //!
 //! The main [Ockam][main-ockam-crate-link] has optional dependency on this crate.
 #![deny(unsafe_code)]

--- a/implementations/rust/ockam/ockam_macros/Cargo.toml
+++ b/implementations/rust/ockam/ockam_macros/Cargo.toml
@@ -27,6 +27,7 @@ description = "End-to-end encryption and mutual authentication for distributed a
 
 [lib]
 proc-macro = true
+path = "src/lib.rs"
 
 [features]
 default = []

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -8,7 +8,11 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-This crate provides shared macros.
+This crate provides shared macros to:
+
+ - clone structs asynchronously
+ - create an ockam node and access its `Context`
+ - write some node-related tests
 
 ## Usage
 
@@ -111,4 +115,3 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
 [discuss-link]: https://github.com/build-trust/ockam/discussions
-

--- a/implementations/rust/ockam/ockam_macros/README.md
+++ b/implementations/rust/ockam/ockam_macros/README.md
@@ -14,6 +14,7 @@ This crate provides shared macros to:
  - create an ockam node and access its `Context`
  - write some node-related tests
 
+
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -23,86 +24,11 @@ Add this to your `Cargo.toml`:
 ockam_macros = "0.28.0"
 ```
 
-All macros except for those used exclusively for testing purposes are re-exported by the `ockam` crate, so you may see examples where the macros are exported from `ockam_macros` if are related to tests or from `ockam` in any other case.
-
-You can read more about how to use the macros and the supported attributes by each of them in the [crate documentation](https://docs.rs/ockam_macros).
-
-### AsyncTryClone
-
-Implements the `AsyncTryClone` trait as defined in [`ockam_core::AsyncTryClone`](https://docs.rs/ockam_core/latest/ockam_core/traits/trait.AsyncTryClone.html).
-
-```rust
-#[derive(ockam::AsyncTryClone)]
-pub struct MyStruct {
-    a: u32,
-}
-```
-
-### Message
-
-Implements the `Message` trait as defined in [`ockam_core::Message`](https://docs.rs/ockam_core/latest/ockam_core/trait.Message.html).
-
-```rust
-#[derive(ockam::Message, Deserialize, Serialize)]
-pub struct MyStruct {
-    a: u32,
-}
-```
-
-### Node
-
-Transforms the `main` function into an async function that sets up a node and provides a `Context` to interact with it.
-
-```rust
-#[ockam::node]
-async fn main(mut ctx: ockam::Context) -> ockam::Result<()> {
-    // ...
-}
-```
-
-If you are executing your code in a `no_std` platform that doesn't support a `main` entry point, you must use the `no_main` attribute:
-
-```rust
-#[ockam::node(no_main)]
-async fn main(mut ctx: ockam::Context) -> ockam::Result<()> {
-    // ...
-}
-```
-
-### Tests
-
-To write node-related tests:
-
-```rust
-#[ockam::test]
-async fn main(mut ctx: ockam::Context) -> ockam::Result<()> {
-    // ...
-}
-```
-
-To write vault-related tests:
-
-```rust
-use ockam_vault::Vault;
-
-fn new_vault() -> Vault {
-    Vault::default()
-}
-
-#[ockam_macros::vault_test]
-fn hkdf() {}
-```
-
-## Develop
-
-Due to dependencies constraints, the tests for all the macros contained in this crate are located in the `ockam` crate.
-
-To test changes done in any of the macros you can use the `macro_expand_playground` from the `ockam` crate to see how a macro expands
-a given input.
-
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 
 [crate-image]: https://img.shields.io/crates/v/ockam_macros.svg
 [crate-link]: https://crates.io/crates/ockam_macros

--- a/implementations/rust/ockam/ockam_macros/src/lib.rs
+++ b/implementations/rust/ockam/ockam_macros/src/lib.rs
@@ -1,3 +1,9 @@
+//! This crate provides shared macros to:
+//!
+//!  - clone structs asynchronously
+//!  - create an ockam node and access its `Context`
+//!  - write some node-related tests
+//!
 #![deny(
     trivial_casts,
     trivial_numeric_casts,

--- a/implementations/rust/ockam/ockam_multiaddr/README.md
+++ b/implementations/rust/ockam/ockam_multiaddr/README.md
@@ -8,9 +8,14 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-This crate supports the concept of [MultiAddr, "Composable and future-proof network addresses"](https://github.com/multiformats/multiaddr).
-Those addresses are used by the `ockam_command` crate as arguments to specify complex services paths involving several
-protocols: TCP, secure channels, service name etc...
+This crate provides an implementation of multiformats.io/multiaddr.
+
+The main entities of this crate are:
+
+- [`MultiAddr`]: A sequence of protocol values.
+- [`Protocol`]: A type that can be read from and written to strings and bytes.
+- [`Codec`]: A type that understands protocols.
+- [`ProtoValue`]: A section of a MultiAddr.
 
 ## Usage
 

--- a/implementations/rust/ockam/ockam_multiaddr/README.md
+++ b/implementations/rust/ockam/ockam_multiaddr/README.md
@@ -8,6 +8,19 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
+This crate supports the concept of [MultiAddr, "Composable and future-proof network addresses"](https://github.com/multiformats/multiaddr).
+Those addresses are used by the `ockam_command` crate as arguments to specify complex services paths involving several
+protocols: TCP, secure channels, service name etc...
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```
+[dependencies]
+ockam_multiaddr = "0.19.0"
+```
+
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -1,4 +1,4 @@
-//! An implementation of multiformats.io/multiaddr.
+//! This crate provides an implementation of multiformats.io/multiaddr.
 //!
 //! The main entities of this crate are:
 //!

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -22,7 +22,13 @@ license = "Apache-2.0"
 publish = true
 repository = "https://github.com/build-trust/ockam/tree/develop/implementations/rust/ockam/ockam_node"
 rust-version = "1.56.0"
-description = "Ockam Node implementation crate"
+description = """This crate provides an implementation of an Ockam [Ockam][main-ockam-crate-link]
+Node and is intended for use by crates that provide features and add-ons
+to the main [Ockam][main-ockam-crate-link] library.
+
+The main [Ockam][main-ockam-crate-link] crate re-exports types defined in
+this crate, when the `"std"` feature is enabled.
+"""
 
 [features]
 default = ["std"]

--- a/implementations/rust/ockam/ockam_node/README.md
+++ b/implementations/rust/ockam/ockam_node/README.md
@@ -1,4 +1,4 @@
-# ockam
+# ockam_node
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -1,4 +1,9 @@
-//! ockam_node - Ockam Node API
+//! This crate provides an implementation of an Ockam [Ockam][main-ockam-crate-link]
+//! Node and is intended for use by crates that provide features and add-ons
+//! to the main [Ockam][main-ockam-crate-link] library.
+//!
+//! The main [Ockam][main-ockam-crate-link] crate re-exports types defined in
+//! this crate, when the `"std"` feature is enabled.
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_transport_ble/README.md
+++ b/implementations/rust/ockam/ockam_transport_ble/README.md
@@ -1,4 +1,4 @@
-# ockam_transport_ble
+# ockam
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
@@ -9,6 +9,7 @@ Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
 This crate provides a BLE Transport for Ockam's Routing Protocol.
+Please read the support [documentation](./documentation.md) for more information.
 
 ## Usage
 
@@ -23,161 +24,7 @@ ockam_transport_ble = "0.40.0"
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
-## Examples
-
-    cargo build --example 04-routing-over-ble-transport-initiator
-
-    cargo run --example 04-routing-over-ble-transport-initiator
-
-    cargo run --example 05-secure-channel-over-ble-transport-initiator
-
-## Transport Model
-
-All Bluetooth Low Energy (BLE) devices use the Generic Attribute
-Profile (GATT).
-
-BLE transports will typically be based around GATT concepts and
-feature the following terminology:
-
-### Client
-
-The device initiating GATT commands and requests. For example, a
-computer or other device managing and collecting data from many
-embedded BLE devices.
-
-### Server
-
-The device which receives GATT commands and requests. For example, a
-small micro-controller collecting sensor data for transmission to a
-Client device.
-
-This can be confusing as we are used to the Client being the small
-device and the Server being the big one!
-
-### Characteristic
-
-A data value transferred between client and server, for example, an
-Ockam packet containing a sensor reading.
-
-### Service
-
-A collection of related characteristics, which operate together to
-perform a particular function. For instance, the Ockam UART (Universal
-Asynchronous Receiver/Transmitter) service contains the
-characteristics required to implement the receive and transmit
-channels.
-
-### Descriptor
-
-A descriptor provides additional information about a
-characteristic. Descriptors are optional and each characteristic can
-have any number of descriptors.
-
-### Identifiers
-
-Services, characteristics, and descriptors are collectively referred
-to as attributes and are identified by UUIDs.
-
-Any implementer may pick a random or pseudorandom UUID for proprietary
-uses, but the Bluetooth SIG have reserved a [range of UUIDs
-(xxxxxxxx-0000-1000-8000-00805F9B34FB)](https://www.bluetooth.com/specifications/assigned-numbers/)
-for standard attributes.
-
-#### InteroperaBLE identifier structure
-
-    xxxxxxxx-xxxx-Mxxx-9xxx-xxxxxxxxxxxx
-                  ^    ^-------------------- Upper bits must be 10_b to represent GUID Variant 1 (i.e. 8, 9, a or b)
-                  |------------------------- Must be 4 to represent Version 4 - rest are random
-
-#### Ockam Identifiers
-
-Ockam Identifiers are in the range:
-
-    xxxxxxxx-b19e-11e2-9e96-0800200c9a66
-
-https://stackoverflow.com/questions/10867405/generating-v5-uuid-what-is-name-and-namespace
-https://www.uuidtools.com/generate/v5
-https://www.uuidtools.com/decode
-
----
-
-## Assigned Identifiers
-
-#### UART Service Identifier
-
-    d973f2e0-b19e-11e2-9e96-0800200c9a66
-
-#### UART Transmit Characteristic Identifier
-
-    d973f2e1-b19e-11e2-9e96-0800200c9a66
-    NOTIFY
-
-#### UART Receive Characteristic Identifier
-
-    d973f2e2-b19e-11e2-9e96-0800200c9a66
-    WRITE_WITHOUT_RESPONSE | WRITE
-
----
-
-## Mandatory identifier
-
-TODO
-
-* https://reelyactive.github.io/ble-identifier-reference.html
-* https://reelyactive.github.io/diy/best-practices-ble-identifiers/
-
-ockam -> 0ca?
-
----
-
-# Setup notes
-
-## Linux
-
-### Dependencies
-
-    apt-get install libdbus-1-dev libssl-dev
-
-### dbus permissions
-
-Edit `/etc/dbus-1/system.d/bluetooth.conf`:
-
-    <policy user="antoine">
-      <allow send_destination="org.bluez"/>
-      <allow send_interface="org.bluez.Agent1"/>
-      <allow send_interface="org.bluez.GattCharacteristic1"/>
-      <allow send_interface="org.bluez.GattDescriptor1"/>
-      <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
-      <allow send_interface="org.freedesktop.DBus.Properties"/>
-    </policy>
-
-## Mac
-
-To use Bluetooth on macOS Big Sur (11) or later, you need to either package your binary into an application bundle with an `Info.plist` including `NSBluetoothAlwaysUsageDescription`, or (for a command-line application such as the examples included with `btleplug`) enable the Bluetooth permission for your terminal.
-
-You can do the latter by going to:
-
-    System Preferences → Security & Privacy → Privacy → Bluetooth
-
-... clicking the '+' button, and selecting 'Terminal' (or iTerm or whichever terminal application you use).
-
-Update: There is currently a bug in macOS Monterey that prevents Bluetooth Discovery for unsigned apps (even if you have given permissions to them)
-
-To fix:
-
-    Keychain Access => System Menu => Certificate Assistant => Create a Certificate...
-
-        Name:             Self Signed Root
-        Identity Type:    Self Signed Root
-        Certificate Type: Code Signing
-
-    codesign -f -o runtime --timestamp -s "Self Signed Root" target/debug/examples/04-routing-over-ble-transport-initiator
-    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Self Signed Root" 04-routing-over-ble-transport-initiator
-    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Apple Development: Antoine van Gelder (R972JJ8RXX)" 04-routing-over-ble-transport-initiator
-    codesign -f -o runtime --timestamp -s "Developer ID Application: Antoine van Gelder (HLUFY5JD2L)" 04-routing-over-ble-transport-initiator
-
-
-    codesign --entitlements Entitlements.plist -f -s "Apple Distribution" 04-routing-over-ble-transport-initiator
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 
 [crate-image]: https://img.shields.io/crates/v/ockam_transport_ble.svg
 [crate-link]: https://crates.io/crates/ockam_transport_ble

--- a/implementations/rust/ockam/ockam_transport_ble/README.md
+++ b/implementations/rust/ockam/ockam_transport_ble/README.md
@@ -1,4 +1,4 @@
-# ockam
+# ockam_transport_ble
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]

--- a/implementations/rust/ockam/ockam_transport_ble/README.md
+++ b/implementations/rust/ockam/ockam_transport_ble/README.md
@@ -1,15 +1,35 @@
 # ockam_transport_ble
 
-### Run:
+[![crate][crate-image]][crate-link]
+[![docs][docs-image]][docs-link]
+[![license][license-image]][license-link]
+[![discuss][discuss-image]][discuss-link]
+
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
+
+This crate provides a BLE Transport for Ockam's Routing Protocol.
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```
+[dependencies]
+ockam_transport_ble = "0.40.0"
+```
+
+## License
+
+This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+## Examples
 
     cargo build --example 04-routing-over-ble-transport-initiator
 
     cargo run --example 04-routing-over-ble-transport-initiator
 
     cargo run --example 05-secure-channel-over-ble-transport-initiator
-
-----
-
 
 ## Transport Model
 
@@ -158,3 +178,15 @@ To fix:
 
 
     codesign --entitlements Entitlements.plist -f -s "Apple Distribution" 04-routing-over-ble-transport-initiator
+
+[crate-image]: https://img.shields.io/crates/v/ockam_transport_ble.svg
+[crate-link]: https://crates.io/crates/ockam_transport_ble
+
+[docs-image]: https://docs.rs/ockam_transport_ble/badge.svg
+[docs-link]: https://docs.rs/ockam_transport_ble
+
+[license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
+[license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE
+
+[discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
+[discuss-link]: https://github.com/build-trust/ockam/discussions

--- a/implementations/rust/ockam/ockam_transport_ble/documentation.md
+++ b/implementations/rust/ockam/ockam_transport_ble/documentation.md
@@ -1,0 +1,157 @@
+# Documentation
+
+## Examples
+
+    cargo build --example 04-routing-over-ble-transport-initiator
+
+    cargo run --example 04-routing-over-ble-transport-initiator
+
+    cargo run --example 05-secure-channel-over-ble-transport-initiator
+
+## Transport Model
+
+All Bluetooth Low Energy (BLE) devices use the Generic Attribute
+Profile (GATT).
+
+BLE transports will typically be based around GATT concepts and
+feature the following terminology:
+
+### Client
+
+The device initiating GATT commands and requests. For example, a
+computer or other device managing and collecting data from many
+embedded BLE devices.
+
+### Server
+
+The device which receives GATT commands and requests. For example, a
+small micro-controller collecting sensor data for transmission to a
+Client device.
+
+This can be confusing as we are used to the Client being the small
+device and the Server being the big one!
+
+### Characteristic
+
+A data value transferred between client and server, for example, an
+Ockam packet containing a sensor reading.
+
+### Service
+
+A collection of related characteristics, which operate together to
+perform a particular function. For instance, the Ockam UART (Universal
+Asynchronous Receiver/Transmitter) service contains the
+characteristics required to implement the receive and transmit
+channels.
+
+### Descriptor
+
+A descriptor provides additional information about a
+characteristic. Descriptors are optional and each characteristic can
+have any number of descriptors.
+
+### Identifiers
+
+Services, characteristics, and descriptors are collectively referred
+to as attributes and are identified by UUIDs.
+
+Any implementer may pick a random or pseudorandom UUID for proprietary
+uses, but the Bluetooth SIG have reserved a [range of UUIDs
+(xxxxxxxx-0000-1000-8000-00805F9B34FB)](https://www.bluetooth.com/specifications/assigned-numbers/)
+for standard attributes.
+
+#### InteroperaBLE identifier structure
+
+    xxxxxxxx-xxxx-Mxxx-9xxx-xxxxxxxxxxxx
+                  ^    ^-------------------- Upper bits must be 10_b to represent GUID Variant 1 (i.e. 8, 9, a or b)
+                  |------------------------- Must be 4 to represent Version 4 - rest are random
+
+#### Ockam Identifiers
+
+Ockam Identifiers are in the range:
+
+    xxxxxxxx-b19e-11e2-9e96-0800200c9a66
+
+https://stackoverflow.com/questions/10867405/generating-v5-uuid-what-is-name-and-namespace
+https://www.uuidtools.com/generate/v5
+https://www.uuidtools.com/decode
+
+---
+
+## Assigned Identifiers
+
+#### UART Service Identifier
+
+    d973f2e0-b19e-11e2-9e96-0800200c9a66
+
+#### UART Transmit Characteristic Identifier
+
+    d973f2e1-b19e-11e2-9e96-0800200c9a66
+    NOTIFY
+
+#### UART Receive Characteristic Identifier
+
+    d973f2e2-b19e-11e2-9e96-0800200c9a66
+    WRITE_WITHOUT_RESPONSE | WRITE
+
+---
+
+## Mandatory identifier
+
+TODO
+
+* https://reelyactive.github.io/ble-identifier-reference.html
+* https://reelyactive.github.io/diy/best-practices-ble-identifiers/
+
+ockam -> 0ca?
+
+---
+
+# Setup notes
+
+## Linux
+
+### Dependencies
+
+    apt-get install libdbus-1-dev libssl-dev
+
+### dbus permissions
+
+Edit `/etc/dbus-1/system.d/bluetooth.conf`:
+
+    <policy user="antoine">
+      <allow send_destination="org.bluez"/>
+      <allow send_interface="org.bluez.Agent1"/>
+      <allow send_interface="org.bluez.GattCharacteristic1"/>
+      <allow send_interface="org.bluez.GattDescriptor1"/>
+      <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+      <allow send_interface="org.freedesktop.DBus.Properties"/>
+    </policy>
+
+## Mac
+
+To use Bluetooth on macOS Big Sur (11) or later, you need to either package your binary into an application bundle with an `Info.plist` including `NSBluetoothAlwaysUsageDescription`, or (for a command-line application such as the examples included with `btleplug`) enable the Bluetooth permission for your terminal.
+
+You can do the latter by going to:
+
+    System Preferences → Security & Privacy → Privacy → Bluetooth
+
+... clicking the '+' button, and selecting 'Terminal' (or iTerm or whichever terminal application you use).
+
+Update: There is currently a bug in macOS Monterey that prevents Bluetooth Discovery for unsigned apps (even if you have given permissions to them)
+
+To fix:
+
+    Keychain Access => System Menu => Certificate Assistant => Create a Certificate...
+
+        Name:             Self Signed Root
+        Identity Type:    Self Signed Root
+        Certificate Type: Code Signing
+
+    codesign -f -o runtime --timestamp -s "Self Signed Root" target/debug/examples/04-routing-over-ble-transport-initiator
+    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Self Signed Root" 04-routing-over-ble-transport-initiator
+    codesign --entitlements Entitlements.plist -f -o runtime --timestamp -s "Apple Development: Antoine van Gelder (R972JJ8RXX)" 04-routing-over-ble-transport-initiator
+    codesign -f -o runtime --timestamp -s "Developer ID Application: Antoine van Gelder (HLUFY5JD2L)" 04-routing-over-ble-transport-initiator
+
+
+    codesign --entitlements Entitlements.plist -f -s "Apple Distribution" 04-routing-over-ble-transport-initiator

--- a/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/lib.rs
@@ -1,15 +1,5 @@
-//! Bluetooth Low Energy (BLE) Transport for Ockam's routing framework
-//!
-//! The `ockam_node` (or `ockam_node_no_std`) crate sits at the core
-//! of the Ockam routing framework, with transport specific
-//! abstraction plugins.  This crate implements a Bluetooth connection
-//! plugin for this architecture.
-//!
-//! You can use Ockam's routing mechanism for cryptographic protocols,
-//! key lifecycle, credential exchange, enrollment, etc, without having
-//! to worry about the transport specifics.
-//!
-
+//! This crate provides a BLE Transport for Ockam's Routing Protocol.
+//! Please read the support [documentation](./documentation.md) for more information.
 #![deny(
     //missing_docs,
     dead_code,

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -8,7 +8,17 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-This crate provides the common code shared among the different ockam's transport protocols.
+This crate provides the common code shared among the different Ockam's transport protocols.
+
+Each specific protocol is then supported in its own crate. For example, the TCP protocol is supported in the `ockam_transport_tcp` crate.
+
+Currently available transports include:
+
+* `ockam_transport_tcp` - TCP transport
+* `ockam_transport_udp` - UDP transport
+* `ockam_transport_ble` - Bluetooth Low Energy Transport
+* `ockam_transport_websocket` - WebSocket Transport
+* `ockam_transport_uds` - Unix Domain Socket Transport
 
 ## Usage
 

--- a/implementations/rust/ockam/ockam_transport_core/README.md
+++ b/implementations/rust/ockam/ockam_transport_core/README.md
@@ -20,6 +20,7 @@ Currently available transports include:
 * `ockam_transport_websocket` - WebSocket Transport
 * `ockam_transport_uds` - Unix Domain Socket Transport
 
+
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -28,8 +29,6 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ockam_transport_core = "0.52.0"
 ```
-
-This crate requires the rust standard library `"std"`.
 
 ## License
 

--- a/implementations/rust/ockam/ockam_transport_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/lib.rs
@@ -9,6 +9,7 @@
 //! * `ockam_transport_ble` - Bluetooth Low Energy Transport
 //! * `ockam_transport_websocket` - WebSocket Transport
 //! * `ockam_transport_uds` - Unix Domain Socket Transport
+//!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/implementations/rust/ockam/ockam_transport_core/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/lib.rs
@@ -1,3 +1,15 @@
+//! This crate provides the common code shared among the different Ockam's transport protocols.
+//!
+//! Each specific protocol is then supported in its own crate. For example, the TCP protocol is supported in the `ockam_transport_tcp` crate.
+//!
+//! Currently available transports include:
+//!
+//! * `ockam_transport_tcp` - TCP transport
+//! * `ockam_transport_udp` - UDP transport
+//! * `ockam_transport_ble` - Bluetooth Low Energy Transport
+//! * `ockam_transport_websocket` - WebSocket Transport
+//! * `ockam_transport_uds` - Unix Domain Socket Transport
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod error;

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -10,19 +10,6 @@ and trustfully with cloud services and other devices.
 
 This crate provides a TCP Transport for Ockam's Routing Protocol.
 
-The Routing Protocol decouples Ockam's suite of cryptographic protocols,
-like secure channels, key lifecycle, credential exchange, enrollment etc. from
-the underlying transport protocols. This allows applications to establish
-end-to-end trust between entities.
-
-TCP is one possible transport for Routing Protocol messages, over time there
-will be more transport implementations.
-
-Currently available transports include:
-
-* `ockam_transport_ble` - Bluetooth Low Energy Transport
-* `ockam_transport_websocket` - WebSocket Transport
-
 ## Usage
 
 Add this to your `Cargo.toml`:

--- a/implementations/rust/ockam/ockam_transport_tcp/README.md
+++ b/implementations/rust/ockam/ockam_transport_tcp/README.md
@@ -10,6 +10,8 @@ and trustfully with cloud services and other devices.
 
 This crate provides a TCP Transport for Ockam's Routing Protocol.
 
+This crate requires the rust standard library `"std"`
+
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -18,8 +20,6 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ockam_transport_tcp = "0.80.0"
 ```
-
-This crate requires the rust standard library `"std"`.
 
 ## License
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -1,13 +1,4 @@
-//! TCP Transport utilities for Ockam's routing framework
-//!
-//! The `ockam_node` crate sits at the core
-//! of the Ockam routing framework, with transport specific
-//! abstraction plugins.  This crate implements a TCP connection
-//! plugin for this architecture.
-//!
-//! You can use Ockam's routing mechanism for cryptographic protocols,
-//! key lifecycle, credential exchange, enrollment, etc, without having
-//! to worry about the transport specifics.
+//! This crate provides a TCP Transport for Ockam's Routing Protocol.
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -1,4 +1,6 @@
 //! This crate provides a TCP Transport for Ockam's Routing Protocol.
+//!
+//! This crate requires the rust standard library `"std"`
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/implementations/rust/ockam/ockam_transport_udp/README.md
+++ b/implementations/rust/ockam/ockam_transport_udp/README.md
@@ -1,14 +1,16 @@
 # ockam_transport_udp
+
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
 [![license][license-image]][license-link]
 [![discuss][discuss-image]][discuss-link]
 
-
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
 This crate provides a UDP Transport for Ockam's Routing Protocol.
+
+### Examples
 
 ## Usage
 
@@ -18,18 +20,6 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ockam_transport_udp = "0.19.0"
 ```
-
-## Test
-
-In `ockam_transport_udp` directory, ran `cargo test`.
-
-## Examples
-
-In `ockam_transport_udp` directory, run an echo server
-with command `cargo run --example echo_server`
-
-Then, run a client that sends a hello message to the server
-with command `cargo run --example client`
 
 ## License
 

--- a/implementations/rust/ockam/ockam_transport_udp/README.md
+++ b/implementations/rust/ockam/ockam_transport_udp/README.md
@@ -1,4 +1,14 @@
 # ockam_transport_udp
+[![crate][crate-image]][crate-link]
+[![docs][docs-image]][docs-link]
+[![license][license-image]][license-link]
+[![discuss][discuss-image]][discuss-link]
+
+
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
+
+This crate provides a UDP Transport for Ockam's Routing Protocol.
 
 ## Usage
 
@@ -27,11 +37,11 @@ This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
 
-[crate-image]: https://img.shields.io/crates/v/ockam_transport_tcp.svg
-[crate-link]: https://crates.io/crates/ockam_transport_tcp
+[crate-image]: https://img.shields.io/crates/v/ockam_transport_udp.svg
+[crate-link]: https://crates.io/crates/ockam_transport_udp
 
-[docs-image]: https://docs.rs/ockam_transport_tcp/badge.svg
-[docs-link]: https://docs.rs/ockam_transport_tcp
+[docs-image]: https://docs.rs/ockam_transport_udp/badge.svg
+[docs-link]: https://docs.rs/ockam_transport_udp
 
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
 [license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE

--- a/implementations/rust/ockam/ockam_transport_udp/README.md
+++ b/implementations/rust/ockam/ockam_transport_udp/README.md
@@ -26,7 +26,7 @@ In `ockam_transport_udp` directory, ran `cargo test`.
 ## Examples
 
 In `ockam_transport_udp` directory, run an echo server
-with command `cargo run --exapmle echo_server`
+with command `cargo run --example echo_server`
 
 Then, run a client that sends a hello message to the server
 with command `cargo run --example client`

--- a/implementations/rust/ockam/ockam_transport_udp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/lib.rs
@@ -1,3 +1,12 @@
+//! This crate provides a UDP Transport for Ockam's Routing Protocol.
+//!
+//! ## Examples
+//
+// In `ockam_transport_udp` directory, run an echo server
+// with command `cargo run --example echo_server`
+//
+// Then, run a client that sends a hello message to the server
+// with command `cargo run --example client`
 use ockam_core::TransportType;
 
 pub use rendezvous_service::UdpRendezvousService;

--- a/implementations/rust/ockam/ockam_transport_uds/README.md
+++ b/implementations/rust/ockam/ockam_transport_uds/README.md
@@ -1,10 +1,13 @@
 # ockam_transport_uds
-
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
 [![license][license-image]][license-link]
 [![discuss][discuss-image]][discuss-link]
 
+Ockam is a library for building devices that communicate securely, privately
+and trustfully with cloud services and other devices.
+
+This crate provides a Unix Domain Socket Transport for Ockam's Routing Protocol.
 
 ## Usage
 
@@ -14,3 +17,19 @@ Add this to your `Cargo.toml`:
 [dependencies]
 ockam_transport_uds = "0.9.0"
 ```
+
+## License
+
+This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+[crate-image]: https://img.shields.io/crates/v/ockam_transport_uds.svg
+[crate-link]: https://crates.io/crates/ockam_transport_uds
+
+[docs-image]: https://docs.rs/ockam_transport_uds/badge.svg
+[docs-link]: https://docs.rs/ockam_transport_uds
+
+[license-image]: https://img.shields.io/badge/License-Apache%202.0-green.svg
+[license-link]: https://github.com/build-trust/ockam/blob/HEAD/LICENSE
+
+[discuss-image]: https://img.shields.io/badge/Discuss-Github%20Discussions-ff70b4.svg
+[discuss-link]: https://github.com/build-trust/ockam/discussions

--- a/implementations/rust/ockam/ockam_transport_uds/README.md
+++ b/implementations/rust/ockam/ockam_transport_uds/README.md
@@ -1,4 +1,5 @@
 # ockam_transport_uds
+
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
 [![license][license-image]][license-link]
@@ -8,6 +9,7 @@ Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
 This crate provides a Unix Domain Socket Transport for Ockam's Routing Protocol.
+
 
 ## Usage
 
@@ -21,6 +23,8 @@ ockam_transport_uds = "0.9.0"
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
+
+[main-ockam-crate-link]: https://crates.io/crates/ockam
 
 [crate-image]: https://img.shields.io/crates/v/ockam_transport_uds.svg
 [crate-link]: https://crates.io/crates/ockam_transport_uds

--- a/implementations/rust/ockam/ockam_transport_uds/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/lib.rs
@@ -1,3 +1,5 @@
+//! This crate provides a Unix Domain Socket Transport for Ockam's Routing Protocol.
+//!
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -1,14 +1,4 @@
-//! WebSocket Transport utilities for Ockam's routing framework.
-//!
-//! The `ockam_node` crate sits at the core
-//! of the Ockam routing framework, with transport specific
-//! abstraction plugins.  This crate implements a WebSocket connection
-//! plugin for this architecture.
-//!
-//! You can use Ockam's routing mechanism for cryptographic protocols,
-//! key lifecycle, credential exchange, enrollment, etc, without having
-//! to worry about the transport specifics.
-//!
+//! This crate provides a WebSocket Transport for Ockam's Routing Protocol.
 #![deny(unsafe_code)]
 #![warn(
 // missing_docs,

--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -1,4 +1,73 @@
 //! This crate provides a WebSocket Transport for Ockam's Routing Protocol.
+//!
+//! This crate requires the rust standard library `"std"`.
+//!
+//! We need to define the behavior of the worker that will be processing incoming messages.
+//!
+//! ```rust,no_run
+//! use ockam_core::{Worker, Result, Routed, async_trait};
+//! use ockam_node::Context;
+//!
+//! struct MyWorker;
+//!
+//! #[async_trait]
+//! impl Worker for MyWorker {
+//!     type Context = Context;
+//!     type Message = String;
+//!
+//!     async fn handle_message(&mut self, _ctx: &mut Context, _msg: Routed<String>) -> Result<()> {
+//!         // ...
+//!         Ok(())
+//!     }
+//! }
+//!
+//! // Now we can write the main function that will run the previous worker. In this case, our worker will be listening for new connections on port 8000 until the process is manually killed.
+//!
+//! use ockam_transport_websocket::WebSocketTransport;
+//! use ockam_core::{AllowAll};
+//! use ockam_node::NodeBuilder;
+//! use ockam_macros::node;
+//!
+//! #[ockam_macros::node(crate = "ockam_node")]
+//! async fn main(mut ctx: Context) -> Result<()> {//!
+//!     let ws = WebSocketTransport::create(&ctx).await?;
+//!     ws.listen("localhost:8000").await?; // Listen on port 8000
+//!
+//!     // Start a worker, of type MyWorker, at address "my_worker"
+//!     ctx.start_worker("my_worker", MyWorker, AllowAll, AllowAll).await?;
+//!
+//!     // Run worker indefinitely in the background
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Finally, we can write another node that connects to the node that is hosting the `MyWorker` worker, and we are ready to send and receive messages between them.
+//!
+//! ```rust,no_run
+//! use ockam_transport_websocket::{WebSocketTransport, WS};
+//! use ockam_core::{route, Result};
+//! use ockam_node::Context;
+//! use ockam_macros::node;
+//!
+//! #[ockam_macros::node(crate = "ockam_node")]
+//! async fn main(mut ctx: Context) -> Result<()> {
+//!     use ockam_node::MessageReceiveOptions;
+//! let ws = WebSocketTransport::create(&ctx).await?;
+//!
+//!     // Define the route to the server's worker.
+//!     let r = route![(WS, "localhost:8000"), "my_worker"];
+//!
+//!     // Now you can send messages to the worker.
+//!     ctx.send(r, "Hello Ockam!".to_string()).await?;
+//!
+//!     // Or receive messages from the server.
+//!     let reply = ctx.receive::<String>().await?;
+//!
+//!     // Stop all workers, stop the node, cleanup and return.
+//!     ctx.stop().await
+//! }
+//! ```
+//!
 #![deny(unsafe_code)]
 #![warn(
 // missing_docs,

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -22,7 +22,7 @@ description = """A software-only Ockam Vault implementation.
 
 [lib]
 crate-type = ["rlib"]
-path = "."
+path = "src/lib.rs"
 
 [features]
 default = ["std", "storage", "rustcrypto"]

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -22,6 +22,7 @@ description = """A software-only Ockam Vault implementation.
 
 [lib]
 crate-type = ["rlib"]
+path = "."
 
 [features]
 default = ["std", "storage", "rustcrypto"]

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -1,4 +1,4 @@
-# ockam
+# ockam_vault
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]

--- a/implementations/rust/ockam/ockam_vault/README.md
+++ b/implementations/rust/ockam/ockam_vault/README.md
@@ -1,4 +1,4 @@
-# ockam_vault
+# ockam
 
 [![crate][crate-image]][crate-link]
 [![docs][docs-image]][docs-link]
@@ -8,11 +8,16 @@
 Ockam is a library for building devices that communicate securely, privately
 and trustfully with cloud services and other devices.
 
-In order to support a variety of cryptographically capable hardware we maintain loose coupling between our protocols and how a specific building block is invoked in a specific hardware. This is achieved using an abstract Vault trait.
+In order to support a variety of cryptographically capable hardware we maintain loose coupling between
+our protocols and how a specific building block is invoked in a specific hardware.
+This is achieved using an abstract Vault trait.
 
-A concrete implementation of the Vault trait is called an Ockam Vault. Over time, and with help from the Ockam open source community, we plan to add vaults for several TEEs, TPMs, HSMs, and Secure Enclaves.
+A concrete implementation of the Vault trait is called an Ockam Vault.
+Over time, and with help from the Ockam open source community, we plan to add vaults for
+several TEEs, TPMs, HSMs, and Secure Enclaves.
 
-This crate provides a software-only Vault implementation that can be used when no cryptographic hardware is available. The primary Ockam crate uses this as the default Vault implementation.
+This crate provides a software-only Vault implementation that can be used when no cryptographic
+hardware is available. The primary Ockam crate uses this as the default Vault implementation.
 
 The main [Ockam][main-ockam-crate-link] has optional dependency on this crate.
 
@@ -25,29 +30,11 @@ Add this to your `Cargo.toml`:
 ockam_vault = "0.75.0"
 ```
 
-## Crate Features
-
-The `ockam_vault` crate has a Cargo feature named `"std"` that is enabled by
-default. In order to use this crate in a `no_std` context this feature can
-disabled as follows
-
-```
-[dependencies]
-ockam_vault = { version = "0.75.0" , default-features = false }
-```
-
-Please note that Cargo features are unioned across the entire dependency
-graph of a project. If any other crate you depend on has not opted out of
-`ockam_vault` default features, Cargo will build `ockam_vault` with the std
-feature enabled whether or not your direct dependency on `ockam_vault`
-has `default-features = false`.
-
 ## License
 
 This code is licensed under the terms of the [Apache License 2.0][license-link].
 
 [main-ockam-crate-link]: https://crates.io/crates/ockam
-[ockam-vault-crate-link]: https://crates.io/crates/ockam_vault
 
 [crate-image]: https://img.shields.io/crates/v/ockam_vault.svg
 [crate-link]: https://crates.io/crates/ockam_vault

--- a/implementations/rust/ockam/ockam_vault/src/lib.rs
+++ b/implementations/rust/ockam/ockam_vault/src/lib.rs
@@ -1,7 +1,15 @@
-//! Software implementation of ockam_core::vault traits.
+//! In order to support a variety of cryptographically capable hardware we maintain loose coupling between
+//! our protocols and how a specific building block is invoked in a specific hardware.
+//! This is achieved using an abstract Vault trait.
 //!
-//! This crate contains one of the possible implementation of the vault traits
-//! which you can use with Ockam library.
+//! A concrete implementation of the Vault trait is called an Ockam Vault.
+//! Over time, and with help from the Ockam open source community, we plan to add vaults for
+//! several TEEs, TPMs, HSMs, and Secure Enclaves.
+//!
+//! This crate provides a software-only Vault implementation that can be used when no cryptographic
+//! hardware is available. The primary Ockam crate uses this as the default Vault implementation.
+//!
+//! The main [Ockam][main-ockam-crate-link] has optional dependency on this crate.
 #![deny(unsafe_code)]
 #![warn(
     missing_docs,

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -97,6 +97,7 @@ RUN set -xe; \
     rustup component add clippy; \
     cargo install --locked cargo-deny; \
     cargo install --locked cargo-nextest; \
+    cargo install --locked cargo-readme; \
     chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
 # Setup erlang
     apt-get update; \

--- a/tools/docker/cloud-node/Dockerfile
+++ b/tools/docker/cloud-node/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Build elixir release of ockam_cloud_node elixir app
-FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c as elixir-app-release-build
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8 as elixir-app-release-build
 COPY . /work
 RUN set -xe; \
     cd implementations/elixir; \

--- a/tools/docker/healthcheck/Dockerfile
+++ b/tools/docker/healthcheck/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1 - Build elixir release of ockam_healthcheck elixir app
-FROM ghcr.io/build-trust/ockam-builder@sha256:d560cb1ed32124e68cb4dc5fc2902240090f122864715756ace06e99e38e6cb2 as elixir-app-release-build
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8 as elixir-app-release-build
 COPY . /work
 RUN set -xe; \
     cd implementations/elixir; \

--- a/tools/docker/ockam/Dockerfile
+++ b/tools/docker/ockam/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c as executable
+FROM ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8 as executable
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
This PR fixes some broken links in the `ockam` crate README since all the documentation has now moved over to `docs.ockam.io`. 

The PR also adds some missing badges and sections (usage, licence) for some of the other READMEs.