### PR TITLE
fix(rust): on enroll, persist project data before updating node's project data

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -130,6 +130,11 @@ async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project
             .await
             .map_err(|e| miette!(e))?,
     };
+    app_state
+        .state()
+        .await
+        .projects
+        .overwrite(&project.name, project.clone())?;
     add_project_info_to_node_state(
         NODE_NAME,
         &app_state.options().await,

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
@@ -5,11 +5,10 @@ use ockam::Context;
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
 use ockam_api::nodes::NodeManagerWorker;
+use ockam_core::compat::rand::random_string;
 use ockam_multiaddr::MultiAddr;
 use std::str::FromStr;
 use tracing::{debug, info};
-
-pub const RELAY_NAME: &str = "default";
 
 pub async fn create_relay(app_state: &AppState) -> Result<()> {
     create_relay_impl(
@@ -32,7 +31,7 @@ pub async fn create_relay_impl(
             debug!(project = %project.name(), "Creating relay at project");
             let project_route = format!("/project/{}", project.name());
             let project_address = MultiAddr::from_str(&project_route).into_diagnostic()?;
-            let req = CreateForwarder::at_project(project_address.clone(), Some(RELAY_NAME.into()));
+            let req = CreateForwarder::at_project(project_address.clone(), Some(random_string()));
             let relay = node_manager_worker
                 .create_forwarder(context, req)
                 .await

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -91,6 +91,7 @@ pub async fn add_project_info_to_node_state(
     opts: &CommandGlobalOpts,
     project_opts: &TrustContextOpts,
 ) -> Result<Option<String>> {
+    debug!(name=%node_name, "Adding project info to state");
     let proj_path = if let Some(path) = project_opts.project_path.clone() {
         Some(path)
     } else if let Ok(proj) = opts.state.projects.default() {
@@ -101,6 +102,7 @@ pub async fn add_project_info_to_node_state(
 
     match &proj_path {
         Some(path) => {
+            debug!(path=%path.display(), "Reading project info from path");
             let s = tokio::fs::read_to_string(path).await?;
             let proj_info: ProjectInfo = serde_json::from_str(&s)?;
             let proj_lookup = ProjectLookup::from_project(&(&proj_info).into()).await?;
@@ -112,7 +114,10 @@ pub async fn add_project_info_to_node_state(
                 .overwrite(proj_lookup.name, proj_config)?;
             Ok(Some(proj_lookup.id))
         }
-        None => Ok(None),
+        None => {
+            debug!("No project info used");
+            Ok(None)
+        }
     }
 }
 


### PR DESCRIPTION
At https://github.com/build-trust/ockam/pull/5458 I overlooked the fact that the `add_project_info_to_node_state` function doesn't persist the project data if it's not there (it overwrites the existing data, but doesn't create it if it doesn't exist).