### PR TITLE
Clean `FlowControls` resources

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/flow_control/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/access_control.rs
@@ -51,7 +51,7 @@ impl OutgoingAccessControl for FlowControlOutgoingAccessControl {
 
         let consumers_info = self.flow_controls.get_consumers_info(&self.flow_control_id);
 
-        if let Some(policy) = consumers_info.0.get(next) {
+        if let Some(policy) = consumers_info.get_policy(next) {
             match policy {
                 FlowControlPolicy::ProducerAllowMultiple => {
                     return crate::allow();
@@ -66,7 +66,7 @@ impl OutgoingAccessControl for FlowControlOutgoingAccessControl {
                 .flow_controls
                 .get_consumers_info(spawner_flow_control_id);
 
-            if let Some(policy) = consumers_info.0.get(next) {
+            if let Some(policy) = consumers_info.get_policy(next) {
                 match policy {
                     FlowControlPolicy::SpawnerAllowOnlyOneMessage => {
                         // We haven't yet sent a message to this address

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/consumers_info.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/consumers_info.rs
@@ -1,0 +1,14 @@
+use crate::compat::collections::BTreeMap;
+use crate::flow_control::FlowControlPolicy;
+use crate::Address;
+
+/// Known Consumers for the given [`FlowControlId`]
+#[derive(Default, Clone, Debug)]
+pub struct ConsumersInfo(pub(super) BTreeMap<Address, FlowControlPolicy>);
+
+impl ConsumersInfo {
+    /// Get [`FlowControlPolicy`] for the given [`Address`]
+    pub fn get_policy(&self, address: &Address) -> Option<FlowControlPolicy> {
+        self.0.get(address).cloned()
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls.rs
@@ -1,0 +1,18 @@
+use crate::compat::collections::BTreeMap;
+use crate::compat::sync::{Arc, RwLock};
+use crate::flow_control::{ConsumersInfo, FlowControlId, ProducerInfo};
+use crate::Address;
+
+/// Storage for all Flow Control-related data
+#[derive(Clone, Debug)]
+pub struct FlowControls {
+    // All known consumers
+    pub(super) consumers: Arc<RwLock<BTreeMap<FlowControlId, ConsumersInfo>>>,
+    // All known producers
+    pub(super) producers: Arc<RwLock<BTreeMap<Address, ProducerInfo>>>,
+    // Allows to find producer by having its additional Address,
+    // e.g. Decryptor by its Encryptor Address or TCP Receiver by its TCP Sender Address
+    pub(super) producers_additional_addresses: Arc<RwLock<BTreeMap<Address, Address>>>,
+    // All known spawners
+    pub(super) spawners: Arc<RwLock<BTreeMap<Address, FlowControlId>>>,
+}

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_api.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_api.rs
@@ -32,6 +32,10 @@ impl FlowControls {
         policy: FlowControlPolicy,
     ) {
         let address = address.into();
+        debug!(
+            "Add Consumer {address} to {flow_control_id} with {:?}",
+            policy
+        );
         let mut consumers = self.consumers.write().unwrap();
         if !consumers.contains_key(flow_control_id) {
             consumers.insert(flow_control_id.clone(), Default::default());
@@ -53,6 +57,9 @@ impl FlowControls {
         additional_addresses: Vec<Address>,
     ) {
         let address = address.into();
+        debug!(
+            "Add Producer {address} with additional_addresses {:?} to {flow_control_id} with spawner {:?}", additional_addresses, spawner_flow_control_id
+        );
         let mut producers = self.producers.write().unwrap();
         producers.insert(
             address.clone(),
@@ -74,6 +81,7 @@ impl FlowControls {
     /// Mark that given [`Address`] is a Spawner for to the given [`FlowControlId`]
     pub fn add_spawner(&self, address: impl Into<Address>, flow_control_id: &FlowControlId) {
         let address = address.into();
+        debug!("Add Spawner {address} with {flow_control_id}");
         let mut spawners = self.spawners.write().unwrap();
 
         spawners.insert(address, flow_control_id.clone());

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_cleanup.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_cleanup.rs
@@ -116,15 +116,20 @@ impl FlowControls {
 
     fn cleanup_consumer(&self, address: &Address) {
         // Just remove this Address from Consumers
-        self.consumers
-            .write()
-            .unwrap()
+        let mut consumers = self.consumers.write().unwrap();
+
+        consumers
             .iter_mut()
-            .for_each(|(_flow_control_id, info)| _ = info.0.remove(address))
+            .for_each(|(_flow_control_id, info)| _ = info.0.remove(address));
+
+        // Remove empty Maps
+        consumers.retain(|_, info| !info.0.is_empty());
     }
 
     /// Clean everything that is possible after [`Address`] no longer exists
     pub fn cleanup_address(&self, address: &Address) {
+        debug!("Cleanup FlowControls for {address}");
+
         self.cleanup_spawner(address);
         self.cleanup_producer(address);
         self.cleanup_consumer(address);

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_cleanup.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_cleanup.rs
@@ -1,0 +1,132 @@
+use crate::flow_control::{FlowControlId, FlowControls};
+use crate::Address;
+
+impl FlowControls {
+    fn cleanup_spawner(&self, address: &Address) {
+        let spawner_flow_control_id = match self.spawners.write().unwrap().remove(address) {
+            None => return, // Wasn't a Spawner
+            Some(id) => id,
+        };
+
+        // Check if Spawners with the same FlowControlId exist
+        let spawners_exist = self
+            .spawners
+            .read()
+            .unwrap()
+            .iter()
+            .any(|(_addr, flow_control_id)| flow_control_id == &spawner_flow_control_id);
+
+        // Another spawner exists, nothing else we can clean up now
+        if spawners_exist {
+            return;
+        }
+
+        // Check if Producers spawned by this Spawner still exist
+        let producers_exist =
+            self.producers.read().unwrap().iter().any(|(_addr, info)| {
+                match &info.spawner_flow_control_id() {
+                    None => false,
+                    Some(id) => id == &spawner_flow_control_id,
+                }
+            });
+
+        // Producers Spawned with this FlowControlId still exist, nothing else we can clean up now
+        if producers_exist {
+            return;
+        }
+
+        // Spawners don't exist, Producers don't exist as well, which means storing Consumers
+        // for that FlowControlId doesn't make sense anymore
+        self.consumers
+            .write()
+            .unwrap()
+            .remove(&spawner_flow_control_id);
+    }
+
+    fn cleanup_producers_spawner(&self, spawner_flow_control_id: &FlowControlId) {
+        // Check if that Spawner still exists
+        let spawner_exists = self
+            .spawners
+            .read()
+            .unwrap()
+            .iter()
+            .any(|x| x.1 == spawner_flow_control_id);
+
+        // Spawner still exists, nothing else we can clean up now
+        if spawner_exists {
+            return;
+        }
+
+        // Check if other Producers spawned by the same Spawner exist
+        let other_producers_exist =
+            self.producers
+                .read()
+                .unwrap()
+                .iter()
+                .any(|x| match x.1.spawner_flow_control_id() {
+                    None => false,
+                    Some(id) => id == spawner_flow_control_id,
+                });
+
+        // No other producer exists as well
+        if other_producers_exist {
+            return;
+        }
+
+        // We can clean Consumers for that FlowControlId
+        self.consumers
+            .write()
+            .unwrap()
+            .remove(spawner_flow_control_id);
+    }
+
+    fn cleanup_producer(&self, address: &Address) {
+        let info = match self.producers.write().unwrap().remove(address) {
+            None => return, // Wasn't a Producer
+            Some(info) => info,
+        };
+
+        // Clean known Additional Addresses for that Producer
+        self.producers_additional_addresses
+            .write()
+            .unwrap()
+            .retain(|_additional_address, main_address| main_address != address);
+
+        // We have a Spawner
+        if let Some(spawner_flow_control_id) = info.spawner_flow_control_id() {
+            self.cleanup_producers_spawner(spawner_flow_control_id);
+        }
+
+        let flow_control_id = info.flow_control_id;
+
+        // Check if other Producers for the same FlowControlId exist
+        let other_producers_exist = self
+            .producers
+            .read()
+            .unwrap()
+            .iter()
+            .any(|x| x.1.flow_control_id() == &flow_control_id);
+        if other_producers_exist {
+            return;
+        }
+
+        // We can clean Consumers for that FlowControlId
+        self.consumers.write().unwrap().remove(&flow_control_id);
+    }
+
+    fn cleanup_consumer(&self, address: &Address) {
+        // Just remove this Address from Consumers
+        self.consumers
+            .write()
+            .unwrap()
+            .iter_mut()
+            .for_each(|(_flow_control_id, info)| _ = info.0.remove(address))
+    }
+
+    /// Clean everything that is possible after [`Address`] no longer exists
+    pub fn cleanup_address(&self, address: &Address) {
+        self.cleanup_spawner(address);
+        self.cleanup_producer(address);
+        self.cleanup_consumer(address);
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_debug.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/flow_controls_debug.rs
@@ -1,0 +1,33 @@
+use crate::flow_control::FlowControls;
+use crate::Address;
+
+impl FlowControls {
+    /// Prints debug information regarding Flow Control for the provided address
+    #[allow(dead_code)]
+    pub fn debug_address(&self, address: &Address) {
+        debug!("Address: {}", address.address());
+        let consumers = self.get_flow_controls_with_consumer(address);
+        if consumers.is_empty() {
+            debug!("    No consumers found");
+        }
+        for consumer in consumers {
+            debug!("    Consumer: {:?}", consumer);
+        }
+
+        let producers = self.get_flow_control_with_producer(address);
+        if producers.is_none() {
+            debug!("    No producer found");
+        }
+        if let Some(producer) = producers {
+            debug!("    Producer: {:?}", producer);
+        }
+
+        let producers = self.find_flow_control_with_producer_address(address);
+        if producers.is_none() {
+            debug!("    No producer alias found");
+        }
+        if let Some(producer) = producers {
+            debug!("    Alias Producer: {:?}", producer);
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/mod.rs
@@ -1,0 +1,14 @@
+mod consumers_info;
+#[allow(clippy::module_inception)]
+mod flow_controls;
+mod flow_controls_api;
+mod flow_controls_cleanup;
+mod flow_controls_debug;
+mod producer_info;
+
+pub use consumers_info::*;
+pub use flow_controls::*;
+pub use flow_controls_api::*;
+pub use flow_controls_cleanup::*;
+pub use flow_controls_debug::*;
+pub use producer_info::*;

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/mod.rs
@@ -12,3 +12,6 @@ pub use flow_controls_api::*;
 pub use flow_controls_cleanup::*;
 pub use flow_controls_debug::*;
 pub use producer_info::*;
+
+#[cfg(test)]
+mod tests;

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/producer_info.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/producer_info.rs
@@ -1,0 +1,20 @@
+use crate::flow_control::FlowControlId;
+
+/// Producer information
+#[derive(Clone, Debug)]
+pub struct ProducerInfo {
+    pub(super) flow_control_id: FlowControlId,
+    pub(super) spawner_flow_control_id: Option<FlowControlId>,
+}
+
+impl ProducerInfo {
+    /// [`FlowControlId`]
+    pub fn flow_control_id(&self) -> &FlowControlId {
+        &self.flow_control_id
+    }
+
+    /// Spawner's [`FlowControlId`]
+    pub fn spawner_flow_control_id(&self) -> &Option<FlowControlId> {
+        &self.spawner_flow_control_id
+    }
+}

--- a/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/tests.rs
+++ b/implementations/rust/ockam/ockam_core/src/flow_control/flow_controls/tests.rs
@@ -1,0 +1,209 @@
+use crate::flow_control::{FlowControlPolicy, FlowControls};
+use crate::Address;
+use rand::distributions::Distribution;
+use rand::distributions::Uniform;
+use rand::prelude::{IteratorRandom, SliceRandom, ThreadRng};
+use rand::Rng;
+
+fn add_random_consumer(flow_controls: &FlowControls, mut rng: &mut ThreadRng) -> Vec<Address> {
+    let address = Address::random_local();
+
+    let choice = Uniform::from(0..3).sample(&mut rng);
+
+    match choice {
+        0 => {
+            // Add a Consumer to a non-existent FlowControlId
+            let flow_control_id = FlowControls::generate_id();
+
+            flow_controls.add_consumer(
+                address.clone(),
+                &flow_control_id,
+                FlowControlPolicy::ProducerAllowMultiple,
+            );
+
+            vec![address]
+        }
+        1 => {
+            // Add a Consumer to a random Spawner
+            let spawner_flow_control_id = flow_controls
+                .spawners
+                .read()
+                .unwrap()
+                .values()
+                .choose(&mut rng)
+                .cloned();
+            match spawner_flow_control_id {
+                Some(spawner_flow_control_id) => {
+                    flow_controls.add_consumer(
+                        address.clone(),
+                        &spawner_flow_control_id,
+                        FlowControlPolicy::SpawnerAllowMultipleMessages,
+                    );
+                    vec![address]
+                }
+                _ => vec![],
+            }
+        }
+        2 => {
+            // Add a Consumer to a random Producer
+            let producer_flow_control_id = flow_controls
+                .producers
+                .read()
+                .unwrap()
+                .iter()
+                .map(|(_addr, info)| info.flow_control_id())
+                .choose(&mut rng)
+                .cloned();
+            match producer_flow_control_id {
+                None => vec![],
+                Some(producer_flow_control_id) => {
+                    flow_controls.add_consumer(
+                        address.clone(),
+                        &producer_flow_control_id,
+                        FlowControlPolicy::ProducerAllowMultiple,
+                    );
+                    vec![address]
+                }
+            }
+        }
+        _ => panic!(),
+    }
+}
+
+fn add_random_spawner(flow_controls: &FlowControls, mut rng: &mut ThreadRng) -> Vec<Address> {
+    let address = Address::random_local();
+
+    let choice: f32 = rng.gen();
+
+    if choice < 0.8 {
+        // Add a Spawner to a new FlowControlId
+        let flow_control_id = FlowControls::generate_id();
+
+        flow_controls.add_spawner(address.clone(), &flow_control_id);
+
+        vec![address]
+    } else {
+        // Add a Spawner to an existing FlowControlId
+        let spawner_flow_control_id = flow_controls
+            .spawners
+            .read()
+            .unwrap()
+            .values()
+            .choose(&mut rng)
+            .cloned();
+
+        match spawner_flow_control_id {
+            Some(spawner_flow_control_id) => {
+                flow_controls.add_spawner(address.clone(), &spawner_flow_control_id);
+                vec![address]
+            }
+            _ => vec![],
+        }
+    }
+}
+
+fn add_random_producer(flow_controls: &FlowControls, mut rng: &mut ThreadRng) -> Vec<Address> {
+    let address = Address::random_local();
+
+    let choice: f32 = rng.gen();
+
+    if choice < 0.5 {
+        // Add a Producer without a Spawner
+        let flow_control_id = FlowControls::generate_id();
+
+        flow_controls.add_producer(address.clone(), &flow_control_id, None, vec![]);
+
+        vec![address]
+    } else {
+        // Add a Producer with a Spawner
+        let flow_control_id = FlowControls::generate_id();
+
+        let spawner_flow_control_id = flow_controls
+            .spawners
+            .read()
+            .unwrap()
+            .values()
+            .choose(&mut rng)
+            .cloned();
+
+        match spawner_flow_control_id {
+            Some(spawner_flow_control_id) => {
+                let choice2: f32 = rng.gen();
+                if choice2 < 0.5 {
+                    // No additional address
+                    flow_controls.add_producer(
+                        address.clone(),
+                        &flow_control_id,
+                        Some(&spawner_flow_control_id),
+                        vec![],
+                    );
+                    vec![address]
+                } else {
+                    // Random additional address
+                    let additional_address = Address::random_local();
+                    flow_controls.add_producer(
+                        address.clone(),
+                        &flow_control_id,
+                        Some(&spawner_flow_control_id),
+                        vec![additional_address.clone()],
+                    );
+                    vec![address, additional_address]
+                }
+            }
+            None => vec![],
+        }
+    }
+}
+
+#[test]
+fn test_cleanup() {
+    let mut rng = rand::thread_rng();
+    let flow_controls = FlowControls::new();
+    let mut addresses = Vec::<Address>::new();
+
+    let n = 100;
+    for _ in 0..n {
+        // Generate an event:
+        // 0.0..0.4 => Add an consumer
+        // 0.4..0.7 => Add a producer
+        // 0.7..0.9 => Add a spawner
+        // 0.9..1.0 => Delete an Address
+        let x: f64 = rng.gen();
+
+        let mut new_addresses = if x < 0.4 {
+            add_random_consumer(&flow_controls, &mut rng)
+        } else if x < 0.7 {
+            add_random_producer(&flow_controls, &mut rng)
+        } else if x < 0.9 {
+            add_random_spawner(&flow_controls, &mut rng)
+        } else {
+            match addresses.iter().enumerate().choose(&mut rng) {
+                None => {}
+                Some((index, address)) => {
+                    let address = address.clone();
+                    addresses.remove(index);
+                    flow_controls.cleanup_address(&address);
+                }
+            };
+
+            vec![]
+        };
+
+        addresses.append(&mut new_addresses);
+    }
+
+    addresses.shuffle(&mut rng);
+
+    for address in addresses.into_iter() {
+        flow_controls.cleanup_address(&address);
+    }
+
+    assert!(flow_controls.consumers.read().unwrap().is_empty());
+    assert!(flow_controls.producers.read().unwrap().is_empty());
+    assert!(flow_controls
+        .producers_additional_addresses
+        .read()
+        .unwrap()
+        .is_empty());
+    assert!(flow_controls.spawners.read().unwrap().is_empty());
+}

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -17,6 +17,7 @@ use crate::metrics::Metrics;
 #[cfg(feature = "metrics")]
 use core::sync::atomic::{AtomicBool, Ordering};
 
+use ockam_core::flow_control::FlowControls;
 #[cfg(feature = "std")]
 use ockam_core::{
     errcode::{Kind, Origin},
@@ -38,10 +39,11 @@ pub struct Executor {
     metrics: Arc<Metrics>,
 }
 
-impl Default for Executor {
-    fn default() -> Self {
+impl Executor {
+    /// Create a new Ockam node [`Executor`] instance
+    pub fn new(flow_controls: &FlowControls) -> Self {
         let rt = Runtime::new().unwrap();
-        let router = Router::new();
+        let router = Router::new(flow_controls);
         #[cfg(feature = "metrics")]
         let metrics = Metrics::new(&rt, router.get_metrics_readout());
         Self {
@@ -50,13 +52,6 @@ impl Default for Executor {
             #[cfg(feature = "metrics")]
             metrics,
         }
-    }
-}
-
-impl Executor {
-    /// Create a new Ockam node [`Executor`] instance
-    pub fn new() -> Self {
-        Executor::default()
     }
 
     /// Get access to the internal message sender

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -47,11 +47,11 @@ impl NodeBuilder {
 
         info!("Initializing ockam node");
 
-        let mut exe = Executor::new();
-        let addr: Address = "app".into();
-
         // Shared instance of FlowControls
         let flow_controls = FlowControls::new();
+
+        let mut exe = Executor::new(&flow_controls);
+        let addr: Address = "app".into();
 
         // The root application worker needs a mailbox and relay to accept
         // messages from workers, and to buffer incoming transcoded data.

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -19,9 +19,9 @@ use ockam_core::{
 #[derive(Default)]
 pub struct InternalMap {
     /// Registry of primary address to worker address record state
-    pub(super) internal: BTreeMap<Address, AddressRecord>,
+    address_records_map: BTreeMap<Address, AddressRecord>,
     /// Alias-registry to map arbitrary address to primary addresses
-    pub(super) addr_map: BTreeMap<Address, Address>,
+    alias_map: BTreeMap<Address, Address>,
     /// The order in which clusters are allocated and de-allocated
     cluster_order: Vec<String>,
     /// Cluster data records
@@ -34,9 +34,61 @@ pub struct InternalMap {
 }
 
 impl InternalMap {
+    pub(super) fn clear_address_records_map(&mut self) {
+        self.address_records_map.clear()
+    }
+
+    pub(super) fn get_address_record(&self, primary_address: &Address) -> Option<&AddressRecord> {
+        self.address_records_map.get(primary_address)
+    }
+
+    pub(super) fn get_address_record_mut(
+        &mut self,
+        primary_address: &Address,
+    ) -> Option<&mut AddressRecord> {
+        self.address_records_map.get_mut(primary_address)
+    }
+
+    pub(super) fn address_records_map(&self) -> &BTreeMap<Address, AddressRecord> {
+        &self.address_records_map
+    }
+
+    pub(super) fn remove_address_record(
+        &mut self,
+        primary_address: &Address,
+    ) -> Option<AddressRecord> {
+        self.address_records_map.remove(primary_address)
+    }
+
+    pub(super) fn insert_address_record(
+        &mut self,
+        primary_address: Address,
+        record: AddressRecord,
+    ) -> Option<AddressRecord> {
+        self.address_records_map.insert(primary_address, record)
+    }
+
+    pub(super) fn remove_alias(&mut self, alias_address: &Address) -> Option<Address> {
+        self.alias_map.remove(alias_address)
+    }
+
+    pub(super) fn insert_alias(&mut self, alias_address: &Address, primary_address: &Address) {
+        _ = self
+            .alias_map
+            .insert(alias_address.clone(), primary_address.clone())
+    }
+
+    pub(super) fn get_primary_address(&self, alias_address: &Address) -> Option<&Address> {
+        self.alias_map.get(alias_address)
+    }
+}
+
+impl InternalMap {
     #[cfg(feature = "metrics")]
     pub(super) fn update_metrics(&self) {
-        self.metrics.0.store(self.internal.len(), Ordering::Release);
+        self.metrics
+            .0
+            .store(self.address_records_map.len(), Ordering::Release);
         self.metrics.1.store(self.clusters.len(), Ordering::Release);
     }
 
@@ -53,7 +105,7 @@ impl InternalMap {
     /// Add an address to a particular cluster
     pub(super) fn set_cluster(&mut self, label: String, primary: Address) -> NodeReplyResult {
         let rec = self
-            .internal
+            .address_records_map
             .get(&primary)
             .ok_or_else(|| NodeError::Address(primary).not_found())?;
 
@@ -77,7 +129,7 @@ impl InternalMap {
     /// Set an address as ready and return the list of waiting pollers
     pub(super) fn set_ready(&mut self, addr: Address) -> Result<Vec<SmallSender<NodeReplyResult>>> {
         let addr_record = self
-            .internal
+            .address_records_map
             .get_mut(&addr)
             .ok_or_else(|| NodeError::Address(addr).not_found())?;
         Ok(addr_record.set_ready())
@@ -85,7 +137,7 @@ impl InternalMap {
 
     /// Get the ready state of an address
     pub(super) fn get_ready(&mut self, addr: Address, reply: SmallSender<NodeReplyResult>) -> bool {
-        self.internal
+        self.address_records_map
             .get_mut(&addr)
             .map_or(false, |rec| rec.ready(reply))
     }
@@ -95,7 +147,7 @@ impl InternalMap {
         let name = self.cluster_order.pop()?;
         let addrs = self.clusters.remove(&name)?;
         Some(
-            self.internal
+            self.address_records_map
                 .iter_mut()
                 .filter_map(|(primary, rec)| {
                     if addrs.contains(primary) {
@@ -128,7 +180,7 @@ impl InternalMap {
                 acc
             });
 
-        self.internal
+        self.address_records_map
             .iter_mut()
             .filter_map(|(addr, rec)| {
                 if clustered.contains(addr) {
@@ -145,9 +197,9 @@ impl InternalMap {
     /// Permanently free all remaining resources associated to a particular address
     pub(super) fn free_address(&mut self, primary: Address) {
         self.stopping.remove(&primary);
-        if let Some(record) = self.internal.remove(&primary) {
+        if let Some(record) = self.address_records_map.remove(&primary) {
             for addr in record.address_set {
-                self.addr_map.remove(&addr);
+                self.alias_map.remove(&addr);
             }
         }
     }
@@ -180,12 +232,8 @@ impl AddressRecord {
         self.sender.clone().expect("No such sender!")
     }
 
-    pub fn sender_drop(&mut self) {
+    pub fn drop_sender(&mut self) {
         self.sender = None;
-    }
-
-    pub fn keep_only_primary_address(&mut self) {
-        self.address_set = vec![self.address_set[0].clone()];
     }
 
     pub fn new(
@@ -226,7 +274,7 @@ impl AddressRecord {
 
     /// Check the integrity of this record
     pub fn check(&self) -> bool {
-        self.state == AddressState::Running
+        self.state == AddressState::Running && self.sender.is_some()
     }
 
     /// Check whether this address has been marked as ready yet and if

--- a/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
@@ -113,7 +113,7 @@ pub(super) async fn immediate(
     router: &mut Router,
     reply: SmallSender<NodeReplyResult>,
 ) -> Result<()> {
-    router.map.internal.clear();
+    router.map.clear_address_records_map();
     router.state.kill();
     reply
         .send(RouterReply::ok())

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -51,18 +51,18 @@ async fn start(
         },
     );
 
-    router.map.internal.insert(addr.clone(), record);
+    router.map.insert_address_record(addr.clone(), record);
 
     #[cfg(feature = "std")]
     if let Ok(Some(dump_internals)) = get_env::<bool>("OCKAM_DUMP_INTERNALS") {
         if dump_internals {
-            trace!("{:#?}", router.map.internal);
+            trace!("{:#?}", router.map.address_records_map());
         }
     }
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]
-    trace!("{:#?}", router.map.internal);
+    trace!("{:#?}", router.map.address_records_map());
 
-    router.map.addr_map.insert(addr.clone(), addr.clone());
+    router.map.insert_alias(&addr, &addr);
 
     // For now we just send an OK back -- in the future we need to
     // communicate the current executor state

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -63,21 +63,17 @@ async fn start(
 
     router
         .map
-        .internal
-        .insert(primary_addr.clone(), address_record);
+        .insert_address_record(primary_addr.clone(), address_record);
 
     #[cfg(feature = "std")]
     if let Ok(Some(_)) = get_env::<String>("OCKAM_DUMP_INTERNALS") {
-        trace!("{:#?}", router.map.internal);
+        trace!("{:#?}", router.map.address_records_map());
     }
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]
     trace!("{:#?}", router.map.internal);
 
     addrs.iter().for_each(|addr| {
-        router
-            .map
-            .addr_map
-            .insert(addr.clone(), primary_addr.clone());
+        router.map.insert_alias(addr, primary_addr);
     });
 
     // For now we just send an OK back -- in the future we need to

--- a/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/stop_processor.rs
@@ -14,7 +14,7 @@ pub(super) async fn exec(
     trace!("Stopping processor '{}'", main_addr);
 
     // First check if the processor exists
-    let mut record = match router.map.internal.remove(main_addr) {
+    let mut record = match router.map.remove_address_record(main_addr) {
         Some(proc) => proc,
         None => {
             reply
@@ -27,7 +27,7 @@ pub(super) async fn exec(
     };
 
     // Remove  main address from addr_map too
-    router.map.addr_map.remove(main_addr);
+    router.map.remove_alias(main_addr);
 
     // Then send processor shutdown signal
     record.stop().await?;

--- a/implementations/rust/ockam/ockam_node/src/router/utils.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/utils.rs
@@ -18,7 +18,7 @@ pub(super) async fn resolve(
 ) -> Result<()> {
     let base = format!("Resolving worker address '{}'...", addr);
 
-    let primary_address = if let Some(p) = router.map.addr_map.get(addr) {
+    let primary_address = if let Some(p) = router.map.get_primary_address(addr) {
         p.clone()
     } else {
         trace!("{} FAILED; no such worker", base);
@@ -30,7 +30,7 @@ pub(super) async fn resolve(
         return Ok(());
     };
 
-    match router.map.internal.get(&primary_address) {
+    match router.map.get_address_record(&primary_address) {
         Some(record) if record.check() => {
             trace!("{} OK", base);
             record.increment_msg_count();


### PR DESCRIPTION
`FlowControls` struct contains much information about `Spawner`s, `Producer`s, and `Consumer`s, which was never freed. This is an imperfect attempt to free those resources when an `Address` is stopped on the node. The problem with that approach is that it's possible to add an `Address` to the `FlowControls` and not start any `Worker` on that `Address`. In this case, `Address` is never stopped by the node, and cleanup for that `Address` is never called. In real life, such a situation should be very rare.