### PR TITLE
docs(rust): fix docs build for api and multiaddr crates

### DIFF
--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ockam-network/ockam/implementations/rust/ockam/
 description = "Ockam's request-response API"
 
 [features]
+default = ["std", "direct-authenticator"]
 std = [
   "either/use_std",
   "hex/std",

--- a/implementations/rust/ockam/ockam_api/src/authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator.rs
@@ -1,2 +1,1 @@
-#[cfg(feature = "direct-authenticator")]
 pub mod direct;

--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ockam-network/ockam"
 description = "An implementation of multiformats.io/multiaddr"
 
 [features]
+default = ["std"]
 std = ["ockam_core/std", "unsigned-varint/std", "serde?/std"]
 cbor = ["minicbor"]
 


### PR DESCRIPTION
The `ockam_api` and `ockam_multiaddr` crates where missing the definition of the default features, causing the `cargo doc` command to fail when compiling the crates in docs.rs