### PR TITLE
test(rust): use only ockam imports

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -1,6 +1,6 @@
 use ockam::identity::{AuthorityService, CredentialsIssuerClient, SecureChannelOptions, TrustContext};
+use ockam::TcpTransportExtension;
 use ockam::{node, route, Context, Result, TcpConnectionOptions};
-use ockam_transport_tcp::TcpTransportExtension;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -1,10 +1,10 @@
 use ockam::access_control::AllowAll;
 use ockam::access_control::IdentityIdAccessControl;
+use ockam::flow_control::FlowControlPolicy;
 use ockam::identity::CredentialsIssuer;
 use ockam::identity::SecureChannelListenerOptions;
+use ockam::TcpTransportExtension;
 use ockam::{node, Context, Result, TcpListenerOptions};
-use ockam_core::flow_control::FlowControlPolicy;
-use ockam_transport_tcp::TcpTransportExtension;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -7,8 +7,8 @@ use ockam::flow_control::FlowControlPolicy;
 use ockam::identity::{
     AuthorityService, CredentialsIssuerClient, SecureChannelListenerOptions, SecureChannelOptions, TrustContext,
 };
+use ockam::TcpTransportExtension;
 use ockam::{node, route, Context, Result, TcpConnectionOptions, TcpListenerOptions};
-use ockam_transport_tcp::TcpTransportExtension;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {


### PR DESCRIPTION
Use only `ockam` imports in the credentials example
