### PR TITLE
docs(rust): fix error that blocks cargo doc --document-private-items

### DIFF
--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
@@ -12,7 +12,7 @@ use crate::internals::{ast, ast::FnVariable, check, ctx::Context, symbol::*};
 ///
 /// The following code:
 /// ```ignore
-/// #[ockam::test)]
+/// #[ockam::test]
 /// async fn my_test(ctx: &mut ockam::Context) -> ockam::Result<()> {
 ///     ctx.stop().await
 /// }


### PR DESCRIPTION
## Current behavior

Running `cargo doc --document-private-items` fails with below error.

```text
error: could not parse code block as Rust code
  --> implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs:14:5
   |
14 |   /// ```ignore
   |  _____^
15 | | /// #[ockam::test)]
16 | | /// async fn my_test(ctx: &mut ockam::Context) -> ockam::Result<()> {
17 | | ///     ctx.stop().await
18 | | /// }
19 | | /// ```
   | |_______^
   |
help: `ignore` code blocks require valid Rust code for syntax highlighting; mark blocks that do not contain Rust code as text: ```text
  --> implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs:14:5
   |
14 | /// ```ignore
   |     ^^^
   = note: error from rustc: mismatched closing delimiter: `)`
   = note: error from rustc: unexpected closing delimiter: `]`
note: the lint level is defined here
  --> implementations/rust/ockam/ockam_macros/src/lib.rs:13:5
   |
13 |     warnings
   |     ^^^^^^^^
   = note: `#[deny(rustdoc::invalid_rust_codeblocks)]` implied by `#[deny(warnings)]`

error: could not document `ockam_macros`

Caused by:
  process didn't exit successfully: `rustdoc --edition=2021 --crate-type proc-macro --crate-name ockam_macros implementations/rust/ockam/ockam_macros/src/lib.rs -o /Users/neil/dev/ockam/target/doc --cfg 'feature="alloc"' --cfg 'feature="default"' --cfg 'feature="no_std"' --cfg 'feature="std"' --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=175 --document-private-items -C metadata=2fa460766abd451c -L dependency=/Users/neil/dev/ockam/target/debug/deps --extern proc_macro2=/Users/neil/dev/ockam/target/debug/deps/libproc_macro2-2f32e266eca00b1d.rmeta --extern quote=/Users/neil/dev/ockam/target/debug/deps/libquote-4a251482631ce2a2.rmeta --extern syn=/Users/neil/dev/ockam/target/debug/deps/libsyn-057a61ce25740ea2.rmeta --extern proc_macro --crate-version 0.30.0` (exit status: 1)
warning: build failed, waiting for other jobs to finish...
```

## Proposed changes

Fixed tiny syntax error. 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.
