### PR TITLE
fix(elixir): handle :stop return from `Ockam.Worker.setup`

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -255,6 +255,9 @@ defmodule Ockam.Worker do
       {:ok, state} ->
         {:noreply, state}
 
+      {:stop, reason, state} ->
+        {:stop, reason, state}
+
       {:error, reason} ->
         {:stop, reason, {:post_init, options}}
     end
@@ -464,6 +467,7 @@ defmodule Ockam.Worker do
       case return_value do
         {:ok, _state} -> :ok
         {:error, _reason} -> :error
+        {:stop, _reason, _state} -> :error
       end
 
     metadata = Map.merge(metadata, %{result: result, return_value: return_value})


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Recent changes to secure channel make it return `{:stop, reason, state}` on error, `Ockam.Worker.setup` handling does not support that return

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Added handling of `{:stop, reason, state}` return.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [ ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ ] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
