### PR TITLE
test(rust): fix the bats test verifying credentials

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
@@ -7,8 +7,11 @@ setup() {
   load load/orchestrator.bash
   load_bats_ext
   setup_home_dir
+}
+
+setup_orchestrator_test() {
   skip_if_orchestrator_tests_not_enabled
-  # copy_local_orchestrator_data
+  copy_local_orchestrator_data
 }
 
 teardown() {
@@ -42,10 +45,14 @@ teardown() {
 }
 
 @test "projects - list" {
+  setup_orchestrator_test
+
   run_success "$OCKAM" project list
 }
 
 @test "space - list" {
+  setup_orchestrator_test
+
   run_success "$OCKAM" space list
 }
 
@@ -145,6 +152,8 @@ teardown() {
 }
 
 @test "elastic encrypted relays" {
+  setup_orchestrator_test
+
   "$OCKAM" project information --output json > /tmp/project.json
 
   run_success "$OCKAM" node create a --project-path /tmp/project.json
@@ -235,6 +244,8 @@ teardown() {
 }
 
 @test "managed authorities" {
+  setup_orchestrator_test
+
   "$OCKAM" project information --output json > /tmp/project.json
 
   run_success "$OCKAM" node create a --project-path /tmp/project.json

--- a/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
@@ -198,7 +198,7 @@ teardown() {
 
   output=$("$OCKAM" secure-channel create \
     --from n1 --to /node/n2/service/l \
-    --identity i1 --authorized $(cat /tmp/i1.identifier) \
+    --identity i1 --authorized $(cat /tmp/i2.identifier) \
       | "$OCKAM" message send hello --from n1 --to -/service/uppercase)
 
   assert [ "$output" == "HELLO" ]

--- a/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/command-reference.bats
@@ -8,7 +8,7 @@ setup() {
   load_bats_ext
   setup_home_dir
   skip_if_orchestrator_tests_not_enabled
-  copy_local_orchestrator_data
+  # copy_local_orchestrator_data
 }
 
 teardown() {
@@ -173,12 +173,13 @@ teardown() {
   run_success "$OCKAM" identity create a
   run_success "$OCKAM" identity create b
 
-  id=$(ockam identity show b --full --encoding hex)
+  id_a=$("$OCKAM" identity show a --full --encoding hex)
+  id_b=$("$OCKAM" identity show b --full --encoding hex)
 
-  "$OCKAM" credential issue --as a --for ${id} --encoding hex > /tmp/b.credential
+  "$OCKAM" credential issue --as a --for ${id_b} --encoding hex > /tmp/b.credential
 
-  run_success "$OCKAM" credential verify --issuer ${id} --credential-path /tmp/b.credential
-  run_success "$OCKAM" credential store c1 --issuer ${id} --credential-path /tmp/b.credential
+  run_success "$OCKAM" credential verify --issuer ${id_a} --credential-path /tmp/b.credential
+  run_success "$OCKAM" credential store c1 --issuer ${id_a} --credential-path /tmp/b.credential
 }
 
 @test "trust anchors" {


### PR DESCRIPTION
This test does not pass because an incorrect issuer was specified for checking a credential.