### PR TITLE
feat(elixir): api endpoint healthcheck

### DIFF
--- a/implementations/elixir/ockam/ockam_healthcheck/README.md
+++ b/implementations/elixir/ockam/ockam_healthcheck/README.md
@@ -3,7 +3,7 @@
 This application runs periodic healthcheck requests to ockam nodes by establishing
 a secure channel and:
 * sending a ping message to the configured worker for default targets
-* sending an Ockam API request with a specified path, method and optionally a body for API endpoint targets, where `200` response is considered a healthy result
+* sending an `Ockam.API.Request` message with a specified path, method and optionally a body for `Ockam.Services.API` endpoint targets, where `200` response is considered a healthy result
 
 Healthcheck results are reported as prometheus metrics using `ockam_metrics` and
 as logs using Logger.
@@ -22,7 +22,7 @@ Format: application environment is a list of maps. For default (ping) targets th
   crontab: ...
 }
 ```
-For API endpoint targets:
+For `Ockam.Services.API` endpoint targets:
 ```elixir
 %{
   name: ...,
@@ -36,11 +36,13 @@ For API endpoint targets:
   crontab: ...
 }
 ```
-An environment variable is a JSON string with the same format. The optional `body` binary for API endpoint targets in the JSON format has to be base64 encoded.
+An environment variable is a JSON string with the same format.
+The `method` field has to be a string representation of one of the methods enumeratated in the `Ockam.API.Request.Header` schema - "get", "post", "put", "delete", or "patch".
+The optional `body` binary for `Ockam.Services.API` endpoint targets in the JSON format has to be base64 encoded, such as with `Base.encode64/2`.
 
-For each target, the application will connect via tcp `host:port` connection, establish secure channel using `api_worker` listener and:
+For each target, the application will connect via TCP `host:port` connection, establish an Ockam secure channel using `api_worker` listener and:
 * for default targets send ping to `healthcheck_worker`
-* for API endpoint targets send an Ockam API request message with the specified `path`, `method` and optionally a `body` to `healthcheck_worker`
+* for `Ockam.Services.API` endpoint targets send an `Ockam.API.Request` message with the specified `path`, `method` and optionally a `body` to `healthcheck_worker`
 
 Frequency for each target is specified in the `crontab` field of that target as a string in the crontab format.
 

--- a/implementations/elixir/ockam/ockam_healthcheck/README.md
+++ b/implementations/elixir/ockam/ockam_healthcheck/README.md
@@ -1,28 +1,50 @@
 ## Ockam healthcheck
 
 This application runs periodic healthcheck requests to ockam nodes by establishing
-a secure channel and sending a ping message to the configured worker.
+a secure channel and:
+* sending a ping message to the configured worker for default targets
+* sending an Ockam API request with a specified path, method and optionally a body for API endpoint targets, where `200` response is considered a healthy result
 
 Healthcheck results are reported as prometheus metrics using `ockam_metrics` and
 as logs using Logger.
 
 ## Configuration
 
-There are two main configurations:
+Healthcheck targets and frequency of calling them are configured as: `:ockam_healthcheck, :targets` application environment or `HEALTHCHECK_TARGETS` environment variable
+Format: application environment is a list of maps. For default (ping) targets the map is formatted as follows:
+```elixir
+%{
+  name: ...,
+  host: ...,
+  port: ...,
+  api_worker: ...,
+  healthcheck_worker: ...,
+  crontab: ...
+}
+```
+For API endpoint targets:
+```elixir
+%{
+  name: ...,
+  host: ...,
+  port: ...,
+  path: ...,
+  method: ...,
+  body: ...,
+  api_worker: ...,
+  healthcheck_worker: ...,
+  crontab: ...
+}
+```
+An environment variable is a JSON string with the same format. The optional `body` binary for API endpoint targets in the JSON format has to be base64 encoded.
 
-- frequency
-  Configured as: `:ockam_healthcheck, :crontab` application environment or `HEALTHCHECK_CRONTAB` environment vatiable
-  Format: string in crontab format
-- healthcheck targets
-  Configured as: `:ockam_healthcheck, :targets` application environment or `HEALTHCHECK_TARGETS` environment vatiable
-  Format: application environment is a list of maps `[%{name: ..., host: ..., port: ..., api_worker: ..., healthcheck_worker: ...}, ...]`, environment variable is a JSON string with the same format
+For each target, the application will connect via tcp `host:port` connection, establish secure channel using `api_worker` listener and:
+* for default targets send ping to `healthcheck_worker`
+* for API endpoint targets send an Ockam API request message with the specified `path`, `method` and optionally a `body` to `healthcheck_worker`
 
-For each target, the application will connect via tcp `host:port` connection, establish secure channel
-using `api_worker` listener and send ping to `healthcheck_worker`.
+Frequency for each target is specified in the `crontab` field of that target as a string in the crontab format.
 
-Each cycle of crontab frequency the targets configuration will be read from the `:ockam_healthcheck, :targets`, which allows Elixir node to control targets.
-
-There is no way currently to control the frequency other than restarting the application.
+There is no way currently to control the targets or the frequency other than restarting the application.
 
 Identity configuration for healthcheck calls:
 

--- a/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
@@ -75,6 +75,7 @@ config :ockam_services,
 
 ## Healthcheck targets config
 targets_config = System.get_env("HEALTHCHECK_TARGETS", "[]")
+api_endpoint_targets_config = System.get_env("HEALTHCHECK_API_ENDPOINT_TARGETS", "[]")
 
 targets =
   case Ockam.Healthcheck.Application.parse_config(targets_config) do
@@ -90,7 +91,22 @@ targets =
       exit(:invalid_config)
   end
 
+api_endpoint_targets =
+  case Ockam.Healthcheck.Application.parse_config(api_endpoint_targets_config) do
+    {:ok, api_endpoint_tagrets} ->
+      api_endpoint_tagrets
+
+    {:error, reason} ->
+      IO.puts(
+        :stderr,
+        "Invalid API endpoint targets configuration #{inspect(api_endpoint_targets_config)} : #{inspect(reason)}"
+      )
+
+      exit(:invalid_config)
+  end
+
 crontab = System.get_env("HEALTHCHECK_CRONTAB")
+api_endpoint_crontab = System.get_env("HEALTHCHECK_API_ENDPOINT_CRONTAB")
 
 identity_source =
   case System.get_env("HEALTHCHECK_IDENTITY_SOURCE", "function") do
@@ -105,7 +121,9 @@ identity_file = System.get_env("HEALTHCHECK_IDENTITY_FILE")
 
 config :ockam_healthcheck,
   crontab: crontab,
+  api_endpoint_crontab: api_endpoint_crontab,
   targets: targets,
+  api_endpoint_targets: api_endpoint_targets,
   identity_source: identity_source,
   identity_file: identity_file,
   identity_function: &Ockam.Healthcheck.generate_identity/0

--- a/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
@@ -75,7 +75,6 @@ config :ockam_services,
 
 ## Healthcheck targets config
 targets_config = System.get_env("HEALTHCHECK_TARGETS", "[]")
-api_endpoint_targets_config = System.get_env("HEALTHCHECK_API_ENDPOINT_TARGETS", "[]")
 
 targets =
   case Ockam.Healthcheck.Application.parse_config(targets_config) do
@@ -91,23 +90,6 @@ targets =
       exit(:invalid_config)
   end
 
-api_endpoint_targets =
-  case Ockam.Healthcheck.Application.parse_config(api_endpoint_targets_config) do
-    {:ok, api_endpoint_tagrets} ->
-      api_endpoint_tagrets
-
-    {:error, reason} ->
-      IO.puts(
-        :stderr,
-        "Invalid API endpoint targets configuration #{inspect(api_endpoint_targets_config)} : #{inspect(reason)}"
-      )
-
-      exit(:invalid_config)
-  end
-
-crontab = System.get_env("HEALTHCHECK_CRONTAB")
-api_endpoint_crontab = System.get_env("HEALTHCHECK_API_ENDPOINT_CRONTAB")
-
 identity_source =
   case System.get_env("HEALTHCHECK_IDENTITY_SOURCE", "function") do
     "function" ->
@@ -120,10 +102,7 @@ identity_source =
 identity_file = System.get_env("HEALTHCHECK_IDENTITY_FILE")
 
 config :ockam_healthcheck,
-  crontab: crontab,
-  api_endpoint_crontab: api_endpoint_crontab,
   targets: targets,
-  api_endpoint_targets: api_endpoint_targets,
   identity_source: identity_source,
   identity_file: identity_file,
   identity_function: &Ockam.Healthcheck.generate_identity/0

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/application.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/application.ex
@@ -88,21 +88,18 @@ defmodule Ockam.Healthcheck.Application do
   def healthcheck_schedule() do
     targets = Application.get_env(:ockam_healthcheck, :targets, [])
 
-    Enum.reduce(targets, [], fn target, acc ->
-      [
-        %{
-          id: "#{target.name}_healthcheck_schedule",
-          start:
-            {SchedEx, :run_every,
-             [
-               Ockam.Healthcheck,
-               :check_target,
-               [target],
-               target.crontab
-             ]}
-        }
-        | acc
-      ]
+    Enum.map(targets, fn target ->
+      %{
+        id: "#{target.name}_healthcheck_schedule",
+        start:
+          {SchedEx, :run_every,
+           [
+             Ockam.Healthcheck,
+             :check_target,
+             [target],
+             target.crontab
+           ]}
+      }
     end)
   end
 

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/application.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/application.ex
@@ -4,6 +4,7 @@ defmodule Ockam.Healthcheck.Application do
   """
   use Application
 
+  alias Ockam.Healthcheck.APIEndpointTarget
   alias Ockam.Healthcheck.Target
 
   require Logger
@@ -19,38 +20,58 @@ defmodule Ockam.Healthcheck.Application do
     case Jason.decode(config_json) do
       {:ok, targets} when is_list(targets) ->
         Enum.reduce(targets, {:ok, []}, fn
-          target, {:ok, targets} ->
-            case target do
-              %{
-                "name" => name,
-                "host" => host,
-                "port" => port
-              }
-              when is_integer(port) ->
-                api_worker = Map.get(target, "api_worker", "api")
-                healthcheck_worker = Map.get(target, "healthcheck_worker", "healthcheck")
-                path = Map.get(target, "path")
-                method = target |> Map.get("method", "nil") |> String.to_existing_atom()
-                body = Map.get(target, "body")
+          %{
+            "name" => name,
+            "host" => host,
+            "port" => port,
+            "path" => path,
+            "method" => method,
+            "crontab" => crontab,
+            "healthcheck_worker" => healthcheck_worker
+          } = target,
+          {:ok, targets}
+          when is_integer(port) ->
+            api_worker = Map.get(target, "api_worker", "api")
+            body = target |> Map.get("body") |> decode_body()
+            method = String.to_existing_atom(method)
 
-                {:ok,
-                 [
-                   %Target{
-                     name: name,
-                     host: host,
-                     port: port,
-                     path: path,
-                     method: method,
-                     body: body,
-                     api_worker: api_worker,
-                     healthcheck_worker: healthcheck_worker
-                   }
-                   | targets
-                 ]}
+            {:ok,
+             [
+               %APIEndpointTarget{
+                 name: name,
+                 host: host,
+                 port: port,
+                 path: path,
+                 method: method,
+                 body: body,
+                 api_worker: api_worker,
+                 healthcheck_worker: healthcheck_worker,
+                 crontab: crontab
+               }
+               | targets
+             ]}
 
-              other ->
-                {:error, {:invalid_target, other}}
-            end
+          %{"name" => name, "host" => host, "port" => port, "crontab" => crontab} = target,
+          {:ok, targets}
+          when is_integer(port) ->
+            api_worker = Map.get(target, "api_worker", "api")
+            healthcheck_worker = Map.get(target, "healthcheck_worker", "healthcheck")
+
+            {:ok,
+             [
+               %Target{
+                 name: name,
+                 host: host,
+                 port: port,
+                 api_worker: api_worker,
+                 healthcheck_worker: healthcheck_worker,
+                 crontab: crontab
+               }
+               | targets
+             ]}
+
+          other, {:ok, _targets} ->
+            {:error, {:invalid_target, other}}
 
           _target, {:error, reason} ->
             {:error, reason}
@@ -65,51 +86,26 @@ defmodule Ockam.Healthcheck.Application do
   end
 
   def healthcheck_schedule() do
-    tab = Application.get_env(:ockam_healthcheck, :crontab)
-    api_endpoint_tab = Application.get_env(:ockam_healthcheck, :api_crontab)
+    targets = Application.get_env(:ockam_healthcheck, :targets, [])
 
-    default_schedule =
-      case tab do
-        nil ->
-          []
-
-        _string ->
-          [
-            %{
-              id: "healthcheck_schedule",
-              start:
-                {SchedEx, :run_every,
-                 [
-                   Ockam.Healthcheck,
-                   :check_targets,
-                   [],
-                   tab
-                 ]}
-            }
-          ]
-      end
-
-    api_endpoint_schedule =
-      case api_endpoint_tab do
-        nil ->
-          []
-
-        _string ->
-          [
-            %{
-              id: "api_healthcheck_schedule",
-              start:
-                {SchedEx, :run_every,
-                 [
-                   Ockam.Healthcheck,
-                   :check_api_endpoints,
-                   [],
-                   api_endpoint_tab
-                 ]}
-            }
-          ]
-      end
-
-    default_schedule ++ api_endpoint_schedule
+    Enum.reduce(targets, [], fn target, acc ->
+      [
+        %{
+          id: "#{target.name}_healthcheck_schedule",
+          start:
+            {SchedEx, :run_every,
+             [
+               Ockam.Healthcheck,
+               :check_target,
+               [target],
+               target.crontab
+             ]}
+        }
+        | acc
+      ]
+    end)
   end
+
+  defp decode_body(nil), do: nil
+  defp decode_body(body), do: Base.decode64!(body)
 end

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/api_endpoint_target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/api_endpoint_target.ex
@@ -1,0 +1,20 @@
+defmodule Ockam.Healthcheck.APIEndpointTarget do
+  @moduledoc """
+  API Endpoint Healthcheck target.
+  Specifies TCP host and port to connect to, secure channel listener API worker,
+  healthcheck worker, path, method and optionally a Base64 encoded body for the endpoint
+  """
+
+  @enforce_keys [:name, :host, :port, :path, :method, :healthcheck_worker, :crontab]
+  defstruct [
+    :name,
+    :host,
+    :port,
+    :path,
+    :method,
+    :body,
+    :crontab,
+    :healthcheck_worker,
+    api_worker: "api"
+  ]
+end

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
@@ -7,5 +7,14 @@ defmodule Ockam.Healthcheck.Target do
   """
 
   @enforce_keys [:name, :host, :port]
-  defstruct [:name, :host, :port, api_worker: "api", healthcheck_worker: "healthcheck"]
+  defstruct [
+    :name,
+    :host,
+    :port,
+    :path,
+    :method,
+    :body,
+    api_worker: "api",
+    healthcheck_worker: "healthcheck"
+  ]
 end

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
@@ -6,14 +6,12 @@ defmodule Ockam.Healthcheck.Target do
   and healthcheck ping endpoint
   """
 
-  @enforce_keys [:name, :host, :port]
+  @enforce_keys [:name, :host, :port, :crontab]
   defstruct [
     :name,
     :host,
     :port,
-    :path,
-    :method,
-    :body,
+    :crontab,
     api_worker: "api",
     healthcheck_worker: "healthcheck"
   ]

--- a/implementations/elixir/ockam/ockam_healthcheck/mix.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/mix.exs
@@ -24,6 +24,7 @@ defmodule Ockam.Healthcheck.MixProject do
       # test
       test_coverage: [output: "_build/cover"],
       preferred_cli_env: ["test.cover": :test],
+      elixirc_paths: elixirc_paths(Mix.env()),
 
       # hex
       description: "Ockam Healthcheck",
@@ -62,6 +63,9 @@ defmodule Ockam.Healthcheck.MixProject do
       licenses: ["Apache-2.0"]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/helpers"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # used by ex_doc
   defp docs do

--- a/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
@@ -151,15 +151,14 @@ defmodule Ockam.Healthcheck.Test do
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :result], %{status: 1},
                     %{target: %{name: "target"}}},
-                   5000
+                   1000
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :ok], %{duration: _duration},
                     %{target: %{name: "target"}}},
-                   5000
-
-    refute_receive {:telemetry_event, [:ockam, :healthcheck, :error], %{duration: _duration},
-                    %{target: %{name: "target"}}},
                    500
+
+    refute_received {:telemetry_event, [:ockam, :healthcheck, :error], %{duration: _duration},
+                     %{target: %{name: "target"}}}
   end
 
   test "healthcheck API endpoint target Error" do
@@ -197,15 +196,14 @@ defmodule Ockam.Healthcheck.Test do
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :result], %{status: 0},
                     %{target: %{name: "target"}}},
-                   5000
-
-    refute_receive {:telemetry_event, [:ockam, :healthcheck, :ok], %{duration: _duration},
-                    %{target: %{name: "target"}}},
-                   5000
+                   1000
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :error], %{duration: _duration},
                     %{target: %{name: "target"}}},
                    500
+
+    refute_received {:telemetry_event, [:ockam, :healthcheck, :ok], %{duration: _duration},
+                     %{target: %{name: "target"}}}
   end
 
   test "healthcheck channel error" do

--- a/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
@@ -72,7 +72,7 @@ defmodule Ockam.Healthcheck.Test do
       :telemetry.detach("test_handler")
     end)
 
-    assert :ok = Ockam.Healthcheck.check_target(target, 1000)
+    assert :ok = Ockam.Healthcheck.check_target(target, :ping_target, 1000)
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :result], %{status: 1},
                     %{target: %{name: "target"}}},
@@ -115,7 +115,7 @@ defmodule Ockam.Healthcheck.Test do
       :telemetry.detach("test_handler")
     end)
 
-    assert {:error, :timeout} = Ockam.Healthcheck.check_target(target, 1000)
+    assert {:error, :timeout} = Ockam.Healthcheck.check_target(target, :ping_target, 1000)
 
     assert_receive {:telemetry_event, [:ockam, :healthcheck, :result], %{status: 0},
                     %{target: %{name: "target"}}},
@@ -140,7 +140,7 @@ defmodule Ockam.Healthcheck.Test do
     }
 
     assert {:error, {:secure_channel_error, :key_exchange_timeout}} =
-             Ockam.Healthcheck.check_target(target, 1000)
+             Ockam.Healthcheck.check_target(target, :ping_target, 1000)
   end
 
   test "healthcheck TCP error" do
@@ -153,6 +153,6 @@ defmodule Ockam.Healthcheck.Test do
     }
 
     assert {:error, {:tcp_connection_error, :econnrefused}} =
-             Ockam.Healthcheck.check_target(target, 1000)
+             Ockam.Healthcheck.check_target(target, :ping_target, 1000)
   end
 end

--- a/implementations/elixir/ockam/ockam_healthcheck/test/helpers/test_api_endpoint.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/test/helpers/test_api_endpoint.ex
@@ -1,0 +1,21 @@
+defmodule Ockam.Healthcheck.TestAPIEndpoint do
+  @moduledoc false
+  use Ockam.Services.API.Endpoint
+
+  alias Ockam.API.Request
+  @impl true
+  def init_endpoint(_config) do
+    {:ok, "STATE",
+     [
+       {:test, :get, "/ok", &healthcheck_ok/2},
+       {:test, :get, "/error", &healthcheck_error/2}
+     ]}
+  end
+
+  def healthcheck_ok(_req, _data), do: {:ok, nil}
+
+  def healthcheck_error(_req, _data), do: {:error, "Error"}
+
+  @impl true
+  def authorize(:test, _req, _bindings), do: true
+end


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

* the only available healthcheck is sending a ping to a worker and receiving any response message
* all healthcheck targets are processed sequentially
* all endpoints run on the same schedule

## Proposed changes

* add additional type of healtcheck - api endpoint - that calls an Ockam API endpoint and upon receiving 200 response, reports endpoint as healthy
* parallelize healthcheck target calls
* allow customizing schedules per target

**THIS PR INTRODUCES BREAKING CHANGES:**
All targets have to have their crontab configured individually, e.g.:
```json
{
  "name": "target",
  "host": "127.0.0.1",
  "port": 4001,
  "api_worker": "api",
  "healthcheck_worker": "healthcheck",
  "crontab": "* * * * *"
}
```
additionally, in order to healthcheck an API endpoint we need to additionally specify at least `path` and `method`:
```json
{
  "name": "api_endpoint_target",
  "host": "127.0.0.1",
  "port": 4001,
  "api_worker": "api",
  "healthcheck_worker": "healthcheck",
  "path": "/",
  "method": "get",
  "crontab": "* * * * *"
}
```
The type is inferred implicitly from the existence (or lack) of the `path` and `method` fields.

The second breaking change is the fact that targets no longer are read from the application config each cycle, which means that we can't modify the target list without restarting the application.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
