### PR TITLE
run ockam test with multiple threads on `cargo nextest`

### DIFF
--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -99,11 +99,11 @@ fn run_04_udp() -> Result<(), Error> {
 fn run_05_secure_channel_over_two_transport_hops() -> Result<(), Error> {
     // Launch responder, wait for it to start up
     let resp = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-responder").spawn()?;
-    resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+    resp.match_stdout("Initializing ockam processor")?;
 
     // Launch middle, wait for it to start up
     let mid = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-middle").spawn()?;
-    mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
+    mid.match_stdout("Initializing ockam processor")?;
 
     // Run initiator to completion
     let (exitcode, stdout) =

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -192,7 +192,7 @@ task test {
       // Use 'cargo nextest' in CI
       exec {
         environment environmentVars()
-        commandLine cargo('--locked', 'nextest', '--config-file', '../../tools/nextest/.config/nextest.toml', 'run')
+        commandLine cargo('--locked', 'nextest', '--config-file', '../../tools/nextest/.config/nextest.toml', 'run', '-E', '!package(ockam_kafka)')
       }
       // Nextest does not currently support doctests,
       // so run doctests using cargo

--- a/tools/nextest/.config/nextest.toml
+++ b/tools/nextest/.config/nextest.toml
@@ -2,10 +2,11 @@
 slow-timeout = { period = "2m", terminate-after = 3, grace-period = "30s" }
 
 [test-groups]
-sequential = { max-threads = 1 }
+sequential = { max-threads = 4 }
 
 [[profile.default.overrides]]
 filter = 'package(hello_ockam)'
+threads-required = 3
 test-group = 'sequential'
 
 [[profile.default.overrides]]
@@ -14,4 +15,5 @@ test-group = 'sequential'
 
 [[profile.default.overrides]]
 filter = 'package(tcp_inlet_and_outlet)'
+threads-required = 2
 test-group = 'sequential'


### PR DESCRIPTION
This PR reduces time it takes to run test with `cargo nextest`, it increase the number of threads taken to run tests that require multithread environments https://nexte.st/book/test-groups.html?highlight=max-thread#comparison-with-threads-required
This PR also disables the `ockam_kafka` test from running so as to reduce kakfa billing