### PR TITLE
feat(rust): environment command & moved text

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -23,31 +23,6 @@ Feedback:
 
 If you have any questions or feedback, please start a discussion
 on Github https://github.com/build-trust/ockam/discussions/new
-
-Environment Variables:
-
-System
-- COLORFGBG: a `string` that defines the foreground and background colors of the terminal.
- If it's not set it has no effect in the Ockam CLI.
-
-CLI Behavior
-- NO_COLOR: a `boolean` that, if set, the colors will be stripped out from output messages.
- Otherwise, let the terminal decide.
-- NO_INPUT: a `boolean` that, if set, the CLI won't ask the user for input.
- Otherwise, let the terminal decide based the terminal features (tty).
-- OCKAM_DISABLE_UPGRADE_CHECK: a `boolean` that, if set, the CLI won't check for ockam upgrades.
-- OCKAM_HOME: a `string` that sets the home directory. Defaults to `~/.ockam`.
-- OCKAM_LOG: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed.
-- OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB.
-- OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node.
-
-Devs Usage
-- OCKAM_HELP_SHOW_HIDDEN: a `boolean` to control the visibility of hidden commands.
-- OCKAM_CONTROLLER_ADDR: a `string` that overrides the default address of the controller.
-- OCKAM_CONTROLLER_IDENTITY_ID: a `string` that overrides the default identifier of the controller.
-
-Internal (to enable some special behavior in the logic)
-- OCKAM_HELP_RENDER_MARKDOWN: a `boolean` to control the markdown rendering of the commands documentation.
 ";
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);

--- a/implementations/rust/ockam/ockam_command/src/environment/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/mod.rs
@@ -1,0 +1,13 @@
+use clap::Args;
+
+const ENVTEXT: &str = include_str!("./static/envtext.txt");
+
+#[derive(Clone, Debug, Args)]
+pub struct EnvironmentCommand {}
+
+impl EnvironmentCommand {
+    pub fn run(self) {
+        println!("{}", ENVTEXT);
+    }
+}
+

--- a/implementations/rust/ockam/ockam_command/src/environment/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/mod.rs
@@ -2,6 +2,7 @@ use clap::Args;
 
 const ENVTEXT: &str = include_str!("./static/envtext.txt");
 
+// Outputs information about environment variables used by Ockam
 #[derive(Clone, Debug, Args)]
 pub struct EnvironmentCommand {}
 

--- a/implementations/rust/ockam/ockam_command/src/environment/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/mod.rs
@@ -11,4 +11,3 @@ impl EnvironmentCommand {
         println!("{}", ENVTEXT);
     }
 }
-

--- a/implementations/rust/ockam/ockam_command/src/environment/static/envtext.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/envtext.txt
@@ -1,0 +1,24 @@
+Environment Variables:
+
+System
+- COLORFGBG: a `string` that defines the foreground and background colors of the terminal.
+  If it's not set it has no effect in the Ockam CLI.
+
+CLI Behavior
+- NO_COLOR: a `boolean` that, if set, the colors will be stripped out from output messages.
+  Otherwise, let the terminal decide.
+- NO_INPUT: a `boolean` that, if set, the CLI won't ask the user for input.
+  Otherwise, let the terminal decide based the terminal features (tty).
+- OCKAM_DISABLE_UPGRADE_CHECK: a `boolean` that, if set, the CLI won't check for ockam upgrades.
+- OCKAM_HOME: a `string` that sets the home directory. Defaults to `~/.ockam`.
+- OCKAM_LOG: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed.
+- OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB.
+- OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node.
+
+Devs Usage
+- OCKAM_HELP_SHOW_HIDDEN: a `boolean` to control the visibility of hidden commands.
+- OCKAM_CONTROLLER_ADDR: a `string` that overrides the default address of the controller.
+- OCKAM_CONTROLLER_IDENTITY_ID: a `string` that overrides the default identifier of the controller.
+
+Internal (to enable some special behavior in the logic)
+- OCKAM_HELP_RENDER_MARKDOWN: a `boolean` to control the markdown rendering of the commands documentation.

--- a/implementations/rust/ockam/ockam_command/src/environment/static/envtext.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/envtext.txt
@@ -1,5 +1,3 @@
-Environment Variables:
-
 System
 - COLORFGBG: a `string` that defines the foreground and background colors of the terminal.
   If it's not set it has no effect in the Ockam CLI.

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -39,6 +39,7 @@ mod util;
 mod vault;
 mod version;
 mod worker;
+mod environment;
 
 use crate::admin::AdminCommand;
 use crate::authority::AuthorityCommand;
@@ -56,6 +57,7 @@ use configuration::ConfigurationCommand;
 use console::Term;
 use credential::CredentialCommand;
 use enroll::EnrollCommand;
+use environment::EnvironmentCommand;
 use error::{Error, Result};
 use identity::IdentityCommand;
 use kafka::consumer::KafkaConsumerCommand;
@@ -263,6 +265,7 @@ pub enum OckamSubcommand {
     Markdown(MarkdownCommand),
     Manpages(ManpagesCommand),
     TrustContext(TrustContextCommand),
+    Environment(EnvironmentCommand),
 }
 
 impl OckamSubcommand {
@@ -366,6 +369,7 @@ impl OckamCommand {
             OckamSubcommand::Markdown(c) => c.run(),
             OckamSubcommand::Manpages(c) => c.run(),
             OckamSubcommand::TrustContext(c) => c.run(options),
+            OckamSubcommand::Environment(c) => c.run(),
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -12,6 +12,7 @@ mod configuration;
 mod credential;
 mod docs;
 mod enroll;
+mod environment;
 mod error;
 mod identity;
 mod kafka;
@@ -39,7 +40,6 @@ mod util;
 mod vault;
 mod version;
 mod worker;
-mod environment;
 
 use crate::admin::AdminCommand;
 use crate::authority::AuthorityCommand;


### PR DESCRIPTION
## Current behavior

Information about Environment Variables is displayed in the footers of other commands taking up a large space.

## Proposed changes

Created a new 'environment' CLI command to display the Environment Variables information separately, and removed the moved text from the other CLI footer.

Closes  issue #4928

## Checks

- [✅] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [✅] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [✅] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [✅] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.