### PR TITLE
remove openssl dependency in ockam_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,7 +3361,6 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_aws",
  "once_cell",
- "openssl",
  "quickcheck",
  "rand",
  "reqwest",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -44,7 +44,6 @@ miette = "5.9.0"
 minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
 nix = "0.26"
 once_cell = { version = "1", optional = true, default-features = false }
-openssl = "0.10.55"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.164", features = ["derive"] }


### PR DESCRIPTION
This PR remove OpenSSL dependency from the ockam_api Cargo.toml file