### PR TITLE
test(rust): add a retry logic in bats tests when fetching project information

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -18,10 +18,30 @@ function load_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     cp -a $OCKAM_HOME_BASE $OCKAM_HOME
     export PROJECT_JSON_PATH="$OCKAM_HOME/project.json"
-    $OCKAM project information --output json >"$PROJECT_JSON_PATH"
-    if [ ! -s "${PROJECT_JSON_PATH}" ]; then
-      echo "Project json file is empty" >&3
+    fetch_orchestrator_data
+  fi
+}
+
+function fetch_orchestrator_data() {
+  max_retries=5
+  i=0
+  while [[ $i -lt $max_retries ]]; do
+    run bash -c "$OCKAM project information --output json >$PROJECT_JSON_PATH"
+    # if status is not 0, retry
+    if [ $status -ne 0 ]; then
+      sleep 5
+      ((i++))
+      continue
+    fi
+    # if file is empty, exit with error
+    if [ ! -s "$PROJECT_JSON_PATH" ]; then
+      echo "Project information is empty" >&3
       exit 1
     fi
+    break
+  done
+  if [ $i -eq $max_retries ]; then
+    echo "Failed to fetch project information" >&3
+    exit 1
   fi
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message.bats
@@ -43,12 +43,14 @@ teardown() {
   assert_success
   m1_identifier=$($OCKAM identity show m1)
 
-  $OCKAM project enroll --member "$m1_identifier" --attribute role=member
+  run "$OCKAM" project enroll --member "$m1_identifier" --attribute role=member
+  assert_success
 
   # m1' identity was added by enroller
   run "$OCKAM" project authenticate --identity m1 --project-path "$PROJECT_JSON_PATH"
+  assert_success
 
-  # m1 is a member,  must be able to contact the project' service
+  # m1 is a member, must be able to contact the project' service
   msg=$(random_str)
   run "$OCKAM" message send --timeout 5 --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
   assert_success


### PR DESCRIPTION
There is some flakiness in the bats tests, where a random test of the `ORCHESTRATOR_TESTS` group [will fail](https://github.com/build-trust/ockam-artifacts/actions/runs/4882020320/jobs/8711614206) if the orchestrator is not responsive, failing to fetch the project details through the `project information` command executed at `load_orchestrator_data`. 

To reduce manual retries on CI, this PR introduces some changes so that it will retry fetching the project information every 5 seconds 5 times before returning an error.