### PR TITLE
Refactor the enroll feature + reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,6 +4295,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tracing",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -46,6 +46,7 @@ open = "5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.0.0-alpha.10", features = ["system-tray"] }
+tracing = "0.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/implementations/rust/ockam/ockam_app/src/app/build.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/build.rs
@@ -1,14 +1,17 @@
 use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu, SystemTrayMenuItem};
 
-use crate::{enroll, quit};
+use crate::enroll::EnrollActions;
+use crate::quit::QuitActions;
 
 /// Create the system tray with all the major functions.
 /// Separate groups of related functions with a native separator
 pub fn create_system_tray() -> SystemTray {
+    let enroll = EnrollActions::new();
+    let quit = QuitActions::new();
     let tray_menu = SystemTrayMenu::new()
-        .add_menu_items(enroll::menu_items())
+        .add_menu_items(vec![enroll.enroll])
         .add_native_item(SystemTrayMenuItem::Separator)
-        .add_menu_items(quit::menu_items());
+        .add_menu_items(vec![enroll.reset, quit.quit]);
 
     SystemTray::new().with_menu(tray_menu)
 }

--- a/implementations/rust/ockam/ockam_app/src/app/process.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/process.rs
@@ -1,14 +1,19 @@
 use tauri::{AppHandle, RunEvent, SystemTrayEvent, Wry};
+use tracing::error;
 
 use crate::{enroll, quit};
 
 /// This is the function dispatching events for the SystemTray
 pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
     if let SystemTrayEvent::MenuItemClick { id, .. } = event {
-        match id.as_str() {
-            enroll::ENROLL_MENU_ID => enroll::on_enroll(app).unwrap(),
-            quit::QUIT_MENU_ID => quit::on_quit(app).unwrap(),
-            _ => {}
+        let result = match id.as_str() {
+            enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
+            enroll::RESET_MENU_ID => enroll::on_reset(app),
+            quit::QUIT_MENU_ID => quit::on_quit(app),
+            _ => Ok(()),
+        };
+        if let Err(e) = result {
+            error!("{:?}", e)
         }
     }
 }

--- a/implementations/rust/ockam/ockam_app/src/app/process.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/process.rs
@@ -1,14 +1,15 @@
 use tauri::{AppHandle, RunEvent, SystemTrayEvent, Wry};
 use tracing::error;
 
+use crate::enroll::DefaultBackend;
 use crate::{enroll, quit};
 
 /// This is the function dispatching events for the SystemTray
 pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
     if let SystemTrayEvent::MenuItemClick { id, .. } = event {
         let result = match id.as_str() {
-            enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
-            enroll::RESET_MENU_ID => enroll::on_reset(app),
+            enroll::ENROLL_MENU_ID => enroll::on_enroll(DefaultBackend, app),
+            enroll::RESET_MENU_ID => enroll::on_reset(DefaultBackend, app),
             quit::QUIT_MENU_ID => quit::on_quit(app),
             _ => Ok(()),
         };

--- a/implementations/rust/ockam/ockam_app/src/enroll/backend.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/backend.rs
@@ -1,7 +1,13 @@
 use crate::enroll;
 
+/// This trait represents all the enroll actions which
+/// can interact with the network or the local configuration
+/// It allows running the application with some mocks of those functions.
 pub trait Backend {
+    /// Trigger the authentication workflow for the current user
     fn enroll_user(&self) -> miette::Result<()>;
+
+    /// Reset the local configuration as if running `ockam reset -y`
     fn reset(&self) -> miette::Result<()>;
 }
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/backend.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/backend.rs
@@ -1,0 +1,18 @@
+use crate::enroll;
+
+pub trait Backend {
+    fn enroll_user(&self) -> miette::Result<()>;
+    fn reset(&self) -> miette::Result<()>;
+}
+
+pub struct DefaultBackend;
+
+impl Backend for DefaultBackend {
+    fn enroll_user(&self) -> miette::Result<()> {
+        enroll::enroll_user::enroll_user()
+    }
+
+    fn reset(&self) -> miette::Result<()> {
+        enroll::reset::reset()
+    }
+}

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -1,6 +1,6 @@
 use miette::miette;
-use ockam::Context;
 
+use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cloud::{enroll::auth0::AuthenticateAuth0Token, CloudRequestWrapper};
 use ockam_command::enroll::{Auth0Provider, Auth0Service};
@@ -18,16 +18,12 @@ use ockam_multiaddr::MultiAddr;
 ///  - connects to the Orchestrator with the retrieved token to create a project
 ///
 #[tauri::command]
-pub fn enroll_user() -> String {
+pub fn enroll_user() {
     let options = CommandGlobalOpts::new(GlobalArgs::default());
-
     if options.state.identities.default().is_err() {
         create_default_identity(&options);
     }
-
-    node_rpc(rpc, options);
-
-    "Enrolled".to_string()
+    node_rpc(rpc, options)
 }
 
 async fn rpc(ctx: Context, options: CommandGlobalOpts) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -1,53 +1,27 @@
-use miette::miette;
-
 use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cloud::{enroll::auth0::AuthenticateAuth0Token, CloudRequestWrapper};
-use ockam_command::enroll::{Auth0Provider, Auth0Service};
+use ockam_command::enroll::{enroll, Auth0Service};
 use ockam_command::identity::create_default_identity;
-use ockam_command::node::util::start_embedded_node;
-use ockam_command::util::{node_rpc, RpcBuilder, DEFAULT_CONTROLLER_ADDRESS};
+use ockam_command::util::embedded_node;
 use ockam_command::{CommandGlobalOpts, GlobalArgs};
-use ockam_core::{env::FromString, CowStr};
-use ockam_multiaddr::MultiAddr;
 
 /// Enroll a user.
 /// This function:
 ///  - creates a default node, with a default identity, if it doesn't exist
 ///  - connects to the Auth0 service to authenticate the user of the Ockam application to retrieve a token
 ///  - connects to the Orchestrator with the retrieved token to create a project
-///
 #[tauri::command]
-pub fn enroll_user() {
+pub fn enroll_user() -> miette::Result<()> {
     let options = CommandGlobalOpts::new(GlobalArgs::default());
     if options.state.identities.default().is_err() {
         create_default_identity(&options);
     }
-    node_rpc(rpc, options)
+    embedded_node(rpc, options)
 }
 
 async fn rpc(ctx: Context, options: CommandGlobalOpts) -> miette::Result<()> {
-    let auth0 = Auth0Service::new(Auth0Provider::Auth0);
-    let dc = auth0.device_code().await?;
-    let uri: &str = &dc.verification_uri_complete;
-    println!("     │ Opening {}", uri);
-    if open::that(uri).is_err() {
-        println!("Couldn't open activation url automatically [url={}]", uri);
-    }
-
-    let token = auth0.poll_token(dc, &options).await?;
-    let node_name = start_embedded_node(&ctx, &options, None).await?;
-    let mut rpc = RpcBuilder::new(&ctx, &options, &node_name).build();
-    let default_addr = MultiAddr::from_string(DEFAULT_CONTROLLER_ADDRESS)
-        .map_err(|e| miette!("The default controller address is incorrect: {:?}", e))?;
-    let token = AuthenticateAuth0Token::new(token);
-    let request = ockam_core::api::Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(
-        token,
-        &default_addr,
-        None::<CowStr>,
-    ));
-    rpc.request(request).await?;
-    let (_res, _dec) = rpc.check_response()?;
-
-    Ok(())
+    // get an Auth0 token
+    let token = Auth0Service::default().get_token(&options).await?;
+    // enroll the current user using that token on the controller
+    enroll(&ctx, &options, token).await
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
@@ -1,15 +1,40 @@
 use tauri::{AppHandle, CustomMenuItem, Wry};
 
+use ockam_api::cli_state::StateDirTrait;
+use ockam_command::{CommandGlobalOpts, GlobalArgs};
+
 use crate::enroll::enroll_user::enroll_user;
+use crate::enroll::reset::reset;
 
 pub const ENROLL_MENU_ID: &str = "enroll";
+pub const RESET_MENU_ID: &str = "reset";
 
 pub fn menu_items() -> Vec<CustomMenuItem> {
-    vec![CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e")]
+    let options = CommandGlobalOpts::new(GlobalArgs::default());
+
+    let enroll_menu_item = CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e");
+    let reset_menu_item = CustomMenuItem::new(RESET_MENU_ID, "Reset...").accelerator("cmd+r");
+    if options.state.projects.default().is_ok() {
+        vec![enroll_menu_item.disabled(), reset_menu_item]
+    } else {
+        vec![enroll_menu_item, reset_menu_item.disabled()]
+    }
 }
 
 /// Enroll the user and show that it has been enrolled
 pub fn on_enroll(app: &AppHandle<Wry>) -> tauri::Result<()> {
     enroll_user();
-    app.tray_handle().get_item("enroll").set_title("Enrolled")
+    app.tray_handle()
+        .get_item(ENROLL_MENU_ID)
+        .set_enabled(false)?;
+    app.tray_handle().get_item(RESET_MENU_ID).set_enabled(true)
+}
+
+/// Reset the persistent state
+pub fn on_reset(app: &AppHandle<Wry>) -> tauri::Result<()> {
+    reset();
+    app.tray_handle()
+        .get_item(ENROLL_MENU_ID)
+        .set_enabled(true)?;
+    app.tray_handle().get_item(RESET_MENU_ID).set_enabled(false)
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
@@ -9,16 +9,32 @@ use crate::enroll::backend::Backend;
 pub const ENROLL_MENU_ID: &str = "enroll";
 pub const RESET_MENU_ID: &str = "reset";
 
-pub fn menu_items() -> Vec<CustomMenuItem> {
-    let options = CommandGlobalOpts::new(GlobalArgs::default());
+#[derive(Clone)]
+pub struct EnrollActions {
+    pub options: CommandGlobalOpts,
+    pub(crate) enroll: CustomMenuItem,
+    pub(crate) reset: CustomMenuItem,
+}
 
-    let enroll_menu_item = CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e");
-    let reset_menu_item = CustomMenuItem::new(RESET_MENU_ID, "Reset...").accelerator("cmd+r");
-    match options.state.projects.default() {
-        Ok(_) => vec![enroll_menu_item.disabled(), reset_menu_item],
-        Err(_) => {
-            info!("There is no default project, please enroll");
-            vec![enroll_menu_item, reset_menu_item.disabled()]
+impl EnrollActions {
+    pub fn new() -> EnrollActions {
+        let enroll = CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e");
+        let reset = CustomMenuItem::new(RESET_MENU_ID, "Reset...").accelerator("cmd+r");
+        let options = CommandGlobalOpts::new(GlobalArgs::default());
+        match options.state.projects.default() {
+            Ok(_) => EnrollActions {
+                options,
+                enroll: enroll.disabled(),
+                reset,
+            },
+            Err(_) => {
+                info!("There is no default project, please enroll");
+                EnrollActions {
+                    options,
+                    enroll,
+                    reset: reset.disabled(),
+                }
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
@@ -46,29 +46,3 @@ pub fn on_reset(backend: impl Backend, app: &AppHandle<Wry>) -> tauri::Result<()
         Ok(())
     }
 }
-
-#[cfg(tests)]
-mod tests {
-    use super::*;
-
-    fn test_enroll_reset() {
-        let backend = TestBackend {};
-        let app = tauri::Builder::default()
-            .build(tauri::generate_context!())
-            .unwrap();
-        on_enroll(backend, &app.handle()).unwrap();
-    }
-
-    /// TEST HELPERS
-    struct TestBackend {}
-
-    impl Backend for TestBackend {
-        fn enroll_user(&self) -> miette::Result<()> {
-            Ok(())
-        }
-
-        fn reset(&self) -> miette::Result<()> {
-            Ok(())
-        }
-    }
-}

--- a/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/menu_items.rs
@@ -1,10 +1,10 @@
 use tauri::{AppHandle, CustomMenuItem, Wry};
+use tracing::info;
 
 use ockam_api::cli_state::StateDirTrait;
 use ockam_command::{CommandGlobalOpts, GlobalArgs};
 
-use crate::enroll::enroll_user::enroll_user;
-use crate::enroll::reset::reset;
+use crate::enroll::backend::Backend;
 
 pub const ENROLL_MENU_ID: &str = "enroll";
 pub const RESET_MENU_ID: &str = "reset";
@@ -14,27 +14,61 @@ pub fn menu_items() -> Vec<CustomMenuItem> {
 
     let enroll_menu_item = CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e");
     let reset_menu_item = CustomMenuItem::new(RESET_MENU_ID, "Reset...").accelerator("cmd+r");
-    if options.state.projects.default().is_ok() {
-        vec![enroll_menu_item.disabled(), reset_menu_item]
-    } else {
-        vec![enroll_menu_item, reset_menu_item.disabled()]
+    match options.state.projects.default() {
+        Ok(_) => vec![enroll_menu_item.disabled(), reset_menu_item],
+        Err(_) => {
+            info!("There is no default project, please enroll");
+            vec![enroll_menu_item, reset_menu_item.disabled()]
+        }
     }
 }
 
 /// Enroll the user and show that it has been enrolled
-pub fn on_enroll(app: &AppHandle<Wry>) -> tauri::Result<()> {
-    enroll_user();
-    app.tray_handle()
-        .get_item(ENROLL_MENU_ID)
-        .set_enabled(false)?;
-    app.tray_handle().get_item(RESET_MENU_ID).set_enabled(true)
+pub fn on_enroll(backend: impl Backend, app: &AppHandle<Wry>) -> tauri::Result<()> {
+    if backend.enroll_user().is_ok() {
+        app.tray_handle()
+            .get_item(ENROLL_MENU_ID)
+            .set_enabled(false)?;
+        app.tray_handle().get_item(RESET_MENU_ID).set_enabled(true)
+    } else {
+        Ok(())
+    }
 }
 
 /// Reset the persistent state
-pub fn on_reset(app: &AppHandle<Wry>) -> tauri::Result<()> {
-    reset();
-    app.tray_handle()
-        .get_item(ENROLL_MENU_ID)
-        .set_enabled(true)?;
-    app.tray_handle().get_item(RESET_MENU_ID).set_enabled(false)
+pub fn on_reset(backend: impl Backend, app: &AppHandle<Wry>) -> tauri::Result<()> {
+    if backend.reset().is_ok() {
+        app.tray_handle()
+            .get_item(ENROLL_MENU_ID)
+            .set_enabled(true)?;
+        app.tray_handle().get_item(RESET_MENU_ID).set_enabled(false)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    use super::*;
+
+    fn test_enroll_reset() {
+        let backend = TestBackend {};
+        let app = tauri::Builder::default()
+            .build(tauri::generate_context!())
+            .unwrap();
+        on_enroll(backend, &app.handle()).unwrap();
+    }
+
+    /// TEST HELPERS
+    struct TestBackend {}
+
+    impl Backend for TestBackend {
+        fn enroll_user(&self) -> miette::Result<()> {
+            Ok(())
+        }
+
+        fn reset(&self) -> miette::Result<()> {
+            Ok(())
+        }
+    }
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/mod.rs
@@ -1,4 +1,5 @@
 mod enroll_user;
 mod menu_items;
+mod reset;
 
 pub use menu_items::*;

--- a/implementations/rust/ockam/ockam_app/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/mod.rs
@@ -1,5 +1,7 @@
+mod backend;
 mod enroll_user;
 mod menu_items;
 mod reset;
 
+pub use backend::*;
 pub use menu_items::*;

--- a/implementations/rust/ockam/ockam_app/src/enroll/reset.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/reset.rs
@@ -1,0 +1,18 @@
+use tracing;
+use tracing::{error, info};
+
+use ockam_command::{CommandGlobalOpts, GlobalArgs};
+
+/// Reset the project.
+/// This function removes all persisted state
+/// So that the user must enroll again in order to be able to access a project
+///
+#[tauri::command]
+pub fn reset() {
+    let options = CommandGlobalOpts::new(GlobalArgs::default());
+    if let Err(e) = options.state.delete(true) {
+        error!("{:?}", e)
+    } else {
+        info!("Local Ockam configuration deleted")
+    }
+}

--- a/implementations/rust/ockam/ockam_app/src/enroll/reset.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/reset.rs
@@ -1,18 +1,20 @@
-use tracing;
-use tracing::{error, info};
+use miette::{miette, IntoDiagnostic};
 
 use ockam_command::{CommandGlobalOpts, GlobalArgs};
 
 /// Reset the project.
 /// This function removes all persisted state
 /// So that the user must enroll again in order to be able to access a project
-///
 #[tauri::command]
-pub fn reset() {
+pub fn reset() -> miette::Result<()> {
     let options = CommandGlobalOpts::new(GlobalArgs::default());
     if let Err(e) = options.state.delete(true) {
-        error!("{:?}", e)
+        Err(miette!("{:?}", e))
     } else {
-        info!("Local Ockam configuration deleted")
+        options
+            .terminal
+            .write_line("Local Ockam configuration deleted")
+            .into_diagnostic()?;
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_app/src/quit/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/quit/menu_items.rs
@@ -2,8 +2,16 @@ use tauri::{AppHandle, CustomMenuItem, Wry};
 
 pub const QUIT_MENU_ID: &str = "quit";
 
-pub fn menu_items() -> Vec<CustomMenuItem> {
-    vec![CustomMenuItem::new("quit".to_string(), "Quit").accelerator("cmd+q")]
+#[derive(Clone)]
+pub struct QuitActions {
+    pub(crate) quit: CustomMenuItem,
+}
+
+impl QuitActions {
+    pub fn new() -> QuitActions {
+        let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("cmd+q");
+        QuitActions { quit }
+    }
 }
 
 /// Quit the application when the user wants to

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -238,18 +238,16 @@ fn node_service(service_name: &str) -> String {
 pub mod enroll {
     use ockam_api::cloud::enroll::auth0::{Auth0Token, AuthenticateAuth0Token};
 
-    use crate::enroll::*;
-
     use super::*;
 
-    pub(crate) fn auth0<'a>(
-        cmd: EnrollCommand,
+    pub fn auth0<'a>(
+        route: &MultiAddr,
         token: Auth0Token,
     ) -> RequestBuilder<'a, CloudRequestWrapper<'a, AuthenticateAuth0Token>> {
         let token = AuthenticateAuth0Token::new(token);
         Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(
             token,
-            &cmd.cloud_opts.route(),
+            route,
             None::<CowStr>,
         ))
     }


### PR DESCRIPTION
This PR refactors the enroll feature so that we reuse code from the `ockam_command` crate.
Additionally it introduces a `reset` action to enable faster manual testing when repeatedly trying to enroll:
<img width="160" alt="image" src="https://github.com/build-trust/ockam/assets/10988/a653a29f-320b-4ecb-a62b-a546c528c7aa">

Reset is only available once the enrollment has been done (and then `Enroll...` is disabled):
<img width="141" alt="image" src="https://github.com/build-trust/ockam/assets/10988/a58a7dc6-067e-4461-8216-6ab35a883d8b">

