### PR TITLE
test(rust): stop using `--project-path` on single env bats tests

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -14,15 +14,16 @@ function skip_if_orchestrator_tests_not_enabled() {
   fi
 }
 
-function load_orchestrator_data() {
+function copy_local_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     cp -a $OCKAM_HOME_BASE $OCKAM_HOME
     export PROJECT_JSON_PATH="$OCKAM_HOME/project.json"
-    fetch_orchestrator_data
+    cp $OCKAM_HOME/projects/default.json $PROJECT_JSON_PATH
   fi
 }
 
 function fetch_orchestrator_data() {
+  copy_local_orchestrator_data
   max_retries=5
   i=0
   while [[ $i -lt $max_retries ]]; do

--- a/implementations/rust/ockam/ockam_command/tests/bats/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message.bats
@@ -12,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 }
 
 teardown() {
@@ -47,18 +47,18 @@ teardown() {
   assert_success
 
   # m1' identity was added by enroller
-  run "$OCKAM" project authenticate --identity m1 --project-path "$PROJECT_JSON_PATH"
+  run "$OCKAM" project authenticate --identity m1
   assert_success
 
   # m1 is a member, must be able to contact the project' service
   msg=$(random_str)
-  run "$OCKAM" message send --timeout 5 --identity m1 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --timeout 5 --identity m1 --to /project/default/service/echo "$msg"
   assert_success
   assert_output "$msg"
 
   # m2 is not a member, must not be able to contact the project' service
   run "$OCKAM" identity create m2
   assert_success
-  run "$OCKAM" message send --timeout 5 --identity m2 --project-path "$PROJECT_JSON_PATH" --to /project/default/service/echo "$msg"
+  run "$OCKAM" message send --timeout 5 --identity m2 --to /project/default/service/echo "$msg"
   assert_failure
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -12,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 }
 
 teardown() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -12,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 }
 
 teardown() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
@@ -12,7 +12,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 }
 
 teardown() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -149,7 +149,7 @@ teardown() {
 
 @test "trust context - trust context with an id and authority using orchestrator; orchestrator enrollment and connection is performed, orchestrator" {
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 
   $OCKAM trust-context create orchestrator-test
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -358,11 +358,11 @@ teardown() {
 
 @test "relay - create relay with default parameters" {
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 
   port=7100
 
-  run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH"
+  run "$OCKAM" node create blue
   assert_success
   $OCKAM tcp-outlet create --at /node/blue --to 127.0.0.1:5000
 
@@ -370,7 +370,7 @@ teardown() {
   run "$OCKAM" relay create $fwd
   assert_success
 
-  run "$OCKAM" node create green --project "$PROJECT_JSON_PATH"
+  run "$OCKAM" node create green
   assert_success
   $OCKAM secure-channel create --from /node/green --to "/project/default/service/forward_to_$fwd/service/api" |
     $OCKAM tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to -/service/outlet

--- a/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
@@ -51,19 +51,19 @@ teardown() {
 # https://docs.ockam.io/
 @test "use-case - end-to-end encryption, orchestrator" {
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 
   port=9001
 
   # Service
-  run "$OCKAM" node create s --project-path "$PROJECT_JSON_PATH"
+  run "$OCKAM" node create s
   run "$OCKAM" tcp-outlet create --at /node/s --to 127.0.0.1:5000
 
   fwd=$(random_str)
   run "$OCKAM" relay create "$fwd" --to /node/s
 
   # Client
-  run "$OCKAM" node create c --project-path "$PROJECT_JSON_PATH"
+  run "$OCKAM" node create c
   run bash -c "$OCKAM secure-channel create --from /node/c --to /project/default/service/forward_to_$fwd/service/api \
               | $OCKAM tcp-inlet create --at /node/c --from 127.0.0.1:$port --to -/service/outlet"
   assert_success
@@ -75,7 +75,7 @@ teardown() {
 # https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac
 @test "use-case - abac" {
   skip_if_orchestrator_tests_not_enabled
-  load_orchestrator_data
+  copy_local_orchestrator_data
 
   port_1=9002
   port_2=9003


### PR DESCRIPTION
This will hopefully help with flaky tests like [this](https://github.com/build-trust/ockam-artifacts/actions/runs/4884062949/jobs/8716282397).

- Only use the `--project-path` argument on tests where multiple `OCKAM_HOME`'s are used
- Since all the tests are using the `default` project (which remains unmodified througout the test suite), all tests that need the project data will copy the local `projects/default.json` file instead of fetching it from the cloud