### PR TITLE
refactor(rust): create relay from desktop app

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -63,7 +63,8 @@ impl Instantiator for ProjectInstantiator {
             .ok_or_else(|| ApiError::message("invalid project protocol in multiaddr"))?;
 
         let mut node_manager = self.node_manager.write().await;
-        let (project_multiaddr, project_identifier) = node_manager.resolve_project(&project)?;
+        let (project_multiaddr, project_identifier) =
+            node_manager.resolve_project(&project).await?;
 
         debug!(addr = %project_multiaddr, "creating secure channel");
         let tcp = multiaddr_to_route(&project_multiaddr, &node_manager.tcp_transport)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -700,7 +700,7 @@ impl NodeManagerWorker {
             (Delete, ["node", "forwarder", remote_address]) => {
                 encode_request_result(self.delete_forwarder(ctx, req, remote_address).await)?
             }
-            (Post, ["node", "forwarder"]) => self.create_forwarder(ctx, req.id(), dec).await?,
+            (Post, ["node", "forwarder"]) => self.create_forwarder_response(ctx, req, dec).await?,
 
             // ==*== Inlets & Outlets ==*==
             (Get, ["node", "inlet"]) => self.get_inlets(req).await.to_vec()?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -701,7 +701,7 @@ impl NodeManagerWorker {
                     .cast::<ockam_multiaddr::proto::Project>()
                     .map(|p| p.to_string())
             }) {
-                let (_, project_identifier) = node_manager.resolve_project(&project)?;
+                let (_, project_identifier) = node_manager.resolve_project(&project).await?;
                 // if we are using the project we need to allow safe communication based on the
                 // project identifier
                 node_manager

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -347,8 +347,7 @@ pub mod test_utils {
     use crate::cli_state::{traits::*, CliState, IdentityConfig, NodeConfig, VaultConfig};
     use crate::config::cli::{CredentialRetrieverConfig, TrustAuthorityConfig, TrustContextConfig};
     use crate::nodes::service::{
-        NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
-        NodeManagerTrustOptions,
+        NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
     };
     use crate::nodes::{NodeManager, NodeManagerWorker, NODEMANAGER_ADDR};
 
@@ -429,7 +428,6 @@ pub mod test_utils {
         let node_manager = NodeManager::create(
             context,
             NodeManagerGeneralOptions::new(cli_state.clone(), node_name, false, None),
-            NodeManagerProjectsOptions::new(Default::default()),
             NodeManagerTransportOptions::new(
                 FlowControls::generate_flow_control_id(), // FIXME
                 tcp.async_try_clone().await?,

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -8,11 +8,9 @@ use ockam::Context;
 use ockam::{NodeBuilder, TcpListenerOptions, TcpTransport};
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use ockam_api::cloud::enroll::auth0::UserInfo;
-use ockam_api::config::lookup::ProjectLookup;
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::service::{
-    NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
-    NodeManagerTrustOptions,
+    NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
 };
 use ockam_api::nodes::{NodeManager, NodeManagerWorker};
 use ockam_command::node::util::init_node_state;
@@ -181,7 +179,7 @@ fn create_node_manager(ctx: Arc<Context>, opts: CommandGlobalOpts) -> NodeManage
 }
 
 /// Make a node manager with a default node called "default"
-async fn make_node_manager(
+pub(crate) async fn make_node_manager(
     ctx: Arc<Context>,
     opts: CommandGlobalOpts,
 ) -> miette::Result<NodeManager> {
@@ -193,9 +191,6 @@ async fn make_node_manager(
         .listen(&"127.0.0.1:0", options)
         .await
         .into_diagnostic()?;
-
-    let projects =
-        ProjectLookup::from_state(opts.state.projects.list().unwrap_or_default()).await?;
     let trust_context_config =
         TrustContextConfigBuilder::new(&opts.state, &TrustContextOpts::default())?
             .with_authority_identity(None)
@@ -205,7 +200,6 @@ async fn make_node_manager(
     let node_manager = NodeManager::create(
         &ctx,
         NodeManagerGeneralOptions::new(opts.state.clone(), NODE_NAME.to_string(), false, None),
-        NodeManagerProjectsOptions::new(projects),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -1,11 +1,12 @@
 use miette::{miette, IntoDiagnostic};
+
 use tauri::{AppHandle, Manager, State, Wry};
 use tracing::log::{error, info};
 
 use ockam::identity::IdentityIdentifier;
 use ockam_api::cli_state;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::{CliState, SpaceConfig};
+use ockam_api::cli_state::SpaceConfig;
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::space::{CreateSpace, Space};
 use ockam_command::enroll::{update_enrolled_identity, OidcService};
@@ -22,21 +23,11 @@ use crate::Result;
 ///  - connects to the Orchestrator with the retrieved token to create a project
 pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
     let app_state: State<AppState> = app.state::<AppState>();
-    if app_state.state().await.identities.default().is_err() {
-        info!("creating a default identity");
-        create_default_identity(app_state.state().await)
-            .await
-            .map_err(|e| {
-                error!("{:?}", e);
-                e
-            })?;
-    };
-
     enroll_with_token(&app_state)
         .await
         .map(|i| info!("Enrolled a new user with identifier {}", i))
         .unwrap_or_else(|e| error!("{:?}", e));
-
+    create_relay(&app_state).await?;
     app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
     Ok(())
 }
@@ -52,7 +43,7 @@ async fn enroll_with_token(app_state: &AppState) -> Result<IdentityIdentifier> {
     app_state.set_user_info(user_info).await?;
 
     // enroll the current user using that token on the controller
-    let node_manager = app_state.node_manager.get().read().await;
+    let node_manager = app_state.node_manager.get().write().await;
     node_manager
         .enroll_auth0(&app_state.context(), &CloudOpts::route(), token)
         .await
@@ -164,4 +155,25 @@ async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project
         .overwrite(&project.name, project.clone())?;
 
     Ok(project)
+}
+
+async fn create_relay(_app_state: &AppState) -> Result<()> {
+    // TODO: the relay creation fails because the NodeManagerWorker is initialized before the
+    //       enrollment, hence, it's not initialized with the project/trust-context info.
+    //       We need to figure out how to update the NodeManagerWorker after the enrollment is done.
+    // let project_route = app_state
+    //     .state()
+    //     .projects
+    //     .default()?
+    //     .config()
+    //     .access_route
+    //     .clone();
+    // let project_address = MultiAddr::from_str(&project_route).into_diagnostic()?;
+    // let req = CreateForwarder::at_project(project_address.clone(), None);
+    // app_state
+    //     .node_manager
+    //     .create_forwarder(&app_state.context(), req)
+    //     .await
+    //     .into_diagnostic()?;
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -57,33 +57,6 @@ async fn enroll_with_token(app_state: &AppState) -> Result<IdentityIdentifier> {
     Ok(identifier)
 }
 
-async fn create_default_identity(state: CliState) -> Result<()> {
-    let vault_state = match state.vaults.default() {
-        Err(_) => {
-            info!("creating a default vault");
-            state.create_vault_state(None).await?
-        }
-        Ok(vault_state) => vault_state,
-    };
-    info!("retrieved the vault state");
-
-    let identity = state
-        .get_identities(vault_state.get().await?)
-        .await?
-        .identities_creation()
-        .create_identity()
-        .await
-        .into_diagnostic()?;
-    info!("created a new identity {}", identity.identifier());
-
-    let identity_state = state
-        .create_identity_state(&identity.identifier(), None)
-        .await?;
-    info!("created a new identity state");
-    state.identities.set_default(identity_state.name())?;
-    Ok(())
-}
-
 async fn retrieve_space(app_state: &AppState) -> Result<Space> {
     info!("retrieving the user space");
     let node_manager = app_state.node_manager.get().read().await;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -14,7 +14,6 @@ use tokio::try_join;
 use ockam::{Address, AsyncTryClone, TcpListenerOptions};
 use ockam::{Context, TcpTransport};
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
-use ockam_api::config::lookup::ProjectLookup;
 use ockam_api::nodes::authority_node;
 use ockam_api::nodes::models::transport::CreateTransportJson;
 use ockam_api::nodes::service::NodeManagerTrustOptions;
@@ -22,9 +21,7 @@ use ockam_api::{
     bootstrapped_identities_store::PreTrustedIdentities,
     nodes::models::transport::{TransportMode, TransportType},
     nodes::{
-        service::{
-            NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
-        },
+        service::{NodeManagerGeneralOptions, NodeManagerTransportOptions},
         NodeManager, NodeManagerWorker, NODEMANAGER_ADDR,
     },
 };
@@ -303,7 +300,6 @@ async fn run_foreground_node(
             ),
     )?;
 
-    let projects = ProjectLookup::from_state(opts.state.projects.list()?).await?;
     let pre_trusted_identities = load_pre_trusted_identities(&cmd)?;
 
     let node_man = NodeManager::create(
@@ -314,7 +310,6 @@ async fn run_foreground_node(
             cmd.launch_config.is_some(),
             pre_trusted_identities,
         ),
-        NodeManagerProjectsOptions::new(projects),
         NodeManagerTransportOptions::new(
             listener.flow_control_id().clone(),
             tcp.async_try_clone().await.into_diagnostic()?,

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -8,8 +8,7 @@ use ockam_api::config::lookup::ProjectLookup;
 
 use ockam_api::cli_state::{ProjectConfig, StateDirTrait};
 use ockam_api::nodes::service::{
-    NodeManagerGeneralOptions, NodeManagerProjectsOptions, NodeManagerTransportOptions,
-    NodeManagerTrustOptions,
+    NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
 };
 use ockam_api::nodes::{NodeManager, NodeManagerWorker, NODEMANAGER_ADDR};
 use ockam_core::env::get_env_with_default;
@@ -63,8 +62,6 @@ pub async fn start_embedded_node_with_vault_and_identity(
     let options = TcpListenerOptions::new();
     let listener = tcp.listen(&bind, options).await?;
 
-    let projects = ProjectLookup::from_state(opts.state.projects.list()?).await?;
-
     let node_man = NodeManager::create(
         ctx,
         NodeManagerGeneralOptions::new(
@@ -73,7 +70,6 @@ pub async fn start_embedded_node_with_vault_and_identity(
             cmd.launch_config.is_some(),
             None,
         ),
-        NodeManagerProjectsOptions::new(projects),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )


### PR DESCRIPTION
## Summary

- extract relay creation as a public function in the `NodeManagerWorker`
- remove the `projects` field from `NodeManager` to load them from the `CliState`: there's no need to set the projects before hand, as we can load when we need them through the CliState

## Work to do

This PR adds the call to create the relay after the user is enrolled. There is a major block that is a little out of scope for this PR: the relay creation fails because the NodeManagerWorker is initialized before the enrollment, hence, it's not initialized with the project/trust-context info. We need to figure out how to update the NodeManagerWorker after the enrollment is done. This problem can be reproduced with:

```rust
ockam reset -y
ockam node create p
ockam enroll
ockam relay create --to p
```

