### PR TITLE
fix(elixir): report healthcheck ok and error logs on different log levels

### DIFF
--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/healthcheck.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/healthcheck.ex
@@ -191,18 +191,26 @@ defmodule Ockam.Healthcheck do
     end
   end
 
-  defp log_healthcheck(message, duration, target) do
-    Logger.debug(
-      message <>
-        " for target #{inspect(target)} " <>
-        "duration: #{inspect(duration)}"
-    )
+  defp log_healthcheck_ok(duration, target) do
+    log_message = log_message("Healthcheck OK", duration, target)
+    Logger.debug(log_message)
+  end
+
+  defp log_healthcheck_error(reason, duration, target) do
+    log_message = log_message("Healthcheck ERROR: #{inspect(reason)}", duration, target)
+    Logger.warn(log_message)
+  end
+
+  defp log_message(message, duration, target) do
+    message <>
+      " for target #{inspect(target)} " <>
+      "duration: #{inspect(duration)}"
   end
 
   def report_check_ok(target, start_time) do
     duration = System.monotonic_time(:millisecond) - start_time
 
-    log_healthcheck("Healthcheck OK", duration, target)
+    log_healthcheck_ok(duration, target)
 
     Telemetry.emit_event([:healthcheck, :result],
       measurements: %{status: 1},
@@ -222,11 +230,7 @@ defmodule Ockam.Healthcheck do
   def report_check_failed(target, reason, start_time) do
     duration = System.monotonic_time(:millisecond) - start_time
 
-    log_healthcheck(
-      "Healthcheck ERROR: #{inspect(reason)}",
-      duration,
-      target
-    )
+    log_healthcheck_error(reason, duration, target)
 
     Telemetry.emit_event([:healthcheck, :result],
       measurements: %{status: 0},


### PR DESCRIPTION

## Current behavior

Currently healthcheck errors are logged at `:debug` level, which makes them hard to find

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Report errors at `:warn` level and ok at `:debug` level.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
