### PR TITLE
chore: remove deprecated services field from projects api

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -31,7 +31,6 @@ impl From<ProjectLookup> for Project {
             id: lookup.id,
             name: lookup.name,
             space_name: "".to_string(),
-            services: vec![],
             access_route: lookup
                 .node_route
                 .map(|r| r.to_string())

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -31,9 +31,6 @@ pub struct Project {
     #[cbor(n(3))]
     pub space_name: String,
 
-    #[cbor(n(4))]
-    pub services: Vec<String>,
-
     #[cbor(n(5))]
     pub access_route: String,
 
@@ -240,21 +237,15 @@ pub struct CreateProject<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<8669570>,
     #[b(1)] pub name: CowStr<'a>,
-    #[b(2)] pub services: Vec<CowStr<'a>>,
     #[b(3)] pub users: Vec<CowStr<'a>>,
 }
 
 impl<'a> CreateProject<'a> {
-    pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(
-        name: S,
-        users: &'a [T],
-        services: &'a [T],
-    ) -> Self {
+    pub fn new<S: Into<CowStr<'a>>, T: AsRef<str>>(name: S, users: &'a [T]) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
             name: name.into(),
-            services: services.iter().map(|x| CowStr::from(x.as_ref())).collect(),
             users: users.iter().map(|x| CowStr::from(x.as_ref())).collect(),
         }
     }
@@ -401,7 +392,6 @@ mod tests {
                 id: String::arbitrary(g),
                 name: String::arbitrary(g),
                 space_name: String::arbitrary(g),
-                services: vec![String::arbitrary(g), String::arbitrary(g)],
                 access_route: String::arbitrary(g),
                 users: vec![String::arbitrary(g), String::arbitrary(g)],
                 space_id: String::arbitrary(g),
@@ -428,7 +418,6 @@ mod tests {
                 #[cfg(feature = "tag")]
                 tag: Default::default(),
                 name: String::arbitrary(g).into(),
-                services: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
                 users: vec![String::arbitrary(g).into(), String::arbitrary(g).into()],
             })
         }

--- a/implementations/rust/ockam/ockam_api/src/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/src/schema.cddl
@@ -43,7 +43,6 @@ project = {
     1: project_id,
     2: project_name,
     3: space_name,
-    4: [+ service_name],
     5: access_route,  ; could be an empty string if the cloud node hasn't started yet (TODO: make it an optional field instead)
     6: [+ user],
     7: space_id,
@@ -62,7 +61,6 @@ projects = [* project]
 create_project = {
     ?0: 8669570,
     1: project_name,
-    2: [+ service_name]
     3: [+ user]
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -32,10 +32,6 @@ pub struct CreateCommand {
 
     #[command(flatten)]
     pub cloud_opts: CloudOpts,
-
-    /// Services enabled for this project.
-    #[arg(display_order = 1100, last = true)]
-    pub services: Vec<String>,
     //TODO:  list of admins
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -303,7 +303,7 @@ pub(crate) mod project {
         space_id: &'a str,
         cloud_route: &'a MultiAddr,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(project_name, &[], &[]);
+        let b = CreateProject::new::<&str, &str>(project_name, &[]);
         Request::post(format!("v1/spaces/{space_id}/projects")).body(CloudRequestWrapper::new(
             b,
             cloud_route,

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -9,10 +9,7 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.args(prefix_args)
         .arg("create")
         .arg("space-name")
-        .arg("project-name")
-        .arg("--")
-        .arg("service-a")
-        .arg("service-b");
+        .arg("project-name");
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently there is unused `services` field in the project APIs
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Remove the field from request and response datastructures
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
