### PR TITLE
Update builder image to bookworm and add net-tools package for netstat

### DIFF
--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:12.3.0@sha256:5e1768ffd3230192358cfbde63443750f8f78f160a449d25007de9828c41976d
+FROM gcc:13.1.0-bookworm@sha256:02046172695139f68f584e6f13b889cf95a04dc2096ab7148b5cba43a2f22af2
 
 ARG RUSTUP_INIT_VERSION=1.25.2
 ARG RUST_VERSION=1.68.0
@@ -59,7 +59,7 @@ RUN set -xe; \
     esac; \
 # Setup base tools
     apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends parallel ca-certificates curl locales xz-utils clang net-tools; \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends parallel ca-certificates curl locales xz-utils clang net-tools libjavascriptcoregtk-4.1-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev; \
 # Setup locale
     LANG=en_US.UTF-8; \
     echo $LANG UTF-8 > /etc/locale.gen; \
@@ -104,11 +104,13 @@ RUN set -xe; \
     cargo install --locked cargo-deny; \
     cargo install --locked cargo-nextest; \
     cargo install --locked cargo-readme; \
+    cargo install --locked tauri-cli; \
     chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
 # Setup erlang
+    echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list; \
     apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends \
-      libncurses5 libwxbase3.0-0v5 libwxgtk3.0-gtk3-0v5 libsctp1 libgtk-3-dev; \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes -t bullseye --no-install-recommends \
+      libtiff5  libncurses5 libwxbase3.0-0v5 libwxgtk3.0-gtk3-0v5 libsctp1 libgtk-3-dev libssl1.1 libgdk-pixbuf2.0-0 libgdk-pixbuf-xlib-2.0-0 libwebp6; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*; \
     ERLANG_PACKAGE="esl-erlang_${ERLANG_VERSION}_${ERLANG_OS}.deb"; \
@@ -151,11 +153,6 @@ RUN set -xe; \
     tar -xf "gh_${GH_CLI_VERSION}_linux_${GH_CLI_OS}.tar.gz" -C /opt/; \
     mv "/opt/gh_${GH_CLI_VERSION}_linux_${GH_CLI_OS}" "${GH_CLI_HOME}"; \
 # Setup Tauri dependencies
-    echo "deb http://deb.debian.org/debian experimental main" >> /etc/apt/sources.list; \
-    echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list; \
-    apt update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes -t experimental libgtk-4-dev vite -y; \
-    DEBIAN_FRONTEND=noninteractive apt-get install javascriptcoregtk-4.1 libsoup-3.0 webkit2gtk-4.1 -y; \
     npm install -g pnpm@${PNPM_VERSION}; \
     npm install -g vite@${VITE_VERSION}; \
 # Setup cosign

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
     cargo install --locked cargo-deny; \
     cargo install --locked cargo-nextest; \
     cargo install --locked cargo-readme; \
-    cargo install --locked tauri-cli; \
+    cargo install tauri-cli --version 2.0.0-alpha.10; \
     chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
 # Setup erlang
     echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list; \

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
     esac; \
 # Setup base tools
     apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends parallel ca-certificates curl locales xz-utils clang; \
+    DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends parallel ca-certificates curl locales xz-utils clang net-tools; \
 # Setup locale
     LANG=en_US.UTF-8; \
     echo $LANG UTF-8 > /etc/locale.gen; \

--- a/tools/docker/ockam/Dockerfile
+++ b/tools/docker/ockam/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/build-trust/ockam-builder@sha256:5ab42598e35509cad3ea9c1e1bd0ed135ed1340c6ae44b762b1c8bbec31d5c68 as executable
+FROM ghcr.io/build-trust/ockam-builder@sha256:0a4c3640f78650e35207a047891e55863d8648a9333ea0bcfe03f09e2d57480c as executable
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

There is an error in CI while using the netstat utility to generate a port and test if it's already in use. The netstat utility doesn't exist in the builder image.

## Proposed changes

- Add the net-tools Debian package that contains netstat tool in the builder Dockerfile #5350 
- Move to Debian bookworm so that we do not have to deal with experimental dependency

<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
