### PR TITLE
build: run the file transfer tests sequentially

### DIFF
--- a/tools/nextest/.config/nextest.toml
+++ b/tools/nextest/.config/nextest.toml
@@ -6,5 +6,9 @@ filter = 'package(hello_ockam)'
 test-group = 'sequential'
 
 [[profile.default.overrides]]
+filter = 'package(file_transfer)'
+test-group = 'sequential'
+
+[[profile.default.overrides]]
 filter = 'package(tcp_inlet_and_outlet)'
 test-group = 'sequential'


### PR DESCRIPTION
This is an attempt to possibly reduce the contention for some tests execution on CI
