### PR TITLE
feat: add list_member_ids api to direct authenticator

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/authenticator/direct/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/authenticator/direct/client.ex
@@ -89,6 +89,20 @@ defmodule Ockam.Credential.Authenticator.Direct.Client do
     end
   end
 
+  @spec list_member_ids(Ockam.Address.route()) :: {:ok, [String.t()]} | {:error, any()}
+  def list_member_ids(api_route) do
+    case ApiClient.sync_request(:get, "/member_ids", "", api_route) do
+      {:ok, %ApiResponse{status: 200, body: response}} ->
+        Ockam.TypedCBOR.decode_strict({:list, :string}, response)
+
+      {:ok, %ApiResponse{status: status, body: body}} ->
+        {:error, {:api_error, status, body}}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
   @spec list_members(Ockam.Address.route()) ::
           {:ok, %{String.t() => AttributesEntry.t()}} | {:error, any()}
   def list_members(api_route) do

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct.rs
@@ -237,9 +237,15 @@ impl Worker for DirectAuthenticator {
                         .await?;
                     Response::ok(req.id()).to_vec()?
                 }
+                (Some(Method::Get), ["member_ids"]) => {
+                    let entries = self.list_members(&from).await?;
+                    let ids: Vec<IdentityIdentifier> = entries.into_keys().collect();
+                    Response::ok(req.id()).body(ids).to_vec()?
+                }
                 // List members attested by our identity (enroller)
                 (Some(Method::Get), [""]) | (Some(Method::Get), ["members"]) => {
                     let entries = self.list_members(&from).await?;
+
                     Response::ok(req.id()).body(entries).to_vec()?
                 }
                 // Delete member if they were attested by our identity (enroller)
@@ -462,6 +468,10 @@ impl DirectAuthenticatorClient {
                 &Request::post("/").body(AddMember::new(id).with_attributes(attributes)),
             )
             .await
+    }
+
+    pub async fn list_member_ids(&self) -> Result<Vec<IdentityIdentifier>> {
+        self.0.request(&Request::get("/member_ids")).await
     }
 
     pub async fn list_members(&self) -> Result<HashMap<IdentityIdentifier, AttributesEntry>> {


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently there is only list_members api, which returns full attribute entries
<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Add an api which only returns identity ids of the members
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
