### PR TITLE
test(rust): use tokio test to simplify some unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,6 +3401,7 @@ dependencies = [
  "spin 0.9.8",
  "subtle",
  "tinyvec",
+ "tokio",
  "tracing",
  "tracing-error",
  "zeroize",

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -62,9 +62,6 @@ debugger = []
 
 tag = ["cddl-cat", "serde_cbor"]
 
-[dev-dependencies]
-quickcheck = "1.0.1"
-
 [dependencies]
 async-trait = "0.1.64"
 backtrace = { version = "0.3", default-features = false, features = ["std", "serialize-serde"], optional = true }
@@ -89,3 +86,7 @@ tinyvec = { version = "1.6.0", features = ["rustc_1_57"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 tracing-error = { version = "0.2", default-features = false, optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
+
+[dev-dependencies]
+quickcheck = "1.0.1"
+tokio = { version = "1.28.1", features = ["full"] }

--- a/implementations/rust/ockam/ockam_core/src/access_control/local.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/local.rs
@@ -38,14 +38,13 @@ impl IncomingAccessControl for LocalSourceOnly {
 
 #[cfg(test)]
 mod tests {
-    use crate::compat::future::poll_once;
     use crate::{
         route, Address, IncomingAccessControl, LocalMessage, LocalOnwardOnly, LocalSourceOnly,
         OutgoingAccessControl, RelayMessage, Result, TransportMessage, TransportType,
     };
 
-    #[test]
-    fn test_onward() -> Result<()> {
+    #[tokio::test]
+    async fn test_onward() -> Result<()> {
         let local_onward_address = Address::random_local();
         let external_onward_address = Address::random(TransportType::new(1));
         let source_address = Address::random_local();
@@ -58,7 +57,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), local_onward_address.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(external_onward_address.clone(), route![], vec![]),
@@ -66,7 +65,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), external_onward_address.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(local_onward_address.clone(), route![], vec![]),
@@ -74,7 +73,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), external_onward_address.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(external_onward_address, route![], vec![]),
@@ -82,13 +81,13 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address, local_onward_address, msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         Ok(())
     }
 
-    #[test]
-    fn test_source() -> Result<()> {
+    #[tokio::test]
+    async fn test_source() -> Result<()> {
         let local_source_address = Address::random_local();
         let external_source_address = Address::random(TransportType::new(1));
         let onward_address = Address::random_local();
@@ -105,7 +104,7 @@ mod tests {
         );
         let msg = RelayMessage::new(local_source_address.clone(), onward_address.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(
@@ -117,7 +116,7 @@ mod tests {
         );
         let msg = RelayMessage::new(external_source_address.clone(), onward_address.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(
@@ -129,7 +128,7 @@ mod tests {
         );
         let msg = RelayMessage::new(external_source_address.clone(), onward_address.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(
@@ -141,7 +140,7 @@ mod tests {
         );
         let msg = RelayMessage::new(local_source_address, onward_address, msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control/onward.rs
@@ -49,14 +49,13 @@ impl OutgoingAccessControl for AllowOnwardAddresses {
 
 #[cfg(test)]
 mod tests {
-    use crate::compat::future::poll_once;
     use crate::{
         route, Address, AllowOnwardAddress, AllowOnwardAddresses, LocalMessage,
         OutgoingAccessControl, RelayMessage, Result, TransportMessage,
     };
 
-    #[test]
-    fn test_1_address() -> Result<()> {
+    #[tokio::test]
+    async fn test_1_address() -> Result<()> {
         let onward_address1 = Address::random_local();
         let onward_address2 = Address::random_local();
         let source_address = Address::random_local();
@@ -69,7 +68,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address1.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address2.clone(), route![], vec![]),
@@ -77,7 +76,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address2.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address1.clone(), route![], vec![]),
@@ -85,7 +84,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address2.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address2, route![], vec![]),
@@ -93,13 +92,13 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address, onward_address1, msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         Ok(())
     }
 
-    #[test]
-    fn test_2_addresses() -> Result<()> {
+    #[tokio::test]
+    async fn test_2_addresses() -> Result<()> {
         let onward_address1 = Address::random_local();
         let onward_address2 = Address::random_local();
         let onward_address3 = Address::random_local();
@@ -113,7 +112,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address1.clone(), msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address2.clone(), route![], vec![]),
@@ -121,7 +120,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address2, msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address3.clone(), route![], vec![]),
@@ -129,7 +128,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address3.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address3.clone(), route![], vec![]),
@@ -137,7 +136,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address.clone(), onward_address1.clone(), msg);
 
-        assert!(!poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(!ac.is_authorized(&msg).await?);
 
         let msg = LocalMessage::new(
             TransportMessage::v1(onward_address1, route![], vec![]),
@@ -145,7 +144,7 @@ mod tests {
         );
         let msg = RelayMessage::new(source_address, onward_address3, msg);
 
-        assert!(poll_once(async { ac.is_authorized(&msg).await })?);
+        assert!(ac.is_authorized(&msg).await?);
 
         Ok(())
     }


### PR DESCRIPTION
This PR uses the `#[tokio::test]` macro on some unit tests. This removes some clippy warnings which I am getting locally though they don't appear on CI though (but I don't know exactly why):
```rust
  assert!(poll_once(async { ac.is_authorized(&msg).await })?);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: you can reduce it to: `ac.is_authorized(&msg)`
```
