### PR TITLE
test(rust): use random ports on bats tests

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "authority - standalone authority, enrollers, members" {
-  port=33000
+  port="$(random_port)"
   PROJECT_JSON_PATH="$OCKAM_HOME/project-authority.json"
 
   run "$OCKAM" identity create authority

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -96,4 +96,9 @@ random_str() {
   echo "$(openssl rand -hex 8)"
 }
 
+# Returns a random port in the range 49152-65535
+random_port() {
+  shuf -i 49152-65535 -n 1
+}
+
 bats_require_minimum_version 1.5.0

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -22,7 +22,7 @@ teardown() {
 # ===== TESTS
 
 @test "portals - create an inlet/outlet pair, a relay in an orchestrator project and move tcp traffic through it" {
-  port=7100
+  port="$(random_port)"
 
   run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH"
   assert_success
@@ -41,7 +41,7 @@ teardown() {
 }
 
 @test "portals - create an inlet using only default arguments, an outlet, a relay in an orchestrator project and move tcp traffic through it" {
-  port=7101
+  port="$(random_port)"
 
   run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH"
   assert_success
@@ -57,7 +57,7 @@ teardown() {
 }
 
 @test "portals - create an inlet (with implicit secure channel creation), an outlet, a relay in an orchestrator project and move tcp traffic through it" {
-  port=7102
+  port="$(random_port)"
 
   run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH"
   assert_success
@@ -75,7 +75,7 @@ teardown() {
 }
 
 @test "portals - inlet/outlet example with credential, not provided" {
-  port=7103
+  port="$(random_port)"
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
   # Setup nodes from a non-enrolled environment
@@ -118,7 +118,7 @@ teardown() {
 }
 
 @test "portals - inlet (with implicit secure channel creation) / outlet example with credential, not provided" {
-  port=7104
+  port="$(random_port)"
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
@@ -156,7 +156,7 @@ teardown() {
 }
 
 @test "portals - inlet/outlet example with credential" {
-  port=7105
+  port="$(random_port)"
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
@@ -197,7 +197,7 @@ teardown() {
 }
 
 @test "portals - inlet (with implicit secure channel creation) / outlet example with enrollment token" {
-  port=7106
+  port="$(random_port)"
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
   green_token=$($OCKAM project ticket --attribute app=app1)
@@ -242,8 +242,8 @@ teardown() {
 
 
 @test "portals - local inlet and outlet, removing and re-creating the outlet" {
-  port=7107
-  node_port=7108
+  port="$(random_port)"
+  node_port="$(random_port)"
 
   setup_home_dir
 
@@ -280,8 +280,8 @@ teardown() {
 
 
 @test "portals - local inlet and outlet passing though a relay, removing and re-creating the outlet" {
-  port=7109
-  node_port=7110
+  port="$(random_port)"
+  node_port="$(random_port)"
 
   run "$OCKAM" node create blue --project "$PROJECT_JSON_PATH" --tcp-listener-address "127.0.0.1:$node_port"
   assert_success

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -50,7 +50,7 @@ teardown() {
 }
 
 @test "trust context - trust context with an offline authority; Credential Exchange is performed" {
-  port=33803
+  port="$(random_port)"
   # Create two identities
   run "$OCKAM" identity create alice
   alice_identity=$($OCKAM identity show alice --full --encoding hex)
@@ -108,8 +108,8 @@ teardown() {
 }
 
 @test "trust context - trust context with an online authority; Credential Exchange is performed" {
-  auth_port=33805
-  node_port=33806
+  auth_port="$(random_port)"
+  node_port="$(random_port)"
   $OCKAM identity create alice
   $OCKAM identity create bob
   $OCKAM identity create attacker

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -354,7 +354,7 @@ teardown() {
   skip_if_orchestrator_tests_not_enabled
   copy_local_orchestrator_data
 
-  port=7100
+  port="$(random_port)"
 
   run "$OCKAM" node create blue
   assert_success
@@ -443,8 +443,8 @@ teardown() {
 # ===== PORTALS (INLET/OUTLET)
 
 @test "portals - tcp inlet CRUD" {
-  outlet_port=6100
-  inlet_port=6101
+  outlet_port="$(random_port)"
+  inlet_port="$(random_port)"
 
   # Create nodes for inlet/outlet pair
   run "$OCKAM" node create n1
@@ -479,11 +479,11 @@ teardown() {
 }
 
 @test "portals - tcp outlet CRUD" {
-  port=6103
+  port="$(random_port)"
   run "$OCKAM" node create n1
   assert_success
 
-  only_port=6104
+  only_port="$(random_port)"
   run "$OCKAM" node create n2
   assert_success
 
@@ -509,7 +509,7 @@ teardown() {
 }
 
 @test "portals - list inlets on a node" {
-  port=6104
+  port="$(random_port)"
   run "$OCKAM" node create n1
   assert_success
   run "$OCKAM" node create n2
@@ -525,7 +525,7 @@ teardown() {
 }
 
 @test "portals - list outlets on a node" {
-  port=6105
+  port="$(random_port)"
   run "$OCKAM" node create n1
 
   run $OCKAM tcp-outlet create --at /node/n1 --to "127.0.0.1:$port" --alias "test-outlet"
@@ -540,7 +540,7 @@ teardown() {
 }
 
 @test "portals - show a tcp inlet" {
-  port=6106
+  port="$(random_port)"
   run "$OCKAM" node create n1
   assert_success
   run "$OCKAM" node create n2
@@ -558,7 +558,7 @@ teardown() {
 }
 
 @test "portals - show a tcp outlet" {
-  port=6107
+  port="$(random_port)"
   run "$OCKAM" node create n1
   assert_success
 
@@ -575,7 +575,7 @@ teardown() {
 }
 
 @test "portals - create an inlet/outlet pair and move tcp traffic through it" {
-  port=6000
+  port="$(random_port)"
   run "$OCKAM" node create n1
   assert_success
   run "$OCKAM" node create n2
@@ -589,7 +589,7 @@ teardown() {
 }
 
 @test "portals - create an inlet/outlet pair with relay through a relay and move tcp traffic through it" {
-  port=6001
+  port="$(random_port)"
   run "$OCKAM" node create relay
   assert_success
   run "$OCKAM" node create blue

--- a/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use-cases.bats
@@ -23,7 +23,7 @@ teardown() {
 
 # https://docs.ockam.io/guides/use-cases/add-end-to-end-encryption-to-any-client-and-server-application-with-no-code-change
 @test "use-case - end-to-end encryption, local" {
-  port=9000
+  port="$(random_port)"
   run "$OCKAM" node create relay
   assert_success
 
@@ -53,7 +53,7 @@ teardown() {
   skip_if_orchestrator_tests_not_enabled
   copy_local_orchestrator_data
 
-  port=9001
+  port="$(random_port)"
 
   # Service
   run "$OCKAM" node create s


### PR DESCRIPTION
Randomly picks a port within the 49152-65535 range to reduce human errors when writing new errors. This is still not ideal, as it's not checking whether the port is actually free.

I saw a [bats test failing](https://github.com/build-trust/ockam/actions/runs/5131490085/jobs/9231653302) because it was trying to bind an already used port. This could be caused because we had bats tests using ports from the registered range (1024-49151), although ⚠️ _the ports 7100 and 6104 were used in more than one test and we didn't notice_ ⚠️ .

