### PR TITLE
fix(rust): overwrite project/trust-context when enrolling

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -173,10 +173,12 @@ async fn default_project(
         check_project_readiness(ctx, opts, cloud_opts, node_name, None, default_project).await?;
     println!("{}", project.output()?);
 
-    opts.state.projects.create(&project.name, project.clone())?;
+    opts.state
+        .projects
+        .overwrite(&project.name, project.clone())?;
     opts.state
         .trust_contexts
-        .create(&project.name, project.clone().try_into()?)?;
+        .overwrite(&project.name, project.clone().try_into()?)?;
     Ok(project)
 }
 


### PR DESCRIPTION
It must `overwrite` and not try to `create` those objects, otherwise it will fail as they could exist already
