### PR TITLE
fix(rust): make sure that the default identity exists in the repository

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -332,12 +332,14 @@ impl NodeManager {
 
         let secure_channels = SecureChannels::builder()
             .with_identities_vault(vault)
-            .with_identities_repository(identities_repository)
+            .with_identities_repository(identities_repository.clone())
             .build();
 
         let policies: Arc<dyn PolicyStorage> = Arc::new(node_state.policies_storage().await?);
 
         let identity = node_state.config().identity().await?;
+        // make sure that the configured identity exists in the repository
+        identities_repository.update_identity(&identity).await?;
 
         let flow_controls = FlowControls::default();
         let medic = Medic::new(flow_controls.clone());


### PR DESCRIPTION
This definitely needs some more thinking about the interplay between the identity configuration and the identities repository + a unit test.

This fix can be tested by creating an identity with an older version of `ockam` (`0.86.0` for example) then running a command like `ockam project list` on `develop`. Without this fix the default identity is not found.
