### PR TITLE
fix(rust): `project create` when creating a new project

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -197,7 +197,9 @@ async fn default_space<'a>(
         ))?;
         space
     };
-
+    opts.state
+        .spaces
+        .overwrite(&default_space.name, SpaceConfig::from(&default_space))?;
     opts.terminal.write_line(&fmt_ok!(
         "Marked this space as your default space, on this machine.\n"
     ))?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -70,10 +70,12 @@ async fn run_impl(
     let project = rpc.parse_response::<Project>()?;
     let project =
         check_project_readiness(ctx, &opts, &cmd.cloud_opts, &node_name, None, project).await?;
-    opts.state.projects.create(&project.name, project.clone())?;
+    opts.state
+        .projects
+        .overwrite(&project.name, project.clone())?;
     opts.state
         .trust_contexts
-        .create(&project.name, project.clone().try_into()?)?;
+        .overwrite(&project.name, project.clone().try_into()?)?;
     rpc.print_response(project)?;
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -463,6 +463,8 @@ teardown() {
   run $OCKAM tcp-inlet create --at /node/n2 --from 6102 --to /node/n1/service/outlet
   assert_success
 
+  sleep 1
+
   # Check that inlet is available for deletion and delete it
   run $OCKAM tcp-inlet show test-inlet --at /node/n2
   assert_output --partial "Alias: test-inlet"
@@ -516,7 +518,10 @@ teardown() {
   assert_success
 
   run $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:$port --to /node/n1/service/outlet --alias tcp-inlet-2
+  assert_success
+  sleep 1
   run $OCKAM tcp-inlet list --at /node/n2
+  assert_success
 
   assert_output --partial "Alias: tcp-inlet-2"
   assert_output --partial "TCP Address: 127.0.0.1:$port"
@@ -548,6 +553,7 @@ teardown() {
 
   run $OCKAM tcp-inlet create --at /node/n2 --from 127.0.0.1:$port --to /node/n1/service/outlet --alias "test-inlet"
   assert_success
+  sleep 1
 
   run $OCKAM tcp-inlet show "test-inlet" --at /node/n2
   assert_success


### PR DESCRIPTION
This PR fixes two problems

#### 1. "project already exists" when running `ockam enroll`

The `check_project_readiness` function was initializing the project config file. Later, when persisting the fully populated config file, it was failing because it expected that file to not exist at that point, returning an `AlreadyExist` error (note the `create` vs `overwrite` calls in the changes).

#### 2. "space not found" when running `ockam project create` right after a fresh `ockam enroll`

After #5018, we stopped using the legacy config.json file, which contained data about spaces and projects. I forgot to update the code that should persist the space that is created within the `ockam enroll` command.