### PR TITLE
feat(rust): display the source location of an error by default

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/error/code.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/code.rs
@@ -408,13 +408,10 @@ impl From<u8> for Kind {
 
 impl core::fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Kind of halfway between debug and display, TBH, but it's only used in
-        // the Error debug output.
-        write!(f, "[Origin::{:?}; Kind::{:?}", self.origin, self.kind,)?;
+        write!(f, "origin: {:?}, kind: {:?}", self.origin, self.kind,)?;
         if self.extra != 0 {
-            write!(f, "; code = {}]", self.extra)
-        } else {
-            write!(f, "]")
-        }
+            write!(f, ", code = {}", self.extra)?
+        };
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_core/src/error/inner/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/inner/mod.rs
@@ -23,7 +23,7 @@ pub(super) struct ErrorData {
     #[cfg(feature = "std")]
     payload: Vec<PayloadEntry>,
     #[cfg(feature = "std")]
-    source_loc: Location,
+    pub(super) source_loc: Location,
     #[cfg(feature = "std")]
     #[serde(skip, default)]
     cause: Option<BoxDynErr>,

--- a/implementations/rust/ockam/ockam_node/src/context/transports.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/transports.rs
@@ -108,10 +108,10 @@ mod tests {
             .await
             .err();
 
-        assert_eq!(
-            result.unwrap().to_string(),
-            "only one transport hop is allowed in a route"
-        );
+        assert!(result
+            .unwrap()
+            .to_string()
+            .contains("only one transport hop is allowed in a route"));
         ctx.stop().await
     }
 


### PR DESCRIPTION
This PR improves the default display of an error to help diagnose issues faster.

# Diagnostic

For example [this discussion](https://github.com/build-trust/ockam/discussions/5016) shows an error which is raised within a `WorkerRelay`.  The error being displayed just mentioned that an operation failed for a given `Address` without telling us what went wrong exactly (a worker was already started at that address).

# Fix

The `Display` instance for an `Error` has been expanded (at least under the `std` flag) to show:

 - a message for the error cause
 - the origin and kind of the error
 - a source location

# Test

Two unit tests have been added for the display.
