### PR TITLE
feat(rust): add timer to close secure channel

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/compat.rs
+++ b/implementations/rust/ockam/ockam_core/src/compat.rs
@@ -225,6 +225,7 @@ pub mod sync {
     use core::convert::Infallible;
 
     pub use alloc::sync::Arc;
+    pub use core::sync::atomic::{AtomicBool, Ordering};
 
     /// Wrap `spin::RwLock` as it does not return LockResult<Guard> like `std::sync::Mutex`.
     #[derive(Debug)]
@@ -289,6 +290,7 @@ pub mod sync {
 /// Provides `std::sync` for `std` targets.
 #[cfg(feature = "std")]
 pub mod sync {
+    pub use std::sync::atomic::{AtomicBool, Ordering};
     pub use std::sync::Arc;
     pub use std::sync::{Mutex, RwLock};
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -27,8 +27,8 @@ use ockam_core::{
 use ockam_core::{AllowOnwardAddress, Result, Worker};
 use ockam_node::callback::CallbackSender;
 use ockam_node::{Context, WorkerBuilder};
-use tracing::{debug, info};
 use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::{debug, info};
 
 /// This struct implements a Worker receiving and sending messages
 /// on one side of the secure channel creation as specified with its role: INITIATOR or REPSONDER

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use core::time::Duration;
+use ockam_core::compat::sync::{AtomicBool, Ordering};
 use ockam_core::compat::{boxed::Box, vec::Vec};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{
@@ -27,7 +28,6 @@ use ockam_core::{
 use ockam_core::{AllowOnwardAddress, Result, Worker};
 use ockam_node::callback::CallbackSender;
 use ockam_node::{Context, WorkerBuilder};
-use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{debug, info};
 
 /// This struct implements a Worker receiving and sending messages

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
@@ -9,6 +9,7 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, Any, Result, Routed, Worker};
 use ockam_node::Context;
+use core::sync::atomic::AtomicBool;
 
 pub(crate) struct IdentityChannelListener {
     secure_channels: Arc<SecureChannels>,
@@ -87,7 +88,7 @@ impl Worker for IdentityChannelListener {
             .create_access_control(ctx.flow_controls(), flow_control_id);
 
         let credentials = self.get_credentials(ctx).await?;
-
+        let flag  = Arc::new(AtomicBool::new(false));
         HandshakeWorker::create(
             ctx,
             self.secure_channels.clone(),
@@ -99,6 +100,7 @@ impl Worker for IdentityChannelListener {
             self.options.trust_context.clone(),
             None,
             None,
+            flag,
             Role::Responder,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/listener.rs
@@ -9,7 +9,6 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{Address, Any, Result, Routed, Worker};
 use ockam_node::Context;
-use core::sync::atomic::AtomicBool;
 
 pub(crate) struct IdentityChannelListener {
     secure_channels: Arc<SecureChannels>,
@@ -88,7 +87,6 @@ impl Worker for IdentityChannelListener {
             .create_access_control(ctx.flow_controls(), flow_control_id);
 
         let credentials = self.get_credentials(ctx).await?;
-        let flag  = Arc::new(AtomicBool::new(false));
         HandshakeWorker::create(
             ctx,
             self.secure_channels.clone(),
@@ -100,7 +98,7 @@ impl Worker for IdentityChannelListener {
             self.options.trust_context.clone(),
             None,
             None,
-            flag,
+            None,
             Role::Responder,
         )
         .await?;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -17,6 +17,7 @@ pub struct SecureChannelOptions {
     pub(crate) trust_context: Option<TrustContext>,
     pub(crate) credentials: Vec<Credential>,
     pub(crate) timeout: Duration,
+    pub(crate) maximum_idle_time: Duration
 }
 
 impl fmt::Debug for SecureChannelOptions {
@@ -39,6 +40,7 @@ impl SecureChannelOptions {
             trust_context: None,
             credentials: vec![],
             timeout: DEFAULT_TIMEOUT,
+            maximum_idle_time: Duration::from_secs(60),
         }
     }
 
@@ -75,6 +77,12 @@ impl SecureChannelOptions {
     /// Freshly generated [`FlowControlId`]
     pub fn producer_flow_control_id(&self) -> FlowControlId {
         self.flow_control_id.clone()
+    }
+
+    /// Sets a maximum_idle_time different from the default 60 secs
+    pub fn with_maximum_idle_time(mut self, maximum_idle_time: Duration) -> Self {
+        self.maximum_idle_time = maximum_idle_time;
+        self
     }
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -17,7 +17,7 @@ pub struct SecureChannelOptions {
     pub(crate) trust_context: Option<TrustContext>,
     pub(crate) credentials: Vec<Credential>,
     pub(crate) timeout: Duration,
-    pub(crate) maximum_idle_time: Duration
+    pub(crate) maximum_idle_time: Duration,
 }
 
 impl fmt::Debug for SecureChannelOptions {

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
@@ -8,13 +8,13 @@ use crate::secure_channel::{
 };
 use crate::{SecureChannel, SecureChannelListener, SecureChannelsBuilder};
 use ockam_core::compat::sync::Arc;
+use ockam_core::compat::sync::{AtomicBool, Ordering};
 use ockam_core::AsyncTryClone;
 use ockam_core::Result;
 use ockam_core::{Address, Route};
-use ockam_node::compat::tokio;
 use ockam_node::compat::tokio::time::sleep;
-use ockam_node::Context;
-use std::sync::atomic::{AtomicBool, Ordering};
+use ockam_node::{spawn, Context};
+
 /// Identity implementation
 #[derive(Clone)]
 pub struct SecureChannels {
@@ -120,7 +120,7 @@ impl SecureChannels {
         let self_clone = self.clone();
         let ctx_clone = ctx.async_try_clone().await?;
         let addr = addresses.encryptor.clone();
-        tokio::spawn(async move {
+        spawn(async move {
             loop {
                 sleep(maximum_idle_time).await;
                 if idle_timeout.load(Ordering::Relaxed) {

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -1117,7 +1117,7 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    
+
     dbg!(ctx.list_workers().await?);
     additional_workers = ctx.list_workers().await?;
 
@@ -1128,9 +1128,7 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
 
 #[allow(non_snake_case)]
 #[ockam_macros::test(timeout = 21000)]
-async fn should_stop_encryptor__and__decryptor__per__timeout(
-    ctx: &mut Context,
-) -> Result<()> {
+async fn should_stop_encryptor__and__decryptor__per__timeout(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels();
     let identities_creation = secure_channels.identities().identities_creation();
 
@@ -1141,13 +1139,13 @@ async fn should_stop_encryptor__and__decryptor__per__timeout(
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier());
 
     let identity_options = SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy);
-    
+
     let bob_listener = secure_channels
         .create_secure_channel_listener(ctx, &bob.identifier(), "bob_listener", identity_options)
         .await?;
-    
+
     let initial_workers = ctx.list_workers().await?;
-    
+
     let mut child_ctx = ctx
         .new_detached_with_mailboxes(Mailboxes::main(
             "child",
@@ -1158,19 +1156,21 @@ async fn should_stop_encryptor__and__decryptor__per__timeout(
 
     ctx.flow_controls()
         .add_consumer("child", bob_listener.flow_control_id());
-    
+
     let sc = {
-        let alice_options = SecureChannelOptions::new().with_trust_policy(alice_trust_policy).with_maximum_idle_time(Duration::new(10, 0));
+        let alice_options = SecureChannelOptions::new()
+            .with_trust_policy(alice_trust_policy)
+            .with_maximum_idle_time(Duration::new(10, 0));
         secure_channels
-        .create_secure_channel(
-            ctx,
-            &alice.identifier(),
-            route!["bob_listener"],
-            alice_options,
-        )
-        .await?
+            .create_secure_channel(
+                ctx,
+                &alice.identifier(),
+                route!["bob_listener"],
+                alice_options,
+            )
+            .await?
     };
-    
+
     child_ctx
         .send(
             route![sc.clone(), child_ctx.address()],
@@ -1189,7 +1189,7 @@ async fn should_stop_encryptor__and__decryptor__per__timeout(
     let works_count = additional_workers.len();
 
     tokio::time::sleep(std::time::Duration::from_secs(20)).await;
-    
+
     additional_workers = ctx.list_workers().await?;
     additional_workers.retain(|w| !initial_workers.contains(w));
     // 3 workers: 1 for encryptor, 1 for decryptor, 1 for spawn
@@ -1197,12 +1197,9 @@ async fn should_stop_encryptor__and__decryptor__per__timeout(
     ctx.stop().await
 }
 
-
 #[allow(non_snake_case)]
 #[ockam_macros::test(timeout = 16000)]
-async fn should_not__stop_encryptor__and__decryptor(
-    ctx: &mut Context,
-) -> Result<()> {
+async fn should_not__stop_encryptor__and__decryptor(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels();
     let identities_creation = secure_channels.identities().identities_creation();
 
@@ -1213,13 +1210,13 @@ async fn should_not__stop_encryptor__and__decryptor(
     let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier());
 
     let identity_options = SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy);
-    
+
     let bob_listener = secure_channels
         .create_secure_channel_listener(ctx, &bob.identifier(), "bob_listener", identity_options)
         .await?;
-    
+
     let initial_workers = ctx.list_workers().await?;
-    
+
     let mut child_ctx = ctx
         .new_detached_with_mailboxes(Mailboxes::main(
             "child",
@@ -1230,19 +1227,21 @@ async fn should_not__stop_encryptor__and__decryptor(
 
     ctx.flow_controls()
         .add_consumer("child", bob_listener.flow_control_id());
-    
+
     let sc = {
-        let alice_options = SecureChannelOptions::new().with_trust_policy(alice_trust_policy).with_maximum_idle_time(Duration::new(10, 0));
+        let alice_options = SecureChannelOptions::new()
+            .with_trust_policy(alice_trust_policy)
+            .with_maximum_idle_time(Duration::new(10, 0));
         secure_channels
-        .create_secure_channel(
-            ctx,
-            &alice.identifier(),
-            route!["bob_listener"],
-            alice_options,
-        )
-        .await?
+            .create_secure_channel(
+                ctx,
+                &alice.identifier(),
+                route!["bob_listener"],
+                alice_options,
+            )
+            .await?
     };
-    
+
     child_ctx
         .send(
             route![sc.clone(), child_ctx.address()],

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -1127,8 +1127,8 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
 }
 
 #[allow(non_snake_case)]
-#[ockam_macros::test(timeout = 400000)]
-async fn should_stop_encryptor__and__decryptor__timeout(
+#[ockam_macros::test(timeout = 21000)]
+async fn should_stop_encryptor__and__decryptor__per__timeout(
     ctx: &mut Context,
 ) -> Result<()> {
     let secure_channels = secure_channels();
@@ -1188,7 +1188,7 @@ async fn should_stop_encryptor__and__decryptor__timeout(
     additional_workers.retain(|w| !initial_workers.contains(w));
     let works_count = additional_workers.len();
 
-    tokio::time::sleep(std::time::Duration::from_secs(11)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
     
     additional_workers = ctx.list_workers().await?;
     additional_workers.retain(|w| !initial_workers.contains(w));
@@ -1199,8 +1199,8 @@ async fn should_stop_encryptor__and__decryptor__timeout(
 
 
 #[allow(non_snake_case)]
-#[ockam_macros::test(timeout = 400000)]
-async fn should_not__stop_encryptor__and__decryptor__timeout(
+#[ockam_macros::test(timeout = 16000)]
+async fn should_not__stop_encryptor__and__decryptor(
     ctx: &mut Context,
 ) -> Result<()> {
     let secure_channels = secure_channels();
@@ -1260,7 +1260,7 @@ async fn should_not__stop_encryptor__and__decryptor__timeout(
     additional_workers.retain(|w| !initial_workers.contains(w));
     let works_count = additional_workers.len();
 
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(7)).await;
 
     child_ctx
         .send(
@@ -1269,7 +1269,7 @@ async fn should_not__stop_encryptor__and__decryptor__timeout(
         )
         .await?;
 
-    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(8)).await;
 
     additional_workers = ctx.list_workers().await?;
     additional_workers.retain(|w| !initial_workers.contains(w));

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -1106,7 +1106,7 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
     let local_info = IdentitySecureChannelLocalInfo::find_info(msg.local_message())?;
     assert_eq!(local_info.their_identity_id(), alice.identifier());
     assert_eq!("Hello, Bob!", msg.body());
-
+    dbg!(ctx.list_workers().await?);
     let mut additional_workers = ctx.list_workers().await?;
 
     additional_workers.retain(|w| !initial_workers.contains(w));
@@ -1117,10 +1117,163 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
         .await?;
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
+    
+    dbg!(ctx.list_workers().await?);
     additional_workers = ctx.list_workers().await?;
 
     additional_workers.retain(|w| !initial_workers.contains(w));
     assert_eq!(additional_workers.len(), (works_count - 2));
+    ctx.stop().await
+}
+
+#[allow(non_snake_case)]
+#[ockam_macros::test(timeout = 400000)]
+async fn should_stop_encryptor__and__decryptor__timeout(
+    ctx: &mut Context,
+) -> Result<()> {
+    let secure_channels = secure_channels();
+    let identities_creation = secure_channels.identities().identities_creation();
+
+    let bob = identities_creation.create_identity().await?;
+    let alice = identities_creation.create_identity().await?;
+
+    let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier());
+    let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier());
+
+    let identity_options = SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy);
+    
+    let bob_listener = secure_channels
+        .create_secure_channel_listener(ctx, &bob.identifier(), "bob_listener", identity_options)
+        .await?;
+    
+    let initial_workers = ctx.list_workers().await?;
+    
+    let mut child_ctx = ctx
+        .new_detached_with_mailboxes(Mailboxes::main(
+            "child",
+            Arc::new(AllowAll),
+            Arc::new(AllowAll),
+        ))
+        .await?;
+
+    ctx.flow_controls()
+        .add_consumer("child", bob_listener.flow_control_id());
+    
+    let sc = {
+        let alice_options = SecureChannelOptions::new().with_trust_policy(alice_trust_policy).with_maximum_idle_time(Duration::new(10, 0));
+        secure_channels
+        .create_secure_channel(
+            ctx,
+            &alice.identifier(),
+            route!["bob_listener"],
+            alice_options,
+        )
+        .await?
+    };
+    
+    child_ctx
+        .send(
+            route![sc.clone(), child_ctx.address()],
+            "Hello, Bob!".to_string(),
+        )
+        .await?;
+
+    let msg = child_ctx.receive::<String>().await?;
+
+    let local_info = IdentitySecureChannelLocalInfo::find_info(msg.local_message())?;
+    assert_eq!(local_info.their_identity_id(), alice.identifier());
+    assert_eq!("Hello, Bob!", msg.body());
+
+    let mut additional_workers = ctx.list_workers().await?;
+    additional_workers.retain(|w| !initial_workers.contains(w));
+    let works_count = additional_workers.len();
+
+    tokio::time::sleep(std::time::Duration::from_secs(11)).await;
+    
+    additional_workers = ctx.list_workers().await?;
+    additional_workers.retain(|w| !initial_workers.contains(w));
+    // 3 workers: 1 for encryptor, 1 for decryptor, 1 for spawn
+    assert_eq!(additional_workers.len(), (works_count - 3));
+    ctx.stop().await
+}
+
+
+#[allow(non_snake_case)]
+#[ockam_macros::test(timeout = 400000)]
+async fn should_not__stop_encryptor__and__decryptor__timeout(
+    ctx: &mut Context,
+) -> Result<()> {
+    let secure_channels = secure_channels();
+    let identities_creation = secure_channels.identities().identities_creation();
+
+    let bob = identities_creation.create_identity().await?;
+    let alice = identities_creation.create_identity().await?;
+
+    let bob_trust_policy = TrustIdentifierPolicy::new(alice.identifier());
+    let alice_trust_policy = TrustIdentifierPolicy::new(bob.identifier());
+
+    let identity_options = SecureChannelListenerOptions::new().with_trust_policy(bob_trust_policy);
+    
+    let bob_listener = secure_channels
+        .create_secure_channel_listener(ctx, &bob.identifier(), "bob_listener", identity_options)
+        .await?;
+    
+    let initial_workers = ctx.list_workers().await?;
+    
+    let mut child_ctx = ctx
+        .new_detached_with_mailboxes(Mailboxes::main(
+            "child",
+            Arc::new(AllowAll),
+            Arc::new(AllowAll),
+        ))
+        .await?;
+
+    ctx.flow_controls()
+        .add_consumer("child", bob_listener.flow_control_id());
+    
+    let sc = {
+        let alice_options = SecureChannelOptions::new().with_trust_policy(alice_trust_policy).with_maximum_idle_time(Duration::new(10, 0));
+        secure_channels
+        .create_secure_channel(
+            ctx,
+            &alice.identifier(),
+            route!["bob_listener"],
+            alice_options,
+        )
+        .await?
+    };
+    
+    child_ctx
+        .send(
+            route![sc.clone(), child_ctx.address()],
+            "Hello, Bob!".to_string(),
+        )
+        .await?;
+
+    let msg = child_ctx.receive::<String>().await?;
+
+    let local_info = IdentitySecureChannelLocalInfo::find_info(msg.local_message())?;
+    assert_eq!(local_info.their_identity_id(), alice.identifier());
+    assert_eq!("Hello, Bob!", msg.body());
+
+    let mut additional_workers = ctx.list_workers().await?;
+    additional_workers.retain(|w| !initial_workers.contains(w));
+    let works_count = additional_workers.len();
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    child_ctx
+        .send(
+            route![sc.clone(), child_ctx.address()],
+            "Hello, Bob!".to_string(),
+        )
+        .await?;
+
+    tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+
+    additional_workers = ctx.list_workers().await?;
+    additional_workers.retain(|w| !initial_workers.contains(w));
+
+    assert_eq!(additional_workers.len(), works_count);
     ctx.stop().await
 }


### PR DESCRIPTION
## Current behavior

Currently, when to establish a secure channel, two workers are created: decrypt and encrypt. However, when the initiator shuts down its connection without explicitly removing the workers, they remain active on the responder side. This can lead to issues such as performance degradation or memory consumption over time.

## Proposed changes
A timer to shut down the workers when a message is not received
