### PR TITLE
test(rust): in bats tests, check if a generated random port number is already in use

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -98,7 +98,23 @@ random_str() {
 
 # Returns a random port in the range 49152-65535
 random_port() {
-  shuf -i 49152-65535 -n 1
+  port=0
+  max_retries=10
+  i=0
+  while [[ $i -lt $max_retries ]]; do
+    port=$(shuf -i 10000-65535 -n 1)
+    netstat -latn -p tcp | grep $port >/dev/null
+    if [[ $? == 1 ]]; then
+      break
+    fi
+    ((i++))
+    continue
+  done
+  if [ $i -eq $max_retries ]; then
+    echo "Failed to find an open port" >&3
+    exit 1
+  fi
+  echo "$port"
 }
 
 bats_require_minimum_version 1.5.0

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -240,7 +240,6 @@ teardown() {
   assert_success
 }
 
-
 @test "portals - local inlet and outlet, removing and re-creating the outlet" {
   port="$(random_port)"
   node_port="$(random_port)"
@@ -277,7 +276,6 @@ teardown() {
   run curl --head --retry-connrefused --retry 20 --retry-max-time 20 --max-time 1 "127.0.0.1:$port"
   assert_success
 }
-
 
 @test "portals - local inlet and outlet passing though a relay, removing and re-creating the outlet" {
   port="$(random_port)"

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -238,7 +238,7 @@ teardown() {
   assert_success
   assert_output --partial "$addr"
 
-#  # Delete the listener
+  # Delete the listener
   run "$OCKAM" tcp-listener delete --at n1 "$addr"
   assert_success
 


### PR DESCRIPTION
We have some flaky tests that fail because the port being used to create a tcp-listener is already in use (generally by another OS process outside of ockam's realm). Failing tests: [1](https://github.com/build-trust/ockam/actions/runs/5166030533/jobs/9306704471?pr=5055), [2](https://github.com/build-trust/ockam/actions/runs/5187990020/jobs/9351034259?pr=5057)

I've modified the `random_port` function to use `netstat` to check if the port is already picked up. Note that collisions might still happen if two tests run in parallel and generate the same random number.