### PR TITLE
feat(rust): fix output formatting of ockam node list

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -4,6 +4,7 @@ use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
 use colorful::Colorful;
+use indoc::formatdoc;
 use miette::Context as _;
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
@@ -141,18 +142,19 @@ impl Output for NodeListOutput {
             ),
         };
         let default = match self.is_default {
-            true => "(default)".to_string(),
+            true => " (default)".to_string(),
             false => "".to_string(),
         };
 
-        let output = format!(
-            r#"Node {node_name} {default} {status}
-{pid}"#,
-            node_name = self
-                .node_name
-                .to_string()
-                .color(OckamColor::PrimaryResource.color()),
-        );
+        let output = formatdoc! {"
+        Node {node_name}{default} {status}
+        {pid}",
+        node_name = self
+            .node_name
+            .to_string()
+            .color(OckamColor::PrimaryResource.color()),
+        };
+
         Ok(output)
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
@@ -23,7 +23,7 @@ teardown() {
   run_success "$OCKAM" node create n2 --verbose
 
   run_success "$OCKAM" node list
-  assert_output --partial "Node n1  UP"
+  assert_output --partial "Node n1 UP"
 
   run_success "$OCKAM" node stop n1
   assert_output --partial "Stopped node 'n1'"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->

In the original implementation of NodeListOutput, when the `self.is_default` field is `false`, an extra whitespace appears in the output when using `format!` macro to construct the final output string.

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

The issue that this PR fixes is described in #5384.

In this fix, the default variable is defined appropriately based on the value of `self.is_default`. In the case that `self.is_default` is `true`, the default variable holds the value " (default)", which includes a space before the "(default)" string. In the case that `self.is_default` is `false`, the default variable holds an empty string, which contains no visible characters.


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->