### PR TITLE
chore(ci): avoiding building typescript ockam_app when checking rust

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,11 +52,9 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
-      - run: ./gradlew build -Pmode=release
       - working-directory: implementations/typescript/ockam/ockam_app
-        run: |
-          pnpm install
-          pnpm run build
+        run: mkdir build
+      - run: ./gradlew build -Pmode=release
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   list_gradle_tasks:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,8 +73,7 @@ jobs:
       - uses: ./.github/actions/gradle_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          pnpm install
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           cd implementations/rust && ../../gradlew lint_cargo_fmt_check
@@ -107,8 +106,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          pnpm install
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           cd implementations/rust && ../../gradlew lint_cargo_clippy
@@ -126,8 +124,7 @@ jobs:
       - uses: ./.github/actions/gradle_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          pnpm install
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           cd implementations/rust && ../../gradlew lint_cargo_deny
@@ -146,8 +143,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          pnpm install
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           cd implementations/rust && ../../gradlew build_docs
@@ -188,8 +184,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          npm install @sveltejs/kit
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           cd implementations/rust && ../../gradlew build_examples
@@ -264,8 +259,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          npm install @sveltejs/kit
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           RUSTFLAGS='-Dwarnings' cargo check --features tag
@@ -307,8 +301,7 @@ jobs:
       - uses: ./.github/actions/cargo_target_dir_cache
       - working-directory: implementations/typescript/ockam/ockam_app
         run: |
-          npm install @sveltejs/kit
-          pnpm run build
+          mkdir build
       - run: |
           rustc --version
           RUSTFLAGS='--cfg tokio_unstable -Dwarnings' cargo check


### PR DESCRIPTION
We should be able to avoid building typescript for rust checks. Also fixes Gradle release build