### PR TITLE
refactor(rust): fix and simplify cli pager used to display help texts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,12 +1096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
-name = "const-str"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b62c6d3ea43cbe0bc5a081f276fd477e4291d168aacc9f9d98073325333c0d4"
-
-[[package]]
 name = "coolor"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,17 +2527,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -2859,12 +2842,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md-5"
@@ -3393,7 +3370,6 @@ dependencies = [
  "assert_cmd",
  "async-recursion",
  "async-trait",
- "atty",
  "clap 4.3.3",
  "clap_complete",
  "clap_mangen",
@@ -3401,8 +3377,6 @@ dependencies = [
  "colorful",
  "colors-transform",
  "console",
- "const-str",
- "crossbeam-channel",
  "ctrlc",
  "dialoguer",
  "duct",
@@ -3414,7 +3388,6 @@ dependencies = [
  "io-lifetimes",
  "is-terminal",
  "itertools",
- "lazy_static",
  "miette",
  "minicbor",
  "nix",
@@ -3442,7 +3415,6 @@ dependencies = [
  "serde_yaml",
  "strip-ansi-escapes",
  "syntect",
- "sysinfo",
  "tempfile",
  "termcolor",
  "termimad",
@@ -3454,7 +3426,7 @@ dependencies = [
  "tracing-appender",
  "tracing-error",
  "tracing-subscriber",
- "validator",
+ "which",
 ]
 
 [[package]]
@@ -5742,7 +5714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
 ]
 
@@ -5774,21 +5746,6 @@ dependencies = [
  "getrandom 0.2.9",
  "md-5",
  "sha1_smol",
-]
-
-[[package]]
-name = "validator"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
-dependencies = [
- "idna 0.2.3",
- "lazy_static",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
 ]
 
 [[package]]
@@ -5993,6 +5950,17 @@ checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -55,7 +55,6 @@ path = "src/bin/ockam.rs"
 anyhow = "1"
 async-recursion = { version = "1.0.0" }
 async-trait = "0.1"
-atty = "0.2.14"
 clap = { version = "4.3.3", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.3.1"
 clap_mangen = "0.2.12"
@@ -63,8 +62,6 @@ cli-table = "0.4"
 colorful = "0.2"
 colors-transform = "0.2.11"
 console = "0.15.7"
-const-str = "0.5.4"
-crossbeam-channel = "0.5"
 ctrlc = { version = "3.4.0", features = ["termination"] }
 dialoguer = "0.10"
 duct = "0.13"
@@ -76,7 +73,6 @@ indoc = "2.0"
 io-lifetimes = "1"
 is-terminal = "0.4"
 itertools = "0.10"
-lazy_static = "1.4.0"
 miette = { version = "5.8.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.19.0", features = ["derive", "alloc", "half"] }
 nix = "0.26"
@@ -103,8 +99,6 @@ serde_json = "1"
 serde_yaml = "0.9"
 strip-ansi-escapes = "0.1.1"
 syntect = "5"
-sysinfo = { version = "0.29", default-features = false }
-tempfile = "3.6"
 termcolor = "1.2.0"
 termimad = "0.23"
 thiserror = "1"
@@ -115,11 +109,11 @@ tracing = { version = "0.1", features = ["attributes"] }
 tracing-appender = "0.2.2"
 tracing-error = "0.2"
 tracing-subscriber = "0.3.9"
-validator = "0.16"
+which = "4.4.0"
 
 [dev-dependencies]
 assert_cmd = "2"
 ockam_api = { path = "../ockam_api", version = "0.32.0", features = ["std", "authenticators"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.30.0" }
-tempfile = "3"
+tempfile = "3.6.0"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -7,6 +7,7 @@ CLI Behavior
   Otherwise, let the terminal decide.
 - NO_INPUT: a `boolean` that, if set, the CLI won't ask the user for input.
   Otherwise, let the terminal decide based the terminal features (tty).
+- PAGER: a `string` that defines the pager to use for long help/usage messages. Defaults to `less`.
 - OCKAM_DISABLE_UPGRADE_CHECK: a `boolean` that, if set, the CLI won't check for ockam upgrades.
 - OCKAM_HOME: a `string` that sets the home directory. Defaults to `~/.ockam`.
 - OCKAM_LOG: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed.

--- a/implementations/rust/ockam/ockam_command/src/pager.rs
+++ b/implementations/rust/ockam/ockam_command/src/pager.rs
@@ -1,0 +1,47 @@
+use crate::util::exitcode;
+use crate::Result;
+use ockam_core::env::get_env_with_default;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+use std::process::Stdio;
+
+pub(crate) fn render_help(help: clap::Error) {
+    let pager = get_env_with_default("PAGER", "less".to_string()).expect("Invalid PAGER value");
+    match which::which(pager) {
+        Ok(pager_binary_path) => {
+            paginate_with(pager_binary_path, help).expect("Failed to paginate help");
+        }
+        // The pager binary was not found, so we just print the help without pagination
+        Err(_) => {
+            help.exit();
+        }
+    }
+}
+
+fn paginate_with(pager_binary_path: PathBuf, help: clap::Error) -> Result<()> {
+    let pager = pager_binary_path.file_name().unwrap().to_string_lossy();
+    let mut pager_cmd = process::Command::new(pager.as_ref());
+    if pager.as_ref() == "less" {
+        pager_cmd.env("LESS", "FRX");
+        // - F: no pagination if the text fits entirely into the window
+        // - R: allow ANSI escapes output formatting
+        // - X: prevents clearing the screen on exit
+        // - using env var in case a lesser `less` poses as `less`
+    }
+    let mut pager_process = pager_cmd.stdin(Stdio::piped()).spawn()?;
+    {
+        let mut pager_stdin = pager_process
+            .stdin
+            .take()
+            .expect("Failed to get pager's stdin");
+        pager_stdin.write_all(help.render().ansi().to_string().as_bytes())?;
+    }
+    let _ = pager_process.wait();
+    let code = if help.use_stderr() {
+        exitcode::USAGE
+    } else {
+        exitcode::OK
+    };
+    process::exit(code);
+}

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -200,6 +200,10 @@ impl<W: TerminalWriter> Terminal<W> {
         }
     }
 
+    pub fn default() -> Self {
+        Self::new(false, false, false, OutputFormat::Plain)
+    }
+
     /// Prompt the user for a confirmation.
     pub fn confirm(&self, msg: &str) -> Result<ConfirmResult> {
         if !self.can_ask_for_user_input() {


### PR DESCRIPTION
The changes introduced at https://github.com/build-trust/ockam/pull/5049 were causing an error on environments where no pager was available (e.g. our release docker image).

An unexpected behavior was also detected when using a non-existent pager: `PAGER=asdasd ockam --help`. In this case, the output was swallowed and nothing was displayed to the user.

This PR fixes the previous problems and simplifies the pager logic, so that:
- we remove the need to use ad-hoc environment variables to control the colorization of the output
- we remove the need of reexecuting the command to apply the desired format
- we remove the need of [running the pager logic when no pager is set](https://github.com/build-trust/ockam/pull/5109/files#diff-f5a30aef85b96ee0c58c26d9c22690c484ea212154879d380cae8bd4b27ce018L508)