### PR TITLE
feat(rust): remove `force` flag from `node start` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,6 +1,7 @@
 use crate::node::{get_node_name, initialize_node_if_default};
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
+use colorful::Colorful;
 use ockam_api::cli_state::StateDirTrait;
 
 const LONG_ABOUT: &str = include_str!("./static/stop/long_about.txt");
@@ -36,6 +37,9 @@ fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
     let node_state = opts.state.nodes.get(&node_name)?;
     node_state.kill_process(cmd.force)?;
-    println!("Stopped node '{}'", &node_name);
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!("Stopped node '{}'", &node_name))
+        .write_line()?;
     Ok(())
 }


### PR DESCRIPTION
We don't have a clear use-case for this flag, and it's making the command more complicated than necessary.