### PR TITLE
allow running bats test with a different ockam command cli version

### DIFF
--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -1,5 +1,8 @@
 name: CARGO_TARGET_DIR Cache
 description: CARGO_TARGET_DIR Cache
+inputs:
+  ockam_dir:
+    description: Ockam Directory
 runs:
   using: composite
   steps:

--- a/.github/actions/cargo_target_dir_cache/action.yml
+++ b/.github/actions/cargo_target_dir_cache/action.yml
@@ -2,7 +2,7 @@ name: CARGO_TARGET_DIR Cache
 description: CARGO_TARGET_DIR Cache
 inputs:
   ockam_dir:
-    description: Ockam Directory
+    description: Ockam root directory to cache (this should be the directory where the target folder is found)
 runs:
   using: composite
   steps:
@@ -10,7 +10,7 @@ runs:
       shell: bash
     - uses: actions/cache@67b839edb68371cc5014f6cea11c9aa77238de78
       with:
-        path: target
+        path: ${{ inputs.ockam_dir != '' && format('{0}/target', inputs.ockam_dir) || 'target' }}
         key: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:5ab42598e35509cad3ea9c1e1bd0ed135ed1340c6ae44b762b1c8bbec31d5c68-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('./rustc_version.txt') }}
         restore-keys: cache-cargo-target-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:5ab42598e35509cad3ea9c1e1bd0ed135ed1340c6ae44b762b1c8bbec31d5c68-
 

--- a/.github/actions/cargo_target_dir_pre_cache/action.yml
+++ b/.github/actions/cargo_target_dir_pre_cache/action.yml
@@ -1,10 +1,15 @@
 name: CARGO_TARGET_DIR Pre Cache
 description: CARGO_TARGET_DIR Pre Cache
+inputs:
+  ockam_dir:
+    description: Ockam Directory
+    default: '.'
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
+        cd ${{ inputs.ockam_dir }}
         crates=($(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_members[] | split(" ")  | .[0] | gsub("-";"_")'))
 
         # Get target folder size

--- a/.github/actions/cargo_target_dir_pre_cache/action.yml
+++ b/.github/actions/cargo_target_dir_pre_cache/action.yml
@@ -2,7 +2,7 @@ name: CARGO_TARGET_DIR Pre Cache
 description: CARGO_TARGET_DIR Pre Cache
 inputs:
   ockam_dir:
-    description: Ockam Directory
+    description: Ockam Root Directory To Cache
     default: '.'
 runs:
   using: composite

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ on:
     inputs:
       commit_sha:
         description: Git commit sha, on which, to run this workflow
+      ockam_command_cli_version:
+        description: SHA to build Ockam CLI
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -370,34 +372,47 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
-      - name: Checkout repository
+      - name: Checkout ockam cli repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
-          ref: ${{ github.event.inputs.release_branch }}
+          ref: ${{ inputs.ockam_command_cli_version != '' && inputs.ockam_command_cli_version || inputs.commit_sha  }}
+          path: ockam_cli
+
+      - name: Checkout ockam bats repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: ${{ inputs.commit_sha }}
+          path: ockam_bats
 
       - name: Use cache cargo_home
-        uses: ./.github/actions/cargo_home_cache
+        uses: ./ockam_bats/.github/actions/cargo_home_cache
       - name: Use cache cargo_target
-        uses: ./.github/actions/cargo_target_dir_cache
+        uses: ./ockam_bats/.github/actions/cargo_target_dir_cache
+        with:
+          ockam_dir: ockam_cli
 
       - name: Build Binary
         shell: bash
+        working-directory: ockam_cli
         run: |
           rustc --version
           set -x
           cargo build --bin ockam
+          echo "PATH=$(pwd)/target/debug:$PATH" >> $GITHUB_ENV;
 
       - name: Run Script On Ubuntu
-        if: matrix.build == 'linux_86'
+        working-directory: ockam_bats
         shell: bash
         run: |
-          export PATH=$(pwd)/target/debug:$PATH;
+          ockam --version
           bats implementations/rust/ockam/ockam_command/tests/bats;
         env:
           OCKAM_DISABLE_UPGRADE_CHECK: 1
 
       - name: Prep cache cargo_target before persisting
-        uses: ./.github/actions/cargo_target_dir_pre_cache
+        uses: ./ockam_bats/.github/actions/cargo_target_dir_pre_cache
+        with:
+          ockam_dir: ockam_cli
 
   ockam_command_cross_build:
     name: Rust - ockam_command_cross_build
@@ -421,7 +436,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
-          ref: ${{ github.event.inputs.release_branch }}
+          ref: ${{ inputs.commit_sha }}
 
       - uses: ./.github/actions/build_binaries
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,9 +37,9 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: Git commit sha, on which, to run this workflow
+        description: Commit SHA, to run workflow
       ockam_command_cli_version:
-        description: SHA to build Ockam CLI
+        description: SHA to build Ockam command CLI
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -405,6 +405,7 @@ jobs:
         shell: bash
         run: |
           ockam --version
+          echo $(which ockam)
           bats implementations/rust/ockam/ockam_command/tests/bats;
         env:
           OCKAM_DISABLE_UPGRADE_CHECK: 1
@@ -449,21 +450,18 @@ jobs:
     name: Rust - test_orchestrator_ockam_command
     runs-on: ubuntu-20.04
     container: ghcr.io/build-trust/artifacts-helper:latest
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: read
 
     steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-        with:
-          ref: ${{ github.event.inputs.release_branch }}
-
       - name: Run Ockam Bats Test On Development Cluster
         uses: build-trust/.github/actions/run_bats_test@custom-actions
         with:
           perform_ockam_enroll: 'true'
           script_path: "/artifacts-scripts"
-          ockam_repository_ref: ${{ github.event.inputs.release_branch }}
+          ockam_repository_ref: ${{ inputs.commit_sha }}
           controller_id: ${{ secrets.ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ID }}
           controller_addr: ${{ secrets.ORCHESTRATOR_DEVELOPMENT_CONTROLLER_ADDRESS }}
+          ockam_cli_repository_ref: ${{ inputs.ockam_command_cli_version }}


### PR DESCRIPTION
This PR allows us run bats test with a different version of ockam command CLI
<img width="1512" alt="Screenshot 2023-07-04 at 1 17 24 PM" src="https://github.com/build-trust/ockam/assets/31141573/8aa4b2f7-37eb-4330-8ddf-03b210203eff">
