### PR TITLE
fix(rust): forced-killed foreground nodes can be recreated with `ockam node create`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -4,13 +4,14 @@ use crate::cli_state::{
     VaultState,
 };
 use crate::config::lookup::ProjectLookup;
-use crate::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
+use crate::nodes::models::transport::CreateTransportJson;
+use backwards_compatibility::*;
 use nix::errno::Errno;
+use ockam_core::compat::collections::HashSet;
 use ockam_core::compat::sync::Arc;
 use ockam_identity::{IdentityIdentifier, LmdbStorage};
 use ockam_vault::Vault;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -167,8 +168,6 @@ pub struct NodeConfig {
     default_vault: PathBuf,
     #[serde(skip)]
     default_identity: PathBuf,
-    // TODO
-    // authorities: AuthoritiesConfig,
 }
 
 impl NodeConfig {
@@ -303,12 +302,7 @@ pub struct NodeSetupConfig {
     /// The field might be missing in previous configuration files, hence it is an Option
     pub authority_node: Option<bool>,
     pub project: Option<ProjectLookup>,
-    transports: HashSet<CreateTransportJson>,
-    // TODO
-    // secure_channels: ?,
-    // inlets: ?,
-    // outlets: ?,
-    // services: ?,
+    pub api_transport: Option<CreateTransportJson>,
 }
 
 impl NodeSetupConfig {
@@ -332,19 +326,17 @@ impl NodeSetupConfig {
         self
     }
 
-    pub fn default_tcp_listener(&self) -> Result<&CreateTransportJson> {
-        self.transports
-            .iter()
-            .find(|t| t.tt == TransportType::Tcp && t.tm == TransportMode::Listen)
-            .ok_or(CliStateError::ResourceNotFound {
-                resource: "tcp listener".to_string(),
-                name: "default".to_string(),
-            })
+    pub fn set_api_transport(mut self, transport: CreateTransportJson) -> Self {
+        self.api_transport = Some(transport);
+        self
     }
 
-    pub fn add_transport(mut self, transport: CreateTransportJson) -> Self {
-        self.transports.insert(transport);
-        self
+    pub fn api_transport(&self) -> Result<&CreateTransportJson> {
+        self.api_transport.as_ref().ok_or_else(|| {
+            CliStateError::InvalidOperation(
+                "The api transport was not set for the node".to_string(),
+            )
+        })
     }
 }
 
@@ -393,10 +385,63 @@ impl NodePaths {
     }
 }
 
+mod backwards_compatibility {
+    use super::*;
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(untagged)]
+    pub(super) enum NodeConfigs {
+        V1(NodeConfigV1),
+        V2(NodeConfig),
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+    pub(super) struct NodeConfigV1 {
+        #[serde(flatten)]
+        pub setup: NodeSetupConfigV1,
+        #[serde(skip)]
+        pub version: ConfigVersion,
+        #[serde(skip)]
+        pub default_vault: PathBuf,
+        #[serde(skip)]
+        pub default_identity: PathBuf,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(untagged)]
+    pub(super) enum NodeSetupConfigs {
+        V1(NodeSetupConfigV1),
+        V2(NodeSetupConfig),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
+    pub(super) struct NodeSetupConfigV1 {
+        pub verbose: u8,
+        #[serde(default)]
+        pub disable_file_logging: bool,
+
+        /// This flag is used to determine how the node status should be
+        /// displayed in print_query_status.
+        /// The field might be missing in previous configuration files, hence it is an Option
+        pub authority_node: Option<bool>,
+        pub project: Option<ProjectLookup>,
+        pub transports: HashSet<CreateTransportJson>,
+    }
+
+    #[cfg(test)]
+    impl NodeSetupConfigV1 {
+        pub fn add_transport(mut self, transport: CreateTransportJson) -> Self {
+            self.transports.insert(transport);
+            self
+        }
+    }
+}
+
 mod traits {
     use super::*;
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
+    use crate::nodes::models::transport::{TransportMode, TransportType};
     use ockam_core::async_trait;
 
     #[async_trait]
@@ -427,6 +472,38 @@ mod traits {
 
         fn delete(&self, name: impl AsRef<str>) -> Result<()> {
             self._delete(&name, false)
+        }
+
+        async fn migrate(&self, node_path: &Path) -> Result<()> {
+            if node_path.is_file() {
+                // If path is a file, it is probably a non supported file (e.g. .DS_Store)
+                return Ok(());
+            }
+            let paths = NodePaths::new(node_path);
+            let contents = std::fs::read_to_string(paths.setup())?;
+            match serde_json::from_str(&contents)? {
+                NodeSetupConfigs::V1(setup) => {
+                    // Get the first tcp-listener from the transports hashmap and
+                    // use it as the api transport
+                    let mut new_setup = NodeSetupConfig {
+                        verbose: setup.verbose,
+                        disable_file_logging: setup.disable_file_logging,
+                        authority_node: setup.authority_node,
+                        project: setup.project,
+                        api_transport: None,
+                    };
+                    if let Some(t) = setup
+                        .transports
+                        .into_iter()
+                        .find(|t| t.tt == TransportType::Tcp && t.tm == TransportMode::Listen)
+                    {
+                        new_setup.api_transport = Some(t);
+                    }
+                    std::fs::write(paths.setup(), serde_json::to_string(&new_setup)?)?;
+                }
+                NodeSetupConfigs::V2(_) => (),
+            }
+            Ok(())
         }
     }
 
@@ -497,10 +574,11 @@ mod traits {
 mod tests {
     use super::*;
     use crate::config::lookup::InternetAddress;
+    use crate::nodes::models::transport::{TransportMode, TransportType};
 
     #[test]
     fn node_config_setup_transports_no_duplicates() {
-        let mut config = NodeSetupConfig {
+        let mut config = NodeSetupConfigV1 {
             verbose: 0,
             disable_file_logging: false,
             authority_node: None,
@@ -532,7 +610,41 @@ mod tests {
                 {"tt":"Tcp","tm":"Listen","addr":{"V4":"127.0.0.1:1020"}}
             ]
         }"#;
-        let config = serde_json::from_str::<NodeSetupConfig>(config_json).unwrap();
+        let config = serde_json::from_str::<NodeSetupConfigV1>(config_json).unwrap();
         assert_eq!(config.transports.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn migrate_node_config_from_v1_to_v2() {
+        // Create a v1 setup.json file
+        let v1_json_json = r#"{
+            "verbose": 0,
+            "authority_node": null,
+            "project": null,
+            "transports": [
+                {"tt":"Tcp","tm":"Listen","addr":{"V4":"127.0.0.1:1020"}}
+            ]
+        }"#;
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let node_dir = tmp_dir.path().join("n");
+        std::fs::create_dir(&node_dir).unwrap();
+        let tmp_file = node_dir.join("setup.json");
+        std::fs::write(&tmp_file, v1_json_json).unwrap();
+
+        // Run migration
+        let nodes_state = NodesState::new(tmp_dir.path().to_path_buf());
+        nodes_state.migrate(&node_dir).await.unwrap();
+
+        // Check migration was done correctly
+        let contents = std::fs::read_to_string(&tmp_file).unwrap();
+        let v2_setup: NodeSetupConfig = serde_json::from_str(&contents).unwrap();
+        assert_eq!(
+            v2_setup.api_transport,
+            Some(CreateTransportJson {
+                tt: TransportType::Tcp,
+                tm: TransportMode::Listen,
+                addr: InternetAddress::V4("127.0.0.1:1020".parse().unwrap())
+            })
+        );
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -41,7 +41,7 @@ pub trait StateDirTrait: Sized + Send + Sync {
     }
 
     /// Do not run any migration by default
-    async fn migrate(&self, _item_path: &Path) -> Result<()> {
+    async fn migrate(&self, _path: &Path) -> Result<()> {
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -311,7 +311,7 @@ async fn start_authority_node(
             .set_verbose(opts.global_args.verbose)
             .set_disable_file_logging(cmd.disable_file_logging)
             .set_authority_node()
-            .add_transport(
+            .set_api_transport(
                 CreateTransportJson::new(
                     TransportType::Tcp,
                     TransportMode::Listen,

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -17,7 +17,7 @@ impl GetCommand {
 
 fn run_impl(opts: CommandGlobalOpts, cmd: GetCommand) -> miette::Result<()> {
     let node_state = opts.state.nodes.get(cmd.alias)?;
-    let addr = &node_state.config().setup().default_tcp_listener()?.addr;
+    let addr = &node_state.config().setup().api_transport()?.addr;
     println!("Address: {addr}");
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -306,7 +306,7 @@ async fn run_foreground_node(
             .setup_mut()
             .set_verbose(opts.global_args.verbose)
             .set_disable_file_logging(cmd.disable_file_logging)
-            .add_transport(
+            .set_api_transport(
                 CreateTransportJson::new(TransportType::Tcp, TransportMode::Listen, bind)
                     .into_diagnostic()?,
             ),

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -65,7 +65,7 @@ async fn run_impl(
         &opts,
         node_setup.verbose, // Previously user-chosen verbosity level
         &node_name,         // The selected node name
-        &node_setup.default_tcp_listener()?.addr.to_string(), // The selected node api address
+        &node_setup.api_transport()?.addr.to_string(), // The selected node api address
         None,               // No project information available
         None,               // No trusted identities
         None,               // "

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -192,12 +192,7 @@ impl<'a> Rpc<'a> {
             RpcMode::Embedded => to,
             RpcMode::Background { ref tcp } => {
                 let node_state = self.opts.state.nodes.get(&self.node_name)?;
-                let port = node_state
-                    .config()
-                    .setup()
-                    .default_tcp_listener()?
-                    .addr
-                    .port();
+                let port = node_state.config().setup().api_transport()?.addr.port();
                 let addr_str = format!("localhost:{port}");
                 let addr = match tcp {
                     None => {
@@ -560,7 +555,7 @@ pub fn process_nodes_multiaddr(addr: &MultiAddr, cli_state: &CliState) -> crate:
                     .ok_or_else(|| miette!("Invalid node address protocol"))?;
                 let node_state = cli_state.nodes.get(alias.to_string())?;
                 let node_setup = node_state.config().setup();
-                let addr = node_setup.default_tcp_listener()?.maddr()?;
+                let addr = node_setup.api_transport()?.maddr()?;
                 processed_addr.try_extend(&addr)?
             }
             _ => processed_addr.push_back_value(&proto)?,
@@ -585,7 +580,7 @@ pub fn clean_nodes_multiaddr(
                 let alias = p.cast::<Node>().expect("Failed to parse node name");
                 let node_state = cli_state.nodes.get(alias.to_string())?;
                 let node_setup = node_state.config().setup();
-                let addr = &node_setup.default_tcp_listener()?.addr;
+                let addr = &node_setup.api_transport()?.addr;
                 match addr {
                     InternetAddress::Dns(dns, _) => new_ma.push_back(DnsAddr::new(dns))?,
                     InternetAddress::V4(v4) => new_ma.push_back(Ip4(*v4.ip()))?,
@@ -719,7 +714,7 @@ mod tests {
         let n_state = cli_state
             .nodes
             .create("n1", NodeConfig::try_from(&cli_state)?)?;
-        n_state.set_setup(&n_state.config().setup_mut().add_transport(
+        n_state.set_setup(&n_state.config().setup_mut().set_api_transport(
             CreateTransportJson::new(TransportType::Tcp, TransportMode::Listen, "127.0.0.0:4000")?,
         ))?;
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
@@ -12,9 +12,28 @@ teardown() {
   teardown_home_dir
 }
 
+# ===== UTILS
+
+force_kill_node() {
+  pid="$(cat $OCKAM_HOME/nodes/$1/pid)"
+  max_retries=5
+  i=0
+  while [[ $i -lt $max_retries ]]; do
+    run kill -9 $pid
+    if [ $status -ne 0 ]; then
+      break
+    fi
+    sleep 0.2
+    ((i=i+1))
+  done
+  if ps -p $pid >/dev/null; then
+    fail "Failed to kill node $1"
+  fi
+}
+
 # ===== TESTS
 
-@test "node - can recreate a background node after it was stopped" {
+@test "node - can recreate a background node after it was gracefully stopped" {
   n="$(random_str)"
   run "$OCKAM" node create "$n"
   assert_success
@@ -31,10 +50,53 @@ teardown() {
   assert_success
 }
 
-@test "node - can recreate a foreground node after it was stopped" {
+@test "node - can recreate a background node after it was killed" {
+  # TODO: move to rust tests
+  skip "The 'kill' command doesn't work as expected on CI. This test will be moved to rust tests soon."
+  # This test emulates the situation where a node is killed by the OS
+  # on a restart or a shutdown. The node should be able to restart without errors.
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  # Fail to create a node with the same name
+  run "$OCKAM" node create "$n"
+  assert_failure
+
+  force_kill_node "$n"
+  force_kill_node "$n"
+
+  # Recreate node
+  run "$OCKAM" node create "$n"
+  assert_success
+}
+
+@test "node - can recreate a foreground node after it was killed" {
+  # TODO: move to rust tests
+  skip "The 'kill' command doesn't work as expected on CI. This test will be moved to rust tests soon."
   n="$(random_str)"
   $OCKAM node create $n -f &
-  sleep 0.1
+  sleep 0.2
+  run "$OCKAM" node show "$n"
+  assert_success
+
+  # Fail to create a node with the same name
+  run "$OCKAM" node create "$n" -f
+  assert_failure
+
+  force_kill_node "$n"
+
+  # Recreate node
+  $OCKAM node create $n -f &
+  sleep 0.2
+  run "$OCKAM" node show "$n"
+  assert_success
+}
+
+@test "node - can recreate a foreground node after it was gracefully stopped" {
+  n="$(random_str)"
+  $OCKAM node create $n -f &
+  sleep 0.2
   run "$OCKAM" node show "$n"
   assert_success
 
@@ -47,7 +109,7 @@ teardown() {
 
   # Recreate node
   $OCKAM node create $n -f &
-  sleep 0.1
+  sleep 0.2
   run "$OCKAM" node show "$n"
   assert_success
 }
@@ -64,7 +126,7 @@ teardown() {
   # Repeat the same with a foreground node
   n="$(random_str)"
   $OCKAM node create $n -vv -f &
-  sleep 0.1
+  sleep 0.2
 
   log_file="$($OCKAM node logs $n)"
   if [ ! -s $log_file ]; then
@@ -84,7 +146,7 @@ teardown() {
   # Repeat the same with a foreground node
   n="$(random_str)"
   $OCKAM node create $n -vv -f --disable-file-logging &
-  sleep 0.1
+  sleep 0.2
 
   log_file="$($OCKAM node logs $n)"
   if [ -s $log_file ]; then


### PR DESCRIPTION
Follow up of https://github.com/build-trust/ockam/pull/5166

These changes fix a problem where a foreground node forcibly killed (e.g. due to an OS restart) was unable to get recreated, as it wasn't removing the previous tcp-listener and we were trying to use it as the "default-tcp-listener", resulting in a "peer not found" error.

To avoid this kind of misuse, the list of transports stored as part of the node config has been replaced by a single transport, which will be overwritten upon restarting a node.

To provide more context:
- We were storing a list of transports so we could recreate them after a node restart, but this feature was never developed
- We were using the first tcp transport of that list to enable communication between the command and the api, which felt unnecessary and can lead to problems if it's not keep properly updated

The following snippet now works as expected:

```sh
ockam node create n -f &
kill -9 $(cat $OCKAM_HOME/nodes/n/pid)
ockam node create n -f &
```
