### PR TITLE
fix(rust): do not allow duplicate inlets outlets creation on NodeManager

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -163,18 +163,18 @@ impl CreateOutlet {
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct InletStatus<'a> {
+pub struct InletStatus {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9302588>,
-    #[b(1)] pub bind_addr: CowStr<'a>,
-    #[b(2)] pub worker_addr: CowStr<'a>,
-    #[b(3)] pub alias: CowStr<'a>,
+    #[n(1)] pub bind_addr: String,
+    #[n(2)] pub worker_addr: String,
+    #[n(3)] pub alias: String,
     /// An optional status payload
-    #[b(4)] pub payload: Option<CowStr<'a>>,
-    #[b(5)] pub outlet_route: CowStr<'a>,
+    #[n(4)] pub payload: Option<String>,
+    #[n(5)] pub outlet_route: String,
 }
 
-impl<'a> Serialize for InletStatus<'a> {
+impl Serialize for InletStatus {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -189,7 +189,7 @@ impl<'a> Serialize for InletStatus<'a> {
     }
 }
 
-impl<'a> InletStatus<'a> {
+impl InletStatus {
     pub fn bad_request(reason: &'static str) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -203,11 +203,11 @@ impl<'a> InletStatus<'a> {
     }
 
     pub fn new(
-        bind_addr: impl Into<CowStr<'a>>,
-        worker_addr: impl Into<CowStr<'a>>,
-        alias: impl Into<CowStr<'a>>,
-        payload: impl Into<Option<CowStr<'a>>>,
-        outlet_route: impl Into<CowStr<'a>>,
+        bind_addr: impl Into<String>,
+        worker_addr: impl Into<String>,
+        alias: impl Into<String>,
+        payload: impl Into<Option<String>>,
+        outlet_route: impl Into<String>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -273,14 +273,14 @@ impl OutletStatus {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct InletList<'a> {
+pub struct InletList {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8401504>,
-    #[b(1)] pub list: Vec<InletStatus<'a>>
+    #[b(1)] pub list: Vec<InletStatus>
 }
 
-impl<'a> InletList<'a> {
-    pub fn new(list: Vec<InletStatus<'a>>) -> Self {
+impl InletList {
+    pub fn new(list: Vec<InletStatus>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -1,11 +1,10 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use minicbor::Decoder;
 use ockam::compat::asynchronous::RwLock;
 use ockam::compat::sync::Mutex;
 use ockam::identity::IdentityIdentifier;
-use ockam::remote::{RemoteForwarder, RemoteForwarderInfo, RemoteForwarderOptions};
+use ockam::remote::{RemoteForwarder, RemoteForwarderOptions};
 use ockam::Result;
 use ockam_core::api::{Error, Id, Request, Response, ResponseBuilder, Status};
 use ockam_core::AsyncTryClone;
@@ -176,9 +175,9 @@ impl NodeManagerWorker {
     pub(super) async fn get_forwarders<'a>(
         &mut self,
         req: &Request<'a>,
-        registry: &'a BTreeMap<String, RemoteForwarderInfo>,
     ) -> ResponseBuilder<Vec<ForwarderInfo<'a>>> {
         debug!("Handling ListForwarders request");
+        let registry = &self.node_manager.read().await.registry.forwarders;
         Response::ok(req.id()).body(
             registry
                 .iter()

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -25,7 +25,7 @@ use crate::nodes::models::secure_channel::{
     SecureChannelListenersList, ShowSecureChannelListenerRequest,
     ShowSecureChannelListenerResponse, ShowSecureChannelRequest, ShowSecureChannelResponse,
 };
-use crate::nodes::registry::{Registry, SecureChannelListenerInfo};
+use crate::nodes::registry::SecureChannelListenerInfo;
 use crate::nodes::service::invalid_multiaddr_error;
 use crate::nodes::service::NodeIdentities;
 use crate::nodes::NodeManager;
@@ -278,14 +278,13 @@ impl NodeManager {
 }
 
 impl NodeManagerWorker {
-    pub(super) fn list_secure_channels(
+    pub(super) async fn list_secure_channels(
         &self,
         req: &Request<'_>,
-        registry: &Registry,
     ) -> ResponseBuilder<Vec<String>> {
+        let registry = &self.node_manager.read().await.registry.secure_channels;
         Response::ok(req.id()).body(
             registry
-                .secure_channels
                 .list()
                 .iter()
                 .map(|v| v.sc().encryptor_address().to_string())
@@ -293,14 +292,18 @@ impl NodeManagerWorker {
         )
     }
 
-    pub(super) fn list_secure_channel_listener(
+    pub(super) async fn list_secure_channel_listener(
         &self,
         req: &Request<'_>,
-        registry: &Registry,
     ) -> ResponseBuilder<SecureChannelListenersList> {
+        let registry = &self
+            .node_manager
+            .read()
+            .await
+            .registry
+            .secure_channel_listeners;
         Response::ok(req.id()).body(SecureChannelListenersList::new(
             registry
-                .secure_channel_listeners
                 .values()
                 .map(ShowSecureChannelListenerResponse::new)
                 .collect(),

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -141,7 +141,7 @@ fn print_node_info(
         for e in &inlets.list {
             println!("    Inlet:");
             println!("      Listen Address: {}", e.bind_addr);
-            if let Some(r) = Route::parse(e.outlet_route.as_ref()) {
+            if let Some(r) = Route::parse(&e.outlet_route) {
                 if let Some(ma) = route_to_multiaddr(&r) {
                     println!("      Route To Outlet: {ma}");
                 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -49,7 +49,7 @@ pub async fn run_impl(
     println!("Inlet:");
     println!("  Alias: {}", inlet_to_show.alias);
     println!("  TCP Address: {}", inlet_to_show.bind_addr);
-    if let Some(r) = Route::parse(inlet_to_show.outlet_route.as_ref()) {
+    if let Some(r) = Route::parse(inlet_to_show.outlet_route) {
         if let Some(ma) = route_to_multiaddr(&r) {
             println!("  To Outlet Address: {ma}");
         }

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -296,9 +296,9 @@ impl Output for Vec<u8> {
     }
 }
 
-impl Output for InletStatus<'_> {
+impl Output for InletStatus {
     fn output(&self) -> Result<String> {
-        let outlet = if let Some(r) = Route::parse(self.outlet_route.as_ref()) {
+        let outlet = if let Some(r) = Route::parse(&self.outlet_route) {
             if let Some(ma) = route_to_multiaddr(&r) {
                 ma.to_string()
             } else {

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals_unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals_unit.bats
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load load/base.bash
+  load_bats_ext
+  setup_home_dir
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "portals - fail to create two TCP outlets with the same alias" {
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  o="$(random_str)"
+  port="$(random_port)"
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port" --alias "$o"
+  assert_success
+
+  port="$(random_port)"
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port" --alias "$o"
+  assert_failure
+}
+
+@test "portals - fail to create two TCP outlets at the same address" {
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  port="$(random_port)"
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port"
+  assert_success
+
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port"
+  assert_failure
+}
+
+@test "portals - fail to create two TCP inlets with the same alias" {
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  o="$(random_str)"
+  port="$(random_port)"
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port" --alias "$o"
+  assert_success
+
+  i="$(random_str)"
+  port="$(random_port)"
+  run "$OCKAM" tcp-inlet create --at "$n" --from "127.0.0.1:$port" --to "/node/$n/service/outlet" --alias "$i"
+  assert_success
+
+  port="$(random_port)"
+  run "$OCKAM" tcp-inlet create --at "$n" --from "127.0.0.1:$port" --to "/node/$n/service/outlet" --alias "$i"
+  assert_failure
+}
+
+@test "portals - fail to create two TCP inlets at the same address" {
+  n="$(random_str)"
+  run "$OCKAM" node create "$n"
+  assert_success
+
+  o="$(random_str)"
+  port="$(random_port)"
+  run "$OCKAM" tcp-outlet create --at "$n" --from /service/outlet --to "127.0.0.1:$port" --alias "$o"
+  assert_success
+
+  port="$(random_port)"
+  run "$OCKAM" tcp-inlet create --at "$n" --from "127.0.0.1:$port" --to "/node/$n/service/outlet"
+  assert_success
+
+  run "$OCKAM" tcp-inlet create --at "$n" --from "127.0.0.1:$port" --to "/node/$n/service/outlet"
+  assert_failure
+}


### PR DESCRIPTION
- Add checks to the inlet/outlet create methods on the NodeManager to prevent creating duplicate entries
- Some minor refactoring around how we access the NodeManager's internal state