### PR TITLE
refactor(rust): improve support for `miette` on `ockam_command`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3337,6 +3337,7 @@ dependencies = [
  "indexmap",
  "kafka-protocol",
  "lru",
+ "miette",
  "minicbor",
  "mockall",
  "nix",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -40,6 +40,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde
 home = "0.5"
 kafka-protocol = "0.6.0"
 lru = "0.10.0"
+miette = "5.9.0"
 minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
 nix = "0.26"
 once_cell = { version = "1", optional = true, default-features = false }

--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -16,6 +16,7 @@ pub use crate::cli_state::traits::*;
 pub use crate::cli_state::trust_contexts::*;
 pub use crate::cli_state::vaults::*;
 use crate::config::cli::LegacyCliConfig;
+use miette::Diagnostic;
 use ockam::identity::Identities;
 use ockam_core::compat::sync::Arc;
 use ockam_core::env::get_env_with_default;
@@ -28,7 +29,7 @@ use thiserror::Error;
 
 type Result<T> = std::result::Result<T, CliStateError>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum CliStateError {
     #[error("IO error")]
     Io(#[from] std::io::Error),

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -1,6 +1,5 @@
+use miette::miette;
 use std::net::{SocketAddrV4, SocketAddrV6};
-
-use anyhow::anyhow;
 
 use ockam::TcpTransport;
 use ockam_core::flow_control::FlowControlId;
@@ -276,7 +275,7 @@ pub fn addr_to_multiaddr<T: Into<Address>>(a: T) -> Option<MultiAddr> {
 /// Tells whether the input MultiAddr references a local node or a remote node.
 ///
 /// This should be called before cleaning the MultiAddr.
-pub fn is_local_node(ma: &MultiAddr) -> anyhow::Result<bool> {
+pub fn is_local_node(ma: &MultiAddr) -> miette::Result<bool> {
     let at_rust_node;
     if let Some(p) = ma.iter().next() {
         match p.code() {
@@ -293,30 +292,30 @@ pub fn is_local_node(ma: &MultiAddr) -> anyhow::Result<bool> {
                 at_rust_node = p
                     .cast::<DnsAddr>()
                     .map(|dnsaddr| (*dnsaddr).eq("localhost"))
-                    .ok_or_else(|| anyhow!("Invalid \"dnsaddr\" value"))?;
+                    .ok_or_else(|| miette!("Invalid \"dnsaddr\" value"))?;
             }
             // A "/ip4" will be local if it matches the loopback address
             Ip4::CODE => {
                 at_rust_node = p
                     .cast::<Ip4>()
                     .map(|ip4| ip4.is_loopback())
-                    .ok_or_else(|| anyhow!("Invalid \"ip4\" value"))?;
+                    .ok_or_else(|| miette!("Invalid \"ip4\" value"))?;
             }
             // A "/ip6" will be local if it matches the loopback address
             Ip6::CODE => {
                 at_rust_node = p
                     .cast::<Ip6>()
                     .map(|ip6| ip6.is_loopback())
-                    .ok_or_else(|| anyhow!("Invalid \"ip6\" value"))?;
+                    .ok_or_else(|| miette!("Invalid \"ip6\" value"))?;
             }
             // A MultiAddr starting with "/service" could reference both local and remote nodes.
             _ => {
-                return Err(anyhow!("Invalid address, protocol not supported"));
+                return Err(miette!("Invalid address, protocol not supported"));
             }
         }
         Ok(at_rust_node)
     } else {
-        Err(anyhow!("Invalid address"))
+        Err(miette!("Invalid address"))
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -1,4 +1,4 @@
-use anyhow::Context as _;
+use miette::{Context as _, IntoDiagnostic};
 use std::path::PathBuf;
 
 use clap::builder::NonEmptyStringValueParser;
@@ -142,7 +142,7 @@ impl SubscriptionCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cmd.cloud_opts.route();
     let mut rpc = Rpc::embedded(&ctx, &opts).await?;
     match cmd.subcommand {
@@ -150,8 +150,9 @@ async fn run_impl(
             json,
             space_id: space,
         } => {
-            let json =
-                std::fs::read_to_string(&json).context(format!("failed to read {:?}", &json))?;
+            let json = std::fs::read_to_string(&json)
+                .into_diagnostic()
+                .context(format!("failed to read {:?}", &json))?;
             let b = ActivateSubscription::existing(space, json);
             let req = Request::post("subscription").body(CloudRequestWrapper::new(
                 b,
@@ -195,6 +196,7 @@ async fn run_impl(
                     subscription_id,
                 } => {
                     let json = std::fs::read_to_string(&json)
+                        .into_diagnostic()
                         .context(format!("failed to read {:?}", &json))?;
                     let subscription_id = utils::subscription_id_from_cmd_args(
                         &ctx,

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -1,3 +1,4 @@
+use crate::util::local_cmd;
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -10,14 +11,11 @@ pub struct GetCommand {
 
 impl GetCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(options, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(options, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: GetCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: GetCommand) -> miette::Result<()> {
     let node_state = opts.state.nodes.get(cmd.alias)?;
     let addr = &node_state.config().setup().default_tcp_listener()?.addr;
     println!("Address: {addr}");

--- a/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get_default_node.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 
+use crate::util::local_cmd;
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
@@ -7,14 +8,11 @@ pub struct GetDefaultNodeCommand {}
 
 impl GetDefaultNodeCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(options) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(options));
     }
 }
 
-fn run_impl(_opts: CommandGlobalOpts) -> crate::Result<()> {
+fn run_impl(_opts: CommandGlobalOpts) -> miette::Result<()> {
     // TODO: get from opts.state.nodes().default()
     todo!()
 }

--- a/implementations/rust/ockam/ockam_command/src/configuration/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/list.rs
@@ -1,3 +1,4 @@
+use crate::util::local_cmd;
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam_api::cli_state::StateDirTrait;
@@ -7,14 +8,11 @@ pub struct ListCommand {}
 
 impl ListCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(options, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(options, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, _cmd: ListCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, _cmd: ListCommand) -> miette::Result<()> {
     for node in opts.state.nodes.list()? {
         opts.terminal.write(&format!("Node: {}\n", node.name()))?;
     }

--- a/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/set_default_node.rs
@@ -1,3 +1,4 @@
+use crate::util::local_cmd;
 use crate::CommandGlobalOpts;
 use clap::Args;
 
@@ -9,14 +10,11 @@ pub struct SetDefaultNodeCommand {
 
 impl SetDefaultNodeCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        if let Err(e) = run_impl(&self.name, &options) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(&self.name, &options));
     }
 }
 
-fn run_impl(_name: &str, _options: &CommandGlobalOpts) -> crate::Result<()> {
+fn run_impl(_name: &str, _options: &CommandGlobalOpts) -> miette::Result<()> {
     // TODO: add symlink to options.state.defaults().node
     todo!()
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -25,7 +25,7 @@ impl GetCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, GetCommand)) -> crate::Result<()> {
+async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, GetCommand)) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -33,7 +33,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: GetCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::get_credential(

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -25,7 +25,7 @@ impl ListCommand {
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     opts.terminal
         .write_line(&fmt_log!("Listing Credentials...\n"))?;
 

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -30,7 +30,7 @@ impl PresentCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, PresentCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -38,7 +38,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: PresentCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(api::credentials::present_credential(&cmd.to, cmd.oneway))

--- a/implementations/rust/ockam/ockam_command/src/credential/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/show.rs
@@ -25,7 +25,7 @@ impl ShowCommand {
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let vault_name = cmd
         .vault
         .clone()
@@ -37,7 +37,7 @@ pub(crate) async fn display_credential(
     opts: &CommandGlobalOpts,
     cred_name: &str,
     vault_name: &str,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let cred = opts.state.credentials.get(cred_name)?;
     let cred_config = cred.config();
 

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -54,7 +54,7 @@ impl StoreCommand {
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, StoreCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     opts.terminal.write_line(&fmt_log!(
         "Storing credential {}...\n",
         cmd.credential_name.clone()

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -49,7 +49,7 @@ impl VerifyCommand {
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, VerifyCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     opts.terminal
         .write_line(&fmt_log!("Verifying credential...\n"))?;
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -57,11 +57,15 @@ impl EnrollCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, EnrollCommand)) -> Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, EnrollCommand)) -> miette::Result<()> {
     run_impl(&ctx, opts, cmd).await
 }
 
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: EnrollCommand) -> Result<()> {
+async fn run_impl(
+    ctx: &Context,
+    opts: CommandGlobalOpts,
+    cmd: EnrollCommand,
+) -> miette::Result<()> {
     opts.terminal.write_line(&fmt_log!(
         "Enrolling your default Ockam identity with Ockam Orchestrator...\n"
     ))?;
@@ -132,7 +136,7 @@ async fn enroll(
     opts: &CommandGlobalOpts,
     cmd: &EnrollCommand,
     node_name: &str,
-) -> Result<()> {
+) -> miette::Result<()> {
     let auth0 = Auth0Service::new(Auth0Provider::Auth0);
     let token = auth0.token(&cmd.cloud_opts, opts).await?;
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
@@ -145,7 +149,7 @@ async fn enroll(
         info!("Already enrolled");
         Ok(())
     } else {
-        Err(miette!("{}", rpc.parse_err_msg(res, dec)).into())
+        Err(miette!("{}", rpc.parse_err_msg(res, dec)))
     }
 }
 
@@ -563,9 +567,9 @@ impl Auth0Service {
         }
     }
 
-    pub(crate) async fn validate_provider_config(&self) -> Result<()> {
+    pub(crate) async fn validate_provider_config(&self) -> miette::Result<()> {
         if let Err(e) = self.device_code().await {
-            return Err(miette!("Invalid OIDC configuration: {}", e).into());
+            return Err(miette!("Invalid OIDC configuration: {}", e));
         }
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -1,12 +1,10 @@
-use crate::version::Version;
 use crate::{exitcode, fmt_log, ExitCode};
-use colorful::Colorful;
 
 use miette::miette;
 use miette::Diagnostic;
 use std::fmt::Debug;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = miette::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum Error {
@@ -94,59 +92,6 @@ impl Error {
             Error::InternalError { exit_code, .. } => *exit_code,
             Error::Unavailable { .. } => exitcode::UNAVAILABLE,
         }
-    }
-}
-
-impl From<anyhow::Error> for Error {
-    fn from(e: anyhow::Error) -> Self {
-        Error::new(exitcode::SOFTWARE, miette!(e.to_string()))
-    }
-}
-
-pub struct ErrorReportHandler;
-
-#[allow(dead_code)]
-impl ErrorReportHandler {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl miette::ReportHandler for ErrorReportHandler {
-    fn debug(&self, error: &dyn Diagnostic, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if f.alternate() {
-            return core::fmt::Debug::fmt(error, f);
-        }
-        let code_as_str = match error.code() {
-            Some(code) => code.to_string(),
-            None => "OCK500".to_string(),
-        };
-
-        writeln!(
-            f,
-            "{} {}\n",
-            code_as_str
-                .color(crate::terminal::OckamColor::FmtERRORBackground.color())
-                .bold(),
-            error
-        )?;
-
-        if let Some(help) = error.help() {
-            writeln!(f, "{}", fmt_log!("{}", help))?;
-        }
-
-        // TODO: wait until we have the dedicated documentation page for errors
-        // if let Some(url) = error.url() {
-        //     writeln!(f, "{}", fmt_log!("{}", url))?;
-        // }
-
-        writeln!(
-            f,
-            "{}",
-            fmt_log!("{}", Version::short().to_string().light_gray())
-        )?;
-
-        Ok(())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -104,11 +104,14 @@ impl From<anyhow::Error> for Error {
 }
 
 pub struct ErrorReportHandler;
+
+#[allow(dead_code)]
 impl ErrorReportHandler {
     pub fn new() -> Self {
         Self
     }
 }
+
 impl miette::ReportHandler for ErrorReportHandler {
     fn debug(&self, error: &dyn Diagnostic, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if f.alternate() {

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -40,14 +40,14 @@ impl CreateCommand {
     async fn run_impl(
         _ctx: Context,
         (options, cmd): (CommandGlobalOpts, CreateCommand),
-    ) -> crate::Result<()> {
+    ) -> miette::Result<()> {
         cmd.create_identity(options).await.map(|_| ())
     }
 
     pub async fn create_identity(
         &self,
         opts: CommandGlobalOpts,
-    ) -> crate::Result<IdentityIdentifier> {
+    ) -> miette::Result<IdentityIdentifier> {
         opts.terminal.write_line(&fmt_log!(
             "Creating identity {}...\n",
             &self

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -30,7 +30,7 @@ impl DeleteCommand {
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let state = opts.state;
     // Check if exists
     match state.identities.get(&cmd.name) {
@@ -42,7 +42,7 @@ async fn run_impl(
         }
         // Return the appropriate error
         Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Identity '{}' not found", &cmd.name).into()),
+            CliStateError::NotFound => Err(miette!("Identity '{}' not found", &cmd.name)),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -1,7 +1,7 @@
 use crate::terminal::OckamColor;
 use crate::util::node_rpc;
 use crate::util::output::Output;
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts};
 
 use clap::Args;
 use colorful::Colorful;
@@ -29,7 +29,10 @@ impl ListCommand {
         node_rpc(Self::run_impl, (options, self))
     }
 
-    async fn run_impl(_ctx: Context, options: (CommandGlobalOpts, ListCommand)) -> Result<()> {
+    async fn run_impl(
+        _ctx: Context,
+        options: (CommandGlobalOpts, ListCommand),
+    ) -> miette::Result<()> {
         let (opts, _cmd) = options;
         let mut identities: Vec<IdentityListOutput> = Vec::new();
 

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -4,6 +4,7 @@ use crate::util::{node_rpc, println_output};
 use crate::{docs, CommandGlobalOpts, EncodeFormat, Result};
 use clap::Args;
 use core::fmt::Write;
+use miette::IntoDiagnostic;
 use ockam::identity::identity::IdentityChangeHistory;
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::identity::{LongIdentityResponse, ShortIdentityResponse};
@@ -42,7 +43,7 @@ impl ShowCommand {
     async fn run_impl(
         _ctx: Context,
         options: (CommandGlobalOpts, ShowCommand),
-    ) -> crate::Result<()> {
+    ) -> miette::Result<()> {
         let (opts, cmd) = options;
         let name = get_identity_name(&opts.state, &cmd.name);
         let state = opts.state.identities.get(&name)?;
@@ -54,8 +55,10 @@ impl ShowCommand {
                 .identities_repository()
                 .await?
                 .get_identity(&identifier)
-                .await?
-                .export()?;
+                .await
+                .into_diagnostic()?
+                .export()
+                .into_diagnostic()?;
 
             if Some(EncodeFormat::Hex) == cmd.encoding {
                 println_output(identity, &opts.global_args.output_format)?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
@@ -29,7 +29,7 @@ impl DeleteCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -30,7 +30,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -1,5 +1,6 @@
 use clap::{command, Args};
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::services::StartKafkaOutletRequest;
 use ockam_api::nodes::models::services::StartServiceRequest;
@@ -15,7 +16,7 @@ use crate::{
     service::start::start_service_impl,
     terminal::OckamColor,
     util::node_rpc,
-    CommandGlobalOpts, Result,
+    CommandGlobalOpts,
 };
 
 /// Create a new Kafka Outlet
@@ -37,7 +38,7 @@ impl CreateCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> miette::Result<()> {
     opts.terminal
         .write_line(&fmt_log!("Creating KafkaOutlet service"))?;
     let CreateCommand {
@@ -47,7 +48,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> R
     } = cmd;
     let is_finished = Mutex::new(false);
     let send_req = async {
-        let tcp = TcpTransport::create(&ctx).await?;
+        let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
 
         let payload = StartKafkaOutletRequest::new(bootstrap_server.clone());
         let payload = StartServiceRequest::new(payload, &addr);

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
@@ -29,7 +29,7 @@ impl DeleteCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -30,7 +30,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -25,7 +25,7 @@ pub struct ArgOpts {
     pub project_route: MultiAddr,
 }
 
-pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> crate::Result<()> {
+pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> miette::Result<()> {
     let ArgOpts {
         endpoint,
         kafka_entity,

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use clap::Args;
 
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_api::cloud::lease_manager::models::influxdb::Token;
 use ockam_core::api::Request;
@@ -42,7 +43,7 @@ impl CreateCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     opts.terminal
         .write_line(&fmt_log!("Creating influxdb token...\n"))?;
 
@@ -75,7 +76,7 @@ async fn run_impl(
     opts.terminal
         .stdout()
         .machine(resp_token.token.to_string())
-        .json(serde_json::to_string_pretty(&resp_token)?)
+        .json(serde_json::to_string_pretty(&resp_token).into_diagnostic()?)
         .plain(
             fmt_ok!("Created influxdb token\n")
                 + &fmt_log!(
@@ -94,7 +95,8 @@ async fn run_impl(
                 )
                 + &fmt_log!(
                     "Expires at {}\n",
-                    PrimitiveDateTime::parse(&resp_token.expires, &Iso8601::DEFAULT)?
+                    PrimitiveDateTime::parse(&resp_token.expires, &Iso8601::DEFAULT)
+                        .into_diagnostic()?
                         .to_string()
                         .color(OckamColor::PrimaryResource.color())
                 ),

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use std::fmt::Write;
 use std::str::FromStr;
 
@@ -42,7 +43,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, trust_opts): (CommandGlobalOpts, CloudOpts, TrustContextOpts),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let is_finished: Mutex<bool> = Mutex::new(false);
 
@@ -72,7 +73,7 @@ async fn run_impl(
     let plain =
         opts.terminal
             .build_list(&tokens, "Tokens", "No active tokens found within service.")?;
-    let json = serde_json::to_string_pretty(&tokens)?;
+    let json = serde_json::to_string_pretty(&tokens).into_diagnostic()?;
     opts.terminal
         .stdout()
         .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use clap::Args;
+use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
@@ -42,13 +43,13 @@ async fn run_impl(
         RevokeCommand,
         TrustContextOpts,
     ),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()
         .await?
-        .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)
+        .build(&MultiAddr::from_str("/service/influxdb_token_lease").into_diagnostic()?)
         .await?;
 
     let req = Request::delete(format!("/{}", cmd.token_id));

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use clap::Args;
+use miette::IntoDiagnostic;
 
 use ockam::Context;
 use ockam_api::cloud::lease_manager::models::influxdb::Token;
@@ -47,13 +48,13 @@ async fn run_impl(
         ShowCommand,
         TrustContextOpts,
     ),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let identity = get_identity_name(&opts.state, &cloud_opts.identity);
     let mut orchestrator_client = OrchestratorApiBuilder::new(&ctx, &opts, &trust_opts)
         .as_identity(identity)
         .with_new_embbeded_node()
         .await?
-        .build(&MultiAddr::from_str("/service/influxdb_token_lease")?)
+        .build(&MultiAddr::from_str("/service/influxdb_token_lease").into_diagnostic()?)
         .await?;
 
     let req = Request::get(format!("/{}", cmd.token_id));

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -71,6 +71,7 @@ use lease::LeaseCommand;
 use manpages::ManpagesCommand;
 use markdown::MarkdownCommand;
 use message::MessageCommand;
+use miette::GraphicalReportHandler;
 use node::NodeCommand;
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use once_cell::sync::Lazy;
@@ -332,8 +333,14 @@ impl OckamCommand {
         // Sets a hook using our own Error Report Handler
         // This allows us to customize how we
         // format the error messages and their content.
-        // let _hook_result = miette::set_hook(Box::new(|_| Box::new(ErrorReportHandler::new())));
-
+        let _hook_result = miette::set_hook(Box::new(|_| {
+            Box::new(
+                GraphicalReportHandler::new()
+                    .with_cause_chain()
+                    .with_footer(fmt_log!("{}", Version::short().to_string().light_gray()))
+                    .with_urls(false),
+            )
+        }));
         let options = CommandGlobalOpts::new(self.global_args.clone());
 
         let _tracing_guard = if !options.global_args.quiet {

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -63,7 +63,7 @@ use console::Term;
 use credential::CredentialCommand;
 use enroll::EnrollCommand;
 use environment::EnvironmentCommand;
-use error::{Error, ErrorReportHandler, Result};
+use error::{Error, Result};
 use identity::IdentityCommand;
 use kafka::consumer::KafkaConsumerCommand;
 use kafka::producer::KafkaProducerCommand;
@@ -332,7 +332,7 @@ impl OckamCommand {
         // Sets a hook using our own Error Report Handler
         // This allows us to customize how we
         // format the error messages and their content.
-        let _hook_result = miette::set_hook(Box::new(|_| Box::new(ErrorReportHandler::new())));
+        // let _hook_result = miette::set_hook(Box::new(|_| Box::new(ErrorReportHandler::new())));
 
         let options = CommandGlobalOpts::new(self.global_args.clone());
 

--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,5 +1,6 @@
 use crate::node::util::{check_default, set_default_node};
 use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::local_cmd;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 
@@ -21,14 +22,11 @@ pub struct DefaultCommand {
 impl DefaultCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         initialize_node_if_default(&opts, &self.node_name);
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
     if check_default(&opts, &node_name) {
         println!("Already set to default node");

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -2,9 +2,9 @@ use crate::terminal::OckamColor;
 use crate::util::output::Output;
 use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, Result};
-use anyhow::Context as _;
 use clap::Args;
 use colorful::Colorful;
+use miette::Context as _;
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::base::NodeStatus;
@@ -32,7 +32,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: Context,
     (opts, _cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     // Before printing node states we verify them.
     // We send a QueryStatus request to every node on
     // record. If the response yields a different pid to the

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -4,6 +4,7 @@ use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::TcpTransport;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::portal::{InletList, OutletList};
@@ -45,10 +46,10 @@ impl ShowCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
 
-    let tcp = TcpTransport::create(&ctx).await?;
+    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();
     let is_default = check_default(&opts, &node_name);
     print_query_status(&mut rpc, &node_name, false, is_default).await?;
@@ -164,7 +165,7 @@ pub async fn print_query_status(
     node_name: &str,
     wait_until_ready: bool,
     is_default: bool,
-) -> Result<()> {
+) -> miette::Result<()> {
     let cli_state = rpc.opts.state.clone();
     if !is_node_up(rpc, wait_until_ready).await? {
         let node_state = cli_state.nodes.get(node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::TcpTransport;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
@@ -39,7 +40,7 @@ impl StartCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, StartCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
 
     let node_state = opts.state.nodes.get(&node_name)?;
@@ -75,7 +76,7 @@ async fn run_impl(
     )?;
 
     // Print node status
-    let tcp = TcpTransport::create(&ctx).await?;
+    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();
     let is_default = check_default(&opts, &node_name);
     print_query_status(&mut rpc, &node_name, true, is_default).await?;

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,5 @@
 use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::local_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
@@ -26,14 +27,11 @@ pub struct StopCommand {
 impl StopCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         initialize_node_if_default(&opts, &self.node_name);
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: StopCommand) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
     let node_state = opts.state.nodes.get(&node_name)?;
     node_state.kill_process(cmd.force)?;

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use miette::miette;
 use tokio_retry::strategy::FixedInterval;
 use tokio_retry::Retry;
 
@@ -7,7 +7,7 @@ use ockam_api::cloud::ORCHESTRATOR_AWAIT_TIMEOUT_MS;
 
 use crate::util::api::CloudOpts;
 use crate::util::{api, RpcBuilder};
-use crate::{CommandGlobalOpts, Result};
+use crate::CommandGlobalOpts;
 
 pub async fn check_for_completion<'a>(
     ctx: &ockam::Context,
@@ -15,7 +15,7 @@ pub async fn check_for_completion<'a>(
     cloud_opts: &CloudOpts,
     api_node: &str,
     operation_id: &str,
-) -> Result<()> {
+) -> miette::Result<()> {
     let retry_strategy =
         FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
 
@@ -39,7 +39,7 @@ pub async fn check_for_completion<'a>(
                 return Ok(operation.to_owned());
             }
         }
-        Err(anyhow!("Operation timed out. Please try again."))
+        Err(miette!("Operation timed out. Please try again."))
     })
     .await?;
 
@@ -50,6 +50,6 @@ pub async fn check_for_completion<'a>(
     if operation.is_successful() {
         Ok(())
     } else {
-        Err(anyhow!("Operation failed. Please try again.").into())
+        Err(miette!("Operation failed. Please try again."))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -1,6 +1,6 @@
 use crate::policy::policy_path;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_abac::{Action, Expr, Resource};
@@ -28,11 +28,18 @@ impl CreateCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
-async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts, cmd: CreateCommand) -> Result<()> {
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: CreateCommand,
+) -> miette::Result<()> {
     let node = extract_address_value(&cmd.at)?;
     let bdy = Policy::new(cmd.expression);
     let req = Request::post(policy_path(&cmd.resource, &cmd.action)).body(bdy);

--- a/implementations/rust/ockam/ockam_command/src/policy/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/delete.rs
@@ -1,6 +1,6 @@
 use crate::policy::policy_path;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_abac::{Action, Resource};
@@ -24,11 +24,18 @@ impl DeleteCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
-async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts, cmd: DeleteCommand) -> Result<()> {
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: DeleteCommand,
+) -> miette::Result<()> {
     let node = extract_address_value(&cmd.at)?;
     let req = Request::delete(policy_path(&cmd.resource, &cmd.action));
     let mut rpc = Rpc::background(ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/policy/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/list.rs
@@ -27,11 +27,18 @@ impl ListCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
-async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts, cmd: ListCommand) -> Result<()> {
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ListCommand,
+) -> miette::Result<()> {
     let resource = cmd.resource;
     let node = extract_address_value(&cmd.at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -64,12 +64,13 @@ pub(crate) async fn add_default_project_policy(
     opts: &CommandGlobalOpts,
     project: ProjectLookup,
     resource: &Resource,
-) -> Result<()> {
+) -> miette::Result<()> {
     let expr = eq([ident("subject.project_id"), str(project.id.to_string())]);
     let bdy = Policy::new(expr);
     let req = Request::post(policy_path(resource, &Action::new("handle_message"))).body(bdy);
 
     let mut rpc = Rpc::background(ctx, opts, node)?;
     rpc.request(req).await?;
-    rpc.is_ok()
+    rpc.is_ok()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -1,6 +1,6 @@
 use crate::policy::policy_path;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_abac::{Action, Resource};
@@ -25,11 +25,18 @@ impl ShowCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
-async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts, cmd: ShowCommand) -> Result<()> {
+async fn run_impl(
+    ctx: &mut Context,
+    opts: CommandGlobalOpts,
+    cmd: ShowCommand,
+) -> miette::Result<()> {
     let node = extract_address_value(&cmd.at)?;
     let req = Request::get(policy_path(&cmd.resource, &cmd.action));
     let mut rpc = Rpc::background(ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -18,7 +18,7 @@ use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 
 use crate::util::{api, node_rpc, Rpc};
-use crate::{docs, fmt_ok, CommandGlobalOpts, Result};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/configure_confluent/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/configure_confluent/after_long_help.txt");
@@ -63,7 +63,7 @@ async fn run_impl(
         CloudOpts,
         AddonConfigureConfluentSubcommand,
     ),
-) -> Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cloud_opts.route();
     let AddonConfigureConfluentSubcommand {
         project_name,

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -17,7 +17,7 @@ use crate::project::addon::disable_addon_endpoint;
 use crate::util::api::CloudOpts;
 
 use crate::util::{node_rpc, Rpc};
-use crate::{fmt_ok, CommandGlobalOpts, Result};
+use crate::{fmt_ok, CommandGlobalOpts};
 
 /// Disable an addon for a project
 #[derive(Clone, Debug, Args)]
@@ -50,7 +50,7 @@ impl AddonDisableSubcommand {
 async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, AddonDisableSubcommand),
-) -> Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cloud_opts.route();
     let AddonDisableSubcommand {
         project_name,

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -13,7 +13,7 @@ use crate::project::addon::base_endpoint;
 use crate::util::api::CloudOpts;
 
 use crate::util::{node_rpc, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use crate::CommandGlobalOpts;
 
 /// List available addons for a project
 #[derive(Clone, Debug, Args)]
@@ -37,7 +37,7 @@ impl AddonListSubcommand {
 async fn run_impl(
     ctx: Context,
     (opts, cloud_opts, cmd): (CommandGlobalOpts, CloudOpts, AddonListSubcommand),
-) -> Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cloud_opts.route();
     let project_name = cmd.project_name;
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -6,8 +6,8 @@ mod list;
 
 use core::fmt::Write;
 
-use anyhow::Context as _;
 use clap::{Args, Subcommand};
+use miette::Context as _;
 
 use ockam_api::cli_state::{CliState, StateDirTrait, StateItemTrait};
 use ockam_api::cloud::addon::Addon;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -44,7 +44,7 @@ impl CreateCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -52,7 +52,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
     let node_name = start_embedded_node(ctx, &opts, None).await?;
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -41,7 +41,7 @@ impl DeleteCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -49,7 +49,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
 
     let node_name = start_embedded_node(ctx, &opts, None).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use anyhow::Context as _;
-use miette::miette;
+use miette::Context as _;
+use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
 use ockam_api::cloud::enroll::auth0::AuthenticateAuth0Token;
@@ -71,7 +71,7 @@ impl EnrollCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, EnrollCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = start_embedded_node(&ctx, &opts, Some(&cmd.trust_opts)).await?;
     let project_as_string: String;
 
@@ -101,8 +101,8 @@ async fn run_impl(
         };
 
         // Read (okta and authority) project parameters from project.json
-        project_as_string = tokio::fs::read_to_string(path).await?;
-        serde_json::from_str(&project_as_string)?
+        project_as_string = tokio::fs::read_to_string(path).await.into_diagnostic()?;
+        serde_json::from_str(&project_as_string).into_diagnostic()?
     };
 
     let project: Project = (&proj).into();
@@ -131,18 +131,23 @@ async fn run_impl(
         let token_issuer_route = {
             let service = MultiAddr::try_from(
                 format!("/service/{}", DefaultAddress::ENROLLMENT_TOKEN_ACCEPTOR).as_str(),
-            )?;
+            )
+            .into_diagnostic()?;
             let mut addr = secure_channel_addr.clone();
             for proto in service.iter() {
-                addr.push_back_value(&proto)?;
+                addr.push_back_value(&proto).into_diagnostic()?;
             }
-            ockam_api::local_multiaddr_to_route(&addr)
-                .context(format!("Invalid MultiAddr {addr}"))?
+            ockam_api::local_multiaddr_to_route(&addr).ok_or(miette!("Invalid MultiAddr {addr}"))?
         };
         let client = TokenAcceptorClient::new(
-            RpcClient::new(route![DefaultAddress::RPC_PROXY, token_issuer_route], &ctx).await?,
+            RpcClient::new(route![DefaultAddress::RPC_PROXY, token_issuer_route], &ctx)
+                .await
+                .into_diagnostic()?,
         );
-        client.present_token(tkn.one_time_code()).await?
+        client
+            .present_token(tkn.one_time_code())
+            .await
+            .into_diagnostic()?
     } else if cmd.okta {
         authenticate_through_okta(
             &ctx,
@@ -156,19 +161,20 @@ async fn run_impl(
     }
 
     let credential_issuer_route = {
-        let service = MultiAddr::try_from("/service/credential_issuer")?;
+        let service = MultiAddr::try_from("/service/credential_issuer").into_diagnostic()?;
         let mut addr = secure_channel_addr.clone();
         for proto in service.iter() {
-            addr.push_back_value(&proto)?;
+            addr.push_back_value(&proto).into_diagnostic()?;
         }
-        ockam_api::local_multiaddr_to_route(&addr).context(format!("Invalid MultiAddr {addr}"))?
+        ockam_api::local_multiaddr_to_route(&addr).ok_or(miette!("Invalid MultiAddr {addr}"))?
     };
 
     let client2 = CredentialsIssuerClient::new(
         route![DefaultAddress::RPC_PROXY, credential_issuer_route],
         &ctx,
     )
-    .await?;
+    .await
+    .into_diagnostic()?;
 
     opts.state
         .projects
@@ -177,7 +183,7 @@ async fn run_impl(
         .trust_contexts
         .overwrite(&project.name, project.clone().try_into()?)?;
 
-    let credential = client2.credential().await?;
+    let credential = client2.credential().await.into_diagnostic()?;
     println!("---");
     println!("{credential}");
     println!("---");
@@ -192,9 +198,12 @@ async fn authenticate_through_okta(
     node_name: &str,
     p: ProjectInfo<'_>,
     secure_channel_addr: MultiAddr,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     // Get auth0 token
-    let okta_config: OktaAuth0 = p.okta_config.context("Okta addon not configured")?.into();
+    let okta_config: OktaAuth0 = p
+        .okta_config
+        .ok_or(miette!("Okta addon not configured"))?
+        .into();
     let auth0 = Auth0Service::new(Auth0Provider::Okta(okta_config));
     let token = auth0.token(&cmd.cloud_opts, opts).await?;
 
@@ -202,12 +211,14 @@ async fn authenticate_through_okta(
     let okta_authenticator_addr = {
         let service = MultiAddr::try_from(
             format!("/service/{}", DefaultAddress::OKTA_IDENTITY_PROVIDER).as_str(),
-        )?;
+        )
+        .into_diagnostic()?;
         let mut addr = secure_channel_addr.clone();
         for proto in service.iter() {
-            addr.push_back_value(&proto)?;
+            addr.push_back_value(&proto).into_diagnostic()?;
         }
-        addr.push_front(Service::new(DefaultAddress::RPC_PROXY))?;
+        addr.push_front(Service::new(DefaultAddress::RPC_PROXY))
+            .into_diagnostic()?;
         addr
     };
 
@@ -224,6 +235,6 @@ async fn authenticate_through_okta(
         Ok(())
     } else {
         eprintln!("{}", rpc.parse_err_msg(res, dec));
-        Err(miette!("Failed to enroll").into())
+        Err(miette!("Failed to enroll"))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/get_credential.rs
@@ -33,13 +33,13 @@ impl GetCredentialCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, GetCredentialCommand),
-) -> Result<()> {
+) -> miette::Result<()> {
     async fn go(
         ctx: &mut Context,
         opts: &CommandGlobalOpts,
         cmd: &GetCredentialCommand,
-    ) -> Result<()> {
-        let tcp = TcpTransport::create(ctx).await?;
+    ) -> miette::Result<()> {
+        let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
         let (to, meta) = clean_multiaddr(&cmd.to, &opts.config.get_lookup()).unwrap();
         let projects_sc = crate::project::util::lookup_projects(
             ctx,

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -106,7 +106,10 @@ impl InfoCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, InfoCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, InfoCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -114,7 +117,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: InfoCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cmd.cloud_opts.route();
     let node_name = start_embedded_node(ctx, &opts, None).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
 
@@ -31,7 +32,10 @@ impl ListCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -39,7 +43,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ListCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
@@ -63,7 +67,7 @@ async fn run_impl(
         &opts
             .terminal
             .build_list(&projects, "Projects", "No projects found on this system.")?;
-    let json = serde_json::to_string_pretty(&projects)?;
+    let json = serde_json::to_string_pretty(&projects).into_diagnostic()?;
 
     for project in &projects {
         opts.state

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -34,7 +34,10 @@ impl ShowCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -42,7 +45,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ShowCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cmd.cloud_opts.route();
     let node_name = start_embedded_node(ctx, &opts, None).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -5,8 +5,7 @@ use ockam_api::identity::EnrollmentTicket;
 use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::Context as _;
-use miette::miette;
+use miette::{miette, IntoDiagnostic};
 use ockam::identity::IdentityIdentifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::{DirectAuthenticatorClient, TokenIssuerClient};
@@ -65,8 +64,8 @@ impl TicketCommand {
         let mut attributes = HashMap::new();
         for attr in &self.attributes {
             let mut parts = attr.splitn(2, '=');
-            let key = parts.next().context("key expected")?;
-            let value = parts.next().context("value expected)")?;
+            let key = parts.next().ok_or(miette!("key expected"))?;
+            let value = parts.next().ok_or(miette!("value expected)"))?;
             attributes.insert(key, value);
         }
         Ok(attributes)
@@ -84,7 +83,7 @@ impl Runner {
         Self { ctx, opts, cmd }
     }
 
-    async fn run(self) -> Result<()> {
+    async fn run(self) -> miette::Result<()> {
         let node_name =
             start_embedded_node(&self.ctx, &self.opts, Some(&self.cmd.trust_opts)).await?;
 
@@ -95,7 +94,11 @@ impl Runner {
             if let Some(tc) = self.cmd.trust_opts.trust_context.as_ref() {
                 let tc = parse_trust_context(&self.opts.state, tc)?;
                 trust_context = Some(tc.clone());
-                let cred_retr = tc.authority()?.own_credential()?;
+                let cred_retr = tc
+                    .authority()
+                    .into_diagnostic()?
+                    .own_credential()
+                    .into_diagnostic()?;
                 let addr = match cred_retr {
                     ockam_api::config::cli::CredentialRetrieverConfig::FromCredentialIssuer(c) => {
                         &c.multiaddr
@@ -103,8 +106,7 @@ impl Runner {
                     _ => {
                         return Err(miette!(
                             "Trust context must be configured with a credential issuer"
-                        )
-                        .into());
+                        ));
                     }
                 };
                 let identity = get_identity_name(&self.opts.state, &self.cmd.cloud_opts.identity);
@@ -112,7 +114,13 @@ impl Runner {
                     &self.ctx,
                     &self.opts,
                     &node_name,
-                    tc.authority()?.identity().await?.identifier().clone(),
+                    tc.authority()
+                        .into_diagnostic()?
+                        .identity()
+                        .await
+                        .into_diagnostic()?
+                        .identifier()
+                        .clone(),
                     addr,
                     Some(identity),
                 )
@@ -143,49 +151,57 @@ impl Runner {
             let direct_authenticator_route = {
                 let service = MultiAddr::try_from(
                     format!("/service/{}", DefaultAddress::DIRECT_AUTHENTICATOR).as_str(),
-                )?;
+                )
+                .into_diagnostic()?;
                 let mut addr = base_addr.clone();
                 for proto in service.iter() {
-                    addr.push_back_value(&proto)?;
+                    addr.push_back_value(&proto).into_diagnostic()?;
                 }
                 ockam_api::local_multiaddr_to_route(&addr)
-                    .context(format!("Invalid MultiAddr {addr}"))?
+                    .ok_or(miette!("Invalid MultiAddr {addr}"))?
             };
             let client = DirectAuthenticatorClient::new(
                 RpcClient::new(
                     route![DefaultAddress::RPC_PROXY, direct_authenticator_route],
                     &self.ctx,
                 )
-                .await?
+                .await
+                .into_diagnostic()?
                 .with_timeout(Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT)),
             );
             client
                 .add_member(id.clone(), self.cmd.attributes()?)
-                .await?
+                .await
+                .into_diagnostic()?
         } else {
             let token_issuer_route = {
                 let service = MultiAddr::try_from(
                     format!("/service/{}", DefaultAddress::ENROLLMENT_TOKEN_ISSUER).as_str(),
-                )?;
+                )
+                .into_diagnostic()?;
                 let mut addr = base_addr.clone();
                 for proto in service.iter() {
-                    addr.push_back_value(&proto)?;
+                    addr.push_back_value(&proto).into_diagnostic()?;
                 }
                 ockam_api::local_multiaddr_to_route(&addr)
-                    .context(format!("Invalid MultiAddr {addr}"))?
+                    .ok_or(miette!("Invalid MultiAddr {addr}"))?
             };
             let client = TokenIssuerClient::new(
                 RpcClient::new(
                     route![DefaultAddress::RPC_PROXY, token_issuer_route],
                     &self.ctx,
                 )
-                .await?
+                .await
+                .into_diagnostic()?
                 .with_timeout(Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT)),
             );
-            let token = client.create_token(self.cmd.attributes()?).await?;
+            let token = client
+                .create_token(self.cmd.attributes()?)
+                .await
+                .into_diagnostic()?;
 
             let ticket = EnrollmentTicket::new(token, project, trust_context);
-            let ticket_serialized = hex::encode(serde_json::to_vec(&ticket)?);
+            let ticket_serialized = hex::encode(serde_json::to_vec(&ticket).into_diagnostic()?);
             print!("{}", ticket_serialized)
         }
 

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -34,7 +34,7 @@ impl DeleteCommand {
 pub async fn run_impl(
     ctx: Context,
     (options, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let relay_name = cmd.relay_name.clone();
     let at = get_node_name(&options.state, &cmd.at);
     let node = extract_address_value(&at)?;

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
@@ -10,7 +11,7 @@ use tokio::try_join;
 use crate::node::get_node_name;
 use crate::terminal::OckamColor;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
 
@@ -32,7 +33,10 @@ impl ListCommand {
     }
 }
 
-async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> Result<()> {
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
@@ -63,7 +67,7 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -
         &format!("Relays on Node {node_name}"),
         &format!("No Relays found on node {node_name}."),
     )?;
-    let json = serde_json::to_string_pretty(&relays)?;
+    let json = serde_json::to_string_pretty(&relays).into_diagnostic()?;
 
     opts.terminal
         .stdout()

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use miette::IntoDiagnostic;
 
 use ockam::Context;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
@@ -6,7 +7,7 @@ use ockam_core::api::Request;
 
 use crate::node::get_node_name;
 use crate::util::{extract_address_value, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
@@ -32,7 +33,10 @@ impl ShowCommand {
     }
 }
 
-async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
+async fn run_impl(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
     let remote_address = &cmd.remote_address;
@@ -47,11 +51,11 @@ async fn run_impl(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -
     println!("  Relay Route: {}", relay_info_response.forwarding_route());
     println!(
         "  Remote Address: {}",
-        relay_info_response.remote_address_ma()?
+        relay_info_response.remote_address_ma().into_diagnostic()?
     );
     println!(
         "  Worker Address: {}",
-        relay_info_response.worker_address_ma()?
+        relay_info_response.worker_address_ma().into_diagnostic()?
     );
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -1,4 +1,5 @@
 use crate::terminal::ConfirmResult;
+use crate::util::local_cmd;
 use crate::{fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
@@ -14,14 +15,11 @@ pub struct ResetCommand {
 
 impl ResetCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> miette::Result<()> {
     if !cmd.yes {
         match opts
             .terminal
@@ -32,7 +30,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> crate::Result<()> {
                 return Ok(());
             }
             ConfirmResult::NonTTY => {
-                return Err(miette!("Use --yes to confirm").into());
+                return Err(miette!("Use --yes to confirm"));
             }
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -1,10 +1,10 @@
 mod parser;
 
 use crate::util::node_rpc;
-use crate::{docs, CommandGlobalOpts, Result};
-use anyhow::Context as _;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
-use miette::miette;
+use miette::Context as _;
+use miette::{miette, IntoDiagnostic};
 use ockam::Context;
 use std::path::PathBuf;
 
@@ -23,15 +23,17 @@ impl RunCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, RunCommand)) -> Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, RunCommand)) -> miette::Result<()> {
     run_impl(&ctx, opts, cmd).await
 }
 
-async fn run_impl(_ctx: &Context, opts: CommandGlobalOpts, cmd: RunCommand) -> Result<()> {
+async fn run_impl(_ctx: &Context, opts: CommandGlobalOpts, cmd: RunCommand) -> miette::Result<()> {
     let path = match cmd.config_path {
         Some(path) => path,
         None => {
-            let mut path = std::env::current_dir().context("Failed to get current directory")?;
+            let mut path = std::env::current_dir()
+                .into_diagnostic()
+                .context("Failed to get current directory")?;
             let default_file_names = ["ockam.yml", "ockam.yaml"];
             let mut found = false;
             for file_name in default_file_names.iter() {
@@ -46,8 +48,7 @@ async fn run_impl(_ctx: &Context, opts: CommandGlobalOpts, cmd: RunCommand) -> R
                 return Err(miette!(
                     "No default configuration file found in current directory.\n\
                     Try passing the path to the config file with the --config-path flag."
-                )
-                .into());
+                ));
             }
             path
         }

--- a/implementations/rust/ockam/ockam_command/src/run/parser.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser.rs
@@ -1,5 +1,5 @@
-use crate::Result;
 use duct::Expression;
+use miette::IntoDiagnostic;
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use ockam_core::compat::collections::HashMap;
 use once_cell::sync::Lazy;
@@ -29,16 +29,16 @@ impl ConfigRunner {
         }
     }
 
-    pub fn go(cli_state: &CliState, path: &Path) -> Result<()> {
+    pub fn go(cli_state: &CliState, path: &Path) -> miette::Result<()> {
         let mut cr = Self::new();
         cr.parse(cli_state, path)?;
         cr.run()?;
         Ok(())
     }
 
-    fn parse(&mut self, cli_state: &CliState, path: &Path) -> Result<()> {
-        let config = std::fs::read_to_string(path)?;
-        let config: Config = serde_yaml::from_str(&config)?;
+    fn parse(&mut self, cli_state: &CliState, path: &Path) -> miette::Result<()> {
+        let config = std::fs::read_to_string(path).into_diagnostic()?;
+        let config: Config = serde_yaml::from_str(&config).into_diagnostic()?;
         let mut visited = HashSet::new();
         let mut nodes = VecDeque::new();
         for (name, node) in config.nodes {
@@ -54,8 +54,7 @@ impl ConfigRunner {
                         "Circular dependency detected: {} -> {}",
                         depends_on,
                         name
-                    )
-                    .into());
+                    ));
                 }
                 // If the dependency has been parsed, remove it from the control
                 // vector and proceed with the current node.
@@ -83,7 +82,7 @@ impl ConfigRunner {
         Ok(())
     }
 
-    fn run(self) -> Result<()> {
+    fn run(self) -> miette::Result<()> {
         for c in self.commands_sorted.into_iter() {
             debug!("Running command: {}", c.id);
             // If a command fails it will show the appropriate error in its subshell.
@@ -137,7 +136,12 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
-    fn parse(self, cli_state: &CliState, node_name: &str, cmds: &mut ConfigRunner) -> Result<()> {
+    fn parse(
+        self,
+        cli_state: &CliState,
+        node_name: &str,
+        cmds: &mut ConfigRunner,
+    ) -> miette::Result<()> {
         let mut insert_command = |subject: &str, name: &str, depends_on, args: &[&str]| {
             debug!("Parsed command: {} {}", binary_path(), args.join(" "));
             let cmd = duct::cmd(binary_path(), args);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -3,7 +3,7 @@ use crate::{
     fmt_log, fmt_ok,
     terminal::OckamColor,
     util::{exitcode, extract_address_value, node_rpc},
-    CommandGlobalOpts, Result,
+    CommandGlobalOpts,
 };
 
 use clap::Args;
@@ -71,7 +71,7 @@ impl CreateCommand {
         opts: &CommandGlobalOpts,
         api_node: &str,
         tcp: &TcpTransport,
-    ) -> Result<MultiAddr> {
+    ) -> miette::Result<MultiAddr> {
         let (to, meta) = clean_nodes_multiaddr(&self.to, &opts.state)
             .into_diagnostic()
             .wrap_err(format!("Could not convert {} into route", &self.to))?;
@@ -85,11 +85,9 @@ impl CreateCommand {
             CredentialExchangeMode::Oneway,
         )
         .await?;
-        Ok(
-            crate::project::util::clean_projects_multiaddr(to, projects_sc)
-                .into_diagnostic()
-                .wrap_err("Could not parse projects from route")?,
-        )
+        crate::project::util::clean_projects_multiaddr(to, projects_sc)
+            .into_diagnostic()
+            .wrap_err("Could not parse projects from route")
     }
 
     // Read the `from` argument and return node name
@@ -98,7 +96,7 @@ impl CreateCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> miette::Result<()> {
     opts.terminal
         .write_line(&fmt_log!("Creating Secure Channel...\n"))?;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -1,6 +1,6 @@
 use crate::{
     util::{api, exitcode, extract_address_value, node_rpc, Rpc},
-    CommandGlobalOpts, OutputFormat, Result,
+    CommandGlobalOpts, OutputFormat,
 };
 use std::str::FromStr;
 
@@ -145,7 +145,10 @@ fn parse_address(input: &str) -> core::result::Result<Address, AddressParseError
     Address::from_str(&buf)
 }
 
-async fn rpc(ctx: Context, (options, command): (CommandGlobalOpts, DeleteCommand)) -> Result<()> {
+async fn rpc(
+    ctx: Context,
+    (options, command): (CommandGlobalOpts, DeleteCommand),
+) -> miette::Result<()> {
     let at = &command.parse_at_node();
     let address = &command.address;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -25,11 +25,11 @@ const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt"
     after_long_help = docs::after_help(AFTER_LONG_HELP),
 )]
 pub struct DeleteCommand {
-    /// Node at which the secure channel was initiated (required)
+    /// Node at which the secure channel was initiated
     #[arg(value_name = "NODE", long, display_order = 800)]
     at: String,
 
-    /// Address at which the channel to be deleted is running (required)
+    /// Address at which the channel to be deleted is running
     #[arg(value_parser(parse_address), display_order = 800)]
     address: Address,
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -33,14 +33,14 @@ impl DeleteCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> crate::Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> miette::Result<()> {
     run_impl(&ctx, (opts, cmd)).await
 }
 
 async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -1,6 +1,6 @@
-use anyhow::anyhow;
 use clap::Args;
 use colorful::Colorful;
+use miette::miette;
 use ockam::Context;
 use ockam_api::nodes::models::secure_channel::{
     SecureChannelListenersList, ShowSecureChannelListenerResponse,
@@ -40,7 +40,10 @@ impl ListCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -48,7 +51,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ListCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
@@ -89,7 +92,7 @@ impl Output for ShowSecureChannelListenerResponse {
     fn output(&self) -> crate::Result<String> {
         let addr = {
             let channel_route = &route![self.addr.clone()];
-            let channel_multiaddr = route_to_multiaddr(channel_route).ok_or(anyhow!(
+            let channel_multiaddr = route_to_multiaddr(channel_route).ok_or(miette!(
                 "Failed to convert route {channel_route} to multi-address"
             ))?;
             channel_multiaddr.to_string()

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -12,8 +12,8 @@ use tokio::try_join;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
-use crate::util::api;
 use crate::util::output::Output;
+use crate::util::{api, parse_node_name};
 use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -49,7 +49,8 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: ListCommand,
 ) -> crate::Result<()> {
-    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&at)?;
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -32,14 +32,14 @@ impl ShowCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> crate::Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> miette::Result<()> {
     run_impl(&ctx, (opts, cmd)).await
 }
 
 async fn run_impl(
     ctx: &Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&at)?;
     let address = &cmd.address;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -1,10 +1,12 @@
 use crate::{
     docs,
-    util::{api, extract_address_value, node_rpc, Rpc},
+    util::{api, node_rpc, Rpc},
     CommandGlobalOpts, Result,
 };
 use clap::Args;
 
+use crate::node::get_node_name;
+use crate::util::parse_node_name;
 use ockam::Context;
 use ockam_api::nodes::models::secure_channel::ShowSecureChannelResponse;
 use ockam_core::Address;
@@ -22,7 +24,7 @@ const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 pub struct ShowCommand {
     /// Node at which the secure channel was initiated
     #[arg(value_name = "NODE_NAME", long, display_order = 800)]
-    at: String,
+    at: Option<String>,
 
     /// Channel address
     #[arg(display_order = 800)]
@@ -30,21 +32,17 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(rpc, (options, self));
-    }
-
-    // Read the `at` argument and return node name
-    fn parse_at_node(&self) -> String {
-        extract_address_value(&self.at).unwrap_or_else(|_| "".to_string())
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(rpc, (opts, self));
     }
 }
 
-async fn rpc(ctx: Context, (options, command): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
-    let at = &command.parse_at_node();
-    let address = &command.address;
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
+    let at = get_node_name(&opts.state, &cmd.at);
+    let node_name = parse_node_name(&at)?;
+    let address = &cmd.address;
 
-    let mut rpc = Rpc::background(&ctx, &options, at)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let request = api::show_secure_channel(address);
     rpc.request(request).await?;
     let response = rpc.parse_response::<ShowSecureChannelResponse>()?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -1,7 +1,7 @@
 use crate::{
     docs,
     util::{api, node_rpc, Rpc},
-    CommandGlobalOpts, Result,
+    CommandGlobalOpts,
 };
 use clap::Args;
 
@@ -37,7 +37,7 @@ impl ShowCommand {
     }
 }
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> Result<()> {
+async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.at);
     let node_name = parse_node_name(&at)?;
     let address = &cmd.address;

--- a/implementations/rust/ockam/ockam_command/src/service/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/config.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Context as _;
+use miette::{Context as _, IntoDiagnostic};
 use serde::{Deserialize, Serialize};
 
 use ockam::identity::IdentityIdentifier;
@@ -86,8 +86,11 @@ pub struct Config {
 impl Config {
     pub(crate) fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
         let s = std::fs::read_to_string(path.as_ref())
+            .into_diagnostic()
             .context(format!("failed to read {:?}", path.as_ref()))?;
-        let c = serde_json::from_str(&s).context(format!("invalid config {:?}", path.as_ref()))?;
+        let c = serde_json::from_str(&s)
+            .into_diagnostic()
+            .context(format!("invalid config {:?}", path.as_ref()))?;
         Ok(c)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -4,7 +4,7 @@ use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{fmt_ok, CommandGlobalOpts};
 use crate::{fmt_warn, Result};
 use clap::{Args, Subcommand};
-use miette::miette;
+use miette::{miette, IntoDiagnostic};
 
 use colorful::Colorful;
 use minicbor::Encode;
@@ -93,7 +93,7 @@ impl StartCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, StartCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -101,9 +101,9 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: StartCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-    let tcp = TcpTransport::create(ctx).await?;
+    let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
     let mut is_hop_service = false;
     let addr = match cmd.create_subcommand {
         StartSubCommand::Hop { addr, .. } => {

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -50,7 +50,7 @@ impl CreateCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -58,7 +58,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
     rpc.request(api::space::create(&cmd)).await?;
     let space = rpc.parse_and_print_response::<Space>()?;

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -37,7 +37,7 @@ impl DeleteCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -45,7 +45,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
 
     let node_name = start_embedded_node(ctx, &opts, None).await?;

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use miette::IntoDiagnostic;
 
 use ockam::Context;
 use ockam_api::cli_state::{SpaceConfig, StateDirTrait};
@@ -31,7 +32,10 @@ impl ListCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -39,7 +43,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ListCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
 
@@ -62,7 +66,7 @@ async fn run_impl(
     let plain = opts
         .terminal
         .build_list(&spaces, "Spaces", "No spaces found.")?;
-    let json = serde_json::to_string_pretty(&spaces)?;
+    let json = serde_json::to_string_pretty(&spaces).into_diagnostic()?;
 
     for space in spaces {
         opts.state

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -34,7 +34,10 @@ impl ShowCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ShowCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -42,7 +45,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ShowCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
 
     let node_name = start_embedded_node(ctx, &opts, None).await?;

--- a/implementations/rust/ockam/ockam_command/src/space/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/util.rs
@@ -11,7 +11,7 @@ async fn refresh_spaces(
     opts: &CommandGlobalOpts,
     api_node: &str,
     controller_route: &MultiAddr,
-) -> Result<()> {
+) -> miette::Result<()> {
     let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
     rpc.request(api::space::list(controller_route)).await?;
     let spaces = rpc.parse_response::<Vec<Space>>()?;

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -56,7 +56,7 @@ impl SubscriptionCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let controller_route = &cmd.cloud_opts.route();
     let mut rpc = Rpc::embedded(&ctx, &opts).await?;
     match cmd.subcommand {

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use clap::Args;
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam_api::nodes::models;
 use serde_json::json;
 
@@ -42,21 +43,21 @@ impl CreateCommand {
         &self,
         opts: &CommandGlobalOpts,
         response: &models::transport::TransportStatus,
-    ) -> crate::Result<()> {
+    ) -> miette::Result<()> {
         // if output format is json, write json to stdout.
         match opts.global_args.output_format {
             OutputFormat::Plain => {
                 if !is_tty(std::io::stdout()) {
-                    println!("{}", response.multiaddr()?);
+                    println!("{}", response.multiaddr().into_diagnostic()?);
                     return Ok(());
                 }
                 let from = get_node_name(&opts.state, &self.node_opts.from);
-                let to = response.socket_addr()?;
+                let to = response.socket_addr().into_diagnostic()?;
                 if opts.global_args.no_color {
                     println!("\n  TCP Connection:");
                     println!("    From: /node/{from}");
                     println!("    To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port());
-                    println!("    Address: {}", response.multiaddr()?);
+                    println!("    Address: {}", response.multiaddr().into_diagnostic()?);
                 } else {
                     println!("\n  TCP Connection:");
                     println!("{}", format!("    From: /node/{from}").light_magenta());
@@ -67,12 +68,13 @@ impl CreateCommand {
                     );
                     println!(
                         "{}",
-                        format!("    Address: {}", response.multiaddr()?).light_magenta()
+                        format!("    Address: {}", response.multiaddr().into_diagnostic()?)
+                            .light_magenta()
                     );
                 }
             }
             OutputFormat::Json => {
-                let json = json!([{"route": response.multiaddr()? }]);
+                let json = json!([{"route": response.multiaddr().into_diagnostic()? }]);
                 println!("{json}");
             }
         }
@@ -83,7 +85,7 @@ impl CreateCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let from = get_node_name(&opts.state, &cmd.node_opts.from);
     let node_name = extract_address_value(&from)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -28,7 +28,7 @@ impl DeleteCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -33,7 +33,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -32,7 +32,7 @@ impl ShowCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -33,7 +33,7 @@ impl DeleteCommand {
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let alias = cmd.alias.clone();
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -32,7 +32,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node.at_node);
     let node_name = extract_address_value(&node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -34,7 +34,7 @@ impl ShowCommand {
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -33,7 +33,7 @@ impl DeleteCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = parse_node_name(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -28,7 +28,10 @@ impl ListCommand {
     }
 }
 
-async fn rpc(mut ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> crate::Result<()> {
+async fn rpc(
+    mut ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -36,7 +39,7 @@ async fn run_impl(
     ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: ListCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     let is_finished: Mutex<bool> = Mutex::new(false);

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -32,7 +32,7 @@ impl ShowCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -10,6 +10,7 @@ use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 use clap::Args;
 use colorful::Colorful;
+use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_abac::Resource;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
@@ -56,7 +57,7 @@ fn default_from_addr() -> String {
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     opts.terminal.write_line(&fmt_log!(
         "Creating TCP Outlet to {}...\n",
         &cmd.to
@@ -116,8 +117,8 @@ pub async fn run_impl(
         .progress_output(&output_messages, &is_finished);
 
     let (outlet_status, _) = try_join!(send_req, progress_output)?;
-    let machine = outlet_status.worker_address()?;
-    let json = serde_json::to_string_pretty(&outlet_status)?;
+    let machine = outlet_status.worker_address().into_diagnostic()?;
+    let json = serde_json::to_string_pretty(&outlet_status).into_diagnostic()?;
 
     opts.terminal
         .stdout()

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -33,7 +33,7 @@ impl DeleteCommand {
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let alias = cmd.alias.clone();
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -32,7 +32,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: ockam::Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -4,8 +4,9 @@ use crate::util::{extract_address_value, node_rpc, Rpc};
 use crate::Result;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
+use miette::miette;
 use ockam::{route, Context};
-use ockam_api::error::ApiError;
+
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};
@@ -35,7 +36,7 @@ impl ShowCommand {
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
@@ -47,7 +48,7 @@ pub async fn run_impl(
     println!("Outlet:");
     println!("  Alias: {}", outlet_to_show.alias);
     let addr = route_to_multiaddr(&route![outlet_to_show.worker_addr.to_string()])
-        .ok_or_else(|| ApiError::generic("Invalid Outlet Address"))?;
+        .ok_or_else(|| miette!("Invalid Outlet Address"))?;
     println!("  From Outlet: {addr}");
     println!("  To TCP: {}", outlet_to_show.tcp_addr);
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/trust_context/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/delete.rs
@@ -6,6 +6,7 @@ use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cli_state::CliStateError;
 
 use crate::terminal::ConfirmResult;
+use crate::util::local_cmd;
 use crate::{docs, fmt_ok, fmt_warn, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
@@ -25,14 +26,11 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e:?}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> miette::Result<()> {
     let DeleteCommand { name } = cmd;
     let state = opts.state.trust_contexts;
     match state.get(&name) {
@@ -58,7 +56,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> crate::Result<()> {
         }
         // Else, return the appropriate error
         Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Trust context '{name}' not found").into()),
+            CliStateError::NotFound => Err(miette!("Trust context '{name}' not found")),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/trust_context/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/list.rs
@@ -2,6 +2,7 @@ use clap::Args;
 use miette::miette;
 use ockam_api::cli_state::traits::StateDirTrait;
 
+use crate::util::local_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
@@ -17,17 +18,14 @@ pub struct ListCommand;
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts) -> miette::Result<()> {
     let states = opts.state.trust_contexts.list()?;
     if states.is_empty() {
-        return Err(miette!("No trust contexts registered on this system!").into());
+        return Err(miette!("No trust contexts registered on this system!"));
     }
     let plain_output = {
         let mut output = String::new();

--- a/implementations/rust/ockam/ockam_command/src/trust_context/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/show.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use ockam_api::cli_state::traits::StateDirTrait;
 
+use crate::util::local_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
@@ -19,14 +20,11 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> miette::Result<()> {
     let name = cmd
         .name
         .unwrap_or(opts.state.trust_contexts.default()?.name().to_string());

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -2,9 +2,9 @@
 
 use std::path::PathBuf;
 
-use anyhow::Context as _;
 use clap::Args;
-use miette::miette;
+use miette::Context as _;
+use miette::{miette, IntoDiagnostic};
 // TODO: maybe we can remove this cross-dependency inside the CLI?
 use minicbor::Decoder;
 use regex::Regex;
@@ -436,9 +436,11 @@ impl TrustContextConfigBuilder {
 
     fn get_from_project_path(&self, path: &PathBuf) -> Option<TrustContextConfig> {
         let s = std::fs::read_to_string(path)
+            .into_diagnostic()
             .context("Failed to read project file")
             .ok()?;
         let proj_info = serde_json::from_str::<ProjectInfo>(&s)
+            .into_diagnostic()
             .context("Failed to parse project info")
             .ok()?;
         let proj: Project = (&proj_info).into();
@@ -496,13 +498,14 @@ pub fn parse_trust_context(
     let tcc = match std::fs::read_to_string(trust_context_input) {
         Ok(s) => {
             let mut tc = serde_json::from_str::<TrustContextConfig>(&s)
-                .context("Failed to parse trust context")?;
+                .into_diagnostic()
+                .wrap_err("Failed to parse trust context")?;
             tc.set_path(PathBuf::from(trust_context_input));
             tc
         }
         Err(_) => {
             let state = cli_state.trust_contexts.get(trust_context_input).ok();
-            let state = state.context("Invalid Trust Context name or path")?;
+            let state = state.ok_or(miette!("Invalid Trust Context name or path"))?;
             let mut tcc = state.config().clone();
             tcc.set_path(state.path().clone());
             tcc
@@ -515,7 +518,8 @@ pub fn parse_trust_context(
 impl CloudOpts {
     pub fn route(&self) -> MultiAddr {
         let default_addr = MultiAddr::from_string(DEFAULT_CONTROLLER_ADDRESS)
-            .context(format!(
+            .into_diagnostic()
+            .wrap_err(format!(
                 "invalid Controller route: {DEFAULT_CONTROLLER_ADDRESS}"
             ))
             .unwrap();
@@ -529,11 +533,11 @@ impl CloudOpts {
 
 ////////////// !== validators
 
-pub(crate) fn validate_cloud_resource_name(s: &str) -> Result<()> {
+pub(crate) fn validate_cloud_resource_name(s: &str) -> miette::Result<()> {
     let project_name_regex = Regex::new(r"^[a-zA-Z0-9]+([a-zA-Z0-9-_\.]?[a-zA-Z0-9])*$").unwrap();
     let is_project_name_valid = project_name_regex.is_match(s);
     if !is_project_name_valid {
-        Err(miette!("Invalid name").into())
+        Err(miette!("Invalid name"))
     } else {
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -1,6 +1,6 @@
-use anyhow::Context;
 use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
+use miette::miette;
 use miette::IntoDiagnostic;
 use ockam_api::cli_state::{StateItemTrait, VaultState};
 
@@ -213,7 +213,7 @@ impl Output for Vec<Project> {
 impl Output for CreateSecureChannelResponse {
     fn output(&self) -> Result<String> {
         let addr = route_to_multiaddr(&route![self.addr.to_string()])
-            .context("Invalid Secure Channel Address")?
+            .ok_or(miette!("Invalid Secure Channel Address"))?
             .to_string();
         Ok(addr)
     }
@@ -227,7 +227,7 @@ impl Output for ShowSecureChannelResponse<'_> {
                     "\n  Secure Channel:\n{} {}\n{} {}\n{} {}",
                     "  •         At: ".light_magenta(),
                     route_to_multiaddr(&route![addr.to_string()])
-                        .context("Invalid Secure Channel Address")?
+                        .ok_or(miette!("Invalid Secure Channel Address"))?
                         .to_string()
                         .light_yellow(),
                     "  •         To: ".light_magenta(),

--- a/implementations/rust/ockam/ockam_command/src/vault/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/create.rs
@@ -39,7 +39,7 @@ impl CreateCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -47,7 +47,7 @@ async fn run_impl(
     _ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let CreateCommand { name, aws_kms, .. } = cmd;
     let config = cli_state::VaultConfig::new(aws_kms)?;
     if opts.state.vaults.is_empty()? {

--- a/implementations/rust/ockam/ockam_command/src/vault/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/default.rs
@@ -1,8 +1,8 @@
-
+use crate::util::local_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
-use miette::{miette};
+use miette::miette;
 use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cli_state::CliStateError;
 
@@ -22,21 +22,18 @@ pub struct DefaultCommand {
 
 impl DefaultCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e:?}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> miette::Result<()> {
     let DefaultCommand { name } = cmd;
     let state = opts.state.vaults;
     match state.get(&name) {
         Ok(v) => {
             // If it exists, warn the user and exit
             if state.is_default(v.name())? {
-                Err(miette!("Vault '{}' is already the default", name).into())
+                Err(miette!("Vault '{}' is already the default", name))
             }
             // Otherwise, set it as default
             else {
@@ -51,7 +48,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> crate::Result<()> {
             }
         }
         Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name).into()),
+            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name)),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/vault/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/default.rs
@@ -1,7 +1,8 @@
+
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
-use miette::miette;
+use miette::{miette};
 use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cli_state::CliStateError;
 

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -33,7 +33,7 @@ impl DeleteCommand {
 async fn rpc(
     mut ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     run_impl(&mut ctx, opts, cmd).await
 }
 
@@ -41,7 +41,7 @@ async fn run_impl(
     _ctx: &mut Context,
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let DeleteCommand { name } = cmd;
     let state = opts.state.vaults;
     match state.get(&name) {
@@ -67,7 +67,7 @@ async fn run_impl(
         }
         // Else, return the appropriate error
         Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name).into()),
+            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name)),
             _ => Err(err.into()),
         },
     }

--- a/implementations/rust/ockam/ockam_command/src/vault/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/list.rs
@@ -2,6 +2,7 @@ use clap::Args;
 
 use ockam_api::cli_state::traits::StateDirTrait;
 
+use crate::util::local_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
@@ -17,14 +18,11 @@ pub struct ListCommand;
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts) -> miette::Result<()> {
     let vaults = opts.state.vaults.list()?;
     let list = opts
         .terminal

--- a/implementations/rust/ockam/ockam_command/src/vault/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/show.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use ockam_api::cli_state::traits::StateDirTrait;
 
+use crate::util::local_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
@@ -19,14 +20,11 @@ pub struct ShowCommand {
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        if let Err(e) = run_impl(opts, self) {
-            eprintln!("{e}");
-            std::process::exit(e.code());
-        }
+        local_cmd(run_impl(opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> crate::Result<()> {
+fn run_impl(opts: CommandGlobalOpts, cmd: ShowCommand) -> miette::Result<()> {
     let name = cmd
         .name
         .unwrap_or(opts.state.vaults.default()?.name().to_string());

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -35,7 +35,7 @@ impl ListCommand {
 async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> crate::Result<()> {
+) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
 


### PR DESCRIPTION
## Main changes

- Replace the `ockam_command` top-most return type from `crate::Result` to `miette::Result` so we can keep all the chained errors information and display it to the user (see next section). The `x::Result -> miette::Result -> x::Result` implies loosing all the report information by miette's, which is the whole purpose of using this tool. The code looks a little ugly with all thos `into_diagnostic`, but we'll remove them as we implement the appropriate traits in different parts of the code.

- A side-effect of the previous change is that we no longer keep a specific `exitcode` next to the error, so we are always returning an `exitcode::SOFTWARE` code when there is an error, an `exitcode::USAGE` when there is a clap parsing error and an `exitcode::OK` if all goes well. 

- Use a customized `GraphicalReportHandler` (miette's default) instead of using one created from scratch by us. The report rendering [internals are quite complex](https://docs.rs/miette/latest/src/miette/handlers/graphical.rs.html#148) for us to try to make our own just yet. We should start with the default to use all the features available and customize it as we get familiar with it.

## What this means for the user

Instead of seeing just the top-most error message:

![image](https://github.com/build-trust/ockam/assets/12375782/ef0a172a-a5cb-481d-8185-57977e159f4e)

We'll be able to display the chained errors' information as well:

![image](https://github.com/build-trust/ockam/assets/12375782/618e52f0-ae26-43a0-a4ba-e9992a9f2923)
