### PR TITLE
Complain deleting nonexistent listeners

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -148,18 +148,18 @@ impl<'a> DeleteSecureChannelListenerRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DeleteSecureChannelListenerResponse<'a> {
+pub struct DeleteSecureChannelListenerResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8642885>,
-    #[b(1)] pub addr: Option<Cow<'a, str>>,
+    #[b(1)] pub addr: Address,
 }
 
-impl<'a> DeleteSecureChannelListenerResponse<'a> {
-    pub fn new(addr: Option<Address>) -> Self {
+impl DeleteSecureChannelListenerResponse {
+    pub fn new(addr: Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.map(|ch| ch.to_string().into()),
+            addr,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -631,7 +631,7 @@ impl NodeManagerWorker {
             (Delete, ["node", "secure_channel_listener"]) => self
                 .delete_secure_channel_listener(req, dec)
                 .await?
-                .to_vec()?,
+                .to_vec(),
             (Get, ["node", "show_secure_channel_listener"]) => {
                 self.show_secure_channel_listener(req, dec).await?
             }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -2,6 +2,7 @@ use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
+use ockam_api::nodes::models::secure_channel::DeleteSecureChannelListenerResponse;
 use ockam_core::Address;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
@@ -47,8 +48,8 @@ async fn run_impl(
     let req = api::delete_secure_channel_listener(&cmd.address);
     rpc.request(req).await?;
     rpc.is_ok()?;
-
-    let addr = format!("/service/{}", cmd.address.address());
+    let res = rpc.parse_response::<DeleteSecureChannelListenerResponse>()?;
+    let addr = res.addr;
     opts.terminal
         .stdout()
         .plain(fmt_ok!(


### PR DESCRIPTION
Addresses #4972 

> Do not print that a secure channel listener was successfully deleted when it is not the case
