### PR TITLE
Remove superfluous flow control

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -446,19 +446,31 @@ impl NodeManager {
         debug!("connecting to {}", &connection.addr);
         let context = Arc::new(connection.ctx.async_try_clone().await?);
 
-        let mut intermediary_services = vec![];
-        for protocol_value in connection.addr.iter() {
-            if protocol_value.code() == Service::CODE {
-                let local = protocol_value
-                    .cast::<Service>()
-                    .ok_or_else(|| ApiError::generic("invalid service address"))?;
-                intermediary_services.push(Address::new(LOCAL, &*local));
-            }
+        let consumer_worker = {
+            // The rationale is simple: whenever we go outside the node we are using flow
+            // control. The last service before that must be a consumer of that flow control
+            // in order to receive the message coming back.
+            let mut consumer_worker = None;
+            let mut everything_local = true;
+            for protocol_value in connection.addr.iter() {
+                if protocol_value.code() == Service::CODE {
+                    let local = protocol_value
+                        .cast::<Service>()
+                        .ok_or_else(|| ApiError::generic("invalid service address"))?;
+                    consumer_worker = Some(Address::new(LOCAL, &*local));
+                }
 
-            if !local_worker(&protocol_value.code())? {
-                break;
+                if !local_worker(&protocol_value.code())? {
+                    everything_local = false;
+                    break;
+                }
             }
-        }
+            if everything_local {
+                None
+            } else {
+                consumer_worker
+            }
+        };
 
         let tcp_transport = node_manager
             .clone()
@@ -491,9 +503,9 @@ impl NodeManager {
 
         debug!("connected to {connection_instance:?}");
 
-        // Every piece of the chain must be part of the session to allow communication
-        for service in intermediary_services {
-            connection_instance.add_consumer(&service);
+        // make sure the service before flow control is a consumer
+        if let Some(address) = consumer_worker {
+            connection_instance.add_consumer(&address);
         }
 
         if connection.add_default_consumers {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -132,12 +132,6 @@ impl NodeManagerWorker {
             }
         };
 
-        // prefix services needs to be part of the session
-        // suffix services are remote so we can safely ignore them
-        for address in req.prefix_route().iter() {
-            connection_instance.add_consumer(address);
-        }
-
         let outlet_route = route![
             req.prefix_route().clone(),
             outlet_route,
@@ -544,10 +538,6 @@ fn replacer(
                     NodeManager::connect(node_manager_arc.clone(), connection).await?;
 
                 *connection_instance_arc.lock().unwrap() = new_connection_instance.clone();
-
-                for address in prefix_route.iter() {
-                    new_connection_instance.add_consumer(address);
-                }
 
                 //we expect a fully normalized MultiAddr
                 let normalized_route = route![


### PR DESCRIPTION
- hide the inlet address from the other side in kafka workers
- removed superfluous flow control

Draft because i want to do some extra validation on the `MultiAddr` instantiation