### PR TITLE
fixed typo in name displayed in github workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   lint_cargo_deny:
-    name: Rust - lint_cargo_clippy
+    name: Rust - lint_cargo_deny
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8


### PR DESCRIPTION
## Current behavior
Line 110 of the rust.yml file has a typo, as mentioned in issue #5114 

## Proposed changes

Fixed the Typo


