### PR TITLE
pin dprint to version 0.39.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,11 +63,10 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - name: Install Dprint
-        run: npm install -g dprint
+        run: npm install -g dprint@0.39.1
       - name: Check Formatting
         run: |
-          echo "disable this check until it is fixed - **/Cargo.toml retrieves no files"
-          # dprint check --config tools/dprint/dprint.json
+          dprint check --config tools/dprint/dprint.json
 
   lint_cargo_fmt_check:
     name: Rust - lint_cargo_fmt_check


### PR DESCRIPTION
This PR pins dprint to an old version `0.39.1` which still supports the `toml-0.5.4.wasm` format