### PR TITLE
feat(rust): add popup window to tcp-outlet/service creation

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -26,7 +26,7 @@ pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
     if let SystemTrayEvent::MenuItemClick { id, .. } = event {
         let result = match id.as_str() {
             enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
-            tcp::outlet::TCP_OUTLET_CREATE_MENU_ID => tcp::outlet::on_create(app),
+            tcp::outlet::SERVICE_CREATE_MENU_ID => tcp::outlet::on_create(app),
             options::RESET_MENU_ID => options::on_reset(app),
             options::QUIT_MENU_ID => options::on_quit(),
             _ => Ok(()),

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -5,6 +5,7 @@ use others as platform;
 
 use crate::app::{configure_tauri_plugin_log, process_application_event, setup_app, AppState};
 use crate::error::Result;
+use tcp::outlet::tcp_outlet_create;
 
 mod app;
 mod enroll;
@@ -24,6 +25,7 @@ pub fn run() {
         .plugin(configure_tauri_plugin_log())
         .setup(move |app| setup_app(app))
         .manage(AppState::new())
+        .invoke_handler(tauri::generate_handler![tcp_outlet_create])
         .build(tauri::generate_context!())
         .expect("Error while building the Ockam application");
 

--- a/implementations/rust/ockam/ockam_app/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/tcp/outlet/create.rs
@@ -1,32 +1,32 @@
+use ockam_command::util::extract_address_value;
 use tauri::{AppHandle, Manager, Wry};
-use tracing::error;
-use tracing::log::info;
-
-use ockam_command::tcp;
-use ockam_command::util::{extract_address_value, get_free_address};
+use tracing::{error, info};
 
 use crate::app::AppState;
-use crate::Result;
+use crate::tcp::outlet::SERVICE_WINDOW_ID;
 
 /// Create a TCP outlet within the default node.
-pub async fn tcp_outlet_create(app: &AppHandle<Wry>) -> Result<()> {
-    info!("creating an outlet");
+#[tauri::command]
+pub async fn tcp_outlet_create(
+    app: AppHandle<Wry>,
+    service: String,
+    port: String,
+) -> tauri::Result<()> {
+    info!(%service, %port, "Creating an outlet");
     let state = app.state::<AppState>();
-    let to = get_free_address()?.to_string();
-    let from = {
-        let from = tcp::outlet::create::default_from_addr();
-        extract_address_value(&from)?
-    };
-
+    let tcp_addr = format!("127.0.0.1:{port}")
+        .parse()
+        .expect("Invalid IP address");
+    let worker_addr = extract_address_value(&service).expect("Invalid service address");
     let mut node_manager = state.node_manager.get().write().await;
     let res = node_manager
-        .create_outlet(&state.context(), to, from, None, true)
+        .create_outlet(&state.context(), tcp_addr, worker_addr, None, true)
         .await;
     match res {
         Err(e) => error!("{:?}", e),
         Ok(s) => info!("the outlet status is {:?}", s),
     }
-
+    app.get_window(SERVICE_WINDOW_ID).map(|w| w.close());
     app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
@@ -1,17 +1,17 @@
 use crate::app::AppState;
-use crate::tcp::outlet::tcp_outlet_create;
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 
-pub const TCP_OUTLET_HEADER_MENU_ID: &str = "tcp_outlet_header";
-pub const TCP_OUTLET_CREATE_MENU_ID: &str = "tcp_outlet_create";
+pub const SERVICE_HEADER_MENU_ID: &str = "service_outlet_header";
+pub const SERVICE_CREATE_MENU_ID: &str = "service_outlet_create";
+pub const SERVICE_WINDOW_ID: &str = "service_creation";
 
 pub(crate) async fn build_outlets_section(
     app_state: &AppState,
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
     let mut tm = tray_menu
-        .add_item(CustomMenuItem::new(TCP_OUTLET_HEADER_MENU_ID, "TCP Outlets").disabled())
-        .add_item(CustomMenuItem::new(TCP_OUTLET_CREATE_MENU_ID, "Create..."));
+        .add_item(CustomMenuItem::new(SERVICE_HEADER_MENU_ID, "Shared services").disabled())
+        .add_item(CustomMenuItem::new(SERVICE_CREATE_MENU_ID, "Create..."));
     for outlet in app_state.tcp_outlet_list().await {
         let outlet_info = format!(
             "{} to {}",
@@ -26,7 +26,11 @@ pub(crate) async fn build_outlets_section(
 
 /// Event listener for the "Create..." menu item
 pub fn on_create(app: &AppHandle<Wry>) -> tauri::Result<()> {
-    let app = app.clone();
-    tauri::async_runtime::spawn(async move { tcp_outlet_create(&app).await });
+    tauri::WindowBuilder::new(
+        app,
+        SERVICE_WINDOW_ID,
+        tauri::WindowUrl::App("service".into()),
+    )
+    .build()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_core/src/api.rs
+++ b/implementations/rust/ockam/ockam_core/src/api.rs
@@ -959,7 +959,7 @@ mod schema_test {
     ];
 
     #[derive(Debug, Clone)]
-    struct Req(Request<'static>);
+    struct Req(Request);
 
     #[derive(Debug, Clone)]
     struct Res(Response);

--- a/implementations/typescript/ockam/ockam_app/build/.gitkeep
+++ b/implementations/typescript/ockam/ockam_app/build/.gitkeep
@@ -1,2 +1,1 @@
-# This file has been added to the repository so that cargo build works at the top-level
-git
+# This file has been added to the repository so that cargo build works at the top-level git

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/+layout.ts
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true
+export const ssr = false

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/+page.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import ServiceCreate from './ServiceCreate.svelte'
+</script>
+
+<ServiceCreate />

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { invoke } from '@tauri-apps/api/tauri';
+
+  let service = "/service/outlet";
+  let port = "10000";
+
+  async function submit() {
+    await invoke('tcp_outlet_create', {service: service, port: port});
+  }
+</script>
+
+<div>
+  <h1>Service details</h1>
+  <div>
+    <label for="name">Service that you want to share:</label>
+    <div>
+      <input id="name" placeholder="{service}" bind:value="{service}" />
+    </div>
+  </div>
+  <div>
+    <label for="name">Service port:</label>
+    <div>
+      <input id="port" placeholder="{port}" bind:value="{port}" />
+    </div>
+  </div>
+  <button on:click="{submit}">Create</button>
+</div>
+
+<style>
+</style>


### PR DESCRIPTION
When clicking the `Create...` button it will open a popup window to input the tcp outlet details (port and service name). The popup window will be closed after clicking the `Create` button.