### PR TITLE
docs(rust): update cli manual docs after `project enroll` rename

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/static/authenticate/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/authenticate/after_long_help.txt
@@ -1,6 +1,6 @@
 ```sh
 # From the admin machine, generate an enrollment ticket
-$ ticket=$(ockam project enroll --attribute component=user)
+$ ticket=$(ockam project ticket --attribute component=user)
 
 # From the user machine, enroll the local identity to the project using the enrollment ticket
 $ ockam project authenticate $ticket --identity control_identity

--- a/implementations/rust/ockam/ockam_command/src/project/static/authenticate/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/authenticate/long_about.txt
@@ -1,3 +1,3 @@
 Ockam offers several pluggable enrollment protocols. One simple option is to use one-time-use enrollment ticket. This is a great option to enroll large fleets of applications, service, or devices. It is also easy to use with automated provisioning scripts and tools.
 
-With this command you can use an enrollment ticket generated with the `ockam project enroll` command to enroll an identity to a project.
+With this command you can use an enrollment ticket generated with the `ockam project ticket` command to enroll an identity to a project.

--- a/implementations/rust/ockam/ockam_command/src/project/static/enroll/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/enroll/after_long_help.txt
@@ -1,7 +1,7 @@
 ```sh
 # To enroll a known identity
-$ ockam project enroll --member id_identifier
+$ ockam project ticket --member id_identifier
 
 # To generate an enrollment ticket that can be used to enroll a device
-$ ockam project enroll --attribute component=control
+$ ockam project ticket --attribute component=control
 ```


### PR DESCRIPTION
Fixes the cli manual mentions to `project enroll` that were introduced while https://github.com/build-trust/ockam/pull/4946 was in progress. 