### PR TITLE
docs: update readme from `websocket` crate

### DIFF
--- a/implementations/rust/ockam/ockam_transport_websocket/README.md
+++ b/implementations/rust/ockam/ockam_transport_websocket/README.md
@@ -38,7 +38,7 @@ use ockam_core::{AllowAll};
 use ockam_node::NodeBuilder;
 use ockam_macros::node;
 
-#[ockam_macros::node(crate = "0.72.0")]
+#[ockam_macros::node(crate = "ockam_node")]
 async fn main(mut ctx: Context) -> Result<()> {//!
     let ws = WebSocketTransport::create(&ctx).await?;
     ws.listen("localhost:8000").await?; // Listen on port 8000
@@ -59,7 +59,7 @@ use ockam_core::{route, Result};
 use ockam_node::Context;
 use ockam_macros::node;
 
-#[ockam_macros::node(crate = "0.72.0")]
+#[ockam_macros::node(crate = "ockam_node")]
 async fn main(mut ctx: Context) -> Result<()> {
     use ockam_node::MessageReceiveOptions;
 let ws = WebSocketTransport::create(&ctx).await?;


### PR DESCRIPTION
Looks like there was some (automatic) changes after the last release causing the [CI check](https://github.com/build-trust/ockam/actions/runs/4889298233/jobs/8727799339?pr=4874) to fail.