### PR TITLE
validate credentials of receiving identity for outgoing messages in inlets and outlets

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
+++ b/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
@@ -68,11 +68,11 @@ where {
 
 impl AbacAccessControl {
     /// Returns true if the identity is authorized
-    pub async fn is_identity_authorized(&self, id: IdentityIdentifier) -> Result<bool> {
+    pub async fn is_identity_authorized(&self, id: &IdentityIdentifier) -> Result<bool> {
         let mut environment = self.environment.clone();
 
         // Get identity attributes and populate the environment:
-        if let Some(attrs) = self.repository.get_attributes(&id).await? {
+        if let Some(attrs) = self.repository.get_attributes(id).await? {
             for (key, value) in attrs.attrs() {
                 if key.find(|c: char| c.is_whitespace()).is_some() {
                     log::warn! {
@@ -159,6 +159,6 @@ impl IncomingAccessControl for AbacAccessControl {
             return Ok(false);
         };
 
-        self.is_identity_authorized(id).await
+        self.is_identity_authorized(&id).await
     }
 }

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -19,6 +19,7 @@ mod parser;
 pub mod attribute_access_control;
 pub mod expr;
 pub mod mem;
+mod policy_outgoing;
 mod storage;
 
 pub use attribute_access_control::AbacAccessControl;
@@ -27,6 +28,7 @@ pub use error::{EvalError, ParseError};
 pub use eval::eval;
 pub use expr::Expr;
 pub use policy::PolicyAccessControl;
+pub use policy_outgoing::OutgoingPolicyFactory;
 pub use traits::PolicyStorage;
 pub use types::{Action, Resource, Subject};
 

--- a/implementations/rust/ockam/ockam_abac/src/policy_outgoing.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy_outgoing.rs
@@ -1,0 +1,109 @@
+use crate::{AbacAccessControl, Action, Env, Expr, PolicyStorage, Resource};
+use core::fmt;
+use core::fmt::{Debug, Formatter};
+use ockam_core::compat::boxed::Box;
+use ockam_core::compat::format;
+use ockam_core::compat::sync::Arc;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{
+    async_trait, AllowAll, DenyAll, Error, LocalInfo, OutgoingAccessControl,
+    OutgoingAccessControlFactory, RelayMessage,
+};
+use ockam_identity::{IdentitiesRepository, IdentityIdentifier, IdentitySecureChannelLocalInfo};
+
+pub struct OutgoingPolicyFactory {
+    policies: Arc<dyn PolicyStorage>,
+    repository: Arc<dyn IdentitiesRepository>,
+    resource: Resource,
+    action: Action,
+    environment: Env,
+}
+
+impl Debug for OutgoingPolicyFactory {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let resource = &self.resource;
+        let action = &self.resource;
+        let environment = &self.environment;
+        f.write_str(format!("resource {resource:?}").as_str())?;
+        f.write_str(format!("action {action:?}").as_str())?;
+        f.write_str(format!("environment {environment:?}").as_str())
+    }
+}
+
+impl OutgoingPolicyFactory {
+    pub fn new(
+        policies: Arc<dyn PolicyStorage>,
+        repository: Arc<dyn IdentitiesRepository>,
+        resource: Resource,
+        action: Action,
+        environment: Env,
+    ) -> Self {
+        Self {
+            policies,
+            repository,
+            resource,
+            action,
+            environment,
+        }
+    }
+}
+
+#[async_trait]
+impl OutgoingAccessControlFactory for OutgoingPolicyFactory {
+    async fn create(
+        &self,
+        local_info: &[LocalInfo],
+    ) -> ockam_core::Result<Arc<dyn OutgoingAccessControl>> {
+        let expr = if let Some(expr) = self
+            .policies
+            .get_policy(&self.resource, &self.action)
+            .await?
+        {
+            if let Expr::Bool(b) = expr {
+                return if b {
+                    Ok(Arc::new(AllowAll))
+                } else {
+                    Ok(Arc::new(DenyAll))
+                };
+            } else {
+                expr
+            }
+        } else {
+            return Ok(Arc::new(DenyAll));
+        };
+
+        let id = if let Ok(info) = IdentitySecureChannelLocalInfo::find_info_from_list(local_info) {
+            info.their_identity_id()
+        } else {
+            return Err(Error::new(
+                Origin::Authorization,
+                Kind::NotFound,
+                "no identity found",
+            ));
+        };
+
+        Ok(Arc::new(StaticPolicy {
+            abac_access_control: AbacAccessControl::new(
+                self.repository.clone(),
+                expr,
+                self.environment.clone(),
+            ),
+            their_identity_identifier: id,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct StaticPolicy {
+    abac_access_control: AbacAccessControl,
+    their_identity_identifier: IdentityIdentifier,
+}
+
+#[async_trait]
+impl OutgoingAccessControl for StaticPolicy {
+    async fn is_authorized(&self, _message: &RelayMessage) -> ockam_core::Result<bool> {
+        self.abac_access_control
+            .is_identity_authorized(&self.their_identity_identifier)
+            .await
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -371,7 +371,7 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
         if let Some(entry) = record {
             let authorized = inner
                 .access_control
-                .is_identity_authorized(entry.their_id())
+                .is_identity_authorized(&entry.their_id())
                 .await?;
 
             if authorized {
@@ -415,7 +415,7 @@ impl<F: ForwarderCreator> KafkaSecureChannelControllerImpl<F> {
 
         let authorized = inner
             .access_control
-            .is_identity_authorized(entry.their_id())
+            .is_identity_authorized(&entry.their_id())
             .await?;
 
         if authorized {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -147,12 +147,7 @@ impl NodeManager {
         let maybe_trust_context_id = self.trust_context.as_ref().map(|c| c.id());
         let resource = Resource::assert_inline(addr.address());
         let ac = self
-            .access_control(
-                &resource,
-                &actions::HANDLE_MESSAGE,
-                maybe_trust_context_id,
-                None,
-            )
+            .incoming_access_control(&resource, &actions::HANDLE_MESSAGE, maybe_trust_context_id)
             .await?;
 
         WorkerBuilder::new(Echoer)
@@ -258,7 +253,7 @@ impl NodeManager {
         let resource = Resource::new(&addr.to_string());
 
         let abac = self
-            .access_control(&resource, &action, Some(project.as_str()), None)
+            .incoming_access_control(&resource, &action, Some(project.as_str()))
             .await?;
 
         let direct = crate::authenticator::direct::DirectAuthenticator::new(

--- a/implementations/rust/ockam/ockam_core/src/access_control.rs
+++ b/implementations/rust/ockam/ockam_core/src/access_control.rs
@@ -1,5 +1,6 @@
 use crate::compat::boxed::Box;
-use crate::{async_trait, RelayMessage, Result};
+use crate::{async_trait, LocalInfo, RelayMessage, Result};
+use alloc::sync::Arc;
 use core::fmt::Debug;
 
 /// Defines the interface for incoming message flow authorization.
@@ -62,6 +63,15 @@ pub trait OutgoingAccessControl: Debug + Send + Sync + 'static {
     // TODO: Consider &mut self
     /// Return true if the message is allowed to pass, and false if not.
     async fn is_authorized(&self, relay_msg: &RelayMessage) -> Result<bool>;
+}
+
+/// Interface for creating outgoing access control instances based on local information
+/// of the first incoming message.
+/// Useful when we don't have all the information on worker bootstrap.
+#[async_trait]
+pub trait OutgoingAccessControlFactory: Debug + Send + Sync + 'static {
+    /// Creates a new outgoing access control given the incoming message
+    async fn create(&self, local_info: &[LocalInfo]) -> Result<Arc<dyn OutgoingAccessControl>>;
 }
 
 mod all;

--- a/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
@@ -81,6 +81,11 @@ impl Mailbox {
     pub fn outgoing_access_control(&self) -> &Arc<dyn OutgoingAccessControl> {
         &self.outgoing
     }
+
+    /// Replaces the outgoing access control with the provided one
+    pub fn replace_outgoing_access_control(&mut self, outgoing: Arc<dyn OutgoingAccessControl>) {
+        self.outgoing = outgoing;
+    }
 }
 
 /// A collection of [`Mailbox`]es for a specific [`Worker`](crate::Worker), [`Processor`](crate::Processor) or `Context`
@@ -157,6 +162,17 @@ impl Mailboxes {
         } else {
             self.additional_mailboxes
                 .iter()
+                .find(|x| &x.address == msg_addr)
+        }
+    }
+
+    /// Returns a mutable reference to the [`Mailbox`] with the given [`Address`]
+    pub fn find_mailbox_mut(&mut self, msg_addr: &Address) -> Option<&mut Mailbox> {
+        if &self.main_mailbox.address == msg_addr {
+            Some(&mut self.main_mailbox)
+        } else {
+            self.additional_mailboxes
+                .iter_mut()
                 .find(|x| &x.address == msg_addr)
         }
     }

--- a/implementations/rust/ockam/ockam_node/src/context/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context.rs
@@ -77,6 +77,11 @@ impl Context {
         &self.mailboxes
     }
 
+    /// Returns a mutable reference to the mailboxes of this context
+    pub fn mailboxes_mut(&mut self) -> &mut Mailboxes {
+        &mut self.mailboxes
+    }
+
     /// Shared [`FlowControls`] instance
     pub fn flow_controls(&self) -> &FlowControls {
         &self.flow_controls

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -99,6 +99,7 @@ impl Processor for TcpInletListenProcessor {
             outlet_listener_route,
             addresses,
             self.options.incoming_access_control.clone(),
+            self.options.outgoing_access_control_factory.clone(),
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
@@ -1,12 +1,13 @@
 use crate::portal::addresses::Addresses;
 use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::{FlowControlId, FlowControls};
-use ockam_core::{Address, AllowAll, IncomingAccessControl};
+use ockam_core::{Address, AllowAll, IncomingAccessControl, OutgoingAccessControlFactory};
 
 /// Trust Options for an Inlet
 #[derive(Debug)]
 pub struct TcpInletOptions {
     pub(super) incoming_access_control: Arc<dyn IncomingAccessControl>,
+    pub(super) outgoing_access_control_factory: Option<Arc<dyn OutgoingAccessControlFactory>>,
 }
 
 impl TcpInletOptions {
@@ -14,6 +15,7 @@ impl TcpInletOptions {
     pub fn new() -> Self {
         Self {
             incoming_access_control: Arc::new(AllowAll),
+            outgoing_access_control_factory: None,
         }
     }
 
@@ -32,6 +34,15 @@ impl TcpInletOptions {
         access_control: Arc<dyn IncomingAccessControl>,
     ) -> Self {
         self.incoming_access_control = access_control;
+        self
+    }
+
+    /// Set outgoing Access Control
+    pub fn with_outgoing_access_control_factory(
+        mut self,
+        outgoing_access_control_factory: Arc<dyn OutgoingAccessControlFactory>,
+    ) -> Self {
+        self.outgoing_access_control_factory = Some(outgoing_access_control_factory);
         self
     }
 
@@ -62,6 +73,7 @@ impl Default for TcpInletOptions {
 pub struct TcpOutletOptions {
     pub(super) consumer: Vec<FlowControlId>,
     pub(super) incoming_access_control: Arc<dyn IncomingAccessControl>,
+    pub(super) outgoing_access_control_factory: Option<Arc<dyn OutgoingAccessControlFactory>>,
 }
 
 impl TcpOutletOptions {
@@ -70,6 +82,7 @@ impl TcpOutletOptions {
         Self {
             consumer: vec![],
             incoming_access_control: Arc::new(AllowAll),
+            outgoing_access_control_factory: None,
         }
     }
 
@@ -88,6 +101,15 @@ impl TcpOutletOptions {
         access_control: Arc<dyn IncomingAccessControl>,
     ) -> Self {
         self.incoming_access_control = access_control;
+        self
+    }
+
+    /// Set outgoing Access Control
+    pub fn with_outgoing_access_control_factory(
+        mut self,
+        outgoing_access_control_factory: Arc<dyn OutgoingAccessControlFactory>,
+    ) -> Self {
+        self.outgoing_access_control_factory = Some(outgoing_access_control_factory);
         self
     }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/outlet_listener.rs
@@ -74,6 +74,7 @@ impl Worker for TcpOutletListenWorker {
     ) -> Result<()> {
         let return_route = msg.return_route();
         let src_addr = msg.src_addr();
+        let local_info = msg.local_message().local_info().to_vec();
 
         if let PortalMessage::Ping = msg.body() {
         } else {
@@ -92,6 +93,8 @@ impl Worker for TcpOutletListenWorker {
             return_route.clone(),
             addresses.clone(),
             self.options.incoming_access_control.clone(),
+            self.options.outgoing_access_control_factory.clone(),
+            local_info,
         )
         .await?;
 


### PR DESCRIPTION
Currently, we don't validate outgoing messages from inlets or outlets. The impact is vastly reduced by the fact that inlets/outlet communication always requires a ping/pong handshake, and this will force validation of the incoming message once during initialization. But after that, the communication will keep going regardless of the remote credential validity, this PR is aimed to fix specifically this case.

The approach used is to update the outgoing access control when the first message is received, capturing the source local_info.