### PR TITLE
fix(rust): fix the persistence of the public key / key id mapping for the aws security module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3682,6 +3682,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-kms",
  "delegate",
+ "hex",
  "ockam_core",
  "ockam_macros",
  "ockam_node",

--- a/implementations/rust/ockam/ockam_node/src/storage/file_key_value_storage.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/file_key_value_storage.rs
@@ -1,20 +1,24 @@
-use crate::{FileValueStorage, InMemoryKeyValueStorage, KeyValueStorage, ValueStorage};
-use ockam_core::compat::boxed::Box;
-use ockam_core::compat::collections::BTreeMap;
-use ockam_core::{async_trait, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+
+use crate::ToStringKey;
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::collections::BTreeMap;
+use ockam_core::compat::string::String;
+use ockam_core::{async_trait, Result};
+
+use crate::{FileValueStorage, InMemoryKeyValueStorage, KeyValueStorage, ValueStorage};
 
 /// Key value storage backed by a file
 /// An additional cache in used to access values in memory and avoid re-reading the file too
 /// frequently
 pub struct FileKeyValueStorage<K, V> {
-    file_storage: FileValueStorage<BTreeMap<K, V>>,
+    file_storage: FileValueStorage<BTreeMap<String, V>>,
     cache: InMemoryKeyValueStorage<K, V>,
 }
 
 impl<
-        K: Ord + Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+        K: Serialize + for<'de> Deserialize<'de> + ToStringKey + Ord + Clone + Send + Sync + 'static,
         V: Default + Serialize + for<'de> Deserialize<'de> + Clone + Send + Sync + 'static,
     > FileKeyValueStorage<K, V>
 {
@@ -29,15 +33,15 @@ impl<
 
 #[async_trait]
 impl<
-        K: Clone + Ord + Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+        K: Serialize + for<'de> Deserialize<'de> + ToStringKey + Ord + Clone + Send + Sync + 'static,
         V: Clone + Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
     > KeyValueStorage<K, V> for FileKeyValueStorage<K, V>
 {
     /// Put a value in the file storage and in cache for faster access
     async fn put(&self, key: K, value: V) -> Result<()> {
         let (k, v) = (key.clone(), value.clone());
-        let f = move |mut map: BTreeMap<K, V>| {
-            map.insert(key.clone(), value.clone());
+        let f = move |mut map: BTreeMap<String, V>| {
+            map.insert(key.to_string_key(), value.clone());
             Ok(map)
         };
         self.file_storage.update_value(f).await?;
@@ -50,8 +54,8 @@ impl<
         if let Some(value) = self.cache.get(key).await? {
             Ok(Some(value))
         } else {
-            let k = key.clone();
-            let f = move |map: BTreeMap<K, V>| Ok(map.get(&k).cloned());
+            let k = key.to_string_key();
+            let f = move |map: BTreeMap<String, V>| Ok(map.get(&k).cloned());
             let retrieved_value = self.file_storage.read_value(f).await?;
             if let Some(retrieved) = retrieved_value.clone() {
                 self.cache.put(key.clone(), retrieved).await?;
@@ -63,8 +67,8 @@ impl<
     /// Delete a value from the file and the cache
     /// Return the value if it was found
     async fn delete(&self, key: &K) -> Result<Option<V>> {
-        let k = key.clone();
-        let f = move |mut map: BTreeMap<K, V>| {
+        let k = key.to_string_key();
+        let f = move |mut map: BTreeMap<String, V>| {
             let removed = map.remove(&k);
             Ok((map, removed))
         };
@@ -76,25 +80,26 @@ impl<
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
     use ockam_core::compat::rand::{thread_rng, RngCore};
     use ockam_core::Result;
     use std::path::PathBuf;
 
     #[tokio::test]
     async fn test_file_key_value_storage() -> Result<()> {
-        let storage: FileKeyValueStorage<u8, Value> =
+        let storage: FileKeyValueStorage<Key, Value> =
             FileKeyValueStorage::create(create_temp_file().as_path())
                 .await
                 .unwrap();
 
         // persist a new value
-        storage.put(1, Value(10)).await.unwrap();
+        storage.put(Key::new(1, 2), Value(10)).await.unwrap();
 
         // retrieve the value
-        let missing = storage.get(&0).await?;
+        let missing = storage.get(&Key::new(0, 0)).await?;
         assert_eq!(missing, None);
 
-        let updated = storage.get(&1).await?;
+        let updated = storage.get(&Key::new(1, 2)).await?;
         assert_eq!(updated, Some(Value(10)));
 
         Ok(())
@@ -109,6 +114,24 @@ pub(crate) mod tests {
         dir.join(file_name)
     }
 
-    #[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug)]
+    #[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
     struct Value(u8);
+
+    #[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
+    struct Key {
+        key1: u8,
+        key2: u8,
+    }
+
+    impl ToStringKey for Key {
+        fn to_string_key(&self) -> String {
+            format!("{}_{}", self.key1, self.key2)
+        }
+    }
+
+    impl Key {
+        fn new(key1: u8, key2: u8) -> Self {
+            Self { key1, key2 }
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_node/src/storage/file_value_storage.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/file_value_storage.rs
@@ -74,7 +74,8 @@ impl<V: Default + Serialize + for<'de> Deserialize<'de>> FileValueStorage<V> {
 
     // Flush vault to target, using temp_path as intermediary file.
     fn flush_to_file(target: &Path, temp_path: &Path, value: &V) -> Result<()> {
-        let data = serde_json::to_vec(value).map_err(|_| ValueStorageError::StorageError)?;
+        let data = serde_json::to_vec(value)
+            .map_err(|e| ValueStorageError::InvalidStorageData(e.to_string()))?;
         use std::io::prelude::*;
         cfg_if! {
             if #[cfg(windows)] {

--- a/implementations/rust/ockam/ockam_node/src/storage/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/mod.rs
@@ -15,6 +15,9 @@ mod in_memory_value_storage;
 /// Trait defining the functions for a key value storage
 mod key_value_storage;
 
+/// This trait defines types which can be used as keys in JSON maps
+mod to_string_key;
+
 /// Trait defining the functions for a value storage
 mod value_storage;
 
@@ -25,4 +28,5 @@ pub use file_value_storage::*;
 pub use in_memory_key_value_storage::*;
 pub use in_memory_value_storage::*;
 pub use key_value_storage::*;
+pub use to_string_key::*;
 pub use value_storage::*;

--- a/implementations/rust/ockam/ockam_node/src/storage/to_string_key.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/to_string_key.rs
@@ -1,0 +1,9 @@
+use ockam_core::compat::string::String;
+
+/// This trait needs to be implemented by structs which are used as keys in a key/value file
+/// This constraint is necessary due to the persistence of values as JSON in the underlying
+/// FileValueStorage
+pub trait ToStringKey {
+    /// Return a string representation to be used as a key in a JSON map
+    fn to_string_key(&self) -> String;
+}

--- a/implementations/rust/ockam/ockam_vault/src/types/public_key.rs
+++ b/implementations/rust/ockam/ockam_vault/src/types/public_key.rs
@@ -1,9 +1,13 @@
-use crate::{PublicKeyVec, SecretType};
 use core::fmt;
+
 use minicbor::{Decode, Encode};
+use ockam_core::compat::string::String;
+use ockam_node::ToStringKey;
 use p256::elliptic_curve::subtle;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
+
+use crate::{PublicKeyVec, SecretType};
 
 /// A public key.
 #[derive(Encode, Decode, Serialize, Deserialize, Clone, Debug, Zeroize, PartialOrd, Ord)]
@@ -19,10 +23,18 @@ pub struct PublicKey {
 }
 
 impl Eq for PublicKey {}
+
 impl PartialEq for PublicKey {
     fn eq(&self, o: &Self) -> bool {
         let choice = subtle::ConstantTimeEq::ct_eq(&self.data[..], &o.data[..]);
         choice.into() && self.stype == o.stype
+    }
+}
+
+/// Instance of ToStringKey to be able to use a PublicKey as a key in a FileKeyValueStorage
+impl ToStringKey for PublicKey {
+    fn to_string_key(&self) -> String {
+        hex::encode(self.data())
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault_aws/Cargo.toml
@@ -65,4 +65,5 @@ tracing = { version = "0.1", default-features = false, features = ["attributes"]
 
 [dev-dependencies]
 aws-credential-types = { version = "0.55.2", default-features = false, features = ["test-util"] }
+hex = { version = "0.4", default-features = false }
 tokio = { version = "1.28", features = ["full"] }

--- a/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
+++ b/implementations/rust/ockam/ockam_vault_aws/src/vault/aws_security_module.rs
@@ -1,16 +1,19 @@
-use crate::vault::aws_kms_client::{AwsKmsClient, AwsKmsConfig};
+use std::path::Path;
+
+use p256::pkcs8::DecodePublicKey;
+use tracing::error;
+
 use ockam_core::compat::sync::Arc;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Error, KeyId, Result};
 use ockam_node::{FileKeyValueStorage, InMemoryKeyValueStorage, KeyValueStorage};
-use ockam_vault::SecretType::NistP256;
-use ockam_vault::{PublicKey, SecretAttributes, SecurityModule, Signature, VaultError};
-use p256::pkcs8::DecodePublicKey;
-use std::path::Path;
+use ockam_vault::{PublicKey, SecretAttributes, SecretType, SecurityModule, Signature, VaultError};
+
+use crate::vault::aws_kms_client::{AwsKmsClient, AwsKmsConfig, KmsClient};
 
 /// Security module implementation using an AWS KMS
 pub struct AwsSecurityModule {
-    client: AwsKmsClient,
+    client: Arc<dyn KmsClient + Send + Sync>,
     storage: Arc<dyn KeyValueStorage<PublicKey, KeyId>>,
 }
 
@@ -30,7 +33,7 @@ impl AwsSecurityModule {
         storage: Arc<dyn KeyValueStorage<PublicKey, KeyId>>,
     ) -> Result<Self> {
         Ok(AwsSecurityModule {
-            client: AwsKmsClient::new(config).await?,
+            client: Arc::new(AwsKmsClient::new(config).await?),
             storage,
         })
     }
@@ -53,12 +56,30 @@ impl AwsSecurityModule {
     ) -> Result<Arc<dyn SecurityModule>> {
         Ok(Arc::new(Self::new(config, storage).await?))
     }
+
+    /// Return the key id corresponding to a public key from the KMS
+    /// This function is particularly inefficient since it lists all the keys
+    /// This is why there is a cache in the AwsSecurityModule struct to avoid this call
+    pub(crate) async fn get_key_id_from_public_key(&self, public_key: &PublicKey) -> Result<KeyId> {
+        for key_id in self.client.list_keys().await? {
+            let one_public_key = self.client.public_key(&key_id).await?;
+            if &one_public_key == public_key {
+                return Ok(key_id);
+            }
+        }
+        error!(%public_key, "key id not found for public key {}", public_key);
+        Err(Error::new(
+            Origin::Vault,
+            Kind::NotFound,
+            crate::vault::aws_kms_client::Error::MissingKeyId,
+        ))
+    }
 }
 
 #[async_trait]
 impl SecurityModule for AwsSecurityModule {
     async fn create_secret(&self, attributes: SecretAttributes) -> Result<KeyId> {
-        if attributes.secret_type() == NistP256 {
+        if attributes.secret_type() == SecretType::NistP256 {
             self.client.create_key().await
         } else {
             Err(VaultError::InvalidKeyType.into())
@@ -82,7 +103,7 @@ impl SecurityModule for AwsSecurityModule {
         if let Some(key_id) = self.storage.get(public_key).await? {
             Ok(key_id)
         } else {
-            let key_id = self.client.get_key_id(public_key).await?;
+            let key_id = self.get_key_id_from_public_key(public_key).await?;
             self.storage.put(public_key.clone(), key_id.clone()).await?;
             Ok(key_id)
         }
@@ -135,7 +156,13 @@ impl AwsSecurityModule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use ockam_core::compat::rand::{thread_rng, RngCore};
     use ockam_node::InMemoryKeyValueStorage;
+    use std::path::PathBuf;
+    use SecretAttributes::*;
 
     /// This test needs to be executed with the following environment variables
     /// AWS_REGION
@@ -148,9 +175,7 @@ mod tests {
         let security_module =
             AwsSecurityModule::new(AwsKmsConfig::default().await?, storage.clone()).await?;
 
-        let key_id = security_module
-            .create_secret(SecretAttributes::NistP256)
-            .await?;
+        let key_id = security_module.create_secret(NistP256).await?;
 
         // the public key can be retrieved using the kms client directly
         // but then the public key <-> key id mapping is not cached
@@ -167,7 +192,9 @@ mod tests {
         let key_id = storage.get(&public_key).await;
         assert!(key_id.is_ok());
 
-        let key_id = security_module.get_key_id(&public_key).await;
+        let key_id = security_module
+            .get_key_id_from_public_key(&public_key)
+            .await;
         assert!(key_id.is_ok());
 
         Ok(())
@@ -177,9 +204,7 @@ mod tests {
     #[ignore]
     async fn test_sign_verify() -> Result<()> {
         let security_module = AwsSecurityModule::default().await?;
-        let key_id = security_module
-            .create_secret(SecretAttributes::NistP256)
-            .await?;
+        let key_id = security_module.create_secret(NistP256).await?;
         let message = b"hello world";
         let signature = security_module.sign(&key_id, &message[..]).await?;
         let public_key = security_module.get_public_key(&key_id).await?;
@@ -200,5 +225,86 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    /// This test checks that the local storage mapping public keys to key ids works
+    #[tokio::test]
+    async fn test_storage() -> Result<()> {
+        let client = Arc::new(FakeKmsClient::default());
+        let storage = Arc::new(FileKeyValueStorage::create(create_temp_file().as_path()).await?);
+        let security_module = AwsSecurityModule { client, storage };
+
+        let key_id = security_module.create_secret(NistP256).await?;
+        let public_key = security_module.get_public_key(&key_id).await?;
+
+        // retrieving the key id should use the mapping stored in a file
+        let actual_key_id = security_module.get_key_id(&public_key).await?;
+
+        assert_eq!(actual_key_id, key_id);
+
+        Ok(())
+    }
+
+    // TESTS IMPLEMENTATION
+
+    pub fn create_temp_file() -> PathBuf {
+        let dir = std::env::temp_dir();
+        let mut rng = thread_rng();
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        let file_name = hex::encode(bytes);
+        dir.join(file_name)
+    }
+
+    struct Key(usize);
+
+    #[derive(Default)]
+    struct FakeKmsClient {
+        keys: RefCell<HashMap<KeyId, Key>>,
+    }
+
+    #[allow(unsafe_code)]
+    unsafe impl Send for FakeKmsClient {}
+
+    #[allow(unsafe_code)]
+    unsafe impl Sync for FakeKmsClient {}
+
+    #[async_trait]
+    impl KmsClient for FakeKmsClient {
+        async fn create_key(&self) -> Result<KeyId> {
+            let key = self.keys.borrow().len() + 1;
+            self.keys.borrow_mut().insert(key.to_string(), Key(key));
+            Ok(key.to_string())
+        }
+
+        async fn delete_key(&self, _key_id: &KeyId) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn public_key(&self, key_id: &KeyId) -> Result<PublicKey> {
+            Ok(PublicKey::new(
+                key_id.as_bytes().to_vec(),
+                SecretType::NistP256,
+            ))
+        }
+
+        /// The list_keys function returns an error to make sure that we
+        /// really use the local storage to get the key id corresponding to a given public key
+        async fn list_keys(&self) -> Result<Vec<KeyId>> {
+            Err(Error::new(Origin::Api, Kind::Other, "can't list keys"))
+        }
+
+        async fn verify(
+            &self,
+            _key_id: &KeyId,
+            _message: &[u8],
+            _signature: &Signature,
+        ) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn sign(&self, _key_id: &KeyId, _message: &[u8]) -> Result<Signature> {
+            Ok(Signature::new(vec![]))
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a persistence issue with the `PublicKey <-> KeyId` mapping that is stored locally for the AWS security module.

# Diagnostic

The issue comes from the fact that we are persisting a map of `Map<PublicKey, KeyId>` using `serde_json` but `PublicKey` can not be used directly as a string key in a JSON map.

# Fix

The fix consists in restricting the kind of keys that are usable in a `FileKeyValueStorage<K, V>`. The keys now must have a `ToStringKey` instance, which is implemented for a `PublicKey` by serializing it as `hex`.

# Test

A test was added to the `AwsSecurityModule` where we use some real file storage to store the `PublicKey <-> KeyId` mapping but a mock `KmsClient` to create a secret.
