### PR TITLE
test(rust): re-introduce some missing vault tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,6 +3352,7 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_aws",
  "once_cell",
+ "openssl",
  "quickcheck",
  "rand",
  "reqwest",
@@ -3776,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -3808,9 +3809,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -44,6 +44,7 @@ miette = "5.9.0"
 minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
 nix = "0.26"
 once_cell = { version = "1", optional = true, default-features = false }
+openssl = "0.10.55"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.164", features = ["derive"] }

--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -65,9 +65,6 @@ alloc = [
 
 storage = ["ockam_node/storage", "std", "serde", "serde_cbor"]
 
-# Feature: this gives access to test suites for testing the implementation of the Vault traits
-vault_tests = []
-
 [dependencies]
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
 arrayref = "0.3"

--- a/implementations/rust/ockam/ockam_vault/src/traits/asymmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/asymmetric_vault.rs
@@ -22,7 +22,7 @@ pub trait AsymmetricVault: Send + Sync {
 }
 
 /// Tests for implementations of the AsymmetricVault trait
-#[cfg(feature = "vault_tests")]
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{EphemeralSecretsStore, Secret, SecretAttributes};

--- a/implementations/rust/ockam/ockam_vault/src/traits/mod.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/mod.rs
@@ -1,20 +1,19 @@
+#[cfg(test)]
+pub use asymmetric_vault::tests::*;
+pub use asymmetric_vault::*;
+#[cfg(test)]
+pub use secrets_store::tests::*;
+pub use secrets_store::*;
+pub use security_module::*;
+#[cfg(test)]
+pub use signer::tests::*;
+pub use signer::*;
+#[cfg(test)]
+pub use symmetric_vault::tests::*;
+pub use symmetric_vault::*;
+
 mod asymmetric_vault;
 pub(crate) mod secrets_store;
 mod security_module;
 mod signer;
 mod symmetric_vault;
-
-pub use asymmetric_vault::*;
-pub use secrets_store::*;
-pub use security_module::*;
-pub use signer::*;
-pub use symmetric_vault::*;
-
-#[cfg(feature = "vault_tests")]
-pub use asymmetric_vault::tests::*;
-#[cfg(feature = "vault_tests")]
-pub use secrets_store::tests::*;
-#[cfg(feature = "vault_tests")]
-pub use signer::tests::*;
-#[cfg(feature = "vault_tests")]
-pub use symmetric_vault::tests::*;

--- a/implementations/rust/ockam/ockam_vault/src/traits/secrets_store.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/secrets_store.rs
@@ -55,7 +55,7 @@ pub trait SecretsStoreReader: Sync + Send {
 }
 
 /// Tests for implementations of the SecretsStore trait
-#[cfg(feature = "vault_tests")]
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{PublicKey, SecretAttributes, SecretType};

--- a/implementations/rust/ockam/ockam_vault/src/traits/signer.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/signer.rs
@@ -17,11 +17,10 @@ pub trait Signer: Send + Sync {
 }
 
 /// Tests for implementations of the Signer trait
-#[cfg(feature = "vault_tests")]
+#[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{SecretAttributes, SecretsStore};
-    use ockam_core::KeyId;
 
     /// This test checks that an ephemeral secret can be used to sign data and that we can verify the signature
     pub async fn test_sign_and_verify_ephemeral_secret(vault: &mut (impl Signer + SecretsStore)) {

--- a/implementations/rust/ockam/ockam_vault/src/traits/symmetric_vault.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/symmetric_vault.rs
@@ -23,7 +23,7 @@ pub trait SymmetricVault: Send + Sync {
     ) -> Result<Buffer<u8>>;
 }
 
-#[cfg(feature = "vault_tests")]
+#[cfg(test)]
 pub mod tests {
     use crate::{EphemeralSecretsStore, SecretAttributes, SymmetricVault};
 

--- a/implementations/rust/ockam/ockam_vault/src/vault/asymmetric_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/asymmetric_impl.rs
@@ -122,7 +122,6 @@ impl Vault {
     }
 }
 
-#[cfg(feature = "vault_tests")]
 #[cfg(test)]
 mod tests {
     use crate as ockam_vault;

--- a/implementations/rust/ockam/ockam_vault/src/vault/secrets_store_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/secrets_store_impl.rs
@@ -3,7 +3,7 @@ use crate::{
     SecretAttributes, SecretsStoreReader, SecurityModule, Signature, StoredSecret, VaultError,
     VaultSecurityModule,
 };
-use ockam_core::{async_trait, compat::boxed::Box, compat::sync::Arc, compat::vec::Vec, Result};
+use ockam_core::{async_trait, compat::boxed::Box, compat::fmt::Vec, compat::sync::Arc, Result};
 use ockam_node::KeyValueStorage;
 
 #[derive(Clone)]
@@ -147,7 +147,6 @@ impl SecurityModule for VaultSecretsStore {
     }
 }
 
-#[cfg(feature = "vault_tests")]
 #[cfg(test)]
 mod tests {
     use crate as ockam_vault;

--- a/implementations/rust/ockam/ockam_vault/src/vault/signer_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/signer_impl.rs
@@ -25,7 +25,6 @@ impl<T: SecretsStore + SecurityModule> Signer for T {
     }
 }
 
-#[cfg(feature = "vault_tests")]
 #[cfg(test)]
 mod tests {
     use crate as ockam_vault;

--- a/implementations/rust/ockam/ockam_vault/src/vault/symmetric_impl.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/symmetric_impl.rs
@@ -105,7 +105,6 @@ impl AeadCore for AesGen {
     type CiphertextOverhead = U0;
 }
 
-#[cfg(feature = "vault_tests")]
 #[cfg(test)]
 mod tests {
     use crate as ockam_vault;


### PR DESCRIPTION
Some vault tests were put behind a feature flag for no good reason. This PR re-integrates those tests in the regular test suite
