### PR TITLE
build: increase nextest timeout to match that defined in tests

### DIFF
--- a/tools/nextest/.config/nextest.toml
+++ b/tools/nextest/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+slow-timeout = { period = "2m", terminate-after = 3, grace-period = "30s" }
+
 [test-groups]
 sequential = { max-threads = 1 }
 


### PR DESCRIPTION
We currently use a 60 second timeout, while there are some tests that have a 3 minute timeout. This mismatch could be causing [flakyness in those tests](https://github.com/build-trust/ockam/actions/runs/4883766556/jobs/8715588094).