### PR TITLE
add ockam command orchestrator ci

### DIFF
--- a/.github/workflows/rust-ignored.yml
+++ b/.github/workflows/rust-ignored.yml
@@ -113,3 +113,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - run: 'echo "Rust - lint_cargo_lock - Ignored"'
+
+  test_orchestrator_ockam_command:
+    name: Rust - test_orchestrator_ockam_command
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "Rust - test_orchestrator_ockam_command - Ignored"'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -392,3 +392,26 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           platform_operating_system: ${{ matrix.os }}
+
+  test_orchestrator_ockam_command:
+    name: Rust - test_orchestrator_ockam_command
+    runs-on: ubuntu-20.04
+    container: ghcr.io/build-trust/artifacts-helper:latest
+    if: github.event_name == 'merge_group'
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: ${{ github.event.inputs.release_branch }}
+
+      - name: Run Ockam Bats Test On Development Cluster
+        uses: build-trust/.github/actions/run_bats_test@custom-actions
+        with:
+          perform_ockam_enroll: 'true'
+          script_path: "/artifacts-scripts"
+          ockam_repository_ref: ${{ github.event.inputs.release_branch }}
+          controller_id: ${{ secrets.ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ID }}
+          controller_addr: ${{ secrets.ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ADDRESS }}


### PR DESCRIPTION
This PR allows us run bats test over orchestrator. It run bats test on [merge queue](https://github.blog/changelog/2022-08-18-merge-group-webhook-event-and-github-actions-workflow-trigger/) so that we can workflows with a mutex lock.

- Create a PR and request for review, on approval, PR is added to merge queue
- On merge queue orchestrator bats test is run, if successful PR is merge, if orchestrator bats test fails, PR exits merge queue and PR author must check cause of failure and fix

More
- [x] To run test with a lock, we will need to set maximum number of build in the merge queue to 1
<img width="552" alt="Screenshot 2023-06-29 at 5 09 41 PM" src="https://github.com/build-trust/ockam/assets/31141573/61f0c19a-5848-411e-b059-ab9a9aba12ce">

- [x] We need to allow the `actions/upload-artifact` action so that we can upload the logs
- [x] Set `ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ID` and `ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ADDRESS` secrets
- [x] Allow read access to the [artifacts-helper](https://github.com/orgs/build-trust/packages/container/package/artifacts-helper) docker image
- [ ] `Let’s skip this for now` 👉We also need to add the `Rust - test_orchestrator_ockam_command` test to list of list of [status check](https://betterprogramming.pub/github-status-checks-and-branch-protection-made-easy-b70d6d9ffc76)
