### PR TITLE
feat(rust): add support for json format on ockam_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,6 +5547,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,12 +5566,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -108,7 +108,7 @@ tokio-retry = "0.3"
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-appender = "0.2.2"
 tracing-error = "0.2"
-tracing-subscriber = "0.3.9"
+tracing-subscriber = { version = "0.3.17", features = ["json"] }
 which = "4.4.0"
 
 [dev-dependencies]

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -11,6 +11,7 @@ CLI Behavior
 - OCKAM_DISABLE_UPGRADE_CHECK: a `boolean` that, if set, the CLI won't check for ockam upgrades.
 - OCKAM_HOME: a `string` that sets the home directory. Defaults to `~/.ockam`.
 - OCKAM_LOG: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed.
+- OCKAM_LOG_FORMAT: a `string` that overrides the default format of the logs. It can be `json` or `pretty`.
 - OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB.
 - OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node.
 


### PR DESCRIPTION
Using the `OCKAM_LOG_FORMAT` env variable, we can now override the default logs format with `json` and `pretty` formats.