### PR TITLE
Fix Typescript Dependabot Path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
 
   # Maintain dependencies for typescript packages
   - package-ecosystem: "npm"
-    directory: "/implementation/typescript"
+    directory: "/implementations/typescript"
     commit-message:
       prefix: "build:"
     schedule:


### PR DESCRIPTION
We were using a wrong path when updating dependency version with dependabot