### PR TITLE
feat(rust): add hex flag to message send

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message.bats
@@ -62,3 +62,10 @@ teardown() {
   run "$OCKAM" message send --timeout 5 --identity m2 --to /project/default/service/echo "$msg"
   assert_failure
 }
+
+@test "message - send a hex encoded message to a project node from an embedded node" {
+  msg=$(random_str)
+  run "$OCKAM" message send "$msg" --to /project/default/service/echo --hex
+  assert_success
+  assert_output "$msg"
+}


### PR DESCRIPTION
Adding support for the hex binary flag to the message send CLI command.
Closes issue #4918 

## Current behavior

ockam message send CLI command doesn't have support for binary messages encoded as hex strings. 

## Proposed changes

ockam message send CLI command will support sending binary messages encoded as hex strings. Adds a '--hex' option telling ockam to interpret the message payload as a hex string and to decode it to a byte array before sending.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

- [✅] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [✅] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [✅] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [✅] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.