### PR TITLE
fix(rust): consistency of `addr` argument in the different `service start` subcommands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -16,25 +16,24 @@ use ockam_core::api::{RequestBuilder, Status};
 /// Start a specified service
 #[derive(Clone, Debug, Args)]
 pub struct StartCommand {
-    #[command(flatten)]
-    pub node_opts: NodeOpts,
-
     #[command(subcommand)]
     pub create_subcommand: StartSubCommand,
+    #[command(flatten)]
+    pub node_opts: NodeOpts,
 }
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum StartSubCommand {
     Hop {
-        #[arg(default_value_t = hop_default_addr())]
+        #[arg(long, default_value_t = hop_default_addr())]
         addr: String,
     },
     Identity {
-        #[arg(default_value_t = identity_default_addr())]
+        #[arg(long, default_value_t = identity_default_addr())]
         addr: String,
     },
     Authenticated {
-        #[arg(default_value_t = authenticated_default_addr())]
+        #[arg(long, default_value_t = authenticated_default_addr())]
         addr: String,
     },
     Verifier {

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -37,15 +37,15 @@ teardown() {
   assert_success
 
   # Check we can start service, but only once with the same name
-  run "$OCKAM" service start identity my_identity --node n1
+  run "$OCKAM" service start identity --addr my_identity --node n1
   assert_success
-  run "$OCKAM" service start identity my_identity --node n1
+  run "$OCKAM" service start identity --addr my_identity --node n1
   assert_failure
 
   # Check we can start service, but only once with the same name
-  run "$OCKAM" service start authenticated my_authenticated --node n1
+  run "$OCKAM" service start authenticated --addr my_authenticated --node n1
   assert_success
-  run "$OCKAM" service start authenticated my_authenticated --node n1
+  run "$OCKAM" service start authenticated --addr my_authenticated --node n1
   assert_failure
 
   # Check we can start service, but only once with the same name


### PR DESCRIPTION
Fixes #3566

Docs updated at https://github.com/build-trust/ockam-documentation/pull/26