### PR TITLE
feat: Enable tracing<->log bridge in ockam_app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,6 +4460,7 @@ dependencies = [
 name = "ockam_app"
 version = "0.1.0"
 dependencies = [
+ "log",
  "miette",
  "muda",
  "ockam",

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -56,3 +56,5 @@ tracing = "0.1"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+default = ["log"]
+log = ["tracing/log"]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -35,6 +35,7 @@ path = "src/lib.rs"
 tauri-build = { version = "2.0.0-alpha.6", features = [] }
 
 [dependencies]
+log = { version = "0.4.19", optional = true }
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 muda = "0.6"
 ockam = { path = "../ockam", version = "^0.90.0", features = ["software_vault"] }
@@ -57,4 +58,4 @@ tracing = "0.1"
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
 default = ["log"]
-log = ["tracing/log"]
+log = ["dep:log", "log/release_max_level_info", "tracing/log"]


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

`ockam_app` uses Tauri's log plugin for output to both stdio and an on-disk log file, but the majority of `ockam_api` and the rest of our internal crate suite makes extensive use of `tracing` crate.

## Proposed changes

Enable the existing `tracing` support for the `log` facade.
https://docs.rs/tracing/latest/tracing/#log-compatibility

The `tracing/log` crate feature I've enabled will cause tracing macros to emit to the `log` facade instead **if no tracing subscriber is active**, so we should more reliably receive logged details from our internal code.

This would optionally allow a future runtime choice between using a tracing-subscriber for the output stream (I generally find it much more readable and the EnvFilter logic more reliable) or the existing formatter supplied by `taurin-plugin-log`.

I've also included the `tracing/release_max_level_info` crate feature, only in our `ockam_app` crate, to reduce a perceived risk about disk usage during ongoing application use stemming from our internal crates' verbosity. This will not affect local use of the app via `cargo tauri dev`, because the crate flag only affects release builds.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
