### PR TITLE
feat(rust): add flag to control whether a node redirects the logs to a file

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -297,6 +297,8 @@ impl Default for ConfigVersion {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
 pub struct NodeSetupConfig {
     pub verbose: u8,
+    #[serde(default)]
+    pub disable_file_logging: bool,
 
     /// This flag is used to determine how the node status should be
     /// displayed in print_query_status.
@@ -314,6 +316,11 @@ pub struct NodeSetupConfig {
 impl NodeSetupConfig {
     pub fn set_verbose(mut self, verbose: u8) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    pub fn set_disable_file_logging(mut self, disable_file_logging: bool) -> Self {
+        self.disable_file_logging = disable_file_logging;
         self
     }
 
@@ -507,6 +514,7 @@ mod tests {
     fn node_config_setup_transports_no_duplicates() {
         let mut config = NodeSetupConfig {
             verbose: 0,
+            disable_file_logging: false,
             authority_node: None,
             project: None,
             transports: HashSet::new(),

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -22,6 +22,12 @@ pub struct NodesState {
 }
 
 impl NodesState {
+    pub fn stdout_logs(&self, name: &str) -> Result<PathBuf> {
+        let dir = self.path(name);
+        std::fs::create_dir_all(&dir)?;
+        Ok(NodePaths::new(&dir).stdout())
+    }
+
     pub fn delete_sigkill(&self, name: &str, sigkill: bool) -> Result<()> {
         self._delete(name, sigkill)
     }
@@ -418,6 +424,17 @@ mod traits {
 
         fn path(&self, name: impl AsRef<str>) -> PathBuf {
             self.dir().join(name.as_ref())
+        }
+
+        /// A node contains several files, and the existence of the main directory is not not enough
+        /// to determine if a node exists as it could be created but empty.
+        fn exists(&self, name: impl AsRef<str>) -> bool {
+            let dir = self.path(&name);
+            if !dir.exists() {
+                return false;
+            }
+            let paths = NodePaths::new(&dir);
+            paths.setup().exists()
         }
 
         fn create(

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -430,6 +430,9 @@ impl OckamCommand {
         // for the node that is being created
         if let OckamSubcommand::Node(c) = &self.subcommand {
             if let NodeSubcommand::Create(c) = &c.subcommand {
+                if c.disable_file_logging {
+                    return None;
+                }
                 if let Ok(s) = opts.state.nodes.get(&c.node_name) {
                     return Some(s.stdout_log());
                 }

--- a/implementations/rust/ockam/ockam_command/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/logs/mod.rs
@@ -3,6 +3,7 @@ use crate::logs::rolling::{RollingConditionBasic, RollingFileAppender};
 use ockam_core::env::{get_env, get_env_with_default};
 use std::io::stdout;
 use std::path::PathBuf;
+use std::str::FromStr;
 use termimad::crossterm::tty::IsTty;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -37,36 +38,36 @@ pub fn setup_logging(
         "ockam_transport_tcp",
         "ockam_vault",
     ];
-    let builder = EnvFilter::builder();
-
-    // Otherwise, use `verbose` to define the log level.
-    let filter = match (stdout().is_tty(), verbose) {
-        // If tty and `verbose` is not set, try to read the log level from the OCKAM_LOG env variable.
-        (true, 0) => match get_env::<String>("OCKAM_LOG") {
-            Ok(Some(s)) if !s.is_empty() => builder.with_env_var("OCKAM_LOG").from_env_lossy(),
-            // Default to info if OCKAM_LOG is not set.
-            _ => builder
-                .with_default_directive(LevelFilter::INFO.into())
-                .parse_lossy(ockam_crates.map(|c| format!("{c}=info")).join(",")),
-        },
-        // If not tty, default to `info` level.
-        (false, 0) | (_, 1) => builder
-            .with_default_directive(LevelFilter::INFO.into())
-            .parse_lossy(ockam_crates.map(|c| format!("{c}=info")).join(",")),
-        // In all other cases, default to the level set by `verbose`.
-        (_, 2) => builder
-            .with_default_directive(LevelFilter::DEBUG.into())
-            .parse_lossy(ockam_crates.map(|c| format!("{c}=debug")).join(",")),
-        _ => builder
-            .with_default_directive(LevelFilter::TRACE.into())
-            .parse_lossy(ockam_crates.map(|c| format!("{c}=trace")).join(",")),
+    let level = {
+        // Parse the the raw log level value (e.g. "info" or "-vvv").
+        let level_raw = match get_env::<String>("OCKAM_LOG") {
+            // If OCKAM_LOG is set, give it priority over `verbose` to define the log level.
+            Ok(Some(s)) if !s.is_empty() => s,
+            // Otherwise, use `verbose` to define the log level.
+            Ok(_) | Err(_) => match verbose {
+                0 => "off".to_string(),
+                1 => "info".to_string(),
+                2 => "debug".to_string(),
+                _ => "trace".to_string(),
+            },
+        };
+        // If the parsed log level is not valid, default to info.
+        let level = LevelFilter::from_str(&level_raw).unwrap_or(LevelFilter::INFO);
+        if level == LevelFilter::OFF {
+            return None;
+        }
+        level
     };
+    let builder = EnvFilter::builder();
+    let filter = builder
+        .with_default_directive(level.into())
+        .parse_lossy(ockam_crates.map(|c| format!("{c}={level}")).join(","));
     let subscriber = tracing_subscriber::registry()
         .with(filter)
         .with(tracing_error::ErrorLayer::default());
-    let (subscriber, guard) = match (verbose, log_path) {
-        (0, None) => return None,
-        (_, None) => {
+    let (subscriber, guard) = match log_path {
+        // If a log path is not provided, log to stdout.
+        None => {
             let color = !no_color && stdout().is_tty();
             let (n, guard) = tracing_appender::non_blocking(stdout());
             let fmt = tracing_subscriber::fmt::Layer::default()
@@ -74,7 +75,8 @@ pub fn setup_logging(
                 .with_writer(n);
             (subscriber.with(fmt).try_init(), Some(guard))
         }
-        (_, Some(log_path)) => {
+        // If a log path is provided, log to a rolling file appender.
+        Some(log_path) => {
             let r = RollingFileAppender::new(
                 log_path,
                 RollingConditionBasic::new()

--- a/implementations/rust/ockam/ockam_command/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/logs/mod.rs
@@ -87,7 +87,7 @@ pub fn setup_logging(
             .expect("Failed to create rolling file appender");
             let (n, guard) = tracing_appender::non_blocking(r);
             let fmt = tracing_subscriber::fmt::Layer::default()
-                .with_ansi(!no_color)
+                .with_ansi(false)
                 .with_writer(n);
             (subscriber.with(fmt).try_init(), Some(guard))
         }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -140,13 +140,13 @@ impl Default for CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) {
         if self.foreground {
             // Create a new node in the foreground (i.e. in this OS process)
-            local_cmd(create_foreground_node(&options, &self));
+            local_cmd(create_foreground_node(&opts, &self));
         } else {
             // Create a new node running in the background (i.e. another, new OS process)
-            node_rpc(run_impl, (options, self))
+            node_rpc(run_impl, (opts, self))
         }
     }
 
@@ -262,7 +262,7 @@ async fn run_foreground_node(
 
     // This node was initially created as a foreground node
     // and there is no existing state for it yet.
-    if !cmd.child_process && opts.state.nodes.get(&node_name).is_err() {
+    if !cmd.child_process && !opts.state.nodes.exists(&node_name) {
         init_node_state(
             &opts,
             &node_name,

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -73,6 +73,7 @@ async fn run_impl(
         None,               // Credential
         None,               // Trust Context
         None,               // Project Name
+        node_setup.disable_file_logging,
     )?;
 
     // Print node status

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -205,13 +205,13 @@ pub fn spawn_node(
     credential: Option<&String>,
     trust_context: Option<&PathBuf>,
     project_name: Option<&String>,
+    disable_file_logging: bool,
 ) -> miette::Result<()> {
     let mut args = vec![
         match verbose {
             0 => "-vv".to_string(),
             v => format!("-{}", "v".repeat(v as usize)),
         },
-        "--no-color".to_string(),
         "node".to_string(),
         "create".to_string(),
         "--tcp-listener-address".to_string(),
@@ -219,6 +219,16 @@ pub fn spawn_node(
         "--foreground".to_string(),
         "--child-process".to_string(),
     ];
+
+    if disable_file_logging {
+        args.push("--disable-file-logging".to_string());
+        if !opts.terminal.is_tty() {
+            args.push("--no-color".to_string());
+        }
+    } else {
+        // We want to disable colors when logging to file
+        args.push("--no-color".to_string());
+    }
 
     if let Some(path) = project {
         args.push("--project-path".to_string());
@@ -279,7 +289,7 @@ pub fn spawn_node(
 
     args.push(name.to_owned());
 
-    run_ockam(opts, name, args)
+    run_ockam(opts, name, args, disable_file_logging)
 }
 
 /// Run the ockam command line with specific arguments
@@ -287,6 +297,7 @@ pub fn run_ockam(
     opts: &CommandGlobalOpts,
     node_name: &str,
     args: Vec<String>,
+    disable_file_logging: bool,
 ) -> miette::Result<()> {
     // On systems with non-obvious path setups (or during
     // development) re-executing the current binary is a more
@@ -294,28 +305,31 @@ pub fn run_ockam(
     let ockam_exe = current_exe().unwrap_or_else(|_| "ockam".into());
     let node_state = opts.state.nodes.get(node_name)?;
 
-    let (mlog, elog) = { (node_state.stdout_log(), node_state.stderr_log()) };
+    let mut cmd = Command::new(ockam_exe);
 
-    let main_log_file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(mlog)
-        .into_diagnostic()
-        .context("failed to open log path")?;
+    if !disable_file_logging {
+        let (mlog, elog) = { (node_state.stdout_log(), node_state.stderr_log()) };
+        let main_log_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(mlog)
+            .into_diagnostic()
+            .context("failed to open log path")?;
+        let stderr_log_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(elog)
+            .into_diagnostic()
+            .context("failed to open stderr log path")?;
+        cmd.stdout(main_log_file).stderr(stderr_log_file);
+    }
 
-    let stderr_log_file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(elog)
-        .into_diagnostic()
-        .context("failed to open stderr log path")?;
-
-    let child = Command::new(ockam_exe)
+    let child = cmd
         .args(args)
-        .stdout(main_log_file)
-        .stderr(stderr_log_file)
         .spawn()
-        .into_diagnostic()?;
+        .into_diagnostic()
+        .context("failed to spawn node")?;
+
     node_state.set_pid(child.id() as i32)?;
 
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -150,7 +150,7 @@ pub(crate) async fn init_node_state(
         .vault(vault_state.path().clone())
         .identity(identity_state.path().clone())
         .build(&opts.state)?;
-    opts.state.nodes.create(node_name, node_config)?;
+    opts.state.nodes.overwrite(node_name, node_config)?;
 
     info!(name=%node_name, "node state initialized");
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -202,6 +202,10 @@ impl<W: TerminalWriter> Terminal<W> {
         }
     }
 
+    pub fn is_tty(&self) -> bool {
+        self.stderr.is_tty()
+    }
+
     pub fn default() -> Self {
         Self::new(false, false, false, OutputFormat::Plain)
     }
@@ -331,6 +335,10 @@ impl<W: TerminalWriter> Terminal<W, ToStdErr> {
 
 // Finished mode
 impl<W: TerminalWriter> Terminal<W, ToStdOut> {
+    pub fn is_tty(&self) -> bool {
+        self.stdout.is_tty()
+    }
+
     pub fn plain<T: Display>(mut self, msg: T) -> Self {
         self.mode.output.plain = Some(msg.to_string());
         self

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -93,7 +93,7 @@ to_uppercase() {
 
 # Returns a random name
 random_str() {
-  echo "$(openssl rand -hex 8)"
+  echo "$(openssl rand -hex 4)"
 }
 
 # Returns a random port in the range 49152-65535

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load load/base.bash
+  load_bats_ext
+  setup_home_dir
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "node - can recreate a background node after it was stopped" {
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  # Fail to create a node with the same name
+  run "$OCKAM" node create "$n"
+  assert_failure
+
+  run "$OCKAM" node stop "$n"
+  assert_success
+
+  # Recreate node
+  run "$OCKAM" node create "$n"
+  assert_success
+}
+
+@test "node - can recreate a foreground node after it was stopped" {
+  n="$(random_str)"
+  $OCKAM node create $n -f &
+  sleep 0.1
+  run "$OCKAM" node show "$n"
+  assert_success
+
+  # Fail to create a node with the same name
+  run "$OCKAM" node create "$n" -f
+  assert_failure
+
+  run "$OCKAM" node stop "$n"
+  assert_success
+
+  # Recreate node
+  $OCKAM node create $n -f &
+  sleep 0.1
+  run "$OCKAM" node show "$n"
+  assert_success
+}
+
+@test "node - logs to file" {
+  n="$(random_str)"
+  $OCKAM node create $n
+
+  log_file="$($OCKAM node logs $n)"
+  if [ ! -s $log_file ]; then
+    fail "Log file shouldn't be empty"
+  fi
+
+  # Repeat the same with a foreground node
+  n="$(random_str)"
+  $OCKAM node create $n -vv -f &
+  sleep 0.1
+
+  log_file="$($OCKAM node logs $n)"
+  if [ ! -s $log_file ]; then
+    fail "Log file shouldn't be empty"
+  fi
+}
+
+@test "node - disable file logging" {
+  n="$(random_str)"
+  $OCKAM node create $n --disable-file-logging
+
+  log_file="$($OCKAM node logs $n)"
+  if [ -s $log_file ]; then
+    fail "Log file should be empty"
+  fi
+
+  # Repeat the same with a foreground node
+  n="$(random_str)"
+  $OCKAM node create $n -vv -f --disable-file-logging &
+  sleep 0.1
+
+  log_file="$($OCKAM node logs $n)"
+  if [ -s $log_file ]; then
+    fail "Log file should be empty"
+  fi
+}

--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -878,7 +878,7 @@ mod schema_test {
     struct Res(Response);
 
     #[derive(Debug, Clone)]
-    struct Er(Error<'static>);
+    struct Er(Error);
 
     impl Arbitrary for Req {
         fn arbitrary(g: &mut Gen) -> Self {
@@ -902,7 +902,7 @@ mod schema_test {
 
     impl Arbitrary for Er {
         fn arbitrary(g: &mut Gen) -> Self {
-            let mut e = Error::new(String::arbitrary(g));
+            let mut e = Error::new(&String::arbitrary(g));
             if bool::arbitrary(g) {
                 e = e.with_method(*g.choose(METHODS).unwrap())
             }


### PR DESCRIPTION
A couple of problems were found on the `node create` command: the first is a bug about how we handle node logs files; the second is an inconsistency about the expected behaviour when passing the `foreground` flag or not.

## Writing to logs

When creating a fresh foreground node with logging enabled (i.e. passing the `-v` flag), it won't persist the logs into files because the logger setup is done before the node state is created:

https://github.com/build-trust/ockam/blob/d4d921fc5a503a7e38c9a4869662da2abf005717/implementations/rust/ockam/ockam_command/src/lib.rs#L428-L440

If the node is stopped (e.g. via ctrl+c, or EOF), and the node is recreated again using `ockam node create ...`, it will start writing the logs into the files beacuse the node state is now accessible when setting up the logger. So, the first time a foreground node is created it won't write into files; subsequent `node create` calls will do.

There are two problems here:
1. We don't have a way to create a fresh foreground node that write the logs into files (you have to recreate it to do so)
2. We don't have a way to create a foreground node that doesn't write the logs into files

Proposed solutions:
1. A little tricky but doable: we just need a way to partially initialize the state (create the main node directory at least), so we can query the logs file path before actually creating the node state
2. Add a new argument to control whether we want to write logs into files or not (`--disable-file-logging`)

## Inconsistency of foreground/background nodes when recreating nodes

There was an inconsistency when creating a background node, where it would return an error when running the command for a stopped node. As explained before, this can be done with foreground nodes and it's a nice feature, since it doesn't force the user to learn/use the `ockam node start` command.

```sh
# The following is expected to work, recreating the node after it was stopped
ockam node create foreground -vv -f
ockam node stop foreground
ockam node create foreground -vv -f

# The following was returning an "Already exists" error
ockam node create background
ockam node stop background
ockam node create background
```

The second case has now the same behaviour as the first one.
