### PR TITLE
docs(rust): update cli manual docs for relay commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -21,14 +21,12 @@ use crate::util::{extract_address_value, node_rpc, process_nodes_multiaddr, RpcB
 use crate::{display_parse_logs, docs, fmt_ok, CommandGlobalOpts};
 use crate::{fmt_log, Result};
 
-const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
 /// Create Relays
 #[derive(Clone, Debug, Args)]
 #[command(
     arg_required_else_help = false,
-    long_about = docs::about(LONG_ABOUT),
     after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,14 +1,20 @@
 use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use ockam::Context;
 use ockam_core::api::{Request, RequestBuilder};
 
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
 /// Delete a Relay
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = false,
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DeleteCommand {
     /// Name assigned to Relay that will be deleted
     #[arg(display_order = 900, required = true)]
@@ -40,9 +46,8 @@ pub async fn run_impl(
     options
         .terminal
         .stdout()
-        .plain(format!(
-            "{}Relay with name {} on Node {} has been deleted.",
-            "✔︎".light_green(),
+        .plain(fmt_ok!(
+            "Relay with name {} on Node {} has been deleted.",
             relay_name,
             node
         ))
@@ -54,7 +59,6 @@ pub async fn run_impl(
 
 /// Construct a request to delete a relay
 fn make_api_request<'a>(cmd: DeleteCommand) -> Result<RequestBuilder<'a>> {
-    let remote_address = format!("forward_to_{}", cmd.relay_name);
-    let request = Request::delete(format!("/node/forwarder/{remote_address}"));
+    let request = Request::delete(format!("/node/forwarder/{}", cmd.relay_name));
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -7,11 +7,16 @@ use ockam_core::api::Request;
 
 use crate::node::get_node_name;
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
-use crate::Result;
+use crate::{docs, CommandGlobalOpts, Result};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
 
 /// List Relays
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = false,
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ListCommand {
     /// Node to list relays from
     #[arg(global = true, long, value_name = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/relay/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/mod.rs
@@ -5,16 +5,24 @@ pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 pub(crate) use show::ShowCommand;
 
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 
 mod create;
 mod delete;
 mod list;
 mod show;
 
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
+
 /// Manage Relays
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, subcommand_required = true)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct RelayCommand {
     #[command(subcommand)]
     subcommand: RelaySubCommand,

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -6,11 +6,16 @@ use ockam_core::api::Request;
 
 use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
-use crate::Result;
+use crate::{docs, CommandGlobalOpts, Result};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
 /// Show a Relay by its alias
 #[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = false,
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ShowCommand {
     /// Name assigned to relay that will be shown (prefixed with forward_to_<name>)
     #[arg(display_order = 900, required = true)]

--- a/implementations/rust/ockam/ockam_command/src/relay/static/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/after_long_help.txt
@@ -1,0 +1,33 @@
+```sh
+# Create two nodes blue and green
+$ ockam node create blue
+$ ockam node create green
+
+# Create a relay to node blue at node green
+$ ockam relay create blue --at /node/green --to /node/blue
+/service/forward_to_blue
+
+# Send a message to the uppercase service on blue via its relay on green
+$ ockam message send hello --to /node/green/service/forward_to_blue/service/uppercase
+```
+
+This can be very useful in establishing communication between applications that cannot otherwise reach each other over the network.
+
+For instance, we can use relays to create an end-to-end secure channel between two nodes that are behind private NATs:
+
+```sh
+# Create another node called yellow
+$ ockam node create yellow
+
+# Create an end-to-end secure channel between yellow and blue.
+# This secure channel is created through blue's relay at green, and we can
+# send end-to-end encrypted messages through it.
+$ ockam secure-channel create --from /node/yellow --to /node/green/service/forward_to_blue/service/api \\
+    | ockam message send hello --from /node/yellow --to -/service/uppercase
+```
+
+In this topology green acts as an encrypted relay between yellow and blue. Yellow and blue can be running in completely separate private networks. Green needs to be reachable from both yellow and blue and only sees encrypted traffic.
+
+You can find more details within the documentation:
+
+- https://docs.ockam.io/reference/command/advanced-routing#relays

--- a/implementations/rust/ockam/ockam_command/src/relay/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/create/after_long_help.txt
@@ -1,33 +1,3 @@
 ```sh
-# Create two nodes blue and green
-$ ockam node create blue
-$ ockam node create green
-
-# Create a relay to node n2 at node n1
-$ ockam relay create blue --at /node/green --to /node/blue
-/service/forward_to_blue
-
-# Send a message to the uppercase service on blue via its relay on green
-$ ockam message send hello --to /node/green/service/forward_to_blue/service/uppercase
+$ ockam relay create r --at n1 --to n2
 ```
-
-This can be very useful in establishing communication between applications
-that cannot otherwise reach each other over the network.
-
-For instance, we can use relays to create an end-to-end secure channel between
-two nodes that are behind private NATs
-
-```sh
-# Create another node called yellow
-$ ockam node create yellow
-
-# Create an end-to-end secure channel between yellow and blue.
-# This secure channel is created through blue's relay at green and we can
-# send end-to-end encrypted messages through it.
-$ ockam secure-channel create --from /node/yellow --to /node/green/service/forward_to_blue/service/api \\
-    | ockam message send hello --from /node/yellow --to -/service/uppercase
-```
-
-In this topology green acts an an encrypted relay between yellow and blue. Yellow and
-blue can be running in completely separate private networks. Green needs to be reachable
-from both yellow and blue and only sees encrypted traffic.

--- a/implementations/rust/ockam/ockam_command/src/relay/static/create/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/create/long_about.txt
@@ -1,3 +1,0 @@
-Relays enable an ockam node to register a forwarding address on another node.
-Any message that arrives at this forwarding address is immediately dispatched
-to the node that registered the forwarding address.

--- a/implementations/rust/ockam/ockam_command/src/relay/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/delete/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam relay delete forward_to_r --at n2
+```

--- a/implementations/rust/ockam/ockam_command/src/relay/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/list/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam relay list --at n2
+```

--- a/implementations/rust/ockam/ockam_command/src/relay/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/long_about.txt
@@ -1,0 +1,3 @@
+It is common to encounter communication topologies where the machine that provides a service is unwilling or is not allowed to open a listening port or expose a bridge node to other networks. This is a common security best practice in enterprise environments, home networks, OT networks, and VPCs across clouds. Application developers may not have control over these choices from the infrastructure / operations layer. This is where relays are useful.
+
+Relays make it possible to establish end-to-end protocols with services operating in a remote private networks, without requiring a remote service to expose listening ports to an outside hostile network like the Internet.

--- a/implementations/rust/ockam/ockam_command/src/relay/static/show/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/relay/static/show/after_long_help.txt
@@ -1,0 +1,3 @@
+```sh
+$ ockam relay show forward_to_r --at n2
+```

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -15,6 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "authority - standalone authority, enrollers, members" {
+  port=33000
   PROJECT_JSON_PATH="$OCKAM_HOME/project-authority.json"
 
   run "$OCKAM" identity create authority
@@ -33,7 +34,7 @@ teardown() {
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   # For the first test we start the node with no direct authentication service nor token enrollment
   trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\", \"project_id\" : \"1\", \"trust_context_id\" : \"1\"}, \"$enroller_identifier\": {\"project_id\": \"1\", \"trust_context_id\": \"1\", \"ockam-role\": \"enroller\"}}"
-  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --no-token-enrollment
+  run "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --no-token-enrollment
   assert_success
   sleep 1 # wait for authority to start TCP listener
 
@@ -41,7 +42,7 @@ teardown() {
   \"name\" : \"default\",
   \"identity\" : \"P6c20e814b56579306f55c64e8747e6c1b4a53d9a3f4ca83c252cc2fbfc72fa94\",
   \"access_route\" : \"/dnsaddr/127.0.0.1/tcp/4000/service/api\",
-  \"authority_access_route\" : \"/dnsaddr/127.0.0.1/tcp/4200/service/api\",
+  \"authority_access_route\" : \"/dnsaddr/127.0.0.1/tcp/$port/service/api\",
   \"authority_identity\" : \"$authority_identity_full\"}" >"$PROJECT_JSON_PATH"
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
@@ -52,7 +53,7 @@ teardown() {
   echo "$trusted" >"$OCKAM_HOME/trusted-anchors.json"
   # Restart the authority node with a trusted identities file and check that m1 can still authenticate
   run "$OCKAM" node delete authority
-  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:4200 --project-identifier 1 --reload-from-trusted-identities-file "$OCKAM_HOME/trusted-anchors.json"
+  run "$OCKAM" authority create --tcp-listener-address=127.0.0.1:$port --project-identifier 1 --reload-from-trusted-identities-file "$OCKAM_HOME/trusted-anchors.json"
   assert_success
   sleep 1 # wait for authority to start TCP listener
 


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/4765

It also fixes
- an inconsistency on the `relay delete` command: it was the only one accepting the relay name without the `forward_to_` prefix 
- a port collision on authority bats tests