### PR TITLE
refactor(elixir): rename identity_keypair to static_keypair

### DIFF
--- a/examples/elixir/get_started/06-secure-channel-over-two-transport-hops-initiator.exs
+++ b/examples/elixir/get_started/06-secure-channel-over-two-transport-hops-initiator.exs
@@ -6,14 +6,14 @@ Ockam.Node.register_address("app")
 # Start the TCP Transport Add-on for Ockam Routing.
 Ockam.Transport.TCP.start()
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Connect to a secure channel listener and perform a handshake.
 alias Ockam.Transport.TCPAddress
 r = [TCPAddress.new("localhost", 3000), "h1", TCPAddress.new("localhost", 4000), "secure_channel_listener"]
-{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, identity_keypair: identity)
+{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, static_keypair: keypair)
 
 # Prepare the message.
 message = %{onward_route: [c, "echoer"], return_route: ["app"], payload: "Hello Ockam!"}

--- a/examples/elixir/get_started/06-secure-channel-over-two-transport-hops-responder.exs
+++ b/examples/elixir/get_started/06-secure-channel-over-two-transport-hops-responder.exs
@@ -3,12 +3,12 @@
 # Create a Echoer type worker at address "echoer".
 {:ok, _echoer} = Echoer.create(address: "echoer")
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Create a secure channel listener that will wait for requests to initiate an Authenticated Key Exchange.
-Ockam.SecureChannel.create_listener(vault: vault, identity_keypair: identity, address: "secure_channel_listener")
+Ockam.SecureChannel.create_listener(vault: vault, static_keypair: keypair, address: "secure_channel_listener")
 
 # Start the TCP Transport Add-on for Ockam Routing and a TCP listener on port 4000.
 Ockam.Transport.TCP.start(listen: [port: 4000])

--- a/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-initiator.ex
+++ b/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-initiator.ex
@@ -9,14 +9,14 @@ Ockam.Transport.TCP.start()
 # Ask for the address of the forwarder, that was printed by responder.
 forwarder_address = IO.gets("Enter forwarder address: ") |> String.trim()
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Connect to a secure channel listener and perform a handshake.
 alias Ockam.Transport.TCPAddress
 r = [TCPAddress.new("1.node.ockam.network", 4000), forwarder_address]
-{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, identity_keypair: identity)
+{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, static_keypair: keypair)
 
 # Prepare the message.
 message = %{onward_route: [c, "echoer"], return_route: ["app"], payload: "Hello Ockam!"}

--- a/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-responder.ex
+++ b/examples/elixir/get_started/08-secure-channel-over-remote-forwarder-responder.ex
@@ -3,12 +3,12 @@
 # Create a Echoer type worker at address "echoer".
 {:ok, _echoer} = Echoer.create(address: "echoer")
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Create a secure channel listener that will wait for requests to initiate an Authenticated Key Exchange.
-Ockam.SecureChannel.create_listener(vault: vault, identity_keypair: identity, address: "secure_channel_listener")
+Ockam.SecureChannel.create_listener(vault: vault, static_keypair: keypair, address: "secure_channel_listener")
 
 # Start the TCP Transport Add-on for Ockam Routing.
 Ockam.Transport.TCP.start()

--- a/examples/elixir/tcp_inlet_and_outlet/03-inlet.exs
+++ b/examples/elixir/tcp_inlet_and_outlet/03-inlet.exs
@@ -6,13 +6,13 @@
 
 Ockam.Transport.TCP.start()
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Connect to a secure channel listener and perform a handshake.
 r = [Ockam.Transport.TCPAddress.new("localhost", 4000), "secure_channel_listener"]
-{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, identity_keypair: identity)
+{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, static_keypair: keypair)
 
 {:ok, _pid} =
   Ockam.Transport.Portal.InletListener.start_link(port: lport, peer_route: [c, "outlet"])

--- a/examples/elixir/tcp_inlet_and_outlet/03-outlet.exs
+++ b/examples/elixir/tcp_inlet_and_outlet/03-outlet.exs
@@ -8,14 +8,14 @@
 # Start the TCP Transport Add-on for Ockam Routing and a TCP listener on port 4000.
 Ockam.Transport.TCP.start(listen: [port: 4000])
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Create a secure channel listener that will wait for requests to initiate an Authenticated Key Exchange.
 Ockam.SecureChannel.create_listener(
   vault: vault,
-  identity_keypair: identity,
+  static_keypair: keypair,
   address: "secure_channel_listener"
 )
 

--- a/examples/elixir/tcp_inlet_and_outlet/04-inlet.exs
+++ b/examples/elixir/tcp_inlet_and_outlet/04-inlet.exs
@@ -6,13 +6,13 @@
 
 Ockam.Transport.TCP.start()
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Connect to a secure channel listener and perform a handshake.
 r = [Ockam.Transport.TCPAddress.new("1.node.ockam.network", 4000), forwarding_address]
-{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, identity_keypair: identity)
+{:ok, c} = Ockam.SecureChannel.create(route: r, vault: vault, static_keypair: keypair)
 
 {:ok, _pid} =
   Ockam.Transport.Portal.InletListener.start_link(port: lport, peer_route: [c, "outlet"])

--- a/examples/elixir/tcp_inlet_and_outlet/04-outlet.exs
+++ b/examples/elixir/tcp_inlet_and_outlet/04-outlet.exs
@@ -11,14 +11,14 @@ alias Ockam.Workers.RemoteForwarder
 # Start the TCP Transport Add-on for Ockam Routing and a TCP listener on port 4000.
 Ockam.Transport.TCP.start(listen: [port: 4000])
 
-# Create a vault and an identity keypair.
+# Create a vault and an static keypair.
 {:ok, vault} = Ockam.Vault.Software.init()
-{:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+{:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
 # Create a secure channel listener that will wait for requests to initiate an Authenticated Key Exchange.
 Ockam.SecureChannel.create_listener(
   vault: vault,
-  identity_keypair: identity,
+  static_keypair: keypair,
   address: "secure_channel_listener"
 )
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/stream/bi_directional/secure_channel.ex
@@ -154,21 +154,21 @@ defmodule Ockam.Examples.Stream.BiDirectional.SecureChannel do
 
   defp create_secure_channel_listener() do
     {:ok, vault} = SoftwareVault.init()
-    {:ok, identity} = Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Vault.secret_generate(vault, type: :curve25519)
 
     SecureChannel.create_listener(
       vault: vault,
-      identity_keypair: identity,
+      static_keypair: keypair,
       address: "SC_listener"
     )
   end
 
   defp create_secure_channel(route_to_listener) do
     {:ok, vault} = SoftwareVault.init()
-    {:ok, identity} = Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Vault.secret_generate(vault, type: :curve25519)
 
     {:ok, c} =
-      SecureChannel.create(route: route_to_listener, vault: vault, identity_keypair: identity)
+      SecureChannel.create(route: route_to_listener, vault: vault, static_keypair: keypair)
 
     {:ok, c}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/protocol.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/key_establishment_protocol/xx/protocol.ex
@@ -6,7 +6,7 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Protocol do
   defstruct [
     # handle to a vault
     :vault,
-    # identity keypair, reference in vault
+    # static keypair, reference in vault
     :s,
     # ephemeral keypair, reference in vault
     :e,
@@ -66,7 +66,7 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Protocol do
   end
 
   defp setup_s(options, state) do
-    case Keyword.get(options, :identity_keypair) do
+    case Keyword.get(options, :static_keypair) do
       nil -> generate_key(:s, state)
       %{private: _priv, public: _pub} = s -> {:ok, %{state | s: s}}
       vault_handle -> turn_vault_private_key_handle_to_keypair(:s, vault_handle, state)

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/listener.ex
@@ -16,12 +16,12 @@ defmodule Ockam.SecureChannel.Listener do
   @impl true
   def setup(options, state) do
     with {:ok, vault} <- Keyword.fetch(options, :vault),
-         {:ok, identity_keypair} <- Keyword.fetch(options, :identity_keypair) do
+         {:ok, static_keypair} <- Keyword.fetch(options, :static_keypair) do
       state = Map.put(state, :vault, vault)
-      state = Map.put(state, :identity_keypair, identity_keypair)
+      state = Map.put(state, :static_keypair, static_keypair)
       {:ok, state}
     else
-      :error -> {:error, {:required_options_missing, [:vault, :identity_keypair], options}}
+      :error -> {:error, {:required_options_missing, [:vault, :static_keypair], options}}
     end
   end
 
@@ -38,7 +38,7 @@ defmodule Ockam.SecureChannel.Listener do
     base_channel_options =
       [role: :responder]
       |> Keyword.put(:vault, state.vault)
-      |> Keyword.put(:identity_keypair, state.identity_keypair)
+      |> Keyword.put(:static_keypair, state.static_keypair)
 
     with {:ok, init_handshake} <- InitHandshake.decode(payload),
          {:ok, responder_init_message} <- make_responder_init_message(message, init_handshake),

--- a/implementations/elixir/ockam/ockam/test/ockam/secure_channel/key_establishment_protocol/xx/protocol_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/secure_channel/key_establishment_protocol/xx/protocol_test.exs
@@ -64,7 +64,7 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Protocol.Tests do
       Protocol.setup(
         [
           vault: vault,
-          identity_keypair: test_case.initiator_static,
+          static_keypair: test_case.initiator_static,
           ephemeral_keypair: test_case.initiator_ephemeral,
           message1_payload: test_case.message_1_payload,
           message3_payload: test_case.message_3_payload
@@ -78,7 +78,7 @@ defmodule Ockam.SecureChannel.KeyEstablishmentProtocol.XX.Protocol.Tests do
       Protocol.setup(
         [
           vault: vault,
-          identity_keypair: test_case.responder_static,
+          static_keypair: test_case.responder_static,
           ephemeral_keypair: test_case.responder_ephemeral,
           message2_payload: test_case.message_2_payload
         ],

--- a/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
@@ -267,16 +267,16 @@ defmodule Ockam.SecureChannel.Tests do
 
   defp create_secure_channel_listener() do
     {:ok, vault} = SoftwareVault.init()
-    {:ok, identity} = Vault.secret_generate(vault, type: :curve25519)
-    SecureChannel.create_listener(vault: vault, identity_keypair: identity)
+    {:ok, keypair} = Vault.secret_generate(vault, type: :curve25519)
+    SecureChannel.create_listener(vault: vault, static_keypair: keypair)
   end
 
   defp create_secure_channel(route_to_listener) do
     {:ok, vault} = SoftwareVault.init()
-    {:ok, identity} = Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Vault.secret_generate(vault, type: :curve25519)
 
     {:ok, c} =
-      SecureChannel.create(route: route_to_listener, vault: vault, identity_keypair: identity)
+      SecureChannel.create(route: route_to_listener, vault: vault, static_keypair: keypair)
 
     {:ok, c}
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/secure_channel.ex
@@ -40,7 +40,7 @@ defmodule Ockam.Services.Provider.SecureChannel do
   def service_options(:secure_channel, args) do
     with {:ok, vault} <- SoftwareVault.init(),
          {:ok, keypair} <- Ockam.Vault.secret_generate(vault, type: :curve25519) do
-      Keyword.merge([vault: vault, identity_keypair: keypair, address: "secure_channel"], args)
+      Keyword.merge([vault: vault, static_keypair: keypair, address: "secure_channel"], args)
     else
       error ->
         raise "error starting service options for secure channel: #{inspect(error)}"
@@ -64,7 +64,7 @@ defmodule Ockam.Services.Provider.SecureChannel do
         [
           identity: :dynamic,
           identity_module: identity_module,
-          encryption_options: [vault: vault, identity_keypair: keypair],
+          encryption_options: [vault: vault, static_keypair: keypair],
           address: "identity_secure_channel",
           trust_policies: trust_policies
         ],

--- a/implementations/elixir/ockam/ockam_services/test/authorization_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/authorization_test.exs
@@ -15,10 +15,10 @@ defmodule Ockam.Services.Authorization.Tests do
 
   setup_all do
     {:ok, vault} = SoftwareVault.init()
-    {:ok, identity} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
     {:ok, channel_listener} =
-      Ockam.SecureChannel.create_listener(vault: vault, identity_keypair: identity)
+      Ockam.SecureChannel.create_listener(vault: vault, static_keypair: keypair)
 
     on_exit(fn ->
       Ockam.Node.stop(channel_listener)
@@ -49,10 +49,10 @@ defmodule Ockam.Services.Authorization.Tests do
 
     refute_receive(%Message{onward_route: [^me], payload: "Hello local"}, 500)
 
-    {:ok, kp} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
     {:ok, channel} =
-      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], identity_keypair: kp)
+      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], static_keypair: keypair)
 
     Router.route(%Message{
       payload: "Hello secure channel",
@@ -85,10 +85,10 @@ defmodule Ockam.Services.Authorization.Tests do
 
     refute_receive(%Message{onward_route: [^me], payload: "Hello transport"}, 500)
 
-    {:ok, kp} = Ockam.Vault.secret_generate(vault, type: :curve25519)
+    {:ok, keypair} = Ockam.Vault.secret_generate(vault, type: :curve25519)
 
     {:ok, channel} =
-      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], identity_keypair: kp)
+      Ockam.SecureChannel.create(vault: vault, route: [channel_listener], static_keypair: keypair)
 
     Router.route(%Message{
       payload: "Hello secure channel",


### PR DESCRIPTION
#2926 
## Proposed changes
Rename identity_keypair to static_keypair, in addition rename currently used return values to "keypair" instead of "identity"
## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
