### PR TITLE
Support identity updates in services

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -28,7 +28,7 @@ async fn main(ctx: Context) -> Result<()> {
     let issuer_connection = tcp.connect("127.0.0.1:5000", TcpConnectionOptions::new()).await?;
     let issuer_channel = node
         .create_secure_channel(
-            &client,
+            &client.identifier(),
             route![issuer_connection, "secure"],
             SecureChannelOptions::new(),
         )
@@ -51,7 +51,7 @@ async fn main(ctx: Context) -> Result<()> {
     let server_connection = tcp.connect("127.0.0.1:4000", TcpConnectionOptions::new()).await?;
     let channel = node
         .create_secure_channel(
-            &client,
+            &client.identifier(),
             route![server_connection, "secure"],
             SecureChannelOptions::new(),
         )

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -32,7 +32,8 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // For a different application this attested attribute set can be different and
     // distinct for each identifier, but for this example we'll keep things simple.
-    let credential_issuer = CredentialsIssuer::new(node.identities(), issuer.clone(), "trust_context".into()).await?;
+    let credential_issuer =
+        CredentialsIssuer::new(node.identities(), issuer.identifier(), "trust_context".into()).await?;
     for identifier in known_identifiers.iter() {
         node.identities()
             .repository()

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -43,7 +43,7 @@ async fn main(ctx: Context) -> Result<()> {
     // Start a secure channel listener that only allows channels where the identity
     // at the other end of the channel can authenticate with the latest private key
     // corresponding to one of the above known public identifiers.
-    node.create_secure_channel_listener(&issuer, "secure", SecureChannelListenerOptions::new())
+    node.create_secure_channel_listener(&issuer.identifier(), "secure", SecureChannelListenerOptions::new())
         .await?;
 
     // Start a credential issuer worker that will only accept incoming requests from

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -37,7 +37,7 @@ async fn main(ctx: Context) -> Result<()> {
     let issuer_connection = tcp.connect("127.0.0.1:5000", TcpConnectionOptions::new()).await?;
     let issuer_channel = node
         .create_secure_channel(
-            &server,
+            &server.identifier(),
             route![issuer_connection, "secure"],
             SecureChannelOptions::new(),
         )
@@ -86,7 +86,7 @@ async fn main(ctx: Context) -> Result<()> {
 
     // Start a secure channel listener that only allows channels with
     // authenticated identities.
-    node.create_secure_channel_listener(&server, "secure", SecureChannelListenerOptions::new())
+    node.create_secure_channel_listener(&server.identifier(), "secure", SecureChannelListenerOptions::new())
         .await?;
 
     // Create a TCP listener and wait for incoming connections

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -60,8 +60,9 @@ async fn main(ctx: Context) -> Result<()> {
     let trust_context = TrustContext::new(
         "trust_context_id".to_string(),
         Some(AuthorityService::new(
+            node.identities().identities_reader(),
             node.credentials(),
-            issuer.clone(),
+            issuer.identifier(),
             Some(Arc::new(CredentialsMemoryRetriever::new(credential))),
         )),
     );

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -78,7 +78,7 @@ async fn main(ctx: Context) -> Result<()> {
         .start(
             node.context(),
             trust_context,
-            server.clone(),
+            server.identifier(),
             "credentials".into(),
             true,
         )

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -61,7 +61,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     //    to retrieve the node credential
 
     // Import the authority identity and route from the information file
-    let project = import_project(project_information_path, node.identities_vault()).await?;
+    let project = import_project(project_information_path, node.identities()).await?;
 
     let flow_controls = FlowControls::default();
     let tcp_route = multiaddr_to_route(&project.authority_route(), &tcp, &flow_controls)

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -102,7 +102,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
             Some(Arc::new(RemoteCredentialsRetriever::new(
                 node.secure_channels(),
                 RemoteCredentialsRetrieverInfo::new(
-                    project.authority_identity(),
+                    project.authority_identity().identifier(),
                     tcp_project_session.route,
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 ),
@@ -124,7 +124,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         .start(
             node.context(),
             trust_context,
-            project.authority_identity(),
+            project.authority_identity().identifier(),
             "credential_exchange".into(),
             true,
         )

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -61,7 +61,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     //    to retrieve the node credential
 
     // Import the authority identity and route from the information file
-    let project = import_project(project_information_path, node.identities_vault()).await?;
+    let project = import_project(project_information_path, node.identities()).await?;
 
     let flow_controls = FlowControls::default();
     let tcp_authority_route = multiaddr_to_route(&project.authority_route(), &tcp, &flow_controls)

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -103,12 +103,13 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     let trust_context = TrustContext::new(
         "trust_context_id".to_string(),
         Some(AuthorityService::new(
+            node.identities().identities_reader(),
             node.credentials(),
-            project.authority_identity(),
+            project.authority_identifier(),
             Some(Arc::new(RemoteCredentialsRetriever::new(
                 node.secure_channels(),
                 RemoteCredentialsRetrieverInfo::new(
-                    project.authority_identity().identifier(),
+                    project.authority_identifier(),
                     tcp_project_session.route,
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 ),
@@ -130,7 +131,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         .start(
             node.context(),
             trust_context,
-            project.authority_identity().identifier(),
+            project.authority_identifier(),
             "credential_exchange".into(),
             true,
         )

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -108,7 +108,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
             Some(Arc::new(RemoteCredentialsRetriever::new(
                 node.secure_channels(),
                 RemoteCredentialsRetrieverInfo::new(
-                    project.authority_identity(),
+                    project.authority_identity().identifier(),
                     tcp_project_session.route,
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 ),
@@ -130,7 +130,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         .start(
             node.context(),
             trust_context,
-            project.authority_identity(),
+            project.authority_identity().identifier(),
             "credential_exchange".into(),
             true,
         )

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -1,13 +1,15 @@
-use anyhow::anyhow;
-use ockam::identity::{IdentitiesCreation, IdentitiesVault, Identity, IdentityIdentifier};
-use ockam_core::errcode::{Kind, Origin};
-use ockam_core::{Error, Result};
-use ockam_multiaddr::MultiAddr;
-use serde_json::{Map, Value};
 use std::fs::File;
 use std::io::Read;
 use std::str::FromStr;
 use std::sync::Arc;
+
+use anyhow::anyhow;
+use serde_json::{Map, Value};
+
+use ockam::identity::{Identities, Identity, IdentityIdentifier};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{Error, Result};
+use ockam_multiaddr::MultiAddr;
 
 /// This struct contains the json data exported
 /// when running `ockam project information > project.json`
@@ -48,13 +50,13 @@ impl Project {
 
 /// Import a project identity into a Vault from a project.json path
 /// and return a Project struct
-pub async fn import_project(path: &str, vault: Arc<dyn IdentitiesVault>) -> Result<Project> {
+pub async fn import_project(path: &str, identities: Arc<Identities>) -> Result<Project> {
     match read_json(path)? {
         Value::Object(values) => {
             let project_identifier = IdentityIdentifier::from_str(get_field_as_str(&values, "identity")?.as_str())?;
 
             let authority_identity = get_field_as_str(&values, "authority_identity")?;
-            let identities_creation = IdentitiesCreation::new(vault);
+            let identities_creation = identities.identities_creation();
             let authority_public_identity = identities_creation
                 .decode_identity(&hex::decode(authority_identity).unwrap())
                 .await?;

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -56,7 +56,7 @@ pub async fn import_project(path: &str, vault: Arc<dyn IdentitiesVault>) -> Resu
             let authority_identity = get_field_as_str(&values, "authority_identity")?;
             let identities_creation = IdentitiesCreation::new(vault);
             let authority_public_identity = identities_creation
-                .import_identity(&hex::decode(authority_identity).unwrap())
+                .decode_identity(&hex::decode(authority_identity).unwrap())
                 .await?;
 
             let authority_access_route = get_field_as_str(&values, "authority_access_route")?;

--- a/implementations/rust/ockam/ockam/README.md
+++ b/implementations/rust/ockam/ockam/README.md
@@ -49,7 +49,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam = "0.86.0"
+ockam = "0.87.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -1,6 +1,5 @@
-use crate::remote::{RemoteForwarder, RemoteForwarderInfo, RemoteForwarderOptions};
-use crate::stream::Stream;
 use core::time::Duration;
+
 use ockam_core::compat::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{
@@ -9,13 +8,16 @@ use ockam_core::{
 };
 use ockam_identity::{
     secure_channels, Credentials, CredentialsServer, Identities, IdentitiesCreation,
-    IdentitiesKeys, IdentitiesRepository, SecureChannelRegistry, SecureChannels,
-    SecureChannelsBuilder, Storage,
+    IdentitiesKeys, IdentitiesRepository, IdentityIdentifier, SecureChannelRegistry,
+    SecureChannels, SecureChannelsBuilder, Storage,
 };
 use ockam_identity::{
     IdentitiesVault, Identity, SecureChannelListenerOptions, SecureChannelOptions,
 };
 use ockam_node::{Context, HasContext, MessageReceiveOptions, MessageSendReceiveOptions};
+
+use crate::remote::{RemoteForwarder, RemoteForwarderInfo, RemoteForwarderOptions};
+use crate::stream::Stream;
 
 /// This struct supports all the ockam services for managing identities
 /// and creating secure channels
@@ -91,8 +93,12 @@ impl Node {
     }
 
     /// Create an Identity
-    pub async fn create_identity(&self) -> Result<Identity> {
-        self.identities_creation().create_identity().await
+    pub async fn create_identity(&self) -> Result<IdentityIdentifier> {
+        Ok(self
+            .identities_creation()
+            .create_identity()
+            .await?
+            .identifier())
     }
 
     /// Import an Identity given its private key and change history
@@ -114,37 +120,37 @@ impl Node {
     /// Spawns a SecureChannel listener at given `Address` with given [`SecureChannelListenerOptions`]
     pub async fn create_secure_channel_listener(
         &self,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         address: impl Into<Address>,
         options: impl Into<SecureChannelListenerOptions>,
     ) -> Result<()> {
         self.secure_channels()
-            .create_secure_channel_listener(self.get_context(), identity, address, options)
+            .create_secure_channel_listener(self.get_context(), identifier, address, options)
             .await
     }
 
     /// Initiate a SecureChannel using `Route` to the SecureChannel listener and [`SecureChannelOptions`]
     pub async fn create_secure_channel(
         &self,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         route: impl Into<Route>,
         options: impl Into<SecureChannelOptions>,
     ) -> Result<Address> {
         self.secure_channels()
-            .create_secure_channel(self.get_context(), identity, route, options)
+            .create_secure_channel(self.get_context(), identifier, route, options)
             .await
     }
 
     /// Extended function to create a SecureChannel with [`SecureChannelOptions`]
     pub async fn create_secure_channel_extended(
         &self,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         route: impl Into<Route>,
         options: impl Into<SecureChannelOptions>,
         timeout: Duration,
     ) -> Result<Address> {
         self.secure_channels()
-            .create_secure_channel_extended(self.get_context(), identity, route, options, timeout)
+            .create_secure_channel_extended(self.get_context(), identifier, route, options, timeout)
             .await
     }
 

--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -108,7 +108,7 @@ impl Node {
 
     /// Import an Identity given that was exported as a hex-encoded string
     pub async fn import_identity_hex(&self, data: &str) -> Result<Identity> {
-        self.identities_creation().import_identity_hex(data).await
+        self.identities_creation().decode_identity_hex(data).await
     }
 
     /// Spawns a SecureChannel listener at given `Address` with given [`SecureChannelListenerOptions`]

--- a/implementations/rust/ockam/ockam/tests/forwarder.rs
+++ b/implementations/rust/ockam/ockam/tests/forwarder.rs
@@ -186,7 +186,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &cloud_identity,
+            &cloud_identity.identifier(),
             "cloud_listener",
             SecureChannelListenerOptions::new(),
         )
@@ -222,7 +222,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
     let cloud_server_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &server_identity,
+            &server_identity.identifier(),
             route![cloud_server_connection, "cloud_listener"],
             SecureChannelOptions::as_producer(
                 &server_flow_controls,
@@ -234,7 +234,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &server_identity,
+            &server_identity.identifier(),
             "server_listener",
             SecureChannelListenerOptions::as_spawner(
                 &server_flow_controls,
@@ -272,7 +272,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
     let cloud_client_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &client_identity,
+            &client_identity.identifier(),
             route![cloud_client_connection, "cloud_listener"],
             SecureChannelOptions::as_producer(
                 &client_flow_controls,
@@ -285,7 +285,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
     let tunnel_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &client_identity,
+            &client_identity.identifier(),
             route![
                 cloud_client_channel,
                 remote_info.remote_address(),

--- a/implementations/rust/ockam/ockam_abac/README.md
+++ b/implementations/rust/ockam/ockam_abac/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_abac = "0.20.0"
+ockam_abac = "0.21.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_api/README.md
+++ b/implementations/rust/ockam/ockam_api/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_api = "0.29.0"
+ockam_api = "0.30.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -103,15 +103,18 @@ impl IdentityAttributesWriter for BootstrapedIdentityStore {
 
 #[async_trait]
 impl IdentitiesReader for BootstrapedIdentityStore {
-    async fn get_identity(&self, identifier: &IdentityIdentifier) -> Result<Option<Identity>> {
+    async fn retrieve_identity(&self, identifier: &IdentityIdentifier) -> Result<Option<Identity>> {
+        self.repository.retrieve_identity(identifier).await
+    }
+    async fn get_identity(&self, identifier: &IdentityIdentifier) -> Result<Identity> {
         self.repository.get_identity(identifier).await
     }
 }
 
 #[async_trait]
 impl IdentitiesWriter for BootstrapedIdentityStore {
-    async fn update_known_identity(&self, identity: &Identity) -> Result<()> {
-        self.repository.update_known_identity(identity).await
+    async fn update_identity(&self, identity: &Identity) -> Result<()> {
+        self.repository.update_identity(identity).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -126,6 +126,14 @@ impl IdentitiesRepository for BootstrapedIdentityStore {
     fn as_attributes_writer(&self) -> Arc<dyn IdentityAttributesWriter> {
         Arc::new(self.clone())
     }
+
+    fn as_identities_reader(&self) -> Arc<dyn IdentitiesReader> {
+        Arc::new(self.clone())
+    }
+
+    fn as_identities_writer(&self) -> Arc<dyn IdentitiesWriter> {
+        Arc::new(self.clone())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -74,7 +74,7 @@ impl IdentityState {
             .make_identities(vault)
             .await?
             .identities_creation()
-            .import_identity(&data)
+            .decode_identity(&data)
             .await?)
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -2,11 +2,12 @@ use std::str::FromStr;
 
 use minicbor::{Decode, Encode};
 
-use crate::error::ApiError;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 use ockam_core::{CowStr, Result};
 use ockam_multiaddr::MultiAddr;
+
+use crate::error::ApiError;
 
 pub mod addon;
 pub mod enroll;
@@ -200,7 +201,7 @@ mod node {
                 ))
                 .as_consumer(&node_manager.flow_controls);
                 let sc_address = secure_channels
-                    .create_secure_channel(ctx, &identity, cloud_route.route, options)
+                    .create_secure_channel(ctx, &identity.identifier(), cloud_route.route, options)
                     .await?;
 
                 (

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -167,10 +167,10 @@ mod node {
             T: Encode<()>,
         {
             let identity_name = ident.map(|i| i.to_string()).clone();
-            let identity = {
+            let identifier = {
                 let node_manager = self.get().read().await;
                 node_manager
-                    .get_identity(None, identity_name.clone())
+                    .get_identifier(None, identity_name.clone())
                     .await?
             };
 
@@ -201,7 +201,7 @@ mod node {
                 ))
                 .as_consumer(&node_manager.flow_controls);
                 let sc_address = secure_channels
-                    .create_secure_channel(ctx, &identity.identifier(), cloud_route.route, options)
+                    .create_secure_channel(ctx, &identifier, cloud_route.route, options)
                     .await?;
 
                 (

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -242,7 +242,7 @@ impl TrustAuthorityConfig {
     pub async fn identity(&self) -> Result<Identity> {
         identities()
             .identities_creation()
-            .import_identity(
+            .decode_identity(
                 &hex::decode(&self.identity)
                     .map_err(|_| ApiError::generic("unable to decode authority identity"))?,
             )
@@ -319,7 +319,7 @@ impl AuthoritiesConfig {
             v.push(
                 identities
                     .identities_creation()
-                    .import_identity(a.identity.as_slice())
+                    .decode_identity(a.identity.as_slice())
                     .await?,
             )
         }
@@ -384,7 +384,7 @@ impl CredentialIssuerConfig {
             .map_err(|_| ApiError::generic("Invalid project authority"))?;
         identities()
             .identities_creation()
-            .import_identity(&encoded)
+            .decode_identity(&encoded)
             .await
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -284,7 +284,7 @@ impl CredentialRetrieverConfig {
             CredentialRetrieverConfig::FromCredentialIssuer(issuer_config) => {
                 let _ = tcp_transport.ok_or_else(|| ApiError::generic("TCP Transport was not provided when credential retriever was defined as an issuer."))?;
                 let credential_issuer_info = RemoteCredentialsRetrieverInfo::new(
-                    issuer_config.resolve_identity().await?,
+                    issuer_config.resolve_identity().await?.identifier(),
                     issuer_config.resolve_route().await?,
                     DefaultAddress::CREDENTIAL_ISSUER.into(),
                 );

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -128,8 +128,9 @@ impl TrustContextConfig {
                     };
 
                 Some(AuthorityService::new(
+                    secure_channels.identities().identities_reader(),
                     secure_channels.identities().credentials(),
-                    identity,
+                    identity.identifier(),
                     credential_retriever,
                 ))
             } else {

--- a/implementations/rust/ockam/ockam_api/src/config/lookup.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/lookup.rs
@@ -278,7 +278,7 @@ impl ProjectAuthority {
                 .map_err(|_| ApiError::generic("Invalid project authority"))?;
             let p = identities()
                 .identities_creation()
-                .import_identity(&a)
+                .decode_identity(&a)
                 .await?;
             Ok(Some(ProjectAuthority::new(p.identifier(), rte, a)))
         } else {

--- a/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
@@ -138,7 +138,7 @@ impl IdentityService {
                         .node_identities
                         .get_default_identities_creation()
                         .await?;
-                    let identity = identities_creation.import_identity(args.identity()).await?;
+                    let identity = identities_creation.decode_identity(args.identity()).await?;
 
                     let body = ValidateIdentityChangeHistoryResponse::new(String::from(
                         identity.identifier(),
@@ -156,7 +156,7 @@ impl IdentityService {
                         .node_identities
                         .get_identities_creation(args.vault_name())
                         .await?;
-                    let identity = identities_creation.import_identity(args.identity()).await?;
+                    let identity = identities_creation.decode_identity(args.identity()).await?;
                     let identities_keys = self
                         .node_identities
                         .get_identities_keys(args.vault_name())
@@ -180,7 +180,7 @@ impl IdentityService {
                         .get_default_identities_creation()
                         .await?;
                     let peer_identity = identities_creation
-                        .import_identity(args.signer_identity())
+                        .decode_identity(args.signer_identity())
                         .await?;
 
                     let identities_keys =
@@ -211,14 +211,14 @@ impl IdentityService {
                         .await?;
 
                     let current_identity = identities_creation
-                        .import_identity(args.current_identity())
+                        .decode_identity(args.current_identity())
                         .await?;
 
                     let body = if args.known_identity().is_empty() {
                         IdentityHistoryComparison::Newer
                     } else {
                         let known_identity = identities_creation
-                            .import_identity(args.known_identity())
+                            .decode_identity(args.known_identity())
                             .await?;
                         current_identity.compare(&known_identity)
                     };

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -112,7 +112,7 @@ mod test {
                 .secure_channels
                 .create_secure_channel_listener(
                     context,
-                    &handle.identity.identifier(),
+                    &handle.identifier,
                     DefaultAddress::SECURE_CHANNEL_LISTENER,
                     SecureChannelListenerOptions::new().as_consumer_with_flow_control_id(
                         flow_controls,

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -58,7 +58,7 @@ impl Authority {
         let identity = secure_channels
             .identities()
             .identities_creation()
-            .import_identity(configuration.identity.export()?.as_slice())
+            .decode_identity(configuration.identity.export()?.as_slice())
             .await?;
         info!(identifier=%identity.identifier(), "retrieved the authority identifier");
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -224,7 +224,7 @@ impl Authority {
         // create and start a credential issuer worker
         let issuer = CredentialsIssuer::new(
             self.identities(),
-            self.identity.clone(),
+            self.identity.identifier(),
             configuration.trust_context_identifier(),
         )
         .await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -1,9 +1,7 @@
-use crate::authenticator::direct::EnrollmentTokenAuthenticator;
-use crate::bootstrapped_identities_store::BootstrapedIdentityStore;
-use crate::echoer::Echoer;
-use crate::nodes::authority_node::authority::EnrollerCheck::{AnyMember, EnrollerOnly};
-use crate::nodes::authority_node::Configuration;
-use crate::{actions, DefaultAddress};
+use std::path::Path;
+
+use tracing::info;
+
 use ockam::identity::{
     Identities, IdentitiesRepository, IdentitiesStorage, IdentitiesVault, Identity,
     IdentityAttributesWriter, SecureChannelListenerOptions, SecureChannels, TrustEveryonePolicy,
@@ -19,8 +17,13 @@ use ockam_node::{Context, WorkerBuilder};
 use ockam_transport_tcp::{TcpListenerOptions, TcpTransport};
 use ockam_vault::storage::FileStorage;
 use ockam_vault::Vault;
-use std::path::Path;
-use tracing::info;
+
+use crate::authenticator::direct::EnrollmentTokenAuthenticator;
+use crate::bootstrapped_identities_store::BootstrapedIdentityStore;
+use crate::echoer::Echoer;
+use crate::nodes::authority_node::authority::EnrollerCheck::{AnyMember, EnrollerOnly};
+use crate::nodes::authority_node::Configuration;
+use crate::{actions, DefaultAddress};
 
 /// This struct represents an Authority, which is an
 /// Identity which other identities trust to authenticate attributes
@@ -95,7 +98,12 @@ impl Authority {
 
         let listener_name = configuration.secure_channel_listener_name();
         self.secure_channels
-            .create_secure_channel_listener(ctx, &self.identity, listener_name.clone(), options)
+            .create_secure_channel_listener(
+                ctx,
+                &self.identity.identifier(),
+                listener_name.clone(),
+                options,
+            )
             .await?;
         info!("started a secure channel listener with name '{listener_name}'");
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -26,7 +26,7 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::{FlowControlId, FlowControls};
 use ockam_core::IncomingAccessControl;
 use ockam_core::{AllowAll, AsyncTryClone, LOCAL};
-use ockam_identity::{Identity, TrustContext};
+use ockam_identity::TrustContext;
 use ockam_multiaddr::proto::Service;
 use ockam_multiaddr::{MultiAddr, Protocol};
 use ockam_node::compat::asynchronous::RwLock;
@@ -106,12 +106,6 @@ pub struct NodeManager {
 }
 
 impl NodeManager {
-    pub(super) async fn identity(&self) -> Result<Identity> {
-        self.identities_repository()
-            .get_identity(&self.identifier())
-            .await
-    }
-
     pub(super) fn identifier(&self) -> IdentityIdentifier {
         self.identifier.clone()
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -40,7 +40,7 @@ impl NodeManagerWorker {
                 }
             }
         } else {
-            Arc::new(node_manager.identity())
+            Arc::new(node_manager.identity().await?)
         };
 
         if let Ok(c) = node_manager
@@ -75,7 +75,7 @@ impl NodeManagerWorker {
         let credential = node_manager
             .trust_context()?
             .authority()?
-            .credential(ctx, &node_manager.identity.identifier())
+            .credential(ctx, &node_manager.identifier())
             .await?;
 
         if request.oneway {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -1,18 +1,21 @@
-use crate::cli_state::traits::StateDirTrait;
-use crate::error::ApiError;
-use crate::local_multiaddr_to_route;
-use crate::nodes::models::credentials::{GetCredentialRequest, PresentCredentialRequest};
-use crate::nodes::service::map_multiaddr_err;
+use std::str::FromStr;
+use std::sync::Arc;
+
 use either::Either;
 use minicbor::Decoder;
+
 use ockam::identity::Credential;
 use ockam::Result;
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
 use ockam_identity::IdentitiesVault;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::{Context, MessageSendReceiveOptions};
-use std::str::FromStr;
-use std::sync::Arc;
+
+use crate::cli_state::traits::StateDirTrait;
+use crate::error::ApiError;
+use crate::local_multiaddr_to_route;
+use crate::nodes::models::credentials::{GetCredentialRequest, PresentCredentialRequest};
+use crate::nodes::service::map_multiaddr_err;
 
 use super::NodeManagerWorker;
 
@@ -91,7 +94,11 @@ impl NodeManagerWorker {
                 .present_credential_mutual(
                     ctx,
                     route,
-                    &[node_manager.trust_context()?.authority()?.identity()],
+                    node_manager
+                        .trust_context()?
+                        .authorities()
+                        .await?
+                        .as_slice(),
                     credential,
                     MessageSendReceiveOptions::new().with_flow_control(&node_manager.flow_controls),
                 )

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -43,7 +43,7 @@ impl NodeManagerWorker {
         if let Ok(c) = node_manager
             .trust_context()?
             .authority()?
-            .credential(ctx, &identity)
+            .credential(ctx, &identity.identifier())
             .await
         {
             Ok(Either::Right(Response::ok(req.id()).body(c)))
@@ -72,7 +72,7 @@ impl NodeManagerWorker {
         let credential = node_manager
             .trust_context()?
             .authority()?
-            .credential(ctx, &node_manager.identity)
+            .credential(ctx, &node_manager.identity.identifier())
             .await?;
 
         if request.oneway {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -576,7 +576,7 @@ impl NodeManagerWorker {
             &hex::decode(encoded_identity).map_err(|_| ApiError::generic("Unable to decode trust context's public identity when starting credential service."))?;
         let i = identities()
             .identities_creation()
-            .import_identity(decoded_identity)
+            .decode_identity(decoded_identity)
             .await?;
 
         let trust_context = TrustContext::new(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -581,7 +581,12 @@ impl NodeManagerWorker {
 
         let trust_context = TrustContext::new(
             encoded_identity.to_string(),
-            Some(AuthorityService::new(node_manager.credentials(), i, None)),
+            Some(AuthorityService::new(
+                node_manager.identities().identities_reader(),
+                node_manager.credentials(),
+                i.identifier(),
+                None,
+            )),
         );
 
         node_manager

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -85,13 +85,7 @@ impl NodeManager {
         }
 
         self.credentials_service()
-            .start(
-                ctx,
-                trust_context,
-                self.identity.identifier(),
-                addr.clone(),
-                !oneway,
-            )
+            .start(ctx, trust_context, self.identifier(), addr.clone(), !oneway)
             .await?;
 
         self.registry
@@ -246,8 +240,7 @@ impl NodeManager {
         let abac = self
             .build_access_control(&resource, &action, project.as_str(), &rule)
             .await?;
-        let issuer =
-            CredentialsIssuer::new(self.identities(), self.identity.identifier(), project).await?;
+        let issuer = CredentialsIssuer::new(self.identities(), self.identifier(), project).await?;
         WorkerBuilder::with_access_control(abac, Arc::new(AllowAll), addr.clone(), issuer)
             .start(ctx)
             .await

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -88,7 +88,7 @@ impl NodeManager {
             .start(
                 ctx,
                 trust_context,
-                self.identity.clone(),
+                self.identity.identifier(),
                 addr.clone(),
                 !oneway,
             )
@@ -247,7 +247,7 @@ impl NodeManager {
             .build_access_control(&resource, &action, project.as_str(), &rule)
             .await?;
         let issuer =
-            CredentialsIssuer::new(self.identities(), self.identity.clone(), project).await?;
+            CredentialsIssuer::new(self.identities(), self.identity.identifier(), project).await?;
         WorkerBuilder::with_access_control(abac, Arc::new(AllowAll), addr.clone(), issuer)
             .start(ctx)
             .await

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -180,7 +180,7 @@ impl NodeManager {
                     .present_credential_mutual(
                         ctx,
                         route![sc_addr.clone(), DefaultAddress::CREDENTIALS_SERVICE],
-                        &[self.trust_context()?.authority()?.identity()],
+                        self.trust_context()?.authorities().await?.as_slice(),
                         credential,
                         MessageSendReceiveOptions::new().with_flow_control(&self.flow_controls),
                     )

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -73,7 +73,13 @@ impl NodeManager {
 
         let sc_addr = self
             .secure_channels
-            .create_secure_channel_extended(ctx, identity, sc_route.clone(), options, timeout)
+            .create_secure_channel_extended(
+                ctx,
+                &identity.identifier(),
+                sc_route.clone(),
+                options,
+                timeout,
+            )
             .await?;
 
         debug!(%sc_route, %sc_addr, "Created secure channel");
@@ -143,7 +149,7 @@ impl NodeManager {
                     None => {
                         self.trust_context()?
                             .authority()?
-                            .credential(ctx, &identity)
+                            .credential(ctx, &identity.identifier())
                             .await?
                     }
                 };
@@ -165,7 +171,7 @@ impl NodeManager {
                     None => {
                         self.trust_context()?
                             .authority()?
-                            .credential(ctx, &identity)
+                            .credential(ctx, &identity.identifier())
                             .await?
                     }
                 };
@@ -217,7 +223,7 @@ impl NodeManager {
         };
 
         secure_channels
-            .create_secure_channel_listener(ctx, &identity, address.clone(), options)
+            .create_secure_channel_listener(ctx, &identity.identifier(), address.clone(), options)
             .await?;
 
         self.registry.secure_channel_listeners.insert(
@@ -278,7 +284,7 @@ impl NodeManager {
     }
 
     pub(super) fn node_identities(&self) -> NodeIdentities {
-        NodeIdentities::new(self.identities_vault(), self.cli_state.clone())
+        NodeIdentities::new(self.identities(), self.cli_state.clone())
     }
 
     pub(crate) async fn get_identity(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -303,7 +303,7 @@ impl NodeManager {
                 Err(CliStateError::NotFound.into())
             }
         } else {
-            Ok(self.identity.clone())
+            self.identity().await
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/verifier.rs
+++ b/implementations/rust/ockam/ockam_api/src/verifier.rs
@@ -90,7 +90,7 @@ impl Verifier {
         let authority = if let Some(ident) = req.authority(data.unverified_issuer()) {
             self.identities
                 .identities_creation()
-                .import_identity(ident)
+                .decode_identity(ident)
                 .await?
         } else {
             let err = Error::new("/verify").with_message("unauthorised issuer");

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -62,7 +62,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         .await?;
     let auth = CredentialsIssuer::new(
         identities.clone(),
-        auth_identity.clone(),
+        auth_identity.identifier(),
         "project42".into(),
     )
     .await?;

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -91,7 +91,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     let exported = member_identity.export()?;
 
     let imported = identities_creation
-        .import_identity(&exported)
+        .decode_identity(&exported)
         .await
         .unwrap();
     let data = identities

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -1,11 +1,10 @@
-use ockam_core::compat::collections::{BTreeMap, HashMap};
-use ockam_core::compat::sync::Arc;
-
 use ockam::identity::credential::Timestamp;
-use ockam::identity::{identities, AttributesEntry, IdentitiesStorage};
+use ockam::identity::{identities, AttributesEntry};
 use ockam::route;
 use ockam_api::bootstrapped_identities_store::{BootstrapedIdentityStore, PreTrustedIdentities};
+use ockam_core::compat::collections::{BTreeMap, HashMap};
 use ockam_core::compat::rand::random_string;
+use ockam_core::compat::sync::Arc;
 use ockam_core::{AllowAll, Result};
 use ockam_identity::{
     CredentialsIssuer, CredentialsIssuerClient, Identities, SecureChannelListenerOptions,
@@ -37,7 +36,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
 
     let boostrapped = BootstrapedIdentityStore::new(
         Arc::new(PreTrustedIdentities::from(pre_trusted)),
-        IdentitiesStorage::create(),
+        identities.repository(),
     );
 
     // Now recreate the identities services with the previous vault
@@ -56,7 +55,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &auth_identity,
+            &auth_identity.identifier(),
             &api_worker_addr,
             SecureChannelListenerOptions::new(),
         )
@@ -79,7 +78,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     let e2a = secure_channels
         .create_secure_channel(
             ctx,
-            &member_identity,
+            &member_identity.identifier(),
             &api_worker_addr,
             SecureChannelOptions::new(),
         )

--- a/implementations/rust/ockam/ockam_command/README.md
+++ b/implementations/rust/ockam/ockam_command/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_command = "0.86.0"
+ockam_command = "0.87.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -58,7 +58,7 @@ impl IssueCommand {
 
         let identity = identities()
             .identities_creation()
-            .import_identity(&identity_as_bytes)
+            .decode_identity(&identity_as_bytes)
             .await?;
         Ok(identity)
     }

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -92,7 +92,7 @@ async fn run_impl(
     )?;
     let credential = identities
         .credentials()
-        .issue_credential(&issuer, credential_data)
+        .issue_credential(&issuer.identifier(), credential_data)
         .await?;
 
     print_encodable(credential, &cmd.encode_format)?;

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -42,7 +42,7 @@ impl StoreCommand {
         };
         let identity = identities()
             .identities_creation()
-            .import_identity(&identity_as_bytes)
+            .decode_identity(&identity_as_bytes)
             .await?;
         Ok(identity)
     }

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -37,7 +37,7 @@ impl VerifyCommand {
         };
         let identity = identities()
             .identities_creation()
-            .import_identity(&identity_as_bytes)
+            .decode_identity(&identity_as_bytes)
             .await?;
         Ok(identity)
     }

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -3,7 +3,6 @@ use crate::CommandGlobalOpts;
 use crate::Result;
 use anyhow::anyhow;
 use clap::Args;
-use ockam::identity::Identity;
 use ockam::{Context, TcpTransport};
 use ockam_api::cli_state::identities::IdentityState;
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -9,6 +9,7 @@ use ockam_api::cli_state::identities::IdentityState;
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
 use ockam_api::cli_state::NodeState;
 use ockam_api::nodes::models::base::NodeStatus;
+use ockam_identity::IdentityIdentifier;
 use std::time::Duration;
 
 /// Display Ockam Status
@@ -20,7 +21,7 @@ pub struct StatusCommand {
 }
 
 struct NodeDetails {
-    identity: Identity,
+    identifier: IdentityIdentifier,
     state: NodeState,
     status: String,
 }
@@ -45,7 +46,7 @@ async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: StatusCommand) ->
     let tcp = TcpTransport::create(ctx).await?;
     for node_state in &node_states {
         let node_infos = NodeDetails {
-            identity: node_state.config().identity().await?,
+            identifier: node_state.config().identity().await?.identifier(),
             state: node_state.clone(),
             status: get_node_status(ctx, &opts, node_state, &tcp).await?,
         };
@@ -115,8 +116,7 @@ async fn print_status(
             println!("{:2}{}", "", line);
         }
 
-        node_details
-            .retain(|nd| nd.identity.identifier() == identity.config().identity.identifier());
+        node_details.retain(|nd| nd.identifier == identity.config().identity.identifier());
         if !node_details.is_empty() {
             println!("{:2}Linked Nodes:", "");
             for (n_idx, node) in node_details.iter().enumerate() {

--- a/implementations/rust/ockam/ockam_core/src/vault/types.rs
+++ b/implementations/rust/ockam/ockam_core/src/vault/types.rs
@@ -1,15 +1,16 @@
-use crate::{
-    errcode::{Kind, Origin},
-    hex_encoding, Error,
-};
-use cfg_if::cfg_if;
 use core::fmt;
+
+use cfg_if::cfg_if;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 #[cfg(feature = "tag")]
 use crate::TypeTag;
+use crate::{
+    errcode::{Kind, Origin},
+    hex_encoding, Error,
+};
 
 /// Curve25519 private key length.
 pub const CURVE25519_SECRET_LENGTH_U32: u32 = 32;
@@ -94,6 +95,7 @@ impl fmt::Debug for SecretKey {
 }
 
 impl Eq for SecretKey {}
+
 impl PartialEq for SecretKey {
     fn eq(&self, o: &Self) -> bool {
         subtle::ConstantTimeEq::ct_eq(&self.0[..], &o.0[..]).into()
@@ -120,6 +122,7 @@ pub struct PublicKey {
 }
 
 impl Eq for PublicKey {}
+
 impl PartialEq for PublicKey {
     fn eq(&self, o: &Self) -> bool {
         let choice = subtle::ConstantTimeEq::ct_eq(&self.data[..], &o.data[..]);
@@ -201,7 +204,7 @@ pub enum SecretType {
     /// Ed 22519 key
     #[n(4)] Ed25519,
     /// NIST P-256 key
-    #[n(5)] NistP256
+    #[n(5)] NistP256,
 }
 
 /// All possible [`SecretKey`] persistence types
@@ -302,7 +305,7 @@ pub enum Secret {
     /// A secret key.
     #[n(0)] Key(#[n(0)] SecretKey),
     /// Reference to an unmanaged, external secret key of AWS KMS.
-    #[n(1)] Aws(#[n(1)] KeyId)
+    #[n(1)] Aws(#[n(1)] KeyId),
 }
 
 impl Secret {

--- a/implementations/rust/ockam/ockam_ffi/README.md
+++ b/implementations/rust/ockam/ockam_ffi/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam-ffi = "0.72.0"
+ockam-ffi = "0.73.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_identity/README.md
+++ b/implementations/rust/ockam/ockam_identity/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_identity = "0.74.0"
+ockam_identity = "0.75.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_identity/src/credentials/authority_service.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/authority_service.rs
@@ -1,5 +1,7 @@
 use crate::credentials::credentials_retriever::CredentialsRetriever;
-use crate::{Credential, Credentials, Identity, IdentityError, IdentityIdentifier};
+use crate::{
+    Credential, Credentials, IdentitiesReader, Identity, IdentityError, IdentityIdentifier,
+};
 use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_node::Context;
@@ -7,28 +9,31 @@ use ockam_node::Context;
 /// An AuthorityService represents an authority which issued credentials
 #[derive(Clone)]
 pub struct AuthorityService {
+    identities_reader: Arc<dyn IdentitiesReader>,
     credentials: Arc<dyn Credentials>,
-    identity: Identity,
+    identifier: IdentityIdentifier,
     own_credential: Option<Arc<dyn CredentialsRetriever>>,
 }
 
 impl AuthorityService {
     /// Create a new authority service
     pub fn new(
+        identities_reader: Arc<dyn IdentitiesReader>,
         credentials: Arc<dyn Credentials>,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         own_credential: Option<Arc<dyn CredentialsRetriever>>,
     ) -> Self {
         Self {
+            identities_reader,
             credentials,
-            identity,
+            identifier,
             own_credential,
         }
     }
 
     /// Return the Public Identity of the Authority
-    pub fn identity(&self) -> Identity {
-        self.identity.clone()
+    pub async fn identity(&self) -> Result<Identity> {
+        self.identities_reader.get_identity(&self.identifier).await
     }
 
     /// Retrieve the credential for an identity within this authority

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
@@ -10,15 +10,19 @@ use ockam_core::{async_trait, route, Address, Result, Route};
 use ockam_node::Context;
 
 use crate::{
-    Credential, CredentialsIssuerClient, Identity, SecureChannelOptions, SecureChannels,
-    TrustMultiIdentifiersPolicy,
+    Credential, CredentialsIssuerClient, Identity, IdentityIdentifier, SecureChannelOptions,
+    SecureChannels, TrustMultiIdentifiersPolicy,
 };
 
 /// Trait for retrieving a credential for a given identity
 #[async_trait]
 pub trait CredentialsRetriever: Send + Sync + 'static {
     /// Retrieve a credential for an identity
-    async fn retrieve(&self, ctx: &Context, for_identity: &Identity) -> Result<Credential>;
+    async fn retrieve(
+        &self,
+        ctx: &Context,
+        for_identity: &IdentityIdentifier,
+    ) -> Result<Credential>;
 }
 
 /// Credentials retriever that retrieves a credential from memory
@@ -36,7 +40,11 @@ impl CredentialsMemoryRetriever {
 #[async_trait]
 impl CredentialsRetriever for CredentialsMemoryRetriever {
     /// Retrieve a credential stored in memory
-    async fn retrieve(&self, _ctx: &Context, _for_identity: &Identity) -> Result<Credential> {
+    async fn retrieve(
+        &self,
+        _ctx: &Context,
+        _for_identity: &IdentityIdentifier,
+    ) -> Result<Credential> {
         Ok(self.credential.clone())
     }
 }
@@ -65,7 +73,11 @@ impl RemoteCredentialsRetriever {
 
 #[async_trait]
 impl CredentialsRetriever for RemoteCredentialsRetriever {
-    async fn retrieve(&self, ctx: &Context, for_identity: &Identity) -> Result<Credential> {
+    async fn retrieve(
+        &self,
+        ctx: &Context,
+        for_identity: &IdentityIdentifier,
+    ) -> Result<Credential> {
         debug!("Getting credential from : {}", &self.issuer.route);
         let resolved_route = ctx
             .resolve_transport_route(&self.flow_controls, self.issuer.route.clone())

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
@@ -10,8 +10,8 @@ use ockam_core::{async_trait, route, Address, Result, Route};
 use ockam_node::Context;
 
 use crate::{
-    Credential, CredentialsIssuerClient, Identity, IdentityIdentifier, SecureChannelOptions,
-    SecureChannels, TrustMultiIdentifiersPolicy,
+    Credential, CredentialsIssuerClient, IdentityIdentifier, SecureChannelOptions, SecureChannels,
+    TrustMultiIdentifiersPolicy,
 };
 
 /// Trait for retrieving a credential for a given identity
@@ -87,7 +87,7 @@ impl CredentialsRetriever for RemoteCredentialsRetriever {
             resolved_route.clone()
         );
 
-        let allowed = vec![self.issuer.identity.identifier()];
+        let allowed = vec![self.issuer.identifier.clone()];
         debug!("Create secure channel to authority");
 
         let flow_control_id = self.flow_controls.generate_id();
@@ -122,7 +122,7 @@ impl CredentialsRetriever for RemoteCredentialsRetriever {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteCredentialsRetrieverInfo {
     /// Issuer identity, used to validate retrieved credentials
-    pub identity: Identity,
+    pub identifier: IdentityIdentifier,
     /// Route used to establish a secure channel to the remote node
     pub route: Route,
     /// Address of the credentials service on the remote node
@@ -131,9 +131,9 @@ pub struct RemoteCredentialsRetrieverInfo {
 
 impl RemoteCredentialsRetrieverInfo {
     /// Create new information for a credential retriever
-    pub fn new(identity: Identity, route: Route, service_address: Address) -> Self {
+    pub fn new(identifier: IdentityIdentifier, route: Route, service_address: Address) -> Self {
         Self {
-            identity,
+            identifier,
             route,
             service_address,
         }

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server.rs
@@ -3,7 +3,7 @@ use crate::credentials::credentials_server_worker::CredentialsServerWorker;
 use crate::credentials::Credentials;
 use crate::identity::Identity;
 use crate::secure_channel::IdentitySecureChannelLocalInfo;
-use crate::TrustContext;
+use crate::{IdentityIdentifier, TrustContext};
 use async_trait::async_trait;
 use minicbor::Decoder;
 use ockam_core::api::{Request, Response, Status};
@@ -44,7 +44,7 @@ pub trait CredentialsServer: Send + Sync {
         &self,
         ctx: &Context,
         trust_context: TrustContext,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         address: Address,
         present_back: bool,
     ) -> Result<()>;
@@ -145,14 +145,14 @@ impl CredentialsServer for CredentialsServerModule {
         &self,
         ctx: &Context,
         trust_context: TrustContext,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         address: Address,
         present_back: bool,
     ) -> Result<()> {
         let worker = CredentialsServerWorker::new(
             self.credentials.clone(),
             trust_context,
-            identity,
+            identifier,
             present_back,
         );
 

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
@@ -81,7 +81,7 @@ impl CredentialsServerWorker {
                     .credentials
                     .receive_presented_credential(
                         &sender,
-                        &[self.trust_context.authority()?.identity()],
+                        self.trust_context.authorities().await?.as_slice(),
                         credential,
                     )
                     .await;
@@ -112,7 +112,7 @@ impl CredentialsServerWorker {
                     .credentials
                     .receive_presented_credential(
                         &sender,
-                        &[self.trust_context.authority()?.identity()],
+                        self.trust_context.authorities().await?.as_slice(),
                         credential,
                     )
                     .await;

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
@@ -131,7 +131,7 @@ impl CredentialsServerWorker {
                     let credential = self
                         .trust_context
                         .authority()?
-                        .credential(ctx, &self.identity)
+                        .credential(ctx, &self.identity.identifier())
                         .await;
                     match credential.as_ref() {
                         Ok(p) if self.present_back => {

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
@@ -12,7 +12,7 @@ use crate::credential::Credential;
 use crate::credentials::Credentials;
 use crate::identity::IdentityIdentifier;
 use crate::secure_channel::IdentitySecureChannelLocalInfo;
-use crate::{Identity, TrustContext};
+use crate::TrustContext;
 
 const TARGET: &str = "ockam::credential_exchange_worker::service";
 
@@ -20,7 +20,7 @@ const TARGET: &str = "ockam::credential_exchange_worker::service";
 pub struct CredentialsServerWorker {
     credentials: Arc<dyn Credentials>,
     trust_context: TrustContext,
-    identity: Identity,
+    identifier: IdentityIdentifier,
     present_back: bool,
 }
 
@@ -28,13 +28,13 @@ impl CredentialsServerWorker {
     pub fn new(
         credentials: Arc<dyn Credentials>,
         trust_context: TrustContext,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         present_back: bool,
     ) -> Self {
         Self {
             credentials,
             trust_context,
-            identity,
+            identifier,
             present_back,
         }
     }
@@ -131,7 +131,7 @@ impl CredentialsServerWorker {
                     let credential = self
                         .trust_context
                         .authority()?
-                        .credential(ctx, &self.identity.identifier())
+                        .credential(ctx, &self.identifier)
                         .await;
                     match credential.as_ref() {
                         Ok(p) if self.present_back => {

--- a/implementations/rust/ockam/ockam_identity/src/credentials/trust_context.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/trust_context.rs
@@ -1,6 +1,7 @@
-use crate::{AuthorityService, IdentityError};
 use ockam_core::compat::string::String;
 use ockam_core::Result;
+
+use crate::{AuthorityService, Identity, IdentityError};
 
 /// A trust context defines which authorities are trusted to attest to which attributes, within a context.
 /// Our first implementation assumes that there is only one authority and it is trusted to attest to all attributes within this context.
@@ -28,5 +29,10 @@ impl TrustContext {
         self.authority
             .as_ref()
             .ok_or_else(|| IdentityError::UnknownAuthority.into())
+    }
+
+    /// Return the authority identities attached to this trust context
+    pub async fn authorities(&self) -> Result<Vec<Identity>> {
+        Ok(vec![self.authority()?.identity().await?])
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/credentials/trust_context.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/trust_context.rs
@@ -1,4 +1,5 @@
 use ockam_core::compat::string::String;
+use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 
 use crate::{AuthorityService, Identity, IdentityError};

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -31,7 +31,10 @@ impl Identities {
 
     /// Return the identities creation service
     pub fn identities_creation(&self) -> Arc<IdentitiesCreation> {
-        Arc::new(IdentitiesCreation::new(self.vault.clone()))
+        Arc::new(IdentitiesCreation::new(
+            self.repository(),
+            self.vault.clone(),
+        ))
     }
 
     /// Return the identities credentials service

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -1,7 +1,7 @@
 use crate::identities::{IdentitiesKeys, IdentitiesRepository, IdentitiesVault};
 use crate::{
     Credentials, CredentialsServer, CredentialsServerModule, IdentitiesBuilder, IdentitiesCreation,
-    IdentitiesStorage,
+    IdentitiesReader, IdentitiesStorage,
 };
 use ockam_core::compat::sync::Arc;
 use ockam_vault::Vault;
@@ -35,6 +35,11 @@ impl Identities {
             self.repository(),
             self.vault.clone(),
         ))
+    }
+
+    /// Return the identities reader
+    pub fn identities_reader(&self) -> Arc<dyn IdentitiesReader> {
+        self.repository().as_identities_reader()
     }
 
     /// Return the identities credentials service

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -24,8 +24,8 @@ impl IdentitiesCreation {
     }
 
     /// Import and verify an `Identity` from its change history in a hex format
-    pub async fn import_identity_hex(&self, data: &str) -> Result<Identity> {
-        self.import_identity(
+    pub async fn decode_identity_hex(&self, data: &str) -> Result<Identity> {
+        self.decode_identity(
             hex::decode(data)
                 .map_err(|_| IdentityError::ConsistencyError)?
                 .as_slice(),
@@ -34,7 +34,7 @@ impl IdentitiesCreation {
     }
 
     /// Import and verify an `Identity` from its change history in a binary format
-    pub async fn import_identity(&self, data: &[u8]) -> Result<Identity> {
+    pub async fn decode_identity(&self, data: &[u8]) -> Result<Identity> {
         let change_history = IdentityChangeHistory::import(data)?;
         let identity_keys = IdentitiesKeys::new(self.vault.clone());
         identity_keys
@@ -63,7 +63,7 @@ impl IdentitiesCreation {
             .await?;
         let identity_history_data: Vec<u8> =
             hex::decode(identity_history).map_err(|_| IdentityError::InvalidInternalState)?;
-        self.import_identity(identity_history_data.as_slice()).await
+        self.decode_identity(identity_history_data.as_slice()).await
     }
 
     /// Cryptographically compute `IdentityIdentifier`

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
@@ -1,16 +1,17 @@
-use crate::alloc::string::ToString;
-use crate::credential::Timestamp;
-use crate::identities::storage::storage::{InMemoryStorage, Storage};
-use crate::identity::IdentityHistoryComparison;
-use crate::identity::{Identity, IdentityChangeConstants, IdentityError, IdentityIdentifier};
-use crate::AttributesEntry;
-use ockam_core::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::collections::BTreeMap;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Result;
+use ockam_core::{async_trait, Error};
+
+use crate::alloc::string::ToString;
+use crate::credential::Timestamp;
+use crate::identities::storage::storage::{InMemoryStorage, Storage};
+use crate::identity::IdentityHistoryComparison;
+use crate::identity::{Identity, IdentityChangeConstants, IdentityError, IdentityIdentifier};
+use crate::AttributesEntry;
 
 /// Repository for data related to identities: key changes and attributes
 #[async_trait]
@@ -153,9 +154,8 @@ impl IdentityAttributesReader for IdentitiesStorage {
 
         let entry: AttributesEntry = minicbor::decode(&entry)?;
 
-        let now = Timestamp::now().ok_or_else(|| {
-            ockam_core::Error::new(Origin::Core, Kind::Internal, "invalid system time")
-        })?;
+        let now = Timestamp::now()
+            .ok_or_else(|| Error::new(Origin::Core, Kind::Internal, "invalid system time"))?;
         match entry.expires() {
             Some(exp) if exp <= now => {
                 self.storage

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
@@ -23,6 +23,12 @@ pub trait IdentitiesRepository:
 
     /// Restrict this repository as a writer for attributes
     fn as_attributes_writer(&self) -> Arc<dyn IdentityAttributesWriter>;
+
+    /// Restrict this repository as a reader for identities
+    fn as_identities_reader(&self) -> Arc<dyn IdentitiesReader>;
+
+    /// Restrict this repository as a writer for identities
+    fn as_identities_writer(&self) -> Arc<dyn IdentitiesWriter>;
 }
 
 #[async_trait]
@@ -32,6 +38,14 @@ impl IdentitiesRepository for IdentitiesStorage {
     }
 
     fn as_attributes_writer(&self) -> Arc<dyn IdentityAttributesWriter> {
+        Arc::new(self.clone())
+    }
+
+    fn as_identities_reader(&self) -> Arc<dyn IdentitiesReader> {
+        Arc::new(self.clone())
+    }
+
+    fn as_identities_writer(&self) -> Arc<dyn IdentitiesWriter> {
         Arc::new(self.clone())
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/tests.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/tests.rs
@@ -42,7 +42,7 @@ async fn test_invalid_signature(ctx: &mut Context) -> Result<()> {
 
             let res = identities::identities()
                 .identities_creation()
-                .import_identity(&identity.export()?)
+                .decode_identity(&identity.export()?)
                 .await;
             if crazy_vault.forged_operation_occurred() {
                 assert!(res.is_err());
@@ -62,7 +62,7 @@ async fn test_invalid_signature(ctx: &mut Context) -> Result<()> {
 async fn check_identity(identity: &mut Identity) -> Result<Identity> {
     identities::identities()
         .identities_creation()
-        .import_identity(&identity.export()?)
+        .decode_identity(&identity.export()?)
         .await
 }
 
@@ -86,14 +86,14 @@ async fn test_eject_signatures(ctx: &mut Context) -> Result<()> {
 
         let res = identities
             .identities_creation()
-            .import_identity(&identity.export()?)
+            .decode_identity(&identity.export()?)
             .await;
         assert!(res.is_ok());
 
         let identity = eject_random_signature(&identity)?;
         let res = identities
             .identities_creation()
-            .import_identity(&identity.export()?)
+            .decode_identity(&identity.export()?)
             .await;
         assert!(res.is_err());
     }

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
@@ -12,7 +12,7 @@ use ockam_core::Result;
 use serde::{Deserialize, Serialize};
 
 /// Identity implementation
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Identity {
     pub(crate) identifier: IdentityIdentifier,
     pub(crate) change_history: IdentityChangeHistory,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change/create_key.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change/create_key.rs
@@ -5,7 +5,7 @@ use ockam_core::vault::PublicKey;
 use serde::{Deserialize, Serialize};
 
 /// Key change data creation
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CreateKeyChangeData {
     prev_change_id: ChangeIdentifier,
     key_attributes: KeyAttributes,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change/identity_change.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change/identity_change.rs
@@ -8,7 +8,7 @@ use ockam_core::Result;
 use serde::{Deserialize, Serialize};
 
 /// Possible types of [`crate::SecureChannels`] changes
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum IdentityChange {
     /// Create key
     CreateKey(CreateKeyChangeData),
@@ -55,7 +55,7 @@ impl IdentityChange {
 
 /// [`crate::SecureChannels`]s are modified using a chain of changes.
 /// Signatures are used to check change validity.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentitySignedChange {
     identifier: ChangeIdentifier,
     change: IdentityChange,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change/rotate_key.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change/rotate_key.rs
@@ -5,7 +5,7 @@ use ockam_core::vault::PublicKey;
 use serde::{Deserialize, Serialize};
 
 /// RotateKeyChangeData
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RotateKeyChangeData {
     prev_change_id: ChangeIdentifier,
     key_attributes: KeyAttributes,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change/signature.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change/signature.rs
@@ -14,7 +14,7 @@ pub enum SignatureType {
 }
 
 /// Signature, its type and data
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Signature {
     stype: SignatureType,
     data: OckamVaultSignature,

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change_history.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change_history.rs
@@ -33,7 +33,7 @@ pub enum IdentityHistoryComparison {
 }
 
 /// Full history of [`crate::secure_channels::SecureChannels`] changes. History and corresponding secret keys are enough to recreate [`crate::secure_channels::SecureChannels`]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IdentityChangeHistory(Vec<IdentitySignedChange>);
 
 impl fmt::Display for IdentityChangeHistory {

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_state.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_state.rs
@@ -1,15 +1,17 @@
-use crate::secure_channel::decryptor::Decryptor;
-use crate::secure_channel::encryptor::Encryptor;
-use crate::secure_channel::{Addresses, Role};
-use crate::{Identity, IdentityIdentifier, SecureChannels, TrustPolicy};
 use alloc::vec::Vec;
+
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{Address, KeyExchanger, Route};
 
+use crate::secure_channel::decryptor::Decryptor;
+use crate::secure_channel::encryptor::Encryptor;
+use crate::secure_channel::{Addresses, Role};
+use crate::{IdentityIdentifier, SecureChannels, TrustPolicy};
+
 pub(crate) struct KeyExchangeState {
     pub(crate) role: Role,
-    pub(crate) identity: Identity,
+    pub(crate) identifier: IdentityIdentifier,
     pub(crate) secure_channels: Arc<SecureChannels>,
     pub(crate) addresses: Addresses,
     pub(crate) remote_route: Route,
@@ -23,7 +25,7 @@ pub(crate) struct KeyExchangeState {
 
 pub(crate) struct IdentityExchangeState {
     pub(crate) role: Role,
-    pub(crate) identity: Identity,
+    pub(crate) identifier: IdentityIdentifier,
     pub(crate) secure_channels: Arc<SecureChannels>,
     pub(crate) encryptor: Option<Encryptor>,
     pub(crate) addresses: Addresses,
@@ -52,7 +54,7 @@ impl KeyExchangeState {
     ) -> IdentityExchangeState {
         IdentityExchangeState {
             role: self.role,
-            identity: self.identity,
+            identifier: self.identifier,
             secure_channels: self.secure_channels,
             remote_route: self.remote_route,
             addresses: self.addresses,
@@ -92,7 +94,7 @@ impl State {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         role: Role,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         secure_channels: Arc<SecureChannels>,
         addresses: Addresses,
         key_exchanger: Box<dyn KeyExchanger>,
@@ -103,7 +105,7 @@ impl State {
     ) -> Self {
         Self::KeyExchange(KeyExchangeState {
             role,
-            identity,
+            identifier,
             secure_channels,
             addresses,
             remote_route,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_worker.rs
@@ -423,7 +423,7 @@ impl IdentityExchangeState {
         self.secure_channels
             .identities()
             .repository()
-            .update_known_identity(&their_identity)
+            .update_identity(&their_identity)
             .await?;
 
         info!(
@@ -447,15 +447,21 @@ impl IdentityExchangeState {
     }
 
     async fn send_identity(&mut self, ctx: &mut Context, first_sender: bool) -> Result<()> {
+        let identity = self
+            .secure_channels
+            .identities
+            .identities_repository
+            .get_identity(&self.identifier)
+            .await?;
         // Prove we posses our Identity key
         let signature = self
             .secure_channels
             .identities()
             .identities_keys()
-            .create_signature(&self.identity, &self.auth_hash, None)
+            .create_signature(&identity, &self.auth_hash, None)
             .await?;
 
-        let exported = self.identity.export()?;
+        let exported = identity.export()?;
         let auth_msg = if first_sender {
             IdentityChannelMessage::Request {
                 identity: exported,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor_worker.rs
@@ -401,7 +401,7 @@ impl IdentityExchangeState {
         let identities = self.secure_channels.identities();
         let their_identity = identities
             .identities_creation()
-            .import_identity(identity.as_slice())
+            .decode_identity(identity.as_slice())
             .await?;
         let their_identity_id = their_identity.identifier();
 

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
@@ -1,29 +1,30 @@
-use crate::identity::Identity;
-use crate::secure_channel::addresses::Addresses;
-use crate::secure_channel::common::{CreateResponderChannelMessage, Role};
-use crate::secure_channel::options::SecureChannelListenerOptions;
-use crate::secure_channel::DecryptorWorker;
-use crate::secure_channels::secure_channels::SecureChannels;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{Address, AllowAll, DenyAll, Result, Routed, Worker};
 use ockam_node::Context;
 
+use crate::secure_channel::addresses::Addresses;
+use crate::secure_channel::common::{CreateResponderChannelMessage, Role};
+use crate::secure_channel::options::SecureChannelListenerOptions;
+use crate::secure_channel::DecryptorWorker;
+use crate::secure_channels::secure_channels::SecureChannels;
+use crate::IdentityIdentifier;
+
 pub(crate) struct IdentityChannelListener {
     secure_channels: Arc<SecureChannels>,
-    identity: Identity,
+    identifier: IdentityIdentifier,
     options: SecureChannelListenerOptions,
 }
 
 impl IdentityChannelListener {
     pub fn new(
         secure_channels: Arc<SecureChannels>,
-        identity: Identity,
+        identifier: IdentityIdentifier,
         options: SecureChannelListenerOptions,
     ) -> Self {
         Self {
             secure_channels,
-            identity,
+            identifier,
             options,
         }
     }
@@ -31,7 +32,7 @@ impl IdentityChannelListener {
     pub async fn create(
         ctx: &Context,
         secure_channels: Arc<SecureChannels>,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         address: Address,
         options: SecureChannelListenerOptions,
     ) -> Result<()> {
@@ -49,7 +50,7 @@ impl IdentityChannelListener {
             flow_controls.add_spawner(&address, flow_control_id);
         }
 
-        let listener = Self::new(secure_channels.clone(), identity.clone(), options);
+        let listener = Self::new(secure_channels.clone(), identifier.clone(), options);
 
         ctx.start_worker(
             address, listener, AllowAll, // TODO: @ac allow to customize
@@ -96,7 +97,7 @@ impl Worker for IdentityChannelListener {
             ctx,
             self.secure_channels.clone(),
             addresses,
-            self.identity.clone(),
+            self.identifier.clone(),
             self.options.trust_policy.clone(),
             access_control.decryptor_outgoing_access_control,
             msg,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/trust_policy/trust_public_key_policy.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/trust_policy/trust_public_key_policy.rs
@@ -35,7 +35,7 @@ impl TrustPolicy for TrustPublicKeyPolicy {
         let their_identity = match self
             .identities
             .identities_repository
-            .get_identity(trust_info.their_identity_id())
+            .retrieve_identity(trust_info.their_identity_id())
             .await?
         {
             Some(their_identity) => their_identity,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
@@ -1,16 +1,18 @@
-use crate::identities::Identities;
-use crate::identities::IdentitiesVault;
-use crate::identity::{Identity, IdentityError};
-use crate::secure_channel::{
-    Addresses, DecryptorWorker, IdentityChannelListener, Role, SecureChannelListenerOptions,
-    SecureChannelOptions, SecureChannelRegistry,
-};
-use crate::SecureChannelsBuilder;
 use core::time::Duration;
+
 use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_core::{Address, Route};
 use ockam_node::Context;
+
+use crate::identities::Identities;
+use crate::identities::IdentitiesVault;
+use crate::identity::IdentityError;
+use crate::secure_channel::{
+    Addresses, DecryptorWorker, IdentityChannelListener, Role, SecureChannelListenerOptions,
+    SecureChannelOptions, SecureChannelRegistry,
+};
+use crate::{IdentityIdentifier, SecureChannelsBuilder};
 
 /// Identity implementation
 #[derive(Clone)]
@@ -60,14 +62,14 @@ impl SecureChannels {
     pub async fn create_secure_channel_listener(
         &self,
         ctx: &Context,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         address: impl Into<Address>,
         options: impl Into<SecureChannelListenerOptions>,
     ) -> Result<()> {
         IdentityChannelListener::create(
             ctx,
             Arc::new(self.clone()),
-            identity,
+            identifier,
             address.into(),
             options.into(),
         )
@@ -80,7 +82,7 @@ impl SecureChannels {
     pub async fn create_secure_channel(
         &self,
         ctx: &Context,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         route: impl Into<Route>,
         options: impl Into<SecureChannelOptions>,
     ) -> Result<Address> {
@@ -95,7 +97,7 @@ impl SecureChannels {
         DecryptorWorker::create_initiator(
             ctx,
             Arc::new(self.clone()),
-            identity.clone(),
+            identifier.clone(),
             route,
             addresses,
             options.trust_policy,
@@ -109,7 +111,7 @@ impl SecureChannels {
     pub async fn create_secure_channel_extended(
         &self,
         ctx: &Context,
-        identity: &Identity,
+        identifier: &IdentityIdentifier,
         route: impl Into<Route>,
         options: impl Into<SecureChannelOptions>,
         timeout: Duration,
@@ -125,7 +127,7 @@ impl SecureChannels {
         DecryptorWorker::create_initiator(
             ctx,
             Arc::new(self.clone()),
-            identity.clone(),
+            identifier.clone(),
             route,
             addresses,
             options.trust_policy,

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -25,7 +25,7 @@ async fn test_channel(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy),
         )
@@ -34,7 +34,7 @@ async fn test_channel(ctx: &mut Context) -> Result<()> {
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy),
         )
@@ -91,7 +91,7 @@ async fn test_channel_send_multiple_messages_both_directions(ctx: &mut Context) 
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy),
         )
@@ -100,7 +100,7 @@ async fn test_channel_send_multiple_messages_both_directions(ctx: &mut Context) 
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy),
         )
@@ -149,7 +149,7 @@ async fn test_channel_registry(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new(),
         )
@@ -158,7 +158,7 @@ async fn test_channel_registry(ctx: &mut Context) -> Result<()> {
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new(),
         )
@@ -217,7 +217,7 @@ async fn test_channel_api(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new(),
         )
@@ -226,7 +226,7 @@ async fn test_channel_api(ctx: &mut Context) -> Result<()> {
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new(),
         )
@@ -327,7 +327,7 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy.clone()),
         )
@@ -336,7 +336,7 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy.clone()),
         )
@@ -345,7 +345,7 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_another_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy),
         )
@@ -354,7 +354,7 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
     let alice_another_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route![alice_channel, "bob_another_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy),
         )
@@ -400,7 +400,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy.clone()),
         )
@@ -409,7 +409,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["bob_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy.clone()),
         )
@@ -418,7 +418,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_another_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy.clone()),
         )
@@ -427,7 +427,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     let alice_another_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route![alice_channel, "bob_another_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy.clone()),
         )
@@ -436,7 +436,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "bob_yet_another_listener",
             SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy),
         )
@@ -445,7 +445,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
     let alice_yet_another_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route![alice_another_channel, "bob_yet_another_listener"],
             SecureChannelOptions::new().with_trust_policy(alice_trust_policy.clone()),
         )
@@ -495,7 +495,7 @@ async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Res
         secure_channels
             .create_secure_channel_listener(
                 ctx,
-                &bob,
+                &bob.identifier(),
                 i.to_string(),
                 SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy.clone()),
             )
@@ -510,7 +510,7 @@ async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Res
         let alice_channel = secure_channels
             .create_secure_channel(
                 ctx,
-                &alice,
+                &alice.identifier(),
                 channel_route,
                 SecureChannelOptions::new().with_trust_policy(alice_trust_policy.clone()),
             )
@@ -590,13 +590,18 @@ async fn access_control__known_participant__should_pass_messages(ctx: &mut Conte
     .await?;
 
     secure_channels
-        .create_secure_channel_listener(ctx, &bob, "listener", SecureChannelListenerOptions::new())
+        .create_secure_channel_listener(
+            ctx,
+            &bob.identifier(),
+            "listener",
+            SecureChannelListenerOptions::new(),
+        )
         .await?;
 
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["listener"],
             SecureChannelOptions::new().with_trust_policy(TrustEveryonePolicy),
         )
@@ -648,13 +653,18 @@ async fn access_control__unknown_participant__should_not_pass_messages(
     .await?;
 
     secure_channels
-        .create_secure_channel_listener(ctx, &bob, "listener", SecureChannelListenerOptions::new())
+        .create_secure_channel_listener(
+            ctx,
+            &bob.identifier(),
+            "listener",
+            SecureChannelListenerOptions::new(),
+        )
         .await?;
 
     let alice_channel = secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["listener"],
             SecureChannelOptions::new().with_trust_policy(TrustEveryonePolicy),
         )

--- a/implementations/rust/ockam/ockam_identity/tests/ciphertext_message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/ciphertext_message_flow_auth.rs
@@ -1,12 +1,14 @@
+use core::time::Duration;
+
+use ockam_core::{route, Result};
+use ockam_identity::SecureChannelOptions;
+use ockam_node::Context;
+
 use crate::common::{
     create_secure_channel, create_secure_channel_listener, create_tcp_connection_with_flow_control,
     create_tcp_connection_without_flow_control, create_tcp_listener_with_flow_control,
     create_tcp_listener_without_flow_control, message_should_not_pass, message_should_pass,
 };
-use core::time::Duration;
-use ockam_core::{route, Result};
-use ockam_identity::SecureChannelOptions;
-use ockam_node::Context;
 
 mod common;
 
@@ -66,7 +68,7 @@ async fn test2(ctx: &mut Context) -> Result<()> {
         .secure_channels
         .create_secure_channel_extended(
             ctx,
-            &channel_to_bob.identity,
+            &channel_to_bob.identifier,
             route![connection_to_bob.address.clone(), "listener"],
             SecureChannelOptions::new(),
             Duration::from_secs(1),
@@ -108,7 +110,7 @@ async fn test3(ctx: &mut Context) -> Result<()> {
         .secure_channels
         .create_secure_channel_extended(
             ctx,
-            &channel_to_bob.identity,
+            &channel_to_bob.identifier,
             route![connection_to_bob.address.clone(), "listener"],
             SecureChannelOptions::new(),
             Duration::from_secs(1),
@@ -150,7 +152,7 @@ async fn test4(ctx: &mut Context) -> Result<()> {
         .secure_channels
         .create_secure_channel_extended(
             ctx,
-            &channel_to_bob.identity,
+            &channel_to_bob.identifier,
             route![connection_to_bob.address.clone(), "listener"],
             SecureChannelOptions::new(),
             Duration::from_secs(1),
@@ -192,7 +194,7 @@ async fn test5(ctx: &mut Context) -> Result<()> {
         .secure_channels
         .create_secure_channel_extended(
             ctx,
-            &channel_to_alice.identity,
+            &channel_to_alice.identifier,
             route![connection_to_alice.address.clone(), "listener"],
             SecureChannelOptions::new(),
             Duration::from_secs(1),

--- a/implementations/rust/ockam/ockam_identity/tests/common/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/common/mod.rs
@@ -6,8 +6,8 @@ use ockam_core::compat::net::SocketAddr;
 use ockam_core::flow_control::{FlowControlId, FlowControlPolicy, FlowControls};
 use ockam_core::{route, Address, AllowAll, Result, Route};
 use ockam_identity::{
-    secure_channels, Identity, IdentityIdentifier, SecureChannelListenerOptions,
-    SecureChannelOptions, SecureChannels,
+    secure_channels, IdentityIdentifier, SecureChannelListenerOptions, SecureChannelOptions,
+    SecureChannels,
 };
 use ockam_node::{Context, MessageReceiveOptions};
 use ockam_transport_tcp::{TcpConnectionOptions, TcpListenerOptions, TcpTransport};
@@ -211,7 +211,7 @@ async fn create_tcp_connection(
 
 #[allow(dead_code)]
 pub struct SecureChannelListenerInfo {
-    pub identity: Identity,
+    pub identifier: IdentityIdentifier,
     pub secure_channels: Arc<SecureChannels>,
 }
 
@@ -252,13 +252,14 @@ pub async fn create_secure_channel_listener(
         options
     };
 
+    let identifier = identity.identifier();
     secure_channels
-        .create_secure_channel_listener(ctx, &identity.identifier(), "listener", options)
+        .create_secure_channel_listener(ctx, &identifier, "listener", options)
         .await?;
 
     let info = SecureChannelListenerInfo {
         secure_channels,
-        identity,
+        identifier,
     };
 
     Ok(info)

--- a/implementations/rust/ockam/ockam_identity/tests/common/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/common/mod.rs
@@ -1,13 +1,16 @@
+use std::sync::Arc;
+
+use rand::random;
+
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::flow_control::{FlowControlId, FlowControlPolicy, FlowControls};
 use ockam_core::{route, Address, AllowAll, Result, Route};
 use ockam_identity::{
-    secure_channels, Identity, SecureChannelListenerOptions, SecureChannelOptions, SecureChannels,
+    secure_channels, Identity, IdentityIdentifier, SecureChannelListenerOptions,
+    SecureChannelOptions, SecureChannels,
 };
 use ockam_node::{Context, MessageReceiveOptions};
 use ockam_transport_tcp::{TcpConnectionOptions, TcpListenerOptions, TcpTransport};
-use rand::random;
-use std::sync::Arc;
 
 #[allow(dead_code)]
 pub async fn message_should_pass(ctx: &Context, address: &Address) -> Result<()> {
@@ -250,7 +253,7 @@ pub async fn create_secure_channel_listener(
     };
 
     secure_channels
-        .create_secure_channel_listener(ctx, &identity, "listener", options)
+        .create_secure_channel_listener(ctx, &identity.identifier(), "listener", options)
         .await?;
 
     let info = SecureChannelListenerInfo {
@@ -264,7 +267,7 @@ pub async fn create_secure_channel_listener(
 #[allow(dead_code)]
 pub struct SecureChannelInfo {
     pub secure_channels: Arc<SecureChannels>,
-    pub identity: Identity,
+    pub identifier: IdentityIdentifier,
     pub address: Address,
 }
 
@@ -285,10 +288,11 @@ pub async fn create_secure_channel(
         options
     };
 
+    let identifier = identity.identifier();
     let address = secure_channels
         .create_secure_channel(
             ctx,
-            &identity,
+            &identifier,
             route![connection.address.clone(), "listener"],
             options,
         )
@@ -296,7 +300,7 @@ pub async fn create_secure_channel(
 
     let info = SecureChannelInfo {
         secure_channels,
-        identity,
+        identifier,
         address,
     };
 

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -46,7 +46,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
         .start(
             ctx,
             trust_context,
-            server.clone(),
+            server.identifier(),
             "credential_exchange".into(),
             false,
         )
@@ -67,7 +67,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
         .build()?;
 
     let credential = credentials
-        .issue_credential(&authority, credential_data)
+        .issue_credential(&authority.identifier(), credential_data)
         .await?;
 
     credentials_service
@@ -108,7 +108,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         .with_attribute("is_admin", b"true")
         .build()?;
     let credential = credentials
-        .issue_credential(&authority, credential_data)
+        .issue_credential(&authority.identifier(), credential_data)
         .await?;
 
     secure_channels
@@ -131,7 +131,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         .start(
             ctx,
             trust_context.clone(),
-            client1.clone(),
+            client1.identifier(),
             "credential_exchange".into(),
             true,
         )
@@ -141,7 +141,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         .with_attribute("is_user", b"true")
         .build()?;
     let credential = credentials
-        .issue_credential(&authority, credential_data)
+        .issue_credential(&authority.identifier(), credential_data)
         .await?;
 
     let channel = secure_channels
@@ -215,7 +215,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
         .start(
             ctx,
             trust_context,
-            server.clone(),
+            server.identifier(),
             "credential_exchange".into(),
             false,
         )
@@ -235,7 +235,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
         .with_attribute("is_superuser", b"true")
         .build()?;
     let credential = credentials
-        .issue_credential(&authority, credential_data)
+        .issue_credential(&authority.identifier(), credential_data)
         .await?;
 
     let counter = Arc::new(AtomicI8::new(0));

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -27,7 +27,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &server,
+            &server.identifier(),
             "listener",
             SecureChannelListenerOptions::new(),
         )
@@ -55,7 +55,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
     let channel = secure_channels
         .create_secure_channel(
             ctx,
-            &client,
+            &client.identifier(),
             route!["listener"],
             SecureChannelOptions::new()
                 .with_trust_policy(TrustIdentifierPolicy::new(server.identifier().clone())),
@@ -114,7 +114,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &client1,
+            &client1.identifier(),
             "listener",
             SecureChannelListenerOptions::new(),
         )
@@ -147,7 +147,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
     let channel = secure_channels
         .create_secure_channel(
             ctx,
-            &client2,
+            &client2.identifier(),
             route!["listener"],
             SecureChannelOptions::new(),
         )
@@ -196,7 +196,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
     secure_channels
         .create_secure_channel_listener(
             ctx,
-            &server,
+            &server.identifier(),
             "listener",
             SecureChannelListenerOptions::new(),
         )
@@ -224,7 +224,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
     let channel = secure_channels
         .create_secure_channel(
             ctx,
-            &client,
+            &client.identifier(),
             route!["listener"],
             SecureChannelOptions::new()
                 .with_trust_policy(TrustIdentifierPolicy::new(server.identifier().clone())),

--- a/implementations/rust/ockam/ockam_identity/tests/plaintext_message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/plaintext_message_flow_auth.rs
@@ -37,7 +37,7 @@ async fn test1(ctx: &mut Context) -> Result<()> {
     bob_secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "listener",
             SecureChannelListenerOptions::as_spawner(
                 &flow_controls_bob,
@@ -49,7 +49,7 @@ async fn test1(ctx: &mut Context) -> Result<()> {
     let channel_to_bob = alice_secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route!["listener"],
             SecureChannelOptions::as_producer(&flow_controls_alice, &flow_control_id_alice_channel),
         )
@@ -140,7 +140,7 @@ async fn test2(ctx: &mut Context) -> Result<()> {
     bob_secure_channels
         .create_secure_channel_listener(
             ctx,
-            &bob,
+            &bob.identifier(),
             "listener",
             SecureChannelListenerOptions::as_spawner(
                 &flow_controls_bob,
@@ -157,7 +157,7 @@ async fn test2(ctx: &mut Context) -> Result<()> {
     let channel_to_bob = alice_secure_channels
         .create_secure_channel(
             ctx,
-            &alice,
+            &alice.identifier(),
             route![connection_to_bob, "listener"],
             SecureChannelOptions::as_producer(
                 &flow_controls_alice,

--- a/implementations/rust/ockam/ockam_identity/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/tests.rs
@@ -16,8 +16,8 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
     let alice = identities_creation.create_identity().await?;
     let bob = identities_creation.create_identity().await?;
 
-    identities_repository.update_known_identity(&bob).await?;
-    identities_repository.update_known_identity(&alice).await?;
+    identities_repository.update_identity(&bob).await?;
+    identities_repository.update_identity(&alice).await?;
 
     // Some state known to both parties. In Noise this would be a computed hash, for example.
     let state = {
@@ -34,8 +34,7 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
 
     let known_bob = identities_repository
         .get_identity(&bob.identifier())
-        .await?
-        .unwrap();
+        .await?;
     if !identities_keys
         .verify_signature(&known_bob, &bob_proof, &state, None)
         .await?
@@ -45,8 +44,7 @@ async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {
 
     let known_alice = identities_repository
         .get_identity(&alice.identifier())
-        .await?
-        .unwrap();
+        .await?;
     if !identities_keys
         .verify_signature(&known_alice, &alice_proof, &state, None)
         .await?
@@ -74,8 +72,8 @@ async fn test_key_rotation(ctx: &mut Context) -> Result<()> {
     identities_keys.rotate_root_key(&mut alice).await?;
     identities_keys.rotate_root_key(&mut bob).await?;
 
-    identities_repository.update_known_identity(&bob).await?;
-    identities_repository.update_known_identity(&alice).await?;
+    identities_repository.update_identity(&bob).await?;
+    identities_repository.update_identity(&alice).await?;
 
     ctx.stop().await?;
 
@@ -93,14 +91,14 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
     let mut alice = identities_creation.create_identity().await?;
     let mut bob = identities_creation.create_identity().await?;
 
-    identities_repository.update_known_identity(&bob).await?;
-    identities_repository.update_known_identity(&alice).await?;
+    identities_repository.update_identity(&bob).await?;
+    identities_repository.update_identity(&alice).await?;
 
     identities_keys.rotate_root_key(&mut alice).await?;
     identities_keys.rotate_root_key(&mut bob).await?;
 
-    identities_repository.update_known_identity(&bob).await?;
-    identities_repository.update_known_identity(&alice).await?;
+    identities_repository.update_identity(&bob).await?;
+    identities_repository.update_identity(&alice).await?;
 
     // Re-Prove
     let state = {
@@ -117,8 +115,7 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
 
     let known_bob = identities_repository
         .get_identity(&bob.identifier())
-        .await?
-        .unwrap();
+        .await?;
     if !identities_keys
         .verify_signature(&known_bob, &bob_proof, &state, None)
         .await?
@@ -128,8 +125,7 @@ async fn test_update_contact_and_reprove(ctx: &mut Context) -> Result<()> {
 
     let known_alice = identities_repository
         .get_identity(&alice.identifier())
-        .await?
-        .unwrap();
+        .await?;
     if !identities_keys
         .verify_signature(&known_alice, &alice_proof, &state, None)
         .await?

--- a/implementations/rust/ockam/ockam_identity/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/tests.rs
@@ -1,9 +1,10 @@
+use rand::{thread_rng, RngCore};
+
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::vault::{SecretAttributes, SecretPersistence, SecretType};
 use ockam_core::{Error, Result};
 use ockam_identity::identities;
 use ockam_node::Context;
-use rand::{thread_rng, RngCore};
 
 #[ockam_macros::test]
 async fn test_auth_use_case(ctx: &mut Context) -> Result<()> {

--- a/implementations/rust/ockam/ockam_key_exchange_xx/README.md
+++ b/implementations/rust/ockam/ockam_key_exchange_xx/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_key_exchange_xx = "0.76.0"
+ockam_key_exchange_xx = "0.77.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_multiaddr/README.md
+++ b/implementations/rust/ockam/ockam_multiaddr/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_multiaddr = "0.20.0"
+ockam_multiaddr = "0.21.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_ble/README.md
+++ b/implementations/rust/ockam/ockam_transport_ble/README.md
@@ -17,7 +17,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_ble = "0.41.0"
+ockam_transport_ble = "0.42.0"
 ```
 
 ## License

--- a/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/examples/05-secure-channel-over-ble-transport-initiator.rs
@@ -39,7 +39,7 @@ async fn async_main(mut ctx: Context) -> Result<()> {
     // Connect to a secure channel listener and perform a handshake.
     let r = route![(BLE, "ockam_ble_1"), "bob_listener"];
     let channel = secure_channels
-        .create_secure_channel(&ctx, &alice, r, SecureChannelOptions::new())
+        .create_secure_channel(&ctx, &alice.identifier(), r, SecureChannelOptions::new())
         .await?;
 
     // Send a message to the "echoer" worker, on a different node, via secure channel.

--- a/implementations/rust/ockam/ockam_transport_udp/README.md
+++ b/implementations/rust/ockam/ockam_transport_udp/README.md
@@ -18,7 +18,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_transport_udp = "0.20.0"
+ockam_transport_udp = "0.21.0"
 ```
 
 ## License


### PR DESCRIPTION
## Current behavior

Several services are referencing an `Identity` field which would need to be updated if there was an independent key rotation on that identity.

## Proposed changes

This PR replaces the reference to an `Identity` with an `IdentityIdentifier` so that the most up to date `Identity` for that identifier can be retrieved when needed. The retrieval is either done via the `IdentitiesRepository` interface or simply via the `IdentitiesReader` when a given module just requires retrieving identities.