### PR TITLE
Update menu_items.rs

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/quit/menu_items.rs
+++ b/implementations/rust/ockam/ockam_app/src/quit/menu_items.rs
@@ -10,7 +10,7 @@ pub struct QuitActions {
 
 impl QuitActions {
     pub fn new() -> QuitActions {
-        let quit = CustomMenuItem::new("quit".to_string(), "Quit").accelerator("cmd+q");
+        let quit = CustomMenuItem::new("quit".to_string(), "Quit Ockam").accelerator("cmd+q");
         QuitActions { quit }
     }
 }


### PR DESCRIPTION
Changed from "Quit" to "Quit Ockam"

Fixes #5363 

## Current behavior

According to Apple's design guidelines, Quit menus should show the name of the app.


## Proposed changes

Textual changes from Quit to Quit Ockam

## Checks


- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

