### PR TITLE
Display user information

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
 
-#[derive(Encode, Decode, Serialize, Deserialize, Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[cbor(transparent)]
 #[serde(transparent)]
 pub struct Token(#[n(0)] pub String);
@@ -25,7 +25,7 @@ mod node {
     use tracing::trace;
 
     use ockam::identity::credential::Attributes;
-    use ockam_core::api::{Request, Response};
+    use ockam_core::api::Request;
     use ockam_core::{self, Result};
     use ockam_multiaddr::MultiAddr;
     use ockam_node::Context;
@@ -46,9 +46,8 @@ mod node {
             token: Auth0Token,
         ) -> Result<()> {
             let request = CloudRequestWrapper::new(AuthenticateAuth0Token::new(token), route, None);
-            Response::parse_response_body(
-                self.enroll_auth0_response(ctx, request).await?.as_slice(),
-            )
+            self.enroll_auth0_response(ctx, request).await?;
+            Ok(())
         }
 
         /// Executes an enrollment process to generate a new set of access tokens using the auth0 flow.
@@ -176,15 +175,15 @@ pub mod auth0 {
         pub error_description: Cow<'a, str>,
     }
 
-    #[derive(serde::Deserialize, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+    #[derive(serde::Deserialize, Debug, Clone)]
+    #[cfg_attr(test, derive(PartialEq, Eq))]
     pub struct Auth0Token {
         pub token_type: TokenType,
         pub access_token: Token,
     }
 
-    #[derive(serde::Deserialize, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+    #[derive(serde::Deserialize, Debug, Clone)]
+    #[cfg_attr(test, derive(PartialEq, Eq))]
     pub struct UserInfo {
         pub sub: String,
         pub nickname: String,
@@ -219,8 +218,8 @@ pub mod auth0 {
 
     // Auxiliary types
 
-    #[derive(serde::Deserialize, Encode, Decode, Debug)]
-    #[cfg_attr(test, derive(PartialEq, Eq, Clone))]
+    #[derive(serde::Deserialize, Encode, Decode, Debug, Clone)]
+    #[cfg_attr(test, derive(PartialEq, Eq))]
     #[rustfmt::skip]
     #[cbor(index_only)]
     pub enum TokenType {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -790,7 +790,9 @@ impl NodeManagerWorker {
             }
 
             // ==*== Enroll ==*==
-            (Post, ["v0", "enroll", "auth0"]) => self.enroll_auth0(ctx, dec.decode()?).await?,
+            (Post, ["v0", "enroll", "auth0"]) => {
+                self.enroll_auth0_response(ctx, dec.decode()?).await?
+            }
             (Get, ["v0", "enroll", "token"]) => self.generate_enrollment_token(ctx, dec).await?,
             (Put, ["v0", "enroll", "token"]) => {
                 self.authenticate_enrollment_token(ctx, dec).await?

--- a/implementations/rust/ockam/ockam_app/src/app/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/mod.rs
@@ -10,6 +10,7 @@ pub use tray_menu::*;
 mod app_state;
 pub(crate) mod events;
 mod logging;
+mod model_state;
 mod process;
 mod tray_menu;
 

--- a/implementations/rust/ockam/ockam_app/src/app/model_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/model_state.rs
@@ -1,0 +1,25 @@
+use ockam_api::cloud::enroll::auth0::UserInfo;
+
+pub struct ModelState {
+    user_info: Option<UserInfo>,
+}
+
+impl Default for ModelState {
+    fn default() -> Self {
+        ModelState::new(None)
+    }
+}
+
+impl ModelState {
+    pub fn new(user_info: Option<UserInfo>) -> Self {
+        Self { user_info }
+    }
+
+    pub fn set_user_info(&mut self, user_info: UserInfo) {
+        self.user_info = Some(user_info)
+    }
+
+    pub fn get_user_info(&self) -> Option<UserInfo> {
+        self.user_info.clone()
+    }
+}

--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -9,15 +9,10 @@ use crate::{enroll, options, tcp};
 
 pub async fn build_tray_menu(app_state: &AppState) -> SystemTrayMenu {
     let mut tray_menu = SystemTrayMenu::new();
-    if app_state.is_enrolled() {
-        tray_menu = build_outlets_section(app_state, tray_menu).await;
-        tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
-        tray_menu = build_options_section(app_state, tray_menu);
-    } else {
-        tray_menu = build_enroll_section(app_state, tray_menu);
-        tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
-        tray_menu = build_options_section(app_state, tray_menu);
-    }
+    tray_menu = build_enroll_section(app_state, tray_menu).await;
+    tray_menu = build_outlets_section(app_state, tray_menu).await;
+    tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
+    tray_menu = build_options_section(app_state, tray_menu);
     tray_menu
 }
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -42,7 +42,14 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
 
 async fn enroll_with_token(app_state: &AppState) -> Result<IdentityIdentifier> {
     // get an Auth0 token
-    let token = Auth0Service::default().get_token_with_pkce().await?;
+    let auth0_service = Auth0Service::default();
+    let token = auth0_service.get_token_with_pkce().await?;
+
+    // retrieve the user information
+    let user_info = auth0_service.get_user_info(token.clone()).await?;
+    info!("the user info is {user_info:?}");
+    app_state.set_user_info(user_info).await;
+
     // enroll the current user using that token on the controller
     let node_manager = app_state.node_manager.get().read().await;
     node_manager

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -5,10 +5,8 @@ use tracing::log::{error, info};
 use ockam::identity::IdentityIdentifier;
 use ockam_api::cli_state::traits::StateDirTrait;
 use ockam_api::cli_state::{CliState, SpaceConfig};
-use ockam_api::cloud::enroll::auth0::AuthenticateAuth0Token;
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::space::{CreateSpace, Space};
-use ockam_api::cloud::CloudRequestWrapper;
 use ockam_command::enroll::{update_enrolled_identity, Auth0Service};
 use ockam_command::util::api::CloudOpts;
 
@@ -46,15 +44,9 @@ async fn enroll_with_token(app_state: &AppState) -> Result<IdentityIdentifier> {
     // get an Auth0 token
     let token = Auth0Service::default().get_token_with_pkce().await?;
     // enroll the current user using that token on the controller
-    let request = CloudRequestWrapper::new(
-        AuthenticateAuth0Token::new(token),
-        &CloudOpts::route(),
-        None,
-    );
-
     let node_manager = app_state.node_manager.get().read().await;
     node_manager
-        .enroll_auth0(&app_state.context(), request)
+        .enroll_auth0(&app_state.context(), &CloudOpts::route(), token)
         .await
         .into_diagnostic()?;
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -1,14 +1,31 @@
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
+#[cfg(target_os = "macos")]
+use tauri_runtime::menu::NativeImage;
 
 use crate::app::AppState;
 use crate::enroll::enroll_user::enroll_user;
 
 pub const ENROLL_MENU_HEADER_ID: &str = "enroll-header";
 pub const ENROLL_MENU_ID: &str = "enroll";
+pub const ENROLL_MENU_USER_NAME: &str = "user-name";
 
-pub fn build_enroll_section(app_state: &AppState, tray_menu: SystemTrayMenu) -> SystemTrayMenu {
+pub async fn build_enroll_section(
+    app_state: &AppState,
+    tray_menu: SystemTrayMenu,
+) -> SystemTrayMenu {
     if app_state.is_enrolled() {
-        tray_menu
+        match app_state.get_user_info().await {
+            Some(user_info) => {
+                let item = CustomMenuItem::new(
+                    ENROLL_MENU_USER_NAME,
+                    format!("{} ({})", user_info.name, user_info.nickname),
+                );
+                #[cfg(target_os = "macos")]
+                let item = item.native_image(NativeImage::User);
+                tray_menu.add_item(item)
+            }
+            None => tray_menu,
+        }
     } else {
         tray_menu
             .add_item(CustomMenuItem::new(ENROLL_MENU_HEADER_ID, "Please enroll").disabled())

--- a/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
@@ -9,6 +9,10 @@ pub(crate) async fn build_outlets_section(
     app_state: &AppState,
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
+    if !app_state.is_enrolled() {
+        return tray_menu;
+    };
+
     let mut tm = tray_menu
         .add_item(CustomMenuItem::new(TCP_OUTLET_HEADER_MENU_ID, "TCP Outlets").disabled())
         .add_item(CustomMenuItem::new(TCP_OUTLET_CREATE_MENU_ID, "Create..."));


### PR DESCRIPTION
This PR displays the user information after enrollment as "Full name (github handle)"
<img width="320" alt="image" src="https://github.com/build-trust/ockam/assets/10988/621b0274-98ec-44ab-bfc8-99fe61fe84f9">

Unfortunately we are reaching the limits of the system tray in terms of graphical display. For example it would have been nice to be able to show the user avatar picture but this is not possible. 
