### PR TITLE
build: don't replace versions in readmes during the release

### DIFF
--- a/implementations/rust/ockam/ockam_core/README.md
+++ b/implementations/rust/ockam/ockam_core/README.md
@@ -23,7 +23,7 @@ be disabled as follows
 
 ```toml
 [dependencies]
-ockam_core = { version = "0.80.0" , default-features = false }
+ockam_core = { version = "<current version>" , default-features = false }
 ```
 
 Please note that Cargo features are unioned across the entire dependency

--- a/tools/scripts/release/release.toml
+++ b/tools/scripts/release/release.toml
@@ -8,6 +8,5 @@ consolidate-pushes = true
 sign-commit = true
 pre-release-commit-message = "chore(rust): crate release {{crate_name}} version {{version}}"
 pre-release-replacements = [
-  { file = "README.md", min = 0, search = "= \".*\"", replace = "= \"{{version}}\"" },
-  { file = "CHANGELOG.md", min = 0, search = "## unreleased", replace = "## {{version}} - {{date}}" },
+    { file = "CHANGELOG.md", min = 0, search = "## unreleased", replace = "## {{version}} - {{date}}" },
 ]


### PR DESCRIPTION
This should fix the currently broken CI job on `develop` and address this issue for the future.
