### PR TITLE
feat(rust): added metadata and terminal concepts

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -212,6 +212,7 @@ impl HandshakeWorker {
                 &addresses,
                 decryptor_outgoing_access_control,
             ))
+            .terminal(addresses.decryptor_remote.clone())
             .start(context)
             .await?;
 
@@ -320,6 +321,7 @@ impl HandshakeWorker {
 
             WorkerBuilder::new(encryptor)
                 .with_mailboxes(Mailboxes::new(main_mailbox, vec![api_mailbox]))
+                .terminal(self.addresses.encryptor.clone())
                 .start(context)
                 .await?;
         }

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -168,8 +168,13 @@ impl Context {
         let (ctx, sender, _) = self.copy_with_mailboxes_detached(mailboxes, drop_sender);
 
         // Create a "detached relay" and register it with the router
-        let (msg, mut rx) =
-            NodeMessage::start_worker(addresses, sender, true, Arc::clone(&self.mailbox_count));
+        let (msg, mut rx) = NodeMessage::start_worker(
+            addresses,
+            sender,
+            true,
+            Arc::clone(&self.mailbox_count),
+            vec![],
+        );
         self.sender
             .send(msg)
             .await

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -1,22 +1,24 @@
-use super::{AddressMeta, AddressRecord, NodeState, Router, SenderPair};
+use super::{AddressRecord, NodeState, Router, SenderPair, WorkerMeta};
 use crate::channel_types::SmallSender;
 use crate::{
     error::{NodeError, NodeReason},
-    NodeReplyResult, RouterReply,
+    AddressMetadata, NodeReplyResult, RouterReason, RouterReply,
 };
+use ockam_core::compat::{sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use ockam_core::env::get_env;
-use ockam_core::{compat::sync::Arc, Address, Result};
+use ockam_core::{Address, Result};
 
 /// Execute a `StartWorker` command
 pub(super) async fn exec(
     router: &mut Router,
-    addrs: Address,
+    addrs: Vec<Address>,
     senders: SenderPair,
+    addresses_metadata: Vec<AddressMetadata>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
     match router.state.node_state() {
-        NodeState::Running => start(router, addrs, senders, reply).await,
+        NodeState::Running => start(router, addrs, senders, addresses_metadata, reply).await,
         NodeState::Stopping(_) => reject(reply).await,
         NodeState::Dead => unreachable!(),
     }?;
@@ -25,18 +27,23 @@ pub(super) async fn exec(
 
 async fn start(
     router: &mut Router,
-    addr: Address,
+    addrs: Vec<Address>,
     senders: SenderPair,
+    addresses_metadata: Vec<AddressMetadata>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
-    router.check_addr_not_exist(&addr, reply).await?;
+    let primary_addr = addrs
+        .first()
+        .ok_or_else(|| NodeError::RouterState(RouterReason::EmptyAddressSet).internal())?;
 
-    debug!("Starting new processor '{}'", &addr);
+    router.check_addr_not_exist(primary_addr, reply).await?;
+
+    debug!("Starting new processor '{}'", &primary_addr);
 
     let SenderPair { msgs, ctrl } = senders;
 
     let record = AddressRecord::new(
-        vec![addr.clone()],
+        addrs.clone(),
         msgs,
         ctrl,
         // We don't keep track of the mailbox count for processors
@@ -45,13 +52,37 @@ async fn start(
         // irrelevant.  We may want to re-visit this decision in the
         // future, if the way processors are used changes.
         Arc::new(0.into()),
-        AddressMeta {
+        WorkerMeta {
             processor: true,
             detached: false,
         },
     );
 
-    router.map.insert_address_record(addr.clone(), record);
+    router
+        .map
+        .insert_address_record(primary_addr.clone(), record);
+
+    for metadata in addresses_metadata {
+        if !addrs.contains(&metadata.address) {
+            warn!(
+                "Address {} is not in the set of addresses for this processor",
+                metadata.address
+            );
+            continue;
+        }
+
+        if metadata.is_terminal {
+            router
+                .map
+                .mark_address_as_terminal(metadata.address.clone());
+        }
+
+        for (key, value) in metadata.attributes {
+            router
+                .map
+                .write_address_metadata(metadata.address.clone(), &key, &value);
+        }
+    }
 
     #[cfg(feature = "std")]
     if let Ok(Some(dump_internals)) = get_env::<bool>("OCKAM_DUMP_INTERNALS") {
@@ -62,7 +93,9 @@ async fn start(
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]
     trace!("{:#?}", router.map.address_records_map());
 
-    router.map.insert_alias(&addr, &addr);
+    addrs.iter().for_each(|addr| {
+        router.map.insert_alias(addr, primary_addr);
+    });
 
     // For now we just send an OK back -- in the future we need to
     // communicate the current executor state
@@ -74,7 +107,7 @@ async fn start(
 }
 
 async fn reject(reply: &SmallSender<NodeReplyResult>) -> Result<()> {
-    trace!("StartWorker command rejected: node shutting down");
+    trace!("StartProcessor command rejected: node shutting down");
     reply
         .send(RouterReply::node_rejected(NodeReason::Shutdown))
         .await

--- a/implementations/rust/ockam/ockam_node/tests/router.rs
+++ b/implementations/rust/ockam/ockam_node/tests/router.rs
@@ -1,0 +1,292 @@
+use ockam_core::{
+    async_trait, route, Address, DenyAll, Mailbox, Mailboxes, Processor, Result, TransportType,
+};
+use ockam_node::{Context, NullWorker, ProcessorBuilder, WorkerBuilder};
+use std::sync::Arc;
+
+struct NullProcessor;
+
+#[async_trait]
+impl Processor for NullProcessor {
+    type Context = Context;
+
+    async fn process(&mut self, _ctx: &mut Context) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_processor(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("simple_processor")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["simple_processor", "non-existing"])
+        .await?
+        .is_none());
+
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("terminal_processor")
+        .terminal()
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context
+            .find_terminal_address(route![
+                "simple_worker",
+                "terminal_processor",
+                "non-existing"
+            ])
+            .await?
+            .unwrap()
+            .address(),
+        "terminal_processor"
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_processor_alias(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .terminal("alias")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["main", "non-existing"])
+        .await?
+        .is_none());
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["main", "alias", "other"])
+            .await?
+            .unwrap()
+            .address(),
+        "alias"
+    );
+
+    context.stop_processor("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(context
+        .find_terminal_address(route!["main", "alias", "other"])
+        .await?
+        .is_none());
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_processor_address_metadata(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("processor_address")
+        .with_metadata_attribute("TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context
+            .read_metadata("processor_address", "TEST_KEY")
+            .await?,
+        Some("TEST_VALUE".to_string())
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("processor_address", "TEST_KEY_2")
+            .await?,
+        Some("TEST_VALUE_2".to_string())
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("processor_address", "MISSING_KEY")
+            .await?,
+        None
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("non-existing-worker", "TEST_KEY")
+            .await?,
+        None
+    );
+
+    context.stop_processor("processor_address").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(
+        context
+            .read_metadata("processor_address", "TEST_KEY")
+            .await?,
+        None
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_worker(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_address("simple_worker")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["simple_worker", "non-existing"])
+        .await?
+        .is_none());
+
+    WorkerBuilder::new(NullWorker {})
+        .with_address("terminal_worker")
+        .terminal()
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["simple_worker", "terminal_worker", "non-existing"])
+            .await?
+            .unwrap()
+            .address(),
+        "terminal_worker"
+    );
+
+    let remote = Address::new(TransportType::new(1), "127.0.0.1");
+    assert_eq!(
+        context
+            .find_terminal_address(route![
+                "simple_worker",
+                remote,
+                "terminal_worker",
+                "non-existing"
+            ])
+            .await?
+            .unwrap()
+            .address(),
+        "127.0.0.1"
+    );
+
+    context.stop_worker("terminal_worker").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(
+        context
+            .find_terminal_address(route!["terminal_worker"])
+            .await?,
+        None
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_worker_alias(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .terminal("alias")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["main", "non-existing"])
+        .await?
+        .is_none());
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["main", "alias", "other"])
+            .await?
+            .unwrap()
+            .address(),
+        "alias"
+    );
+
+    context.stop_worker("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(context
+        .find_terminal_address(route!["main", "alias", "other"])
+        .await?
+        .is_none());
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_address_metadata(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_address("worker_address")
+        .with_metadata_attribute("TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context.read_metadata("worker_address", "TEST_KEY").await?,
+        Some("TEST_VALUE".to_string())
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("worker_address", "TEST_KEY_2")
+            .await?,
+        Some("TEST_VALUE_2".to_string())
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("worker_address", "MISSING_KEY")
+            .await?,
+        None
+    );
+
+    assert_eq!(
+        context
+            .read_metadata("non-existing-worker", "TEST_KEY")
+            .await?,
+        None
+    );
+
+    context.stop_worker("worker_address").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(
+        context.read_metadata("worker_address", "TEST_KEY").await?,
+        None
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_address_metadata_worker_alias(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .with_metadata_attribute("main", "TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("alias", "TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context.read_metadata("alias", "TEST_KEY_2").await?,
+        Some("TEST_VALUE_2".to_string())
+    );
+
+    context.stop_worker("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(context.read_metadata("alias", "TEST_KEY_2").await?, None);
+
+    context.stop().await
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
@@ -83,6 +83,7 @@ impl TcpRecvProcessor {
         );
         ProcessorBuilder::new(receiver)
             .with_mailboxes(Mailboxes::new(mailbox, vec![internal]))
+            .terminal(addresses.receiver_address().clone())
             .start(ctx)
             .await?;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -105,7 +105,8 @@ impl TcpSendWorker {
         );
 
         WorkerBuilder::new(sender_worker)
-            .with_mailboxes(Mailboxes::new(main_mailbox, vec![internal_mailbox]))
+            .with_mailboxes(Mailboxes::new(main_mailbox.clone(), vec![internal_mailbox]))
+            .terminal(addresses.sender_address().clone())
             .start(ctx)
             .await?;
 


### PR DESCRIPTION
This is the first PR toward outgoing message validation.

Currently, there is no way to tell apart local addresses from remote ones, and it's impossible to determine the remote identity when going outside the node just by reading the route.

Here I introduce the concept of terminal address, every address that talks to a remote endpoint is deemed terminal, such as TCP transport, secure channel, etc…
Common workers and producers should not be affected in any way.
I also added a more broad concept of address metadata: since now, we can understand which address is local, it's nice to be able to associate arbitrary data to a specific address (for example the remote identity of a terminal address).

see `test/router.rs` to see the builder syntax.