### PR TITLE
Elaborate on reason for atty exemption in OSV Scanner configuration

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,6 +1,6 @@
 [[IgnoredVulns]]
 id = "RUSTSEC-2021-0145"
-reason = "Affects Windows OS which we don't support currently"
+reason = "atty crate pulled in from transitive dependency env_logger used by kafka-protocol and quickcheck"
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2021-0127"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The existing exemption for `atty` in this scanner tool is a true remark, but it doesn't indicate why we couldn't remediate the issue instead by removing our usage of the `atty` crate.

## Proposed changes

Update the wording on the exemption to clarify how atty is included in our dependency tree and why we can't eliminate it at this time.

I have also documented the required cleanup if env_logger is ever updated in #4891.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
