### PR TITLE
Fix the re-enrolling after a reset

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state.rs
@@ -129,6 +129,12 @@ impl CliState {
         Ok(state)
     }
 
+    /// Reset all directories and return a new CliState
+    pub async fn reset(&self) -> Result<CliState> {
+        self.delete(true)?;
+        Self::initialize_cli_state().await
+    }
+
     fn migrate(&self) -> Result<()> {
         // If there is a `config.json` file, migrate its contents to the spaces and project states.
         let legacy_config_path = self.dir.join("config.json");

--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -47,13 +47,24 @@ pub trait StateDirTrait: Sized + Send + Sync {
     }
 
     fn load(root_path: &Path) -> Result<Self> {
+        let dir = Self::create_dirs(root_path)?;
+        Ok(Self::new(dir))
+    }
+
+    /// Recreate all the state directories
+    fn reset(&self, root_path: &Path) -> Result<PathBuf> {
+        Self::create_dirs(root_path)
+    }
+
+    /// Create all the state directories
+    fn create_dirs(root_path: &Path) -> Result<PathBuf> {
         let dir = Self::build_dir(root_path);
         if Self::has_data_dir() {
             std::fs::create_dir_all(dir.join(DATA_DIR_NAME))?;
         } else {
             std::fs::create_dir_all(&dir)?;
-        }
-        Ok(Self::new(dir))
+        };
+        Ok(dir)
     }
 
     fn dir(&self) -> &PathBuf;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -334,7 +334,7 @@ impl NodeManager {
         transport_options: NodeManagerTransportOptions,
         trust_options: NodeManagerTrustOptions,
     ) -> Result<Self> {
-        info!("NodeManager::create: create transports");
+        info!("create transports");
         let api_transport_id = random_alias();
         let mut transports = BTreeMap::new();
         transports.insert(
@@ -342,7 +342,7 @@ impl NodeManager {
             transport_options.api_transport_flow_control_id.clone(),
         );
 
-        info!("NodeManager::create: create the identity repository");
+        info!("create the identity repository");
         let cli_state = general_options.cli_state;
         let node_state = cli_state.nodes.get(&general_options.node_name)?;
 
@@ -361,7 +361,7 @@ impl NodeManager {
                 Some(f) => BootstrapedIdentityStore::new(Arc::new(f), repository.clone()),
             });
 
-        info!("NodeManager::create: create the secure channels service");
+        info!("create the secure channels service");
         let secure_channels = SecureChannels::builder()
             .with_identities_vault(vault)
             .with_identities_repository(identities_repository.clone())
@@ -395,14 +395,14 @@ impl NodeManager {
             policies,
         };
 
-        info!("NodeManager::create: {}", s.node_name);
         if !general_options.skip_defaults {
-            info!("NodeManager::create: starting default services");
+            info!("starting default services");
             if let Some(tc) = trust_options.trust_context_config {
-                info!("NodeManager::create: configuring trust context");
+                info!("configuring trust context");
                 s.configure_trust_context(&tc).await?;
             }
         }
+        info!("created a node manager for the node: {}", s.node_name);
 
         Ok(s)
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -334,7 +334,7 @@ impl NodeManager {
         transport_options: NodeManagerTransportOptions,
         trust_options: NodeManagerTrustOptions,
     ) -> Result<Self> {
-        info!("create transports");
+        debug!("create transports");
         let api_transport_id = random_alias();
         let mut transports = BTreeMap::new();
         transports.insert(
@@ -342,7 +342,7 @@ impl NodeManager {
             transport_options.api_transport_flow_control_id.clone(),
         );
 
-        info!("create the identity repository");
+        debug!("create the identity repository");
         let cli_state = general_options.cli_state;
         let node_state = cli_state.nodes.get(&general_options.node_name)?;
 
@@ -361,7 +361,7 @@ impl NodeManager {
                 Some(f) => BootstrapedIdentityStore::new(Arc::new(f), repository.clone()),
             });
 
-        info!("create the secure channels service");
+        debug!("create the secure channels service");
         let secure_channels = SecureChannels::builder()
             .with_identities_vault(vault)
             .with_identities_repository(identities_repository.clone())
@@ -369,7 +369,7 @@ impl NodeManager {
 
         let policies: Arc<dyn PolicyStorage> = Arc::new(node_state.policies_storage().await?);
 
-        info!("NodeManager::create: start the Medic");
+        debug!("start the Medic");
         let medic_handle = MedicHandle::start_medic(ctx).await?;
 
         let mut s = Self {
@@ -396,9 +396,9 @@ impl NodeManager {
         };
 
         if !general_options.skip_defaults {
-            info!("starting default services");
+            debug!("starting default services");
             if let Some(tc) = trust_options.trust_context_config {
-                info!("configuring trust context");
+                debug!("configuring trust context");
                 s.configure_trust_context(&tc).await?;
             }
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -334,6 +334,7 @@ impl NodeManager {
         transport_options: NodeManagerTransportOptions,
         trust_options: NodeManagerTrustOptions,
     ) -> Result<Self> {
+        info!("NodeManager::create: create transports");
         let api_transport_id = random_alias();
         let mut transports = BTreeMap::new();
         transports.insert(
@@ -341,6 +342,7 @@ impl NodeManager {
             transport_options.api_transport_flow_control_id.clone(),
         );
 
+        info!("NodeManager::create: create the identity repository");
         let cli_state = general_options.cli_state;
         let node_state = cli_state.nodes.get(&general_options.node_name)?;
 
@@ -359,6 +361,7 @@ impl NodeManager {
                 Some(f) => BootstrapedIdentityStore::new(Arc::new(f), repository.clone()),
             });
 
+        info!("NodeManager::create: create the secure channels service");
         let secure_channels = SecureChannels::builder()
             .with_identities_vault(vault)
             .with_identities_repository(identities_repository.clone())
@@ -366,6 +369,7 @@ impl NodeManager {
 
         let policies: Arc<dyn PolicyStorage> = Arc::new(node_state.policies_storage().await?);
 
+        info!("NodeManager::create: start the Medic");
         let medic_handle = MedicHandle::start_medic(ctx).await?;
 
         let mut s = Self {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -77,7 +77,7 @@ impl NodeManagerWorker {
                 let node_manager = self.node_manager.write().await;
                 let mut session = Session::new(ping_route);
                 session.set_replacer(repl);
-                node_manager.sessions.lock().unwrap().add(session);
+                node_manager.add_session(session);
             }
             result
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -309,7 +309,7 @@ impl NodeManagerWorker {
                         ctx,
                     );
                     session.set_replacer(repl);
-                    node_manager.sessions.lock().unwrap().add(session);
+                    node_manager.add_session(session);
                 }
 
                 Response::ok(req_id).body(InletStatus::new(

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -24,7 +24,6 @@ use crate::app::model_state_repository::{LmdbModelStateRepository, ModelStateRep
 use crate::Result;
 
 pub const NODE_NAME: &str = "default";
-pub const SPACE_NAME: &str = "default";
 pub const PROJECT_NAME: &str = "default";
 
 /// The AppState struct contains all the state managed by `tauri`.

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -195,13 +195,8 @@ async fn make_node_manager(
         .await
         .into_diagnostic()?;
 
-    let projects = ProjectLookup::from_state(
-        opts.state
-            .projects
-            .list()
-            .unwrap_or(std::default::Default::default()),
-    )
-    .await?;
+    let projects =
+        ProjectLookup::from_state(opts.state.projects.list().unwrap_or_default()).await?;
     let trust_context_config =
         TrustContextConfigBuilder::new(&opts.state, &TrustContextOpts::default())?
             .with_authority_identity(None)

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use miette::{miette, IntoDiagnostic};
 use tauri::async_runtime::{block_on, spawn, RwLock};
-use tracing::log::{error, info};
+use tracing::{error, info};
 
 use ockam::Context;
 use ockam::{NodeBuilder, TcpListenerOptions, TcpTransport};

--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -12,7 +12,7 @@ pub async fn build_tray_menu(app_state: &AppState) -> SystemTrayMenu {
     tray_menu = build_enroll_section(app_state, tray_menu).await;
     tray_menu = build_outlets_section(app_state, tray_menu).await;
     tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
-    tray_menu = build_options_section(app_state, tray_menu);
+    tray_menu = build_options_section(app_state, tray_menu).await;
     tray_menu
 }
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -84,14 +84,16 @@ async fn create_default_identity(state: CliState) -> Result<()> {
         .into_diagnostic()?;
     info!("created a new identity {}", identity.identifier());
 
-    let _ = state
+    let identity_state = state
         .create_identity_state(&identity.identifier(), None)
         .await?;
     info!("created a new identity state");
+    state.identities.set_default(identity_state.name())?;
     Ok(())
 }
 
 async fn retrieve_space(app_state: &AppState) -> Result<Space> {
+    info!("retrieving the user space");
     let node_manager = app_state.node_manager.get().read().await;
     let spaces = {
         node_manager
@@ -121,6 +123,7 @@ async fn retrieve_space(app_state: &AppState) -> Result<Space> {
 }
 
 async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project> {
+    info!("retrieving the user project");
     let node_manager = app_state.node_manager.get().read().await;
     let projects = {
         node_manager

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -21,9 +21,9 @@ use crate::Result;
 ///  - connects to the Orchestrator with the retrieved token to create a project
 pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
     let app_state: State<AppState> = app.state::<AppState>();
-    if app_state.state().identities.default().is_err() {
+    if app_state.state().await.identities.default().is_err() {
         info!("creating a default identity");
-        create_default_identity(app_state.state())
+        create_default_identity(app_state.state().await)
             .await
             .map_err(|e| {
                 error!("{:?}", e);
@@ -59,7 +59,7 @@ async fn enroll_with_token(app_state: &AppState) -> Result<IdentityIdentifier> {
 
     let space = retrieve_space(app_state).await?;
     let _ = retrieve_project(app_state, &space).await?;
-    let identifier = update_enrolled_identity(&app_state.options(), NODE_NAME)
+    let identifier = update_enrolled_identity(&app_state.options().await, NODE_NAME)
         .await
         .into_diagnostic()?;
     Ok(identifier)
@@ -116,6 +116,7 @@ async fn retrieve_space(app_state: &AppState) -> Result<Space> {
     };
     app_state
         .state()
+        .await
         .spaces
         .overwrite(&space.name, SpaceConfig::from(&space))?;
 
@@ -146,6 +147,7 @@ async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project
     };
     app_state
         .state()
+        .await
         .projects
         .overwrite(&project.name, project.clone())?;
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -9,11 +9,11 @@ pub const ENROLL_MENU_HEADER_ID: &str = "enroll-header";
 pub const ENROLL_MENU_ID: &str = "enroll";
 pub const ENROLL_MENU_USER_NAME: &str = "user-name";
 
-pub async fn build_enroll_section(
+pub(crate) async fn build_enroll_section(
     app_state: &AppState,
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
-    if app_state.is_enrolled() {
+    if app_state.is_enrolled().await {
         match app_state.get_user_info().await {
             Some(user_info) => {
                 let item = CustomMenuItem::new(

--- a/implementations/rust/ockam/ockam_app/src/options/reset.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/reset.rs
@@ -10,15 +10,8 @@ use crate::Result;
 /// So that the user must enroll again in order to be able to access a project
 pub async fn reset(app: &AppHandle<Wry>) -> Result<()> {
     let app_state = app.state::<AppState>();
-    let state = app_state.state();
-
-    if let Err(e) = state.delete(true) {
-        Err(miette!("{:?}", e).into())
-    } else {
-        info!("Local Ockam configuration deleted");
-        let result = app_state.reset().await;
-        info!("Application state recreated");
-        app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
-        result.map_err(|e| miette!(e).into())
-    }
+    let result = app_state.reset().await;
+    info!("Application state recreated");
+    app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+    result.map_err(|e| miette!(e).into())
 }

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -6,8 +6,11 @@ use crate::options::reset;
 pub const RESET_MENU_ID: &str = "reset";
 pub const QUIT_MENU_ID: &str = "quit";
 
-pub fn build_options_section(app_state: &AppState, tray_menu: SystemTrayMenu) -> SystemTrayMenu {
-    let tm = if app_state.is_enrolled() {
+pub(crate) async fn build_options_section(
+    app_state: &AppState,
+    tray_menu: SystemTrayMenu,
+) -> SystemTrayMenu {
+    let tm = if app_state.is_enrolled().await {
         tray_menu.add_item(CustomMenuItem::new(RESET_MENU_ID, "Reset").accelerator("cmd+r"))
     } else {
         tray_menu

--- a/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/tcp/outlet/tray_menu.rs
@@ -1,6 +1,7 @@
-use crate::app::AppState;
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 use tauri_runtime::menu::SystemTrayMenuItem;
+
+use crate::app::AppState;
 
 pub const SERVICE_HEADER_MENU_ID: &str = "service_outlet_header";
 pub const SERVICE_CREATE_MENU_ID: &str = "service_outlet_create";
@@ -10,7 +11,7 @@ pub(crate) async fn build_outlets_section(
     app_state: &AppState,
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
-    if !app_state.is_enrolled() {
+    if !app_state.is_enrolled().await {
         return tray_menu;
     };
 


### PR DESCRIPTION
This PR allows a user to enroll, then reset and enroll again.

The fix consists in:

 - recreating / initializing a full `CliState` after wiping out the Ockam home directory (and associating that state to the `AppState)
    
 - resetting the `NodeManager` that is associated to the `AppState`
   - stopping the `Medic` instance (I changed a bit the API to do this)
   - recreating a new `NodeManager`

 - resetting the `ModelStateRepository` since the `CliState` has been reinitialized with different paths

There is one remaining issue. When re-enrolling:

 - the browser window stays open with the redirect link
 - the app never receives a token and times-out after 30s.
 - then another enroll eventually works

I will investigate this issue separately.
