### PR TITLE
feat(rust): add delete and list subcommands for kafka consumer/producer commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -48,7 +48,7 @@ mod test {
         KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
     };
     use crate::nodes::registry::KafkaServiceKind;
-    use crate::test::NodeManagerHandle;
+    use crate::test_utils::NodeManagerHandle;
     use crate::DefaultAddress;
 
     //TODO: upgrade to 13 by adding a metadata request to map uuid<=>topic_name
@@ -148,7 +148,7 @@ mod test {
     async fn producer__flow_with_mock_kafka__content_encryption_and_decryption(
         context: &mut Context,
     ) -> ockam::Result<()> {
-        let handler = crate::util::test::start_manager_for_tests(context).await?;
+        let handler = crate::util::test_utils::start_manager_for_tests(context).await?;
 
         let consumer_bootstrap_port = create_kafka_service(
             context,

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -689,7 +689,7 @@ mod test {
     async fn kafka_portal_worker__metadata_exchange__response_changed(
         context: &mut Context,
     ) -> ockam::Result<()> {
-        let handler = crate::test::start_manager_for_tests(context).await?;
+        let handler = crate::test_utils::start_manager_for_tests(context).await?;
 
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
             handler.secure_channels.clone(),

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -171,6 +171,29 @@ impl DefaultAddress {
     pub const KAFKA_CONSUMER: &'static str = "kafka_consumer";
     pub const KAFKA_PRODUCER: &'static str = "kafka_producer";
     pub const RPC_PROXY: &'static str = "rpc_proxy_service";
+
+    pub fn is_valid(name: &str) -> bool {
+        matches!(
+            name,
+            Self::IDENTITY_SERVICE
+                | Self::AUTHENTICATED_SERVICE
+                | Self::FORWARDING_SERVICE
+                | Self::UPPERCASE_SERVICE
+                | Self::ECHO_SERVICE
+                | Self::HOP_SERVICE
+                | Self::CREDENTIALS_SERVICE
+                | Self::SECURE_CHANNEL_LISTENER
+                | Self::DIRECT_AUTHENTICATOR
+                | Self::CREDENTIAL_ISSUER
+                | Self::ENROLLMENT_TOKEN_ISSUER
+                | Self::ENROLLMENT_TOKEN_ACCEPTOR
+                | Self::VERIFIER
+                | Self::OKTA_IDENTITY_PROVIDER
+                | Self::KAFKA_CONSUMER
+                | Self::KAFKA_PRODUCER
+                | Self::RPC_PROXY
+        )
+    }
 }
 
 pub mod actions {
@@ -242,5 +265,46 @@ impl<'de> Deserialize<'de> for HexByteVec {
 impl fmt::Display for HexByteVec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.serialize(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DefaultAddress;
+
+    #[test]
+    fn test_default_address_is_valid() {
+        assert!(!DefaultAddress::is_valid("foo"));
+        assert!(DefaultAddress::is_valid(DefaultAddress::IDENTITY_SERVICE));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::AUTHENTICATED_SERVICE
+        ));
+        assert!(DefaultAddress::is_valid(DefaultAddress::FORWARDING_SERVICE));
+        assert!(DefaultAddress::is_valid(DefaultAddress::UPPERCASE_SERVICE));
+        assert!(DefaultAddress::is_valid(DefaultAddress::ECHO_SERVICE));
+        assert!(DefaultAddress::is_valid(DefaultAddress::HOP_SERVICE));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::CREDENTIALS_SERVICE
+        ));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::SECURE_CHANNEL_LISTENER
+        ));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::DIRECT_AUTHENTICATOR
+        ));
+        assert!(DefaultAddress::is_valid(DefaultAddress::CREDENTIAL_ISSUER));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::ENROLLMENT_TOKEN_ISSUER
+        ));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::ENROLLMENT_TOKEN_ACCEPTOR
+        ));
+        assert!(DefaultAddress::is_valid(DefaultAddress::VERIFIER));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::OKTA_IDENTITY_PROVIDER
+        ));
+        assert!(DefaultAddress::is_valid(DefaultAddress::KAFKA_CONSUMER));
+        assert!(DefaultAddress::is_valid(DefaultAddress::KAFKA_PRODUCER));
+        assert!(DefaultAddress::is_valid(DefaultAddress::RPC_PROXY));
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,6 +1,6 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::net::SocketAddr;
-use ockam_core::{CowBytes, CowStr};
+use ockam_core::{Address, CowBytes, CowStr};
 
 use serde::Serialize;
 
@@ -34,6 +34,29 @@ impl<'a, T> StartServiceRequest<'a, T> {
 
     pub fn request(&'a self) -> &'a T {
         &self.req
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct DeleteServiceRequest<'a> {
+    #[cfg(feature = "tag")]
+    #[n(0)] tag: TypeTag<9359178>,
+    #[b(1)] addr: CowStr<'a>,
+}
+
+impl<'a> DeleteServiceRequest<'a> {
+    pub fn new<S: Into<CowStr<'a>>>(addr: S) -> Self {
+        Self {
+            #[cfg(feature = "tag")]
+            tag: TypeTag,
+            addr: addr.into(),
+        }
+    }
+
+    pub fn address(&'a self) -> Address {
+        Address::from(self.addr.as_ref())
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -4,6 +4,7 @@ use ockam::remote::RemoteForwarderInfo;
 use ockam_core::compat::collections::BTreeMap;
 use ockam_core::{Address, Route};
 use ockam_identity::{SecureChannel, SecureChannelListener};
+use std::fmt::Display;
 
 #[derive(Default)]
 pub(crate) struct SecureChannelRegistry {
@@ -112,9 +113,19 @@ pub(crate) struct CredentialsServiceInfo {}
 #[derive(Default)]
 pub(crate) struct AuthenticatorServiceInfo {}
 
+#[derive(Eq, PartialEq)]
 pub(crate) enum KafkaServiceKind {
     Consumer,
     Producer,
+}
+
+impl Display for KafkaServiceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KafkaServiceKind::Consumer => write!(f, "consumer"),
+            KafkaServiceKind::Producer => write!(f, "producer"),
+        }
+    }
 }
 
 pub(crate) struct KafkaServiceInfo {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -27,11 +27,11 @@ use crate::kafka::{
 };
 use crate::nodes::models::portal::CreateInlet;
 use crate::nodes::models::services::{
-    ServiceList, ServiceStatus, StartAuthenticatedServiceRequest, StartAuthenticatorRequest,
-    StartCredentialsService, StartEchoerServiceRequest, StartHopServiceRequest,
-    StartIdentityServiceRequest, StartKafkaConsumerRequest, StartKafkaProducerRequest,
-    StartOktaIdentityProviderRequest, StartServiceRequest, StartUppercaseServiceRequest,
-    StartVerifierService,
+    DeleteServiceRequest, ServiceList, ServiceStatus, StartAuthenticatedServiceRequest,
+    StartAuthenticatorRequest, StartCredentialsService, StartEchoerServiceRequest,
+    StartHopServiceRequest, StartIdentityServiceRequest, StartKafkaConsumerRequest,
+    StartKafkaProducerRequest, StartOktaIdentityProviderRequest, StartServiceRequest,
+    StartUppercaseServiceRequest, StartVerifierService,
 };
 use crate::nodes::registry::{
     AuthenticatorServiceInfo, CredentialsServiceInfo, KafkaServiceInfo, KafkaServiceKind, Registry,
@@ -768,6 +768,32 @@ impl NodeManagerWorker {
         Ok(())
     }
 
+    pub(crate) async fn delete_kafka_service<'a>(
+        &'a self,
+        ctx: &Context,
+        req: &'a Request<'_>,
+        dec: &mut Decoder<'_>,
+        kind: KafkaServiceKind,
+    ) -> Result<ResponseBuilder> {
+        let body: DeleteServiceRequest = dec.decode()?;
+        let address = body.address();
+        let mut node_manager = self.node_manager.write().await;
+        let res = match node_manager.registry.kafka_services.get(&address) {
+            None => Response::not_found(req.id()),
+            Some(e) => {
+                if kind.eq(e.kind()) {
+                    ctx.stop_worker(address.clone()).await?;
+                    node_manager.registry.kafka_services.remove(&address);
+                    Response::ok(req.id())
+                } else {
+                    error!(address = %address, "Service is not a kafka {}", kind.to_string());
+                    Response::internal_error(req.id())
+                }
+            }
+        };
+        Ok(res)
+    }
+
     fn extract_project<'a>(
         &self,
         req: &'a Request<'_>,
@@ -779,11 +805,36 @@ impl NodeManagerWorker {
             .ok_or_else(|| bad_request(req, "invalid project route"))
     }
 
-    pub(super) fn list_services<'a>(
+    pub(super) async fn list_services_of_type<'a>(
         &self,
         req: &Request<'a>,
-        registry: &'a Registry,
-    ) -> ResponseBuilder<ServiceList<'a>> {
+        service_type: &'a str,
+    ) -> Result<Vec<u8>> {
+        if !DefaultAddress::is_valid(service_type) {
+            return Ok(Response::bad_request(req.id())
+                .body(format!("Service type '{service_type}' doesn't exist"))
+                .to_vec()?);
+        }
+        let n = self.node_manager.read().await;
+        let services = Self::list_services_impl(&n.registry);
+        let filtered = services
+            .into_iter()
+            .filter(|service| service.service_type == service_type)
+            .collect();
+        Ok(Response::ok(req.id())
+            .body(ServiceList::new(filtered))
+            .to_vec()?)
+    }
+
+    pub(super) async fn list_services<'a>(&self, req: &Request<'a>) -> Result<Vec<u8>> {
+        let n = self.node_manager.read().await;
+        let services = Self::list_services_impl(&n.registry);
+        Ok(Response::ok(req.id())
+            .body(ServiceList::new(services))
+            .to_vec()?)
+    }
+
+    fn list_services_impl(registry: &Registry) -> Vec<ServiceStatus> {
         let mut list = Vec::new();
         registry.identity_services.keys().for_each(|addr| {
             list.push(ServiceStatus::new(
@@ -840,6 +891,6 @@ impl NodeManagerWorker {
             .keys()
             .for_each(|addr| list.push(ServiceStatus::new(addr.address(), "Authority")));
 
-        Response::ok(req.id()).body(ServiceList::new(list))
+        list
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -338,7 +338,7 @@ pub fn local_worker(code: &Code) -> Result<bool> {
 }
 
 #[cfg(test)]
-pub mod test {
+pub mod test_utils {
     use ockam::identity::SecureChannels;
     use ockam::Result;
     use ockam_core::compat::sync::Arc;

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -84,7 +84,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
 
     let msgs = vec![
         format!(
-            "Buildling KafkaConsumer service {}",
+            "Building KafkaConsumer service {}",
             &addr.to_string().color(OckamColor::PrimaryResource.color())
         ),
         format!(

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
@@ -1,0 +1,52 @@
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
+use clap::Args;
+use colorful::Colorful;
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
+/// Delete a Kafka Consumer
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
+pub struct DeleteCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+
+    /// Kafka consumer service address
+    pub address: String,
+}
+
+impl DeleteCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let req = Request::delete("/node/services/kafka_consumer").body(
+        models::services::DeleteServiceRequest::new(cmd.address.clone()),
+    );
+    rpc.request(req).await?;
+    rpc.is_ok()?;
+
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!(
+            "Kafka consumer with address `{}` successfully deleted",
+            cmd.address
+        ))
+        .write_line()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -1,0 +1,57 @@
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
+
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::nodes::models;
+
+use ockam_api::DefaultAddress;
+use ockam_core::api::Request;
+
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
+/// List Kafka Consumers
+#[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
+pub struct ListCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ListCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    rpc.request(Request::get(format!(
+        "/node/services/{}",
+        DefaultAddress::KAFKA_CONSUMER
+    )))
+    .await?;
+    let services = rpc.parse_response::<models::services::ServiceList>()?;
+    if services.list.is_empty() {
+        opts.terminal
+            .stdout()
+            .plain(fmt_err!("No Kafka Consumers found on this node"))
+            .write_line()?;
+    } else {
+        let mut buf = String::new();
+        buf.push_str("Kafka Consumers:\n");
+        for service in services.list {
+            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+        }
+        opts.terminal.stdout().plain(buf).write_line()?;
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/mod.rs
@@ -1,7 +1,11 @@
 mod create;
+mod delete;
+mod list;
 
 use clap::{command, Args, Subcommand};
 
+use crate::kafka::consumer::delete::DeleteCommand;
+use crate::kafka::consumer::list::ListCommand;
 use crate::CommandGlobalOpts;
 
 use self::create::CreateCommand;
@@ -17,12 +21,16 @@ pub struct KafkaConsumerCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum KafkaConsumerSubcommand {
     Create(CreateCommand),
+    Delete(DeleteCommand),
+    List(ListCommand),
 }
 
 impl KafkaConsumerCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             KafkaConsumerSubcommand::Create(c) => c.run(options),
+            KafkaConsumerSubcommand::Delete(c) => c.run(options),
+            KafkaConsumerSubcommand::List(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/static/delete/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To delete a kafka consumers on the default node
+$ ockam kafka-consumer delete kcaddr
+
+# To delete a kafka consumers on a specific node
+$ ockam kafka-consumer delete kcaddr --node n
+```

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/static/list/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To list the kafka consumers on the default node
+$ ockam kafka-consumer list
+
+# To list the kafka consumers on a specific node
+$ ockam kafka-consumer list --node n
+```

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -86,7 +86,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> c
 
     let msgs = vec![
         format!(
-            "Buildling KafkaConsumer service {}",
+            "Building KafkaProducer service {}",
             &addr.to_string().color(OckamColor::PrimaryResource.color())
         ),
         format!(

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
@@ -1,0 +1,52 @@
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
+use clap::Args;
+use colorful::Colorful;
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
+/// Delete a Kafka Producer
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
+pub struct DeleteCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+
+    /// Kafka producer service address
+    pub address: String,
+}
+
+impl DeleteCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> crate::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let req = Request::delete("/node/services/kafka_producer").body(
+        models::services::DeleteServiceRequest::new(cmd.address.clone()),
+    );
+    rpc.request(req).await?;
+    rpc.is_ok()?;
+
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!(
+            "Kafka producer with address `{}` successfully deleted",
+            cmd.address
+        ))
+        .write_line()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -1,0 +1,57 @@
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
+
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::nodes::models;
+
+use ockam_api::DefaultAddress;
+use ockam_core::api::Request;
+
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
+/// List Kafka Producers
+#[derive(Args, Clone, Debug)]
+#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
+pub struct ListCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ListCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> crate::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    rpc.request(Request::get(format!(
+        "/node/services/{}",
+        DefaultAddress::KAFKA_PRODUCER
+    )))
+    .await?;
+    let services = rpc.parse_response::<models::services::ServiceList>()?;
+    if services.list.is_empty() {
+        opts.terminal
+            .stdout()
+            .plain(fmt_err!("No Kafka Producers found on this node"))
+            .write_line()?;
+    } else {
+        let mut buf = String::new();
+        buf.push_str("Kafka Producers:\n");
+        for service in services.list {
+            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+        }
+        opts.terminal.stdout().plain(buf).write_line()?;
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/mod.rs
@@ -1,7 +1,11 @@
 mod create;
+mod delete;
+mod list;
 
 use clap::{command, Args, Subcommand};
 
+use crate::kafka::producer::delete::DeleteCommand;
+use crate::kafka::producer::list::ListCommand;
 use crate::CommandGlobalOpts;
 
 use self::create::CreateCommand;
@@ -17,12 +21,16 @@ pub struct KafkaProducerCommand {
 #[derive(Clone, Debug, Subcommand)]
 pub enum KafkaProducerSubcommand {
     Create(CreateCommand),
+    Delete(DeleteCommand),
+    List(ListCommand),
 }
 
 impl KafkaProducerCommand {
     pub fn run(self, options: CommandGlobalOpts) {
         match self.subcommand {
             KafkaProducerSubcommand::Create(c) => c.run(options),
+            KafkaProducerSubcommand::Delete(c) => c.run(options),
+            KafkaProducerSubcommand::List(c) => c.run(options),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/static/delete/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To delete a kafka producers on the default node
+$ ockam kafka-producer delete kcaddr
+
+# To delete a kafka producers on a specific node
+$ ockam kafka-producer delete kcaddr --node n
+```

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/static/list/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To list the kafka producers on the default node
+$ ockam kafka-producer list
+
+# To list the kafka producers on a specific node
+$ ockam kafka-producer list --node n
+```


### PR DESCRIPTION
The `show` commands in this case doesn't make too much sense, as we would be returning the service address, which is the command main argument. This command would make sense if, in the future, we store more data about the kafka services in the NodeManager registry.