### PR TITLE
Leaner enroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -626,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
 dependencies = [
  "base64-simd",
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "num-integer",
  "ryu",
  "time",
@@ -739,9 +739,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f838d03a705d72b12389b8930bd14cacf493be1380bfb15720d4d12db5ab03ac"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
  "serde",
 ]
@@ -889,13 +889,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
- "regex-automata 0.1.10",
+ "regex-automata 0.3.3",
  "serde",
 ]
 
@@ -1243,7 +1242,7 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics 0.23.0",
+ "core-graphics 0.23.1",
  "foreign-types 0.5.0",
  "libc",
  "objc",
@@ -1313,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "convert_case"
@@ -1363,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "core-graphics"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506752f2b58723339d41d013009be97e549860785a366e2a5e75dfbd9725b48e"
+checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1442,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -1627,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "ryu",
  "serde",
 ]
@@ -1695,12 +1694,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.1",
- "darling_macro 0.20.1",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1719,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1744,23 +1743,23 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.1",
+ "darling_core 0.20.3",
  "quote",
  "syn 2.0.27",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1950,9 +1949,9 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dissimilar"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210ec60ae7d710bed8683e333e9d2855a8a56a3e9892b38bad3bb0d4d29b0d5e"
+checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
 name = "doc-comment"
@@ -1968,9 +1967,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519b83cd10f5f6e969625a409f735182bea5558cd8b64c655806ceaae36f1999"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dtoa-short"
@@ -1999,7 +1998,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da904daa6ce71bb51e03fd0529b08bad4b18bae89e176873c7bae9eb91a19ce"
 dependencies = [
- "darling 0.20.1",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.27",
@@ -2019,9 +2018,9 @@ checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -2210,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2307,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
- "rustix 0.38.2",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -3117,7 +3116,7 @@ checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
- "itoa 1.0.8",
+ "itoa 1.0.9",
 ]
 
 [[package]]
@@ -3170,7 +3169,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "pin-project-lite",
  "socket2 0.4.9",
  "tokio",
@@ -3374,7 +3373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.2",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -3420,9 +3419,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -3920,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "mips-mcu"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03a97ce7dfe942a6601816d623c8bf7d84263fb1a85e4aefbd94be5a24ff5dd"
+checksum = "12e013a0a363fb974cdb892ffe2039f128fcbc04cec786a82ad382d605067bb4"
 
 [[package]]
 name = "mips-rt"
@@ -4218,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -4980,9 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathdiff"
@@ -5179,9 +5178,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
+checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
 dependencies = [
  "base64 0.21.2",
  "indexmap 1.9.3",
@@ -5218,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
+checksum = "edc55135a600d700580e406b4de0d59cb9ad25e344a3a091a97ded2622ec4ec6"
 
 [[package]]
 name = "ppv-lite86"
@@ -5345,9 +5344,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
 dependencies = [
  "memchr",
 ]
@@ -5557,8 +5556,8 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -5572,13 +5571,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -5589,9 +5588,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
@@ -5697,14 +5696,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver 1.0.18",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.37.22"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -5716,9 +5715,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -5772,9 +5771,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rustyline"
@@ -5812,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safemem"
@@ -5848,9 +5847,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -5864,9 +5863,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -5878,9 +5877,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -5891,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5930,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -6015,16 +6014,16 @@ version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0a21fba416426ac927b1691996e82079f8b6156e920c85345f135b2e9ba2de"
+checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6047,16 +6046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+checksum = "21e47d95bc83ed33b2ecf84f4187ad1ab9685d18ff28db000c99deac8ce180e3"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -6070,11 +6069,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+checksum = "ea3cee93715c2e266b9338b7544da68a9f24e227722ba482bd1c024367c77c65"
 dependencies = [
- "darling 0.20.1",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.27",
@@ -6082,12 +6081,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.24"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "ryu",
  "serde",
  "unsafe-libyaml",
@@ -6228,9 +6227,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6295,9 +6294,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smawk"
@@ -6761,9 +6760,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.8"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
+checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 
 [[package]]
 name = "tauri"
@@ -6791,7 +6790,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "reqwest",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6823,7 +6822,7 @@ dependencies = [
  "cargo_toml",
  "heck 0.4.1",
  "json-patch",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_json",
  "swift-rs",
@@ -6846,7 +6845,7 @@ dependencies = [
  "png",
  "proc-macro2",
  "quote",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_json",
  "sha2 0.10.7",
@@ -6954,7 +6953,7 @@ dependencies = [
  "phf 0.10.1",
  "proc-macro2",
  "quote",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_json",
  "serde_with",
@@ -6992,7 +6991,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.2",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -7046,7 +7045,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
@@ -7084,18 +7083,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7118,7 +7117,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "itoa 1.0.8",
+ "itoa 1.0.9",
  "libc",
  "num_threads",
  "serde",
@@ -7281,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7302,9 +7301,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -7455,9 +7454,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04366e99ff743345622cd00af2af01d711dc2d1ef59250d7347698d21b546729"
+checksum = "a84e0202ea606ba5ebee8507ab2bfbe89b98551ed9b8f0be198109275cff284b"
 dependencies = [
  "basic-toml",
  "dissimilar",
@@ -7502,9 +7501,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-linebreak"
@@ -7555,9 +7554,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "unsigned-varint"
@@ -7585,9 +7584,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -8189,9 +8188,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]
@@ -8288,9 +8287,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a56c84a8ccd4258aed21c92f70c0f6dea75356b6892ae27c24139da456f9336"
+checksum = "47430998a7b5d499ccee752b41567bc3afc57e1327dc855b1a2aa44ce29b5fa1"
 
 [[package]]
 name = "xmlparser"

--- a/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
@@ -37,8 +37,8 @@ impl SpaceConfig {
     }
 }
 
-impl From<&Space<'_>> for SpaceConfig {
-    fn from(s: &Space<'_>) -> Self {
+impl From<&Space> for SpaceConfig {
+    fn from(s: &Space) -> Self {
         Self {
             name: s.name.to_string(),
             id: s.id.to_string(),

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -12,9 +12,9 @@ pub struct Addon {
     #[serde(skip)]
     #[n(0)]
     pub tag: TypeTag<1530077>,
-    #[b(1)]
+    #[n(1)]
     pub id: String,
-    #[b(2)]
+    #[n(2)]
     pub description: String,
     #[n(3)]
     pub enabled: bool,
@@ -28,7 +28,7 @@ pub struct ConfluentConfig {
     #[serde(skip)]
     #[cbor(n(0))] pub tag: TypeTag<1697996>,
 
-    #[cbor(b(1))] pub bootstrap_server: String,
+    #[cbor(n(1))] pub bootstrap_server: String,
 }
 
 impl ConfluentConfig {
@@ -70,7 +70,7 @@ pub struct DisableAddon {
     #[serde(skip)]
     #[cbor(n(0))] pub tag: TypeTag<8677807>,
 
-    #[cbor(b(1))] pub addon_id: String,
+    #[cbor(n(1))] pub addon_id: String,
 }
 
 impl DisableAddon {

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -1,24 +1,21 @@
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Clone))]
 #[cbor(map)]
-pub struct Addon<'a> {
+pub struct Addon {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)]
     pub tag: TypeTag<1530077>,
     #[b(1)]
-    #[serde(borrow)]
-    pub id: CowStr<'a>,
+    pub id: String,
     #[b(2)]
-    #[serde(borrow)]
-    pub description: CowStr<'a>,
+    pub description: String,
     #[n(3)]
     pub enabled: bool,
 }
@@ -26,17 +23,16 @@ pub struct Addon<'a> {
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ConfluentConfig<'a> {
+pub struct ConfluentConfig {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[cbor(n(0))] pub tag: TypeTag<1697996>,
 
-    #[serde(borrow)]
-    #[cbor(b(1))] pub bootstrap_server: CowStr<'a>,
+    #[cbor(b(1))] pub bootstrap_server: String,
 }
 
-impl<'a> ConfluentConfig<'a> {
-    pub fn new<S: Into<CowStr<'a>>>(bootstrap_server: S) -> Self {
+impl ConfluentConfig {
+    pub fn new<S: Into<String>>(bootstrap_server: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -69,17 +65,16 @@ impl ConfluentConfigResponse {
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DisableAddon<'a> {
+pub struct DisableAddon {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[cbor(n(0))] pub tag: TypeTag<8677807>,
 
-    #[serde(borrow)]
-    #[cbor(b(1))] pub addon_id: CowStr<'a>,
+    #[cbor(b(1))] pub addon_id: String,
 }
 
-impl<'a> DisableAddon<'a> {
-    pub fn new<S: Into<CowStr<'a>>>(addon_id: S) -> Self {
+impl DisableAddon {
+    pub fn new<S: Into<String>>(addon_id: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -24,6 +24,7 @@ mod node {
     use minicbor::Decoder;
     use tracing::trace;
 
+    use ockam::identity::credential::Attributes;
     use ockam_core::api::Request;
     use ockam_core::{self, Result};
     use ockam_node::Context;
@@ -32,18 +33,16 @@ mod node {
     use crate::cloud::enroll::enrollment_token::{EnrollmentToken, RequestEnrollmentToken};
     use crate::cloud::{CloudRequestWrapper, ORCHESTRATOR_RESTART_TIMEOUT};
     use crate::nodes::NodeManagerWorker;
-    use ockam::identity::credential::Attributes;
 
     const TARGET: &str = "ockam_api::cloud::enroll";
 
     impl NodeManagerWorker {
         /// Executes an enrollment process to generate a new set of access tokens using the auth0 flow.
-        pub(crate) async fn enroll_auth0(
-            &mut self,
-            ctx: &mut Context,
-            dec: &mut Decoder<'_>,
+        pub async fn enroll_auth0(
+            &self,
+            ctx: &Context,
+            req_wrapper: CloudRequestWrapper<AuthenticateAuth0Token>,
         ) -> Result<Vec<u8>> {
-            let req_wrapper: CloudRequestWrapper<AuthenticateAuth0Token> = dec.decode()?;
             let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body: AuthenticateAuth0Token = req_wrapper.req;
             let req_builder = Request::post("v0/enroll").body(req_body);
@@ -205,8 +204,9 @@ pub mod auth0 {
 }
 
 pub mod enrollment_token {
-    use ockam::identity::credential::Attributes;
     use serde::Serialize;
+
+    use ockam::identity::credential::Attributes;
 
     use super::*;
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -14,8 +14,8 @@ pub struct Invitation<'a> {
     #[b(1)] pub id: CowStr<'a>,
     #[b(2)] pub inviter: CowStr<'a>,
     #[b(3)] pub invitee: CowStr<'a>,
-    #[b(4)] pub scope: Scope,
-    #[b(5)] pub state: State,
+    #[n(4)] pub scope: Scope,
+    #[n(5)] pub state: State,
     #[b(6)] pub space_id: CowStr<'a>,
     #[b(7)] pub project_id: Option<CowStr<'a>>,
 }
@@ -47,7 +47,7 @@ pub struct CreateInvitation<'a> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<1886440>,
     #[b(1)] pub invitee: CowStr<'a>,
-    #[b(2)] pub scope: Scope,
+    #[n(2)] pub scope: Scope,
     #[b(3)] pub space_id: CowStr<'a>,
     #[b(4)] pub project_id: Option<CowStr<'a>>,
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/invitation.rs
@@ -1,9 +1,8 @@
 use minicbor::{Decode, Encode};
-use serde::{Deserialize, Serialize};
-
 use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use serde::{Deserialize, Serialize};
 
 #[derive(Encode, Decode, Serialize, Debug)]
 #[cfg_attr(test, derive(Clone))]
@@ -70,10 +69,9 @@ impl<'a> CreateInvitation<'a> {
 
 mod node {
     use minicbor::Decoder;
-    use tracing::trace;
-
     use ockam_core::{self, Result};
     use ockam_node::Context;
+    use tracing::trace;
 
     use crate::cloud::{BareCloudRequestWrapper, CloudRequestWrapper};
     use crate::nodes::NodeManager;
@@ -88,7 +86,7 @@ mod node {
         pub(crate) async fn create_invitation(
             &mut self,
             ctx: &mut Context,
-            req: &Request<'_>,
+            req: &Request,
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: CloudRequestWrapper<CreateInvitation> = dec.decode()?;
@@ -126,7 +124,7 @@ mod node {
         pub(crate) async fn list_invitations(
             &mut self,
             ctx: &mut Context,
-            req: &Request<'_>,
+            req: &Request,
             dec: &mut Decoder<'_>,
         ) -> Result<Vec<u8>> {
             let req_wrapper: BareCloudRequestWrapper = dec.decode()?;
@@ -157,7 +155,7 @@ mod node {
         pub(crate) async fn accept_invitation(
             &mut self,
             ctx: &mut Context,
-            req: &Request<'_>,
+            req: &Request,
             dec: &mut Decoder<'_>,
             id: &str,
         ) -> Result<Vec<u8>> {
@@ -189,7 +187,7 @@ mod node {
         pub(crate) async fn reject_invitation(
             &mut self,
             ctx: &mut Context,
-            req: &Request<'_>,
+            req: &Request,
             dec: &mut Decoder<'_>,
             id: &str,
         ) -> Result<Vec<u8>> {
@@ -223,11 +221,10 @@ mod node {
 #[cfg(test)]
 mod tests {
     use minicbor::Decoder;
-    use quickcheck::{Arbitrary, Gen};
-
     use ockam_core::compat::collections::HashMap;
     use ockam_core::{Routed, Worker};
     use ockam_node::Context;
+    use quickcheck::{Arbitrary, Gen};
 
     use crate::{Method, Request, Response};
 
@@ -330,10 +327,11 @@ mod tests {
     }
 
     mod node_api {
+        use ockam_core::route;
+
         use crate::cloud::CloudRequestWrapper;
         use crate::nodes::NodeManager;
         use crate::{route_to_multiaddr, Status};
-        use ockam_core::route;
 
         use super::*;
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/lease_manager/models/influxdb.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/lease_manager/models/influxdb.rs
@@ -5,21 +5,21 @@ use serde::{Deserialize, Serialize};
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[cbor(map)]
 pub struct Token {
-    #[cbor(b(1))]
+    #[cbor(n(1))]
     pub id: String,
 
-    #[cbor(b(2))]
+    #[cbor(n(2))]
     pub issued_for: String,
 
-    #[cbor(b(3))]
+    #[cbor(n(3))]
     pub created_at: String,
 
-    #[cbor(b(4))]
+    #[cbor(n(4))]
     pub expires: String,
 
-    #[cbor(b(5))]
+    #[cbor(n(5))]
     pub token: String,
 
-    #[cbor(b(6))]
+    #[cbor(n(6))]
     pub status: String,
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -40,8 +40,8 @@ pub struct CloudRequestWrapper<T> {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<8956240>,
     #[b(1)] pub req: T,
-    #[b(2)] route: String,
-    #[b(3)] pub identity_name: Option<String>,
+    #[n(2)] route: String,
+    #[n(3)] pub identity_name: Option<String>,
 }
 
 impl<T> CloudRequestWrapper<T> {

--- a/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
@@ -1,42 +1,25 @@
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
-#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone)]
 #[cbor(map)]
-pub struct Operation<'a> {
+pub struct Operation {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[cbor(n(0))]
     pub tag: TypeTag<2432199>,
 
     #[cbor(b(1))]
-    #[serde(borrow)]
-    pub id: CowStr<'a>,
+    pub id: String,
 
     #[cbor(n(2))]
     pub status: Status,
 }
 
-impl Clone for Operation<'_> {
-    fn clone(&self) -> Self {
-        self.to_owned()
-    }
-}
-
-impl Operation<'_> {
-    pub fn to_owned<'r>(&self) -> Operation<'r> {
-        Operation {
-            #[cfg(feature = "tag")]
-            tag: self.tag.to_owned(),
-            id: self.id.to_owned(),
-            status: self.status.clone(),
-        }
-    }
-
+impl Operation {
     pub fn is_successful(&self) -> bool {
         self.status == Status::Succeeded
     }
@@ -50,33 +33,16 @@ impl Operation<'_> {
     }
 }
 
-#[derive(Encode, Decode, Serialize, Deserialize, Debug, Default)]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Default, Clone)]
 #[cbor(map)]
-pub struct CreateOperationResponse<'a> {
+pub struct CreateOperationResponse {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[cbor(n(0))]
     pub tag: TypeTag<9056534>,
 
     #[cbor(b(1))]
-    #[serde(borrow)]
-    pub operation_id: CowStr<'a>,
-}
-
-impl Clone for CreateOperationResponse<'_> {
-    fn clone(&self) -> Self {
-        self.to_owned()
-    }
-}
-
-impl CreateOperationResponse<'_> {
-    pub fn to_owned<'r>(&self) -> CreateOperationResponse<'r> {
-        CreateOperationResponse {
-            #[cfg(feature = "tag")]
-            tag: self.tag.to_owned(),
-            operation_id: self.operation_id.to_owned(),
-        }
-    }
+    pub operation_id: String,
 }
 
 #[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
@@ -12,7 +12,7 @@ pub struct Operation {
     #[cbor(n(0))]
     pub tag: TypeTag<2432199>,
 
-    #[cbor(b(1))]
+    #[cbor(n(1))]
     pub id: String,
 
     #[cbor(n(2))]
@@ -41,7 +41,7 @@ pub struct CreateOperationResponse {
     #[cbor(n(0))]
     pub tag: TypeTag<9056534>,
 
-    #[cbor(b(1))]
+    #[cbor(n(1))]
     pub operation_id: String,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -101,11 +101,11 @@ impl Project {
 pub struct OktaConfig {
     #[cfg(feature = "tag")]
     #[serde(skip)]
-    #[cbor(b(0))] pub tag: TypeTag<6434814>,
-    #[cbor(b(1))] pub tenant_base_url: Url,
-    #[cbor(b(2))] pub certificate: String,
-    #[cbor(b(3))] pub client_id: String,
-    #[cbor(b(4))] pub attributes: Vec<String>,
+    #[cbor(n(0))] pub tag: TypeTag<6434814>,
+    #[cbor(n(1))] pub tenant_base_url: Url,
+    #[cbor(n(2))] pub certificate: String,
+    #[cbor(n(3))] pub client_id: String,
+    #[cbor(n(4))] pub attributes: Vec<String>,
 }
 
 impl OktaConfig {
@@ -171,13 +171,13 @@ pub struct InfluxDBTokenLeaseManagerConfig {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[cbor(n(0))] pub tag: TypeTag<4166488>,
-    #[cbor(b(1))] pub endpoint: String,
-    #[cbor(b(2))] pub token: String,
-    #[cbor(b(3))] pub org_id: String,
-    #[cbor(b(4))] pub permissions: String,
-    #[cbor(b(5))] pub max_ttl_secs: i32,
-    #[cbor(b(6))] pub user_access_rule: Option<String>,
-    #[cbor(b(7))] pub admin_access_rule: Option<String>,
+    #[cbor(n(1))] pub endpoint: String,
+    #[cbor(n(2))] pub token: String,
+    #[cbor(n(3))] pub org_id: String,
+    #[cbor(n(4))] pub permissions: String,
+    #[cbor(n(5))] pub max_ttl_secs: i32,
+    #[cbor(n(6))] pub user_access_rule: Option<String>,
+    #[cbor(n(7))] pub admin_access_rule: Option<String>,
 }
 
 impl InfluxDBTokenLeaseManagerConfig {
@@ -215,8 +215,8 @@ impl InfluxDBTokenLeaseManagerConfig {
 pub struct CreateProject {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<8669570>,
-    #[b(1)] pub name: String,
-    #[b(3)] pub users: Vec<String>,
+    #[n(1)] pub name: String,
+    #[n(3)] pub users: Vec<String>,
 }
 
 impl CreateProject {

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -258,7 +258,11 @@ mod node {
                 route,
                 None,
             );
-            Response::parse_response(self.create_project_response(ctx, request, space_id).await?)
+            Response::parse_response_body(
+                self.create_project_response(ctx, request, space_id)
+                    .await?
+                    .as_slice(),
+            )
         }
 
         pub(crate) async fn create_project_response(
@@ -294,7 +298,7 @@ mod node {
             let bytes = self
                 .list_projects_response(ctx, CloudRequestWrapper::bare(route))
                 .await?;
-            Response::parse_response(bytes)
+            Response::parse_response_body(bytes.as_slice())
         }
 
         pub(crate) async fn list_projects_response(
@@ -325,9 +329,10 @@ mod node {
             route: &MultiAddr,
             project_id: &str,
         ) -> Result<Project> {
-            Response::parse_response(
+            Response::parse_response_body(
                 self.get_project_response(ctx, CloudRequestWrapper::bare(route), project_id)
-                    .await?,
+                    .await?
+                    .as_slice(),
             )
         }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -60,12 +60,13 @@ mod node {
             route: &MultiAddr,
             identity_name: Option<String>,
         ) -> Result<Space> {
-            Response::parse_response(
+            Response::parse_response_body(
                 self.create_space_response(
                     ctx,
                     CloudRequestWrapper::new(req, route, identity_name),
                 )
-                .await?,
+                .await?
+                .as_slice(),
             )
         }
 
@@ -95,9 +96,10 @@ mod node {
         }
 
         pub async fn list_spaces(&self, ctx: &Context, route: &MultiAddr) -> Result<Vec<Space>> {
-            Response::parse_response(
+            Response::parse_response_body(
                 self.list_spaces_response(ctx, CloudRequestWrapper::bare(route))
-                    .await?,
+                    .await?
+                    .as_slice(),
             )
         }
 
@@ -126,9 +128,10 @@ mod node {
         }
 
         pub async fn get_space(&self, ctx: &Context, route: &MultiAddr, id: &str) -> Result<Space> {
-            Response::parse_response(
+            Response::parse_response_body(
                 self.get_space_response(ctx, CloudRequestWrapper::bare(route), id)
-                    .await?,
+                    .await?
+                    .as_slice(),
             )
         }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -11,9 +11,9 @@ pub struct Space {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] pub tag: TypeTag<7574645>,
-    #[b(1)] pub id: String,
-    #[b(2)] pub name: String,
-    #[b(3)] pub users: Vec<String>,
+    #[n(1)] pub id: String,
+    #[n(2)] pub name: String,
+    #[n(3)] pub users: Vec<String>,
 }
 
 #[derive(Encode, Decode, Debug)]
@@ -23,8 +23,8 @@ pub struct Space {
 pub struct CreateSpace {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<2321503>,
-    #[b(1)] pub name: String,
-    #[b(2)] pub users: Vec<String>,
+    #[n(1)] pub name: String,
+    #[n(2)] pub users: Vec<String>,
 }
 
 impl CreateSpace {

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -60,13 +60,16 @@ mod node {
             route: &MultiAddr,
             identity_name: Option<String>,
         ) -> Result<Space> {
-            let bytes = self
-                .create_space_response(ctx, CloudRequestWrapper::new(req, route, identity_name))
-                .await?;
-            Response::parse_response::<Space>(bytes)
+            Response::parse_response(
+                self.create_space_response(
+                    ctx,
+                    CloudRequestWrapper::new(req, route, identity_name),
+                )
+                .await?,
+            )
         }
 
-        pub async fn create_space_response(
+        pub(crate) async fn create_space_response(
             &self,
             ctx: &Context,
             req_wrapper: CloudRequestWrapper<CreateSpace>,
@@ -92,13 +95,13 @@ mod node {
         }
 
         pub async fn list_spaces(&self, ctx: &Context, route: &MultiAddr) -> Result<Vec<Space>> {
-            let bytes = self
-                .list_spaces_response(ctx, CloudRequestWrapper::bare(route))
-                .await?;
-            Response::parse_response::<Vec<Space>>(bytes)
+            Response::parse_response(
+                self.list_spaces_response(ctx, CloudRequestWrapper::bare(route))
+                    .await?,
+            )
         }
 
-        pub async fn list_spaces_response(
+        pub(crate) async fn list_spaces_response(
             &self,
             ctx: &Context,
             req_wrapper: BareCloudRequestWrapper,
@@ -123,10 +126,10 @@ mod node {
         }
 
         pub async fn get_space(&self, ctx: &Context, route: &MultiAddr, id: &str) -> Result<Space> {
-            let bytes = self
-                .get_space_response(ctx, CloudRequestWrapper::bare(route), id)
-                .await?;
-            Response::parse_response::<Space>(bytes)
+            Response::parse_response(
+                self.get_space_response(ctx, CloudRequestWrapper::bare(route), id)
+                    .await?,
+            )
         }
 
         pub(crate) async fn get_space_response(

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -11,10 +11,10 @@ use ockam_core::TypeTag;
 pub struct ActivateSubscription {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<3888657>,
-    #[b(1)] pub space_id: Option<String>,
-    #[b(2)] pub subscription_data: String,
-    #[b(3)] pub space_name: Option<String>,
-    #[b(4)] pub owner_emails: Option<Vec<String>>,
+    #[n(1)] pub space_id: Option<String>,
+    #[n(2)] pub subscription_data: String,
+    #[n(3)] pub space_name: Option<String>,
+    #[n(4)] pub owner_emails: Option<Vec<String>>,
 }
 
 impl ActivateSubscription {
@@ -56,19 +56,19 @@ pub struct Subscription {
     #[serde(skip)]
     #[n(0)]
     pub tag: TypeTag<3783606>,
-    #[b(1)]
+    #[n(1)]
     pub id: String,
-    #[b(2)]
+    #[n(2)]
     marketplace: String,
-    #[b(3)]
+    #[n(3)]
     pub status: String,
-    #[b(4)]
+    #[n(4)]
     pub entitlements: String,
-    #[b(5)]
+    #[n(5)]
     pub metadata: String,
-    #[b(6)]
+    #[n(6)]
     pub contact_info: String,
-    #[b(7)]
+    #[n(7)]
     pub space_id: Option<String>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -1,7 +1,6 @@
 use minicbor::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use ockam_core::CowStr;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
@@ -9,18 +8,18 @@ use ockam_core::TypeTag;
 #[cfg_attr(test, derive(Clone))]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ActivateSubscription<'a> {
+pub struct ActivateSubscription {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<3888657>,
-    #[b(1)] pub space_id: Option<CowStr<'a>>,
-    #[b(2)] pub subscription_data: CowStr<'a>,
-    #[b(3)] pub space_name: Option<CowStr<'a>>,
-    #[b(4)] pub owner_emails: Option<Vec<CowStr<'a>>>,
+    #[b(1)] pub space_id: Option<String>,
+    #[b(2)] pub subscription_data: String,
+    #[b(3)] pub space_name: Option<String>,
+    #[b(4)] pub owner_emails: Option<Vec<String>>,
 }
 
-impl<'a> ActivateSubscription<'a> {
+impl ActivateSubscription {
     /// Activates a subscription for an existing space
-    pub fn existing<S: Into<CowStr<'a>>>(space_id: S, subscription_data: S) -> Self {
+    pub fn existing<S: Into<String>>(space_id: S, subscription_data: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -33,9 +32,9 @@ impl<'a> ActivateSubscription<'a> {
 
     /// Activates a subscription for a space that will be newly created with the given space name
     #[allow(unused)]
-    pub fn create<S: Into<CowStr<'a>>, T: AsRef<str>>(
+    pub fn create<S: Into<String>, T: AsRef<str>>(
         space_name: S,
-        owner_emails: &'a [T],
+        owner_emails: &[T],
         subscription_data: S,
     ) -> Self {
         Self {
@@ -44,12 +43,7 @@ impl<'a> ActivateSubscription<'a> {
             space_id: None,
             subscription_data: subscription_data.into(),
             space_name: Some(space_name.into()),
-            owner_emails: Some(
-                owner_emails
-                    .iter()
-                    .map(|x| CowStr::from(x.as_ref()))
-                    .collect(),
-            ),
+            owner_emails: Some(owner_emails.iter().map(|x| x.as_ref().into()).collect()),
         }
     }
 }
@@ -57,32 +51,25 @@ impl<'a> ActivateSubscription<'a> {
 #[derive(Encode, Decode, Serialize, Deserialize, Debug)]
 #[cfg_attr(test, derive(Clone))]
 #[cbor(map)]
-pub struct Subscription<'a> {
+pub struct Subscription {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)]
     pub tag: TypeTag<3783606>,
     #[b(1)]
-    #[serde(borrow)]
-    pub id: CowStr<'a>,
+    pub id: String,
     #[b(2)]
-    #[serde(borrow)]
-    marketplace: CowStr<'a>,
+    marketplace: String,
     #[b(3)]
-    #[serde(borrow)]
-    pub status: CowStr<'a>,
+    pub status: String,
     #[b(4)]
-    #[serde(borrow)]
-    pub entitlements: CowStr<'a>,
+    pub entitlements: String,
     #[b(5)]
-    #[serde(borrow)]
-    pub metadata: CowStr<'a>,
+    pub metadata: String,
     #[b(6)]
-    #[serde(borrow)]
-    pub contact_info: CowStr<'a>,
+    pub contact_info: String,
     #[b(7)]
-    #[serde(borrow)]
-    pub space_id: Option<CowStr<'a>>,
+    pub space_id: Option<String>,
 }
 
 mod node {

--- a/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/identity_service.rs
@@ -1,14 +1,17 @@
-use crate::identity::models::*;
-use crate::nodes::service::NodeIdentities;
 use core::convert::Infallible;
+
 use minicbor::encode::Write;
 use minicbor::{Decoder, Encode};
+use tracing::trace;
+
 use ockam::identity::IdentityHistoryComparison;
 use ockam_core::api::{Error, Id, Method, Request, Response, Status};
 use ockam_core::{Result, Routed, Worker};
 use ockam_node::Context;
 use ockam_vault::Signature;
-use tracing::trace;
+
+use crate::identity::models::*;
+use crate::nodes::service::NodeIdentities;
 
 /// Vault Service Worker
 pub struct IdentityService {
@@ -72,7 +75,7 @@ impl IdentityService {
 
     async fn handle_request<W>(
         &mut self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
         enc: W,
     ) -> Result<()>

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
@@ -84,8 +84,8 @@ impl KafkaMessageInterceptor for InletInterceptorImpl {
 struct MessageWrapper {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<1652221>,
-    #[b(1)] consumer_decryptor_address: Address,
-    #[b(2)] content: Vec<u8>
+    #[n(1)] consumer_decryptor_address: Address,
+    #[n(2)] content: Vec<u8>
 }
 
 impl InletInterceptorImpl {

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -218,7 +218,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Newtype around [`Vec<u8>`] that provides base-16 string encoding using serde.
 #[derive(Debug, Clone, Default, Encode, Decode)]
 #[cbor(transparent)]
-pub struct HexByteVec(#[b(0)] pub Vec<u8>);
+pub struct HexByteVec(#[n(0)] pub Vec<u8>);
 
 impl HexByteVec {
     pub fn as_slice(&self) -> &[u8] {

--- a/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/authority_node/configuration.rs
@@ -111,8 +111,8 @@ impl OktaConfiguration {
     }
 
     /// Return the list of attributes managed by Okta as a vector of str
-    pub(crate) fn attributes(&self) -> Vec<&str> {
-        self.attributes.iter().map(|a| a.as_str()).collect()
+    pub(crate) fn attributes(&self) -> Vec<String> {
+        self.attributes.clone()
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
@@ -1,7 +1,6 @@
 //! Nodemanager API types
 
 use minicbor::{Decode, Encode};
-use ockam_core::CowStr;
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -12,19 +11,19 @@ use ockam_core::TypeTag;
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct NodeStatus<'a> {
+pub struct NodeStatus {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6586555>,
-    #[b(1)] pub node_name: CowStr<'a>,
-    #[b(2)] pub status: CowStr<'a>,
+    #[b(1)] pub node_name: String,
+    #[b(2)] pub status: String,
     #[n(3)] pub workers: u32,
     #[n(4)] pub pid: i32,
 }
 
-impl<'a> NodeStatus<'a> {
+impl NodeStatus {
     pub fn new(
-        node_name: impl Into<CowStr<'a>>,
-        status: impl Into<CowStr<'a>>,
+        node_name: impl Into<String>,
+        status: impl Into<String>,
         workers: u32,
         pid: i32,
     ) -> Self {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/base.rs
@@ -14,8 +14,8 @@ use ockam_core::TypeTag;
 pub struct NodeStatus {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6586555>,
-    #[b(1)] pub node_name: String,
-    #[b(2)] pub status: String,
+    #[n(1)] pub node_name: String,
+    #[n(2)] pub status: String,
     #[n(3)] pub workers: u32,
     #[n(4)] pub pid: i32,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -4,11 +4,9 @@ use ockam::identity::IdentityIdentifier;
 use ockam::remote::RemoteForwarderInfo;
 use ockam::route;
 use ockam_core::flow_control::FlowControlId;
-use ockam_core::CowStr;
-use ockam_multiaddr::MultiAddr;
-
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
+use ockam_multiaddr::MultiAddr;
 
 use crate::error::ApiError;
 use crate::route_to_multiaddr;
@@ -17,28 +15,28 @@ use crate::route_to_multiaddr;
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateForwarder<'a> {
+pub struct CreateForwarder {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3386455>,
     /// Address to create forwarder at.
     #[n(1)] address: MultiAddr,
     /// Forwarder alias.
-    #[b(2)] alias: Option<CowStr<'a>>,
+    #[b(2)] alias: Option<String>,
     /// Forwarding service is at rust node.
     #[n(3)] at_rust_node: bool,
     /// An authorised identity for secure channels.
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
-    #[n(4)] authorized: Option<IdentityIdentifier>
+    #[n(4)] authorized: Option<IdentityIdentifier>,
 }
 
-impl<'a> CreateForwarder<'a> {
+impl CreateForwarder {
     pub fn at_project(address: MultiAddr, alias: Option<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: Default::default(),
             address,
-            alias: alias.map(|s| s.into()),
+            alias,
             at_rust_node: false,
             authorized: None,
         }
@@ -54,7 +52,7 @@ impl<'a> CreateForwarder<'a> {
             #[cfg(feature = "tag")]
             tag: Default::default(),
             address,
-            alias: alias.map(|s| s.into()),
+            alias,
             at_rust_node,
             authorized: auth,
         }
@@ -81,48 +79,48 @@ impl<'a> CreateForwarder<'a> {
 #[derive(Debug, Clone, Decode, Encode, serde::Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ForwarderInfo<'a> {
+pub struct ForwarderInfo {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] tag: TypeTag<2757430>,
-    #[b(1)] forwarding_route: CowStr<'a>,
-    #[b(2)] remote_address: CowStr<'a>,
-    #[b(3)] worker_address: CowStr<'a>,
+    #[b(1)] forwarding_route: String,
+    #[b(2)] remote_address: String,
+    #[b(3)] worker_address: String,
     #[n(4)] flow_control_id: Option<FlowControlId>,
 }
 
-impl<'a> ForwarderInfo<'a> {
-    pub fn forwarding_route(&'a self) -> &'a str {
+impl ForwarderInfo {
+    pub fn forwarding_route(&self) -> &str {
         &self.forwarding_route
     }
 
-    pub fn remote_address(&'a self) -> &'a str {
+    pub fn remote_address(&self) -> &str {
         &self.remote_address
     }
 
-    pub fn flow_control_id(&'a self) -> &Option<FlowControlId> {
+    pub fn flow_control_id(&self) -> &Option<FlowControlId> {
         &self.flow_control_id
     }
 
-    pub fn remote_address_ma(&'a self) -> Result<MultiAddr, ockam_core::Error> {
+    pub fn remote_address_ma(&self) -> Result<MultiAddr, ockam_core::Error> {
         route_to_multiaddr(&route![self.remote_address.to_string()])
             .ok_or_else(|| ApiError::generic("Invalid Remote Address"))
     }
 
-    pub fn worker_address_ma(&'a self) -> Result<MultiAddr, ockam_core::Error> {
+    pub fn worker_address_ma(&self) -> Result<MultiAddr, ockam_core::Error> {
         route_to_multiaddr(&route![self.worker_address.to_string()])
             .ok_or_else(|| ApiError::generic("Invalid Worker Address"))
     }
 }
 
-impl<'a> From<RemoteForwarderInfo> for ForwarderInfo<'a> {
+impl From<RemoteForwarderInfo> for ForwarderInfo {
     fn from(inner: RemoteForwarderInfo) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: Default::default(),
-            forwarding_route: inner.forwarding_route().to_string().into(),
-            remote_address: inner.remote_address().to_string().into(),
-            worker_address: inner.worker_address().to_string().into(),
+            forwarding_route: inner.forwarding_route().to_string(),
+            remote_address: inner.remote_address().into(),
+            worker_address: inner.worker_address().to_string(),
             flow_control_id: inner.flow_control_id().clone(),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -21,7 +21,7 @@ pub struct CreateForwarder {
     /// Address to create forwarder at.
     #[n(1)] address: MultiAddr,
     /// Forwarder alias.
-    #[b(2)] alias: Option<String>,
+    #[n(2)] alias: Option<String>,
     /// Forwarding service is at rust node.
     #[n(3)] at_rust_node: bool,
     /// An authorised identity for secure channels.
@@ -83,9 +83,9 @@ pub struct ForwarderInfo {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] tag: TypeTag<2757430>,
-    #[b(1)] forwarding_route: String,
-    #[b(2)] remote_address: String,
-    #[b(3)] worker_address: String,
+    #[n(1)] forwarding_route: String,
+    #[n(2)] remote_address: String,
+    #[n(3)] worker_address: String,
     #[n(4)] flow_control_id: Option<FlowControlId>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -138,7 +138,7 @@ pub struct CreateOutlet {
     #[n(3)] pub alias: Option<String>,
     /// Allow the outlet to be reachable from the default secure channel, useful when we want to
     /// tighten the flow control
-    #[b(4)] pub reachable_from_default_secure_channel: bool,
+    #[n(4)] pub reachable_from_default_secure_channel: bool,
 }
 
 impl CreateOutlet {
@@ -276,7 +276,7 @@ impl OutletStatus {
 pub struct InletList {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8401504>,
-    #[b(1)] pub list: Vec<InletStatus>
+    #[n(1)] pub list: Vec<InletStatus>
 }
 
 impl InletList {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -30,12 +30,12 @@ pub enum CredentialExchangeMode {
 pub struct CreateSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6300395>,
-    #[b(1)] pub addr: String,
-    #[b(2)] pub authorized_identifiers: Option<Vec<String>>,
+    #[n(1)] pub addr: String,
+    #[n(2)] pub authorized_identifiers: Option<Vec<String>>,
     #[n(3)] pub credential_exchange_mode: CredentialExchangeMode,
     #[n(4)] pub timeout: Option<Duration>,
-    #[b(5)] pub identity_name: Option<String>,
-    #[b(6)] pub credential_name: Option<String>,
+    #[n(5)] pub identity_name: Option<String>,
+    #[n(6)] pub credential_name: Option<String>,
 }
 
 impl CreateSecureChannelRequest {
@@ -98,10 +98,10 @@ impl CreateSecureChannelResponse {
 pub struct CreateSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8112242>,
-    #[b(1)] pub addr: String,
-    #[b(2)] pub authorized_identifiers: Option<Vec<String>>,
-    #[b(3)] pub vault: Option<String>,
-    #[b(4)] pub identity: Option<String>,
+    #[n(1)] pub addr: String,
+    #[n(2)] pub authorized_identifiers: Option<Vec<String>>,
+    #[n(3)] pub vault: Option<String>,
+    #[n(4)] pub identity: Option<String>,
 }
 
 impl CreateSecureChannelListenerRequest {
@@ -130,7 +130,7 @@ impl CreateSecureChannelListenerRequest {
 pub struct DeleteSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8293631>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl DeleteSecureChannelListenerRequest {
@@ -150,7 +150,7 @@ impl DeleteSecureChannelListenerRequest {
 pub struct DeleteSecureChannelListenerResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8642885>,
-    #[b(1)] pub addr: Address,
+    #[n(1)] pub addr: Address,
 }
 
 impl DeleteSecureChannelListenerResponse {
@@ -170,7 +170,7 @@ impl DeleteSecureChannelListenerResponse {
 pub struct ShowSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3538219>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl ShowSecureChannelListenerRequest {
@@ -211,7 +211,7 @@ impl ShowSecureChannelListenerResponse {
 pub struct DeleteSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8472592>,
-    #[b(1)] pub channel: String,
+    #[n(1)] pub channel: String,
 }
 
 impl DeleteSecureChannelRequest {
@@ -230,7 +230,7 @@ impl DeleteSecureChannelRequest {
 pub struct DeleteSecureChannelResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6953395>,
-    #[b(1)] pub channel: Option<String>,
+    #[n(1)] pub channel: Option<String>,
 }
 
 impl DeleteSecureChannelResponse {
@@ -249,7 +249,7 @@ impl DeleteSecureChannelResponse {
 pub struct ShowSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3277982>,
-    #[b(1)] pub channel: String,
+    #[n(1)] pub channel: String,
 }
 
 impl ShowSecureChannelRequest {
@@ -269,9 +269,9 @@ pub struct ShowSecureChannelResponse {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] tag: TypeTag<4566220>,
-    #[b(1)] pub channel: Option<String>,
-    #[b(2)] pub route: Option<String>,
-    #[b(3)] pub authorized_identifiers: Option<Vec<String>>,
+    #[n(1)] pub channel: Option<String>,
+    #[n(2)] pub route: Option<String>,
+    #[n(3)] pub authorized_identifiers: Option<Vec<String>>,
     #[n(4)] pub flow_control_id: Option<FlowControlId>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -1,18 +1,17 @@
 use std::time::Duration;
 
 use minicbor::{Decode, Encode};
+use serde::Serialize;
 
-use crate::nodes::registry::{SecureChannelInfo, SecureChannelListenerInfo};
 use ockam::identity::IdentityIdentifier;
-use ockam_core::compat::borrow::Cow;
 use ockam_core::flow_control::FlowControlId;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
-use ockam_core::{route, Address, CowStr, Result};
+use ockam_core::{route, Address, Result};
 use ockam_multiaddr::MultiAddr;
-use serde::Serialize;
 
 use crate::error::ApiError;
+use crate::nodes::registry::{SecureChannelInfo, SecureChannelListenerInfo};
 use crate::route_to_multiaddr;
 
 #[derive(Debug, Clone, Copy, Decode, Encode)]
@@ -28,18 +27,18 @@ pub enum CredentialExchangeMode {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateSecureChannelRequest<'a> {
+pub struct CreateSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6300395>,
-    #[b(1)] pub addr: CowStr<'a>,
-    #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
+    #[b(1)] pub addr: String,
+    #[b(2)] pub authorized_identifiers: Option<Vec<String>>,
     #[n(3)] pub credential_exchange_mode: CredentialExchangeMode,
     #[n(4)] pub timeout: Option<Duration>,
-    #[b(5)] pub identity_name: Option<CowStr<'a>>,
-    #[b(6)] pub credential_name: Option<CowStr<'a>>,
+    #[b(5)] pub identity_name: Option<String>,
+    #[b(6)] pub credential_name: Option<String>,
 }
 
-impl<'a> CreateSecureChannelRequest<'a> {
+impl CreateSecureChannelRequest {
     pub fn new(
         addr: &MultiAddr,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
@@ -50,13 +49,13 @@ impl<'a> CreateSecureChannelRequest<'a> {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.to_string().into(),
+            addr: addr.to_string(),
             authorized_identifiers: authorized_identifiers
-                .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
+                .map(|x| x.into_iter().map(|y| y.to_string()).collect()),
             credential_exchange_mode,
             timeout: None,
-            identity_name: identity_name.map(|x| x.into()),
-            credential_name: credential_name.map(|x| x.into()),
+            identity_name,
+            credential_name,
         }
     }
 }
@@ -69,7 +68,7 @@ pub struct CreateSecureChannelResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6056513>,
     #[n(1)] pub addr: Address,
-    #[n(2)] pub flow_control_id: FlowControlId
+    #[n(2)] pub flow_control_id: FlowControlId,
 }
 
 impl CreateSecureChannelResponse {
@@ -96,16 +95,16 @@ impl CreateSecureChannelResponse {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateSecureChannelListenerRequest<'a> {
+pub struct CreateSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8112242>,
-    #[b(1)] pub addr: Cow<'a, str>,
-    #[b(2)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
-    #[b(3)] pub vault: Option<CowStr<'a>>,
-    #[b(4)] pub identity: Option<CowStr<'a>>,
+    #[b(1)] pub addr: String,
+    #[b(2)] pub authorized_identifiers: Option<Vec<String>>,
+    #[b(3)] pub vault: Option<String>,
+    #[b(4)] pub identity: Option<String>,
 }
 
-impl<'a> CreateSecureChannelListenerRequest<'a> {
+impl CreateSecureChannelListenerRequest {
     pub fn new(
         addr: &Address,
         authorized_identifiers: Option<Vec<IdentityIdentifier>>,
@@ -115,11 +114,11 @@ impl<'a> CreateSecureChannelListenerRequest<'a> {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.to_string().into(),
+            addr: addr.to_string(),
             authorized_identifiers: authorized_identifiers
-                .map(|x| x.into_iter().map(|y| y.to_string().into()).collect()),
-            vault: vault.map(|x| x.into()),
-            identity: identity.map(|x| x.into()),
+                .map(|x| x.into_iter().map(|y| y.to_string()).collect()),
+            vault,
+            identity,
         }
     }
 }
@@ -128,18 +127,18 @@ impl<'a> CreateSecureChannelListenerRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DeleteSecureChannelListenerRequest<'a> {
+pub struct DeleteSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8293631>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> DeleteSecureChannelListenerRequest<'a> {
+impl DeleteSecureChannelListenerRequest {
     pub fn new(addr: &Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.to_string().into(),
+            addr: addr.to_string(),
         }
     }
 }
@@ -168,18 +167,18 @@ impl DeleteSecureChannelListenerResponse {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ShowSecureChannelListenerRequest<'a> {
+pub struct ShowSecureChannelListenerRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3538219>,
-    #[b(1)] pub addr: Cow<'a, str>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> ShowSecureChannelListenerRequest<'a> {
+impl ShowSecureChannelListenerRequest {
     pub fn new(addr: &Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            addr: addr.to_string().into(),
+            addr: addr.to_string(),
         }
     }
 }
@@ -209,18 +208,18 @@ impl ShowSecureChannelListenerResponse {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DeleteSecureChannelRequest<'a> {
+pub struct DeleteSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8472592>,
-    #[b(1)] pub channel: Cow<'a, str>,
+    #[b(1)] pub channel: String,
 }
 
-impl<'a> DeleteSecureChannelRequest<'a> {
+impl DeleteSecureChannelRequest {
     pub fn new(channel: &Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            channel: channel.to_string().into(),
+            channel: channel.to_string(),
         }
     }
 }
@@ -228,18 +227,18 @@ impl<'a> DeleteSecureChannelRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DeleteSecureChannelResponse<'a> {
+pub struct DeleteSecureChannelResponse {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6953395>,
-    #[b(1)] pub channel: Option<Cow<'a, str>>,
+    #[b(1)] pub channel: Option<String>,
 }
 
-impl<'a> DeleteSecureChannelResponse<'a> {
+impl DeleteSecureChannelResponse {
     pub fn new(channel: Option<Address>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            channel: channel.map(|ch| ch.to_string().into()),
+            channel: channel.map(|ch| ch.to_string()),
         }
     }
 }
@@ -247,18 +246,18 @@ impl<'a> DeleteSecureChannelResponse<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ShowSecureChannelRequest<'a> {
+pub struct ShowSecureChannelRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3277982>,
-    #[b(1)] pub channel: Cow<'a, str>,
+    #[b(1)] pub channel: String,
 }
 
-impl<'a> ShowSecureChannelRequest<'a> {
+impl ShowSecureChannelRequest {
     pub fn new(channel: &Address) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            channel: channel.to_string().into(),
+            channel: channel.to_string(),
         }
     }
 }
@@ -266,27 +265,27 @@ impl<'a> ShowSecureChannelRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode, Serialize)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ShowSecureChannelResponse<'a> {
+pub struct ShowSecureChannelResponse {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] tag: TypeTag<4566220>,
-    #[b(1)] pub channel: Option<Cow<'a, str>>,
-    #[b(2)] pub route: Option<Cow<'a, str>>,
-    #[b(3)] pub authorized_identifiers: Option<Vec<CowStr<'a>>>,
+    #[b(1)] pub channel: Option<String>,
+    #[b(2)] pub route: Option<String>,
+    #[b(3)] pub authorized_identifiers: Option<Vec<String>>,
     #[n(4)] pub flow_control_id: Option<FlowControlId>,
 }
 
-impl<'a> ShowSecureChannelResponse<'a> {
+impl ShowSecureChannelResponse {
     pub fn new(info: Option<&SecureChannelInfo>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            channel: info.map(|info| info.sc().encryptor_address().to_string().into()),
-            route: info.map(|info| info.route().to_string().into()),
+            channel: info.map(|info| info.sc().encryptor_address().to_string()),
+            route: info.map(|info| info.route().to_string()),
             authorized_identifiers: info
                 .map(|info| {
                     info.authorized_identifiers()
-                        .map(|ids| ids.iter().map(|iid| iid.to_string().into()).collect())
+                        .map(|ids| ids.iter().map(|iid| iid.to_string()).collect())
                 })
                 .unwrap_or(None),
             flow_control_id: info.map(|info| info.sc().flow_control_id().clone()),
@@ -300,7 +299,7 @@ impl<'a> ShowSecureChannelResponse<'a> {
 pub struct SecureChannelListenersList {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5141124>,
-    #[n(1)] pub list: Vec<ShowSecureChannelListenerResponse>
+    #[n(1)] pub list: Vec<ShowSecureChannelListenerResponse>,
 }
 
 impl SecureChannelListenersList {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,6 +1,6 @@
 use minicbor::{Decode, Encode};
 use ockam_core::compat::net::SocketAddr;
-use ockam_core::{Address, CowBytes, CowStr};
+use ockam_core::Address;
 
 use serde::Serialize;
 
@@ -11,15 +11,15 @@ use ockam_multiaddr::MultiAddr;
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartServiceRequest<'a, T> {
+pub struct StartServiceRequest<T> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3470984>,
-    #[b(1)] addr: CowStr<'a>,
+    #[b(1)] addr: String,
     #[n(2)] req: T,
 }
 
-impl<'a, T> StartServiceRequest<'a, T> {
-    pub fn new<S: Into<CowStr<'a>>>(req: T, addr: S) -> Self {
+impl<T> StartServiceRequest<T> {
+    pub fn new<S: Into<String>>(req: T, addr: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -28,11 +28,11 @@ impl<'a, T> StartServiceRequest<'a, T> {
         }
     }
 
-    pub fn address(&'a self) -> &'a str {
+    pub fn address(&self) -> &str {
         &self.addr
     }
 
-    pub fn request(&'a self) -> &'a T {
+    pub fn request(&self) -> &T {
         &self.req
     }
 }
@@ -40,14 +40,14 @@ impl<'a, T> StartServiceRequest<'a, T> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct DeleteServiceRequest<'a> {
+pub struct DeleteServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9359178>,
-    #[b(1)] addr: CowStr<'a>,
+    #[b(1)] addr: String,
 }
 
-impl<'a> DeleteServiceRequest<'a> {
-    pub fn new<S: Into<CowStr<'a>>>(addr: S) -> Self {
+impl DeleteServiceRequest {
+    pub fn new<S: Into<String>>(addr: S) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -55,8 +55,8 @@ impl<'a> DeleteServiceRequest<'a> {
         }
     }
 
-    pub fn address(&'a self) -> Address {
-        Address::from(self.addr.as_ref())
+    pub fn address(&self) -> Address {
+        Address::from(self.addr.clone())
     }
 }
 
@@ -82,13 +82,13 @@ impl StartKafkaOutletRequest {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartKafkaConsumerRequest<'a> {
+pub struct StartKafkaConsumerRequest {
     #[b(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),
-    #[b(3)] project_route: CowStr<'a>,
+    #[b(3)] project_route: String,
 }
 
-impl<'a> StartKafkaConsumerRequest<'a> {
+impl StartKafkaConsumerRequest {
     pub fn new(
         bootstrap_server_addr: SocketAddr,
         brokers_port_range: impl Into<(u16, u16)>,
@@ -97,7 +97,7 @@ impl<'a> StartKafkaConsumerRequest<'a> {
         Self {
             bootstrap_server_addr,
             brokers_port_range: brokers_port_range.into(),
-            project_route: project_route.to_string().into(),
+            project_route: project_route.to_string(),
         }
     }
 
@@ -107,7 +107,7 @@ impl<'a> StartKafkaConsumerRequest<'a> {
     pub fn brokers_port_range(&self) -> (u16, u16) {
         self.brokers_port_range
     }
-    pub fn project_route(&self) -> &CowStr<'a> {
+    pub fn project_route(&self) -> &String {
         &self.project_route
     }
 }
@@ -115,13 +115,13 @@ impl<'a> StartKafkaConsumerRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartKafkaProducerRequest<'a> {
+pub struct StartKafkaProducerRequest {
     #[b(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),
-    #[b(3)] project_route: CowStr<'a>,
+    #[b(3)] project_route: String,
 }
 
-impl<'a> StartKafkaProducerRequest<'a> {
+impl StartKafkaProducerRequest {
     pub fn new(
         bootstrap_server_addr: SocketAddr,
         brokers_port_range: impl Into<(u16, u16)>,
@@ -130,7 +130,7 @@ impl<'a> StartKafkaProducerRequest<'a> {
         Self {
             bootstrap_server_addr,
             brokers_port_range: brokers_port_range.into(),
-            project_route: project_route.to_string().into(),
+            project_route: project_route.to_string(),
         }
     }
 
@@ -140,7 +140,7 @@ impl<'a> StartKafkaProducerRequest<'a> {
     pub fn brokers_port_range(&self) -> (u16, u16) {
         self.brokers_port_range
     }
-    pub fn project_route(&self) -> &CowStr<'a> {
+    pub fn project_route(&self) -> &String {
         &self.project_route
     }
 }
@@ -149,14 +149,14 @@ impl<'a> StartKafkaProducerRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartIdentityServiceRequest<'a> {
+pub struct StartIdentityServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6129106>,
-    #[b(1)] pub addr: CowStr<'a>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> StartIdentityServiceRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartIdentityServiceRequest {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -169,14 +169,14 @@ impl<'a> StartIdentityServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartAuthenticatedServiceRequest<'a> {
+pub struct StartAuthenticatedServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5179596>,
-    #[b(1)] pub addr: CowStr<'a>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> StartAuthenticatedServiceRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartAuthenticatedServiceRequest {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -189,14 +189,14 @@ impl<'a> StartAuthenticatedServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartUppercaseServiceRequest<'a> {
+pub struct StartUppercaseServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8177400>,
-    #[b(1)] pub addr: CowStr<'a>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> StartUppercaseServiceRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartUppercaseServiceRequest {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -209,14 +209,14 @@ impl<'a> StartUppercaseServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartEchoerServiceRequest<'a> {
+pub struct StartEchoerServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7636656>,
-    #[b(1)] pub addr: CowStr<'a>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> StartEchoerServiceRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartEchoerServiceRequest {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -229,14 +229,14 @@ impl<'a> StartEchoerServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartHopServiceRequest<'a> {
+pub struct StartHopServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7361428>,
-    #[b(1)] pub addr: CowStr<'a>,
+    #[b(1)] pub addr: String,
 }
 
-impl<'a> StartHopServiceRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartHopServiceRequest {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -248,16 +248,16 @@ impl<'a> StartHopServiceRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartAuthenticatorRequest<'a> {
+pub struct StartAuthenticatorRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2749734>,
-    #[b(1)] addr: CowStr<'a>,
-    #[b(3)] proj: CowBytes<'a>,
+    #[b(1)] addr: String,
+    #[b(3)] proj: Vec<u8>,
     // FIXME: test id old format still matches with this
 }
 
-impl<'a> StartAuthenticatorRequest<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>, proj: impl Into<CowBytes<'a>>) -> Self {
+impl StartAuthenticatorRequest {
+    pub fn new(addr: impl Into<String>, proj: impl Into<Vec<u8>>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -266,11 +266,11 @@ impl<'a> StartAuthenticatorRequest<'a> {
         }
     }
 
-    pub fn address(&'a self) -> &'a str {
+    pub fn address(&self) -> &str {
         &self.addr
     }
 
-    pub fn project(&'a self) -> &'a [u8] {
+    pub fn project(&self) -> &[u8] {
         &self.proj
     }
 }
@@ -278,14 +278,14 @@ impl<'a> StartAuthenticatorRequest<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartVerifierService<'a> {
+pub struct StartVerifierService {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9580740>,
-    #[b(1)] addr: CowStr<'a>,
+    #[b(1)] addr: String,
 }
 
-impl<'a> StartVerifierService<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl StartVerifierService {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -293,7 +293,7 @@ impl<'a> StartVerifierService<'a> {
         }
     }
 
-    pub fn address(&'a self) -> &'a str {
+    pub fn address(&self) -> &str {
         &self.addr
     }
 }
@@ -301,20 +301,16 @@ impl<'a> StartVerifierService<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartCredentialsService<'a> {
+pub struct StartCredentialsService {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6467937>,
-    #[b(1)] public_identity: CowStr<'a>,
-    #[b(2)] addr: CowStr<'a>,
+    #[b(1)] public_identity: String,
+    #[b(2)] addr: String,
     #[n(3)] oneway: bool,
 }
 
-impl<'a> StartCredentialsService<'a> {
-    pub fn new(
-        public_identity: impl Into<CowStr<'a>>,
-        addr: impl Into<CowStr<'a>>,
-        oneway: bool,
-    ) -> Self {
+impl StartCredentialsService {
+    pub fn new(public_identity: impl Into<String>, addr: impl Into<String>, oneway: bool) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -324,7 +320,7 @@ impl<'a> StartCredentialsService<'a> {
         }
     }
 
-    pub fn address(&'a self) -> &'a str {
+    pub fn address(&self) -> &str {
         &self.addr
     }
 
@@ -332,7 +328,7 @@ impl<'a> StartCredentialsService<'a> {
         self.oneway
     }
 
-    pub fn public_identity(&'a self) -> &'a str {
+    pub fn public_identity(&self) -> &str {
         &self.public_identity
     }
 }
@@ -341,23 +337,23 @@ impl<'a> StartCredentialsService<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartOktaIdentityProviderRequest<'a> {
+pub struct StartOktaIdentityProviderRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2291842>,
-    #[b(1)] addr: CowStr<'a>,
-    #[b(2)] tenant_base_url: CowStr<'a>,
-    #[b(3)] certificate: CowStr<'a>,
-    #[b(4)] attributes: Vec<&'a str>,
-    #[b(5)] proj: CowBytes<'a>
+    #[b(1)] addr: String,
+    #[b(2)] tenant_base_url: String,
+    #[b(3)] certificate: String,
+    #[b(4)] attributes: Vec<String>,
+    #[b(5)] proj: Vec<u8>
 }
 
-impl<'a> StartOktaIdentityProviderRequest<'a> {
+impl StartOktaIdentityProviderRequest {
     pub fn new(
-        addr: impl Into<CowStr<'a>>,
-        tenant_base_url: impl Into<CowStr<'a>>,
-        certificate: impl Into<CowStr<'a>>,
-        attributes: Vec<&'a str>,
-        proj: impl Into<CowBytes<'a>>,
+        addr: impl Into<String>,
+        tenant_base_url: impl Into<String>,
+        certificate: impl Into<String>,
+        attributes: Vec<String>,
+        proj: impl Into<Vec<u8>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
@@ -370,19 +366,19 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
         }
     }
 
-    pub fn address(&'a self) -> &'a str {
+    pub fn address(&self) -> &str {
         &self.addr
     }
-    pub fn tenant_base_url(&'a self) -> &'a str {
+    pub fn tenant_base_url(&self) -> &str {
         &self.tenant_base_url
     }
-    pub fn certificate(&'a self) -> &'a str {
+    pub fn certificate(&self) -> &str {
         &self.certificate
     }
-    pub fn project(&'a self) -> &'a [u8] {
+    pub fn project(&self) -> &[u8] {
         &self.proj
     }
-    pub fn attributes(&self) -> &[&str] {
+    pub fn attributes(&self) -> &[String] {
         &self.attributes
     }
 }
@@ -390,16 +386,16 @@ impl<'a> StartOktaIdentityProviderRequest<'a> {
 #[derive(Debug, Clone, Serialize, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ServiceStatus<'a> {
+pub struct ServiceStatus {
     #[cfg(feature = "tag")]
     #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<8542064>,
-    #[b(2)] pub addr: CowStr<'a>,
-    #[b(3)] pub service_type: CowStr<'a>,
+    #[b(2)] pub addr: String,
+    #[b(3)] pub service_type: String,
 }
 
-impl<'a> ServiceStatus<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>, service_type: impl Into<CowStr<'a>>) -> Self {
+impl ServiceStatus {
+    pub fn new(addr: impl Into<String>, service_type: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -413,15 +409,15 @@ impl<'a> ServiceStatus<'a> {
 #[derive(Debug, Clone, Serialize, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ServiceList<'a> {
+pub struct ServiceList {
     #[cfg(feature = "tag")]
     #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<9587601>,
-    #[b(1)] pub list: Vec<ServiceStatus<'a>>
+    #[b(1)] pub list: Vec<ServiceStatus>
 }
 
-impl<'a> ServiceList<'a> {
-    pub fn new(list: Vec<ServiceStatus<'a>>) -> Self {
+impl ServiceList {
+    pub fn new(list: Vec<ServiceStatus>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -14,7 +14,7 @@ use ockam_multiaddr::MultiAddr;
 pub struct StartServiceRequest<T> {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<3470984>,
-    #[b(1)] addr: String,
+    #[n(1)] addr: String,
     #[n(2)] req: T,
 }
 
@@ -43,7 +43,7 @@ impl<T> StartServiceRequest<T> {
 pub struct DeleteServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9359178>,
-    #[b(1)] addr: String,
+    #[n(1)] addr: String,
 }
 
 impl DeleteServiceRequest {
@@ -64,7 +64,7 @@ impl DeleteServiceRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaOutletRequest {
-    #[b(1)] pub bootstrap_server_addr: String,
+    #[n(1)] pub bootstrap_server_addr: String,
 }
 
 impl StartKafkaOutletRequest {
@@ -83,9 +83,9 @@ impl StartKafkaOutletRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaConsumerRequest {
-    #[b(1)] pub bootstrap_server_addr: SocketAddr,
+    #[n(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),
-    #[b(3)] project_route: String,
+    #[n(3)] project_route: String,
 }
 
 impl StartKafkaConsumerRequest {
@@ -116,9 +116,9 @@ impl StartKafkaConsumerRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaProducerRequest {
-    #[b(1)] pub bootstrap_server_addr: SocketAddr,
+    #[n(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),
-    #[b(3)] project_route: String,
+    #[n(3)] project_route: String,
 }
 
 impl StartKafkaProducerRequest {
@@ -152,7 +152,7 @@ impl StartKafkaProducerRequest {
 pub struct StartIdentityServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6129106>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl StartIdentityServiceRequest {
@@ -172,7 +172,7 @@ impl StartIdentityServiceRequest {
 pub struct StartAuthenticatedServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5179596>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl StartAuthenticatedServiceRequest {
@@ -192,7 +192,7 @@ impl StartAuthenticatedServiceRequest {
 pub struct StartUppercaseServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<8177400>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl StartUppercaseServiceRequest {
@@ -212,7 +212,7 @@ impl StartUppercaseServiceRequest {
 pub struct StartEchoerServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7636656>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl StartEchoerServiceRequest {
@@ -232,7 +232,7 @@ impl StartEchoerServiceRequest {
 pub struct StartHopServiceRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7361428>,
-    #[b(1)] pub addr: String,
+    #[n(1)] pub addr: String,
 }
 
 impl StartHopServiceRequest {
@@ -251,8 +251,8 @@ impl StartHopServiceRequest {
 pub struct StartAuthenticatorRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2749734>,
-    #[b(1)] addr: String,
-    #[b(3)] proj: Vec<u8>,
+    #[n(1)] addr: String,
+    #[n(3)] proj: Vec<u8>,
     // FIXME: test id old format still matches with this
 }
 
@@ -281,7 +281,7 @@ impl StartAuthenticatorRequest {
 pub struct StartVerifierService {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<9580740>,
-    #[b(1)] addr: String,
+    #[n(1)] addr: String,
 }
 
 impl StartVerifierService {
@@ -304,8 +304,8 @@ impl StartVerifierService {
 pub struct StartCredentialsService {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<6467937>,
-    #[b(1)] public_identity: String,
-    #[b(2)] addr: String,
+    #[n(1)] public_identity: String,
+    #[n(2)] addr: String,
     #[n(3)] oneway: bool,
 }
 
@@ -340,11 +340,11 @@ impl StartCredentialsService {
 pub struct StartOktaIdentityProviderRequest {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2291842>,
-    #[b(1)] addr: String,
-    #[b(2)] tenant_base_url: String,
-    #[b(3)] certificate: String,
-    #[b(4)] attributes: Vec<String>,
-    #[b(5)] proj: Vec<u8>
+    #[n(1)] addr: String,
+    #[n(2)] tenant_base_url: String,
+    #[n(3)] certificate: String,
+    #[n(4)] attributes: Vec<String>,
+    #[n(5)] proj: Vec<u8>
 }
 
 impl StartOktaIdentityProviderRequest {
@@ -390,8 +390,8 @@ pub struct ServiceStatus {
     #[cfg(feature = "tag")]
     #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<8542064>,
-    #[b(2)] pub addr: String,
-    #[b(3)] pub service_type: String,
+    #[n(2)] pub addr: String,
+    #[n(3)] pub service_type: String,
 }
 
 impl ServiceStatus {
@@ -413,7 +413,7 @@ pub struct ServiceList {
     #[cfg(feature = "tag")]
     #[serde(skip_serializing)]
     #[n(0)] tag: TypeTag<9587601>,
-    #[b(1)] pub list: Vec<ServiceStatus>
+    #[n(1)] pub list: Vec<ServiceStatus>
 }
 
 impl ServiceList {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/workers.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/workers.rs
@@ -9,7 +9,7 @@ use ockam_core::TypeTag;
 pub struct WorkerStatus {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2610323>,
-    #[b(2)] pub addr: String,
+    #[n(2)] pub addr: String,
 }
 
 impl WorkerStatus {
@@ -29,7 +29,7 @@ impl WorkerStatus {
 pub struct WorkerList {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7336987>,
-    #[b(1)] pub list: Vec<WorkerStatus>,
+    #[n(1)] pub list: Vec<WorkerStatus>,
 }
 
 impl WorkerList {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/workers.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/workers.rs
@@ -1,5 +1,4 @@
 use minicbor::{Decode, Encode};
-use ockam_core::CowStr;
 
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
@@ -7,14 +6,14 @@ use ockam_core::TypeTag;
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct WorkerStatus<'a>  {
+pub struct WorkerStatus {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<2610323>,
-    #[b(2)] pub addr: CowStr<'a>,
+    #[b(2)] pub addr: String,
 }
 
-impl<'a> WorkerStatus<'a> {
-    pub fn new(addr: impl Into<CowStr<'a>>) -> Self {
+impl WorkerStatus {
+    pub fn new(addr: impl Into<String>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
@@ -27,14 +26,14 @@ impl<'a> WorkerStatus<'a> {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct WorkerList<'a> {
+pub struct WorkerList {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<7336987>,
-    #[b(1)] pub list: Vec<WorkerStatus<'a>>
+    #[b(1)] pub list: Vec<WorkerStatus>,
 }
 
-impl<'a> WorkerList<'a> {
-    pub fn new(list: Vec<WorkerStatus<'a>>) -> Self {
+impl WorkerList {
+    pub fn new(list: Vec<WorkerStatus>) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -763,12 +763,17 @@ impl NodeManagerWorker {
 
             // ==*== Projects ==*==
             (Post, ["v1", "spaces", space_id, "projects"]) => {
-                self.create_project(ctx, dec, space_id).await?
+                self.create_project_response(ctx, dec.decode()?, space_id)
+                    .await?
             }
-            (Get, ["v0", "projects"]) => self.list_projects(ctx, dec).await?,
-            (Get, ["v0", "projects", project_id]) => self.get_project(ctx, dec, project_id).await?,
+            (Get, ["v0", "projects"]) => self.list_projects_response(ctx, dec.decode()?).await?,
+            (Get, ["v0", "projects", project_id]) => {
+                self.get_project_response(ctx, dec.decode()?, project_id)
+                    .await?
+            }
             (Delete, ["v0", "projects", space_id, project_id]) => {
-                self.delete_project(ctx, dec, space_id, project_id).await?
+                self.delete_project_response(ctx, dec.decode()?, space_id, project_id)
+                    .await?
             }
 
             // ==*== Enroll ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -20,7 +20,7 @@ use super::NodeManagerWorker;
 impl NodeManagerWorker {
     pub(super) async fn get_credential(
         &mut self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
         ctx: &Context,
     ) -> Result<Either<ResponseBuilder<Error>, ResponseBuilder<Credential>>> {
@@ -58,7 +58,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn present_credential(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
         ctx: &Context,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
@@ -1,9 +1,11 @@
-use crate::local_multiaddr_to_route;
-use crate::nodes::models::flow_controls::AddConsumer;
 use minicbor::Decoder;
+
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
 use ockam_core::Result;
 use ockam_node::Context;
+
+use crate::local_multiaddr_to_route;
+use crate::nodes::models::flow_controls::AddConsumer;
 
 use super::NodeManagerWorker;
 
@@ -11,7 +13,7 @@ impl NodeManagerWorker {
     pub(super) fn add_consumer(
         &self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let request: AddConsumer = dec.decode()?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -109,12 +109,12 @@ impl NodeManagerWorker {
         }
     }
 
-    pub(super) async fn delete_forwarder<'a>(
+    pub(super) async fn delete_forwarder(
         &mut self,
         ctx: &mut Context,
-        req: &Request<'_>,
-        remote_address: &'a str,
-    ) -> Result<ResponseBuilder<Option<ForwarderInfo<'a>>>, ResponseBuilder<Error>> {
+        req: &Request,
+        remote_address: &str,
+    ) -> Result<ResponseBuilder<Option<ForwarderInfo>>, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
 
         debug!(%remote_address , "Handling DeleteForwarder request");
@@ -149,11 +149,11 @@ impl NodeManagerWorker {
         }
     }
 
-    pub(super) async fn show_forwarder<'a>(
+    pub(super) async fn show_forwarder(
         &mut self,
-        req: &Request<'_>,
-        remote_address: &'a str,
-    ) -> Result<ResponseBuilder<Option<ForwarderInfo<'a>>>, ResponseBuilder<Error>> {
+        req: &Request,
+        remote_address: &str,
+    ) -> Result<ResponseBuilder<Option<ForwarderInfo>>, ResponseBuilder<Error>> {
         debug!("Handling ShowForwarder request");
         let node_manager = self.node_manager.read().await;
         if let Some(forwarder_to_show) = node_manager.registry.forwarders.get(remote_address) {
@@ -172,10 +172,10 @@ impl NodeManagerWorker {
         }
     }
 
-    pub(super) async fn get_forwarders<'a>(
+    pub(super) async fn get_forwarders(
         &mut self,
-        req: &Request<'a>,
-    ) -> ResponseBuilder<Vec<ForwarderInfo<'a>>> {
+        req: &Request,
+    ) -> ResponseBuilder<Vec<ForwarderInfo>> {
         debug!("Handling ListForwarders request");
         let registry = &self.node_manager.read().await.registry.forwarders;
         Response::ok(req.id()).body(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -16,8 +16,8 @@ use crate::error::ApiError;
 pub struct SendMessage {
     #[cfg(feature = "tag")]
     #[n(0)] pub tag: TypeTag<8400702>,
-    #[b(1)] pub route: String,
-    #[b(2)] pub message: Vec<u8>,
+    #[n(1)] pub route: String,
+    #[n(2)] pub message: Vec<u8>,
 }
 
 impl SendMessage {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -4,14 +4,12 @@ use minicbor::Decoder;
 
 use ockam::{Address, Context, Result};
 use ockam_abac::expr::{and, eq, ident, str};
-
 use ockam_abac::{Action, Env, Expr, PolicyAccessControl, Resource};
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{route, IncomingAccessControl};
 use ockam_identity::{identities, AuthorityService, CredentialsIssuer, TrustContext};
-
 use ockam_multiaddr::MultiAddr;
 use ockam_node::WorkerBuilder;
 
@@ -340,7 +338,7 @@ impl NodeManager {
         addr: Address,
         tenant_base_url: &str,
         certificate: &str,
-        attributes: &[&str],
+        attributes: &[String],
         project: &str,
     ) -> Result<()> {
         use crate::nodes::registry::OktaIdentityProviderServiceInfo;
@@ -372,7 +370,7 @@ impl NodeManagerWorker {
     pub(super) async fn start_identity_service(
         &mut self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -385,7 +383,7 @@ impl NodeManagerWorker {
     pub(super) async fn start_authenticated_service(
         &mut self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -400,7 +398,7 @@ impl NodeManagerWorker {
     pub(super) async fn start_uppercase_service(
         &mut self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -413,7 +411,7 @@ impl NodeManagerWorker {
     pub(super) async fn start_echoer_service(
         &mut self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -426,7 +424,7 @@ impl NodeManagerWorker {
     pub(super) async fn start_hop_service(
         &mut self,
         ctx: &Context,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -437,10 +435,10 @@ impl NodeManagerWorker {
     }
 
     //TODO: split this into the different services it really starts
-    pub(super) async fn start_authenticator_service<'a>(
+    pub(super) async fn start_authenticator_service(
         &mut self,
         ctx: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -477,10 +475,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()))
     }
 
-    pub(super) async fn start_okta_identity_provider_service<'a>(
+    pub(super) async fn start_okta_identity_provider_service(
         &mut self,
         ctx: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -501,10 +499,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()))
     }
 
-    pub(super) async fn start_verifier_service<'a>(
+    pub(super) async fn start_verifier_service(
         &mut self,
         ctx: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -529,10 +527,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()))
     }
 
-    pub(super) async fn start_credentials_service<'a>(
+    pub(super) async fn start_credentials_service(
         &mut self,
         ctx: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
@@ -565,10 +563,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()))
     }
 
-    pub(super) async fn start_kafka_outlet_service<'a>(
+    pub(super) async fn start_kafka_outlet_service(
         &mut self,
         context: &Context,
-        request: &'a Request<'_>,
+        request: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<Vec<u8>> {
         let body: StartServiceRequest<StartKafkaOutletRequest> = dec.decode()?;
@@ -614,10 +612,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(request.id()).to_vec()?)
     }
 
-    pub(super) async fn start_kafka_consumer_service<'a>(
+    pub(super) async fn start_kafka_consumer_service(
         &mut self,
         context: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<Vec<u8>> {
         let body: StartServiceRequest<StartKafkaConsumerRequest> = dec.decode()?;
@@ -644,10 +642,10 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()).to_vec()?)
     }
 
-    pub(super) async fn start_kafka_producer_service<'a>(
+    pub(super) async fn start_kafka_producer_service(
         &mut self,
         context: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<Vec<u8>> {
         let body: StartServiceRequest<StartKafkaProducerRequest> = dec.decode()?;
@@ -675,10 +673,10 @@ impl NodeManagerWorker {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) async fn start_kafka_service_impl<'a>(
+    pub(super) async fn start_kafka_service_impl(
         &mut self,
         context: &Context,
-        request: &'a Request<'_>,
+        request: &Request,
         local_interceptor_address: Address,
         bind_ip: IpAddr,
         server_bootstrap_port: u16,
@@ -769,10 +767,10 @@ impl NodeManagerWorker {
         Ok(())
     }
 
-    pub(crate) async fn delete_kafka_service<'a>(
-        &'a self,
+    pub(crate) async fn delete_kafka_service(
+        &self,
         ctx: &Context,
-        req: &'a Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
         kind: KafkaServiceKind,
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
@@ -809,10 +807,10 @@ impl NodeManagerWorker {
         Ok(res)
     }
 
-    pub(super) async fn list_services_of_type<'a>(
+    pub(super) async fn list_services_of_type(
         &self,
-        req: &Request<'a>,
-        service_type: &'a str,
+        req: &Request,
+        service_type: &str,
     ) -> Result<Vec<u8>> {
         if !DefaultAddress::is_valid(service_type) {
             let err_body = Error::new(req.path())
@@ -830,7 +828,7 @@ impl NodeManagerWorker {
             .to_vec()?)
     }
 
-    pub(super) async fn list_services<'a>(&self, req: &Request<'a>) -> Result<Vec<u8>> {
+    pub(super) async fn list_services(&self, req: &Request) -> Result<Vec<u8>> {
         let n = self.node_manager.read().await;
         let services = Self::list_services_impl(&n.registry);
         Ok(Response::ok(req.id())

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
@@ -1,9 +1,11 @@
-use crate::nodes::models::policy::{Expression, Policy, PolicyList};
 use either::Either;
 use minicbor::Decoder;
+
 use ockam_abac::{Action, Resource};
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
 use ockam_core::Result;
+
+use crate::nodes::models::policy::{Expression, Policy, PolicyList};
 
 use super::NodeManager;
 
@@ -12,7 +14,7 @@ impl NodeManager {
         &self,
         resource: &str,
         action: &str,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder<()>, ResponseBuilder<Error>> {
         let p: Policy = dec.decode()?;
@@ -24,7 +26,7 @@ impl NodeManager {
 
     pub(super) async fn get_policy<'a>(
         &self,
-        req: &'a Request<'_>,
+        req: &'a Request,
         resource: &str,
         action: &str,
     ) -> Result<Either<ResponseBuilder<Error>, ResponseBuilder<Policy>>> {
@@ -43,7 +45,7 @@ impl NodeManager {
 
     pub(super) async fn list_policies(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         res: &str,
     ) -> Result<ResponseBuilder<PolicyList>, ResponseBuilder<Error>> {
         let r = Resource::new(res);
@@ -54,7 +56,7 @@ impl NodeManager {
 
     pub(super) async fn del_policy(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         res: &str,
         act: &str,
     ) -> Result<ResponseBuilder<()>, ResponseBuilder<Error>> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -451,13 +451,7 @@ impl NodeManagerWorker {
         }
 
         node_manager
-            .create_secure_channel_listener_impl(
-                addr,
-                authorized_identifiers,
-                vault,
-                identity,
-                ctx,
-            )
+            .create_secure_channel_listener_impl(addr, authorized_identifiers, vault, identity, ctx)
             .await?;
 
         let response = Response::ok(req.id());

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
@@ -1,19 +1,20 @@
-use crate::nodes::models::transport::{
-    CreateTcpConnection, CreateTcpListener, DeleteTransport, TransportList, TransportMode,
-    TransportStatus, TransportType,
-};
-use crate::nodes::service::ApiTransport;
+use std::net::SocketAddr;
+
 use minicbor::Decoder;
+
 use ockam::Result;
 use ockam_core::api::{Error, Request, Response, ResponseBuilder};
-
 use ockam_core::Address;
 use ockam_node::Context;
 use ockam_transport_tcp::{
     TcpConnectionOptions, TcpListenerInfo, TcpListenerOptions, TcpSenderInfo, TcpTransport,
 };
 
-use std::net::SocketAddr;
+use crate::nodes::models::transport::{
+    CreateTcpConnection, CreateTcpListener, DeleteTransport, TransportList, TransportMode,
+    TransportStatus, TransportType,
+};
+use crate::nodes::service::ApiTransport;
 
 use super::NodeManagerWorker;
 
@@ -72,7 +73,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn get_tcp_connections(
         &self,
-        req: &Request<'_>,
+        req: &Request,
     ) -> ResponseBuilder<TransportList> {
         let tcp_transport = &self.node_manager.read().await.tcp_transport;
         let map = |info: &TcpSenderInfo| {
@@ -98,7 +99,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn get_tcp_connection(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         address: String,
     ) -> Result<ResponseBuilder<TransportStatus>, ResponseBuilder<Error>> {
         let tcp_transport = &self.node_manager.read().await.tcp_transport;
@@ -124,10 +125,7 @@ impl NodeManagerWorker {
         Ok(Response::ok(req.id()).body(status))
     }
 
-    pub(super) async fn get_tcp_listeners(
-        &self,
-        req: &Request<'_>,
-    ) -> ResponseBuilder<TransportList> {
+    pub(super) async fn get_tcp_listeners(&self, req: &Request) -> ResponseBuilder<TransportList> {
         let tcp_transport = &self.node_manager.read().await.tcp_transport;
 
         let map = |info: &TcpListenerInfo| {
@@ -153,7 +151,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn get_tcp_listener(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         address: String,
     ) -> Result<ResponseBuilder<TransportStatus>, ResponseBuilder<Error>> {
         let tcp_transport = &self.node_manager.read().await.tcp_transport;
@@ -181,7 +179,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn create_tcp_connection<'a>(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
         ctx: &Context,
     ) -> Result<ResponseBuilder<TransportStatus>, ResponseBuilder<Error>> {
@@ -233,7 +231,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn create_tcp_listener<'a>(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder<TransportStatus>, ResponseBuilder<Error>> {
         let node_manager = self.node_manager.read().await;
@@ -272,7 +270,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn delete_tcp_connection(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder<()>, ResponseBuilder<Error>> {
         let node_manager = self.node_manager.read().await;
@@ -319,7 +317,7 @@ impl NodeManagerWorker {
 
     pub(super) async fn delete_tcp_listener(
         &self,
-        req: &Request<'_>,
+        req: &Request,
         dec: &mut Decoder<'_>,
     ) -> Result<ResponseBuilder<()>, ResponseBuilder<Error>> {
         let node_manager = self.node_manager.read().await;

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -47,7 +47,7 @@ impl Server {
         project: String,
         tenant_base_url: &str,
         certificate: &str,
-        attributes: &[&str],
+        attributes: &[String],
     ) -> Result<Self> {
         let certificate = reqwest::Certificate::from_pem(certificate.as_bytes())
             .map_err(|err| ApiError::generic(&err.to_string()))?;

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -444,7 +444,7 @@ pub mod test_utils {
         )
         .await?;
 
-        let mut node_manager_worker = NodeManagerWorker::new(node_manager);
+        let node_manager_worker = NodeManagerWorker::new(node_manager);
         let node_manager = node_manager_worker.get().clone();
         let secure_channels = node_manager.read().await.secure_channels.clone();
 

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -17,6 +17,10 @@ use ockam_command::node::util::init_node_state;
 use ockam_command::util::api::{TrustContextConfigBuilder, TrustContextOpts};
 use ockam_command::{CommandGlobalOpts, GlobalArgs, Terminal};
 
+pub const NODE_NAME: &str = "default";
+pub const SPACE_NAME: &str = "default";
+pub const PROJECT_NAME: &str = "default";
+
 /// The AppState struct contains all the state managed by `tauri`.
 /// It can be retrieved with the `AppHandle<Wry>` parameter and the `AppHandle::state()` method
 /// Note that it contains a `NodeManagerWorker`. This makes the desktop app a full-fledged node
@@ -117,8 +121,7 @@ async fn make_node_manager(
     ctx: Arc<Context>,
     opts: CommandGlobalOpts,
 ) -> miette::Result<NodeManager> {
-    let node_name = "default";
-    init_node_state(&opts, node_name, None, None).await?;
+    init_node_state(&opts, NODE_NAME, None, None).await?;
 
     let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
     let options = TcpListenerOptions::new();
@@ -135,7 +138,7 @@ async fn make_node_manager(
 
     let node_manager = NodeManager::create(
         &ctx,
-        NodeManagerGeneralOptions::new(opts.state.clone(), node_name.to_string(), false, None),
+        NodeManagerGeneralOptions::new(opts.state.clone(), NODE_NAME.to_string(), false, None),
         NodeManagerProjectsOptions::new(projects),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -1,4 +1,7 @@
-use crate::app::{configure_tauri_plugin_log, process_application_event, setup_app, AppState};
+use crate::app::{
+    configure_tauri_plugin_log, make_system_tray, process_application_event,
+    process_system_tray_event, setup_app, AppState,
+};
 use crate::error::Result;
 
 mod app;

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -1,7 +1,9 @@
-use crate::app::{
-    configure_tauri_plugin_log, make_system_tray, process_application_event,
-    process_system_tray_event, setup_app, AppState,
-};
+#[cfg(target_os = "macos")]
+use macos as platform;
+#[cfg(not(target_os = "macos"))]
+use others as platform;
+
+use crate::app::{configure_tauri_plugin_log, process_application_event, setup_app, AppState};
 use crate::error::Result;
 
 mod app;
@@ -14,11 +16,6 @@ mod tcp;
 mod macos;
 #[cfg(not(target_os = "macos"))]
 mod others;
-
-#[cfg(target_os = "macos")]
-use macos as platform;
-#[cfg(not(target_os = "macos"))]
-use others as platform;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -1,14 +1,13 @@
-use miette::{Context as _, IntoDiagnostic};
 use std::path::PathBuf;
 
 use clap::builder::NonEmptyStringValueParser;
 use clap::{Args, Subcommand};
+use miette::{Context as _, IntoDiagnostic};
 
 use ockam::Context;
 use ockam_api::cloud::subscription::{ActivateSubscription, Subscription};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::subscription::utils;
@@ -157,7 +156,7 @@ async fn run_impl(
             let req = Request::post("subscription").body(CloudRequestWrapper::new(
                 b,
                 controller_route,
-                None::<CowStr>,
+                None,
             ));
 
             rpc.request(req).await?;
@@ -207,10 +206,8 @@ async fn run_impl(
                         space_id,
                     )
                     .await?;
-                    let req =
-                        Request::put(format!("subscription/{subscription_id}/contact_info")).body(
-                            CloudRequestWrapper::new(json, controller_route, None::<CowStr>),
-                        );
+                    let req = Request::put(format!("subscription/{subscription_id}/contact_info"))
+                        .body(CloudRequestWrapper::new(json, controller_route, None));
                     rpc.request(req).await?;
                     rpc.parse_and_print_response::<Subscription>()?;
                 }
@@ -228,12 +225,10 @@ async fn run_impl(
                         space_id,
                     )
                     .await?;
-                    let req = Request::put(format!("subscription/{subscription_id}/space_id"))
-                        .body(CloudRequestWrapper::new(
-                            new_space_id,
-                            controller_route,
-                            None::<CowStr>,
-                        ));
+                    let req =
+                        Request::put(format!("subscription/{subscription_id}/space_id")).body(
+                            CloudRequestWrapper::new(new_space_id, controller_route, None),
+                        );
                     rpc.request(req).await?;
                     rpc.parse_and_print_response::<Subscription>()?;
                 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -128,7 +128,7 @@ pub async fn enroll_with_node(
 ) -> miette::Result<()> {
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).build();
     rpc.request(api::enroll::auth0(route, token)).await?;
-    let (res, dec) = rpc.check_response()?;
+    let (res, dec) = rpc.parse_response_header()?;
     if res.status() == Some(Status::Ok) {
         info!("Enrolled successfully");
         Ok(())
@@ -136,7 +136,7 @@ pub async fn enroll_with_node(
         info!("Already enrolled");
         Ok(())
     } else {
-        Err(miette!("{}", Response::parse_err_msg(&[], res, dec)))
+        Err(miette!("{}", Response::parse_err_msg(res, dec)))
     }
 }
 
@@ -150,7 +150,7 @@ async fn default_space(ctx: &Context, opts: &CommandGlobalOpts, node_name: &str)
     let send_req = async {
         rpc.request(api::space::list(&CloudOpts::route())).await?;
         *is_finished.lock().await = true;
-        rpc.parse_response::<Vec<Space>>()
+        rpc.parse_response_body::<Vec<Space>>()
     };
 
     let message = vec![format!("Checking for any existing spaces...")];
@@ -184,7 +184,7 @@ async fn default_space(ctx: &Context, opts: &CommandGlobalOpts, node_name: &str)
 
             rpc.request(api::space::create(cmd)).await?;
             *is_finished.lock().await = true;
-            rpc.parse_response::<Space>()
+            rpc.parse_response_body::<Space>()
         };
 
         let message = vec![format!(
@@ -246,7 +246,7 @@ async fn default_project(
     let send_req = async {
         rpc.request(api::project::list(&CloudOpts::route())).await?;
         *is_finished.lock().await = true;
-        rpc.parse_response::<Vec<Project>>()
+        rpc.parse_response_body::<Vec<Project>>()
     };
 
     let message = vec![format!("Checking for any existing projects...")];
@@ -273,7 +273,7 @@ async fn default_project(
             rpc.request(api::project::create(name, &space.id, &CloudOpts::route()))
                 .await?;
             *is_finished.lock().await = true;
-            rpc.parse_response::<Project>()
+            rpc.parse_response_body::<Project>()
         };
 
         let message = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -206,8 +206,7 @@ async fn default_space(ctx: &Context, opts: &CommandGlobalOpts, node_name: &str)
         let space = available_spaces
             .drain(..1)
             .next()
-            .expect("already checked that is not empty")
-            ;
+            .expect("already checked that is not empty");
 
         opts.terminal.write_line(&fmt_log!(
             "Found space {}.",
@@ -308,8 +307,7 @@ async fn default_project(
             None => available_projects
                 .drain(..1)
                 .next()
-                .expect("already checked that is not empty")
-                ,
+                .expect("already checked that is not empty"),
             Some(p) => p.to_owned(),
         };
         opts.terminal.write_line(&fmt_log!(
@@ -335,7 +333,7 @@ async fn default_project(
     Ok(project)
 }
 
-async fn update_enrolled_identity(
+pub async fn update_enrolled_identity(
     opts: &CommandGlobalOpts,
     node_name: &str,
 ) -> Result<IdentityIdentifier> {

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -50,7 +50,7 @@ async fn run_impl(
         DefaultAddress::KAFKA_CONSUMER
     )))
     .await?;
-    let services = rpc.parse_response::<models::services::ServiceList>()?;
+    let services = rpc.parse_response_body::<models::services::ServiceList>()?;
     if services.list.is_empty() {
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -50,7 +50,7 @@ async fn run_impl(
         DefaultAddress::KAFKA_PRODUCER
     )))
     .await?;
-    let services = rpc.parse_response::<models::services::ServiceList>()?;
+    let services = rpc.parse_response_body::<models::services::ServiceList>()?;
     if services.list.is_empty() {
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -113,11 +113,8 @@ async fn rpc(
             cmd.message.as_bytes().to_vec()
         };
 
-        rpc.request_with_timeout(
-            req(&to, msg_bytes.as_slice()),
-            Duration::from_secs(cmd.timeout),
-        )
-        .await?;
+        rpc.request_with_timeout(req(&to, msg_bytes), Duration::from_secs(cmd.timeout))
+            .await?;
         let res = {
             let res = rpc.parse_response::<Vec<u8>>()?;
             if cmd.hex {
@@ -141,6 +138,6 @@ async fn rpc(
     go(&mut ctx, opts, cmd).await
 }
 
-pub(crate) fn req<'a>(to: &'a MultiAddr, message: &'a [u8]) -> RequestBuilder<'a, SendMessage<'a>> {
+pub(crate) fn req(to: &MultiAddr, message: Vec<u8>) -> RequestBuilder<SendMessage> {
     Request::post("v0/message").body(SendMessage::new(to, message))
 }

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -116,7 +116,7 @@ async fn rpc(
         rpc.request_with_timeout(req(&to, msg_bytes), Duration::from_secs(cmd.timeout))
             .await?;
         let res = {
-            let res = rpc.parse_response::<Vec<u8>>()?;
+            let res = rpc.parse_response_body::<Vec<u8>>()?;
             if cmd.hex {
                 hex::encode(res)
             } else {

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -458,7 +458,7 @@ async fn start_services(ctx: &Context, cfg: &Config) -> miette::Result<()> {
     Ok(())
 }
 
-async fn send_req_to_node_manager<T>(ctx: &Context, req: RequestBuilder<'_, T>) -> Result<()>
+async fn send_req_to_node_manager<T>(ctx: &Context, req: RequestBuilder<T>) -> Result<()>
 where
     T: Encode<()>,
 {

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -59,7 +59,7 @@ async fn run_impl(
 
         let send_req = async {
             let node_status = if rpc.request(api::query_status()).await.is_ok() {
-                let resp = rpc.parse_response::<NodeStatus>()?;
+                let resp = rpc.parse_response_body::<NodeStatus>()?;
                 if let Ok(node_state) = opts.state.nodes.get(&node_name) {
                     // Update the persisted configuration data with the pids
                     // responded by nodes.

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -213,27 +213,27 @@ pub async fn print_query_status(
         // Get list of services for the node
         let mut rpc = rpc.clone();
         rpc.request(api::list_services()).await?;
-        let services = rpc.parse_response::<ServiceList>()?;
+        let services = rpc.parse_response_body::<ServiceList>()?;
 
         // Get list of TCP listeners for node
         let mut rpc = rpc.clone();
         rpc.request(api::list_tcp_listeners()).await?;
-        let tcp_listeners = rpc.parse_response::<TransportList>()?;
+        let tcp_listeners = rpc.parse_response_body::<TransportList>()?;
 
         // Get list of Secure Channel Listeners
         let mut rpc = rpc.clone();
         rpc.request(api::list_secure_channel_listener()).await?;
-        let secure_channel_listeners = rpc.parse_response::<SecureChannelListenersList>()?;
+        let secure_channel_listeners = rpc.parse_response_body::<SecureChannelListenersList>()?;
 
         // Get list of inlets
         let mut rpc = rpc.clone();
         rpc.request(api::list_inlets()).await?;
-        let inlets = rpc.parse_response::<InletList>()?;
+        let inlets = rpc.parse_response_body::<InletList>()?;
 
         // Get list of outlets
         let mut rpc = rpc.clone();
         rpc.request(api::list_outlets()).await?;
-        let outlets = rpc.parse_response::<OutletList>()?;
+        let outlets = rpc.parse_response_body::<OutletList>()?;
 
         let node_state = cli_state.nodes.get(node_name)?;
         let node_port = node_state

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -163,7 +163,7 @@ fn print_node_info(
         for e in &list.list {
             println!("    Service:");
             println!("      Type: {}", e.service_type);
-            if let Some(ma) = addr_to_multiaddr(e.addr.as_ref()) {
+            if let Some(ma) = addr_to_multiaddr(e.addr.as_str()) {
                 println!("      Address: {ma}");
             }
         }

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -35,7 +35,7 @@ pub async fn check_for_completion<'a>(
         {
             let operation = rpc.parse_response::<Operation>()?;
             if operation.is_completed() {
-                return Ok(operation.to_owned());
+                return Ok(operation);
             }
         }
         Err(miette!("Operation timed out. Please try again."))

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -33,7 +33,7 @@ pub async fn check_for_completion<'a>(
             .await
             .is_ok()
         {
-            let operation = rpc.parse_response::<Operation>()?;
+            let operation = rpc.parse_response_body::<Operation>()?;
             if operation.is_completed() {
                 return Ok(operation);
             }

--- a/implementations/rust/ockam/ockam_command/src/policy/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/list.rs
@@ -58,7 +58,7 @@ async fn run_impl(
         let req = Request::get(format!("/policy/{resource}"));
 
         rpc.request(req).await?;
-        rpc.parse_response::<PolicyList>()
+        rpc.parse_response_body::<PolicyList>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -54,7 +54,7 @@ pub(crate) async fn has_policy(
     let req = Request::get(format!("/policy/{resource}"));
     let mut rpc = Rpc::background(ctx, opts, node)?;
     rpc.request(req).await?;
-    let pol: PolicyList = rpc.parse_response()?;
+    let pol: PolicyList = rpc.parse_response_body()?;
     Ok(!pol.expressions().is_empty())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -41,7 +41,7 @@ async fn run_impl(
     let req = Request::get(policy_path(&cmd.resource, &cmd.action));
     let mut rpc = Rpc::background(ctx, &opts, &node)?;
     rpc.request(req).await?;
-    let pol: Policy = rpc.parse_response()?;
+    let pol: Policy = rpc.parse_response_body()?;
     println!("{}", pol.expression());
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -74,7 +74,7 @@ async fn run_impl(
     );
     let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
-    let res = rpc.parse_response::<CreateOperationResponse>()?;
+    let res = rpc.parse_response_body::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
     check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
@@ -83,7 +83,7 @@ async fn run_impl(
     let mut rpc = rpc.clone();
     rpc.request(api::project::show(&project_id, controller_route))
         .await?;
-    let project: Project = rpc.parse_response()?;
+    let project: Project = rpc.parse_response_body()?;
     check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
 
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -9,14 +9,12 @@ use ockam_api::cloud::operation::CreateOperationResponse;
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::operation::util::check_for_completion;
 use crate::project::addon::configure_addon_endpoint;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
-
 use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
@@ -26,8 +24,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/configure_confluent/after_l
 /// Configure the Confluent Cloud addon for a project
 #[derive(Clone, Debug, Args)]
 #[command(
-    long_about = docs::about(LONG_ABOUT),
-    after_long_help = docs::after_help(AFTER_LONG_HELP),
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
 )]
 pub struct AddonConfigureConfluentSubcommand {
     /// Ockam project name
@@ -74,11 +72,7 @@ async fn run_impl(
         configure_addon_endpoint(&opts.state, &project_name)?,
         addon_id
     );
-    let req = Request::post(endpoint).body(CloudRequestWrapper::new(
-        body,
-        controller_route,
-        None::<CowStr>,
-    ));
+    let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -171,7 +171,7 @@ async fn run_impl(
     let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
 
     rpc.request(req).await?;
-    let res = rpc.parse_response::<CreateOperationResponse>()?;
+    let res = rpc.parse_response_body::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
     // Wait until project is ready again
@@ -181,7 +181,7 @@ async fn run_impl(
     let mut rpc = rpc.clone();
     rpc.request(api::project::show(&project_id, controller_route))
         .await?;
-    let project: Project = rpc.parse_response()?;
+    let project: Project = rpc.parse_response_body()?;
     check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
 
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -7,19 +7,16 @@ use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
-
 use ockam_api::cloud::operation::CreateOperationResponse;
 use ockam_api::cloud::project::{InfluxDBTokenLeaseManagerConfig, Project};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::operation::util::check_for_completion;
 use crate::project::addon::configure_addon_endpoint;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
-
 use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
@@ -29,8 +26,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/configure_influxdb/after_lo
 /// Configure the InfluxDB Cloud addon for a project
 #[derive(Clone, Debug, Args)]
 #[command(
-    long_about = docs::about(LONG_ABOUT),
-    after_long_help = docs::after_help(AFTER_LONG_HELP),
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
 )]
 pub struct AddonConfigureInfluxdbSubcommand {
     /// Ockam Project Name
@@ -171,11 +168,7 @@ async fn run_impl(
         configure_addon_endpoint(&opts.state, &project_name)?,
         add_on_id
     );
-    let req = Request::post(endpoint).body(CloudRequestWrapper::new(
-        body,
-        controller_route,
-        None::<CowStr>,
-    ));
+    let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
 
     rpc.request(req).await?;
     let res = rpc.parse_response::<CreateOperationResponse>()?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -134,7 +134,7 @@ async fn run_impl(
     );
     let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
-    let res = rpc.parse_response::<CreateOperationResponse>()?;
+    let res = rpc.parse_response_body::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
     check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
@@ -142,7 +142,7 @@ async fn run_impl(
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     rpc.request(api::project::show(&project_id, controller_route))
         .await?;
-    let project: Project = rpc.parse_response()?;
+    let project: Project = rpc.parse_response_body()?;
     check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
 
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -15,7 +15,6 @@ use ockam_api::cloud::project::{OktaConfig, Project};
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_api::minicbor_url::Url;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::enroll::{Auth0Service, OktaAuth0Provider};
 use crate::node::util::delete_embedded_node;
@@ -119,7 +118,7 @@ async fn run_impl(
         _ => query_certificate_chain(domain)?,
     };
 
-    let okta_config = OktaConfig::new(base_url, certificate, client_id, &attributes);
+    let okta_config = OktaConfig::new(base_url, certificate, client_id, attributes);
     let body = okta_config.clone();
 
     // Validate okta configuration
@@ -133,11 +132,7 @@ async fn run_impl(
         configure_addon_endpoint(&opts.state, &project_name)?,
         addon_id
     );
-    let req = Request::post(endpoint).body(CloudRequestWrapper::new(
-        body,
-        controller_route,
-        None::<CowStr>,
-    ));
+    let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -3,19 +3,15 @@ use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
-
 use ockam_api::cloud::addon::DisableAddon;
 use ockam_api::cloud::operation::CreateOperationResponse;
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::operation::util::check_for_completion;
 use crate::project::addon::disable_addon_endpoint;
-
 use crate::util::api::CloudOpts;
-
 use crate::util::{node_rpc, Rpc};
 use crate::{fmt_ok, CommandGlobalOpts};
 
@@ -61,11 +57,7 @@ async fn run_impl(
     let body = DisableAddon::new(addon_id);
     let endpoint = disable_addon_endpoint(&opts.state, &project_name)?;
 
-    let req = Request::post(endpoint).body(CloudRequestWrapper::new(
-        body,
-        controller_route,
-        None::<CowStr>,
-    ));
+    let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
     let res = rpc.parse_response::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -59,7 +59,7 @@ async fn run_impl(
 
     let req = Request::post(endpoint).body(CloudRequestWrapper::new(body, controller_route, None));
     rpc.request(req).await?;
-    let res = rpc.parse_response::<CreateOperationResponse>()?;
+    let res = rpc.parse_response_body::<CreateOperationResponse>()?;
     let operation_id = res.operation_id;
 
     check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -68,7 +68,7 @@ impl ConfigureAddonCommand {
     }
 }
 
-impl Output for Addon<'_> {
+impl Output for Addon {
     fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Addon:")?;
@@ -80,7 +80,7 @@ impl Output for Addon<'_> {
     }
 }
 
-impl Output for Vec<Addon<'_>> {
+impl Output for Vec<Addon> {
     fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No addons found".to_string());

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -62,7 +62,7 @@ async fn run_impl(
         &CloudOpts::route(),
     ))
     .await?;
-    let project = rpc.parse_response::<Project>()?;
+    let project = rpc.parse_response_body::<Project>()?;
     let operation_id = project.operation_id.clone().unwrap();
     check_for_completion(ctx, &opts, rpc.node_name(), &operation_id).await?;
     let project = check_project_readiness(ctx, &opts, &node_name, None, project).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -134,7 +134,7 @@ async fn run_impl(
     let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     rpc.request(api::project::show(&id, controller_route))
         .await?;
-    let info: ProjectInfo = rpc.parse_response::<Project>()?.into();
+    let info: ProjectInfo = rpc.parse_response_body::<Project>()?.into();
 
     rpc.print_response(&info)?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -51,7 +51,7 @@ async fn run_impl(
 
     let send_req = async {
         rpc.request(api::project::list(&CloudOpts::route())).await?;
-        let r = rpc.parse_response::<Vec<Project>>()?;
+        let r = rpc.parse_response_body::<Vec<Project>>()?;
 
         *is_finished.lock().await = true;
         Ok(r)

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -123,7 +123,7 @@ pub async fn create_secure_channel_to_project(
     let req = Request::post("/node/secure_channel").body(payload);
     rpc.request(req).await?;
 
-    let sc = rpc.parse_response::<CreateSecureChannelResponse>()?;
+    let sc = rpc.parse_response_body::<CreateSecureChannelResponse>()?;
     Ok(sc.multiaddr()?)
 }
 
@@ -147,7 +147,7 @@ pub async fn create_secure_channel_to_authority(
     );
     let req = Request::post("/node/secure_channel").body(payload);
     rpc.request(req).await?;
-    let res = rpc.parse_response::<CreateSecureChannelResponse>()?;
+    let res = rpc.parse_response_body::<CreateSecureChannelResponse>()?;
     let addr = res.multiaddr()?;
     Ok(addr)
 }
@@ -201,7 +201,7 @@ pub async fn check_project_readiness(
                 .await
                 .is_ok()
             {
-                let p = rpc.parse_response::<Project>()?;
+                let p = rpc.parse_response_body::<Project>()?;
                 if p.is_ready() {
                     return Ok(p);
                 }
@@ -316,7 +316,7 @@ pub async fn refresh_projects(
 ) -> miette::Result<()> {
     let mut rpc = RpcBuilder::new(ctx, opts, api_node).tcp(tcp)?.build();
     rpc.request(api::project::list(controller_route)).await?;
-    let projects = rpc.parse_response::<Vec<Project>>()?;
+    let projects = rpc.parse_response_body::<Vec<Project>>()?;
     for project in projects {
         opts.state
             .projects

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -203,7 +203,7 @@ pub async fn check_project_readiness(
             {
                 let p = rpc.parse_response::<Project>()?;
                 if p.is_ready() {
-                    return Ok(p.to_owned());
+                    return Ok(p);
                 }
             }
             Err(miette!("Project creation timed out. Plaese try again."))

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -162,7 +162,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
     Ok(())
 }
 
-impl Output for ForwarderInfo<'_> {
+impl Output for ForwarderInfo {
     fn output(&self) -> Result<String> {
         let output = format!(
             r#"

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -109,7 +109,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
 
         *is_finished.lock().await = true;
 
-        rpc.parse_response::<ForwarderInfo>()
+        rpc.parse_response_body::<ForwarderInfo>()
     };
 
     let output_messages = vec![

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -54,7 +54,7 @@ async fn run_impl(
         rpc.request(Request::get("/node/forwarder")).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<Vec<ForwarderInfo>>()
+        rpc.parse_response_body::<Vec<ForwarderInfo>>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -45,7 +45,7 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::get(format!("/node/forwarder/{remote_address}")))
         .await?;
-    let relay_info_response = rpc.parse_response::<ForwarderInfo>()?;
+    let relay_info_response = rpc.parse_response_body::<ForwarderInfo>()?;
 
     rpc.is_ok()?;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -123,7 +123,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
         let request = Request::post("/node/secure_channel").body(payload);
 
         rpc.request(request).await?;
-        let resp = rpc.parse_response::<CreateSecureChannelResponse>()?;
+        let resp = rpc.parse_response_body::<CreateSecureChannelResponse>()?;
         *is_finished.lock().await = true;
 
         Ok(resp)

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -155,7 +155,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> m
         let address = &cmd.address;
         let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
         rpc.request(api::delete_secure_channel(address)).await?;
-        let res = rpc.parse_response::<DeleteSecureChannelResponse>()?;
+        let res = rpc.parse_response_body::<DeleteSecureChannelResponse>()?;
         cmd.print_output(&node_name, address, &opts, res);
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -53,7 +53,7 @@ impl DeleteCommand {
     ) {
         match response.channel {
             Some(address) => {
-                let route = &route![address.to_string()];
+                let route = &route![address];
                 match route_to_multiaddr(route) {
                     Some(multiaddr) => {
                         // if stdout is not interactive/tty write the secure channel address to it

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -100,7 +100,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
 
     let send_req = async {
         rpc.request(api::list_secure_channels()).await?;
-        let channel_identifiers = rpc.parse_response::<Vec<String>>()?;
+        let channel_identifiers = rpc.parse_response_body::<Vec<String>>()?;
 
         *is_finished.lock().await = true;
         Ok(channel_identifiers)
@@ -122,7 +122,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
                 ockam_api::nodes::models::secure_channel::ShowSecureChannelRequest,
             > = api::show_secure_channel(&Address::from(channel_addr));
             rpc.request(request).await?;
-            let show_response = rpc.parse_response::<ShowSecureChannelResponse>()?;
+            let show_response = rpc.parse_response_body::<ShowSecureChannelResponse>()?;
             let secure_channel_output =
                 cmd.build_output(&node_name, channel_addr, show_response)?;
             *is_finished.lock().await = true;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -48,7 +48,7 @@ async fn run_impl(
     let req = api::delete_secure_channel_listener(&cmd.address);
     rpc.request(req).await?;
     rpc.is_ok()?;
-    let res = rpc.parse_response::<DeleteSecureChannelListenerResponse>()?;
+    let res = rpc.parse_response_body::<DeleteSecureChannelListenerResponse>()?;
     let addr = res.addr;
     opts.terminal
         .stdout()

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -67,7 +67,7 @@ async fn run_impl(
 
     let send_req = async {
         rpc.request(api::list_secure_channel_listener()).await?;
-        let res = rpc.parse_response::<SecureChannelListenersList>()?;
+        let res = rpc.parse_response_body::<SecureChannelListenersList>()?;
 
         *is_finished.lock().await = true;
         Ok(res)

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -47,7 +47,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> mie
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let request = api::show_secure_channel(address);
     rpc.request(request).await?;
-    let response = rpc.parse_response::<ShowSecureChannelResponse>()?;
+    let response = rpc.parse_response_body::<ShowSecureChannelResponse>()?;
 
     rpc.print_response(response)?;
 

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -56,7 +56,7 @@ async fn run_impl(
 
     let send_req = async {
         rpc.request(api::list_services()).await?;
-        let r = rpc.parse_response::<ServiceList>()?;
+        let r = rpc.parse_response_body::<ServiceList>()?;
 
         *is_finished.lock().await = true;
         crate::Result::Ok(r)

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -90,7 +90,7 @@ async fn run_impl(
     Ok(())
 }
 
-impl Output for ServiceStatus<'_> {
+impl Output for ServiceStatus {
     fn output(&self) -> crate::Result<String> {
         let mut output = String::new();
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -5,7 +5,7 @@ use minicbor::Encode;
 
 use ockam::{Context, TcpTransport};
 use ockam_api::DefaultAddress;
-use ockam_core::api::{RequestBuilder, Status};
+use ockam_core::api::RequestBuilder;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
@@ -170,10 +170,10 @@ where
     let mut rpc = RpcBuilder::new(ctx, opts, node_name).tcp(tcp)?.build();
     rpc.request(req).await?;
 
-    let (res, _dec) = rpc.check_response()?;
-    match res.status() {
-        Some(Status::Ok) => Ok(()),
-        _ => Err(miette!("Failed to start {} service", serv_name).into()),
+    if rpc.is_ok().is_ok() {
+        Ok(())
+    } else {
+        Err(miette!("Failed to start {} service", serv_name).into())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,17 +1,17 @@
+use clap::{Args, Subcommand};
+use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
+use minicbor::Encode;
+
+use ockam::{Context, TcpTransport};
+use ockam_api::DefaultAddress;
+use ockam_core::api::{RequestBuilder, Status};
+
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::{api, node_rpc, RpcBuilder};
 use crate::{fmt_ok, CommandGlobalOpts};
 use crate::{fmt_warn, Result};
-use clap::{Args, Subcommand};
-use miette::{miette, IntoDiagnostic};
-
-use colorful::Colorful;
-use minicbor::Encode;
-use ockam::{Context, TcpTransport};
-
-use ockam_api::DefaultAddress;
-use ockam_core::api::{RequestBuilder, Status};
 
 /// Start a specified service
 #[derive(Clone, Debug, Args)]
@@ -161,7 +161,7 @@ pub(crate) async fn start_service_impl<T>(
     opts: &CommandGlobalOpts,
     node_name: &str,
     serv_name: &str,
-    req: RequestBuilder<'_, T>,
+    req: RequestBuilder<T>,
     tcp: Option<&'_ TcpTransport>,
 ) -> Result<()>
 where

--- a/implementations/rust/ockam/ockam_command/src/service/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/util.rs
@@ -4,7 +4,7 @@ use ockam_api::nodes::models::services::ServiceList;
 use crate::util::output::Output;
 use crate::Result;
 
-impl Output for ServiceList<'_> {
+impl Output for ServiceList {
     fn output(&self) -> Result<String> {
         if self.list.is_empty() {
             return Ok("No services found".to_string());

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -57,7 +57,7 @@ async fn run_impl(
     cmd: CreateCommand,
 ) -> miette::Result<()> {
     let mut rpc = Rpc::embedded(ctx, &opts).await?;
-    rpc.request(api::space::create(&cmd)).await?;
+    rpc.request(api::space::create(cmd)).await?;
     let space = rpc.parse_and_print_response::<Space>()?;
     opts.state
         .spaces

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -53,7 +53,7 @@ async fn run_impl(
         rpc.request(api::space::list(&CloudOpts::route())).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<Vec<Space>>()
+        rpc.parse_response_body::<Vec<Space>>()
     };
 
     let output_messages = vec![format!("Listing Spaces...\n",)];

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -95,7 +95,7 @@ async fn get_node_status(
         .is_ok()
     {
         let resp = rpc.parse_response::<NodeStatusModel>()?;
-        node_status = resp.status.to_string();
+        node_status = resp.status;
     }
 
     Ok(node_status)

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -94,7 +94,7 @@ async fn get_node_status(
         .await
         .is_ok()
     {
-        let resp = rpc.parse_response::<NodeStatusModel>()?;
+        let resp = rpc.parse_response_body::<NodeStatusModel>()?;
         node_status = resp.status;
     }
 

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -7,7 +7,6 @@ use ockam::Context;
 use ockam_api::cloud::subscription::Subscription;
 use ockam_api::cloud::CloudRequestWrapper;
 use ockam_core::api::Request;
-use ockam_core::CowStr;
 
 use crate::node::util::delete_embedded_node;
 use crate::util::api::CloudOpts;
@@ -123,13 +122,13 @@ pub mod utils {
         let subscriptions = rpc.parse_response::<Vec<Subscription>>()?;
         let subscription = subscriptions
             .into_iter()
-            .find(|s| s.space_id == Some(CowStr::from(space_id)))
+            .find(|s| s.space_id == Some(space_id.into()))
             .ok_or_else(|| miette!("no subscription found for space {}", space_id))?;
-        Ok(subscription.id.to_string())
+        Ok(subscription.id)
     }
 }
 
-impl Output for Subscription<'_> {
+impl Output for Subscription {
     fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Subscription")?;
@@ -138,16 +137,16 @@ impl Output for Subscription<'_> {
         write!(
             w,
             "\n  Space id: {}",
-            self.space_id.as_ref().unwrap_or(&CowStr::from("N/A"))
+            self.space_id.clone().unwrap_or("N/A".to_string())
         )?;
-        write!(w, "\n  Entitlements: {}", self.entitlements.as_ref())?;
-        write!(w, "\n  Metadata: {}", self.metadata.as_ref())?;
-        write!(w, "\n  Contact info: {}", self.contact_info.as_ref())?;
+        write!(w, "\n  Entitlements: {}", self.entitlements)?;
+        write!(w, "\n  Metadata: {}", self.metadata)?;
+        write!(w, "\n  Contact info: {}", self.contact_info)?;
         Ok(w)
     }
 }
 
-impl Output for Vec<Subscription<'_>> {
+impl Output for Vec<Subscription> {
     fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No subscriptions found".to_string());
@@ -160,11 +159,11 @@ impl Output for Vec<Subscription<'_>> {
             write!(
                 w,
                 "\n  Space id: {}",
-                s.space_id.as_ref().unwrap_or(&CowStr::from("N/A"))
+                s.space_id.as_ref().unwrap_or(&"N/A".to_string())
             )?;
-            write!(w, "\n  Entitlements: {}", s.entitlements.as_ref())?;
-            write!(w, "\n  Metadata: {}", s.metadata.as_ref())?;
-            write!(w, "\n  Contact info: {}", s.contact_info.as_ref())?;
+            write!(w, "\n  Entitlements: {}", s.entitlements)?;
+            write!(w, "\n  Metadata: {}", s.metadata)?;
+            write!(w, "\n  Contact info: {}", s.contact_info)?;
             writeln!(w)?;
         }
         Ok(w)

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -119,7 +119,7 @@ pub mod utils {
         let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
         let req = Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
         rpc.request(req).await?;
-        let subscriptions = rpc.parse_response::<Vec<Subscription>>()?;
+        let subscriptions = rpc.parse_response_body::<Vec<Subscription>>()?;
         let subscription = subscriptions
             .into_iter()
             .find(|s| s.space_id == Some(space_id.into()))

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -91,7 +91,7 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let request = api::create_tcp_connection(&cmd);
     rpc.request(request).await?;
-    let response = rpc.parse_response::<models::transport::TransportStatus>()?;
+    let response = rpc.parse_response_body::<models::transport::TransportStatus>()?;
 
     cmd.print_output(&opts, &response)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -53,7 +53,7 @@ async fn run_impl(
         rpc.request(Request::get("/node/tcp/connection")).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<models::transport::TransportList>()
+        rpc.parse_response_body::<models::transport::TransportList>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -44,7 +44,7 @@ async fn run_impl(
         &cmd.address
     )))
     .await?;
-    let res = rpc.parse_response::<models::transport::TransportStatus>()?;
+    let res = rpc.parse_response_body::<models::transport::TransportStatus>()?;
 
     println!("TCP Connection:");
     println!("  Type: {}", res.tt);

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -154,7 +154,7 @@ async fn rpc(
             match rpc.is_ok() {
                 Ok(_) => {
                     *is_finished.lock().await = true;
-                    break rpc.parse_response::<InletStatus>()?;
+                    break rpc.parse_response_body::<InletStatus>()?;
                 }
                 Err(_) => {
                     if let Some(spinner) = progress_bar.as_ref() {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -52,7 +52,7 @@ async fn run_impl(
         rpc.request(Request::get("/node/inlet")).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<models::portal::InletList>()
+        rpc.parse_response_body::<models::portal::InletList>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -58,7 +58,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to show a tcp inlet
-fn make_api_request<'a>(cmd: ShowCommand) -> Result<RequestBuilder<'a>> {
+fn make_api_request(cmd: ShowCommand) -> Result<RequestBuilder> {
     let alias = cmd.alias;
     let request = Request::get(format!("/node/inlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -44,7 +44,7 @@ pub async fn run_impl(
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;
 
-    let inlet_to_show = rpc.parse_response::<InletStatus>()?;
+    let inlet_to_show = rpc.parse_response_body::<InletStatus>()?;
 
     println!("Inlet:");
     println!("  Alias: {}", inlet_to_show.alias);

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -40,7 +40,7 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     rpc.request(Request::post("/node/tcp/listener").body(CreateTcpListener::new(cmd.address)))
         .await?;
-    let response = rpc.parse_response::<models::transport::TransportStatus>()?;
+    let response = rpc.parse_response_body::<models::transport::TransportStatus>()?;
 
     let socket = response.socket_addr().into_diagnostic()?;
     let port = socket.port();

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -59,7 +59,7 @@ async fn run_impl(
         rpc.request(api::list_tcp_listeners()).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<TransportList>()
+        rpc.parse_response_body::<TransportList>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -41,7 +41,7 @@ async fn run_impl(
     let mut rpc = Rpc::background(&ctx, &opts, &node)?;
     rpc.request(Request::get(format!("/node/tcp/listener/{}", &cmd.address)))
         .await?;
-    let res = rpc.parse_response::<models::transport::TransportStatus>()?;
+    let res = rpc.parse_response_body::<models::transport::TransportStatus>()?;
 
     println!("TCP Listener:");
     println!("  Type: {}", res.tt);

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -151,5 +151,5 @@ pub async fn send_request(
     let mut rpc = Rpc::background(ctx, opts, &to_node)?;
     let req = Request::post("/node/outlet").body(payload);
     rpc.request(req).await?;
-    rpc.parse_response::<OutletStatus>()
+    rpc.parse_response_body::<OutletStatus>()
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -85,5 +85,5 @@ pub async fn send_request(
     let to_node = get_node_name(&opts.state, &to_node.into());
     let mut rpc = Rpc::background(ctx, opts, &to_node)?;
     rpc.request(Request::get("/node/outlet")).await?;
-    rpc.parse_response::<OutletList>()
+    rpc.parse_response_body::<OutletList>()
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -46,7 +46,7 @@ pub async fn run_impl(
     rpc.request(make_api_request(cmd)?).await?;
     rpc.is_ok()?;
 
-    let outlet_to_show = rpc.parse_response::<OutletStatus>()?;
+    let outlet_to_show = rpc.parse_response_body::<OutletStatus>()?;
 
     println!("Outlet:");
     println!("  Alias: {}", outlet_to_show.alias);

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -58,7 +58,7 @@ pub async fn run_impl(
 }
 
 /// Construct a request to show a tcp outlet
-fn make_api_request<'a>(cmd: ShowCommand) -> Result<RequestBuilder<'a>> {
+fn make_api_request(cmd: ShowCommand) -> Result<RequestBuilder> {
     let alias = cmd.alias;
     let request = Request::get(format!("/node/outlet/{alias}"));
     Ok(request)

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -27,7 +27,7 @@ use ockam_core::api::RequestBuilder;
 use ockam_core::api::{Request, Response};
 use ockam_core::env::{get_env_with_default, FromString};
 use ockam_core::flow_control::FlowControlId;
-use ockam_core::{Address, CowStr};
+use ockam_core::Address;
 use ockam_multiaddr::MultiAddr;
 
 use crate::project::ProjectInfo;
@@ -38,59 +38,59 @@ use crate::Result;
 ////////////// !== generators
 
 /// Construct a request to query node status
-pub(crate) fn query_status() -> RequestBuilder<'static, ()> {
+pub(crate) fn query_status() -> RequestBuilder<()> {
     Request::get("/node")
 }
 
 /// Construct a request to query node tcp listeners
-pub(crate) fn list_tcp_listeners() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_tcp_listeners() -> RequestBuilder<()> {
     Request::get("/node/tcp/listener")
 }
 
 /// Construct a request to create node tcp connection
 pub(crate) fn create_tcp_connection(
     cmd: &crate::tcp::connection::CreateCommand,
-) -> RequestBuilder<'static, models::transport::CreateTcpConnection> {
+) -> RequestBuilder<models::transport::CreateTcpConnection> {
     let payload = models::transport::CreateTcpConnection::new(cmd.address.clone());
 
     Request::post("/node/tcp/connection").body(payload)
 }
 
 /// Construct a request to print a list of services for the given node
-pub(crate) fn list_services() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_services() -> RequestBuilder<()> {
     Request::get("/node/services")
 }
 
 /// Construct a request to print a list of inlets for the given node
-pub(crate) fn list_inlets() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_inlets() -> RequestBuilder<()> {
     Request::get("/node/inlet")
 }
 
 /// Construct a request to print a list of outlets for the given node
-pub(crate) fn list_outlets() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_outlets() -> RequestBuilder<()> {
     Request::get("/node/outlet")
 }
 
 /// Construct a request builder to list all secure channels on the given node
-pub(crate) fn list_secure_channels() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_secure_channels() -> RequestBuilder<()> {
     Request::get("/node/secure_channel")
 }
 
 /// Construct a request builder to list all workers on the given node
-pub(crate) fn list_workers() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_workers() -> RequestBuilder<()> {
     Request::get("/node/workers")
 }
 
 pub(crate) fn delete_secure_channel(
     addr: &Address,
-) -> RequestBuilder<'static, models::secure_channel::DeleteSecureChannelRequest<'static>> {
+) -> RequestBuilder<models::secure_channel::DeleteSecureChannelRequest> {
     let payload = models::secure_channel::DeleteSecureChannelRequest::new(addr);
     Request::delete("/node/secure_channel").body(payload)
 }
 
 pub(crate) fn show_secure_channel(
     addr: &Address,
-) -> RequestBuilder<'static, models::secure_channel::ShowSecureChannelRequest<'static>> {
+) -> RequestBuilder<models::secure_channel::ShowSecureChannelRequest> {
     let payload = models::secure_channel::ShowSecureChannelRequest::new(addr);
     Request::get("/node/show_secure_channel").body(payload)
 }
@@ -116,13 +116,13 @@ pub(crate) fn create_secure_channel_listener(
 }
 
 /// Construct a request to list Secure Channel Listeners
-pub(crate) fn list_secure_channel_listener() -> RequestBuilder<'static, ()> {
+pub(crate) fn list_secure_channel_listener() -> RequestBuilder<()> {
     Request::get("/node/secure_channel_listener")
 }
 
 pub(crate) fn delete_secure_channel_listener(
     addr: &Address,
-) -> RequestBuilder<'static, models::secure_channel::DeleteSecureChannelListenerRequest<'static>> {
+) -> RequestBuilder<models::secure_channel::DeleteSecureChannelListenerRequest> {
     let payload = models::secure_channel::DeleteSecureChannelListenerRequest::new(addr);
     Request::delete("/node/secure_channel_listener").body(payload)
 }
@@ -130,21 +130,19 @@ pub(crate) fn delete_secure_channel_listener(
 /// Construct a request to show Secure Channel Listener
 pub(crate) fn show_secure_channel_listener(
     addr: &Address,
-) -> RequestBuilder<'static, models::secure_channel::ShowSecureChannelListenerRequest<'static>> {
+) -> RequestBuilder<models::secure_channel::ShowSecureChannelListenerRequest> {
     let payload = models::secure_channel::ShowSecureChannelListenerRequest::new(addr);
     Request::get("/node/show_secure_channel_listener").body(payload)
 }
 
 /// Construct a request to start a Hop Service
-pub(crate) fn start_hop_service(addr: &str) -> RequestBuilder<'static, StartHopServiceRequest> {
+pub(crate) fn start_hop_service(addr: &str) -> RequestBuilder<StartHopServiceRequest> {
     let payload = StartHopServiceRequest::new(addr);
     Request::post(node_service(DefaultAddress::HOP_SERVICE)).body(payload)
 }
 
 /// Construct a request to start an Identity Service
-pub(crate) fn start_identity_service(
-    addr: &str,
-) -> RequestBuilder<'static, StartIdentityServiceRequest> {
+pub(crate) fn start_identity_service(addr: &str) -> RequestBuilder<StartIdentityServiceRequest> {
     let payload = StartIdentityServiceRequest::new(addr);
     Request::post(node_service(DefaultAddress::IDENTITY_SERVICE)).body(payload)
 }
@@ -152,52 +150,49 @@ pub(crate) fn start_identity_service(
 /// Construct a request to start an Authenticated Service
 pub(crate) fn start_authenticated_service(
     addr: &str,
-) -> RequestBuilder<'static, StartAuthenticatedServiceRequest> {
+) -> RequestBuilder<StartAuthenticatedServiceRequest> {
     let payload = StartAuthenticatedServiceRequest::new(addr);
     Request::post(node_service(DefaultAddress::AUTHENTICATED_SERVICE)).body(payload)
 }
 
 /// Construct a request to start a Verifier Service
-pub(crate) fn start_verifier_service(addr: &str) -> RequestBuilder<'static, StartVerifierService> {
+pub(crate) fn start_verifier_service(addr: &str) -> RequestBuilder<StartVerifierService> {
     let payload = StartVerifierService::new(addr);
     Request::post(node_service(DefaultAddress::VERIFIER)).body(payload)
 }
 
 /// Construct a request to start a Credential Service
-pub(crate) fn start_credentials_service<'a>(
-    public_identity: &'a str,
-    addr: &'a str,
+pub(crate) fn start_credentials_service(
+    public_identity: &str,
+    addr: &str,
     oneway: bool,
-) -> RequestBuilder<'static, StartCredentialsService<'a>> {
+) -> RequestBuilder<StartCredentialsService> {
     let payload = StartCredentialsService::new(public_identity, addr, oneway);
     Request::post(node_service(DefaultAddress::CREDENTIALS_SERVICE)).body(payload)
 }
 
 /// Construct a request to start an Authenticator Service
-pub(crate) fn start_authenticator_service<'a>(
-    addr: &'a str,
-    project: &'a str,
-) -> RequestBuilder<'static, StartAuthenticatorRequest<'a>> {
+pub(crate) fn start_authenticator_service(
+    addr: &str,
+    project: &str,
+) -> RequestBuilder<StartAuthenticatorRequest> {
     let payload = StartAuthenticatorRequest::new(addr, project.as_bytes());
     Request::post(node_service(DefaultAddress::DIRECT_AUTHENTICATOR)).body(payload)
 }
 
-pub(crate) fn add_consumer(
-    id: FlowControlId,
-    address: MultiAddr,
-) -> RequestBuilder<'static, AddConsumer> {
+pub(crate) fn add_consumer(id: FlowControlId, address: MultiAddr) -> RequestBuilder<AddConsumer> {
     let payload = AddConsumer::new(id, address);
     Request::post("/node/flow_controls/add_consumer").body(payload)
 }
 
 pub(crate) fn start_okta_service(
-    cfg: &'_ OktaIdentityProviderConfig,
-) -> RequestBuilder<'static, StartOktaIdentityProviderRequest<'_>> {
+    cfg: &OktaIdentityProviderConfig,
+) -> RequestBuilder<StartOktaIdentityProviderRequest> {
     let payload = StartOktaIdentityProviderRequest::new(
         &cfg.address,
         &cfg.tenant_base_url,
         &cfg.certificate,
-        cfg.attributes.iter().map(|s| s as &str).collect(),
+        cfg.attributes.clone(),
         cfg.project.as_bytes(),
     );
     Request::post(format!(
@@ -220,10 +215,10 @@ pub(crate) mod credentials {
         Request::post("/node/credentials/actions/present").body(b)
     }
 
-    pub(crate) fn get_credential<'r>(
+    pub(crate) fn get_credential(
         overwrite: bool,
         identity_name: Option<String>,
-    ) -> RequestBuilder<'r, GetCredentialRequest> {
+    ) -> RequestBuilder<GetCredentialRequest> {
         let b = GetCredentialRequest::new(overwrite, identity_name);
         Request::post("/node/credentials/actions/get").body(b)
     }
@@ -240,16 +235,12 @@ pub mod enroll {
 
     use super::*;
 
-    pub fn auth0<'a>(
+    pub fn auth0(
         route: &MultiAddr,
         token: Auth0Token,
-    ) -> RequestBuilder<'a, CloudRequestWrapper<'a, AuthenticateAuth0Token>> {
+    ) -> RequestBuilder<CloudRequestWrapper<AuthenticateAuth0Token>> {
         let token = AuthenticateAuth0Token::new(token);
-        Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(
-            token,
-            route,
-            None::<CowStr>,
-        ))
+        Request::post("v0/enroll/auth0").body(CloudRequestWrapper::new(token, route, None))
     }
 }
 
@@ -261,30 +252,26 @@ pub(crate) mod space {
 
     use super::*;
 
-    pub(crate) fn create(cmd: &CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
-        let b = CreateSpace::new(&cmd.name, &cmd.admins);
-        Request::post("v0/spaces").body(CloudRequestWrapper::new(
-            b,
-            &CloudOpts::route(),
-            None::<CowStr>,
-        ))
+    pub(crate) fn create(cmd: CreateCommand) -> RequestBuilder<CloudRequestWrapper<CreateSpace>> {
+        let b = CreateSpace::new(cmd.name, cmd.admins);
+        Request::post("v0/spaces").body(CloudRequestWrapper::new(b, &CloudOpts::route(), None))
     }
 
     pub(crate) fn list(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::get("v0/spaces").body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn show<'a>(
+    pub(crate) fn show(
         id: &str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::get(format!("v0/spaces/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn delete<'a>(
+    pub(crate) fn delete(
         id: &str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::delete(format!("v0/spaces/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 }
@@ -295,16 +282,16 @@ pub(crate) mod project {
 
     use super::*;
 
-    pub(crate) fn create<'a>(
-        project_name: &'a str,
-        space_id: &'a str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, CloudRequestWrapper<'a, CreateProject<'a>>> {
-        let b = CreateProject::new::<&str, &str>(project_name, &[]);
+    pub(crate) fn create(
+        project_name: &str,
+        space_id: &str,
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<CloudRequestWrapper<CreateProject>> {
+        let b = CreateProject::new(project_name.to_string(), vec![]);
         Request::post(format!("v1/spaces/{space_id}/projects")).body(CloudRequestWrapper::new(
             b,
             cloud_route,
-            None::<CowStr>,
+            None,
         ))
     }
 
@@ -312,18 +299,18 @@ pub(crate) mod project {
         Request::get("v0/projects").body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn show<'a>(
+    pub(crate) fn show(
         id: &str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::get(format!("v0/projects/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 
-    pub(crate) fn delete<'a>(
-        space_id: &'a str,
-        project_id: &'a str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+    pub(crate) fn delete(
+        space_id: &str,
+        project_id: &str,
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::delete(format!("v0/projects/{space_id}/{project_id}"))
             .body(CloudRequestWrapper::bare(cloud_route))
     }
@@ -333,10 +320,10 @@ pub(crate) mod project {
 pub(crate) mod operation {
     use super::*;
 
-    pub(crate) fn show<'a>(
+    pub(crate) fn show(
         id: &str,
-        cloud_route: &'a MultiAddr,
-    ) -> RequestBuilder<'a, BareCloudRequestWrapper<'a>> {
+        cloud_route: &MultiAddr,
+    ) -> RequestBuilder<BareCloudRequestWrapper> {
         Request::get(format!("v1/operations/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -287,7 +287,7 @@ impl<'a> OrchestratorApi<'a> {
 
         info!("Response is OK!");
 
-        self.rpc.parse_response()
+        self.rpc.parse_response_body()
     }
 
     pub async fn request<T>(&mut self, req: RequestBuilder<T>) -> Result<()>

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -1,26 +1,25 @@
-use cli_table::{Cell, Style, Table};
 use core::fmt::Write;
+
+use cli_table::{Cell, Style, Table};
+use colorful::Colorful;
 use miette::miette;
 use miette::IntoDiagnostic;
-use ockam_api::cli_state::{StateItemTrait, VaultState};
 
 use ockam::identity::credential::Credential;
-
+use ockam_api::cli_state::{StateItemTrait, VaultState};
 use ockam_api::cloud::project::Project;
-
-use ockam_api::nodes::models::portal::{InletStatus, OutletStatus};
-
-use crate::project::ProjectInfo;
-use crate::terminal::OckamColor;
-use crate::util::comma_separated;
-use crate::Result;
-use colorful::Colorful;
 use ockam_api::cloud::space::Space;
+use ockam_api::nodes::models::portal::{InletStatus, OutletStatus};
 use ockam_api::nodes::models::secure_channel::{
     CreateSecureChannelResponse, ShowSecureChannelResponse,
 };
 use ockam_api::route_to_multiaddr;
 use ockam_core::{route, Route};
+
+use crate::project::ProjectInfo;
+use crate::terminal::OckamColor;
+use crate::util::comma_separated;
+use crate::Result;
 
 /// Trait to control how a given type will be printed as a CLI output.
 ///
@@ -60,7 +59,7 @@ impl<O: Output> Output for &O {
     }
 }
 
-impl Output for Space<'_> {
+impl Output for Space {
     fn output(&self) -> Result<String> {
         let mut w = String::new();
         write!(w, "Space").into_diagnostic()?;
@@ -92,7 +91,7 @@ impl Output for Space<'_> {
     }
 }
 
-impl Output for Vec<Space<'_>> {
+impl Output for Vec<Space> {
     fn output(&self) -> Result<String> {
         if self.is_empty() {
             return Ok("No spaces found".to_string());
@@ -219,7 +218,7 @@ impl Output for CreateSecureChannelResponse {
     }
 }
 
-impl Output for ShowSecureChannelResponse<'_> {
+impl Output for ShowSecureChannelResponse {
     fn output(&self) -> Result<String> {
         let s = match &self.channel {
             Some(addr) => {
@@ -231,13 +230,13 @@ impl Output for ShowSecureChannelResponse<'_> {
                         .to_string()
                         .light_yellow(),
                     "  •         To: ".light_magenta(),
-                    self.route.as_ref().unwrap().light_yellow(),
+                    self.route.clone().unwrap().light_yellow(),
                     "  • Authorized: ".light_magenta(),
                     self.authorized_identifiers
                         .as_ref()
-                        .unwrap_or(&Vec::<ockam_core::CowStr>::from(["none".into()]))
+                        .unwrap_or(&vec!["none".to_string()])
                         .iter()
-                        .map(|id| id.light_yellow().to_string())
+                        .map(|id| id.clone().light_yellow().to_string())
                         .collect::<Vec<String>>()
                         .join("\n\t")
                 )

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -80,7 +80,7 @@ async fn run_impl(
     Ok(())
 }
 
-impl Output for WorkerStatus<'_> {
+impl Output for WorkerStatus {
     fn output(&self) -> crate::Result<String> {
         Ok(format!(
             "Worker {}",

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -54,7 +54,7 @@ async fn run_impl(
         rpc.request(api::list_workers()).await?;
 
         *is_finished.lock().await = true;
-        rpc.parse_response::<WorkerList>()
+        rpc.parse_response_body::<WorkerList>()
     };
 
     let output_messages = vec![format!(

--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -89,7 +89,7 @@ pub struct Request {
     /// The request identifier.
     #[n(1)] id: Id,
     /// The resource path.
-    #[b(2)] path: String,
+    #[n(2)] path: String,
     /// The request method.
     ///
     /// It is wrapped in an `Option` to be forwards compatible, i.e. adding
@@ -476,11 +476,11 @@ pub struct Error {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5359172>,
     /// The resource path of this error.
-    #[b(1)] path: Option<String>,
+    #[n(1)] path: Option<String>,
     /// The request method of this error.
     #[n(2)] method: Option<Method>,
     /// The actual error message.
-    #[b(3)] message: Option<String>,
+    #[n(3)] message: Option<String>,
     /// The cause of the error, if any.
     #[b(4)] cause: Option<Box<Error>>,
 

--- a/implementations/rust/ockam/ockam_identity/src/credential/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credential/credential.rs
@@ -22,10 +22,10 @@ pub struct Credential {
     #[n(0)] tag: TypeTag<3796735>,
     /// CBOR-encoded [`CredentialData`].
     #[cbor(with = "minicbor::bytes")]
-    #[b(1)] pub data: Vec<u8>,
+    #[n(1)] pub data: Vec<u8>,
     /// Cryptographic signature of attributes data.
     #[cbor(with = "minicbor::bytes")]
-    #[b(2)] pub signature: Vec<u8>,
+    #[n(2)] pub signature: Vec<u8>,
 }
 
 impl Credential {

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
@@ -44,7 +44,7 @@ impl CredentialsServerWorker {
     async fn handle_request(
         &mut self,
         ctx: &mut Context,
-        req: &Request<'_>,
+        req: &Request,
         sender: IdentityIdentifier,
         dec: &mut Decoder<'_>,
     ) -> Result<Vec<u8>> {

--- a/implementations/rust/ockam/ockam_node/src/api.rs
+++ b/implementations/rust/ockam/ockam_node/src/api.rs
@@ -1,18 +1,20 @@
 #![allow(missing_docs)]
 
-use crate::{Context, MessageSendReceiveOptions};
 use core::fmt::Display;
+
 use minicbor::Encode;
+
 use ockam_core::api::RequestBuilder;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{LocalInfo, Result, Route};
-
 #[cfg(feature = "tag")]
 use {
     cddl_cat::context::BasicContext,
     ockam_core::api::{assert_request_match, merged_cddl},
     once_cell::race::OnceBox,
 };
+
+use crate::{Context, MessageSendReceiveOptions};
 
 #[cfg(feature = "tag")]
 pub fn cddl() -> &'static BasicContext {
@@ -26,7 +28,7 @@ pub async fn request<T>(
     label: &str,
     #[allow(unused_variables)] struct_name: impl Into<Option<&str>>,
     route: impl Into<Route> + Display,
-    req: RequestBuilder<'_, T>,
+    req: RequestBuilder<T>,
 ) -> Result<Vec<u8>>
 where
     T: Encode<()>,
@@ -48,7 +50,7 @@ pub async fn request_with_options<T>(
     label: &str,
     #[allow(unused_variables)] struct_name: impl Into<Option<&str>>,
     route: impl Into<Route> + Display,
-    req: RequestBuilder<'_, T>,
+    req: RequestBuilder<T>,
     options: MessageSendReceiveOptions,
 ) -> Result<Vec<u8>>
 where
@@ -80,7 +82,7 @@ pub async fn request_with_local_info<T>(
     label: &str,
     #[allow(unused_variables)] struct_name: impl Into<Option<&str>>,
     route: impl Into<Route> + Display,
-    req: RequestBuilder<'_, T>,
+    req: RequestBuilder<T>,
 ) -> Result<(Vec<u8>, Vec<LocalInfo>)>
 where
     T: Encode<()>,

--- a/implementations/rust/ockam/ockam_node/src/rpc_client.rs
+++ b/implementations/rust/ockam/ockam_node/src/rpc_client.rs
@@ -47,7 +47,7 @@ impl RpcClient {
     }
 
     /// Encode request header and body (if any) and send the package to the server.
-    pub async fn request<T, R>(&self, req: &RequestBuilder<'_, T>) -> Result<R>
+    pub async fn request<T, R>(&self, req: &RequestBuilder<T>) -> Result<R>
     where
         T: Encode<()>,
         R: for<'a> Decode<'a, ()>,
@@ -70,7 +70,7 @@ impl RpcClient {
     }
 
     /// Encode request header and body (if any) and send the package to the server.
-    pub async fn request_no_resp_body<T>(&self, req: &RequestBuilder<'_, T>) -> Result<()>
+    pub async fn request_no_resp_body<T>(&self, req: &RequestBuilder<T>) -> Result<()>
     where
         T: Encode<()>,
     {


### PR DESCRIPTION
This PR refactors the enroll functionality from the desktop app by calling directly the `NodeManager` for:

 - getting the user space and creating one if there is none
 - getting the user project and creating one if there is none

### `NodeManager` API

Some functions of the `NodeManager` are now more directly accessible. For example the `create_space` function can now be called without having to start decoding a `Response`:

```rust
pub async fn create_space(
    &self,
    ctx: &Context,
    req: CreateSpace,
    route: &MultiAddr,
    identity_name: Option<String>,
) -> Result<Space> {
    Response::parse_response(
        self.create_space_response(ctx, CloudRequestWrapper::new(req, route, identity_name)).await?
    )
}

pub(crate) async fn create_space_response(
    &self,
    ctx: &Context,
    req_wrapper: CloudRequestWrapper<CreateSpace>,
) -> Result<Vec<u8>> {
....
```

That function delegates its implementation to `create_space_response` which creates a space by making a request to the controller and returning the response as a list of bytes. 

The `create_space_response` function is convenient for implementing the routing API of a `NodeManager` since we don't need to decode the response, we can just forward it as `Vec<u8>`:
```rust
(Post, ["v0", "spaces"]) => self.create_space_response(ctx, dec.decode()?).await?,
```

#### Generalization

The approach above has been implemented for the "space" and "project" parts of the `NodeManager` API but should be generalized so that:

 - all the routes are implementing this approach: to list workers, create policies etc...
 - we can define a `NodeManagerApi` trait defining all the `NodeManager` functions (and maybe different traits for different domains)
 - we can create a `NodeManagerClient` struct implementing the `NodeManagerApi` trait and implement it by creating requests, then decoding responses. This way we will be able to interact with a remote node using a well-typed and consistent API
 - all functions of the desktop app can access the `NodeManagerApi` directly without having to create any request
 - possibly the use for an "embedded node" in the `ockam_command` crate disappears since the `NodeManager` can be used directly

### Decoding responses

In order to introduce reusable `NodeManager` functions I had to:

 1. move some utility functions to the [`Response` struct](https://github.com/build-trust/ockam/compare/etorreborre/refactoring/leaner-enroll?expand=1#diff-1956a8258c1f4f6fe6f14fe58aace63355c293b7a09192ea689f90fdf888c087R131) (to parse the response status and body)
 
The `Response` API is not really great (for example `is_ok()` does not return a `bool`) but I haven't tried to improve it much for now.

 2. change the constraints on [`parse_response`](https://github.com/build-trust/ockam/compare/etorreborre/refactoring/leaner-enroll?expand=1#diff-1956a8258c1f4f6fe6f14fe58aace63355c293b7a09192ea689f90fdf888c087R133). It now requires a `T: for<'a> Decode<'a, ()>` (instead of just `Decode<'a, ()>`)

 3. fix the derived `Decode` instances for all the data types used in the API for the `NodeManager`. Because of the change in 2. the  lifetime polymorphic (I removed their `<'a>` parameter) structs cannot have a general enough `Decode` instance. 
 
So I simplified those data types to avoid them being lifetime polymorphic. The impact is more allocations but I couldn't find another way to make this work. In the end, I think this is a reasonable trade-off if we get more flexibility and modularity. That being said I'm all ears if someone can find a way to get the best of both worlds