### PR TITLE
feat: Use vite live builds for Tauri frontends

### DIFF
--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -1,8 +1,14 @@
 {
   "build": {
-    "beforeBuildCommand": "cd ../../typescript/ockam/ockam_app && pnpm run build",
-    "beforeDevCommand": "cd ../../typescript/ockam/ockam_app && pnpm run build",
-    "devPath": "../../../typescript/ockam/ockam_app/build",
+    "beforeBuildCommand": {
+      "cwd": "../../../typescript/ockam/ockam_app",
+      "script": "pnpm run build"
+    },
+    "beforeDevCommand": {
+      "cwd": "../../../typescript/ockam/ockam_app",
+      "script": "pnpm run dev"
+    },
+    "devPath": "http://localhost:5173",
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {

--- a/tools/nix/parts/typescript.nix
+++ b/tools/nix/parts/typescript.nix
@@ -34,21 +34,9 @@ in {
           if pkgs ? "nodejs-${cfg.nodeVersion}"
           then pkgs."nodejs-${cfg.nodeVersion}"
           else throw "unsupported nodejs version for nixpkgs: ${cfg.nodeVersion}";
-        # TODO: Latest is 8.6.6 as of 2023-07-02
-        pnpm = let
-          pname = "pnpm";
-          # NOTE: Bumping version must always be accompanied by changing the sha512 hash
-          version = "6.7.6";
-          # https://raw.githubusercontent.com/nixos/nixpkgs/nixpkgs-unstable/pkgs/development/node-packages/node-packages.nix
-          src = pkgs.fetchurl {
-            url = "https://registry.npmjs.org/pnpm/-/${pname}-${version}.tgz";
-            sha512 = "sha512-VhO6zVIuhVkKXP3kWMZs9W5b3rhcztq524WoAc9OEwjmj7SiKyp0UNltaaLR0VRjFGJPuQOcqDbNkWwzao6dUw==";
-          };
-        in
-          pkgs.nodePackages.pnpm.override {
-            inherit src version;
-            node = config.packages.nodejs;
-          };
+        pnpm = pkgs.nodePackages.pnpm.override {
+          node = config.packages.nodejs;
+        };
       };
     };
   };


### PR DESCRIPTION
- build(typescript): upgrade pnpm to nixpkgs version
- chore(rust): reconfigure tauri build to use vite live builds

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

We're currently using prod-like builds for Vite/Svelte which have more friction for small iterations on DOM UI elements.

## Proposed changes

Revise the `tauri.conf.json` to use `vite dev` rather than `vite build`, so that realtime changes to the components are reflected almost immediatley and comparatively expensive bundling/minification steps can be skipped until a release-ready artifact is desired.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
