### PR TITLE
fix(rust): print number of rekeys correctly

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/key_tracker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/key_tracker.rs
@@ -41,7 +41,7 @@ impl KeyTracker {
     pub(crate) fn get_key(&self, nonce: u64) -> Result<Option<KeyId>> {
         debug!(
             "The current number of rekeys is {}, the rekey interval is {}",
-            self.current_key, self.renewal_interval
+            self.number_of_rekeys, self.renewal_interval
         );
 
         // for example 2 rekeys happened, renewal every 10 keys


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->
#### Fixes #5416

## Current behavior
The `DEBUG` message informing about rekeys is incorrect:

```
[ockam_identity::secure_channel::key_tracker][DEBUG] The current number of rekeys is 2072b15a0f7e9af6, the rekey interval is 32
```

It show the current key id instead of the current number of rekeys.

## Proposed changes
The `DEBUG` message has been modified to use `self.number_of_rekeys` instead of `self.current_key`.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
