### PR TITLE
fix(rust): remove automatic node initialization on some node subcommands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/default.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node_if_default};
+use crate::node::get_node_name;
 use crate::util::local_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
@@ -16,20 +16,18 @@ const AFTER_LONG_HELP: &str = include_str!("./static/default/after_long_help.txt
     after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct DefaultCommand {
-    /// Name of the node.
-    #[arg()]
-    node_name: Option<String>,
+    /// Name of the node to set as default
+    node_name: String,
 }
 
 impl DefaultCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         local_cmd(run_impl(opts, self));
     }
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: DefaultCommand) -> miette::Result<()> {
-    let name = get_node_name(&opts.state, &cmd.node_name);
+    let name = get_node_name(&opts.state, &Some(cmd.node_name));
     if opts.state.nodes.is_default(&name)? {
         Err(miette!("The node '{name}' is already the default"))
     } else {

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,5 +1,5 @@
+use crate::node::get_node_name;
 use crate::node::util::{delete_all_nodes, delete_node};
-use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::local_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
@@ -17,7 +17,7 @@ const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt"
     after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct DeleteCommand {
-    /// Name of the node.
+    /// Name of the node to be deleted
     #[arg(group = "nodes")]
     node_name: Option<String>,
 
@@ -32,7 +32,6 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         local_cmd(run_impl(opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,5 +1,5 @@
+use crate::node::get_node_name;
 use crate::node::util::check_default;
-use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{api, node_rpc, Rpc, RpcBuilder};
 use crate::{docs, CommandGlobalOpts, OutputFormat, Result};
 use clap::Args;
@@ -33,14 +33,13 @@ const IS_NODE_UP_MAX_ATTEMPTS: usize = 60; // 3 seconds
     after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct ShowCommand {
-    /// Name of the node.
+    /// Name of the node to retrieve the details from
     #[arg()]
     node_name: Option<String>,
 }
 
 impl ShowCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         node_rpc(run_impl, (opts, self))
     }
 }
@@ -50,7 +49,6 @@ async fn run_impl(
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
-
     let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
     let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();
     let is_default = check_default(&opts, &node_name);

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -24,8 +24,7 @@ const AFTER_LONG_HELP: &str = include_str!("./static/start/after_long_help.txt")
     after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct StartCommand {
-    /// Name of the node.
-    #[arg()]
+    /// Name of the node to be started
     node_name: Option<String>,
 
     #[arg(long, default_value = "false")]
@@ -41,7 +40,7 @@ impl StartCommand {
 
 async fn run_impl(
     ctx: ockam::Context,
-    (opts, cmd): (CommandGlobalOpts, StartCommand),
+    (mut opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
 
@@ -59,22 +58,22 @@ async fn run_impl(
     }
     node_state.kill_process(false)?;
     let node_setup = node_state.config().setup();
+    opts.global_args.verbose = node_setup.verbose;
 
     // Restart node
     spawn_node(
         &opts,
-        node_setup.verbose, // Previously user-chosen verbosity level
-        &node_name,         // The selected node name
+        &node_name,                                    // The selected node name
         &node_setup.api_transport()?.addr.to_string(), // The selected node api address
-        None,               // No project information available
-        None,               // No trusted identities
-        None,               // "
-        None,               // "
-        None,               // Launch config
-        None,               // Authority Identity
-        None,               // Credential
-        None,               // Trust Context
-        None,               // Project Name
+        None,                                          // No project information available
+        None,                                          // No trusted identities
+        None,                                          // "
+        None,                                          // "
+        None,                                          // Launch config
+        None,                                          // Authority Identity
+        None,                                          // Credential
+        None,                                          // Trust Context
+        None,                                          // Project Name
         node_setup.disable_file_logging,
     )?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -1,4 +1,4 @@
-use crate::node::{get_node_name, initialize_node_if_default};
+use crate::node::get_node_name;
 use crate::util::local_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
@@ -19,7 +19,6 @@ const AFTER_LONG_HELP: &str = include_str!("./static/stop/after_long_help.txt");
 )]
 pub struct StopCommand {
     /// Name of the node.
-    #[arg()]
     node_name: Option<String>,
     /// Whether to use the SIGTERM or SIGKILL signal to stop the node
     #[arg(short, long)]
@@ -28,7 +27,6 @@ pub struct StopCommand {
 
 impl StopCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         local_cmd(run_impl(opts, self));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -193,7 +193,6 @@ pub fn check_default(opts: &CommandGlobalOpts, name: &str) -> bool {
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_node(
     opts: &CommandGlobalOpts,
-    verbose: u8,
     name: &str,
     address: &str,
     project: Option<&PathBuf>,
@@ -208,7 +207,7 @@ pub fn spawn_node(
     disable_file_logging: bool,
 ) -> miette::Result<()> {
     let mut args = vec![
-        match verbose {
+        match opts.global_args.verbose {
             0 => "-vv".to_string(),
             v => format!("-{}", "v".repeat(v as usize)),
         },

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -4,7 +4,7 @@ use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
 use crate::util::parsers::socket_addr_parser;
 use crate::util::{
-    bind_to_port_check, find_available_port, node_rpc, parse_node_name, process_nodes_multiaddr,
+    find_available_port, node_rpc, parse_node_name, port_is_free_guard, process_nodes_multiaddr,
     RpcBuilder,
 };
 use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts};
@@ -102,8 +102,7 @@ async fn rpc(
     let is_finished: Mutex<bool> = Mutex::new(false);
     let progress_bar = opts.terminal.progress_spinner();
     let send_req = async {
-        // Check if the port is used by some other services or process
-        bind_to_port_check(&cmd.from)?;
+        port_is_free_guard(&cmd.from)?;
 
         let project = opts
             .state

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -612,7 +612,7 @@ pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
     data.iter().map(AsRef::as_ref).intersperse(", ").collect()
 }
 
-pub fn bind_to_port_check(address: &SocketAddr) -> Result<()> {
+pub fn port_is_free_guard(address: &SocketAddr) -> Result<()> {
     let port = address.port();
     let ip = address.ip();
     if TcpListener::bind((ip, port)).is_err() {


### PR DESCRIPTION
- Remove automatic node initialization on some node subcommands. For example, `node delete` was creating a background node under the hood just to stop it, which didn't make sense.

- Remove manual port allocation to default tcp listener on `node create` command
