### PR TITLE
bump nif version

### DIFF
--- a/implementations/elixir/ockam/ockam_vault_software/mix.exs
+++ b/implementations/elixir/ockam/ockam_vault_software/mix.exs
@@ -1,11 +1,11 @@
 defmodule Ockam.Vault.Software.MixProject do
   use Mix.Project
 
-  @version "0.86.0"
+  @version "0.87.0"
 
   @elixir_requirement "~> 1.12"
 
-  @ockam_release_url "https://github.com/metaclips/ockam/releases"
+  @ockam_release_url "https://github.com/build-trust/ockam/releases"
 
   @download_libs [
     {"ockam.linux_x86_64_gnu_elixir_ffi.so",


### PR DESCRIPTION
This PR bumps NIF version to 0.87.0 and also reverts it to the build-trust repository