### PR TITLE
refactor(rust): use better names for symmetric keys involved in secure channels

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
@@ -194,14 +194,14 @@ impl Handshake {
         // k1, k2 = HKDF(ck, zerolen, 2)
         let mut state = self.state.clone();
         let (k1, k2) = self.compute_final_keys(&mut state).await?;
-        let (encryption_key, decryption_key) = if role.is_initiator() {
+        let (encryptor_key, decryptor_key) = if role.is_initiator() {
             (k2, k1)
         } else {
             (k1, k2)
         };
         state.status = Ready(HandshakeKeys {
-            encryption_key,
-            decryption_key,
+            encryptor_key,
+            decryptor_key,
         });
         // now remove the ephemeral keys which are not useful anymore
         self.state = state;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
@@ -42,11 +42,13 @@ pub(super) enum Status {
     Ready(HandshakeKeys),
 }
 
-/// At the end of a successful handshake a pair of encryption/decryption keys is available
+/// At the end of a successful handshake two symmetric encryption keys are available,
+/// one for each direction of the communication, so that one key is use by the Encryptor
+/// and the other key is used by the decryptor
 #[derive(Debug, Clone)]
 pub(super) struct HandshakeKeys {
-    pub(super) encryption_key: KeyId,
-    pub(super) decryption_key: KeyId,
+    pub(super) encryptor_key: KeyId,
+    pub(super) decryptor_key: KeyId,
 }
 
 /// The end result of a handshake with identity/credentials exchange is

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -282,7 +282,7 @@ impl HandshakeWorker {
         let decryptor = DecryptorHandler::new(
             self.role.str(),
             self.addresses.clone(),
-            handshake_results.handshake_keys.decryption_key,
+            handshake_results.handshake_keys.decryptor_key,
             to_xx_initialized(self.secure_channels.identities.vault()),
             handshake_results.their_identifier.clone(),
         );
@@ -294,7 +294,7 @@ impl HandshakeWorker {
                 self.addresses.clone(),
                 self.remote_route()?,
                 Encryptor::new(
-                    handshake_results.handshake_keys.encryption_key,
+                    handshake_results.handshake_keys.encryptor_key,
                     0,
                     to_xx_initialized(self.secure_channels.identities.vault()),
                 ),


### PR DESCRIPTION
The current names are confusing since they make as if asymmetric encryption was used.