### PR TITLE
feat(rust): full local kafka implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,6 @@ dependencies = [
  "quickcheck",
  "rand",
  "reqwest",
- "rust-embed",
  "serde",
  "serde_json",
  "sysinfo",
@@ -4424,40 +4423,6 @@ name = "roff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
-
-[[package]]
-name = "rust-embed"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b68543d5527e158213414a92832d2aab11a84d2571a5eb021ebe22c43aab066"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4e0f0ced47ded9a68374ac145edd65a6c1fa13a96447b873660b2a568a0fd7"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 1.0.109",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "7.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
-dependencies = [
- "sha2 0.10.6",
- "walkdir",
-]
 
 [[package]]
 name = "rustc-demangle"

--- a/implementations/rust/ockam/ockam/src/remote/worker.rs
+++ b/implementations/rust/ockam/ockam/src/remote/worker.rs
@@ -61,7 +61,8 @@ impl Worker for RemoteForwarder {
                         .map_err(|_| OckamError::InvalidHubResponse)?;
                     let payload =
                         String::from_utf8(payload).map_err(|_| OckamError::InvalidHubResponse)?;
-                    if payload != self.registration_payload {
+                    // using ends_with() instead of == to allow for prefixes
+                    if !payload.ends_with(&self.registration_payload) {
                         return Err(OckamError::InvalidHubResponse.into());
                     }
 

--- a/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
+++ b/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
@@ -15,7 +15,7 @@ use crate::{eval, Env, Expr};
 use ockam_core::compat::format;
 use ockam_core::compat::string::ToString;
 use ockam_core::compat::sync::Arc;
-use ockam_identity::{IdentitiesRepository, IdentitySecureChannelLocalInfo};
+use ockam_identity::{IdentitiesRepository, IdentityIdentifier, IdentitySecureChannelLocalInfo};
 
 /// This AccessControl uses a storage for authenticated attributes in order
 /// to verify if a policy expression is valid
@@ -66,21 +66,9 @@ where {
     }
 }
 
-#[async_trait]
-impl IncomingAccessControl for AbacAccessControl {
-    /// Return true if the sender of the message is validated by the expression stored in AbacAccessControl
-    async fn is_authorized(&self, msg: &RelayMessage) -> Result<bool> {
-        // Get identity identifier from message metadata:
-        let id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info(msg.local_message()) {
-            info.their_identity_id().clone()
-        } else {
-            log::debug! {
-                policy = %self.expression,
-                "identity identifier not found; access denied"
-            }
-            return Ok(false);
-        };
-
+impl AbacAccessControl {
+    /// Returns true if the identity is authorized
+    pub async fn is_identity_authorized(&self, id: IdentityIdentifier) -> Result<bool> {
         let mut environment = self.environment.clone();
 
         // Get identity attributes and populate the environment:
@@ -153,5 +141,24 @@ impl IncomingAccessControl for AbacAccessControl {
                 Ok(false)
             }
         }
+    }
+}
+
+#[async_trait]
+impl IncomingAccessControl for AbacAccessControl {
+    /// Returns true if the sender of the message is validated by the expression stored in AbacAccessControl
+    async fn is_authorized(&self, msg: &RelayMessage) -> Result<bool> {
+        // Get identity identifier from message metadata:
+        let id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info(msg.local_message()) {
+            info.their_identity_id()
+        } else {
+            log::debug! {
+                policy = %self.expression,
+                "identity identifier not found; access denied"
+            }
+            return Ok(false);
+        };
+
+        self.is_identity_authorized(id).await
     }
 }

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -45,7 +45,6 @@ nix = "0.26"
 once_cell = { version = "1", optional = true, default-features = false }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
-rust-embed = "6"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 sysinfo = "0.29"

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -77,11 +77,7 @@ impl<'a> BareCloudRequestWrapper<'a> {
 }
 
 mod node {
-    use std::time::Duration;
-
     use minicbor::Encode;
-    use rust_embed::EmbeddedFile;
-
     use ockam::identity::{IdentityIdentifier, SecureChannelOptions, TrustIdentifierPolicy};
     use ockam_core::api::RequestBuilder;
     use ockam_core::compat::str::FromStr;
@@ -90,11 +86,11 @@ mod node {
     use ockam_multiaddr::MultiAddr;
     use ockam_node::api::request_with_options;
     use ockam_node::{Context, MessageSendReceiveOptions, DEFAULT_TIMEOUT};
+    use std::time::Duration;
 
     use crate::cloud::OCKAM_CONTROLLER_IDENTITY_ID;
     use crate::error::ApiError;
     use crate::nodes::{NodeManager, NodeManagerWorker};
-    use crate::StaticFiles;
 
     impl NodeManager {
         /// Load controller identity id from file.
@@ -106,18 +102,7 @@ mod node {
                 trace!(idt = %idt, "Read controller identity id from env");
                 return Ok(idt);
             }
-            match StaticFiles::get("controller.id") {
-                Some(EmbeddedFile { data, .. }) => {
-                    let s = core::str::from_utf8(data.as_ref()).map_err(|err| {
-                        ApiError::generic(&format!("Failed to parse controller identity id: {err}"))
-                    })?;
-                    trace!(idt = %s, "Read controller identity id from file");
-                    Ok(IdentityIdentifier::from_str(s)?)
-                }
-                None => Err(ApiError::generic(
-                    "Failed to import controller identity id from file",
-                )),
-            }
+            IdentityIdentifier::from_str(include_str!("../../static/controller.id"))
         }
 
         /// Return controller identity's identifier.

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -20,8 +20,8 @@ use crate::port_range::PortRange;
 
 type BrokerId = i32;
 
-/// Shared structure for every kafka worker to keep track of which brokers are being proxied
-/// with the relative inlet listener socket address.
+/// Shared structure for every kafka worker (consumer or producer services)
+/// to keep track of which brokers are being proxied with the relative inlet listener socket address.
 /// Also takes care of creating inlets dynamically when they are not present yet.
 #[derive(Debug, Clone)]
 pub(crate) struct KafkaInletController {
@@ -34,14 +34,14 @@ struct KafkaInletMapInner {
     port_range: PortRange,
     current_port: u16,
     bind_ip: IpAddr,
-    project_multiaddr: MultiAddr,
+    outlet_node_multiaddr: MultiAddr,
     local_interceptor_route: Route,
     remote_interceptor_route: Route,
 }
 
 impl KafkaInletController {
     pub(crate) fn new(
-        project_multiaddr: MultiAddr,
+        outlet_node_multiaddr: MultiAddr,
         local_interceptor_route: Route,
         remote_interceptor_route: Route,
         bind_ip: IpAddr,
@@ -49,7 +49,7 @@ impl KafkaInletController {
     ) -> KafkaInletController {
         Self {
             inner: Arc::new(Mutex::new(KafkaInletMapInner {
-                project_multiaddr,
+                outlet_node_multiaddr,
                 broker_map: HashMap::new(),
                 current_port: port_range.start(),
                 port_range,
@@ -91,7 +91,7 @@ impl KafkaInletController {
             Self::request_inlet_creation(
                 context,
                 socket_address,
-                inner.project_multiaddr.clone(),
+                inner.outlet_node_multiaddr.clone(),
                 inner.local_interceptor_route.clone(),
                 route![
                     inner.remote_interceptor_route.clone(),

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -32,10 +32,8 @@ mod test {
     use ockam::Context;
     use ockam_core::async_trait;
     use ockam_core::compat::sync::Arc;
-    use ockam_core::flow_control::FlowControlPolicy;
     use ockam_core::route;
     use ockam_core::Address;
-    use ockam_identity::SecureChannelListenerOptions;
     use ockam_multiaddr::proto::Service;
     use ockam_multiaddr::MultiAddr;
     use ockam_node::compat::tokio;
@@ -47,9 +45,7 @@ mod test {
     use crate::kafka::{
         KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
     };
-    use crate::nodes::registry::KafkaServiceKind;
     use crate::test_utils::NodeManagerHandle;
-    use crate::DefaultAddress;
 
     //TODO: upgrade to 13 by adding a metadata request to map uuid<=>topic_name
     const TEST_KAFKA_API_VERSION: i16 = 12;
@@ -70,42 +66,16 @@ mod test {
 
     async fn create_kafka_service(
         context: &Context,
-        handle: &NodeManagerHandle,
+        handler: &NodeManagerHandle,
         listener_address: Address,
         outlet_address: Address,
-        kind: KafkaServiceKind,
     ) -> ockam::Result<u16> {
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new_extended(
-            handle.secure_channels.clone(),
+            handler.secure_channels.clone(),
             MultiAddr::try_from("/service/api")?,
             HopForwarderCreator {},
+            "test_trust_context_id".to_string(),
         );
-
-        //the possibility to accept secure channels is the only real
-        //difference between consumer and producer
-        if let KafkaServiceKind::Consumer = kind {
-            secure_channel_controller
-                .create_consumer_listener(context)
-                .await?;
-
-            let options = SecureChannelListenerOptions::new();
-            context.flow_controls().add_consumer(
-                crate::kafka::KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS,
-                &options.spawner_flow_control_id(),
-                FlowControlPolicy::SpawnerAllowMultipleMessages,
-            );
-
-            // in a normal setup the secure channel listener is already created
-            handle
-                .secure_channels
-                .create_secure_channel_listener(
-                    context,
-                    &handle.identifier,
-                    DefaultAddress::SECURE_CHANNEL_LISTENER,
-                    options,
-                )
-                .await?;
-        }
 
         let mut interceptor_multiaddr = MultiAddr::default();
         interceptor_multiaddr.push_back(Service::new(listener_address.address()))?;
@@ -118,7 +88,7 @@ mod test {
             (0, 0).try_into().unwrap(),
         );
 
-        let (socket_address, _) = handle
+        let (socket_address, _) = handler
             .tcp
             .create_inlet(
                 "127.0.0.1:0",
@@ -150,7 +120,6 @@ mod test {
             &handler,
             "kafka_consumer_listener".into(),
             "kafka_consumer_outlet".into(),
-            KafkaServiceKind::Consumer,
         )
         .await?;
 
@@ -159,7 +128,6 @@ mod test {
             &handler,
             "kafka_producer_listener".into(),
             "kafka_producer_outlet".into(),
-            KafkaServiceKind::Producer,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -200,6 +200,10 @@ mod test {
                 TcpOutletOptions::new(),
             )
             .await?;
+
+        // give the secure channel between producer and consumer to finish initialization
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
         let plain_fetch_response = simulate_kafka_consumer_and_read_response(
             consumer_bootstrap_port,
             &mut consumer_mock_kafka,

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -4,20 +4,22 @@
 mod inlet_controller;
 mod integration_test;
 mod length_delimited;
+mod outlet_controller;
+mod outlet_service;
 mod portal_listener;
 mod portal_worker;
 mod protocol_aware;
 mod secure_channel_map;
 
 pub(crate) use inlet_controller::KafkaInletController;
+pub(crate) use outlet_service::prefix_forwarder::PrefixForwarderService;
+pub(crate) use outlet_service::OutletManagerService;
 pub(crate) use portal_listener::KafkaPortalListener;
 pub(crate) use secure_channel_map::KafkaSecureChannelControllerImpl;
 
-pub const ORCHESTRATOR_KAFKA_CONSUMERS: &str = "kafka_consumers";
-pub const ORCHESTRATOR_KAFKA_INTERCEPTOR_ADDRESS: &str = "kafka_interceptor";
-pub const ORCHESTRATOR_KAFKA_BOOTSTRAP_ADDRESS: &str = "kafka_bootstrap";
-
-pub const KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS: &str = "kafka_secure_channel_controller";
+pub const KAFKA_OUTLET_CONSUMERS: &str = "kafka_consumers";
+pub const KAFKA_OUTLET_INTERCEPTOR_ADDRESS: &str = "kafka_interceptor";
+pub const KAFKA_OUTLET_BOOTSTRAP_ADDRESS: &str = "kafka_bootstrap";
 
 pub fn kafka_outlet_address(broker_id: i32) -> String {
     format!("kafka_outlet_{}", broker_id)

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
@@ -1,0 +1,97 @@
+use crate::kafka::kafka_outlet_address;
+use crate::nodes::models::portal::{CreateOutlet, OutletStatus};
+use crate::nodes::NODEMANAGER_ADDR;
+use minicbor::Decoder;
+use ockam::compat::tokio::sync::Mutex;
+use ockam_core::api::{Request, Response, Status};
+use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::Arc;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{route, Error};
+use ockam_core::{Address, Result};
+use ockam_node::Context;
+
+type BrokerId = i32;
+
+/// Shared structure for every kafka worker (in the outlet service)
+/// to keep track of which brokers are being proxied with the relative outlet socket address.
+/// Also takes care of creating outlet dynamically when they are not present yet.
+#[derive(Debug, Clone)]
+pub(crate) struct KafkaOutletController {
+    inner: Arc<Mutex<KafkaOutletMapInner>>,
+}
+
+#[derive(Debug)]
+struct KafkaOutletMapInner {
+    broker_map: HashMap<BrokerId, String>,
+}
+
+impl KafkaOutletController {
+    pub(crate) fn new() -> KafkaOutletController {
+        Self {
+            inner: Arc::new(Mutex::new(KafkaOutletMapInner {
+                broker_map: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Asserts the presence of an outlet for a specific broker
+    /// on first time it'll create the inlet and return the relative address
+    /// on the second one it'll just return the address
+    pub(crate) async fn assert_outlet_for_broker(
+        &self,
+        context: &Context,
+        broker_id: BrokerId,
+        tcp_address: String,
+    ) -> Result<Address> {
+        let outlet_address = kafka_outlet_address(broker_id);
+        let mut inner = self.inner.lock().await;
+        if !inner.broker_map.contains_key(&broker_id) {
+            let tcp_address = Self::request_outlet_creation(
+                context,
+                tcp_address,
+                kafka_outlet_address(broker_id),
+            )
+            .await?;
+            inner.broker_map.insert(broker_id, tcp_address);
+        }
+        Ok(outlet_address.into())
+    }
+
+    async fn request_outlet_creation(
+        context: &Context,
+        tcp_address: String,
+        worker_address: String,
+    ) -> Result<String> {
+        let buffer: Vec<u8> = context
+            .send_and_receive(
+                route![NODEMANAGER_ADDR],
+                Request::post("/node/outlet")
+                    .body(CreateOutlet::new(tcp_address, worker_address, None, false))
+                    .to_vec()?,
+            )
+            .await?;
+
+        let mut decoder = Decoder::new(&buffer);
+        let response: Response = decoder.decode()?;
+
+        let status = response.status().unwrap_or(Status::InternalServerError);
+        if status != Status::Ok {
+            return Err(Error::new(
+                Origin::Transport,
+                Kind::Invalid,
+                format!("cannot create outlet: {}", status),
+            ));
+        }
+        if !response.has_body() {
+            Err(Error::new(
+                Origin::Transport,
+                Kind::Unknown,
+                "invalid create outlet response",
+            ))
+        } else {
+            let status: OutletStatus = decoder.decode()?;
+            Ok(status.tcp_addr.to_string())
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
@@ -1,0 +1,139 @@
+use crate::kafka::outlet_controller::KafkaOutletController;
+use crate::kafka::portal_worker::KafkaPortalWorker;
+use crate::kafka::protocol_aware::OutletInterceptorImpl;
+use crate::kafka::{KAFKA_OUTLET_BOOTSTRAP_ADDRESS, KAFKA_OUTLET_INTERCEPTOR_ADDRESS};
+use ockam::{Any, Context, Result, Routed, Worker};
+use ockam_abac::AbacAccessControl;
+use ockam_core::flow_control::{
+    FlowControlId, FlowControlOutgoingAccessControl, FlowControlPolicy, FlowControls,
+};
+use ockam_core::Address;
+use ockam_identity::{SecureChannels, TRUST_CONTEXT_ID};
+use ockam_node::WorkerBuilder;
+use std::sync::Arc;
+
+/// This service handles the central component which is responsible for creating connections
+/// to the kafka cluster as well as act as a relay for consumers.
+/// Normally this services is hosted by the Orchestrator (with a different implementation),
+/// this implementation was created to allow local usage.
+pub(crate) struct OutletManagerService {
+    outlet_controller: KafkaOutletController,
+    incoming_access_control: Arc<AbacAccessControl>,
+    flow_control_id: FlowControlId,
+    spawner_flow_control_id: FlowControlId,
+    outgoing_access_control: Arc<FlowControlOutgoingAccessControl>,
+}
+
+impl OutletManagerService {
+    pub(crate) async fn create(
+        context: &Context,
+        secure_channels: Arc<SecureChannels>,
+        trust_context_id: &str,
+        default_secure_channel_listener_flow_control_id: FlowControlId,
+    ) -> Result<()> {
+        let flow_controls = context.flow_controls();
+
+        let worker_address = Address::from_string(KAFKA_OUTLET_INTERCEPTOR_ADDRESS);
+        flow_controls.add_consumer(
+            worker_address.clone(),
+            &default_secure_channel_listener_flow_control_id,
+            FlowControlPolicy::SpawnerAllowMultipleMessages,
+        );
+
+        let flow_control_id = FlowControls::generate_id();
+        let spawner_flow_control_id = FlowControls::generate_id();
+
+        flow_controls.add_spawner(worker_address.clone(), &spawner_flow_control_id);
+
+        // add the default outlet as consumer for the interceptor
+        flow_controls.add_consumer(
+            KAFKA_OUTLET_BOOTSTRAP_ADDRESS,
+            &flow_control_id,
+            FlowControlPolicy::ProducerAllowMultiple,
+        );
+
+        let worker = OutletManagerService {
+            outlet_controller: KafkaOutletController::new(),
+            incoming_access_control: Arc::new(AbacAccessControl::create(
+                secure_channels.identities().repository(),
+                TRUST_CONTEXT_ID,
+                trust_context_id,
+            )),
+            flow_control_id: flow_control_id.clone(),
+            outgoing_access_control: Arc::new(FlowControlOutgoingAccessControl::new(
+                flow_controls,
+                flow_control_id.clone(),
+                Some(spawner_flow_control_id.clone()),
+            )),
+            spawner_flow_control_id,
+        };
+
+        let incoming = worker.incoming_access_control.clone();
+        let outgoing = worker.outgoing_access_control.clone();
+        WorkerBuilder::new(worker)
+            .with_address(worker_address)
+            .with_incoming_access_control_arc(incoming)
+            .with_outgoing_access_control_arc(outgoing)
+            .start(context)
+            .await
+            .map(|_| ())
+    }
+}
+
+#[ockam::worker]
+impl Worker for OutletManagerService {
+    type Message = Any;
+    type Context = Context;
+
+    async fn handle_message(
+        &mut self,
+        context: &mut Context,
+        message: Routed<Self::Message>,
+    ) -> Result<()> {
+        let source_address = message.src_addr();
+        let mut message = message.into_local_message();
+
+        // Remove our address
+        message.transport_mut().onward_route.step()?;
+        let onward_route = message.transport().onward_route.clone();
+
+        // Retrieve the flow id from the previous hop if it exists
+        let secure_channel_flow_control_id = context
+            .flow_controls()
+            .find_flow_control_with_producer_address(&source_address)
+            .map(|x| x.flow_control_id().clone());
+
+        let worker_address = KafkaPortalWorker::create_outlet_side_kafka_portal(
+            context,
+            None,
+            onward_route,
+            Arc::new(OutletInterceptorImpl::new(
+                self.outlet_controller.clone(),
+                self.flow_control_id.clone(),
+            )),
+            &context.flow_controls().clone(),
+            secure_channel_flow_control_id,
+            Some(self.flow_control_id.clone()),
+            Some(self.spawner_flow_control_id.clone()),
+            self.incoming_access_control.clone(),
+            self.outgoing_access_control.clone(),
+        )
+        .await?;
+
+        message
+            .transport_mut()
+            .onward_route
+            .modify()
+            .prepend(worker_address.clone());
+
+        trace!(
+            "forwarding message: onward={:?}; return={:?}; worker={:?}",
+            &message.transport().onward_route,
+            &message.transport().return_route,
+            worker_address
+        );
+
+        context.forward(message).await?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/mod.rs
@@ -1,0 +1,4 @@
+mod interceptor_listener;
+pub(crate) mod prefix_forwarder;
+
+pub(crate) use interceptor_listener::OutletManagerService;

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/prefix_forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/prefix_forwarder.rs
@@ -1,0 +1,107 @@
+use crate::kafka::KAFKA_OUTLET_CONSUMERS;
+
+use crate::DefaultAddress;
+use core::str::from_utf8;
+use ockam::{Context, Result, Routed, Worker};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::flow_control::{FlowControlId, FlowControlPolicy};
+use ockam_core::{Address, AllowAll, AllowOnwardAddress};
+
+/// This service applies a prefix to the provided static forwarding address.
+/// This service was created mainly to keep full compatibility with the existing
+/// erlang implementation.
+pub struct PrefixForwarderService {
+    prefix: String,
+    secure_channel_listener_flow_control_id: FlowControlId,
+}
+impl PrefixForwarderService {
+    pub async fn create(
+        context: &Context,
+        secure_channel_listener_flow_control_id: FlowControlId,
+    ) -> Result<()> {
+        // add the this worker as consumer for the secure channel listener
+        let worker_address = Address::from_string(KAFKA_OUTLET_CONSUMERS);
+        context.flow_controls().add_consumer(
+            worker_address.clone(),
+            &secure_channel_listener_flow_control_id,
+            FlowControlPolicy::SpawnerAllowMultipleMessages,
+        );
+
+        let worker = Self {
+            prefix: "consumer_".to_string(),
+            secure_channel_listener_flow_control_id,
+        };
+
+        context
+            .start_worker_with_access_control(
+                worker_address,
+                worker,
+                AllowAll,
+                AllowOnwardAddress(DefaultAddress::FORWARDING_SERVICE.into()),
+            )
+            .await
+    }
+}
+
+#[ockam::worker]
+impl Worker for PrefixForwarderService {
+    type Message = Vec<u8>;
+    type Context = Context;
+
+    async fn handle_message(
+        &mut self,
+        ctx: &mut Context,
+        msg: Routed<Self::Message>,
+    ) -> Result<()> {
+        // the payload is just a string
+        let address = match msg.payload().get(1..) {
+            Some(address) => match from_utf8(address) {
+                Ok(v) => v.to_string(),
+                Err(_e) => {
+                    return Err(ockam_core::Error::new(
+                        Origin::Application,
+                        Kind::Invalid,
+                        "invalid address",
+                    ));
+                }
+            },
+            None => {
+                return Err(ockam_core::Error::new(
+                    Origin::Application,
+                    Kind::Invalid,
+                    "invalid address",
+                ));
+            }
+        };
+
+        let new_address = format!("{}_{}", &self.prefix, address);
+
+        debug!(
+            "prefix forwarder, renamed from {} to {}",
+            address, new_address
+        );
+
+        let mut bytes = new_address.clone().into_bytes();
+        let mut new_payload: Vec<u8> = vec![bytes.len() as u8];
+        new_payload.append(&mut bytes);
+
+        let mut message = msg.into_local_message();
+        let transport_message = message.transport_mut();
+
+        transport_message.onward_route.step()?;
+
+        // prefix consumer_ to the address
+        transport_message.payload = new_payload;
+
+        ctx.forward(message).await?;
+
+        // The new forwarder needs to be reachable by the default secure channel listener
+        ctx.flow_controls().add_consumer(
+            Address::from_string(new_address),
+            &self.secure_channel_listener_flow_control_id,
+            FlowControlPolicy::SpawnerAllowMultipleMessages,
+        );
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
@@ -43,7 +43,7 @@ impl Worker for KafkaPortalListener {
 
         let inlet_responder_address = message.transport().return_route.next()?.clone();
 
-        let worker_address = KafkaPortalWorker::start_kafka_portal(
+        let worker_address = KafkaPortalWorker::create_inlet_side_kafka_portal(
             context,
             self.secure_channel_controller.clone(),
             self.uuid_to_name.clone(),

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
@@ -1,0 +1,184 @@
+use crate::kafka::outlet_controller::KafkaOutletController;
+use alloc::sync::Arc;
+use bytes::BytesMut;
+
+use kafka_protocol::messages::request_header::RequestHeader;
+use kafka_protocol::messages::{ApiKey, MetadataResponse, ResponseHeader};
+use kafka_protocol::protocol::buf::ByteBuf;
+use kafka_protocol::protocol::Decodable;
+
+use ockam_core::async_trait;
+use ockam_core::compat::collections::HashMap;
+use ockam_core::compat::sync::Mutex;
+use ockam_node::Context;
+use std::convert::TryFrom;
+use std::io::{Error, ErrorKind};
+
+use ockam_core::flow_control::{FlowControlId, FlowControlPolicy};
+use tinyvec::alloc;
+use tracing::warn;
+
+use crate::kafka::portal_worker::InterceptError;
+use crate::kafka::protocol_aware::utils::decode_body;
+use crate::kafka::protocol_aware::{CorrelationId, KafkaMessageInterceptor, RequestInfo};
+
+/// Intercepts responses of type `Metadata` to extract the list of brokers
+/// then creates an outlet for each of them through [`KafkaOutletController`]
+#[derive(Clone)]
+pub(crate) struct OutletInterceptorImpl {
+    request_map: Arc<Mutex<HashMap<CorrelationId, RequestInfo>>>,
+    outlet_controller: KafkaOutletController,
+    flow_control_id: FlowControlId,
+}
+
+impl OutletInterceptorImpl {
+    pub(crate) fn new(
+        outlet_controller: KafkaOutletController,
+        flow_control_id: FlowControlId,
+    ) -> Self {
+        Self {
+            request_map: Arc::new(Mutex::new(HashMap::new())),
+            outlet_controller,
+            flow_control_id,
+        }
+    }
+}
+
+#[async_trait]
+impl KafkaMessageInterceptor for OutletInterceptorImpl {
+    async fn intercept_request(
+        &self,
+        _context: &mut Context,
+        mut original: BytesMut,
+    ) -> Result<BytesMut, InterceptError> {
+        let mut buffer = original.peek_bytes(0..original.len());
+
+        let api_key_num = buffer
+            .peek_bytes(0..2)
+            .try_get_i16()
+            .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
+
+        let api_key = ApiKey::try_from(api_key_num).map_err(|_| {
+            warn!("unknown request api: {api_key_num}");
+            InterceptError::Io(Error::from(ErrorKind::InvalidData))
+        })?;
+
+        let version = buffer
+            .peek_bytes(2..4)
+            .try_get_i16()
+            .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
+
+        let result = RequestHeader::decode(&mut buffer, api_key.request_header_version(version));
+        let header = match result {
+            Ok(header) => header,
+            Err(_) => {
+                //the error doesn't contain any useful information
+                warn!("cannot decode request kafka header");
+                return Err(InterceptError::Io(Error::from(ErrorKind::InvalidData)));
+            }
+        };
+
+        let api_key = ApiKey::try_from(api_key_num).map_err(|_| {
+            warn!("unknown request api: {api_key_num}");
+            InterceptError::Io(Error::from(ErrorKind::InvalidData))
+        })?;
+
+        debug!(
+            "request: length: {}, correlation {}, version {}, api {:?}",
+            buffer.len(),
+            header.correlation_id,
+            header.request_api_version,
+            api_key
+        );
+
+        if api_key == ApiKey::MetadataKey {
+            self.request_map.lock().unwrap().insert(
+                header.correlation_id,
+                RequestInfo {
+                    request_api_key: ApiKey::MetadataKey,
+                    request_api_version: header.request_api_version,
+                },
+            );
+        }
+
+        Ok(original)
+    }
+
+    async fn intercept_response(
+        &self,
+        context: &mut Context,
+        mut original: BytesMut,
+    ) -> Result<BytesMut, InterceptError> {
+        let mut buffer = original.peek_bytes(0..original.len());
+
+        //we can/need to decode only mapped requests
+        let correlation_id = buffer
+            .peek_bytes(0..4)
+            .try_get_i32()
+            .map_err(|_| InterceptError::Io(Error::from(ErrorKind::InvalidData)))?;
+
+        let result = self
+            .request_map
+            .lock()
+            .unwrap()
+            .get(&correlation_id)
+            .cloned();
+
+        if let Some(request_info) = result {
+            let result = ResponseHeader::decode(
+                &mut buffer,
+                request_info
+                    .request_api_key
+                    .response_header_version(request_info.request_api_version),
+            );
+
+            let _header = match result {
+                Ok(header) => header,
+                Err(_) => {
+                    //the error doesn't contain any useful information
+                    warn!("cannot decode response kafka header");
+                    return Err(InterceptError::Io(Error::from(ErrorKind::InvalidData)));
+                }
+            };
+
+            debug!(
+                "response: length: {}, correlation {}, version {}, api {:?}",
+                buffer.len(),
+                correlation_id,
+                request_info.request_api_version,
+                request_info.request_api_key
+            );
+
+            if request_info.request_api_key == ApiKey::MetadataKey {
+                let response: MetadataResponse =
+                    decode_body(&mut buffer, request_info.request_api_version)?;
+
+                for (broker_id, metadata) in response.brokers {
+                    let outlet_address = self
+                        .outlet_controller
+                        .assert_outlet_for_broker(
+                            context,
+                            broker_id.0,
+                            format!("{}:{}", metadata.host, metadata.port),
+                        )
+                        .await
+                        .map_err(InterceptError::Ockam)?;
+
+                    // allow the interceptor to reach the outlet
+                    context.flow_controls().add_consumer(
+                        outlet_address,
+                        &self.flow_control_id,
+                        FlowControlPolicy::ProducerAllowMultiple,
+                    );
+                }
+            }
+        } else {
+            debug!(
+                "response unmapped: length: {}, correlation {}",
+                buffer.len(),
+                correlation_id,
+            );
+        }
+        Ok(original)
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
@@ -1,4 +1,7 @@
-use crate::kafka::secure_channel_map::{KafkaSecureChannelController, UniqueSecureChannelId};
+use crate::kafka::portal_worker::InterceptError;
+use crate::kafka::secure_channel_map::KafkaSecureChannelController;
+use crate::kafka::KafkaInletController;
+use bytes::BytesMut;
 use kafka_protocol::messages::ApiKey;
 use minicbor::{Decode, Encode};
 use ockam_core::compat::{
@@ -6,14 +9,19 @@ use ockam_core::compat::{
     fmt::Debug,
     sync::{Arc, Mutex},
 };
-use ockam_core::AsyncTryClone;
+use ockam_core::{async_trait, Address};
+
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use ockam_node::Context;
 
+mod metadata_interceptor;
 mod request;
 mod response;
 mod tests;
+
 pub(super) mod utils;
+pub(crate) use metadata_interceptor::OutletInterceptorImpl;
 
 #[derive(Clone, Debug)]
 struct RequestInfo {
@@ -27,11 +35,46 @@ type CorrelationId = i32;
 /// only from one connection
 pub(super) type TopicUuidMap = Arc<Mutex<HashMap<String, String>>>;
 
-#[derive(AsyncTryClone)]
-pub(crate) struct Interceptor {
+#[async_trait]
+pub(crate) trait KafkaMessageInterceptor: Send + Sync + 'static {
+    async fn intercept_request(
+        &self,
+        context: &mut Context,
+        original: BytesMut,
+    ) -> Result<BytesMut, InterceptError>;
+
+    async fn intercept_response(
+        &self,
+        context: &mut Context,
+        original: BytesMut,
+    ) -> Result<BytesMut, InterceptError>;
+}
+
+#[derive(Clone)]
+pub(crate) struct InletInterceptorImpl {
     request_map: Arc<Mutex<HashMap<CorrelationId, RequestInfo>>>,
     uuid_to_name: TopicUuidMap,
     secure_channel_controller: Arc<dyn KafkaSecureChannelController>,
+    inlet_map: KafkaInletController,
+}
+
+#[async_trait]
+impl KafkaMessageInterceptor for InletInterceptorImpl {
+    async fn intercept_request(
+        &self,
+        context: &mut Context,
+        original: BytesMut,
+    ) -> Result<BytesMut, InterceptError> {
+        self.intercept_request_impl(context, original).await
+    }
+
+    async fn intercept_response(
+        &self,
+        context: &mut Context,
+        original: BytesMut,
+    ) -> Result<BytesMut, InterceptError> {
+        self.intercept_response_impl(context, original).await
+    }
 }
 
 #[derive(Debug, Clone, Decode, Encode)]
@@ -40,20 +83,22 @@ pub(crate) struct Interceptor {
 ///Wraps the content within every record batch
 struct MessageWrapper {
     #[cfg(feature = "tag")]
-    #[n(0)] tag: TypeTag<1652220>,
-    #[b(1)] secure_channel_identifier: UniqueSecureChannelId,
+    #[n(0)] tag: TypeTag<1652221>,
+    #[b(1)] consumer_decryptor_address: Address,
     #[b(2)] content: Vec<u8>
 }
 
-impl Interceptor {
+impl InletInterceptorImpl {
     pub(crate) fn new(
         secure_channel_controller: Arc<dyn KafkaSecureChannelController>,
         uuid_to_name: TopicUuidMap,
-    ) -> Interceptor {
+        inlet_map: KafkaInletController,
+    ) -> InletInterceptorImpl {
         Self {
             request_map: Arc::new(Mutex::new(Default::default())),
             uuid_to_name,
             secure_channel_controller,
+            inlet_map,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
@@ -18,12 +18,12 @@ use tracing::warn;
 
 use crate::kafka::portal_worker::InterceptError;
 use crate::kafka::protocol_aware::utils::{decode_body, encode_request};
-use crate::kafka::protocol_aware::{Interceptor, MessageWrapper, RequestInfo};
+use crate::kafka::protocol_aware::{InletInterceptorImpl, MessageWrapper, RequestInfo};
 
-impl Interceptor {
+impl InletInterceptorImpl {
     ///Parse request and map request <=> response
     /// fails if anything in the parsing fails to avoid leaking clear text payloads
-    pub(crate) async fn intercept_request(
+    pub(crate) async fn intercept_request_impl(
         &self,
         context: &mut Context,
         mut original: BytesMut,
@@ -188,7 +188,8 @@ impl Interceptor {
                             let wrapper = MessageWrapper {
                                 #[cfg(feature = "tag")]
                                 tag: TypeTag,
-                                secure_channel_identifier: encrypted_content.secure_channel_id,
+                                consumer_decryptor_address: encrypted_content
+                                    .consumer_decryptor_address,
                                 content: encrypted_content.content,
                             };
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -1,32 +1,33 @@
-use crate::kafka::{KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS, ORCHESTRATOR_KAFKA_CONSUMERS};
+use crate::kafka::KAFKA_OUTLET_CONSUMERS;
 use crate::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
 use crate::nodes::models::secure_channel::{
     CreateSecureChannelRequest, CreateSecureChannelResponse, CredentialExchangeMode,
+    DeleteSecureChannelRequest, DeleteSecureChannelResponse,
 };
 use crate::nodes::NODEMANAGER_ADDR;
 use crate::DefaultAddress;
 use minicbor::Decoder;
+use ockam_abac::AbacAccessControl;
 use ockam_core::api::{Request, Response, Status};
 use ockam_core::compat::collections::{HashMap, HashSet};
 use ockam_core::compat::sync::Arc;
 use ockam_core::errcode::{Kind, Origin};
-use ockam_core::Message;
-use ockam_core::{async_trait, route, Address, Error, Result, Routed, Worker};
+use ockam_core::{async_trait, route, Address, Error, Result};
 use ockam_identity::{
     DecryptionRequest, DecryptionResponse, EncryptionRequest, EncryptionResponse,
-    SecureChannelRegistryEntry, SecureChannels,
+    SecureChannelRegistryEntry, SecureChannels, TRUST_CONTEXT_ID,
 };
 use ockam_multiaddr::proto::Service;
 use ockam_multiaddr::MultiAddr;
 use ockam_node::compat::tokio::sync::Mutex;
+use ockam_node::compat::tokio::sync::MutexGuard;
 use ockam_node::Context;
-use serde::{Deserialize, Serialize};
 
 pub(crate) struct KafkaEncryptedContent {
     /// The encrypted content
     pub(crate) content: Vec<u8>,
-    /// The secure channel id used to encrypt the content
-    pub(crate) secure_channel_id: UniqueSecureChannelId,
+    /// The secure channel identifier used to encrypt the content
+    pub(crate) consumer_decryptor_address: Address,
 }
 
 /// Offer simple APIs to encrypt and decrypt kafka messages.
@@ -52,12 +53,12 @@ pub(crate) trait KafkaSecureChannelController: Send + Sync {
         content: Vec<u8>,
     ) -> Result<KafkaEncryptedContent>;
 
-    /// Decrypts the content based on the unique secure channel identifier
+    /// Decrypts the content based on the consumer decryptor address
     /// the secure channel is expected to be already initialized.
     async fn decrypt_content_for(
         &self,
         context: &mut Context,
-        secure_channel_id: UniqueSecureChannelId,
+        consumer_decryptor_address: &Address,
         encrypted_content: Vec<u8>,
     ) -> Result<Vec<u8>>;
 
@@ -87,11 +88,17 @@ impl NodeManagerForwarderCreator {
         forwarder_service: MultiAddr,
         alias: String,
     ) -> Result<()> {
+        let is_rust = true;
         let buffer: Vec<u8> = context
             .send_and_receive(
                 route![NODEMANAGER_ADDR],
                 Request::post("/node/forwarder")
-                    .body(CreateForwarder::at_project(forwarder_service, Some(alias)))
+                    .body(CreateForwarder::at_node(
+                        forwarder_service,
+                        Some(alias),
+                        is_rust,
+                        None,
+                    ))
                     .to_vec()?,
             )
             .await?;
@@ -131,14 +138,6 @@ impl ForwarderCreator for NodeManagerForwarderCreator {
     }
 }
 
-///Unique identifier for a specific secure_channel.
-/// Used in order to distinguish between secure channels created between
-/// the same identities.
-#[derive(Debug, Clone, Serialize, Deserialize, Message)]
-struct SecureChannelIdentifierMessage {
-    secure_channel_identifier: UniqueSecureChannelId,
-}
-
 pub(crate) struct KafkaSecureChannelControllerImpl<F: ForwarderCreator> {
     inner: Arc<Mutex<InnerSecureChannelControllerImpl<F>>>,
 }
@@ -152,35 +151,35 @@ impl<F: ForwarderCreator> Clone for KafkaSecureChannelControllerImpl<F> {
     }
 }
 
-/// An identifier of the secure channel **instance**
-pub(crate) type UniqueSecureChannelId = u64;
 type TopicPartition = (String, i32);
 struct InnerSecureChannelControllerImpl<F: ForwarderCreator> {
-    //we are using encryptor api address as unique _local_ identifier
-    //of the secure channel
-    id_encryptor_map: HashMap<UniqueSecureChannelId, Address>,
-    topic_encryptor_map: HashMap<TopicPartition, (UniqueSecureChannelId, Address)>,
-    project_multiaddr: MultiAddr,
+    // we identity the secure channel instance by using the decryptor of the consumer
+    // which is known to both parties
+    topic_encryptor_map: HashMap<TopicPartition, Address>,
+    outlet_node_multiaddr: MultiAddr,
     topic_forwarder_set: HashSet<TopicPartition>,
     forwarder_creator: F,
     secure_channels: Arc<SecureChannels>,
+    access_control: AbacAccessControl,
 }
 
 impl KafkaSecureChannelControllerImpl<NodeManagerForwarderCreator> {
     pub(crate) fn new(
         secure_channels: Arc<SecureChannels>,
-        project_multiaddr: MultiAddr,
+        outlet_node_multiaddr: MultiAddr,
+        trust_context_id: String,
     ) -> KafkaSecureChannelControllerImpl<NodeManagerForwarderCreator> {
-        let mut orchestrator_multiaddr = project_multiaddr.clone();
+        let mut orchestrator_multiaddr = outlet_node_multiaddr.clone();
         orchestrator_multiaddr
-            .push_back(Service::new(ORCHESTRATOR_KAFKA_CONSUMERS))
+            .push_back(Service::new(KAFKA_OUTLET_CONSUMERS))
             .unwrap();
         Self::new_extended(
             secure_channels,
-            project_multiaddr,
+            outlet_node_multiaddr,
             NodeManagerForwarderCreator {
                 orchestrator_multiaddr,
             },
+            trust_context_id,
         )
     }
 }
@@ -189,68 +188,30 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
     /// to manually specify `ForwarderCreator`, for testing purposes
     pub(crate) fn new_extended(
         secure_channels: Arc<SecureChannels>,
-        project_multiaddr: MultiAddr,
+        outlet_node_multiaddr: MultiAddr,
         forwarder_creator: F,
+        trust_context_id: String,
     ) -> KafkaSecureChannelControllerImpl<F> {
+        let access_control = AbacAccessControl::create(
+            secure_channels.identities().repository(),
+            TRUST_CONTEXT_ID,
+            &trust_context_id,
+        );
+
         Self {
             inner: Arc::new(Mutex::new(InnerSecureChannelControllerImpl {
-                id_encryptor_map: Default::default(),
                 topic_encryptor_map: Default::default(),
                 topic_forwarder_set: Default::default(),
                 secure_channels,
                 forwarder_creator,
-                project_multiaddr,
+                outlet_node_multiaddr,
+                access_control,
             })),
         }
     }
 
-    pub(crate) async fn create_consumer_listener(&self, context: &Context) -> Result<()> {
-        context
-            .start_worker(
-                Address::from_string(KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS),
-                SecureChannelControllerListener::<F> {
-                    controller: self.clone(),
-                },
-            )
-            .await
-    }
-
     pub(crate) fn into_trait(self) -> Arc<dyn KafkaSecureChannelController> {
         Arc::new(self)
-    }
-
-    //add a mapping from remote producer
-    async fn add_mapping(&self, id: UniqueSecureChannelId, encryptor_address: Address) {
-        self.inner
-            .lock()
-            .await
-            .id_encryptor_map
-            .insert(id, encryptor_address);
-    }
-}
-
-struct SecureChannelControllerListener<F: ForwarderCreator> {
-    controller: KafkaSecureChannelControllerImpl<F>,
-}
-
-#[ockam::worker]
-impl<F: ForwarderCreator> Worker for SecureChannelControllerListener<F> {
-    type Message = SecureChannelIdentifierMessage;
-    type Context = Context;
-
-    async fn handle_message(
-        &mut self,
-        context: &mut Self::Context,
-        message: Routed<Self::Message>,
-    ) -> Result<()> {
-        //todo: is there a better way to extract it from the context?
-        let encryptor_address = message.return_route().next().cloned()?;
-
-        self.controller
-            .add_mapping(message.secure_channel_identifier, encryptor_address.clone())
-            .await;
-
-        context.send(message.return_route(), ()).await
     }
 }
 
@@ -266,7 +227,7 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
                     .body(CreateSecureChannelRequest::new(
                         &destination,
                         None,
-                        CredentialExchangeMode::None,
+                        CredentialExchangeMode::Mutual,
                         None,
                         None,
                     ))
@@ -297,15 +258,51 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
         }
     }
 
+    async fn request_secure_channel_deletion(
+        context: &Context,
+        encryptor_address: &Address,
+    ) -> Result<()> {
+        let buffer: Vec<u8> = context
+            .send_and_receive(
+                route![NODEMANAGER_ADDR],
+                Request::delete("/node/secure_channel")
+                    .body(DeleteSecureChannelRequest::new(encryptor_address))
+                    .to_vec()?,
+            )
+            .await?;
+
+        let mut decoder = Decoder::new(&buffer);
+        let response: Response = decoder.decode()?;
+
+        let status = response.status().unwrap_or(Status::InternalServerError);
+        if status != Status::Ok {
+            return Err(Error::new(
+                Origin::Transport,
+                Kind::Invalid,
+                format!("cannot delete secure channel: {}", status),
+            ));
+        }
+        if !response.has_body() {
+            Err(Error::new(
+                Origin::Transport,
+                Kind::Unknown,
+                "invalid delete secure channel response",
+            ))
+        } else {
+            let _secure_channel_response: DeleteSecureChannelResponse = decoder.decode()?;
+            Ok(())
+        }
+    }
+
     ///returns encryptor api address
     async fn get_or_create_secure_channel_for(
         &self,
         context: &mut Context,
         topic_name: &str,
         partition: i32,
-    ) -> Result<(UniqueSecureChannelId, SecureChannelRegistryEntry)> {
-        //here we should have the orchestrator address and expect forwarders to be
-        // present in the orchestrator with the format "consumer_{topic_name}_{partition}"
+    ) -> Result<SecureChannelRegistryEntry> {
+        // here we should have the orchestrator address and expect forwarders to be
+        // present in the orchestrator with the format "consumer__{topic_name}_{partition}"
 
         let topic_partition_key = (topic_name.to_string(), partition);
         //consumer__ prefix is added by the orchestrator
@@ -313,46 +310,35 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
 
         let mut inner = self.inner.lock().await;
 
-        let (random_unique_id, encryptor_address) = {
+        let encryptor_address = {
             if let Some(encryptor_address) = inner.topic_encryptor_map.get(&topic_partition_key) {
                 encryptor_address.clone()
             } else {
-                trace!("creating new secure channel to {topic_partition_address}");
+                debug!("creating new secure channel to {topic_partition_address}");
 
-                let mut destination = inner.project_multiaddr.clone();
+                let mut destination = inner.outlet_node_multiaddr.clone();
                 destination.push_back(Service::new(topic_partition_address.clone()))?;
                 destination.push_back(Service::new(DefaultAddress::SECURE_CHANNEL_LISTENER))?;
 
-                let encryptor_address =
+                let producer_encryptor_address =
                     Self::request_secure_channel_creation(context, destination).await?;
 
-                trace!("created secure channel to {topic_partition_address}");
-
-                let random_unique_id: UniqueSecureChannelId = rand::random();
-                inner.topic_encryptor_map.insert(
-                    topic_partition_key,
-                    (random_unique_id, encryptor_address.clone()),
-                );
-
-                let message = SecureChannelIdentifierMessage {
-                    secure_channel_identifier: random_unique_id,
+                match Self::validate_consumer_credentials(&inner, &producer_encryptor_address).await
+                {
+                    Ok(producer_encryptor_address) => producer_encryptor_address,
+                    Err(error) => {
+                        Self::request_secure_channel_deletion(context, &producer_encryptor_address)
+                            .await?;
+                        return Err(error);
+                    }
                 };
 
-                //communicate to the other end the random id associated with this
-                //secure channel, and wait to an empty reply to avoid race conditions
-                //on the order of encryption/decryption of messages
-                context
-                    .send_and_receive(
-                        route![
-                            encryptor_address.clone(),
-                            KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS
-                        ],
-                        message,
-                    )
-                    .await?;
+                inner
+                    .topic_encryptor_map
+                    .insert(topic_partition_key, producer_encryptor_address.clone());
 
-                trace!("assigned id {random_unique_id} to {topic_partition_address}");
-                (random_unique_id, encryptor_address)
+                debug!("created secure channel to {topic_partition_address}");
+                producer_encryptor_address
             }
         };
 
@@ -360,7 +346,6 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
             .secure_channels
             .secure_channel_registry()
             .get_channel_by_encryptor_address(&encryptor_address)
-            .map(|entry| (random_unique_id, entry))
             .ok_or_else(|| {
                 Error::new(
                     Origin::Channel,
@@ -370,35 +355,72 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
             })
     }
 
+    async fn validate_consumer_credentials(
+        inner: &MutexGuard<'_, InnerSecureChannelControllerImpl<F>>,
+        producer_encryptor_address: &Address,
+    ) -> Result<Address> {
+        let record = inner
+            .secure_channels
+            .secure_channel_registry()
+            .get_channel_by_encryptor_address(producer_encryptor_address);
+
+        if let Some(entry) = record {
+            let authorized = inner
+                .access_control
+                .is_identity_authorized(entry.their_id())
+                .await?;
+
+            if authorized {
+                Ok(producer_encryptor_address.clone())
+            } else {
+                Err(Error::new(
+                    Origin::Transport,
+                    Kind::Invalid,
+                    "unauthorized secure channel for consumer",
+                ))
+            }
+        } else {
+            Err(Error::new(
+                Origin::Transport,
+                Kind::Unknown,
+                "cannot find secure channel entry",
+            ))
+        }
+    }
+
     ///return decryptor api address
     async fn get_secure_channel_for(
         &self,
-        secure_channel_id: UniqueSecureChannelId,
+        consumer_decryptor_address: &Address,
     ) -> Result<SecureChannelRegistryEntry> {
         let inner = self.inner.lock().await;
-        if let Some(encryptor_address) = inner.id_encryptor_map.get(&secure_channel_id) {
-            inner
-                .secure_channels
-                .secure_channel_registry()
-                .get_channel_list()
-                .iter()
-                .find(|entry| {
-                    entry.encryptor_messaging_address() == encryptor_address
-                        && !entry.is_initiator()
-                })
-                .cloned()
-                .ok_or_else(|| {
-                    Error::new(
-                        Origin::Channel,
-                        Kind::Unknown,
-                        format!("secure channel no longer exists: {encryptor_address}"),
-                    )
-                })
+        let entry = inner
+            .secure_channels
+            .secure_channel_registry()
+            .get_channel_by_decryptor_address(consumer_decryptor_address)
+            .ok_or_else(|| {
+                Error::new(
+                    Origin::Channel,
+                    Kind::Unknown,
+                    format!(
+                        "secure channel decrypt doesn't exists: {}",
+                        consumer_decryptor_address.address()
+                    ),
+                )
+            })?;
+
+        let authorized = inner
+            .access_control
+            .is_identity_authorized(entry.their_id())
+            .await?;
+
+        if authorized {
+            Ok(entry)
         } else {
             Err(Error::new(
-                Origin::Channel,
-                Kind::Unknown,
-                "missing secure channel",
+                Origin::Transport,
+                Kind::Invalid,
+                "unauthorized secure channel",
             ))
         }
     }
@@ -413,11 +435,13 @@ impl<F: ForwarderCreator> KafkaSecureChannelController for KafkaSecureChannelCon
         partition_id: i32,
         content: Vec<u8>,
     ) -> Result<KafkaEncryptedContent> {
-        let (unique_id, secure_channel_entry) = self
+        let secure_channel_entry = self
             .get_or_create_secure_channel_for(context, topic_name, partition_id)
             .await?;
 
-        trace!("encrypting content with {unique_id}");
+        let consumer_decryptor_address = secure_channel_entry.their_decryptor_address();
+
+        trace!("encrypting content with {consumer_decryptor_address}");
         let encryption_response: EncryptionResponse = context
             .send_and_receive(
                 route![secure_channel_entry.encryptor_api_address().clone()],
@@ -433,20 +457,22 @@ impl<F: ForwarderCreator> KafkaSecureChannelController for KafkaSecureChannelCon
             }
         };
 
-        trace!("encrypted content with {unique_id}");
+        trace!("encrypted content with {consumer_decryptor_address}");
         Ok(KafkaEncryptedContent {
             content: encrypted_content,
-            secure_channel_id: unique_id,
+            consumer_decryptor_address,
         })
     }
 
     async fn decrypt_content_for(
         &self,
         context: &mut Context,
-        secure_channel_id: UniqueSecureChannelId,
+        consumer_decryptor_address: &Address,
         encrypted_content: Vec<u8>,
     ) -> Result<Vec<u8>> {
-        let secure_channel_entry = self.get_secure_channel_for(secure_channel_id).await?;
+        let secure_channel_entry = self
+            .get_secure_channel_for(consumer_decryptor_address)
+            .await?;
 
         let decrypt_response = context
             .send_and_receive(

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -88,7 +88,11 @@ impl NodeManagerForwarderCreator {
         forwarder_service: MultiAddr,
         alias: String,
     ) -> Result<()> {
-        let is_rust = true;
+        let is_rust = forwarder_service
+            .first()
+            .map(|value| value.cast::<ockam_multiaddr::proto::Project>().is_none())
+            .unwrap_or(true);
+
         let buffer: Vec<u8> = context
             .send_and_receive(
                 route![NODEMANAGER_ADDR],

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -168,6 +168,7 @@ impl DefaultAddress {
     pub const ENROLLMENT_TOKEN_ACCEPTOR: &'static str = "enrollment_token_acceptor";
     pub const VERIFIER: &'static str = "verifier";
     pub const OKTA_IDENTITY_PROVIDER: &'static str = "okta";
+    pub const KAFKA_OUTLET: &'static str = "kafka_outlet";
     pub const KAFKA_CONSUMER: &'static str = "kafka_consumer";
     pub const KAFKA_PRODUCER: &'static str = "kafka_producer";
     pub const RPC_PROXY: &'static str = "rpc_proxy_service";
@@ -212,10 +213,6 @@ pub mod resources {
 use core::fmt;
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-#[derive(rust_embed::RustEmbed)]
-#[folder = "./static"]
-pub(crate) struct StaticFiles;
 
 /// Newtype around [`Vec<u8>`] that provides base-16 string encoding using serde.
 #[derive(Debug, Clone, Default, Encode, Decode)]

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
@@ -53,6 +53,7 @@ impl Instantiator for SecureChannelInstantiator {
             ConnectionInstanceBuilder::extract(&builder.current_multiaddr, match_start, 1);
 
         let transport_route = builder.transport_route.clone();
+
         debug!(%secure_piece, %transport_route, "creating secure channel");
         let route = local_multiaddr_to_route(&secure_piece)
             .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -136,6 +136,9 @@ pub struct CreateOutlet<'a> {
     #[b(2)] pub worker_addr: Cow<'a, str>,
     /// A human-friendly alias for this portal endpoint
     #[b(3)] pub alias: Option<CowStr<'a>>,
+    /// Allow the outlet to be reachable from the default secure channel, useful when we want to
+    /// tighten the flow control
+    #[b(4)] pub reachable_from_default_secure_channel: bool,
 }
 
 impl<'a> CreateOutlet<'a> {
@@ -143,6 +146,7 @@ impl<'a> CreateOutlet<'a> {
         tcp_addr: impl Into<Cow<'a, str>>,
         worker_addr: impl Into<Cow<'a, str>>,
         alias: impl Into<Option<CowStr<'a>>>,
+        reachable_from_default_secure_channel: bool,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -150,6 +154,7 @@ impl<'a> CreateOutlet<'a> {
             tcp_addr: tcp_addr.into(),
             worker_addr: worker_addr.into(),
             alias: alias.into(),
+            reachable_from_default_secure_channel,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -63,6 +63,25 @@ impl<'a> DeleteServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
+pub struct StartKafkaOutletRequest {
+    #[b(1)] pub bootstrap_server_addr: String,
+}
+
+impl StartKafkaOutletRequest {
+    pub fn new(bootstrap_server_addr: impl Into<String>) -> Self {
+        Self {
+            bootstrap_server_addr: bootstrap_server_addr.into(),
+        }
+    }
+
+    pub fn bootstrap_server_addr(&self) -> &str {
+        &self.bootstrap_server_addr
+    }
+}
+
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
 pub struct StartKafkaConsumerRequest<'a> {
     #[b(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -662,6 +662,9 @@ impl NodeManagerWorker {
                 .start_okta_identity_provider_service(ctx, req, dec)
                 .await?
                 .to_vec()?,
+            (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => {
+                self.start_kafka_outlet_service(ctx, req, dec).await?
+            }
             (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
                 self.start_kafka_consumer_service(ctx, req, dec).await?
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -18,7 +18,6 @@ use ockam_node::Context;
 
 use crate::cli_state::traits::StateDirTrait;
 use crate::cli_state::StateItemTrait;
-use crate::kafka::KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS;
 use crate::nodes::connection::Connection;
 use crate::nodes::models::secure_channel::{
     CreateSecureChannelListenerRequest, CreateSecureChannelRequest, CreateSecureChannelResponse,
@@ -209,12 +208,6 @@ impl NodeManager {
 
         ctx.flow_controls().add_consumer(
             DefaultAddress::CREDENTIALS_SERVICE,
-            listener.flow_control_id(),
-            FlowControlPolicy::SpawnerAllowMultipleMessages,
-        );
-
-        ctx.flow_controls().add_consumer(
-            KAFKA_SECURE_CHANNEL_CONTROLLER_ADDRESS,
             listener.flow_control_id(),
             FlowControlPolicy::SpawnerAllowMultipleMessages,
         );

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -344,12 +344,16 @@ pub mod test_utils {
     use ockam_core::compat::sync::Arc;
     use ockam_core::flow_control::FlowControls;
     use ockam_core::AsyncTryClone;
-    use ockam_identity::IdentityIdentifier;
+    use ockam_identity::{
+        CredentialData, Credentials, Identity, IdentityIdentifier, InMemoryStorage, KeyAttributes,
+    };
     use ockam_node::compat::asynchronous::RwLock;
-    use ockam_node::Context;
+    use ockam_node::{Context, InMemoryKeyValueStorage};
     use ockam_transport_tcp::TcpTransport;
+    use ockam_vault::{Secret, SecretAttributes};
 
     use crate::cli_state::{traits::*, CliState, IdentityConfig, NodeConfig, VaultConfig};
+    use crate::config::cli::{CredentialRetrieverConfig, TrustAuthorityConfig, TrustContextConfig};
     use crate::nodes::service::{
         ApiTransport, NodeManagerGeneralOptions, NodeManagerProjectsOptions,
         NodeManagerTransportOptions, NodeManagerTrustOptions,
@@ -395,19 +399,34 @@ pub mod test_utils {
             .await?;
 
         let identity_name = hex::encode(rand::random::<[u8; 4]>());
+
+        // Premise: we need an identity and a credential before the node manager starts.
+        // Since the LMDB can trigger some race conditions, we first use the memory storage
+        // export the identity and credentials,then import in the LMDB after secure-channel
+        // has been re-created
         let secure_channels = SecureChannels::builder()
             .with_identities_vault(vault)
             .with_identities_repository(cli_state.identities.identities_repository().await?)
+            .with_identities_storage(InMemoryStorage::create())
+            .with_vault_storage(InMemoryKeyValueStorage::create())
             .build();
 
-        let identity = secure_channels
+        let identity = create_identity_zero(&secure_channels).await?;
+
+        let credential = secure_channels
             .identities()
-            .identities_creation()
-            .create_identity()
+            .issue_credential(
+                &identity.identifier(),
+                CredentialData::builder(identity.identifier(), identity.identifier())
+                    .with_attribute("trust_context_id", b"test_trust_context_id")
+                    .build()
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
         drop(secure_channels);
+
         let config = IdentityConfig::new(&identity.identifier()).await;
         cli_state.identities.create(&identity_name, config).unwrap();
 
@@ -417,7 +436,7 @@ pub mod test_utils {
 
         let node_manager = NodeManager::create(
             context,
-            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, true, None),
+            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, false, None),
             NodeManagerProjectsOptions::new(Default::default()),
             NodeManagerTransportOptions::new(
                 ApiTransport {
@@ -430,13 +449,23 @@ pub mod test_utils {
                 },
                 tcp.async_try_clone().await?,
             ),
-            NodeManagerTrustOptions::new(None),
+            NodeManagerTrustOptions::new(Some(TrustContextConfig::new(
+                "test_trust_context".to_string(),
+                Some(TrustAuthorityConfig::new(
+                    identity.export_hex().unwrap(),
+                    Some(CredentialRetrieverConfig::FromMemory(credential)),
+                )),
+            ))),
         )
         .await?;
 
         let mut node_manager_worker = NodeManagerWorker::new(node_manager);
         let node_manager = node_manager_worker.get().clone();
         let secure_channels = node_manager.read().await.secure_channels.clone();
+
+        // since we re-created secure-channels, we rewrite the identity in the LMDB storage
+        create_identity_zero(&secure_channels).await?;
+
         context
             .start_worker(NODEMANAGER_ADDR, node_manager_worker)
             .await?;
@@ -448,5 +477,23 @@ pub mod test_utils {
             secure_channels: secure_channels.clone(),
             identifier: identity.identifier(),
         })
+    }
+
+    async fn create_identity_zero(secure_channels: &Arc<SecureChannels>) -> Result<Identity> {
+        let identity_key_id = secure_channels
+            .vault()
+            .import_ephemeral_secret(Secret::new([0u8; 32].to_vec()), SecretAttributes::Ed25519)
+            .await?;
+
+        let identity = secure_channels
+            .identities()
+            .identities_creation()
+            .create_identity_with_existing_key(
+                &identity_key_id,
+                KeyAttributes::new("OCKAM_RK".to_string(), SecretAttributes::Ed25519),
+            )
+            .await
+            .unwrap();
+        Ok(identity)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -12,6 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
 use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::process_nodes_multiaddr;
 use crate::{
     display_parse_logs, fmt_log, fmt_ok,
     kafka::{
@@ -66,6 +67,9 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
         brokers_port_range,
         project_route,
     } = cmd;
+
+    let project_route = process_nodes_multiaddr(&project_route, &opts.state)?;
+
     let is_finished = Mutex::new(false);
     let send_req = async {
         let tcp = TcpTransport::create(&ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
@@ -4,13 +4,19 @@ use ockam_api::{port_range::PortRange, DefaultAddress};
 use ockam_multiaddr::MultiAddr;
 
 pub(crate) mod consumer;
+pub(crate) mod outlet;
 pub(crate) mod producer;
 
+const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: &str = "localhost:9092";
 const KAFKA_DEFAULT_PROJECT_ROUTE: &str = "/project/default";
 const KAFKA_DEFAULT_CONSUMER_SERVER: &str = "127.0.0.1:4000";
 const KAFKA_DEFAULT_CONSUMER_PORT_RANGE: &str = "4001-4100";
 const KAFKA_DEFAULT_PRODUCER_SERVER: &str = "127.0.0.1:5000";
 const KAFKA_DEFAULT_PRODUCER_PORT_RANGE: &str = "5001-5100";
+
+fn kafka_default_outlet_addr() -> String {
+    DefaultAddress::KAFKA_OUTLET.to_string()
+}
 
 fn kafka_consumer_default_addr() -> String {
     DefaultAddress::KAFKA_CONSUMER.to_string()
@@ -22,6 +28,10 @@ fn kafka_producer_default_addr() -> String {
 
 fn kafka_default_project_route() -> MultiAddr {
     MultiAddr::from_str(KAFKA_DEFAULT_PROJECT_ROUTE).expect("Failed to parse default project route")
+}
+
+fn kafka_default_outlet_server() -> String {
+    KAFKA_DEFAULT_BOOTSTRAP_ADDRESS.to_string()
 }
 
 fn kafka_default_consumer_server() -> SocketAddr {

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -1,0 +1,89 @@
+use clap::{command, Args};
+use colorful::Colorful;
+use ockam::{Context, TcpTransport};
+use ockam_api::nodes::models::services::StartKafkaOutletRequest;
+use ockam_api::nodes::models::services::StartServiceRequest;
+use ockam_core::api::Request;
+
+use tokio::{sync::Mutex, try_join};
+
+use crate::node::get_node_name;
+use crate::{
+    fmt_log, fmt_ok,
+    kafka::{kafka_default_outlet_addr, kafka_default_outlet_server},
+    node::NodeOpts,
+    service::start::start_service_impl,
+    terminal::OckamColor,
+    util::node_rpc,
+    CommandGlobalOpts, Result,
+};
+
+/// Create a new Kafka Outlet
+#[derive(Clone, Debug, Args)]
+pub struct CreateCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+    /// The local address of the service
+    #[arg(long, default_value_t = kafka_default_outlet_addr())]
+    addr: String,
+    /// The address of the kafka bootstrap broker
+    #[arg(long, default_value_t = kafka_default_outlet_server())]
+    bootstrap_server: String,
+}
+
+impl CreateCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, (options, self));
+    }
+}
+
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+    opts.terminal
+        .write_line(&fmt_log!("Creating KafkaOutlet service"))?;
+    let CreateCommand {
+        node_opts,
+        addr,
+        bootstrap_server,
+    } = cmd;
+    let is_finished = Mutex::new(false);
+    let send_req = async {
+        let tcp = TcpTransport::create(&ctx).await?;
+
+        let payload = StartKafkaOutletRequest::new(bootstrap_server.clone());
+        let payload = StartServiceRequest::new(payload, &addr);
+        let req = Request::post("/node/services/kafka_outlet").body(payload);
+        let node_name = get_node_name(&opts.state, &node_opts.at_node);
+
+        start_service_impl(&ctx, &opts, &node_name, "KafkaOutlet", req, Some(&tcp)).await?;
+        *is_finished.lock().await = true;
+
+        Ok::<_, crate::Error>(())
+    };
+
+    let msgs = vec![
+        format!(
+            "Building KafkaOutlet service {}",
+            &addr.to_string().color(OckamColor::PrimaryResource.color())
+        ),
+        format!(
+            "Starting KafkaOutlet service, connecting to {}",
+            &bootstrap_server
+                .to_string()
+                .color(OckamColor::PrimaryResource.color())
+        ),
+    ];
+    let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+    let (_, _) = try_join!(send_req, progress_output)?;
+
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!(
+            "KafkaOutlet service started at {}\n",
+            &bootstrap_server
+                .to_string()
+                .color(OckamColor::PrimaryResource.color())
+        ))
+        .write_line()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/mod.rs
@@ -1,0 +1,25 @@
+mod create;
+
+use self::create::CreateCommand;
+use crate::CommandGlobalOpts;
+use clap::{command, Args, Subcommand};
+
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
+pub struct KafkaOutletCommand {
+    #[command(subcommand)]
+    subcommand: KafkaOutletSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum KafkaOutletSubcommand {
+    Create(CreateCommand),
+}
+
+impl KafkaOutletCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            KafkaOutletSubcommand::Create(c) => c.run(options),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -12,6 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use tokio::{sync::Mutex, try_join};
 
 use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::process_nodes_multiaddr;
 use crate::{
     display_parse_logs, fmt_log, fmt_ok,
     kafka::{
@@ -67,8 +68,10 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> c
         brokers_port_range,
         project_route,
     } = cmd;
-    let is_finished = Mutex::new(false);
 
+    let project_route = process_nodes_multiaddr(&project_route, &opts.state)?;
+
+    let is_finished = Mutex::new(false);
     let send_req = async {
         let tcp = TcpTransport::create(&ctx).await?;
         let node_name = get_node_name(&opts.state, &node_opts.at_node);

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -54,6 +54,7 @@ use crate::terminal::{Terminal, TerminalStream};
 use authenticated::AuthenticatedCommand;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
+use crate::kafka::outlet::KafkaOutletCommand;
 use colorful::Colorful;
 use completion::CompletionCommand;
 use configuration::ConfigurationCommand;
@@ -274,6 +275,7 @@ pub enum OckamSubcommand {
     TcpOutlet(TcpOutletCommand),
     TcpInlet(TcpInletCommand),
 
+    KafkaOutlet(KafkaOutletCommand),
     KafkaConsumer(KafkaConsumerCommand),
     KafkaProducer(KafkaProducerCommand),
 
@@ -382,6 +384,7 @@ impl OckamCommand {
             OckamSubcommand::Message(c) => c.run(options),
             OckamSubcommand::Relay(c) => c.run(options),
 
+            OckamSubcommand::KafkaOutlet(c) => c.run(options),
             OckamSubcommand::TcpListener(c) => c.run(options),
             OckamSubcommand::TcpConnection(c) => c.run(options),
             OckamSubcommand::TcpOutlet(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -141,7 +141,7 @@ fn make_api_request<'a>(cmd: CreateCommand) -> crate::Result<RequestBuilder<'a, 
     let tcp_addr = cmd.to.to_string();
     let worker_addr = cmd.from;
     let alias = cmd.alias.map(|a| a.into());
-    let payload = CreateOutlet::new(tcp_addr, worker_addr, alias);
+    let payload = CreateOutlet::new(tcp_addr, worker_addr, alias, true);
     let request = Request::post("/node/outlet").body(payload);
     Ok(request)
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/completer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/completer.rs
@@ -145,6 +145,8 @@ impl ExchangeCompleter {
             &self.addresses.decryptor_remote
         );
 
+        let their_decryptor_address = self.remote_route.iter().last();
+
         let info = SecureChannelRegistryEntry::new(
             self.addresses.encryptor.clone(),
             self.addresses.encryptor_api.clone(),
@@ -153,6 +155,7 @@ impl ExchangeCompleter {
             self.role.is_initiator(),
             self.identity_identifier,
             self.their_identity.identifier(),
+            their_decryptor_address.unwrap().clone(),
         );
 
         secure_channels

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/registry.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/registry.rs
@@ -14,10 +14,12 @@ pub struct SecureChannelRegistryEntry {
     is_initiator: bool,
     my_id: IdentityIdentifier,
     their_id: IdentityIdentifier,
+    their_decryptor_address: Address,
 }
 
 impl SecureChannelRegistryEntry {
     /// Create new registry entry
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         encryptor_messaging_address: Address,
         encryptor_api_address: Address,
@@ -26,6 +28,7 @@ impl SecureChannelRegistryEntry {
         is_initiator: bool,
         my_id: IdentityIdentifier,
         their_id: IdentityIdentifier,
+        their_decryptor_address: Address,
     ) -> Self {
         Self {
             encryptor_messaging_address,
@@ -35,6 +38,7 @@ impl SecureChannelRegistryEntry {
             is_initiator,
             my_id,
             their_id,
+            their_decryptor_address,
         }
     }
 
@@ -70,6 +74,11 @@ impl SecureChannelRegistryEntry {
     /// Their `IdentityIdentifier`
     pub fn their_id(&self) -> IdentityIdentifier {
         self.their_id.clone()
+    }
+
+    /// Their `Decryptor` address
+    pub fn their_decryptor_address(&self) -> Address {
+        self.their_decryptor_address.clone()
     }
 }
 
@@ -128,5 +137,18 @@ impl SecureChannelRegistry {
             .unwrap()
             .get(encryptor_address)
             .cloned()
+    }
+
+    /// Get SecureChannel with given decryptor messaging address
+    pub fn get_channel_by_decryptor_address(
+        &self,
+        decryptor_address: &Address,
+    ) -> Option<SecureChannelRegistryEntry> {
+        self.registry
+            .read()
+            .unwrap()
+            .iter()
+            .find(|(_, entry)| entry.decryptor_messaging_address == *decryptor_address)
+            .map(|(_, entry)| entry.clone())
     }
 }


### PR DESCRIPTION
Implemented a local Kafka usage scenario to pass data locally.
I achieved this by replicating the same logic of the elixir side, keeping full compatibility with the elixir implementation.
What was missing was the `outlet` node, the node which connects to the Kafka cluster.
These components were missing:
 - `OutletManager`: intercepts Kafka traffic and dynamically creates outlets (the existing implementation was generalized to allow any arbitrary interceptor)
 - `PrefixForwarder`: adds a prefix to the static forwarder
 - the `KafkaOutlet` service, which starts the bootstrap outlet as well as above services.

In this implementation, the more general Kafka use case is hardened, applying credential validation, between producer and consumer, and flow control to every interaction. To simplify a bit, the existing implementation of the random unique ID associated to each topic/partition was dropped in favor of directly using the secure channel decryptor address of the consumer instead, removing the secure channel controller listener on the consumer side.