### PR TITLE
feat(rust): use default node when -at argument is none

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -1,5 +1,6 @@
+use crate::node::get_node_name;
 use crate::policy::policy_path;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
@@ -10,7 +11,7 @@ use ockam_core::api::Request;
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME")]
-    at: String,
+    at: Option<String>,
 
     #[arg(short, long)]
     resource: Resource,
@@ -40,10 +41,11 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
 ) -> miette::Result<()> {
-    let node = extract_address_value(&cmd.at)?;
+    let at = get_node_name(&opts.state, &cmd.at);
+    let node_name = parse_node_name(&at)?;
     let bdy = Policy::new(cmd.expression);
     let req = Request::post(policy_path(&cmd.resource, &cmd.action)).body(bdy);
-    let mut rpc = Rpc::background(ctx, &opts, &node)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.request(req).await?;
     rpc.is_ok()?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/policy/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/delete.rs
@@ -1,10 +1,9 @@
+use crate::node::get_node_name;
 use crate::policy::policy_path;
-
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
-
 use ockam::Context;
 use ockam_abac::{Action, Resource};
 use ockam_core::api::Request;
@@ -12,7 +11,7 @@ use ockam_core::api::Request;
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME")]
-    at: String,
+    at: Option<String>,
 
     #[arg(short, long)]
     resource: Resource,
@@ -43,21 +42,30 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
 ) -> miette::Result<()> {
-    let node = parse_node_name(&cmd.at)?;
+    let at = get_node_name(&opts.state, &cmd.at);
+    let node_name = parse_node_name(&at)?;
     if opts
         .terminal
         .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this policy?")?
     {
-        let req = Request::delete(policy_path(&cmd.resource, &cmd.action));
-        let mut rpc = Rpc::background(ctx, &opts, &node)?;
+        let policy_path = policy_path(&cmd.resource, &cmd.action);
+        let req = Request::delete(&policy_path);
+        let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
         rpc.request(req).await?;
         rpc.is_ok()?;
 
         opts.terminal
             .stdout()
-            .plain(fmt_ok!("Policy with name '{}' has been deleted", &cmd.at))
-            .machine(&cmd.at)
-            .json(serde_json::json!({ "policy": { "at": &cmd.at } }))
+            .plain(fmt_ok!(
+                "Policy with path '{}' has been deleted",
+                &policy_path
+            ))
+            .machine(&policy_path)
+            .json(serde_json::json!({ "policy": {
+                "resource": &cmd.resource.to_string(),
+                "action": &cmd.action.to_string(),
+                "at": &node_name}
+            }))
             .write_line()?;
     }
     Ok(())


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Use default node when -at argument is none of the next commands:
`secure-channel delete`
`policy delete`
`policy list`
`policy create`

https://github.com/build-trust/ockam/issues/5332
https://github.com/build-trust/ockam/issues/5333
https://github.com/build-trust/ockam/issues/5334
https://github.com/build-trust/ockam/issues/5335

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
