### PR TITLE
feat(rust): adding rotate-key to ockam_command cli

### DIFF
--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -254,6 +254,13 @@ impl Node {
         self.identities().identities_keys()
     }
 
+    /*
+    pub fn rotate_keys(&self) -> Arc<IdentitiesKeys> {
+        todo!();
+        self.identities().identities_keys().rotate_key();
+    }
+    */
+
     /// Return services to manage credentials
     pub fn credentials(&self) -> Arc<dyn Credentials> {
         self.identities().credentials()

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/identity.rs
@@ -46,3 +46,43 @@ impl<'a> ShortIdentityResponse<'a> {
         }
     }
 }
+
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct RotateKeyResponse<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)] tag: TypeTag<6005979>,
+    #[b(1)] pub label: Cow<'a, str>,
+}
+
+impl<'a> RotateKeyResponse<'a> {
+    pub fn new(label: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            label: label.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode, Serialize)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct RotateKeyRequest<'a> {
+    #[cfg(feature = "tag")]
+    #[serde(skip)]
+    #[n(0)] tag: TypeTag<4029174>,
+    #[b(1)] pub label: Cow<'a, str>,
+}
+
+impl<'a> RotateKeyRequest<'a> {
+    pub fn new(label: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            label: label.into(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -529,11 +529,11 @@ impl NodeManager {
 impl NodeManagerWorker {
     //////// Request matching and response handling ////////
 
-    async fn handle_request(
+    async fn handle_request<'a>(
         &mut self,
         ctx: &mut Context,
-        req: &Request<'_>,
-        dec: &mut Decoder<'_>,
+        req: &Request<'a>,
+        dec: &mut Decoder<'a>,
     ) -> Result<Vec<u8>> {
         debug! {
             target: TARGET,
@@ -566,6 +566,10 @@ impl NodeManagerWorker {
                         node_manager.transports.len() as u32,
                     ))
                     .to_vec()?
+            }
+
+            (Post, ["node", "identity", "actions", "rotate_key"]) => {
+                self.rotate_key(req, dec).await?.to_vec()?
             }
 
             // ==*== Tcp Connection ==*==

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod rotate_key;
 mod default;
 mod delete;
 mod list;
@@ -10,6 +11,7 @@ pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 use ockam_api::cli_state::CliState;
 pub(crate) use show::ShowCommand;
+pub(crate) use rotate_key::RotateKeyCommand;
 
 use crate::util::OckamConfig;
 use crate::{docs, fmt_warn, CommandGlobalOpts, GlobalArgs, Result};
@@ -40,6 +42,8 @@ pub enum IdentitySubcommand {
     List(ListCommand),
     Default(DefaultCommand),
     Delete(DeleteCommand),
+    /// Rotate Keys,
+    RotateKey(RotateKeyCommand),
 }
 
 impl IdentityCommand {
@@ -50,6 +54,7 @@ impl IdentityCommand {
             IdentitySubcommand::List(c) => c.run(options),
             IdentitySubcommand::Delete(c) => c.run(options),
             IdentitySubcommand::Default(c) => c.run(options),
+            IdentitySubcommand::RotateKey(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/rotate_key.rs
@@ -1,0 +1,40 @@
+use crate::node::NodeOpts;
+use crate::util::{node_rpc, Rpc};
+use crate::CommandGlobalOpts;
+use clap::Args;
+use ockam::Context;
+use ockam_api::nodes::models::identity::{RotateKeyRequest, RotateKeyResponse};
+use ockam_core::api::Request;
+
+fn default_key_label() -> String {
+    "OCKAM_RK".to_string()
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct RotateKeyCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+    #[arg(short, long, default_value_t=default_key_label())]
+    label: String,
+}
+
+impl RotateKeyCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(run_impl, (options, self))
+    }
+}
+
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, RotateKeyCommand),
+) -> crate::Result<()> {
+    let mut rpc = Rpc::background(&ctx, &opts, &cmd.node_opts.api_node)?;
+    // XXX Should this be post?
+    // XXX Is this the best way to pass arguments?
+    let request =
+        Request::post("/node/identity/actions/rotate_key").body(RotateKeyRequest::new(cmd.label));
+    rpc.request(request).await?;
+    rpc.parse_response::<RotateKeyResponse>()?;
+    println!("key rotated!");
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -81,6 +81,23 @@ teardown() {
   assert_output --partial "/service/vault_service"
 }
 
+@test "create a node and show its identity then rotate keys" {
+  run $OCKAM node create n1
+  assert_success
+
+  run $OCKAM identity rotate-key --node n1
+  assert_success
+  assert_output --regexp '^key rotated'
+
+  run $OCKAM identity show --node n1
+  assert_success
+  assert_output --regexp '^P'
+
+  run $OCKAM identity rotate-key --node n1
+  assert_success
+  assert_output --regexp '^key rotated'
+}
+
 # ===== VAULT
 
 @test "vault - create and check show/list output" {


### PR DESCRIPTION
This commit adds the rotate-key command to the CLI. It can be used via `ockam identity rotate-key --node n1 --label OCKAM_RK` or the label argument can be omitted to use the default label of "OCKAM_RK", e.g. `ockam identity rotate-key --node n1`.

In response to issue: https://github.com/build-trust/ockam/issues/3685

This is a replacement for https://github.com/build-trust/ockam/pull/3841

<!-- Thank you for sending a pull request :heart: -->

## Current Behavior

`ockam identity rotate-key` did not exists.

## Proposed Changes

create cli command `ockam identity rotate-key`

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
