### PR TITLE
refactor(rust): remove usage/mention of long tests env var

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/BATS.md
+++ b/implementations/rust/ockam/ockam_command/tests/bats/BATS.md
@@ -36,11 +36,6 @@ Unit tests doesn't need any special setup. This will run the simple local-only t
 bats implementations/rust/ockam/ockam_command/tests/bats
 ```
 
-This will run all local-only tests, including the long ones:
-```bash
-LONG_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/bats
-```
-
 ## How to run the orchestrator tests
 
 The orchestrator tests require having an enrolled identity under `$OCKAM_HOME` (by default set at `$HOME/.ockam`), which will be copied to each test environment.
@@ -53,14 +48,9 @@ ockam enroll
 
 After this command completes, you will be able to run the orchestrator tests.
 
-This will run the simple orchestrator tests that don't take too long:
+This will run the simple orchestrator tests:
 ```bash
 ORCHESTRATOR_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/bats
-```
-
-This will run all orchestrator tests, including the long ones that can take several minutes to complete:
-```bash
-ORCHESTRATOR_TESTS=1 LONG_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/bats
 ```
 
 ## Executing the tests in parallel

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -14,12 +14,6 @@ function skip_if_orchestrator_tests_not_enabled() {
   fi
 }
 
-function skip_if_long_tests_not_enabled() {
-  if [ -z "${LONG_TESTS}" ]; then
-    skip "LONG_TESTS are not enabled"
-  fi
-}
-
 function load_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     cp -a $OCKAM_HOME_BASE $OCKAM_HOME


### PR DESCRIPTION
Working on assigned issue - #4830

## Current behavior
As described in issue #4830, in the past there was a usage of the LONG_TESTS env variable, currently its no longer needed as there are no long bats tests.

## Proposed changes
BATS.md:
- Removed mention of LONG_TESTS env variable
- Removed sentance "that don't take too long" that points that there are longer tests.
orchestrator.bash:
- Removed helper function "skip_if_long_tests_not_enabled()"

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.