### PR TITLE
fix(elixir): report duration metrics for asynchronous APIs

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/api/request.ex
@@ -4,7 +4,17 @@ defmodule Ockam.API.Request do
   """
 
   alias Ockam.API.Request
-  defstruct [:id, :path, :method, :body, from_route: [], to_route: [], local_metadata: %{}]
+
+  defstruct [
+    :id,
+    :path,
+    :method,
+    :body,
+    from_route: [],
+    to_route: [],
+    local_metadata: %{},
+    start_time: nil
+  ]
 
   @max_id 65_534
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -225,7 +225,7 @@ defmodule Ockam.Worker do
             address: address,
             all_addresses: [address],
             module: module,
-            started_at: System.os_time(:millisecond),
+            started_at: System.monotonic_time(:millisecond),
             last_message_ts: nil,
             authorization: Authorization.expand_config(authorization),
             attributes: attributes,
@@ -289,7 +289,7 @@ defmodule Ockam.Worker do
   def is_idle?(state) do
     idle_timeout = Map.get(state, :idle_timeout, :infinity)
 
-    now = System.os_time(:millisecond)
+    now = System.monotonic_time(:millisecond)
 
     last_activity =
       case Map.get(state, :last_message_ts) do
@@ -329,7 +329,7 @@ defmodule Ockam.Worker do
         end
       end)
 
-    last_message_ts = System.os_time(:millisecond)
+    last_message_ts = System.monotonic_time(:millisecond)
 
     case return_value do
       {:ok, returned_state} ->

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/healthcheck.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/healthcheck.ex
@@ -22,7 +22,7 @@ defmodule Ockam.Healthcheck do
         %Target{} = target,
         timeout \\ 5000
       ) do
-    start_time = System.os_time(:millisecond)
+    start_time = System.monotonic_time(:millisecond)
 
     case ping_target(target, timeout) do
       :ok ->
@@ -156,7 +156,7 @@ defmodule Ockam.Healthcheck do
   end
 
   def report_check_ok(target, start_time) do
-    duration = System.os_time(:millisecond) - start_time
+    duration = System.monotonic_time(:millisecond) - start_time
 
     log_healthcheck("Healthcheck OK", duration, target)
 
@@ -176,7 +176,7 @@ defmodule Ockam.Healthcheck do
   end
 
   def report_check_failed(target, reason, start_time) do
-    duration = System.os_time(:millisecond) - start_time
+    duration = System.monotonic_time(:millisecond) - start_time
 
     log_healthcheck(
       "Healthcheck ERROR: #{inspect(reason)}",

--- a/implementations/elixir/ockam/ockam_services/lib/services/api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/api.ex
@@ -50,13 +50,16 @@ defmodule Ockam.Services.API do
   """
   @callback path_group(String.t()) :: String.t()
 
+  def path_group(_path), do: "all"
+
   @doc """
   Send Ockam.API.Response to the from_route of the reply using address as a return_route
   """
-  def reply(%Request{} = request, status, body, address) do
+  def reply(%Request{} = request, status, body, address, module \\ __MODULE__) do
     response = Response.reply_to(request, status_code(status), body)
     reply_message = Response.to_message(response, [address])
     Router.route(reply_message)
+    emit_request_stop(module, request, {:reply, response}, address)
     {:reply, response}
   end
 
@@ -64,26 +67,25 @@ defmodule Ockam.Services.API do
   Send Ockam.API.Response to the from_route of the reply
   with an error status and body created from `reason` using address as a return_route
   """
-  def reply_error(request, reason, address) do
+  def reply_error(request, reason, address, module \\ __MODULE__) do
     status = status_code(reason)
     body = CBOR.encode(error_message(reason))
-    reply(request, status, body, address)
+    reply(request, status, body, address, module)
   end
 
   def handle_message(module, message, state) do
     case Request.from_message(message) do
       {:ok, request} ->
-        start_time = emit_request_start(module, request, state)
+        start_time = emit_request_start(module, request, state.address)
+        request = %{request | start_time: start_time}
 
-        {reply, state} = handle_request(module, request, state)
-
-        emit_request_stop(module, start_time, request, reply, state)
+        {_reply, state} = handle_request(module, request, state)
 
         {:ok, state}
 
       {:error, {:decode_error, reason, data}} ->
         Logger.debug("Decode error: cannot decode request #{data}: #{inspect(reason)}")
-        reply = reply_error(message, {:bad_request, :decode_error}, state.address)
+        reply = reply_error(message, {:bad_request, :decode_error}, state.address, module)
         emit_decode_error(message, reply, state)
         {:ok, state}
     end
@@ -92,20 +94,22 @@ defmodule Ockam.Services.API do
   def handle_request(module, request, state) do
     case module.handle_request(request, state) do
       {:reply, status, body, state} ->
-        reply = reply(request, status, body, state.address)
+        reply = reply(request, status, body, state.address, module)
         {reply, state}
 
       {:noreply, state} ->
+        ## No response, but still emit reply=false stop event
+        emit_request_stop(module, request, :noreply, state.address)
         {:noreply, state}
 
       {:error, reason, state} ->
         ## TODO: handle errors differently to return error response
-        reply = reply_error(request, reason, state.address)
+        reply = reply_error(request, reason, state.address, module)
         {reply, state}
 
       {:error, reason} ->
         ## TODO: handle errors differently to return error response
-        reply = reply_error(request, reason, state.address)
+        reply = reply_error(request, reason, state.address, module)
         {reply, state}
     end
   end
@@ -202,7 +206,8 @@ defmodule Ockam.Services.API do
         API.handle_message(__MODULE__, message, state)
       end
 
-      def path_group(_path), do: "all"
+      @impl Ockam.Services.API
+      defdelegate path_group(path), to: API
 
       defoverridable path_group: 1
     end
@@ -212,36 +217,38 @@ defmodule Ockam.Services.API do
 
   @handle_request_event [:api, :handle_request]
 
-  defp emit_request_start(module, request, state) do
+  defp emit_request_start(module, request, address) do
     request_metadata = request_metadata(module, request)
-    state_metadata = state_metadata(state)
+    state_metadata = %{address: address}
     metadata = Map.merge(request_metadata, state_metadata)
     Telemetry.emit_start_event(@handle_request_event, metadata: metadata)
   end
 
-  defp emit_request_stop(module, start_time, request, reply, state) do
+  defp emit_request_stop(module, request, reply, address) do
     request_metadata = request_metadata(module, request)
     reply_metadata = reply_metadata(reply)
-    state_metadata = state_metadata(state)
+    state_metadata = %{address: address}
+    start_time = request.start_time || System.monotonic_time()
     metadata = request_metadata |> Map.merge(reply_metadata) |> Map.merge(state_metadata)
     Telemetry.emit_stop_event(@handle_request_event, start_time, metadata: metadata)
   end
 
-  defp emit_decode_error(message, reply, state) do
+  defp emit_decode_error(message, reply, address) do
     message_metadata = message_metadata(message)
     reply_metadata = reply_metadata(reply)
-    state_metadata = state_metadata(state)
+    state_metadata = %{address: address}
     metadata = message_metadata |> Map.merge(reply_metadata) |> Map.merge(state_metadata)
     Telemetry.emit_event(@handle_request_event ++ [:decode_error], metadata: metadata)
   end
 
-  defp state_metadata(state) do
-    %{address: state.address}
-  end
-
   defp request_metadata(module, %Request{} = request) do
     path_group = module.path_group(request.path)
-    %{path_group: path_group, method: request.method, from_route: request.from_route}
+
+    %{
+      path_group: path_group,
+      method: request.method,
+      from_route: request.from_route
+    }
   end
 
   defp reply_metadata(:noreply) do


### PR DESCRIPTION
## Current behavior

Currently we only report request duration when the api handler finishes. With asynchronous APIs we might have api handlers returning :noreply and then calling `API.reply`.

## Proposed changes

To support that added request duration reporting in `reply` function

<!-- Thank you for sending a pull request :heart: -->


<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->


<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
