### PR TITLE
docs(rust): include documentation for CLI commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,6 +1,7 @@
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::is_tty;
 use crate::{
+    docs,
     util::{api, extract_address_value, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
@@ -9,7 +10,10 @@ use colorful::Colorful;
 use ockam_api::nodes::models;
 use serde_json::json;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct TcpConnectionNodeOpts {
     /// Node that will initiate the connection
     #[arg(global = true, short, long, value_name = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,13 +1,15 @@
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{node::NodeOpts, CommandGlobalOpts};
+use crate::{docs, node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
 /// Delete a TCP connection
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true)]
+#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     #[command(flatten)]
     node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,6 +1,6 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::Context;
 use clap::Args;
 use cli_table::{print_stdout, Cell, Style, Table};
@@ -8,8 +8,11 @@ use ockam_api::nodes::models;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_core::api::Request;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
 /// List TCP connections
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ListCommand {
     #[command(flatten)]
     node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -7,10 +7,13 @@ use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
 use crate::util::{node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
 /// Show a TCP connection
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ShowCommand {
     #[command(flatten)]
     pub node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -7,7 +7,7 @@ use crate::util::{
     bind_to_port_check, exitcode, extract_address_value, find_available_port, node_rpc,
     process_nodes_multiaddr, RpcBuilder,
 };
-use crate::{display_parse_logs, fmt_log, fmt_ok, CommandGlobalOpts, Result};
+use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts, Result};
 use anyhow::anyhow;
 use clap::Args;
 use colorful::Colorful;
@@ -28,8 +28,11 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
 /// Create TCP Inlets
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct CreateCommand {
     /// Node on which to start the tcp inlet.
     #[arg(long, display_order = 900, id = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,15 +1,18 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use ockam::Context;
 use ockam_core::api::{Request, RequestBuilder};
 
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
 /// Delete a TCP Inlet
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     /// Name assigned to inlet that will be deleted
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,6 +1,6 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam_api::nodes::models;
@@ -8,8 +8,11 @@ use ockam_api::route_to_multiaddr;
 use ockam_core::api::Request;
 use ockam_core::Route;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
 /// List TCP Inlets
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ListCommand {
     #[command(flatten)]
     node: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,17 +1,19 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam::{Context, Route};
 use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
+
 /// Delete a TCP Inlet
 #[derive(Clone, Debug, Args)]
-#[command()]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ShowCommand {
     /// Name assigned to inlet that will be shown
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,7 +1,7 @@
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::Rpc;
 use crate::util::{node_rpc, parse_node_name};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam_api::nodes::models;
 use ockam_api::nodes::models::transport::CreateTcpListener;
@@ -9,8 +9,11 @@ use ockam_core::api::Request;
 use ockam_multiaddr::proto::{DnsAddr, Tcp};
 use ockam_multiaddr::MultiAddr;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
 /// Create a TCP listener
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct CreateCommand {
     /// Node at which to create the listener
     #[arg(global = true, long, value_name = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -8,10 +8,13 @@ use ockam_core::api::Request;
 
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, Rpc};
-use crate::{node::NodeOpts, CommandGlobalOpts};
+use crate::{docs, node::NodeOpts, CommandGlobalOpts};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
 /// Delete a TCP listener
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     #[command(flatten)]
     node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -5,10 +5,13 @@ use ockam_api::nodes::models::transport::{TransportList, TransportStatus};
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
 
 /// List TCP listeners
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ListCommand {
     #[command(flatten)]
     node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -7,10 +7,13 @@ use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
 use crate::util::{node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
+
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
 /// Show a TCP listener
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ShowCommand {
     #[command(flatten)]
     pub node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -6,7 +6,7 @@ use crate::terminal::OckamColor;
 use crate::util::parsers::socket_addr_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::{display_parse_logs, fmt_log};
-use crate::{fmt_ok, CommandGlobalOpts};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 use clap::Args;
 use colorful::Colorful;
@@ -19,8 +19,11 @@ use std::net::SocketAddr;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
 /// Create TCP Outlets
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct CreateCommand {
     /// Node on which to start the tcp outlet.
     #[arg(long, display_order = 900, id = "NODE")]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,15 +1,18 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use ockam::Context;
 use ockam_core::api::{Request, RequestBuilder};
 
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
 /// Delete a TCP Outlet
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     /// Name assigned to outlet that will be deleted
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,6 +1,6 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{exitcode, extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use ockam_api::nodes::models::portal::OutletList;
@@ -8,8 +8,11 @@ use ockam_api::{error::ApiError, route_to_multiaddr};
 use ockam_core::api::Request;
 use ockam_core::route;
 
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
 /// List TCP Outlets
 #[derive(Clone, Debug, Args)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ListCommand {
     #[command(flatten)]
     node_opts: NodeOpts,

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,8 +1,8 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use crate::Result;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam::{route, Context};
 use ockam_api::error::ApiError;
@@ -10,9 +10,11 @@ use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
 
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
+
 /// Delete a TCP Outlet
 #[derive(Clone, Debug, Args)]
-#[command()]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct ShowCommand {
     /// Name assigned to outlet that will be shown
     #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -7,10 +7,17 @@ use ockam_api::cli_state;
 use ockam_api::cli_state::traits::StateDirTrait;
 
 use crate::util::node_rpc;
-use crate::{fmt_info, fmt_ok, CommandGlobalOpts};
+use crate::{docs, fmt_info, fmt_ok, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
 /// Create a vault
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct CreateCommand {
     #[arg(hide_default_value = true, default_value_t = hex::encode(&random::<[u8;4]>()))]
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/vault/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/default.rs
@@ -1,12 +1,19 @@
-use crate::{fmt_ok, CommandGlobalOpts};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 use anyhow::anyhow;
 use clap::Args;
 use colorful::Colorful;
 use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cli_state::CliStateError;
 
+const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt");
+
 /// Change the default vault
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DefaultCommand {
     /// Name of the vault to be set as default
     name: String,

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -8,10 +8,17 @@ use ockam_api::cli_state::CliStateError;
 
 use crate::terminal::ConfirmResult;
 use crate::util::node_rpc;
-use crate::{fmt_ok, fmt_warn, CommandGlobalOpts};
+use crate::{docs, fmt_ok, fmt_warn, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
 /// Delete a vault
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct DeleteCommand {
     /// Name of the vault
     pub name: String,

--- a/implementations/rust/ockam/ockam_command/src/vault/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/list.rs
@@ -2,10 +2,17 @@ use anyhow::anyhow;
 use clap::Args;
 use ockam_api::cli_state::traits::StateDirTrait;
 
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
 
 /// List vaults
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ListCommand;
 
 impl ListCommand {

--- a/implementations/rust/ockam/ockam_command/src/vault/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/show.rs
@@ -1,10 +1,17 @@
 use clap::Args;
 use ockam_api::cli_state::traits::StateDirTrait;
 
-use crate::CommandGlobalOpts;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
 /// Show the details of a vault
 #[derive(Clone, Debug, Args)]
+#[command(
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct ShowCommand {
     /// Name of the vault
     pub name: Option<String>,


### PR DESCRIPTION
We had the documentation in place but we forgot to include it in the commands definitions.