### PR TITLE
chore(ci): enable ockam_app package build with gradle build

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -238,11 +238,27 @@ jobs:
         target: ${{ matrix.target }}
         platform_operating_system: ${{ matrix.os }}
 
-    - name: Build archive
+    - name: Copy Artifacts
       run: |
         set -x
         cp target/${{ matrix.target }}/release/ockam ockam.${{ matrix.target }}
-        echo "ASSET=ockam.${{ matrix.target }}" >> $GITHUB_ENV
+        echo "ASSET_OCKAM_CLI=ockam.${{ matrix.target }}" >> $GITHUB_ENV
+        
+        if [ -e "target/${{ matrix.target }}/release/bundle/dmg/Ockam Desktop*dmg" ]; then
+          cp "target/${{ matrix.target }}/release/bundle/dmg/Ockam Desktop*dmg" "Ockam Desktop ${{ matrix.target }}.dmg"
+          echo "ASSET_OCKAM_DESKTOP_DMG="Ockam Desktop ${{ matrix.target }}.dmg" >> $GITHUB_ENV
+        fi
+        
+        if [ -e "target/${{ matrix.target }}/release/bundle/ockam-desktop*.deb" ]; then
+          cp target/${{ matrix.target }}/release/bundle/ockam-desktop*.deb "ockam-desktop-${{ matrix.target }}.deb"
+          echo "ASSET_OCKAM_DESKTOP_DEB=ockam-desktop-${{ matrix.target }}.deb" >> $GITHUB_ENV
+        fi
+        
+        if [ -e "target/${{ matrix.target }}/release/bundle/ockam-desktop*.AppImage" ]; then
+          cp "target/${{ matrix.target }}/release/bundle/ockam-desktop*.AppImage" "Ockam Desktop ${{ matrix.target }}.AppImage"
+          echo "ASSET_OCKAM_DESKTOP_APPIMAGE=Ockam Desktop ${{ matrix.target }}.AppImage" >> $GITHUB_ENV
+        fi
+        
         ls $GITHUB_WORKSPACE
 
     - name: Install Cosign
@@ -255,26 +271,59 @@ jobs:
         PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         COSIGN_PASSWORD: '${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}'
       run: |
-        cosign sign-blob --yes --key env://PRIVATE_KEY ${{ env.ASSET }} > ${{ env.ASSET }}.sig
+        cosign sign-blob --yes --key env://PRIVATE_KEY ${{ env.ASSET_OCKAM_CLI }} > ${{ env.ASSET_OCKAM_CLI }}.sig
 
-    - name: Upload release archive
+    - name: Upload CLI release archive
       uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
+        asset_path: ${{ env.ASSET_OCKAM_CLI }}
+        asset_name: ${{ env.ASSET_OCKAM_CLI }}
         asset_content_type: application/octet-stream
 
-    - name: Upload Signature
+    - name: Upload CLI Signature
       uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}.sig
-        asset_name: ${{ env.ASSET }}.sig
+        asset_path: ${{ env.ASSET_OCKAM_CLI }}.sig
+        asset_name: ${{ env.ASSET_OCKAM_CLI }}.sig
+        asset_content_type: application/octet-stream
+
+    - name: Upload MacOS Desktop App release
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_DESKTOP_DMG }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_DESKTOP_DMG }}
+        asset_name: ${{ env.ASSET_OCKAM_DESKTOP_DMG }}
+        asset_content_type: application/octet-stream
+
+    - name: Upload Debian Desktop App Package
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_DESKTOP_DEB }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_DESKTOP_DEB }}
+        asset_name: ${{ env.ASSET_OCKAM_DESKTOP_DEB }}
+        asset_content_type: application/octet-stream
+
+    - name: Upload Linux AppImage Desktop App
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_DESKTOP_APPIMAGE }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_DESKTOP_APPIMAGE }}
+        asset_name: ${{ env.ASSET_OCKAM_DESKTOP_APPIMAGE }}
         asset_content_type: application/octet-stream
 
   build_elixir_nifs:

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -46,7 +46,7 @@ ext {
     command = ['cargo']
     command.addAll(arguments)
 
-    if (command.contains('build') && mode == 'release') {
+    if (command.contains('build') && !command.contains('tauri') && mode == 'release') {
       command.add('--release')
     }
 
@@ -147,6 +147,8 @@ task build {
     exec {
       environment environmentVars()
       commandLine cargo('--locked', 'build')
+      workingDir "ockam/ockam_app"
+      commandLine cargo('--locked', 'tauri', 'build')
     }
   }
 }

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -12,21 +12,21 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "Ockam",
-    "version": "0.1.0"
+    "productName": "Ockam Desktop"
   },
   "tauri": {
     "systemTray": {
       "iconPath": "icons/icon.png",
       "iconAsTemplate": true
     },
+    "security": {
+      "csp": null
+    },
     "bundle": {
       "active": true,
       "category": "DeveloperTool",
-      "copyright": "",
-      "deb": {
-        "depends": []
-      },
+      "identifier": "io.ockam.app",
+      "publisher": "Ockam",
       "externalBin": [],
       "icon": [
         "icons/32x32.png",
@@ -35,8 +35,14 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "io.ockam.app",
-      "longDescription": "",
+      "resources": [],
+      "shortDescription": "Ockam Desktop",
+      "longDescription": "End-to-end encryption and mutual authentication for distributed applications.",
+      "targets": [
+        "deb",
+        "appimage",
+        "dmg"
+      ],
       "macOS": {
         "entitlements": null,
         "exceptionDomain": "",
@@ -44,18 +50,16 @@
         "providerShortName": null,
         "signingIdentity": null
       },
-      "resources": [],
-      "shortDescription": "",
-      "targets": "all",
+      "deb": {
+      },
+      "appimage": {
+        "bundleMediaFramework": false
+      },
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
         "timestampUrl": ""
       }
-    },
-    "security": {
-      "csp": null
-    },
-    "windows": []
+    }
   }
 }


### PR DESCRIPTION
added building tauri packages in `gradle build`, renamed the package to ockam desktop to avoid conflict.
~~added `ockam` CLI command in debian/ubuntu package~~
~~Only linux package has been validated so far.~~