### PR TITLE
fix(elixir): return :ok tuple with identity from get_remote_identity calls

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel.ex
@@ -19,6 +19,7 @@ defmodule Ockam.SecureChannel do
   defdelegate start_link_channel(options, handshake_timeout \\ 30_000), to: Channel
   defdelegate get_remote_identity(worker), to: Channel
   defdelegate get_remote_identity_id(worker), to: Channel
+  defdelegate get_remote_identity_with_id(worker), to: Channel
   defdelegate listener_child_spec(args), to: Channel
   defdelegate established?(worker), to: Channel
   defdelegate disconnect(worker), to: Channel

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
@@ -186,10 +186,18 @@ defmodule Ockam.SecureChannel.Channel do
     end
   end
 
+  @spec get_remote_identity_with_id(Ockam.Address.t()) ::
+          {:ok, Ockam.Identity.t(), String.t()} | {:error, any()}
+  def get_remote_identity_with_id(worker) do
+    Ockam.Worker.call(worker, :get_remote_identity_with_id)
+  end
+
+  @spec get_remote_identity(Ockam.Address.t()) :: {:ok, Ockam.Identity.t()} | {:error, any()}
   def get_remote_identity(worker) do
     Ockam.Worker.call(worker, :get_remote_identity)
   end
 
+  @spec get_remote_identity(Ockam.Address.t()) :: {:ok, String.t()} | {:error, any()}
   def get_remote_identity_id(worker) do
     Ockam.Worker.call(worker, :get_remote_identity_id)
   end
@@ -240,27 +248,47 @@ defmodule Ockam.SecureChannel.Channel do
   @impl true
   def handle_call(
         :get_remote_identity,
-        _form,
+        _from,
         %{state: %Channel{channel_state: %Established{peer_identity: remote_identity}}} = state
       ) do
-    {:reply, remote_identity, state}
+    {:reply, {:ok, remote_identity}, state}
   end
 
-  def handle_call(:get_remote_identity, _form, state) do
+  def handle_call(:get_remote_identity, _from, state) do
     {:reply, {:error, :handshake_not_finished}, state}
   end
 
   @impl true
   def handle_call(
         :get_remote_identity_id,
-        _form,
+        _from,
         %{state: %Channel{channel_state: %Established{peer_identity_id: remote_identity_id}}} =
           state
       ) do
-    {:reply, remote_identity_id, state}
+    {:reply, {:ok, remote_identity_id}, state}
   end
 
-  def handle_call(:get_remote_identity_id, _form, state) do
+  def handle_call(:get_remote_identity_id, _from, state) do
+    {:reply, {:error, :handshake_not_finished}, state}
+  end
+
+  @impl true
+  def handle_call(
+        :get_remote_identity_with_id,
+        _from,
+        %{
+          state: %Channel{
+            channel_state: %Established{
+              peer_identity: remote_identity,
+              peer_identity_id: remote_identity_id
+            }
+          }
+        } = state
+      ) do
+    {:reply, {:ok, remote_identity, remote_identity_id}, state}
+  end
+
+  def handle_call(:get_remote_identity_with_id, _from, state) do
     {:reply, {:error, :handshake_not_finished}, state}
   end
 

--- a/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
@@ -275,8 +275,9 @@ defmodule Ockam.SecureChannel.Tests do
 
     ref1 = Process.monitor(channel_pid)
 
-    assert alice == SecureChannel.get_remote_identity(channel)
-    assert alice_id == SecureChannel.get_remote_identity_id(channel)
+    assert {:ok, alice} == SecureChannel.get_remote_identity(channel)
+    assert {:ok, alice_id} == SecureChannel.get_remote_identity_id(channel)
+    assert {:ok, alice, alice_id} == SecureChannel.get_remote_identity_with_id(channel)
 
     {:ok, me} = Ockam.Node.register_random_address()
     Ockam.Router.route("PING!", [channel, me], [me])

--- a/implementations/elixir/ockam/ockam_metrics/test/ockam_metrics/telemetry_poller_test.exs
+++ b/implementations/elixir/ockam/ockam_metrics/test/ockam_metrics/telemetry_poller_test.exs
@@ -35,8 +35,8 @@ defmodule Ockam.Metrics.TelemetryPoller.Tests do
     channel_pid = Ockam.Node.whereis(channel)
     ref1 = Process.monitor(channel_pid)
 
-    assert alice == SecureChannel.get_remote_identity(channel)
-    assert alice_id == SecureChannel.get_remote_identity_id(channel)
+    assert {:ok, alice} == SecureChannel.get_remote_identity(channel)
+    assert {:ok, alice_id} == SecureChannel.get_remote_identity_id(channel)
 
     {:ok, channel2} =
       SecureChannel.create_channel(

--- a/implementations/elixir/ockam/ockam_services/lib/services/metrics/telemetry_poller.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/metrics/telemetry_poller.ex
@@ -55,7 +55,7 @@ defmodule Ockam.Services.Metrics.TelemetryPoller do
 
     channels_with_credentials =
       Enum.filter(responders, fn responder ->
-        remote_identity = Ockam.SecureChannel.get_remote_identity_id(responder)
+        {:ok, remote_identity} = Ockam.SecureChannel.get_remote_identity_id(responder)
 
         case AttributeStorage.get_attribute_set(remote_identity) do
           {:ok, _set} -> true


### PR DESCRIPTION

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently we return either identity itself, or `{:error, reason}` tuple

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Change identity return to `{:ok, identity}` for consistency with other function apis.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
