### PR TITLE
Identity data persistence

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -430,7 +430,7 @@ mod tests {
                         let entry_name = entry.file_name().into_string().unwrap();
                         found_entries.push(format!("{dir_name}/{entry_name}"));
                         if entry.path().is_dir() {
-                            assert_eq!(entry_name, "data");
+                            assert_eq!(entry_name, DATA_DIR_NAME);
                             entry.path().read_dir().unwrap().for_each(|entry| {
                                 let entry = entry.unwrap();
                                 let file_name = entry.file_name().into_string().unwrap();
@@ -452,7 +452,7 @@ mod tests {
                         let entry = entry.unwrap();
                         let entry_name = entry.file_name().into_string().unwrap();
                         if entry.path().is_dir() {
-                            assert_eq!(entry_name, "data");
+                            assert_eq!(entry_name, DATA_DIR_NAME);
                             entry.path().read_dir().unwrap().for_each(|entry| {
                                 let entry = entry.unwrap();
                                 let file_name = entry.file_name().into_string().unwrap();

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -131,6 +131,20 @@ impl CliState {
         Ok(())
     }
 
+    pub fn delete_identity(&self, identity_state: IdentityState) -> Result<()> {
+        // Abort if identity is being used by some running node.
+        for node in self.nodes.list()? {
+            if node.config().identity_config()?.identifier() == identity_state.identifier() {
+                return Err(CliStateError::Invalid(format!(
+                    "Can't delete identity '{}' because is currently in use by node '{}'",
+                    &identity_state.name(),
+                    &node.name()
+                )));
+            }
+        }
+        identity_state.delete()
+    }
+
     /// Returns the default directory for the CLI state.
     pub fn default_dir() -> Result<PathBuf> {
         Ok(get_env_with_default::<PathBuf>(

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -76,7 +76,7 @@ impl CliState {
     pub fn initialize() -> Result<Self> {
         let dir = Self::default_dir()?;
         std::fs::create_dir_all(dir.join("defaults"))?;
-        Executor::new().execute_future(Self::initialize_cli_state())?
+        Executor::execute_future(Self::initialize_cli_state())?
     }
 
     /// Create a new CliState by initializing all of its components

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -232,12 +232,16 @@ impl CliState {
 
     /// Return a test CliState with a random root directory
     pub fn test() -> Result<Self> {
-        let tests_dir = home::home_dir()
+        Self::new(&Self::test_dir()?)
+    }
+
+    /// Return a random root directory
+    pub fn test_dir() -> Result<PathBuf> {
+        Ok(home::home_dir()
             .ok_or(CliStateError::NotFound)?
             .join(".ockam")
             .join(".tests")
-            .join(random_name());
-        Self::new(&tests_dir)
+            .join(random_name()))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -172,9 +172,8 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
-    pub fn try_default() -> Result<Self> {
-        let cli_state = CliState::try_default()?;
-        Self::try_from(&cli_state)
+    pub fn new(cli_state: &CliState) -> Result<Self> {
+        Self::try_from(cli_state)
     }
 
     pub fn setup(&self) -> &NodeSetupConfig {
@@ -252,7 +251,7 @@ impl NodeConfigBuilder {
         Ok(NodeConfig {
             default_vault: vault,
             default_identity: identity,
-            ..NodeConfig::try_default()?
+            ..NodeConfig::new(cli_state)?
         })
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -6,6 +6,7 @@ use crate::cli_state::{
 use crate::config::lookup::ProjectLookup;
 use crate::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
 use nix::errno::Errno;
+use ockam_core::compat::sync::Arc;
 use ockam_identity::{IdentityIdentifier, LmdbStorage};
 use ockam_vault::Vault;
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -6,13 +6,12 @@ use crate::cli_state::{
 use crate::config::lookup::ProjectLookup;
 use crate::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
 use nix::errno::Errno;
-use ockam_identity::{IdentitiesVault, Identity, LmdbStorage};
+use ockam_identity::{IdentityIdentifier, LmdbStorage};
 use ockam_vault::Vault;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 use sysinfo::{Pid, System, SystemExt};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -200,11 +199,10 @@ impl NodeConfig {
         Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
     }
 
-    pub async fn identity(&self) -> Result<Identity> {
-        let vault: Arc<dyn IdentitiesVault> = self.vault().await?;
+    pub async fn identifier(&self) -> Result<IdentityIdentifier> {
         let state_path = std::fs::canonicalize(&self.default_identity)?;
         let state = IdentityState::load(state_path)?;
-        state.get(vault).await
+        Ok(state.identifier())
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -167,16 +167,6 @@ pub trait StateDirTrait: Sized {
 pub trait StateItemTrait: Sized {
     type Config: Serialize + for<'a> Deserialize<'a> + Send;
 
-    fn cli_state(&self) -> Result<CliState> {
-        CliState::new(
-            self.path()
-                .parent()
-                .expect("no parent dir")
-                .parent()
-                .expect("no parent dir"),
-        )
-    }
-
     /// Create a new item with the given config.
     fn new(path: PathBuf, config: Self::Config) -> Result<Self>;
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -287,10 +287,3 @@ mod tests {
         }
     }
 }
-
-trait FileSystem {
-    fn create_dir_all(dir: PathBuf) -> Result<()>;
-    fn read_dir(path: PathBuf) -> Result<Vec<PathBuf>>;
-    fn remove_file(path: PathBuf) -> Result<()>;
-    fn write(path: PathBuf, contents: &str) -> Result<()>;
-}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -1,6 +1,6 @@
 use super::Result;
 use crate::cli_state::traits::StateItemTrait;
-use crate::cli_state::{CliStateError, StateDirTrait};
+use crate::cli_state::{CliStateError, StateDirTrait, DATA_DIR_NAME};
 use ockam_identity::IdentitiesVault;
 use ockam_vault::Vault;
 use ockam_vault_aws::{AwsKmsConfig, AwsSecurityModule};
@@ -55,7 +55,7 @@ impl VaultState {
     fn build_data_path(name: &str, path: &Path) -> PathBuf {
         path.parent()
             .expect("Should have parent")
-            .join("data")
+            .join(DATA_DIR_NAME)
             .join(format!("{name}-storage.json"))
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -169,16 +169,12 @@ mod node {
             let identity_name = ident.map(|i| i.to_string()).clone();
             let identifier = {
                 let node_manager = self.get().read().await;
-                node_manager
-                    .get_identifier(None, identity_name.clone())
-                    .await?
+                node_manager.get_identifier(identity_name.clone()).await?
             };
 
             let secure_channels = {
                 let mut node_manager = self.get().write().await;
-                node_manager
-                    .get_secure_channels(None, identity_name.clone())
-                    .await?
+                node_manager.get_secure_channels(None).await?
             };
 
             let (sc_address, flow_controls, _sc_flow_control_id) = {

--- a/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
@@ -100,7 +100,7 @@ impl IdentityService {
                 [identity_name] => {
                     match self
                         .node_identities
-                        .get_identity(identity_name.to_string(), None)
+                        .get_identity(identity_name.to_string())
                         .await?
                     {
                         Some(identity) => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/authority.rs
@@ -57,7 +57,7 @@ impl Authority {
             .with_identities_repository(repository)
             .build();
 
-        let identifier = configuration.identity.identifier();
+        let identifier = configuration.identifier();
         info!(identifier=%identifier, "retrieved the authority identifier");
 
         Ok(Authority {

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -1,7 +1,7 @@
 use crate::bootstrapped_identities_store::PreTrustedIdentities;
 use crate::DefaultAddress;
 use ockam::identity::credential::Timestamp;
-use ockam::identity::{AttributesEntry, Identity, IdentityIdentifier};
+use ockam::identity::{AttributesEntry, IdentityIdentifier};
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::fmt;
 use ockam_core::compat::fmt::{Display, Formatter};
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Configuration {
     /// Authority identity or identity associated with the newly created node
-    pub identity: Identity,
+    pub identifier: IdentityIdentifier,
 
     /// path where the storage for identity attributes should be persisted
     pub storage_path: PathBuf,
@@ -53,6 +53,11 @@ pub struct Configuration {
 
 /// Local and private functions for the authority configuration
 impl Configuration {
+    /// Return the authority identity identifier
+    pub(crate) fn identifier(&self) -> IdentityIdentifier {
+        self.identifier.clone()
+    }
+
     /// Return the project identifier as bytes
     pub(crate) fn project_identifier(&self) -> String {
         self.project_identifier.clone()

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -114,10 +114,6 @@ impl NodeManager {
         self.secure_channels.identities()
     }
 
-    pub(super) fn identities_vault(&self) -> Arc<dyn IdentitiesVault> {
-        self.identities().vault()
-    }
-
     pub(super) fn identities_repository(&self) -> Arc<dyn IdentitiesRepository> {
         self.identities().repository().clone()
     }
@@ -337,10 +333,6 @@ impl NodeManager {
 
         let policies: Arc<dyn PolicyStorage> = Arc::new(node_state.policies_storage().await?);
 
-        let identity = node_state.config().identity().await?;
-        // make sure that the configured identity exists in the repository
-        identities_repository.update_identity(&identity).await?;
-
         let flow_controls = FlowControls::default();
         let medic = Medic::new(flow_controls.clone());
         let sessions = medic.sessions();
@@ -359,7 +351,7 @@ impl NodeManager {
                     .unwrap()
                     .authority()
                     .is_ok(),
-            identifier: identity.identifier(),
+            identifier: node_state.config().identifier().await?,
             secure_channels,
             projects: Arc::new(projects_options.projects),
             trust_context: None,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use std::sync::Arc;
 
 use either::Either;
 use minicbor::Decoder;
@@ -7,7 +6,6 @@ use minicbor::Decoder;
 use ockam::identity::Credential;
 use ockam::Result;
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
-use ockam_identity::IdentitiesVault;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::{Context, MessageSendReceiveOptions};
 
@@ -30,15 +28,11 @@ impl NodeManagerWorker {
         let request: GetCredentialRequest = dec.decode()?;
 
         let identifier = if let Some(identity) = &request.identity_name {
-            let idt_state = node_manager.cli_state.identities.get(identity)?;
-            match idt_state.get(node_manager.identities_vault()).await {
-                Ok(idt) => idt.identifier(),
-                Err(_) => {
-                    let default_vault = &node_manager.cli_state.vaults.default()?.get().await?;
-                    let vault: Arc<dyn IdentitiesVault> = default_vault.clone();
-                    idt_state.get(vault).await?.identifier()
-                }
-            }
+            node_manager
+                .cli_state
+                .identities
+                .get(identity)?
+                .identifier()
         } else {
             node_manager.identifier()
         };

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -411,7 +411,7 @@ pub mod test {
             .unwrap();
 
         drop(secure_channels);
-        let config = IdentityConfig::new(&identity).await;
+        let config = IdentityConfig::new(&identity.identifier()).await;
         cli_state.identities.create(&identity_name, config).unwrap();
 
         let node_name = hex::encode(rand::random::<[u8; 4]>());

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -243,7 +243,7 @@ async fn start_authority_node(
 
     // Retrieve the authority identity if it has been created before
     // otherwise create a new one
-    let identity = match &cmd.identity {
+    let identifier = match &cmd.identity {
         Some(identity_name) => {
             debug!(name=%identity_name, "getting identity from state");
             opts.state
@@ -251,12 +251,12 @@ async fn start_authority_node(
                 .get(identity_name)
                 .context("Identity not found")?
                 .config()
-                .identity()
+                .identifier()
         }
         None => {
             debug!("getting default identity from state");
             match opts.state.identities.default() {
-                Ok(state) => state.config().identity(),
+                Ok(state) => state.config().identifier(),
                 Err(_) => {
                     debug!("creating default identity");
                     let cmd = identity::CreateCommand::new("authority".into(), None);
@@ -265,7 +265,7 @@ async fn start_authority_node(
             }
         }
     };
-    debug!(identifier=%identity.identifier(), "authority identifier");
+    debug!(identifier=%identifier, "authority identifier");
 
     let okta_configuration = match (&cmd.tenant_base_url, &cmd.certificate, &cmd.attributes) {
         (Some(tenant_base_url), Some(certificate), Some(attributes)) => Some(OktaConfiguration {
@@ -296,10 +296,10 @@ async fn start_authority_node(
             )?),
     )?;
 
-    let trusted_identities = cmd.trusted_identities(&identity.identifier())?;
+    let trusted_identities = cmd.trusted_identities(&identifier)?;
 
     let configuration = authority_node::Configuration {
-        identity,
+        identifier,
         storage_path: opts.state.identities.identities_repository_path()?,
         vault_path: opts.state.vaults.default()?.vault_file_path().clone(),
         project_identifier: cmd.project_identifier.clone(),

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -33,7 +33,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: GetCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::get_credential(
         cmd.overwrite,
         cmd.identity,

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -19,8 +19,9 @@ pub struct GetCommand {
 }
 
 impl GetCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -33,7 +34,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: GetCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::get_credential(
         cmd.overwrite,

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -20,7 +20,7 @@ pub struct GetCommand {
 
 impl GetCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,6 +1,6 @@
 use ockam_core::compat::collections::HashMap;
 
-use crate::identity::default_identity_name;
+use crate::identity::get_identity_name;
 use crate::{
     util::{node_rpc, print_encodable},
     vault::default_vault_name,
@@ -67,11 +67,7 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, IssueCommand),
 ) -> crate::Result<()> {
-    let identity_name = cmd
-        .as_identity
-        .clone()
-        .unwrap_or_else(|| default_identity_name(&opts.state));
-
+    let identity_name = get_identity_name(&opts.state, cmd.as_identity.clone())?;
     let ident_state = opts.state.identities.get(&identity_name)?;
     let auth_identity_identifier = ident_state.config().identifier().clone();
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -25,8 +25,8 @@ pub struct IssueCommand {
     #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
     pub attributes: Vec<String>,
 
-    #[arg(default_value_t = default_vault_name())]
-    pub vault: String,
+    #[arg()]
+    pub vault: Option<String>,
 
     /// Encoding Format
     #[arg(long = "encoding", value_enum, default_value = "plain")]
@@ -85,7 +85,11 @@ async fn run_impl(
         auth_identity_identifier.to_string(),
     );
 
-    let vault = opts.state.vaults.get(&cmd.vault)?.get().await?;
+    let vault_name = cmd
+        .vault
+        .clone()
+        .unwrap_or_else(|| default_vault_name(&opts.state));
+    let vault = opts.state.vaults.get(&vault_name)?.get().await?;
     let identities = opts.state.get_identities(vault).await?;
     let issuer = ident_state.identifier();
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,7 +1,7 @@
 use ockam_core::compat::collections::HashMap;
 
+use crate::identity::default_identity_name;
 use crate::{
-    identity::default_identity_name,
     util::{node_rpc, print_encodable},
     vault::default_vault_name,
     CommandGlobalOpts, EncodeFormat, Result,
@@ -15,8 +15,8 @@ use ockam_identity::{identities, Identity};
 
 #[derive(Clone, Debug, Args)]
 pub struct IssueCommand {
-    #[arg(long = "as", default_value_t = default_identity_name())]
-    pub as_identity: String,
+    #[arg(long = "as")]
+    pub as_identity: Option<String>,
 
     #[arg(long = "for", value_name = "IDENTITY_ID")]
     pub for_identity: String,
@@ -67,7 +67,12 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, IssueCommand),
 ) -> crate::Result<()> {
-    let ident_state = opts.state.identities.get(&cmd.as_identity)?;
+    let identity_name = cmd
+        .as_identity
+        .clone()
+        .unwrap_or_else(|| default_identity_name(&opts.state));
+
+    let ident_state = opts.state.identities.get(&identity_name)?;
     let auth_identity_identifier = ident_state.config().identifier().clone();
 
     let mut attrs = cmd.attributes()?;

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,6 +1,6 @@
 use ockam_core::compat::collections::HashMap;
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::{
     util::{node_rpc, print_encodable},
     vault::default_vault_name,
@@ -35,6 +35,7 @@ pub struct IssueCommand {
 
 impl IssueCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_identity(&opts, &self.as_identity);
         node_rpc(run_impl, (opts, self));
     }
 
@@ -67,7 +68,7 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, IssueCommand),
 ) -> crate::Result<()> {
-    let identity_name = get_identity_name(&opts, cmd.as_identity.clone())?;
+    let identity_name = get_identity_name(&opts.state, &cmd.as_identity);
     let ident_state = opts.state.identities.get(&identity_name)?;
     let auth_identity_identifier = ident_state.config().identifier().clone();
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -67,7 +67,7 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, IssueCommand),
 ) -> crate::Result<()> {
-    let identity_name = get_identity_name(&opts.state, cmd.as_identity.clone())?;
+    let identity_name = get_identity_name(&opts, cmd.as_identity.clone())?;
     let ident_state = opts.state.identities.get(&identity_name)?;
     let auth_identity_identifier = ident_state.config().identifier().clone();
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -1,6 +1,6 @@
 use ockam_core::compat::collections::HashMap;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::{
     util::{node_rpc, print_encodable},
     vault::default_vault_name,
@@ -35,7 +35,7 @@ pub struct IssueCommand {
 
 impl IssueCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.as_identity);
+        initialize_identity_if_default(&opts, &self.as_identity);
         node_rpc(run_impl, (opts, self));
     }
 

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -10,8 +10,8 @@ use crate::{
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    #[arg(default_value_t = default_vault_name())]
-    pub vault: String,
+    #[arg()]
+    pub vault: Option<String>,
 }
 
 impl ListCommand {
@@ -26,8 +26,12 @@ async fn run_impl(
 ) -> crate::Result<()> {
     let cred_states = opts.state.credentials.list()?;
 
+    let vault_name = cmd
+        .vault
+        .clone()
+        .unwrap_or_else(|| default_vault_name(&opts.state));
     for cred_state in cred_states {
-        display_credential(&opts, cred_state.name(), &cmd.vault).await?;
+        display_credential(&opts, cred_state.name(), &vault_name).await?;
     }
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -68,7 +68,7 @@ pub async fn validate_encoded_cred(
 ) -> Result<()> {
     let vault = opts.state.vaults.get(vault)?.get().await?;
     let identities = opts.state.get_identities(vault).await?;
-    let identity = identities.repository().get_identity(&issuer).await?;
+    let identity = identities.repository().get_identity(issuer).await?;
 
     let bytes = match hex::decode(encoded_cred) {
         Ok(b) => b,

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::api::{self};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -38,7 +38,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: PresentCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::present_credential(&cmd.to, cmd.oneway))
         .await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::api::{self};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -21,8 +21,9 @@ pub struct PresentCommand {
 }
 
 impl PresentCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -38,7 +39,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: PresentCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::present_credential(&cmd.to, cmd.oneway))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_multiaddr::MultiAddr;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::api::{self};
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -22,7 +22,7 @@ pub struct PresentCommand {
 
 impl PresentCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/show.rs
@@ -12,8 +12,8 @@ pub struct ShowCommand {
     #[arg()]
     pub credential_name: String,
 
-    #[arg(default_value_t = default_vault_name())]
-    pub vault: String,
+    #[arg()]
+    pub vault: Option<String>,
 }
 
 impl ShowCommand {
@@ -26,9 +26,11 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    display_credential(&opts, &cmd.credential_name, &cmd.vault).await?;
-
-    Ok(())
+    let vault_name = cmd
+        .vault
+        .clone()
+        .unwrap_or_else(|| default_vault_name(&opts.state));
+    display_credential(&opts, &cmd.credential_name, &vault_name).await
 }
 
 pub(crate) async fn display_credential(

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use crate::{
     util::{node_rpc, random_name},
-    vault::default_vault_name,
     CommandGlobalOpts, Result,
 };
 use anyhow::anyhow;
@@ -26,8 +25,8 @@ pub struct StoreCommand {
     #[arg(group = "credential_value", value_name = "CREDENTIAL_FILE", long)]
     pub credential_path: Option<PathBuf>,
 
-    #[arg(default_value_t = default_vault_name())]
-    pub vault: String,
+    #[arg()]
+    pub vault: Option<String>,
 }
 
 impl StoreCommand {

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -21,8 +21,8 @@ pub struct VerifyCommand {
     #[arg(group = "credential_value", value_name = "CREDENTIAL_FILE", long)]
     pub credential_path: Option<PathBuf>,
 
-    #[arg(default_value_t = default_vault_name())]
-    pub vault: String,
+    #[arg()]
+    pub vault: Option<String>,
 }
 
 impl VerifyCommand {
@@ -53,10 +53,14 @@ async fn run_impl(
         _ => return Err(anyhow!("Credential or Credential Path argument must be provided").into()),
     };
 
+    let vault_name = cmd
+        .vault
+        .clone()
+        .unwrap_or_else(|| default_vault_name(&opts.state));
     match validate_encoded_cred(
         &cred_as_str,
         &cmd.issuer().await?.identifier(),
-        &cmd.vault,
+        &vault_name,
         &opts,
     )
     .await

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -514,10 +514,10 @@ async fn update_enrolled_identity(opts: &CommandGlobalOpts, node_name: &str) -> 
     let identities = opts.state.identities.list()?;
 
     let node_state = opts.state.nodes.get(node_name)?;
-    let node_identity = node_state.config().identity().await?;
+    let node_identifier = node_state.config().identifier().await?;
 
     for mut identity in identities {
-        if node_identity.identifier() == identity.config().identity.identifier() {
+        if node_identifier == identity.config().identifier() {
             identity.set_enrollment_status()?;
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -29,6 +29,7 @@ use crate::space::util::config;
 use crate::terminal::OckamColor;
 use crate::util::api::CloudOpts;
 
+use crate::identity::get_identity_name;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, fmt_err, fmt_log, fmt_ok, fmt_para, CommandGlobalOpts, Result, PARSER_LOGS};
 
@@ -112,11 +113,11 @@ async fn default_space<'a>(
     cloud_opts: &CloudOpts,
     node_name: &str,
 ) -> Result<Space<'a>> {
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     // Get available spaces for node's identity
     opts.terminal.write_line(&fmt_log!(
         "Getting available spaces for {}",
-        cloud_opts
-            .identity
+        identity
             .to_string()
             .color(OckamColor::PrimaryResource.color())
     ))?;
@@ -210,12 +211,10 @@ async fn default_project(
     space: &Space<'_>,
 ) -> Result<Project> {
     // Get available project for the given space
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     opts.terminal.write_line(&fmt_log!(
         "Getting avaiable projects for {}",
-        cloud_opts
-            .identity
-            .to_string()
-            .color(OckamColor::PrimaryResource.color())
+        identity.color(OckamColor::PrimaryResource.color())
     ))?;
 
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -29,7 +29,7 @@ use crate::space::util::config;
 use crate::terminal::OckamColor;
 use crate::util::api::CloudOpts;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, fmt_err, fmt_log, fmt_ok, fmt_para, CommandGlobalOpts, Result, PARSER_LOGS};
 
@@ -49,7 +49,7 @@ pub struct EnrollCommand {
 
 impl EnrollCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.cloud_opts.identity);
+        initialize_identity_if_default(&opts, &self.cloud_opts.identity);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -113,7 +113,7 @@ async fn default_space<'a>(
     cloud_opts: &CloudOpts,
     node_name: &str,
 ) -> Result<Space<'a>> {
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     // Get available spaces for node's identity
     opts.terminal.write_line(&fmt_log!(
         "Getting available spaces for {}",
@@ -211,7 +211,7 @@ async fn default_project(
     space: &Space<'_>,
 ) -> Result<Project> {
     // Get available project for the given space
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     opts.terminal.write_line(&fmt_log!(
         "Getting avaiable projects for {}",
         identity.color(OckamColor::PrimaryResource.color())

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -29,7 +29,7 @@ use crate::space::util::config;
 use crate::terminal::OckamColor;
 use crate::util::api::CloudOpts;
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, fmt_err, fmt_log, fmt_ok, fmt_para, CommandGlobalOpts, Result, PARSER_LOGS};
 
@@ -48,8 +48,9 @@ pub struct EnrollCommand {
 }
 
 impl EnrollCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_identity(&opts, &self.cloud_opts.identity);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -113,7 +114,7 @@ async fn default_space<'a>(
     cloud_opts: &CloudOpts,
     node_name: &str,
 ) -> Result<Space<'a>> {
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     // Get available spaces for node's identity
     opts.terminal.write_line(&fmt_log!(
         "Getting available spaces for {}",
@@ -211,7 +212,7 @@ async fn default_project(
     space: &Space<'_>,
 ) -> Result<Project> {
     // Get available project for the given space
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     opts.terminal.write_line(&fmt_log!(
         "Getting avaiable projects for {}",
         identity.color(OckamColor::PrimaryResource.color())

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -70,7 +70,7 @@ impl CreateCommand {
             .await?;
 
         let identifier = identity.identifier();
-        output.push_str(&format!("Identity created: {}", identifier.clone()));
+        output.push_str(&format!("Identity created: {}", identifier));
 
         options
             .terminal

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -64,6 +64,11 @@ impl CreateCommand {
             .create_identity()
             .await?;
 
+        options
+            .state
+            .create_identity_state(&identity.identifier(), Some(&self.name))
+            .await?;
+
         let identifier = identity.identifier();
         output.push_str(&format!("Identity created: {}", identifier.clone()));
 

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -31,12 +31,12 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let state = opts.state.identities;
+    let state = opts.state;
     // Check if exists
-    match state.get(&cmd.name) {
+    match state.identities.get(&cmd.name) {
         // If it exists, proceed
-        Ok(_) => {
-            state.delete(&cmd.name)?;
+        Ok(identity_state) => {
+            state.delete_identity(identity_state)?;
             println!("Identity '{}' deleted", cmd.name);
             Ok(())
         }

--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -1,10 +1,11 @@
-use crate::util::exitcode;
 use crate::util::output::Output;
+use crate::util::{exitcode, node_rpc};
 use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};
+use ockam_node::Context;
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -22,42 +23,50 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(options, self) {
-            eprintln!("{e:?}");
-            std::process::exit(e.code());
-        }
+        node_rpc(Self::run_impl, (options, self))
     }
-}
 
-fn run_impl(opts: CommandGlobalOpts, cmd: ListCommand) -> crate::Result<()> {
-    let idts = opts.state.identities.list()?;
-    if idts.is_empty() {
-        return Err(crate::Error::new(
-            exitcode::IOERR,
-            anyhow!("No identities registered on this system!"),
-        ));
-    }
-    for (idx, identity) in idts.iter().enumerate() {
-        let state = opts.state.identities.get(identity.name())?;
-        let default = if opts.state.identities.default()?.name() == identity.name() {
-            " (default)"
-        } else {
-            ""
-        };
-        println!("Identity[{idx}]:");
-        println!("{:2}Name: {}{}", "", &identity.name(), default);
-        if cmd.full {
-            let identity = state.config().identity.export()?;
-            let output = LongIdentityResponse::new(identity);
-            println!("{:2}{}", "", &output.output()?);
-        } else {
-            let output =
-                ShortIdentityResponse::new(state.config().identity.identifier().to_string());
-            println!("{:2}Identifier: {}", "", &output.output()?);
-        };
-        if idx < idts.len() - 1 {
-            println!();
+    async fn run_impl(
+        _ctx: Context,
+        options: (CommandGlobalOpts, ListCommand),
+    ) -> crate::Result<()> {
+        let (opts, cmd) = options;
+        let idts = opts.state.identities.list()?;
+        if idts.is_empty() {
+            return Err(crate::Error::new(
+                exitcode::IOERR,
+                anyhow!("No identities registered on this system!"),
+            ));
         }
+        for (idx, identity) in idts.iter().enumerate() {
+            let state = opts.state.identities.get(identity.name())?;
+            let default = if opts.state.identities.default()?.name() == identity.name() {
+                " (default)"
+            } else {
+                ""
+            };
+            println!("Identity[{idx}]:");
+            println!("{:2}Name: {}{}", "", &identity.name(), default);
+            if cmd.full {
+                let identifier = state.config().identifier();
+                let identity = opts
+                    .state
+                    .identities
+                    .identities_repository()
+                    .await?
+                    .get_identity(&identifier)
+                    .await?;
+                let identity = identity.export()?;
+                let output = LongIdentityResponse::new(identity);
+                println!("{:2}{}", "", &output.output()?);
+            } else {
+                let output = ShortIdentityResponse::new(state.config().identifier().to_string());
+                println!("{:2}Identifier: {}", "", &output.output()?);
+            };
+            if idx < idts.len() - 1 {
+                println!();
+            }
+        }
+        Ok(())
     }
-    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -54,7 +54,7 @@ impl IdentityCommand {
 
 /// If the required identity is the default identity but if it has not been initialized yet
 /// then initialize it
-pub fn initialize_identity(opts: &CommandGlobalOpts, name: &Option<String>) {
+pub fn initialize_identity_if_default(opts: &CommandGlobalOpts, name: &Option<String>) {
     let name = get_identity_name(&opts.state, name);
     if name == "default" && opts.state.identities.default().is_err() {
         create_default_identity(opts);
@@ -81,9 +81,7 @@ pub fn get_default_identity_name(cli_state: &CliState) -> String {
 fn create_default_identity(opts: &CommandGlobalOpts) {
     let default = "default";
     let create_command = CreateCommand::new(default.into(), None);
-    let mut quiet_opts = opts.clone();
-    quiet_opts.set_quiet();
-    create_command.run(quiet_opts);
+    create_command.run(opts.clone().set_quiet());
 
     if let Ok(mut logs) = PARSER_LOGS.lock() {
         logs.push(fmt_log!("No default identity was found."));
@@ -95,5 +93,37 @@ fn create_default_identity(opts: &CommandGlobalOpts) {
             "Setting identity {} as default for local operations...\n",
             default.color(OckamColor::PrimaryResource.color())
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::OckamConfig;
+    use crate::GlobalArgs;
+    use ockam_api::cli_state::StateItemTrait;
+
+    #[test]
+    fn test_initialize() {
+        let config = OckamConfig::load_with_dir(CliState::test_dir().unwrap()).unwrap();
+        let opts = CommandGlobalOpts::new(GlobalArgs::default(), config).set_quiet();
+
+        // on start-up there is no default identity
+        let _ = opts.state.identities.default().and_then(|i| i.delete());
+        assert!(opts.state.identities.default().is_err());
+
+        // if no name is given then the default identity is initialized
+        initialize_identity_if_default(&opts, &None);
+        assert!(opts.state.identities.default().is_ok());
+
+        // if "default" is given as a name the default identity is initialized
+        opts.state.identities.default().unwrap().delete().unwrap();
+        initialize_identity_if_default(&opts, &Some("default".into()));
+        assert!(opts.state.identities.default().is_ok());
+
+        // if the name of another identity is given then the default identity is not initialized
+        opts.state.identities.default().unwrap().delete().unwrap();
+        initialize_identity_if_default(&opts, &Some("other".into()));
+        assert!(opts.state.identities.default().is_err());
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -56,9 +56,9 @@ impl IdentityCommand {
 
 // If a name is given try to parse it as an identity name, otherwise return the default identity name
 pub fn get_identity_name(cli_state: &CliState, name: Option<String>) -> Result<String> {
-    match name.clone() {
-        Some(n) => identity_name_parser(&cli_state, &n),
-        None => default_identity_name(&cli_state),
+    match name {
+        Some(n) => identity_name_parser(cli_state, &n),
+        None => default_identity_name(cli_state),
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,8 +1,7 @@
-use crate::identity::default_identity_name;
+use crate::identity::get_identity_name;
 use crate::util::output::Output;
 use crate::util::{node_rpc, println_output};
 use crate::{docs, CommandGlobalOpts, EncodeFormat, Result};
-use anyhow::anyhow;
 use clap::Args;
 use core::fmt::Write;
 use ockam::identity::identity::IdentityChangeHistory;
@@ -20,7 +19,7 @@ long_about = docs::about(LONG_ABOUT),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct ShowCommand {
-    #[arg(long)]
+    #[arg()]
     name: Option<String>,
 
     #[arg(short, long)]
@@ -44,13 +43,7 @@ impl ShowCommand {
         options: (CommandGlobalOpts, ShowCommand),
     ) -> crate::Result<()> {
         let (opts, cmd) = options;
-        let name = default_identity_name(&opts.state);
-        if name.is_empty() {
-            return Err(anyhow!(
-                "Default identity not found. Have you run 'ockam identity create'?"
-            )
-            .into());
-        }
+        let name = get_identity_name(&opts.state, cmd.name)?;
         let state = opts.state.identities.get(&name)?;
         if cmd.full {
             let identifier = state.config().identifier();

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::util::output::Output;
 use crate::util::{node_rpc, println_output};
 use crate::{docs, CommandGlobalOpts, EncodeFormat, Result};
@@ -34,8 +34,9 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(Self::run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_identity(&opts, &self.name);
+        node_rpc(Self::run_impl, (opts, self))
     }
 
     async fn run_impl(
@@ -43,7 +44,7 @@ impl ShowCommand {
         options: (CommandGlobalOpts, ShowCommand),
     ) -> crate::Result<()> {
         let (opts, cmd) = options;
-        let name = get_identity_name(&opts, cmd.name)?;
+        let name = get_identity_name(&opts.state, &cmd.name);
         let state = opts.state.identities.get(&name)?;
         if cmd.full {
             let identifier = state.config().identifier();

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -1,4 +1,4 @@
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::util::output::Output;
 use crate::util::{node_rpc, println_output};
 use crate::{docs, CommandGlobalOpts, EncodeFormat, Result};
@@ -35,7 +35,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.name);
+        initialize_identity_if_default(&opts, &self.name);
         node_rpc(Self::run_impl, (opts, self))
     }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -43,7 +43,7 @@ impl ShowCommand {
         options: (CommandGlobalOpts, ShowCommand),
     ) -> crate::Result<()> {
         let (opts, cmd) = options;
-        let name = get_identity_name(&opts.state, cmd.name)?;
+        let name = get_identity_name(&opts, cmd.name)?;
         let state = opts.state.identities.get(&name)?;
         if cmd.full {
             let identifier = state.config().identifier();

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -11,6 +11,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
+use crate::node::get_node_name;
 use crate::{
     fmt_log, fmt_ok,
     kafka::{
@@ -70,16 +71,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
             StartKafkaConsumerRequest::new(bootstrap_server, brokers_port_range, project_route);
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post("/node/services/kafka_consumer").body(payload);
-
-        start_service_impl(
-            &ctx,
-            &opts,
-            &node_opts.api_node,
-            "KafkaConsumer",
-            req,
-            Some(&tcp),
-        )
-        .await?;
+        let node_name = get_node_name(&opts.state, node_opts.api_node.clone())?;
+        start_service_impl(&ctx, &opts, &node_name, "KafkaConsumer", req, Some(&tcp)).await?;
 
         *is_finished.lock().await = true;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -11,7 +11,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{
     fmt_log, fmt_ok,
     kafka::{
@@ -49,7 +49,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -11,7 +11,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::{
     fmt_log, fmt_ok,
     kafka::{
@@ -48,8 +48,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -71,7 +72,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
             StartKafkaConsumerRequest::new(bootstrap_server, brokers_port_range, project_route);
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post("/node/services/kafka_consumer").body(payload);
-        let node_name = get_node_name(&opts.state, node_opts.api_node.clone())?;
+        let node_name = get_node_name(&opts.state, &node_opts.api_node);
         start_service_impl(&ctx, &opts, &node_name, "KafkaConsumer", req, Some(&tcp)).await?;
 
         *is_finished.lock().await = true;

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -11,7 +11,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{
     fmt_log, fmt_ok,
     kafka::{
@@ -49,7 +49,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -11,7 +11,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::{
     fmt_log, fmt_ok,
     kafka::{
@@ -48,8 +48,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -68,7 +69,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> c
 
     let send_req = async {
         let tcp = TcpTransport::create(&ctx).await?;
-        let node_name = get_node_name(&opts.state, node_opts.api_node.clone())?;
+        let node_name = get_node_name(&opts.state, &node_opts.api_node);
 
         let payload =
             StartKafkaProducerRequest::new(bootstrap_server, brokers_port_range, project_route);

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -8,6 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
+use crate::identity::get_identity_name;
 use crate::{
     docs,
     util::{
@@ -42,8 +43,9 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
-        .as_identity(cloud_opts.identity.clone())
+        .as_identity(identity)
         .with_new_embbeded_node()
         .await?
         .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::{
     docs,
     util::{
@@ -29,13 +29,9 @@ const HELP_DETAIL: &str = "";
 pub struct CreateCommand {}
 
 impl CreateCommand {
-    pub fn run(
-        self,
-        options: CommandGlobalOpts,
-        cloud_opts: CloudOpts,
-        trust_opts: TrustContextOpts,
-    ) {
-        node_rpc(run_impl, (options, cloud_opts, trust_opts));
+    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
+        initialize_identity(&opts, &cloud_opts.identity);
+        node_rpc(run_impl, (opts, cloud_opts, trust_opts));
     }
 }
 
@@ -43,7 +39,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::{
     docs,
     util::{
@@ -30,7 +30,7 @@ pub struct CreateCommand {}
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
-        initialize_identity(&opts, &cloud_opts.identity);
+        initialize_identity_if_default(&opts, &cloud_opts.identity);
         node_rpc(run_impl, (opts, cloud_opts, trust_opts));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -43,7 +43,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -8,6 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
+use crate::identity::get_identity_name;
 use crate::{
     docs,
     util::{
@@ -55,8 +56,9 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
-        .as_identity(cloud_opts.identity.clone())
+        .as_identity(identity)
         .with_new_embbeded_node()
         .await?
         .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::{
     docs,
     util::{
@@ -42,13 +42,9 @@ ${token
 pub struct ListCommand;
 
 impl ListCommand {
-    pub fn run(
-        self,
-        options: CommandGlobalOpts,
-        cloud_opts: CloudOpts,
-        trust_opts: TrustContextOpts,
-    ) {
-        node_rpc(run_impl, (options, cloud_opts, trust_opts));
+    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
+        initialize_identity(&opts, &cloud_opts.identity);
+        node_rpc(run_impl, (opts, cloud_opts, trust_opts));
     }
 }
 
@@ -56,7 +52,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::{
     docs,
     util::{
@@ -43,7 +43,7 @@ pub struct ListCommand;
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
-        initialize_identity(&opts, &cloud_opts.identity);
+        initialize_identity_if_default(&opts, &cloud_opts.identity);
         node_rpc(run_impl, (opts, cloud_opts, trust_opts));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -56,7 +56,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -5,6 +5,7 @@ use ockam::Context;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
+use crate::identity::get_identity_name;
 use crate::{
     docs,
     util::{
@@ -46,8 +47,9 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
-        .as_identity(cloud_opts.identity.clone())
+        .as_identity(identity)
         .with_new_embbeded_node()
         .await?
         .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::{
     docs,
     util::{
@@ -29,7 +29,7 @@ pub struct RevokeCommand {
 
 impl RevokeCommand {
     pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
-        initialize_identity(&opts, &cloud_opts.identity);
+        initialize_identity_if_default(&opts, &cloud_opts.identity);
         node_rpc(run_impl, (opts, cloud_opts, self, trust_opts));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::{
     docs,
     util::{
@@ -28,13 +28,9 @@ pub struct RevokeCommand {
 }
 
 impl RevokeCommand {
-    pub fn run(
-        self,
-        options: CommandGlobalOpts,
-        cloud_opts: CloudOpts,
-        trust_opts: TrustContextOpts,
-    ) {
-        node_rpc(run_impl, (options, cloud_opts, self, trust_opts));
+    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
+        initialize_identity(&opts, &cloud_opts.identity);
+        node_rpc(run_impl, (opts, cloud_opts, self, trust_opts));
     }
 }
 
@@ -47,7 +43,7 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -47,7 +47,7 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -8,6 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
+use crate::identity::get_identity_name;
 use crate::{
     docs,
     util::{
@@ -51,8 +52,9 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
+    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
-        .as_identity(cloud_opts.identity.clone())
+        .as_identity(identity)
         .with_new_embbeded_node()
         .await?
         .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::{
     docs,
     util::{
@@ -34,7 +34,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
-        initialize_identity(&opts, &cloud_opts.identity);
+        initialize_identity_if_default(&opts, &cloud_opts.identity);
         node_rpc(run_impl, (opts, cloud_opts, self, trust_opts));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 use termimad::{minimad::TextTemplate, MadSkin};
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::{
     docs,
     util::{
@@ -33,13 +33,9 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(
-        self,
-        options: CommandGlobalOpts,
-        cloud_opts: CloudOpts,
-        trust_opts: TrustContextOpts,
-    ) {
-        node_rpc(run_impl, (options, cloud_opts, self, trust_opts));
+    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustContextOpts) {
+        initialize_identity(&opts, &cloud_opts.identity);
+        node_rpc(run_impl, (opts, cloud_opts, self, trust_opts));
     }
 }
 
@@ -52,7 +48,7 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -52,7 +52,7 @@ async fn run_impl(
         TrustContextOpts,
     ),
 ) -> crate::Result<()> {
-    let identity = get_identity_name(&opts.state, cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cloud_opts.identity.clone())?;
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -204,7 +204,7 @@ pub struct CommandGlobalOpts {
 
 impl CommandGlobalOpts {
     fn new(global_args: GlobalArgs, config: OckamConfig) -> Self {
-        let state = CliState::try_default().expect("Failed to load the local Ockam configuration");
+        let state = CliState::initialize().expect("Failed to load the local Ockam configuration");
         let terminal = Terminal::new(
             global_args.quiet,
             global_args.no_color,

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -182,6 +182,14 @@ impl Default for GlobalArgs {
     }
 }
 
+impl GlobalArgs {
+    pub fn set_quiet(&self) -> Self {
+        let mut clone = self.clone();
+        clone.quiet = true;
+        clone
+    }
+}
+
 #[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
 pub enum OutputFormat {
     Plain,
@@ -219,8 +227,11 @@ impl CommandGlobalOpts {
         }
     }
 
-    pub fn set_quiet(&mut self) {
-        self.terminal.set_quiet()
+    pub fn set_quiet(&self) -> Self {
+        let mut clone = self.clone();
+        clone.global_args = clone.global_args.set_quiet();
+        clone.terminal = clone.terminal.set_quiet();
+        clone
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -218,6 +218,10 @@ impl CommandGlobalOpts {
             terminal,
         }
     }
+
+    pub fn set_quiet(&mut self) {
+        self.terminal.set_quiet()
+    }
 }
 
 #[derive(Clone, Debug, Subcommand)]

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -8,6 +8,7 @@ use ockam_api::nodes::service::message::SendMessage;
 use ockam_core::api::{Request, RequestBuilder};
 use ockam_multiaddr::MultiAddr;
 
+use crate::identity::get_identity_name;
 use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::{clean_nodes_multiaddr, extract_address_value, node_rpc, RpcBuilder};
@@ -60,11 +61,12 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             let tcp = TcpTransport::create(ctx).await?;
             (api_node, Some(tcp))
         } else {
+            let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
             let api_node = start_embedded_node_with_vault_and_identity(
                 ctx,
                 opts,
                 None,
-                Some(cmd.cloud_opts.identity.clone()),
+                Some(identity),
                 Some(&cmd.trust_context_opts),
             )
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -61,7 +61,7 @@ async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) ->
             let tcp = TcpTransport::create(ctx).await?;
             (api_node, Some(tcp))
         } else {
-            let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
+            let identity = get_identity_name(&opts, cmd.cloud_opts.identity.clone())?;
             let api_node = start_embedded_node_with_vault_and_identity(
                 ctx,
                 opts,

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::service::message::SendMessage;
 use ockam_core::api::{Request, RequestBuilder};
 use ockam_multiaddr::MultiAddr;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::{clean_nodes_multiaddr, extract_address_value, node_rpc, RpcBuilder};
@@ -49,7 +49,7 @@ pub struct SendCommand {
 
 impl SendCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.cloud_opts.identity);
+        initialize_identity_if_default(&opts, &self.cloud_opts.identity);
         node_rpc(rpc, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -243,7 +243,7 @@ async fn run_foreground_node(
 
     add_project_info_to_node_state(&node_name, &opts, cfg, &cmd.trust_context_opts).await?;
 
-    let trust_context_config = TrustContextConfigBuilder::new(&cmd.trust_context_opts)
+    let trust_context_config = TrustContextConfigBuilder::new(&opts.state, &cmd.trust_context_opts)
         .with_authority_identity(cmd.authority_identity.as_ref())
         .with_credential_name(cmd.credential.as_ref())
         .build();

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -507,8 +507,8 @@ async fn start_authority_node(
 
         // retrieve the authority identity if it has been created before
         // otherwise create a new one
-        let identity = match opts.state.identities.default() {
-            Ok(state) => state.config().identity(),
+        let identifier = match opts.state.identities.default() {
+            Ok(state) => state.config().identifier(),
             Err(_) => {
                 let cmd = identity::CreateCommand::new("authority".into(), None);
                 cmd.create_identity(opts.clone()).await?
@@ -520,7 +520,7 @@ async fn start_authority_node(
             .map_err(|e| crate::Error::new(exitcode::CONFIG, anyhow!("{e}")))?;
 
         let configuration = authority_node::Configuration {
-            identity,
+            identifier,
             storage_path: opts.state.identities.identities_repository_path()?,
             vault_path: opts.state.vaults.default()?.vault_file_path().clone(),
             project_identifier: authenticator_config.project.clone(),

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -174,7 +174,7 @@ pub fn parse_launch_config(config_or_path: &str) -> Result<Config> {
     }
 }
 
-async fn run_impl(
+pub(crate) async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -28,7 +28,7 @@ impl DefaultCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_name = get_node_name(&opts.state, cmd.node_name)?;
     if check_default(&opts, &node_name) {
         println!("Already set to default node");
     } else {

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,5 +1,5 @@
+use crate::node::get_node_name;
 use crate::node::util::{check_default, set_default_node};
-use crate::node::{default_node_name, node_name_parser};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
@@ -14,8 +14,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt
 )]
 pub struct DefaultCommand {
     /// Name of the node.
-    #[arg(default_value_t = default_node_name(), value_parser = node_name_parser)]
-    node_name: String,
+    #[arg()]
+    node_name: Option<String>,
 }
 
 impl DefaultCommand {
@@ -28,11 +28,12 @@ impl DefaultCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
-    if check_default(&opts, &cmd.node_name) {
+    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    if check_default(&opts, &node_name) {
         println!("Already set to default node");
     } else {
-        set_default_node(&opts, &cmd.node_name)?;
-        println!("Set node '{}' as default", &cmd.node_name);
+        set_default_node(&opts, &node_name)?;
+        println!("Set node '{}' as default", &node_name);
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,5 +1,5 @@
-use crate::node::get_node_name;
 use crate::node::util::{check_default, set_default_node};
+use crate::node::{get_node_name, initialize_node};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
@@ -20,6 +20,7 @@ pub struct DefaultCommand {
 
 impl DefaultCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());
@@ -28,7 +29,7 @@ impl DefaultCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_name)?;
+    let node_name = get_node_name(&opts.state, &cmd.node_name);
     if check_default(&opts, &node_name) {
         println!("Already set to default node");
     } else {

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,5 +1,5 @@
 use crate::node::util::{check_default, set_default_node};
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
@@ -20,7 +20,7 @@ pub struct DefaultCommand {
 
 impl DefaultCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,5 +1,5 @@
-use crate::node::get_node_name;
 use crate::node::util::{delete_all_nodes, delete_node};
+use crate::node::{get_node_name, initialize_node};
 use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
@@ -31,6 +31,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());
@@ -43,7 +44,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
         delete_all_nodes(opts, cmd.force)?;
     } else {
         let state = &opts.state.nodes;
-        let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+        let node_name = get_node_name(&opts.state, &cmd.node_name);
         match state.get(&node_name) {
             // If it exists, proceed
             Ok(_) => {

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,5 +1,5 @@
 use crate::node::util::{delete_all_nodes, delete_node};
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
@@ -31,7 +31,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -15,8 +15,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/logs/after_long_help.txt");
 )]
 pub struct LogCommand {
     /// Name of the node.
-    #[arg(default_value_t = default_node_name(), value_parser = node_name_parser)]
-    node_name: String,
+    #[arg()]
+    node_name: Option<String>,
 
     /// Show the standard error log file.
     #[arg(long = "err")]
@@ -33,7 +33,8 @@ impl LogCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: LogCommand) -> crate::Result<PathBuf> {
-    let node_state = opts.state.nodes.get(&cmd.node_name)?;
+    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_state = opts.state.nodes.get(&node_name)?;
 
     let log_file_path = if cmd.show_err {
         node_state.stderr_log()

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -25,7 +25,7 @@ pub struct LogCommand {
 
 impl LogCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());

--- a/implementations/rust/ockam/ockam_command/src/node/logs.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/logs.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -25,6 +25,7 @@ pub struct LogCommand {
 
 impl LogCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());
@@ -33,7 +34,7 @@ impl LogCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: LogCommand) -> crate::Result<PathBuf> {
-    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_name);
     let node_state = opts.state.nodes.get(&node_name)?;
 
     let log_file_path = if cmd.show_err {

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -80,28 +80,27 @@ impl NodeCommand {
 #[derive(Clone, Debug, Args)]
 pub struct NodeOpts {
     /// Override the default API node
-    #[arg(
-        global = true,
-        id = "node",
-        value_name = "NODE",
-        short,
-        long,
-        default_value_t = default_node_name(), value_parser = node_name_parser
-    )]
-    pub api_node: String,
+    #[arg(global = true, id = "node", value_name = "NODE", short, long)]
+    pub api_node: Option<String>,
 }
 
-pub fn default_node_name() -> String {
-    CliState::try_default()
-        .unwrap()
+pub fn get_node_name(cli_state: &CliState, node_name: Option<String>) -> Result<String> {
+    match node_name {
+        Some(n) => node_name_parser(cli_state, &n),
+        None => Ok(default_node_name(cli_state)),
+    }
+}
+
+pub fn default_node_name(cli_state: &CliState) -> String {
+    cli_state
         .nodes
         .default()
         .map(|n| n.name().to_string())
         .unwrap_or_else(|_| "default".to_string())
 }
 
-pub fn node_name_parser(node_name: &str) -> Result<String> {
-    if node_name == "default" && CliState::try_default().unwrap().nodes.default().is_err() {
+pub fn node_name_parser(cli_state: &CliState, node_name: &str) -> Result<String> {
+    if node_name == "default" && cli_state.nodes.default().is_err() {
         return Ok(spawn_default_node(node_name));
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -189,7 +189,7 @@ pub async fn print_query_status(
         let node_state = cli_state.nodes.get(node_name)?;
         // Get short id for the node
         let default_id = match node_state.config().identity_config() {
-            Ok(resp) => resp.identity.identifier().to_string(),
+            Ok(resp) => resp.identifier().to_string(),
             Err(_) => String::from("None"),
         };
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -161,7 +161,7 @@ pub async fn print_query_status(
     wait_until_ready: bool,
     is_default: bool,
 ) -> Result<()> {
-    let cli_state = cli_state::CliState::try_default()?;
+    let cli_state = rpc.opts.state.clone();
     if !is_node_up(rpc, wait_until_ready).await? {
         let node_state = cli_state.nodes.get(node_name)?;
         let node_port = node_state
@@ -258,7 +258,7 @@ pub async fn is_node_up(rpc: &mut Rpc<'_>, wait_until_ready: bool) -> Result<boo
     let timeout =
         FixedInterval::from_millis(IS_NODE_UP_TIME_BETWEEN_CHECKS_MS as u64).take(attempts);
 
-    let cli_state = cli_state::CliState::try_default()?;
+    let cli_state = rpc.opts.state.clone();
     let node_name = rpc.node_name().to_owned();
     let now = std::time::Instant::now();
     for t in timeout {

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,5 +1,5 @@
-use crate::node::get_node_name;
 use crate::node::util::check_default;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
@@ -35,8 +35,9 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -44,7 +45,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_name);
 
     let tcp = TcpTransport::create(&ctx).await?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,5 +1,5 @@
 use crate::node::util::check_default;
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
@@ -36,7 +36,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -3,9 +3,9 @@ use clap::Args;
 use ockam::TcpTransport;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
-use crate::node::get_node_name;
 use crate::node::show::print_query_status;
 use crate::node::util::{check_default, spawn_node};
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts};
 
@@ -32,8 +32,9 @@ pub struct StartCommand {
 }
 
 impl StartCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -41,7 +42,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_name);
 
     let node_state = opts.state.nodes.get(&node_name)?;
     // Check if node is already running

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -5,7 +5,7 @@ use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
 use crate::node::show::print_query_status;
 use crate::node::util::{check_default, spawn_node};
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts};
 
@@ -33,7 +33,7 @@ pub struct StartCommand {
 
 impl StartCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -15,8 +15,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/stop/after_long_help.txt");
 )]
 pub struct StopCommand {
     /// Name of the node.
-    #[arg(default_value_t = default_node_name(), value_parser = node_name_parser)]
-    node_name: String,
+    #[arg()]
+    node_name: Option<String>,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
     #[arg(long)]
     force: bool,
@@ -32,8 +32,9 @@ impl StopCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
-    let node_state = opts.state.nodes.get(&cmd.node_name)?;
+    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_state = opts.state.nodes.get(&node_name)?;
     node_state.kill_process(cmd.force)?;
-    println!("Stopped node '{}'", &cmd.node_name);
+    println!("Stopped node '{}'", &node_name);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -24,7 +24,7 @@ pub struct StopCommand {
 
 impl StopCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_name);
+        initialize_node_if_default(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -24,6 +24,7 @@ pub struct StopCommand {
 
 impl StopCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_name);
         if let Err(e) = run_impl(opts, self) {
             eprintln!("{e}");
             std::process::exit(e.code());
@@ -32,7 +33,7 @@ impl StopCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_name.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_name);
     let node_state = opts.state.nodes.get(&node_name)?;
     node_state.kill_process(cmd.force)?;
     println!("Stopped node '{}'", &node_name);

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -142,9 +142,19 @@ pub(crate) async fn init_node_state(
     debug!(name=%node_name, "initializing node state");
     // Get vault specified in the argument, or get the default
     let vault_state = opts.state.create_vault_state(vault_name).await?;
+
+    // create an identity for the node
+    let identity = opts
+        .state
+        .get_identities(vault_state.get().await?)
+        .await?
+        .identities_creation()
+        .create_identity()
+        .await?;
+
     let identity_state = opts
         .state
-        .create_identity_state(identity_name, vault_state.get().await?)
+        .create_identity_state(&identity.identifier(), identity_name)
         .await?;
 
     // Create the node with the given vault and identity

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -54,7 +54,7 @@ pub async fn start_embedded_node_with_vault_and_identity(
     };
 
     let trust_context_config = match trust_opts {
-        Some(t) => TrustContextConfigBuilder::new(&opts.state, t).build(),
+        Some(t) => TrustContextConfigBuilder::new(&opts.state, t)?.build(),
         None => None,
     };
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -54,7 +54,7 @@ pub async fn start_embedded_node_with_vault_and_identity(
     };
 
     let trust_context_config = match trust_opts {
-        Some(t) => TrustContextConfigBuilder::new(t).build(),
+        Some(t) => TrustContextConfigBuilder::new(&opts.state, t).build(),
         None => None,
     };
 

--- a/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
@@ -17,6 +17,7 @@ use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{CommandGlobalOpts, Result};
 
+use crate::identity::get_identity_name;
 use crate::project::util::create_secure_channel_to_authority;
 use ockam_api::authenticator::direct::TokenAcceptorClient;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -104,13 +105,14 @@ async fn run_impl(
             ProjectAuthority::from_raw(&proj.authority_access_route, &proj.authority_identity)
                 .await?
                 .ok_or_else(|| anyhow!("Authority details not configured"))?;
+        let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
         create_secure_channel_to_authority(
             &ctx,
             &opts,
             &node_name,
             authority.identity_id().clone(),
             authority.address(),
-            Some(cmd.cloud_opts.identity.to_string()),
+            Some(identity),
         )
         .await?
     };

--- a/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
@@ -105,7 +105,7 @@ async fn run_impl(
             ProjectAuthority::from_raw(&proj.authority_access_route, &proj.authority_identity)
                 .await?
                 .ok_or_else(|| anyhow!("Authority details not configured"))?;
-        let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
+        let identity = get_identity_name(&opts, cmd.cloud_opts.identity.clone())?;
         create_secure_channel_to_authority(
             &ctx,
             &opts,

--- a/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
@@ -17,7 +17,7 @@ use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{CommandGlobalOpts, Result};
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::project::util::create_secure_channel_to_authority;
 use ockam_api::authenticator::direct::TokenAcceptorClient;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -55,6 +55,7 @@ fn parse_enroll_ticket(input: &str) -> Result<EnrollmentTicket> {
 
 impl AuthenticateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_identity(&opts, &self.cloud_opts.identity);
         node_rpc(run_impl, (opts, self));
     }
 }
@@ -105,7 +106,7 @@ async fn run_impl(
             ProjectAuthority::from_raw(&proj.authority_access_route, &proj.authority_identity)
                 .await?
                 .ok_or_else(|| anyhow!("Authority details not configured"))?;
-        let identity = get_identity_name(&opts, cmd.cloud_opts.identity.clone())?;
+        let identity = get_identity_name(&opts.state, &cmd.cloud_opts.identity);
         create_secure_channel_to_authority(
             &ctx,
             &opts,

--- a/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/authenticate.rs
@@ -17,7 +17,7 @@ use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::{node_rpc, RpcBuilder};
 use crate::{CommandGlobalOpts, Result};
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::project::util::create_secure_channel_to_authority;
 use ockam_api::authenticator::direct::TokenAcceptorClient;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -55,7 +55,7 @@ fn parse_enroll_ticket(input: &str) -> Result<EnrollmentTicket> {
 
 impl AuthenticateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.cloud_opts.identity);
+        initialize_identity_if_default(&opts, &self.cloud_opts.identity);
         node_rpc(run_impl, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -18,7 +18,7 @@ use ockam_node::RpcClient;
 use crate::identity::get_identity_name;
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::create_secure_channel_to_authority;
-use crate::util::api::{CloudOpts, TrustContextOpts};
+use crate::util::api::{parse_trust_context, CloudOpts, TrustContextOpts};
 use crate::util::node_rpc;
 use crate::{CommandGlobalOpts, Result};
 
@@ -84,6 +84,7 @@ impl Runner {
 
         let (base_addr, _flow_control_id) =
             if let Some(tc) = self.cmd.trust_opts.trust_context.as_ref() {
+                let tc = parse_trust_context(&self.opts.state, &tc)?;
                 trust_context = Some(tc.clone());
                 let cred_retr = tc.authority()?.own_credential()?;
                 let addr = match cred_retr {

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -84,7 +84,7 @@ impl Runner {
 
         let (base_addr, _flow_control_id) =
             if let Some(tc) = self.cmd.trust_opts.trust_context.as_ref() {
-                let tc = parse_trust_context(&self.opts.state, &tc)?;
+                let tc = parse_trust_context(&self.opts.state, tc)?;
                 trust_context = Some(tc.clone());
                 let cred_retr = tc.authority()?.own_credential()?;
                 let addr = match cred_retr {

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -15,6 +15,7 @@ use ockam_core::route;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
 use ockam_node::RpcClient;
 
+use crate::identity::get_identity_name;
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{CloudOpts, TrustContextOpts};
@@ -96,25 +97,29 @@ impl Runner {
                         .into());
                     }
                 };
+                let identity =
+                    get_identity_name(&self.opts.state, self.cmd.cloud_opts.identity.clone())?;
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,
                     &node_name,
                     tc.authority()?.identity().await?.identifier().clone(),
                     addr,
-                    Some(self.cmd.cloud_opts.identity.clone()),
+                    Some(identity),
                 )
                 .await?;
 
                 (sc_addr, Some(sc_flow_control_id))
             } else if let (Some(p), Some(a)) = get_project(&self.cmd.to, &map)? {
+                let identity =
+                    get_identity_name(&self.opts.state, self.cmd.cloud_opts.identity.clone())?;
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,
                     &node_name,
                     a.identity_id().clone(),
                     a.address(),
-                    Some(self.cmd.cloud_opts.identity.clone()),
+                    Some(identity),
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -98,8 +98,7 @@ impl Runner {
                         .into());
                     }
                 };
-                let identity =
-                    get_identity_name(&self.opts.state, self.cmd.cloud_opts.identity.clone())?;
+                let identity = get_identity_name(&self.opts, self.cmd.cloud_opts.identity.clone())?;
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,
@@ -112,8 +111,7 @@ impl Runner {
 
                 (sc_addr, Some(sc_flow_control_id))
             } else if let (Some(p), Some(a)) = get_project(&self.cmd.to, &map)? {
-                let identity =
-                    get_identity_name(&self.opts.state, self.cmd.cloud_opts.identity.clone())?;
+                let identity = get_identity_name(&self.opts, self.cmd.cloud_opts.identity.clone())?;
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -15,7 +15,7 @@ use ockam_core::route;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
 use ockam_node::RpcClient;
 
-use crate::identity::get_identity_name;
+use crate::identity::{get_identity_name, initialize_identity};
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{parse_trust_context, CloudOpts, TrustContextOpts};
@@ -45,6 +45,7 @@ pub struct TicketCommand {
 
 impl TicketCommand {
     pub fn run(self, options: CommandGlobalOpts) {
+        initialize_identity(&options, &self.cloud_opts.identity);
         node_rpc(
             |ctx, (opts, cmd)| Runner::new(ctx, opts, cmd).run(),
             (options, self),
@@ -98,7 +99,7 @@ impl Runner {
                         .into());
                     }
                 };
-                let identity = get_identity_name(&self.opts, self.cmd.cloud_opts.identity.clone())?;
+                let identity = get_identity_name(&self.opts.state, &self.cmd.cloud_opts.identity);
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,
@@ -111,7 +112,7 @@ impl Runner {
 
                 (sc_addr, Some(sc_flow_control_id))
             } else if let (Some(p), Some(a)) = get_project(&self.cmd.to, &map)? {
-                let identity = get_identity_name(&self.opts, self.cmd.cloud_opts.identity.clone())?;
+                let identity = get_identity_name(&self.opts.state, &self.cmd.cloud_opts.identity);
                 let (sc_addr, sc_flow_control_id) = create_secure_channel_to_authority(
                     &self.ctx,
                     &self.opts,

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -15,7 +15,7 @@ use ockam_core::route;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
 use ockam_node::RpcClient;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{parse_trust_context, CloudOpts, TrustContextOpts};
@@ -45,7 +45,7 @@ pub struct TicketCommand {
 
 impl TicketCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        initialize_identity(&options, &self.cloud_opts.identity);
+        initialize_identity_if_default(&options, &self.cloud_opts.identity);
         node_rpc(
             |ctx, (opts, cmd)| Runner::new(ctx, opts, cmd).run(),
             (options, self),

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -14,7 +14,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 use tokio::sync::Mutex;
 use tokio::try_join;
 
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
 use crate::util::{extract_address_value, node_rpc, process_nodes_multiaddr, RpcBuilder};
@@ -37,8 +37,8 @@ pub struct CreateCommand {
     relay_name: String,
 
     /// Node for which to create the relay
-    #[arg(long, id = "NODE", display_order = 900, default_value_t = default_node_name(), value_parser = node_name_parser)]
-    to: String,
+    #[arg(long, id = "NODE", display_order = 900)]
+    to: Option<String>,
 
     /// Route to the node at which to create the relay (optional)
     #[arg(long, id = "ROUTE", display_order = 900, value_parser = parse_at, default_value_t = default_forwarder_at())]
@@ -74,7 +74,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     opts.terminal.write_line(&fmt_log!("Creating Relay"))?;
 
     let tcp = TcpTransport::create(&ctx).await?;
-    let api_node = extract_address_value(&cmd.to)?;
+    let to = get_node_name(&opts.state, cmd.to.clone())?;
+    let api_node = extract_address_value(&to)?;
     let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
 
     let ma = process_nodes_multiaddr(&cmd.at, &opts.state)?;

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -14,7 +14,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 use tokio::sync::Mutex;
 use tokio::try_join;
 
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
 use crate::util::{extract_address_value, node_rpc, process_nodes_multiaddr, RpcBuilder};
@@ -50,8 +50,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.to);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -74,7 +75,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     opts.terminal.write_line(&fmt_log!("Creating Relay"))?;
 
     let tcp = TcpTransport::create(&ctx).await?;
-    let to = get_node_name(&opts.state, cmd.to.clone())?;
+    let to = get_node_name(&opts.state, &cmd.to);
     let api_node = extract_address_value(&to)?;
     let at_rust_node = is_local_node(&cmd.at).context("Argument --at is not valid")?;
 

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -14,7 +14,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 use tokio::sync::Mutex;
 use tokio::try_join;
 
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
 use crate::util::{extract_address_value, node_rpc, process_nodes_multiaddr, RpcBuilder};
@@ -51,7 +51,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.to);
+        initialize_node_if_default(&opts, &self.to);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::default_node_name;
+use crate::node::{default_node_name, get_node_name};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -15,8 +15,8 @@ pub struct DeleteCommand {
     relay_name: String,
 
     /// Node on which to delete the Relay. If not provided, the default node will be used
-    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }
 
 impl DeleteCommand {
@@ -30,7 +30,11 @@ pub async fn run_impl(
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let relay_name = cmd.relay_name.clone();
-    let node = extract_address_value(&cmd.at)?;
+    let at = cmd
+        .at
+        .clone()
+        .unwrap_or_else(|| default_node_name(&options.state));
+    let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, get_node_name};
+use crate::node::default_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::default_node_name;
+use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -30,10 +30,7 @@ pub async fn run_impl(
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let relay_name = cmd.relay_name.clone();
-    let at = cmd
-        .at
-        .clone()
-        .unwrap_or_else(|| default_node_name(&options.state));
+    let at = get_node_name(&options.state, &cmd.at);
     let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::{default_node_name, get_node_name};
+use crate::node::default_node_name;
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::default_node_name;
+use crate::node::{default_node_name, get_node_name};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -14,8 +14,8 @@ use crate::Result;
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
     /// Node to list relays from
-    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name())]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }
 
 impl ListCommand {
@@ -25,7 +25,11 @@ impl ListCommand {
 }
 
 async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> Result<()> {
-    let node_name = extract_address_value(&cmd.at)?;
+    let at = cmd
+        .at
+        .clone()
+        .unwrap_or_else(|| default_node_name(&opts.state));
+    let node_name = extract_address_value(&at)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get("/node/forwarder")).await?;
     let response = rpc.parse_response::<Vec<ForwarderInfo>>()?;

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::default_node_name;
+use crate::node::get_node_name;
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -25,10 +25,7 @@ impl ListCommand {
 }
 
 async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> Result<()> {
-    let at = cmd
-        .at
-        .clone()
-        .unwrap_or_else(|| default_node_name(&opts.state));
+    let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get("/node/forwarder")).await?;

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::default_node_name;
+use crate::node::{default_node_name, get_node_name};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -17,8 +17,8 @@ pub struct ShowCommand {
     remote_address: String,
 
     /// Node which relay belongs to
-    #[arg(display_order = 901, global = true, long, value_name = "NODE", default_value_t = default_node_name())]
-    pub at: String,
+    #[arg(display_order = 901, global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }
 
 impl ShowCommand {
@@ -28,7 +28,11 @@ impl ShowCommand {
 }
 
 async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
-    let node_name = extract_address_value(&cmd.at)?;
+    let at = cmd
+        .at
+        .clone()
+        .unwrap_or_else(|| default_node_name(&opts.state));
+    let node_name = extract_address_value(&at)?;
     let remote_address = &cmd.remote_address;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get(format!("/node/forwarder/{remote_address}")))

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::{default_node_name, get_node_name};
+use crate::node::default_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
-use crate::node::default_node_name;
+use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
@@ -28,10 +28,7 @@ impl ShowCommand {
 }
 
 async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
-    let at = cmd
-        .at
-        .clone()
-        .unwrap_or_else(|| default_node_name(&opts.state));
+    let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
     let remote_address = &cmd.remote_address;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -9,6 +9,7 @@ use colorful::Colorful;
 use ockam_core::api::Request;
 use serde_json::json;
 
+use crate::identity::get_identity_name;
 use crate::util::api::CloudOpts;
 use crate::util::{clean_nodes_multiaddr, is_tty, RpcBuilder};
 use ockam::{identity::IdentityIdentifier, route, Context, TcpTransport};
@@ -163,11 +164,12 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     // Delegate the request to create a secure channel to the from node.
     let mut rpc = RpcBuilder::new(&ctx, &opts, from).tcp(&tcp)?.build();
 
+    let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
     let payload = models::secure_channel::CreateSecureChannelRequest::new(
         to,
         authorized_identifiers,
         CredentialExchangeMode::Mutual,
-        Some(cmd.cloud_opts.identity.clone()),
+        Some(identity),
         cmd.credential.clone(),
     );
     let request = Request::post("/node/secure_channel").body(payload);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -9,7 +9,7 @@ use colorful::Colorful;
 use ockam_core::api::Request;
 use serde_json::json;
 
-use crate::identity::{get_identity_name, initialize_identity};
+use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::util::api::CloudOpts;
 use crate::util::{clean_nodes_multiaddr, is_tty, RpcBuilder};
 use ockam::{identity::IdentityIdentifier, route, Context, TcpTransport};
@@ -45,7 +45,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_identity(&opts, &self.cloud_opts.identity);
+        initialize_identity_if_default(&opts, &self.cloud_opts.identity);
         node_rpc(rpc, (opts, self));
     }
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -164,7 +164,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     // Delegate the request to create a secure channel to the from node.
     let mut rpc = RpcBuilder::new(&ctx, &opts, from).tcp(&tcp)?.build();
 
-    let identity = get_identity_name(&opts.state, cmd.cloud_opts.identity.clone())?;
+    let identity = get_identity_name(&opts, cmd.cloud_opts.identity.clone())?;
     let payload = models::secure_channel::CreateSecureChannelRequest::new(
         to,
         authorized_identifiers,

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/common.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/common.rs
@@ -1,10 +1,8 @@
 use clap::Args;
 
-use crate::node::{default_node_name, node_name_parser};
-
 #[derive(Clone, Debug, Args)]
 pub struct SecureChannelListenerNodeOpts {
     /// Node
-    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name(), value_parser = node_name_parser)]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -9,6 +9,7 @@ use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
 use super::common::SecureChannelListenerNodeOpts;
+use crate::node::get_node_name;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{CommandGlobalOpts, Result};
 
@@ -47,9 +48,8 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let at = &cmd.node_opts.at;
-
-    let node = extract_address_value(at)?;
+    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = Request::post("/node/secure_channel_listener").body(
         CreateSecureChannelListenerRequest::new(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -9,7 +9,7 @@ use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{CommandGlobalOpts, Result};
 
@@ -36,6 +36,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -48,7 +49,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let at = get_node_name(&opts.state, &cmd.node_opts.at);
     let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = Request::post("/node/secure_channel_listener").body(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -9,7 +9,7 @@ use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{CommandGlobalOpts, Result};
 
@@ -36,7 +36,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -4,6 +4,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
+use crate::node::get_node_name;
 use crate::util::{api, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -32,9 +33,8 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let at = &cmd.node_opts.at;
-
-    let node = extract_address_value(at)?;
+    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = api::delete_secure_channel_listener(&cmd.address);
     rpc.request(req).await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{api, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -21,6 +21,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -33,7 +34,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let at = get_node_name(&opts.state, &cmd.node_opts.at);
     let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = api::delete_secure_channel_listener(&cmd.address);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -21,7 +21,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::api;
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -31,14 +31,12 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::list_secure_channel_listener()).await?;
     let res = rpc.parse_response::<Vec<String>>()?;
 
-    println!(
-        "Secure channel listeners for node `{}`:",
-        &cmd.node_opts.api_node
-    );
+    println!("Secure channel listeners for node `{}`:", &node_name);
     for addr in res {
         println!("  {addr}");
     }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::api;
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -18,7 +18,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 use ockam::Context;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::api;
 use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -17,8 +17,9 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -31,7 +32,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::list_secure_channel_listener()).await?;
     let res = rpc.parse_response::<Vec<String>>()?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -5,6 +5,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
+use crate::node::get_node_name;
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -35,8 +36,8 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let at = &cmd.node_opts.at;
-    let node = extract_address_value(at)?;
+    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let node = extract_address_value(&at)?;
     let address = &cmd.address;
 
     let mut rpc = Rpc::background(ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -24,6 +24,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -36,7 +37,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, cmd.node_opts.at.clone())?;
+    let at = get_node_name(&opts.state, &cmd.node_opts.at);
     let node = extract_address_value(&at)?;
     let address = &cmd.address;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -5,7 +5,7 @@ use ockam::Context;
 use ockam_core::Address;
 
 use super::common::SecureChannelListenerNodeOpts;
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -24,7 +24,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -3,7 +3,7 @@ use ockam::{Context, TcpTransport};
 
 use ockam_api::nodes::models::services::ServiceList;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{api, extract_address_value, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
@@ -29,7 +29,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let tcp = TcpTransport::create(ctx).await?;
 
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).tcp(&tcp)?.build();

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -3,7 +3,7 @@ use ockam::{Context, TcpTransport};
 
 use ockam_api::nodes::models::services::ServiceList;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{api, extract_address_value, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
@@ -15,8 +15,9 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -29,7 +30,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
     let tcp = TcpTransport::create(ctx).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -3,7 +3,7 @@ use ockam::{Context, TcpTransport};
 
 use ockam_api::nodes::models::services::ServiceList;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, extract_address_value, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
@@ -16,7 +16,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::Result;
@@ -94,20 +94,20 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: StartCommand,
 ) -> crate::Result<()> {
-    let node_name = &cmd.node_opts.api_node;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
     let tcp = TcpTransport::create(ctx).await?;
     let addr = match cmd.create_subcommand {
         StartSubCommand::Identity { addr, .. } => {
-            start_identity_service(ctx, &opts, node_name, &addr, Some(&tcp)).await?;
+            start_identity_service(ctx, &opts, &node_name, &addr, Some(&tcp)).await?;
             addr
         }
         StartSubCommand::Authenticated { addr, .. } => {
             let req = api::start_authenticated_service(&addr);
-            start_service_impl(ctx, &opts, node_name, "Authenticated", req, Some(&tcp)).await?;
+            start_service_impl(ctx, &opts, &node_name, "Authenticated", req, Some(&tcp)).await?;
             addr
         }
         StartSubCommand::Verifier { addr, .. } => {
-            start_verifier_service(ctx, &opts, node_name, &addr, Some(&tcp)).await?;
+            start_verifier_service(ctx, &opts, &node_name, &addr, Some(&tcp)).await?;
             addr
         }
         StartSubCommand::Credentials {
@@ -117,11 +117,12 @@ async fn run_impl(
             ..
         } => {
             let req = api::start_credentials_service(&identity, &addr, oneway);
-            start_service_impl(ctx, &opts, node_name, "Credentials", req, Some(&tcp)).await?;
+            start_service_impl(ctx, &opts, &node_name, "Credentials", req, Some(&tcp)).await?;
             addr
         }
         StartSubCommand::Authenticator { addr, project, .. } => {
-            start_authenticator_service(ctx, &opts, node_name, &addr, &project, Some(&tcp)).await?;
+            start_authenticator_service(ctx, &opts, &node_name, &addr, &project, Some(&tcp))
+                .await?;
             addr
         }
     };

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::Result;
@@ -78,7 +78,7 @@ fn authenticator_default_addr() -> String {
 
 impl StartCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::Result;
@@ -77,8 +77,9 @@ fn authenticator_default_addr() -> String {
 }
 
 impl StartCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -94,7 +95,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: StartCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let tcp = TcpTransport::create(ctx).await?;
     let addr = match cmd.create_subcommand {
         StartSubCommand::Identity { addr, .. } => {

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -45,7 +45,7 @@ async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: StatusCommand) ->
     let tcp = TcpTransport::create(ctx).await?;
     for node_state in &node_states {
         let node_infos = NodeDetails {
-            identifier: node_state.config().identity().await?.identifier(),
+            identifier: node_state.config().identifier().await?,
             state: node_state.clone(),
             status: get_node_status(ctx, &opts, node_state, &tcp).await?,
         };
@@ -106,16 +106,14 @@ async fn print_status(
 
     for (i_idx, identity) in identities.iter().enumerate() {
         println!("Identity[{i_idx}]");
-        if default_identity.config().identity.identifier()
-            == identity.config().identity.identifier()
-        {
+        if default_identity.config().identifier() == identity.config().identifier() {
             println!("{:2}Default: yes", "")
         }
         for line in identity.to_string().lines() {
             println!("{:2}{}", "", line);
         }
 
-        node_details.retain(|nd| nd.identifier == identity.config().identity.identifier());
+        node_details.retain(|nd| nd.identifier == identity.config().identifier());
         if !node_details.is_empty() {
             println!("{:2}Linked Nodes:", "");
             for (n_idx, node) in node_details.iter().enumerate() {

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::is_tty;
 use crate::{
     util::{api, extract_address_value, node_rpc, Rpc},
@@ -32,7 +32,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.from);
+        initialize_node_if_default(&opts, &self.node_opts.from);
         node_rpc(run_impl, (opts, self))
     }
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,3 +1,4 @@
+use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
@@ -24,7 +25,8 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
 
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let req = Request::delete("/node/tcp/connection")

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
@@ -17,7 +17,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
@@ -16,8 +16,9 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -25,7 +26,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
 
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
@@ -24,7 +24,8 @@ async fn run_impl(
     ctx: ockam::Context,
     (options, command): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&command.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, command.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(Request::get("/node/tcp/connection")).await?;
     let response = rpc.parse_response::<models::transport::TransportList>()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
@@ -16,7 +16,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::Context;
@@ -15,18 +15,19 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 async fn run_impl(
     ctx: ockam::Context,
-    (options, command): (CommandGlobalOpts, ListCommand),
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&options.state, command.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get("/node/tcp/connection")).await?;
     let response = rpc.parse_response::<models::transport::TransportList>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -28,7 +28,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(Request::get(format!("/node/tcp/connection/{}", &cmd.id)))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -20,7 +20,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -19,8 +19,9 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self));
     }
 }
 
@@ -28,7 +29,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(Request::get(format!("/node/tcp/connection/{}", &cmd.id)))

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
@@ -72,7 +72,7 @@ fn default_to_addr() -> MultiAddr {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.at);
+        initialize_node_if_default(&opts, &self.at);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
@@ -71,8 +71,9 @@ fn default_to_addr() -> MultiAddr {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.at);
+        node_rpc(rpc, (opts, self));
     }
 }
 
@@ -80,7 +81,7 @@ async fn rpc(ctx: Context, (opts, mut cmd): (CommandGlobalOpts, CreateCommand)) 
     opts.terminal.write_line(&fmt_log!("Creating TCP Inlet"))?;
     cmd.to = process_nodes_multiaddr(&cmd.to, &opts.state)?;
 
-    let node_name = get_node_name(&opts.state, cmd.at.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.at);
     let node = extract_address_value(&node_name)?;
 
     let tcp = TcpTransport::create(&ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -31,7 +31,8 @@ pub async fn run_impl(
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let alias = cmd.alias.clone();
-    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -22,7 +22,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -25,7 +25,8 @@ async fn run_impl(
     ctx: ockam::Context,
     (options, command): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&command.node.api_node)?;
+    let node_name = get_node_name(&options.state, command.node.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(Request::get("/node/inlet")).await?;
     let response = rpc.parse_response::<models::portal::InletList>()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -17,7 +17,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node.api_node);
+        initialize_node_if_default(&opts, &self.node.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -16,18 +16,19 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 async fn run_impl(
     ctx: ockam::Context,
-    (options, command): (CommandGlobalOpts, ListCommand),
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&options.state, command.node.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node.api_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get("/node/inlet")).await?;
     let response = rpc.parse_response::<models::portal::InletList>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -32,7 +32,8 @@ pub async fn run_impl(
     ctx: Context,
     (options, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -23,18 +23,19 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 pub async fn run_impl(
     ctx: Context,
-    (options, cmd): (CommandGlobalOpts, ShowCommand),
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -24,7 +24,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::util::Rpc;
 use crate::util::{node_rpc, parse_node_name};
 use crate::CommandGlobalOpts;
@@ -13,8 +13,8 @@ use ockam_multiaddr::MultiAddr;
 #[derive(Args, Clone, Debug)]
 pub struct CreateCommand {
     /// Node at which to create the listener
-    #[arg(global = true, long, value_name = "NODE", default_value_t = default_node_name(), value_parser = node_name_parser)]
-    pub at: String,
+    #[arg(global = true, long, value_name = "NODE")]
+    pub at: Option<String>,
 
     /// Address for this listener (eg. 127.0.0.1:7000)
     pub address: String,
@@ -30,7 +30,8 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let node_name = parse_node_name(&cmd.at)?;
+    let node_name = get_node_name(&opts.state, cmd.at.clone())?;
+    let node_name = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(
         Request::post("/node/tcp/listener").body(CreateTransport::new(

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::Rpc;
 use crate::util::{node_rpc, parse_node_name};
 use crate::CommandGlobalOpts;
@@ -22,7 +22,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.at);
+        initialize_node_if_default(&opts, &self.at);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::Rpc;
 use crate::util::{node_rpc, parse_node_name};
 use crate::CommandGlobalOpts;
@@ -21,8 +21,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.at);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -30,7 +31,7 @@ async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.at.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.at);
     let node_name = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -6,6 +6,7 @@ use ockam::Context;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
+use crate::node::get_node_name;
 use crate::util::{node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 
@@ -28,7 +29,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let node = parse_node_name(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     let req = Request::delete("/node/tcp/listener")
         .body(models::transport::DeleteTransport::new(&cmd.id));

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -6,7 +6,7 @@ use ockam::Context;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 
@@ -21,7 +21,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -6,7 +6,7 @@ use ockam::Context;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{node_rpc, Rpc};
 use crate::{node::NodeOpts, CommandGlobalOpts};
 
@@ -20,8 +20,9 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self));
     }
 }
 
@@ -29,7 +30,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     let req = Request::delete("/node/tcp/listener")

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -3,7 +3,7 @@ use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::Context;
 use ockam_api::nodes::models::transport::{TransportList, TransportStatus};
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -28,7 +28,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let mut rpc = Rpc::background(ctx, &opts, &cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::list_tcp_listeners()).await?;
     let res = rpc.parse_response::<TransportList>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -3,7 +3,7 @@ use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::Context;
 use ockam_api::nodes::models::transport::{TransportList, TransportStatus};
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -15,6 +15,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -28,7 +29,7 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::list_tcp_listeners()).await?;
     let res = rpc.parse_response::<TransportList>()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -3,7 +3,7 @@ use cli_table::{print_stdout, Cell, Style, Table};
 use ockam::Context;
 use ockam_api::nodes::models::transport::{TransportList, TransportStatus};
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
@@ -15,7 +15,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(rpc, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -28,7 +28,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(Request::get(format!("/node/tcp/listener/{}", &cmd.id)))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -19,8 +19,9 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self));
     }
 }
 
@@ -28,7 +29,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(Request::get(format!("/node/tcp/listener/{}", &cmd.id)))

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::extract_address_value;
 use ockam::Context;
 use ockam_api::nodes::models;
@@ -20,7 +20,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
@@ -24,8 +24,8 @@ use std::net::SocketAddr;
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     /// Node on which to start the tcp outlet.
-    #[arg(long, display_order = 900, id = "NODE", default_value_t = default_node_name(), value_parser = node_name_parser)]
-    at: String,
+    #[arg(long, display_order = 900, id = "NODE")]
+    at: Option<String>,
 
     /// Address of the tcp outlet.
     #[arg(long, display_order = 901, id = "OUTLET_ADDRESS", default_value_t = default_from_addr())]
@@ -55,7 +55,9 @@ pub async fn run_impl(
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
     opts.terminal.write_line(&fmt_log!("Creating TCP Outlet"))?;
-    let node = extract_address_value(&cmd.at)?;
+
+    let node_name = get_node_name(&opts.state, cmd.at.clone())?;
+    let node = extract_address_value(&node_name)?;
     let project = opts
         .state
         .nodes

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
@@ -41,8 +41,9 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.at);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -56,7 +57,7 @@ pub async fn run_impl(
 ) -> crate::Result<()> {
     opts.terminal.write_line(&fmt_log!("Creating TCP Outlet"))?;
 
-    let node_name = get_node_name(&opts.state, cmd.at.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.at);
     let node = extract_address_value(&node_name)?;
     let project = opts
         .state

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
@@ -42,7 +42,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.at);
+        initialize_node_if_default(&opts, &self.at);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -31,8 +31,8 @@ pub async fn run_impl(
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let alias = cmd.alias.clone();
-
-    let node = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -22,7 +22,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -21,25 +21,25 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 pub async fn run_impl(
     ctx: Context,
-    (options, cmd): (CommandGlobalOpts, DeleteCommand),
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
     let alias = cmd.alias.clone();
-    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(make_api_request(cmd)?).await?;
 
     rpc.is_ok()?;
 
-    options
-        .terminal
+    opts.terminal
         .stdout()
         .plain(format!(
             "{} TCP Outlet with alias {alias} on Node {node} has been deleted.",

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -25,7 +25,8 @@ async fn run_impl(
     ctx: ockam::Context,
     (options, command): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&command.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, command.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(Request::get("/node/outlet")).await?;
     let response = rpc.parse_response::<OutletList>()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -16,18 +16,19 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 async fn run_impl(
     ctx: ockam::Context,
-    (options, command): (CommandGlobalOpts, ListCommand),
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&options.state, command.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get("/node/outlet")).await?;
     let response = rpc.parse_response::<OutletList>()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use anyhow::anyhow;
@@ -17,7 +17,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::NodeOpts;
+use crate::node::{get_node_name, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -33,7 +33,8 @@ pub async fn run_impl(
     ctx: Context,
     (options, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = extract_address_value(&cmd.node_opts.api_node)?;
+    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, NodeOpts};
+use crate::node::{get_node_name, initialize_node, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -24,18 +24,19 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.node_opts.api_node);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
 pub async fn run_impl(
     ctx: Context,
-    (options, cmd): (CommandGlobalOpts, ShowCommand),
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&options.state, cmd.node_opts.api_node.clone())?;
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.api_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &options, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node, NodeOpts};
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
@@ -25,7 +25,7 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.node_opts.api_node);
+        initialize_node_if_default(&opts, &self.node_opts.api_node);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -225,6 +225,10 @@ impl<W: TerminalWriter> Terminal<W> {
         // to ask the user for input.  Otherwise, let the terminal decide based on the `is_tty` value
         no_input || get_env_with_default("NO_INPUT", false).unwrap_or(false)
     }
+
+    pub fn set_quiet(&mut self) {
+        self.quiet = true
+    }
 }
 
 // Logging mode

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -226,8 +226,10 @@ impl<W: TerminalWriter> Terminal<W> {
         no_input || get_env_with_default("NO_INPUT", false).unwrap_or(false)
     }
 
-    pub fn set_quiet(&mut self) {
-        self.quiet = true
+    pub fn set_quiet(&self) -> Self {
+        let mut clone = self.clone();
+        clone.quiet = true;
+        clone
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
@@ -32,7 +32,7 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd, tco): (CommandGlobalOpts, CreateCommand, TrustContextOpts),
 ) -> crate::Result<()> {
-    let tcc = TrustContextConfigBuilder::new(&opts.state, &tco)
+    let tcc = TrustContextConfigBuilder::new(&opts.state, &tco)?
         .with_credential_name(cmd.credential.as_ref())
         .use_default_trust_context(false)
         .build();

--- a/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
@@ -32,7 +32,7 @@ async fn run_impl(
     _ctx: Context,
     (opts, cmd, tco): (CommandGlobalOpts, CreateCommand, TrustContextOpts),
 ) -> crate::Result<()> {
-    let tcc = TrustContextConfigBuilder::new(&tco)
+    let tcc = TrustContextConfigBuilder::new(&opts.state, &tco)
         .with_credential_name(cmd.credential.as_ref())
         .use_default_trust_context(false)
         .build();

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -26,7 +26,6 @@ use ockam_core::env::{get_env_with_default, FromString};
 use ockam_core::{Address, CowStr};
 use ockam_multiaddr::MultiAddr;
 
-use crate::identity::{default_identity_name, identity_name_parser};
 use crate::project::ProjectInfo;
 use crate::service::config::OktaIdentityProviderConfig;
 use crate::util::DEFAULT_CONTROLLER_ADDRESS;
@@ -335,8 +334,8 @@ pub(crate) const OCKAM_CONTROLLER_ADDR: &str = "OCKAM_CONTROLLER_ADDR";
 
 #[derive(Clone, Debug, Args)]
 pub struct CloudOpts {
-    #[arg(global = true, value_name = "IDENTITY", long, default_value_t = default_identity_name(), value_parser = identity_name_parser)]
-    pub identity: String,
+    #[arg(global = true, value_name = "IDENTITY", long)]
+    pub identity: Option<String>,
 }
 
 #[derive(Clone, Debug, Args, Default)]

--- a/implementations/rust/ockam/ockam_command/src/util/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/config.rs
@@ -1,5 +1,6 @@
 //! Handle local node configuration
 
+use std::path::PathBuf;
 use std::{ops::Deref, sync::RwLockReadGuard};
 
 use crate::Result;
@@ -26,6 +27,10 @@ impl Deref for OckamConfig {
 impl OckamConfig {
     pub fn load() -> Result<OckamConfig> {
         let dir = cli::OckamConfig::dir();
+        Self::load_with_dir(dir)
+    }
+
+    pub fn load_with_dir(dir: PathBuf) -> Result<OckamConfig> {
         let inner = Config::<cli::OckamConfig>::load(&dir, "config")?;
         inner.write().dir = Some(dir);
         Ok(Self { inner })

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -102,7 +102,7 @@ impl<'a> RpcBuilder<'a> {
 pub struct Rpc<'a> {
     ctx: &'a Context,
     buf: Vec<u8>,
-    opts: &'a CommandGlobalOpts,
+    pub opts: &'a CommandGlobalOpts,
     node_name: String,
     to: Route,
     mode: RpcMode<'a>,

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -672,7 +672,7 @@ mod tests {
             .identities_creation()
             .create_identity()
             .await?;
-        let idt_config = IdentityConfig::new(&idt).await;
+        let idt_config = IdentityConfig::new(&idt.identifier()).await;
         cli_state
             .identities
             .create(&cli_state::random_name(), idt_config)?;

--- a/implementations/rust/ockam/ockam_command/src/vault/attach_key.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/attach_key.rs
@@ -54,7 +54,7 @@ async fn run_impl(opts: CommandGlobalOpts, cmd: AttachKeyCommand) -> crate::Resu
             .await?
     };
     let idt_name = cli_state::random_name();
-    let idt_config = IdentityConfig::new(&idt).await;
+    let idt_config = IdentityConfig::new(&idt.identifier()).await;
     opts.state.identities.create(&idt_name, idt_config)?;
     println!("Identity attached to vault: {idt_name}");
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -5,7 +5,6 @@ mod delete;
 mod list;
 mod show;
 
-use crate::error::Error;
 use crate::vault::attach_key::AttachKeyCommand;
 use crate::vault::create::CreateCommand;
 use crate::vault::default::DefaultCommand;
@@ -55,18 +54,7 @@ impl VaultCommand {
     }
 }
 
-pub fn default_vault_name() -> String {
-    let res_cli = CliState::try_default();
-
-    let cli_state = match res_cli {
-        Ok(cli_state) => cli_state,
-        Err(err) => {
-            eprintln!("Error initializing command state. \n\n {err:?}");
-            let command_err: Error = err.into();
-            std::process::exit(command_err.code());
-        }
-    };
-
+pub fn default_vault_name(cli_state: &CliState) -> String {
     cli_state
         .vaults
         .default()

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{default_node_name, node_name_parser};
+use crate::node::get_node_name;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
@@ -19,8 +19,8 @@ after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct ListCommand {
     /// Node at which to lookup workers (required)
-    #[arg(value_name = "NODE", long, default_value_t = default_node_name(), value_parser = node_name_parser, display_order = 800)]
-    at: String,
+    #[arg(value_name = "NODE", long, display_order = 800)]
+    at: Option<String>,
 }
 
 impl ListCommand {
@@ -33,7 +33,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    if let Ok(node_state) = opts.state.nodes.get(&cmd.at) {
+    let at = get_node_name(&opts.state, cmd.at.clone())?;
+    if let Ok(node_state) = opts.state.nodes.get(&at) {
         let tcp = TcpTransport::create(&ctx).await?;
         let mut rpc = RpcBuilder::new(&ctx, &opts, node_state.name())
             .tcp(&tcp)?

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -1,4 +1,4 @@
-use crate::node::get_node_name;
+use crate::node::{get_node_name, initialize_node};
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
@@ -24,8 +24,9 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node(&opts, &self.at);
+        node_rpc(run_impl, (opts, self))
     }
 }
 
@@ -33,7 +34,7 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, cmd.at.clone())?;
+    let at = get_node_name(&opts.state, &cmd.at);
     if let Ok(node_state) = opts.state.nodes.get(&at) {
         let tcp = TcpTransport::create(&ctx).await?;
         let mut rpc = RpcBuilder::new(&ctx, &opts, node_state.name())

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node};
+use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
@@ -25,7 +25,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node(&opts, &self.at);
+        initialize_node_if_default(&opts, &self.at);
         node_rpc(run_impl, (opts, self))
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -113,6 +113,19 @@ impl Executor {
         Ok(res)
     }
 
+    /// Execute a future and block until a result is returned
+    #[cfg(feature = "std")]
+    pub fn execute_future<F>(&mut self, future: F) -> Result<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let join_body = self.rt.spawn(future);
+        self.rt
+            .block_on(join_body)
+            .map_err(|e| Error::new(Origin::Executor, Kind::Unknown, e))
+    }
+
     #[cfg(not(feature = "std"))]
     /// Initialise and run the Ockam node executor context
     ///

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -115,14 +115,14 @@ impl Executor {
 
     /// Execute a future and block until a result is returned
     #[cfg(feature = "std")]
-    pub fn execute_future<F>(&mut self, future: F) -> Result<F::Output>
+    pub fn execute_future<F>(future: F) -> Result<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let join_body = self.rt.spawn(future);
-        self.rt
-            .block_on(join_body)
+        let rt = Runtime::new().unwrap();
+        let join_body = rt.spawn(future);
+        rt.block_on(join_body)
             .map_err(|e| Error::new(Origin::Executor, Kind::Unknown, e))
     }
 


### PR DESCRIPTION
This PR remove some data duplication for the storage of identities.

# Context

This PR is a follow-up to [a previous fix](https://github.com/build-trust/ockam/pull/4936) where an identity read from a configuration file was not found in the identities repository.

In general, if a components needs to access the most recent version of an `Identity` given its identifier, it will use the `IdentitiesRepository` which is implemented using the `LMDB` database storing all the data related to an identity (except for its keys which are stored in a `Vault`).

However at the moment the identity change history is also stored in independent configuration files, making it harder to ensure the consistency of data between the 2 storages.

This PR removes the identity history data from the individual configuration files (`alice.json`, `bob.json`, etc...). 

# Configuration file migration

In order to do this a migration step has been introduced to the loading of configuration data (which will help the migration of other configuration files, for `Vault` in particular).

# CliState initialization

However in order to do this it was important to control the exact moment where the `CliState` is loaded, so that the migrations only run once, at the beginning of the application. This needed some work to:

 1. remove the use of `CliState` by `IdentitiesState` for its implementation of the `delete` method (where `CliState` is used to check if a node is still using that identity))

 2. remove the initialization of a `CliState` by many command-line arguments parsers in order to get default values for node names and identities (note: this is why, in general, a value parser should never have any side effect)

(most of the files modified by this PR are the result of this change)

# Testing

This PR was tested by creating an identity with a previous `ockam` version then show this identity with the new version
```
ockam_old identity create i1
ockam_new identity show --name i1 --full
cat ~/.ockam/identities/i1.json
```
The identity `i1` is fully displayed and the `json` file has been migrated so that it contains only the identity identifier and the enrollement status.
