### PR TITLE
chore(rust): upgraded tauri and added muda dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,6 +3407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7668b7cff6a51fe61cdde64cd27c8a220786f399501b57ebe36f7d8112fd68"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "kuchiki"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,6 +3503,25 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.7",
  "thiserror",
+]
+
+[[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
 ]
 
 [[package]]
@@ -3839,6 +3869,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "muda"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b141f55dd7831b7c1c0e9551165f6eee87021a356a437c00f3bdc2aeafc3ec"
+dependencies = [
+ "cocoa",
+ "crossbeam-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc",
+ "once_cell",
+ "png",
+ "thiserror",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4234,6 +4284,7 @@ name = "ockam_app"
 version = "0.1.0"
 dependencies = [
  "miette",
+ "muda",
  "ockam",
  "ockam_api",
  "ockam_command",

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -32,10 +32,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 path = "src/lib.rs"
 
 [build-dependencies]
-tauri-build = { version = "2.0.0-alpha.5", features = [] }
+tauri-build = { version = "2.0.0-alpha.6", features = [] }
 
 [dependencies]
 miette = { version = "5.8.0", features = ["fancy-no-backtrace"] }
+muda = "0.6"
 ockam = { path = "../ockam", version = "^0.90.0", features = ["software_vault"] }
 ockam_api = { path = "../ockam_api", version = "0.33.0", features = ["std", "authenticators"] }
 ockam_command = { path = "../ockam_command", version = "^0.90.0" }
@@ -44,7 +45,7 @@ ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.24.0", features = 
 open = "4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri = { version = "2.0.0-alpha.9", features = ["system-tray"] }
+tauri = { version = "2.0.0-alpha.10", features = ["system-tray"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.


### PR DESCRIPTION
Since [downgrade is not an option](https://github.com/build-trust/ockam/pull/5242), let's keep tauri up-to-date to latest alpha until 2 stable is released.
