### PR TITLE
refactor(rust): add more meaningful error messages for `CLiState` errors

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/credentials.rs
@@ -46,16 +46,14 @@ impl CredentialConfig {
     }
 
     pub fn credential(&self) -> Result<Credential> {
-        let bytes = match hex::decode(&self.encoded_credential) {
-            Ok(b) => b,
-            Err(e) => {
-                return Err(CliStateError::Invalid(format!(
-                    "Unable to hex decode credential. {e}"
-                )));
-            }
-        };
-        minicbor::decode::<Credential>(&bytes)
-            .map_err(|e| CliStateError::Invalid(format!("Unable to decode credential. {e}")))
+        let bytes = hex::decode(&self.encoded_credential).map_err(|e| {
+            error!(%e, "Unable to hex-decode credential");
+            CliStateError::InvalidOperation("Unable to hex-decode credential".to_string())
+        })?;
+        minicbor::decode::<Credential>(&bytes).map_err(|e| {
+            error!(%e, "Unable to decode credential");
+            CliStateError::InvalidOperation("Unable to decode credential".to_string())
+        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -330,7 +330,10 @@ impl NodeSetupConfig {
         self.transports
             .iter()
             .find(|t| t.tt == TransportType::Tcp && t.tm == TransportMode::Listen)
-            .ok_or(CliStateError::NotFound)
+            .ok_or(CliStateError::ResourceNotFound {
+                resource: "tcp listener".to_string(),
+                name: "default".to_string(),
+            })
     }
 
     pub fn add_transport(mut self, transport: CreateTransportJson) -> Self {
@@ -415,7 +418,10 @@ mod traits {
             config: <<Self as StateDirTrait>::Item as StateItemTrait>::Config,
         ) -> Result<Self::Item> {
             if self.exists(&name) {
-                return Err(CliStateError::AlreadyExists);
+                return Err(CliStateError::AlreadyExists {
+                    resource: Self::default_filename().to_string(),
+                    name: name.as_ref().to_string(),
+                });
             }
             let state = Self::Item::init(self.path(&name), config)?;
             if !self.default_path()?.exists() {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -17,7 +17,10 @@ pub struct VaultsState {
 impl VaultsState {
     pub async fn create_async(&self, name: &str, config: VaultConfig) -> Result<VaultState> {
         if self.exists(name) {
-            return Err(CliStateError::AlreadyExists);
+            return Err(CliStateError::AlreadyExists {
+                resource: Self::default_filename().to_string(),
+                name: name.to_string(),
+            });
         }
         let state = VaultState::new(self.path(name), config)?;
         state.get().await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport/json.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport/json.rs
@@ -19,7 +19,9 @@ impl CreateTransportJson {
         Ok(Self {
             tt,
             tm,
-            addr: InternetAddress::new(addr).ok_or(CliStateError::Unknown)?,
+            addr: InternetAddress::new(addr).ok_or(CliStateError::InvalidOperation(
+                "Invalid address '{addr}'".to_string(),
+            ))?,
         })
     }
 

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,10 +1,10 @@
 use crate::util::node_rpc;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
-use miette::miette;
+use colorful::Colorful;
+
 use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::CliStateError;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -32,18 +32,16 @@ async fn run_impl(
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> miette::Result<()> {
     let state = opts.state;
-    // Check if exists
-    match state.identities.get(&cmd.name) {
-        // If it exists, proceed
-        Ok(identity_state) => {
-            state.delete_identity(identity_state)?;
-            println!("Identity '{}' deleted", cmd.name);
-            Ok(())
-        }
-        // Return the appropriate error
-        Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Identity '{}' not found", &cmd.name)),
-            _ => Err(err.into()),
-        },
-    }
+    let idt = state.identities.get(&cmd.name)?;
+    state.delete_identity(idt)?;
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!(
+            "The identity named '{}' has been deleted.",
+            &cmd.name
+        ))
+        .machine(&cmd.name)
+        .json(serde_json::json!({ "name": &cmd.name }))
+        .write_line()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -337,7 +337,7 @@ impl OckamCommand {
             Box::new(
                 GraphicalReportHandler::new()
                     .with_cause_chain()
-                    .with_footer(fmt_log!("{}", Version::short().to_string().light_gray()))
+                    .with_footer(Version::short().light_gray().to_string())
                     .with_urls(false),
             )
         }));

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -108,7 +108,7 @@ async fn rpc(
         let msg_bytes = if cmd.hex {
             hex::decode(cmd.message)
                 .into_diagnostic()
-                .context("Invalid hex string")?
+                .context("The message is not a valid hex string")?
         } else {
             cmd.message.as_bytes().to_vec()
         };

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -467,11 +467,7 @@ async fn spawn_background_node(
     addr: SocketAddr,
 ) -> miette::Result<()> {
     // Check if the port is used by some other services or process
-    if !bind_to_port_check(&addr) {
-        return Err(miette!(
-            "Another process is listening on the provided port!"
-        ));
-    }
+    bind_to_port_check(&addr)?;
 
     let node_name = parse_node_name(&cmd.node_name)?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -137,7 +137,8 @@ pub(crate) async fn init_node_state(
         .identities_creation()
         .create_identity()
         .await
-        .into_diagnostic()?;
+        .into_diagnostic()
+        .wrap_err("Failed to create identity")?;
 
     let identity_state = opts
         .state
@@ -178,11 +179,6 @@ pub fn delete_all_nodes(opts: CommandGlobalOpts, force: bool) -> miette::Result<
             deletion_errors
         ));
     }
-    Ok(())
-}
-
-pub fn set_default_node(opts: &CommandGlobalOpts, name: &str) -> miette::Result<()> {
-    opts.state.nodes.set_default(name)?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/trust_context/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/default.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::CliStateError;
 
 const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt");
@@ -30,27 +29,20 @@ impl DefaultCommand {
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> miette::Result<()> {
     let DefaultCommand { name } = cmd;
     let state = opts.state.trust_contexts;
-    match state.get(&name) {
-        Ok(v) => {
-            // If it exists, warn the user and exit
-            if state.is_default(v.name())? {
-                Err(miette!("Trust context '{name}' is already the default"))
-            }
-            // Otherwise, set it as default
-            else {
-                state.set_default(v.name())?;
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("Trust context '{name}' is now the default"))
-                    .machine(&name)
-                    .json(serde_json::json!({ "trust-context": {"name": name} }))
-                    .write_line()?;
-                Ok(())
-            }
-        }
-        Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Trust context '{name}' not found")),
-            _ => Err(err.into()),
-        },
+    let tc = state.get(&name)?;
+    // If it exists, warn the user and exit
+    if state.is_default(tc.name())? {
+        Err(miette!("The trust context '{name}' is already the default"))
+    }
+    // Otherwise, set it as default
+    else {
+        state.set_default(tc.name())?;
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!("The trust context '{name}' is now the default"))
+            .machine(&name)
+            .json(serde_json::json!({ "trust-context": {"name": name} }))
+            .write_line()?;
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -518,12 +518,12 @@ pub fn parse_node_name(input: &str) -> Result<String> {
     let maddr = MultiAddr::from_str(input)
         .into_diagnostic()
         .wrap_err("Invalid format for node name argument")?;
-    let err_message = String::from("A MultiAddr node must follow the format /node/<name>");
+    let err_message = String::from("A node MultiAddr must follow the format /node/<name>");
     if let Some(p) = maddr.iter().next() {
         if p.code() == proto::Node::CODE {
             let node_name = p
                 .cast::<proto::Node>()
-                .ok_or(miette!("Failed to parse `node` protocol"))?
+                .ok_or(miette!("Failed to parse the 'node' protocol"))?
                 .to_string();
             if !node_name.is_empty() {
                 return Ok(node_name);
@@ -545,7 +545,7 @@ pub fn process_nodes_multiaddr(addr: &MultiAddr, cli_state: &CliState) -> crate:
             Node::CODE => {
                 let alias = proto
                     .cast::<Node>()
-                    .ok_or_else(|| miette!("invalid node address protocol"))?;
+                    .ok_or_else(|| miette!("Invalid node address protocol"))?;
                 let node_state = cli_state.nodes.get(alias.to_string())?;
                 let node_setup = node_state.config().setup();
                 let addr = node_setup.default_tcp_listener()?.maddr()?;
@@ -605,10 +605,13 @@ pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
     data.iter().map(AsRef::as_ref).intersperse(", ").collect()
 }
 
-pub fn bind_to_port_check(address: &SocketAddr) -> bool {
+pub fn bind_to_port_check(address: &SocketAddr) -> Result<()> {
     let port = address.port();
     let ip = address.ip();
-    TcpListener::bind((ip, port)).is_ok()
+    if TcpListener::bind((ip, port)).is_err() {
+        return Err(miette!("Another process is already listening on port {port}!").into());
+    }
+    Ok(())
 }
 
 pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {

--- a/implementations/rust/ockam/ockam_command/src/vault/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/default.rs
@@ -4,7 +4,6 @@ use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::CliStateError;
 
 const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt");
@@ -29,27 +28,20 @@ impl DefaultCommand {
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> miette::Result<()> {
     let DefaultCommand { name } = cmd;
     let state = opts.state.vaults;
-    match state.get(&name) {
-        Ok(v) => {
-            // If it exists, warn the user and exit
-            if state.is_default(v.name())? {
-                Err(miette!("Vault '{}' is already the default", name))
-            }
-            // Otherwise, set it as default
-            else {
-                state.set_default(v.name())?;
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("Vault '{name}' is now the default"))
-                    .machine(&name)
-                    .json(serde_json::json!({ "vault": {"name": name} }))
-                    .write_line()?;
-                Ok(())
-            }
-        }
-        Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name)),
-            _ => Err(err.into()),
-        },
+    let v = state.get(&name)?;
+    // If it exists, warn the user and exit
+    if state.is_default(v.name())? {
+        Err(miette!("The vault '{}' is already the default", name))
+    }
+    // Otherwise, set it as default
+    else {
+        state.set_default(v.name())?;
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!("The vault '{name}' is now the default"))
+            .machine(&name)
+            .json(serde_json::json!({ "vault": {"name": name} }))
+            .write_line()?;
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -1,10 +1,8 @@
 use clap::Args;
 use colorful::Colorful;
-use miette::miette;
 
 use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::CliStateError;
 
 use crate::terminal::ConfirmResult;
 use crate::util::node_rpc;
@@ -44,31 +42,19 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let DeleteCommand { name } = cmd;
     let state = opts.state.vaults;
-    match state.get(&name) {
-        // If it exists, proceed
-        Ok(_) => {
-            if let ConfirmResult::No = opts.terminal.confirm(&fmt_warn!(
-                "This will delete the vault with name '{name}'. Do you want to continue?"
-            ))? {
-                // If the user has not confirmed, exit
-                return Ok(());
-            }
-
-            state.delete(&name)?;
-
-            opts.terminal
-                .stdout()
-                .plain(fmt_ok!("Vault with name '{name}' has been deleted"))
-                .machine(&name)
-                .json(serde_json::json!({ "vault": { "name": &name } }))
-                .write_line()?;
-
-            Ok(())
-        }
-        // Else, return the appropriate error
-        Err(err) => match err {
-            CliStateError::NotFound => Err(miette!("Vault '{}' not found", name)),
-            _ => Err(err.into()),
-        },
+    state.get(&name)?;
+    if let ConfirmResult::No = opts.terminal.confirm(&fmt_warn!(
+        "This will delete the vault named '{name}'. Do you wish to proceed?"
+    ))? {
+        // If the user has not confirmed, exit
+        return Ok(());
     }
+    state.delete(&name)?;
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!("The vault named '{name}' has been deleted"))
+        .machine(&name)
+        .json(serde_json::json!({ "vault": { "name": &name } }))
+        .write_line()?;
+    Ok(())
 }


### PR DESCRIPTION
Add new error types for `CliStateError` and also extend some existing errors to include more information.

For example:

```sh
# Before
$ ockam node show <nonexistent-node>
× not found

# Now
$ ockam node show <nonexistent-node>
× Unable to find node named n2
```

This change also allows us to simplify the commands where we were manually checking a `NotFound` error to write the error message. Example [here](https://github.com/build-trust/ockam/pull/5150/files#diff-0d69316ec86013b48ba4411821faebcbc204624e786f5c2811223c696e2898f9L45-L46).