### PR TITLE
update macos version for gradle test

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
     name: Gradle - list_gradle_tasks
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         java: [8, 11, 16, 17]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR updates version of MacOS used in Gradle test as version 10.15 is currently deprecated in GitHub action https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/