### PR TITLE
refactor(rust): return the shared secure channels struct when no vault is specified

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -172,8 +172,8 @@ mod node {
             };
 
             let secure_channels = {
-                let mut node_manager = self.get().write().await;
-                node_manager.get_secure_channels(None).await?
+                let node_manager = self.get().write().await;
+                node_manager.secure_channels.clone()
             };
 
             let sc = {


### PR DESCRIPTION
The name change should make it clear that we might be rebuilding a new struct when a `Vault` is specified.
Otherwise we use the `SecureChannels` shared on the `NodeManager`.

I also removed the case where we already know that we can use the shared instance.