### PR TITLE
fix(elixir): cache identity used by healthcheck

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/sidecar.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/sidecar.ex
@@ -4,6 +4,8 @@ defmodule Ockam.Identity.Sidecar do
   Data structure contains a reference to identity stored
   in the sidecar node.
   """
+  @behaviour Ockam.Identity
+
   alias Ockam.API.Client, as: ApiClient
   alias Ockam.API.Response, as: ApiResponse
 
@@ -90,6 +92,18 @@ defmodule Ockam.Identity.Sidecar do
              IdentityRequest.compare_identity_change_history(current_identity, known_identity)
            ) do
       IdentityResponse.compare_identity_change_history(body)
+    end
+  end
+
+  @spec check_local_private_key(vault_name :: String.t(), identity :: t()) ::
+          :ok | {:error, reason :: any()}
+  def check_local_private_key(vault_name, identity) do
+    case create_signature(vault_name, identity, "") do
+      {:ok, _proof} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/identity/stub.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/identity/stub.ex
@@ -3,6 +3,8 @@ defmodule Ockam.Identity.Stub do
   Stub for `Ockam.Identity`
   """
 
+  @behaviour Ockam.Identity
+
   @type t() :: binary()
   @type proof() :: binary()
 
@@ -52,6 +54,10 @@ defmodule Ockam.Identity.Stub do
 
   def compare_identity_change_history(identity, known_identity) do
     {:error, {:history_update_not_supported, identity, known_identity}}
+  end
+
+  def check_local_private_key(_vault_name, _identity) do
+    :ok
   end
 
   def random() do

--- a/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/config/runtime.exs
@@ -105,4 +105,4 @@ config :ockam_healthcheck,
   targets: targets,
   identity_source: identity_source,
   identity_file: identity_file,
-  identity_function: &Ockam.Healthcheck.generate_identity/0
+  identity_function: &Ockam.Healthcheck.get_identity/0


### PR DESCRIPTION
## Current behavior

Healthcheck is generating a new identity on every check, which means potentially thousands of new identities per day.
Since it does not clean up the identities, keys data can fill up memory or disk where they stored.
It's not necessary to use a new identity every time, so they can be cached.

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

Using :persistent_term to cache identity for healthchecks
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
