### PR TITLE
lint rust docs in docs.ockam.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ on:
         description: SHA to build Ockam command CLI
       ockam_crate_version_to_test_with_docs_examples:
         description: Ockam crate version to tests docs.ockam.io library examples
+      ockam_docs_ref:
+        description: SHA or branch to run ockam docs test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -456,3 +458,27 @@ jobs:
       - name: Run Ockam Examples
         working-directory: ockam_examples
         run: cargo test -p hello_ockam
+
+  lint_docs_ockam_io_rust_examples:
+    name: Rust - lint_docs_ockam_io_rust_examples
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/build-trust/ockam-builder@sha256:5ab42598e35509cad3ea9c1e1bd0ed135ed1340c6ae44b762b1c8bbec31d5c68
+
+    steps:
+      - name: Checkout Ockam Repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: ${{ inputs.commit_sha }}
+          path: ockam
+
+      - name: Checkout Ockam Documentation Repository
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: ${{ inputs.ockam_docs_ref == '' && 'develop' || inputs.ockam_docs_ref }}
+          repository: build-trust/ockam-documentation
+          path: ockam-documentation
+
+      - name: Check Rust Documentation
+        run: |
+          CHECK_MD_DIR="ockam-documentation/reference/libraries/rust" CHECK_MD_DIR_RUST_EXAMPLE="ockam/examples/rust/get_started" OCKAM_HOME="ockam" ockam/tools/docs/check_documentation.sh

--- a/examples/rust/get_started/examples/vault-and-identities.rs
+++ b/examples/rust/get_started/examples/vault-and-identities.rs
@@ -1,0 +1,14 @@
+use ockam::node;
+use ockam::{Context, Result};
+
+#[ockam::node]
+async fn main(ctx: Context) -> Result<()> {
+    // Create default node to safely store secret keys for Alice
+    let mut node = node(ctx);
+
+    // Create an Identity to represent Alice.
+    let _alice = node.create_identity().await?;
+
+    // Stop the node.
+    node.stop().await
+}

--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -144,3 +144,14 @@ fn run_hello() -> Result<(), Error> {
     assert!(stdout.contains("App Received: Hello Ockam!"));
     Ok(())
 }
+
+#[test]
+#[serial]
+fn vault_and_identity() -> Result<(), Error> {
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --example vault-and-identities").run()?;
+
+    // Assert successful run conditions
+    assert_eq!(Some(0), exitcode);
+    assert!(stdout.contains("No more workers left.  Goodbye!"));
+    Ok(())
+}

--- a/tools/docs/check_documentation.sh
+++ b/tools/docs/check_documentation.sh
@@ -1,36 +1,13 @@
 #!/usr/bin/env bash
-
+set -e
 if [ -z "$OCKAM_HOME" ]; then
   echo "Please set OCKAM_HOME to the repo root"
   exit 1
 fi
 
-# Getting Started Guide
-export GUIDE_DOCS="$OCKAM_HOME/documentation/guides/rust"
-export GUIDE_EXAMPLES="$OCKAM_HOME/examples/rust/get_started/examples"
-
 # Hello Ockam ReadMe
 export HELLO_DOC="$OCKAM_HOME/README.md"
 export HELLO_EXAMPLE="$OCKAM_HOME/examples/rust/get_started/examples"
-
-# Kafka
-export KAFKA_DOCS="$OCKAM_HOME/documentation/use-cases/end-to-end-encryption-through-kafka"
-export KAFKA_EXAMPLES="$OCKAM_HOME/examples/rust/ockam_kafka/examples"
-
-# E2E
-export E2E_DOCS="$OCKAM_HOME/documentation/use-cases/end-to-end-encryption-with-rust"
-export E2E_EXAMPLES="$OCKAM_HOME/examples/rust/get_started/examples" # TODO
-
-# documentation/use-cases/secure-remote-access-tunnels
-export INLET_DOCS="$OCKAM_HOME/documentation/use-cases/secure-remote-access-tunnels"
-export INLET_EXAMPLES="$OCKAM_HOME/examples/rust/tcp_inlet_and_outlet/examples"
-
-# documentation/use-cases/end-to-end-encrypt-all-application-layer-communication
-export E2EAALC_DOCS="$OCKAM_HOME/documentation/use-cases/end-to-end-encrypt-all-application-layer-communication"
-export E2EAALC_EXAMPLES="$OCKAM_HOME/examples/rust/tcp_inlet_and_outlet/examples"
-
-# documentation/use-cases/run-ockam-on-riscv
-# This documentation is not using compiled code, it could drift from the current Ockam API.
 
 # Tools home
 export TOOLS_DIR="$OCKAM_HOME/tools/docs"
@@ -48,7 +25,7 @@ ERR=0
 function check_directory {
   doc_dir=$1
   dir=$2
-  for page in $(find "$doc_dir" -name README.md); do
+  for page in $(find "$doc_dir" -name "*.md"); do
     check_readme "$page" "$dir"
   done
 }
@@ -63,13 +40,15 @@ function check_readme {
   fi
 }
 
-check_directory "$GUIDE_DOCS" "$GUIDE_EXAMPLES"
-check_directory "$KAFKA_DOCS" "$KAFKA_EXAMPLES"
-check_directory "$E2E_DOCS" "$E2E_EXAMPLES"
-check_directory "$INLET_DOCS" "$INLET_EXAMPLES"
-check_directory "$E2EAALC_DOCS" "$E2EAALC_EXAMPLES"
-
 check_readme "$HELLO_DOC" "$HELLO_EXAMPLE"
+
+if [[ -n $CHECK_MD_FILE && -n $CHECK_MD_DIR_RUST_EXAMPLE ]]; then
+  check_readme "$CHECK_MD_FILE" "$CHECK_MD_DIR_RUST_EXAMPLE"
+fi
+
+if [[ -n $CHECK_MD_DIR && -n $CHECK_MD_DIR_RUST_EXAMPLE ]]; then
+  check_directory "$CHECK_MD_DIR" "$CHECK_MD_DIR_RUST_EXAMPLE"
+fi
 
 if [[ $ERR -eq 0 ]]; then
   echo "All okay"


### PR DESCRIPTION
This PR allows us check Rust code documentation in the docs.ockam.io website ensuring they are same with Rust example in this repository