### PR TITLE
fix(rust): retrieve the correct key id for a public key with aws kms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,12 +3666,14 @@ name = "ockam_vault_aws"
 version = "0.1.0"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-kms",
  "delegate",
  "ockam_core",
  "ockam_macros",
  "ockam_node",
  "ockam_vault",
+ "p256",
  "sha2 0.10.6",
  "thiserror",
  "tokio",

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -53,7 +53,7 @@ impl Project {
 pub async fn import_project(path: &str, identities: Arc<Identities>) -> Result<Project> {
     match read_json(path)? {
         Value::Object(values) => {
-            let project_identifier = IdentityIdentifier::from_string(get_field_as_str(&values, "identity")?.as_str());
+            let project_identifier = IdentityIdentifier::from_hex(get_field_as_str(&values, "identity")?.as_str());
 
             let authority_identity = get_field_as_str(&values, "authority_identity")?;
             let identities_creation = identities.identities_creation();

--- a/examples/rust/get_started/src/project.rs
+++ b/examples/rust/get_started/src/project.rs
@@ -53,7 +53,7 @@ impl Project {
 pub async fn import_project(path: &str, identities: Arc<Identities>) -> Result<Project> {
     match read_json(path)? {
         Value::Object(values) => {
-            let project_identifier = IdentityIdentifier::from_str(get_field_as_str(&values, "identity")?.as_str())?;
+            let project_identifier = IdentityIdentifier::from_string(get_field_as_str(&values, "identity")?.as_str());
 
             let authority_identity = get_field_as_str(&values, "authority_identity")?;
             let identities_creation = identities.identities_creation();

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -348,7 +348,7 @@ mod tests {
     fn create_identity_config() -> IdentityConfig {
         let data = hex::decode("0144c7eb72dd1e633f38e0d0521e9d5eb5072f6418176529eb1b00189e4d69ad2e000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020c6c52380125d42b0b4da922b1cff8503a258c3497ec8ac0b4a3baa0d9ca7b3780301014075064b902bda9d16db81ab5f38fbcf226a0e904e517a8c087d379ea139df1f2d7fee484ac7e1c2b7ab2da75f85adef6af7ddb05e7fa8faf180820cb9e86def02").unwrap();
         let identity = Identity::new(
-            IdentityIdentifier::from_string(
+            IdentityIdentifier::from_hex(
                 "fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
             ),
             IdentityChangeHistory::import(data.to_vec().as_slice()).unwrap(),

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -319,11 +319,8 @@ mod traits {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
-    use ockam_identity::IdentityChangeHistory;
-
     use super::*;
+    use ockam_identity::IdentityChangeHistory;
 
     #[test]
     fn test_serialize() {
@@ -351,10 +348,9 @@ mod tests {
     fn create_identity_config() -> IdentityConfig {
         let data = hex::decode("0144c7eb72dd1e633f38e0d0521e9d5eb5072f6418176529eb1b00189e4d69ad2e000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020c6c52380125d42b0b4da922b1cff8503a258c3497ec8ac0b4a3baa0d9ca7b3780301014075064b902bda9d16db81ab5f38fbcf226a0e904e517a8c087d379ea139df1f2d7fee484ac7e1c2b7ab2da75f85adef6af7ddb05e7fa8faf180820cb9e86def02").unwrap();
         let identity = Identity::new(
-            IdentityIdentifier::from_str(
-                "Pfa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
-            )
-            .unwrap(),
+            IdentityIdentifier::from_string(
+                "   fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
+            ),
             IdentityChangeHistory::import(data.to_vec().as_slice()).unwrap(),
         );
         IdentityConfig {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -349,7 +349,7 @@ mod tests {
         let data = hex::decode("0144c7eb72dd1e633f38e0d0521e9d5eb5072f6418176529eb1b00189e4d69ad2e000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020c6c52380125d42b0b4da922b1cff8503a258c3497ec8ac0b4a3baa0d9ca7b3780301014075064b902bda9d16db81ab5f38fbcf226a0e904e517a8c087d379ea139df1f2d7fee484ac7e1c2b7ab2da75f85adef6af7ddb05e7fa8faf180820cb9e86def02").unwrap();
         let identity = Identity::new(
             IdentityIdentifier::from_string(
-                "   fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
+                "fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
             ),
             IdentityChangeHistory::import(data.to_vec().as_slice()).unwrap(),
         );

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -40,9 +40,13 @@ pub struct VaultState {
 impl VaultState {
     pub async fn get(&self) -> Result<Arc<Vault>> {
         if self.config.aws_kms {
-            let config = AwsKmsConfig::new();
+            let config = AwsKmsConfig::default().await?;
             Ok(Vault::create_with_security_module(
-                AwsSecurityModule::create(config).await?,
+                AwsSecurityModule::create_with_storage_path(
+                    config,
+                    self.vault_file_path().as_path(),
+                )
+                .await?,
             ))
         } else {
             let vault =

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -74,7 +74,6 @@ impl<'a> BareCloudRequestWrapper<'a> {
 }
 
 mod node {
-    use std::str::FromStr;
     use std::time::Duration;
 
     use minicbor::Encode;
@@ -109,7 +108,7 @@ mod node {
                         ApiError::generic(&format!("Failed to parse controller identity id: {err}"))
                     })?;
                     trace!(idt = %s, "Read controller identity id from file");
-                    IdentityIdentifier::from_str(s)
+                    Ok(IdentityIdentifier::from_string(s))
                 }
                 None => Err(ApiError::generic(
                     "Failed to import controller identity id from file",

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -108,7 +108,7 @@ mod node {
                         ApiError::generic(&format!("Failed to parse controller identity id: {err}"))
                     })?;
                     trace!(idt = %s, "Read controller identity id from file");
-                    Ok(IdentityIdentifier::from_string(s))
+                    Ok(IdentityIdentifier::from_hex(s))
                 }
                 None => Err(ApiError::generic(
                     "Failed to import controller identity id from file",

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -407,7 +407,7 @@ mod tests {
                 users: vec![String::arbitrary(g), String::arbitrary(g)],
                 space_id: String::arbitrary(g),
                 identity: bool::arbitrary(g)
-                    .then(|| IdentityIdentifier::from_string(&String::arbitrary(g))),
+                    .then(|| IdentityIdentifier::from_hex(&String::arbitrary(g))),
                 authority_access_route: bool::arbitrary(g).then(|| String::arbitrary(g)),
                 authority_identity: bool::arbitrary(g)
                     .then(|| hex::encode(<Vec<u8>>::arbitrary(g))),

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -407,7 +407,7 @@ mod tests {
                 users: vec![String::arbitrary(g), String::arbitrary(g)],
                 space_id: String::arbitrary(g),
                 identity: bool::arbitrary(g)
-                    .then(|| IdentityIdentifier::from_key_id(&String::arbitrary(g))),
+                    .then(|| IdentityIdentifier::from_string(&String::arbitrary(g))),
                 authority_access_route: bool::arbitrary(g).then(|| String::arbitrary(g)),
                 authority_identity: bool::arbitrary(g)
                     .then(|| hex::encode(<Vec<u8>>::arbitrary(g))),

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -335,10 +335,10 @@ mod tests {
 
     #[test]
     fn test_parse_trusted_identities() {
-        let identity1 = IdentityIdentifier::from_string(
+        let identity1 = IdentityIdentifier::from_hex(
             "e86be15e83d1c93e24dd1967010b01b6df491b459725fd9ae0bebfd7c1bf8ea3",
         );
-        let identity2 = IdentityIdentifier::from_string(
+        let identity2 = IdentityIdentifier::from_hex(
             "6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94",
         );
 

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -332,18 +332,15 @@ mod tests {
     use super::*;
     use ockam_core::compat::collections::HashMap;
     use ockam_identity::IdentityIdentifier;
-    use std::str::FromStr;
 
     #[test]
     fn test_parse_trusted_identities() {
-        let identity1 = IdentityIdentifier::from_str(
-            "Pe86be15e83d1c93e24dd1967010b01b6df491b459725fd9ae0bebfd7c1bf8ea3",
-        )
-        .unwrap();
-        let identity2 = IdentityIdentifier::from_str(
-            "P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94",
-        )
-        .unwrap();
+        let identity1 = IdentityIdentifier::from_string(
+            "e86be15e83d1c93e24dd1967010b01b6df491b459725fd9ae0bebfd7c1bf8ea3",
+        );
+        let identity2 = IdentityIdentifier::from_string(
+            "6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94",
+        );
 
         let trusted = format!("{{\"{identity1}\": {{\"name\": \"value\", \"project_id\": \"1\", \"trust_context_id\": \"1\"}}, \"{identity2}\": {{\"project_id\" : \"1\", \"trust_context_id\" : \"1\", \"ockam-role\" : \"enroller\"}}}}");
         let actual = parse_trusted_identities(trusted.as_str()).unwrap();

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::{anyhow, Context as _};
 
 use ockam_core::api::Request;
@@ -112,7 +110,7 @@ pub async fn create_secure_channel_to_project(
     credential_exchange_mode: CredentialExchangeMode,
     identity: Option<String>,
 ) -> crate::Result<(MultiAddr, FlowControlId)> {
-    let authorized_identifier = vec![IdentityIdentifier::from_str(project_identity)?];
+    let authorized_identifier = vec![IdentityIdentifier::from_string(project_identity)];
     let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
 
     let payload = models::secure_channel::CreateSecureChannelRequest::new(

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -110,7 +110,7 @@ pub async fn create_secure_channel_to_project(
     credential_exchange_mode: CredentialExchangeMode,
     identity: Option<String>,
 ) -> crate::Result<(MultiAddr, FlowControlId)> {
-    let authorized_identifier = vec![IdentityIdentifier::from_string(project_identity)];
+    let authorized_identifier = vec![IdentityIdentifier::from_hex(project_identity)];
     let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
 
     let payload = models::secure_channel::CreateSecureChannelRequest::new(

--- a/implementations/rust/ockam/ockam_identity/src/credential/credential_data.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/credential_data.rs
@@ -394,10 +394,10 @@ Attributes: {"name": "value"}
 
         CredentialData {
             schema: Some(SchemaId(1)),
-            subject: IdentityIdentifier::from_key_id(
+            subject: IdentityIdentifier::from_string(
                 "6474cfdbf547240b6d716bff89c976810859bc3f47be8ea620df12a392ea6cb7",
             ),
-            issuer: IdentityIdentifier::from_key_id(
+            issuer: IdentityIdentifier::from_string(
                 "0db4fec87ff764485f1311e68d6f474e786f1fdbafcd249a5eb73dd681fd1d5d",
             ),
             attributes,

--- a/implementations/rust/ockam/ockam_identity/src/credential/credential_data.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/credential_data.rs
@@ -394,10 +394,10 @@ Attributes: {"name": "value"}
 
         CredentialData {
             schema: Some(SchemaId(1)),
-            subject: IdentityIdentifier::from_string(
+            subject: IdentityIdentifier::from_hex(
                 "6474cfdbf547240b6d716bff89c976810859bc3f47be8ea620df12a392ea6cb7",
             ),
-            issuer: IdentityIdentifier::from_string(
+            issuer: IdentityIdentifier::from_hex(
                 "0db4fec87ff764485f1311e68d6f474e786f1fdbafcd249a5eb73dd681fd1d5d",
             ),
             attributes,

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -77,9 +77,7 @@ impl IdentitiesCreation {
         change_history: &IdentityChangeHistory,
     ) -> Result<IdentityIdentifier> {
         let root_public_key = change_history.get_first_root_public_key()?;
-        let key_id = self.vault.get_key_id(&root_public_key).await?;
-
-        Ok(IdentityIdentifier::from_key_id(&key_id))
+        Ok(IdentityIdentifier::from_public_key(&root_public_key))
     }
 
     /// Create an `Identity` with a key previously created in the Vault. Extended version
@@ -124,7 +122,6 @@ impl IdentitiesCreation {
 mod tests {
     use super::*;
     use crate::identities;
-    use core::str::FromStr;
 
     #[tokio::test]
     async fn test_identity_creation() -> Result<()> {
@@ -149,9 +146,9 @@ mod tests {
         );
 
         let missing = repository
-            .retrieve_identity(&IdentityIdentifier::from_str(
-                "Pe92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638",
-            )?)
+            .retrieve_identity(&IdentityIdentifier::from_string(
+                "e92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638",
+            ))
             .await?;
         assert_eq!(missing, None, "a missing identity returns None");
 

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -122,11 +122,9 @@ impl IdentitiesCreation {
 
 #[cfg(test)]
 mod tests {
-    use core::str::FromStr;
-
-    use crate::identities;
-
     use super::*;
+    use crate::identities;
+    use core::str::FromStr;
 
     #[tokio::test]
     async fn test_identity_creation() -> Result<()> {

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -146,7 +146,7 @@ mod tests {
         );
 
         let missing = repository
-            .retrieve_identity(&IdentityIdentifier::from_string(
+            .retrieve_identity(&IdentityIdentifier::from_hex(
                 "e92f183eb4c324804ef4d62962dea94cf095a265d4d28500c34e1a4e0d5ef638",
             ))
             .await?;

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
@@ -99,16 +99,14 @@ impl Display for Identity {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::str::FromStr;
 
     #[test]
     fn test_display() {
         let data = hex::decode("0144c7eb72dd1e633f38e0d0521e9d5eb5072f6418176529eb1b00189e4d69ad2e000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020c6c52380125d42b0b4da922b1cff8503a258c3497ec8ac0b4a3baa0d9ca7b3780301014075064b902bda9d16db81ab5f38fbcf226a0e904e517a8c087d379ea139df1f2d7fee484ac7e1c2b7ab2da75f85adef6af7ddb05e7fa8faf180820cb9e86def02").unwrap();
         let identity = Identity::new(
-            IdentityIdentifier::from_str(
-                "Pfa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
-            )
-            .unwrap(),
+            IdentityIdentifier::from_string(
+                "fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
+            ),
             IdentityChangeHistory::import(data.to_vec().as_slice()).unwrap(),
         );
 

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity.rs
@@ -104,7 +104,7 @@ mod tests {
     fn test_display() {
         let data = hex::decode("0144c7eb72dd1e633f38e0d0521e9d5eb5072f6418176529eb1b00189e4d69ad2e000547c93239ba3d818ec26c9cdadd2a35cbdf1fa3b6d1a731e06164b1079fb7b8084f434b414d5f524b03012000000020c6c52380125d42b0b4da922b1cff8503a258c3497ec8ac0b4a3baa0d9ca7b3780301014075064b902bda9d16db81ab5f38fbcf226a0e904e517a8c087d379ea139df1f2d7fee484ac7e1c2b7ab2da75f85adef6af7ddb05e7fa8faf180820cb9e86def02").unwrap();
         let identity = Identity::new(
-            IdentityIdentifier::from_string(
+            IdentityIdentifier::from_hex(
                 "fa804b7fca12a19eed206ae180b5b576860ae6512f196c189d90661bcc434b50",
             ),
             IdentityChangeHistory::import(data.to_vec().as_slice()).unwrap(),

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_identifier.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_identifier.rs
@@ -23,11 +23,11 @@ impl IdentityIdentifier {
     /// Create an IdentityIdentifier from a public key
     pub fn from_public_key(public_key: &PublicKey) -> Self {
         let hashed = VaultSecurityModule::sha256(public_key.data());
-        Self::from_string(hex::encode(hashed).as_str())
+        Self::from_hex(hex::encode(hashed).as_str())
     }
 
     /// Create an IdentityIdentifier from a hashed and hex-encoded public key
-    pub fn from_string(string: &str) -> Self {
+    pub fn from_hex(string: &str) -> Self {
         Self(format!("{}{}", Self::PREFIX, string.trim()))
     }
 
@@ -132,7 +132,7 @@ mod test {
 
     impl Arbitrary for Id {
         fn arbitrary(g: &mut Gen) -> Self {
-            Self(IdentityIdentifier::from_string(&String::arbitrary(g)))
+            Self(IdentityIdentifier::from_hex(&String::arbitrary(g)))
         }
     }
 

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -215,7 +215,7 @@ async fn test_channel_rejected_trust_policy(ctx: &mut Context) -> Result<()> {
     let bob = identities_creation.create_identity().await?;
 
     let alice_broken_trust_policy =
-        TrustIdentifierPolicy::new(IdentityIdentifier::from_string("random-text"));
+        TrustIdentifierPolicy::new(IdentityIdentifier::from_hex("random-text"));
 
     secure_channels
         .create_secure_channel_listener(

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -215,7 +215,7 @@ async fn test_channel_rejected_trust_policy(ctx: &mut Context) -> Result<()> {
     let bob = identities_creation.create_identity().await?;
 
     let alice_broken_trust_policy =
-        TrustIdentifierPolicy::new(IdentityIdentifier::from_key_id("random-text"));
+        TrustIdentifierPolicy::new(IdentityIdentifier::from_string("random-text"));
 
     secure_channels
         .create_secure_channel_listener(

--- a/implementations/rust/ockam/ockam_vault/src/types/public_key.rs
+++ b/implementations/rust/ockam/ockam_vault/src/types/public_key.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// A public key.
-#[derive(Encode, Decode, Serialize, Deserialize, Clone, Debug, Zeroize)]
+#[derive(Encode, Decode, Serialize, Deserialize, Clone, Debug, Zeroize, PartialOrd, Ord)]
 #[zeroize(drop)]
 #[rustfmt::skip]
 #[cbor(map)]

--- a/implementations/rust/ockam/ockam_vault/src/types/secret_attributes.rs
+++ b/implementations/rust/ockam/ockam_vault/src/types/secret_attributes.rs
@@ -55,7 +55,7 @@ impl SecretAttributes {
 }
 
 /// All possible [`SecretType`]s
-#[derive(Serialize, Deserialize, Copy, Clone, Debug, Encode, Decode, Eq, PartialEq, Zeroize)]
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Encode, Decode, Eq, PartialEq, Zeroize, PartialOrd, Ord)]
 #[rustfmt::skip]
 #[cbor(index_only)]
 pub enum SecretType {

--- a/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
@@ -36,6 +36,8 @@ std = [
   "ockam_vault/std",
 ]
 
+storage = ["ockam_vault/storage"]
+
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library, requires nightly.
 no_std = [
@@ -56,9 +58,11 @@ ockam_core = { path = "../ockam_core", version = "^0.80.0", default_features = f
 ockam_macros = { path = "../ockam_macros", version = "^0.29.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.83.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.76.0", default_features = false }
+p256 = { version = "0.13.2", default_features = false }
 sha2 = { version = "0.10", default-features = false }
 thiserror = { version = "1.0.38" }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 
 [dev-dependencies]
+aws-credential-types = { version = "0.55.2", default-features = false, features = ["test-util"] }
 tokio = { version = "1.27", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_kms_client.rs
+++ b/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_kms_client.rs
@@ -164,7 +164,7 @@ impl AwsKmsClient {
             for key in keys {
                 if let Some(key_id) = key.key_id() {
                     let one_public_key = self.public_key(&key_id.to_string()).await?;
-                    if one_public_key == public_key.clone() {
+                    if &one_public_key == public_key {
                         return Ok(key_id.into());
                     }
                 }

--- a/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
+++ b/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
@@ -182,12 +182,12 @@ mod tests {
             .await?;
         let message = b"hello world";
         let signature = security_module.sign(&key_id, &message[..]).await?;
+        let public_key = security_module.get_public_key(&key_id).await?;
 
         // Verify locally
         assert!(
             security_module
-                .client
-                .verify(&key_id, &message[..], &signature)
+                .verify(&public_key, message, &signature)
                 .await?
         );
 

--- a/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
+++ b/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
@@ -1,24 +1,57 @@
 use crate::vault::aws_kms_client::{AwsKmsClient, AwsKmsConfig};
 use ockam_core::compat::sync::Arc;
-use ockam_core::{async_trait, KeyId, Result};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{async_trait, Error, KeyId, Result};
+use ockam_node::{FileKeyValueStorage, InMemoryKeyValueStorage, KeyValueStorage};
 use ockam_vault::SecretType::NistP256;
 use ockam_vault::{PublicKey, SecretAttributes, SecurityModule, Signature, VaultError};
+use p256::pkcs8::DecodePublicKey;
+use std::path::Path;
 
 /// Security module implementation using an AWS KMS
 pub struct AwsSecurityModule {
     client: AwsKmsClient,
+    storage: Arc<dyn KeyValueStorage<PublicKey, KeyId>>,
 }
 
 impl AwsSecurityModule {
+    /// Create a default AWS security module
+    pub async fn default() -> Result<Self> {
+        AwsSecurityModule::new(
+            AwsKmsConfig::default().await?,
+            InMemoryKeyValueStorage::create(),
+        )
+        .await
+    }
+
     /// Create a new AWS security module
-    pub async fn new(config: AwsKmsConfig) -> Result<Self> {
+    pub async fn new(
+        config: AwsKmsConfig,
+        storage: Arc<dyn KeyValueStorage<PublicKey, KeyId>>,
+    ) -> Result<Self> {
         Ok(AwsSecurityModule {
             client: AwsKmsClient::new(config).await?,
+            storage,
         })
     }
-    /// Create a new AWS security module
-    pub async fn create(config: AwsKmsConfig) -> Result<Arc<dyn SecurityModule>> {
-        Ok(Arc::new(Self::new(config).await?))
+    /// Create a new AWS security module, with a specific file storage path
+    pub async fn create_with_storage_path(
+        config: AwsKmsConfig,
+        path: &Path,
+    ) -> Result<Arc<dyn SecurityModule>> {
+        Self::create_with_key_value_storage(
+            config,
+            Arc::new(FileKeyValueStorage::create(path).await?),
+        )
+        .await
+    }
+
+    /// Create a new AWS security module, with a specific key value storage
+    pub async fn create_with_key_value_storage(
+        config: AwsKmsConfig,
+        storage: Arc<dyn KeyValueStorage<PublicKey, KeyId>>,
+    ) -> Result<Arc<dyn SecurityModule>> {
+        Ok(Arc::new(Self::new(config, storage).await?))
     }
 }
 
@@ -33,11 +66,26 @@ impl SecurityModule for AwsSecurityModule {
     }
 
     async fn get_public_key(&self, key_id: &KeyId) -> Result<PublicKey> {
-        self.client.public_key(key_id).await
+        let public_key = self.client.public_key(key_id).await?;
+
+        // if the public key <-> key id mapping has not been stored locally
+        // then store it in order to avoid a call to client.get_key_id when computing a identity
+        // identifier from the list of identity changes
+        if self.storage.get(&public_key).await?.is_none() {
+            self.storage.put(public_key.clone(), key_id.clone()).await?;
+        }
+        Ok(public_key)
     }
 
     async fn get_key_id(&self, public_key: &PublicKey) -> Result<KeyId> {
-        self.client.compute_key_id(public_key).await
+        // try to get the key id from local storage first
+        if let Some(key_id) = self.storage.get(public_key).await? {
+            Ok(key_id)
+        } else {
+            let key_id = self.client.get_key_id(public_key).await?;
+            self.storage.put(public_key.clone(), key_id.clone()).await?;
+            Ok(key_id)
+        }
     }
 
     async fn get_attributes(&self, _key_id: &KeyId) -> Result<SecretAttributes> {
@@ -52,13 +100,105 @@ impl SecurityModule for AwsSecurityModule {
         self.client.sign(key_id, message).await
     }
 
+    /// Verify the signature of a message locally
+    /// This should return the same result as self.client.verify
+    /// The main differences are:
+    ///   - a call to self.client.verify takes more time
+    ///   - a call to self.client.verify can be logged on AWS and benefit from additional access control checks
     async fn verify(
         &self,
         public_key: &PublicKey,
         message: &[u8],
         signature: &Signature,
     ) -> Result<bool> {
-        let key_id = self.get_key_id(public_key).await?;
-        self.client.verify(&key_id, message, signature).await
+        use p256::ecdsa::{signature::Verifier as _, Signature, VerifyingKey};
+
+        let verifying_key =
+            VerifyingKey::from_public_key_der(public_key.data()).map_err(Self::from_pkcs8)?;
+        let ecdsa_signature = Signature::from_der(signature.as_ref()).map_err(Self::from_ecdsa)?;
+        Ok(verifying_key.verify(message, &ecdsa_signature).is_ok())
+    }
+}
+
+impl AwsSecurityModule {
+    pub(crate) fn from_ecdsa(e: p256::ecdsa::Error) -> Error {
+        Error::new(Origin::Vault, Kind::Unknown, e)
+    }
+
+    pub(crate) fn from_pkcs8<T: core::fmt::Display>(e: T) -> Error {
+        #[cfg(feature = "no_std")]
+        use ockam_core::compat::string::ToString;
+        Error::new(Origin::Vault, Kind::Unknown, e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_node::InMemoryKeyValueStorage;
+
+    /// This test needs to be executed with the following environment variables
+    /// AWS_REGION
+    /// AWS_ACCESS_KEY_ID
+    /// AWS_SECRET_ACCESS_KEY
+    #[tokio::test]
+    #[ignore]
+    async fn test_store_public_key_key_id_mapping() -> Result<()> {
+        let storage = InMemoryKeyValueStorage::create();
+        let security_module =
+            AwsSecurityModule::new(AwsKmsConfig::default().await?, storage.clone()).await?;
+
+        let key_id = security_module
+            .create_secret(SecretAttributes::NistP256)
+            .await?;
+
+        // the public key can be retrieved using the kms client directly
+        // but then the public key <-> key id mapping is not cached
+        let public_key = security_module.client.public_key(&key_id).await;
+        assert!(public_key.is_ok());
+        assert!(storage.get(&public_key?).await?.is_none());
+
+        // when the public key is retrieved using the security module
+        // then the public key <-> key id mapping is cached locally
+        let public_key = security_module.get_public_key(&key_id).await;
+        assert!(public_key.is_ok());
+
+        let public_key = public_key?;
+        let key_id = storage.get(&public_key).await;
+        assert!(key_id.is_ok());
+
+        let key_id = security_module.get_key_id(&public_key).await;
+        assert!(key_id.is_ok());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_sign_verify() -> Result<()> {
+        let security_module = AwsSecurityModule::default().await?;
+        let key_id = security_module
+            .create_secret(SecretAttributes::NistP256)
+            .await?;
+        let message = b"hello world";
+        let signature = security_module.sign(&key_id, &message[..]).await?;
+
+        // Verify locally
+        assert!(
+            security_module
+                .client
+                .verify(&key_id, &message[..], &signature)
+                .await?
+        );
+
+        // Verify remotely
+        assert!(
+            security_module
+                .client
+                .verify(&key_id, message, &signature)
+                .await?
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes the use of the AWS KMS as a backend for a `Vault`.

# Observed issue

When using the `AttachKey` command to create an identity a call to the AWS KMS client was performed to retrieve the key id corresponding to a given public key. 

This call is necessary because when we compute an `IdentityIdentifier` for an identity we derive it from the key id related to the public key used for the first change in the change history.
Before this PR the call to `kms_client.compute_key_id(&public_key)` was not implemented correctly and could not retrieve the key id.

# Diagnostic

The trouble is that there is no efficient implementation of this operation with the AWS KMS. That operation needs to list all the existing keys to retrieve the key with the right public key.

# Proposed fix

This PR fixes the issue by:

 - adding a local storage for public key <-> key id when the AWS security module is used
 - retrieving the key id directly from storage when the public key id is given and the mapping exists
 - retrieving the key id from the AWS KMS if it has never been accessed before (and then store the mapping locally)
 - doing a local verification of signatures instead of using the AWS KMS and incurring a remote call
 - removing the computation of an `IdentityIdentifier` from the key id associated to a public key. Now the identity identifier is directly a sha256 hash of the first public key of an identity

# Tests

Several tests have been added to:

 - check the low-level behaviour of the storage of the public key <-> key id mapping
 - check that a signature can be verified both locally and remotely with a given AWS KMS key
 - check that the identity creation done when running the `attach-key` command works when using an AWS KMS backend

Note: those tests cannot be part of the test suite for now because they require an access to an AWS account to create keys.
