### PR TITLE
ci: notice file issue #626 updates

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -305,3 +305,24 @@ jobs:
         run: |
           mv tools/semgrep/.semgrepignore . & \
           semgrep --verbose --config="r2c" --config="tools/semgrep/rules/example.yaml"
+
+  # Check notice file for update
+  notice_update:
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/build-trust/ockam-builder@sha256:cecb1860acd571278b2e7f8ecb3ffe405447ee844615134f93ddd11b1f3e2ca8
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - run: cargo deny --all-features  list --config=tools/cargo-deny/deny.toml --layout crate --format json | ./tools/scripts/release/parseCrates.sh > update.txt
+      - run: |
+          test=`cat update.txt`
+          printf "%s\n" "$test"
+      - name: Fail if notice update needed
+        shell: bash
+        run: |
+          test=`cat update.txt`
+          compare="NOTICE file update required."
+          if [[ $test == $compare ]]; then
+            exit 1
+          fi

--- a/tools/scripts/release/parseCrates.sh
+++ b/tools/scripts/release/parseCrates.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Example Usage: 
+# cargo deny --all-features list --config=tools/cargo-deny/deny.toml --layout=crate --format json | ./parseCrates.sh > NOTICE
+
+OPEN_BRACKET=$(expr 0)      # count open brackets, diff between a license name and library name
+                            # set to 1 as we remove the 1st instance before counting
+LICENSE_STRING=""
+FILEOUT=""
+PROJECT=""
+VERSION=""
+URL=""
+
+OLD_CKSUM=$(cat NOTICE | cksum)         # cksum old file, compare value to new below
+
+FILEOUT=$(printf "%25s %40s" "Crate Name" "License" )
+FILEOUT+=$(printf "\n------------------------------------------------------------------")
+
+# Derive input
+INPUT=$(jq "." $1 | tr -d '{},()":')
+
+# Set IFS to newline
+IFS=$'\n'
+
+for line in $INPUT
+do 
+
+    # We have the closing bracket, set OPEN_BRACKET to 0, remove any leading commas from
+    # licensing, and build output for this library & licensing
+    # NOTE: Important this check is before check for '[', otherwise crates w/o license 
+    # are presented incorrectly
+    if [[ $line == *"]"* ]]; then
+        IFS=$' '
+        OPEN_BRACKET=$(expr 0)      # reset OPEN_BRACKET status
+        LICENSE_STRING="${LICENSE_STRING#,}"    # remove any leading comma
+        LICENSE_STRING=$(echo $LICENSE_STRING | sed 's/ //g')       # remove leading spaces from LICENSES
+        LICENSE_STRING=$(echo $LICENSE_STRING | sed 's/,/, /g')     # add space after commas in LICENSES
+        FILEOUT+=$(printf "\n%25s %40s" "$PROJECT" "$LICENSE_STRING")
+        LICENSE_STRING=""           # reset LICENSE_STRING
+        IFS=$'\n'
+        continue        # skip to next iteration/line
+    fi
+
+    # closing bracket, lets subtract from OPEN_BRACKET
+    if [[ $line == *"licenses ["* ]]; then
+        OPEN_BRACKET=$(expr 1)
+        continue        # skip to next iteration/line
+    fi
+
+    # Keep appending license names until we hit closing bracket
+    if [[ $OPEN_BRACKET -eq 1 ]]; then
+        LICENSE_STRING+=", $line"
+        continue        # skip to next iteration/line
+    fi
+    
+    # This line contains our library, version, and URL
+    if [[ $OPEN_BRACKET -eq 0 ]] && [[ ${#line} -gt 3 ]]; then
+        IFS=$' '
+        read -r PROJECT VERSION URL <<<"$line"
+        PROJECT=$(echo "$PROJECT" | sed 's/"//g')
+        VERSION=$(echo "$VERSION" | sed 's/"//g')
+        URL=$(echo "$URL" | sed 's/"//g')
+        URL="${URL/registry+}"      # remove 'registry+' from start of URL
+        IFS=$'\n'
+    fi
+
+done
+
+# Comment out next 6 lines to disable cksum checking
+NEW_CKSUM=$(printf "%s\n" $FILEOUT | cksum)     # cksum new results, compare to old
+
+if [[ $OLD_CKSUM != $NEW_CKSUM ]]; then
+    # Save new notice file
+    printf "%s\n" "$FILEOUT"        # Note: could not get echo to parse line breaks
+fi
+
+# NOTE: Uncomment to save output w/o checking cksum values
+# printf "%s\n" "$FILEOUT"        # Note: could not get echo to parse line breaks
+
+


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently the NOTICE file is out of date with no automated way to update that easily.

## Proposed changes

Added job to all.yml to run the parseCrates.sh script. It will check if the notice file needs updating and fail if it's out of date. Cargo-deny can be piped into the parseCrates.sh file and it will create an updated NOTICE file in a similar format to the current version.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
