### PR TITLE
test(rust): temporary ignore file-transfer tests

### DIFF
--- a/examples/rust/file_transfer/tests/tests.rs
+++ b/examples/rust/file_transfer/tests/tests.rs
@@ -13,26 +13,31 @@ const TINY_FILE_SIZE: u32 = 100;
 const MEDIUM_FILE_SIZE: u32 = 100 * 1024;
 
 #[test]
+#[ignore]
 fn tiny_file_transfer() -> Result<(), Error> {
     do_file_transfer(TINY_FILE_SIZE, None)
 }
 
 #[test]
+#[ignore]
 fn tiny_file_transfer_small_chunks() -> Result<(), Error> {
     do_file_transfer(TINY_FILE_SIZE, Some(SMALL_CHUNK_SIZE))
 }
 
 #[test]
+#[ignore]
 fn medium_file_transfer() -> Result<(), Error> {
     do_file_transfer(MEDIUM_FILE_SIZE, None)
 }
 
 #[test]
+#[ignore]
 fn medium_file_transfer_small_chunks() -> Result<(), Error> {
     do_file_transfer(MEDIUM_FILE_SIZE, Some(SMALL_CHUNK_SIZE))
 }
 
 #[test]
+#[ignore]
 fn medium_file_transfer_large_chunks() -> Result<(), Error> {
     do_file_transfer(MEDIUM_FILE_SIZE, Some(LARGE_CHUNK_SIZE))
 }

--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -77,6 +77,7 @@ fn run_03_inlet_outlet_seperate_processes_secure_channel() -> Result<(), Error> 
 }
 
 #[test]
+#[ignore]
 fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_hub() -> Result<(), Error> {
     let port = rand::thread_rng().gen_range(10000..65535);
     // Spawn outlet, wait for it to start up, grab dynamic forwarding address


### PR DESCRIPTION
As they rely on a cloud node that doesn't exist. Related issue: https://github.com/build-trust/ockam/issues/5288
