### PR TITLE
feat(rust): foreground nodes will always write logs to stdout

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -301,8 +301,6 @@ impl Default for ConfigVersion {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
 pub struct NodeSetupConfig {
     pub verbose: u8,
-    #[serde(default)]
-    pub disable_file_logging: bool,
 
     /// This flag is used to determine how the node status should be
     /// displayed in print_query_status.
@@ -315,11 +313,6 @@ pub struct NodeSetupConfig {
 impl NodeSetupConfig {
     pub fn set_verbose(mut self, verbose: u8) -> Self {
         self.verbose = verbose;
-        self
-    }
-
-    pub fn set_disable_file_logging(mut self, disable_file_logging: bool) -> Self {
-        self.disable_file_logging = disable_file_logging;
         self
     }
 
@@ -421,11 +414,10 @@ mod backwards_compatibility {
         V2(NodeSetupConfig),
     }
 
+    // The change was replacing the `transports` field with `api_transport`
     #[derive(Serialize, Deserialize, Debug, Clone, Default, Eq, PartialEq)]
     pub(super) struct NodeSetupConfigV1 {
         pub verbose: u8,
-        #[serde(default)]
-        pub disable_file_logging: bool,
 
         /// This flag is used to determine how the node status should be
         /// displayed in print_query_status.
@@ -494,7 +486,6 @@ mod traits {
                     // use it as the api transport
                     let mut new_setup = NodeSetupConfig {
                         verbose: setup.verbose,
-                        disable_file_logging: setup.disable_file_logging,
                         authority_node: setup.authority_node,
                         project: setup.project,
                         api_transport: None,
@@ -587,7 +578,6 @@ mod tests {
     fn node_config_setup_transports_no_duplicates() {
         let mut config = NodeSetupConfigV1 {
             verbose: 0,
-            disable_file_logging: false,
             authority_node: None,
             project: None,
             transports: HashSet::new(),

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -430,7 +430,7 @@ impl OckamCommand {
         // for the node that is being created
         if let OckamSubcommand::Node(c) = &self.subcommand {
             if let NodeSubcommand::Create(c) = &c.subcommand {
-                if c.disable_file_logging {
+                if c.logging_to_stdout() {
                     return None;
                 }
                 // In the case where a node is explicitly created in foreground mode, we need

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -74,7 +74,7 @@ async fn run_impl(
         None,                                          // Credential
         None,                                          // Trust Context
         None,                                          // Project Name
-        node_setup.disable_file_logging,
+        true,                                          // Restarted nodes will log to files
     )?;
 
     // Print node status

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -32,14 +32,12 @@ setup_python_server() {
   if [[ ! -f "$p" ]]; then
     mkdir -p "${p%/*}" && touch "$p"
     pushd "$(mktemp -d 2>/dev/null || mktemp -d -t 'tmpdir')" &>/dev/null || {
-      echo "pushd failed"
       exit 1
     }
     python3 -m http.server --bind 127.0.0.1 5000 &
     pid="$!"
     echo "$pid" >"$p"
     popd || {
-      echo "popd failed"
       exit 1
     }
   fi

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
@@ -113,7 +113,7 @@ force_kill_node() {
   assert_success
 }
 
-@test "node - logs to file" {
+@test "node - background node logs to file" {
   n="$(random_str)"
   $OCKAM node create $n
 
@@ -121,30 +121,11 @@ force_kill_node() {
   if [ ! -s $log_file ]; then
     fail "Log file shouldn't be empty"
   fi
-
-  # Repeat the same with a foreground node
-  n="$(random_str)"
-  $OCKAM node create $n -vv -f &
-  sleep 1
-
-  log_file="$($OCKAM node logs $n)"
-  if [ ! -s $log_file ]; then
-    fail "Log file shouldn't be empty"
-  fi
 }
 
-@test "node - disable file logging" {
+@test "node - foreground node logs to stdout only" {
   n="$(random_str)"
-  $OCKAM node create $n --disable-file-logging
-
-  log_file="$($OCKAM node logs $n)"
-  if [ -s $log_file ]; then
-    fail "Log file should be empty"
-  fi
-
-  # Repeat the same with a foreground node
-  n="$(random_str)"
-  $OCKAM node create $n -vv -f --disable-file-logging &
+  $OCKAM node create $n -vv -f &
   sleep 1
 
   log_file="$($OCKAM node logs $n)"

--- a/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
@@ -4,6 +4,7 @@ setup_suite() {
   load load/base.bash
   setup_python_server
   OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force
+  export BATS_TEST_TIMEOUT=300
 }
 
 teardown_suite() {


### PR DESCRIPTION
- Remove the `--disable-file-logging` flag
- Background nodes (`node create`) will always write the logs to the nodes' configuration log files
- Foreground ndoes (`node create -f`) will always write the logs to stdout, so the user can decide where to redirect the output (if needed)

```sh
# Backgrdound nodes log to the node's log files
$ ockam node create

# Foregrond nodes log to stdout
$ ockam node create -f -vv
```