### PR TITLE
add build dir before gradle release build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,11 +52,9 @@ jobs:
       - uses: ./.github/actions/cargo_home_cache
       - uses: ./.github/actions/cargo_target_dir_cache
       - uses: ./.github/actions/elixir_cache
-      - run: ./gradlew build -Pmode=release
       - working-directory: implementations/typescript/ockam/ockam_app
-        run: |
-          pnpm install
-          pnpm run build
+        run: mkdir build
+      - run: ./gradlew build -Pmode=release
       - uses: ./.github/actions/cargo_target_dir_pre_cache
 
   list_gradle_tasks:


### PR DESCRIPTION
[This fixes gradle release build](https://github.com/build-trust/ockam/actions/runs/5463270292/jobs/9943753475?pr=5214#step:8:3480) ensuring we generate a build directory before calling `./gradlew build -Pmode=release`