### PR TITLE
refactor(rust): replace `SecureChannelListenerNodeOpts` with `NodeOpts`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -8,8 +8,7 @@ use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Request, Status};
 use ockam_core::{Address, Route};
 
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::secure_channel::listener::utils::SecureChannelListenerNodeOpts;
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, Result};
 
@@ -25,7 +24,7 @@ const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt"
 )]
 pub struct CreateCommand {
     #[command(flatten)]
-    node_opts: SecureChannelListenerNodeOpts,
+    node_opts: NodeOpts,
 
     /// Address for this listener
     address: Address,
@@ -43,7 +42,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -56,7 +55,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, &cmd.node_opts.at);
+    let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = Request::post("/node/secure_channel_listener").body(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -3,8 +3,7 @@ use clap::Args;
 use ockam::Context;
 use ockam_core::Address;
 
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::secure_channel::listener::utils::SecureChannelListenerNodeOpts;
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -23,12 +22,12 @@ pub struct DeleteCommand {
     address: Address,
 
     #[command(flatten)]
-    node_opts: SecureChannelListenerNodeOpts,
+    node_opts: NodeOpts,
 }
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -41,7 +40,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, &cmd.node_opts.at);
+    let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     let req = api::delete_secure_channel_listener(&cmd.address);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
@@ -2,7 +2,6 @@ pub mod create;
 pub mod delete;
 pub mod list;
 pub mod show;
-mod utils;
 
 pub(crate) use create::CreateCommand;
 pub(crate) use delete::DeleteCommand;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -4,8 +4,7 @@ use miette::miette;
 use ockam::Context;
 use ockam_core::Address;
 
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::secure_channel::listener::utils::SecureChannelListenerNodeOpts;
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{api, exitcode, extract_address_value, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -24,12 +23,12 @@ pub struct ShowCommand {
     address: Address,
 
     #[command(flatten)]
-    node_opts: SecureChannelListenerNodeOpts,
+    node_opts: NodeOpts,
 }
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_opts.at);
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
         node_rpc(rpc, (opts, self));
     }
 }
@@ -42,7 +41,7 @@ async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> crate::Result<()> {
-    let at = get_node_name(&opts.state, &cmd.node_opts.at);
+    let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&at)?;
     let address = &cmd.address;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/utils.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/utils.rs
@@ -1,8 +1,0 @@
-use clap::Args;
-
-#[derive(Clone, Debug, Args)]
-pub struct SecureChannelListenerNodeOpts {
-    /// Node
-    #[arg(global = true, long, value_name = "NODE")]
-    pub at: Option<String>,
-}


### PR DESCRIPTION
## Current behavior

`ockam secure-channel-listener create/delete/show --at n1` uses `SecureChannelListenerNodeOpts` as nodeopts.

## Proposed changes

Use `NodeOpts` instead.

Fixes #4973 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
