### PR TITLE
feat(rust): added a direct local kafka for simple deployments

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -43,7 +43,8 @@ mod test {
     use crate::kafka::protocol_aware::utils::{encode_request, encode_response};
     use crate::kafka::secure_channel_map::ForwarderCreator;
     use crate::kafka::{
-        KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
+        ConsumerNodeAddr, KafkaInletController, KafkaPortalListener,
+        KafkaSecureChannelControllerImpl,
     };
     use crate::test_utils::NodeManagerHandle;
 
@@ -72,8 +73,8 @@ mod test {
     ) -> ockam::Result<u16> {
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new_extended(
             handler.secure_channels.clone(),
-            MultiAddr::try_from("/service/api")?,
-            HopForwarderCreator {},
+            ConsumerNodeAddr::Relay(MultiAddr::try_from("/service/api")?),
+            Some(HopForwarderCreator {}),
             "test_trust_context_id".to_string(),
         );
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use inlet_controller::KafkaInletController;
 pub(crate) use outlet_service::prefix_forwarder::PrefixForwarderService;
 pub(crate) use outlet_service::OutletManagerService;
 pub(crate) use portal_listener::KafkaPortalListener;
+pub(crate) use secure_channel_map::ConsumerNodeAddr;
 pub(crate) use secure_channel_map::KafkaSecureChannelControllerImpl;
 
 pub const KAFKA_OUTLET_CONSUMERS: &str = "kafka_consumers";

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -172,6 +172,7 @@ impl DefaultAddress {
     pub const KAFKA_OUTLET: &'static str = "kafka_outlet";
     pub const KAFKA_CONSUMER: &'static str = "kafka_consumer";
     pub const KAFKA_PRODUCER: &'static str = "kafka_producer";
+    pub const KAFKA_DIRECT: &'static str = "kafka_direct";
     pub const RPC_PROXY: &'static str = "rpc_proxy_service";
 
     pub fn is_valid(name: &str) -> bool {
@@ -193,6 +194,8 @@ impl DefaultAddress {
                 | Self::OKTA_IDENTITY_PROVIDER
                 | Self::KAFKA_CONSUMER
                 | Self::KAFKA_PRODUCER
+                | Self::KAFKA_OUTLET
+                | Self::KAFKA_DIRECT
                 | Self::RPC_PROXY
         )
     }
@@ -215,6 +218,8 @@ impl DefaultAddress {
             Self::OKTA_IDENTITY_PROVIDER,
             Self::KAFKA_CONSUMER,
             Self::KAFKA_PRODUCER,
+            Self::KAFKA_OUTLET,
+            Self::KAFKA_DIRECT,
             Self::RPC_PROXY,
         ]
         .iter()

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -145,6 +145,45 @@ impl StartKafkaProducerRequest {
     }
 }
 
+#[derive(Debug, Clone, Decode, Encode)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct StartKafkaDirectRequest {
+    #[n(1)] bind_address: SocketAddr,
+    #[n(2)] bootstrap_server_addr: String,
+    #[n(3)] brokers_port_range: (u16, u16),
+    #[n(4)] consumer_route: Option<String>,
+}
+
+impl StartKafkaDirectRequest {
+    pub fn new(
+        bind_address: SocketAddr,
+        bootstrap_server_addr: String,
+        brokers_port_range: impl Into<(u16, u16)>,
+        consumer_route: Option<MultiAddr>,
+    ) -> Self {
+        Self {
+            bind_address,
+            bootstrap_server_addr,
+            brokers_port_range: brokers_port_range.into(),
+            consumer_route: consumer_route.map(|a| a.to_string()),
+        }
+    }
+
+    pub fn bind_address(&self) -> SocketAddr {
+        self.bind_address
+    }
+    pub fn bootstrap_server_addr(&self) -> &str {
+        &self.bootstrap_server_addr
+    }
+    pub fn brokers_port_range(&self) -> (u16, u16) {
+        self.brokers_port_range
+    }
+    pub fn consumer_route(&self) -> Option<String> {
+        self.consumer_route.clone()
+    }
+}
+
 /// Request body when instructing a node to start an Identity service
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -117,6 +117,8 @@ pub(crate) struct AuthenticatorServiceInfo {}
 pub(crate) enum KafkaServiceKind {
     Consumer,
     Producer,
+    Outlet,
+    Direct,
 }
 
 impl Display for KafkaServiceKind {
@@ -124,6 +126,8 @@ impl Display for KafkaServiceKind {
         match self {
             KafkaServiceKind::Consumer => write!(f, "consumer"),
             KafkaServiceKind::Producer => write!(f, "producer"),
+            KafkaServiceKind::Outlet => write!(f, "outlet"),
+            KafkaServiceKind::Direct => write!(f, "direct"),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -659,6 +659,10 @@ impl NodeManagerWorker {
             (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => {
                 self.start_kafka_outlet_service(ctx, req, dec).await?
             }
+            (Delete, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_request_result(
+                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Outlet)
+                    .await,
+            )?,
             (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
                 self.start_kafka_consumer_service(ctx, req, dec).await?
             }
@@ -677,6 +681,13 @@ impl NodeManagerWorker {
                         .await,
                 )?
             }
+            (Post, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => {
+                self.start_kafka_direct_service(ctx, req, dec).await?
+            }
+            (Delete, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_request_result(
+                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Direct)
+                    .await,
+            )?,
             (Get, ["node", "services"]) => self.list_services(req).await?,
             (Get, ["node", "services", service_type]) => {
                 self.list_services_of_type(req, service_type).await?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -59,21 +59,6 @@ impl NodeManager {
             ));
         }
 
-        // Check that there is no entry in the registry with the same tcp address
-        if self
-            .registry
-            .outlets
-            .values()
-            .any(|outlet| outlet.tcp_addr == tcp_addr)
-        {
-            let message = format!("A TCP outlet with tcp address '{tcp_addr}' already exists",);
-            return Err(ockam_core::Error::new(
-                Origin::Node,
-                Kind::AlreadyExists,
-                message,
-            ));
-        }
-
         let worker_addr = Address::from_string(&worker_addr);
 
         let check_credential = self.enable_credential_checks;

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
@@ -1,0 +1,57 @@
+use std::net::SocketAddr;
+
+use crate::kafka::direct::rpc::{start, ArgOpts};
+use crate::node::initialize_node_if_default;
+use crate::{
+    kafka::{
+        kafka_default_consumer_port_range, kafka_default_consumer_server,
+        kafka_default_outlet_server, kafka_direct_default_addr,
+    },
+    node::NodeOpts,
+    util::{node_rpc, parsers::socket_addr_parser},
+    CommandGlobalOpts,
+};
+use clap::{command, Args};
+use ockam_api::port_range::PortRange;
+use ockam_multiaddr::MultiAddr;
+
+/// Create a new Kafka Direct Consumer
+#[derive(Clone, Debug, Args)]
+pub struct CreateCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+    /// The local address of the service
+    #[arg(long, default_value_t = kafka_direct_default_addr())]
+    addr: String,
+    /// The address where to bind and where the client will connect to alongside its port, <address>:<port>.
+    /// In case just a port is specified, the default loopback address (127.0.0.1) will be used
+    #[arg(long, default_value_t = kafka_default_consumer_server(), value_parser = socket_addr_parser)]
+    bind_address: SocketAddr,
+    /// The address of the kafka bootstrap broke
+    #[arg(long, default_value_t = kafka_default_outlet_server())]
+    bootstrap_server: String,
+    /// Local port range dynamically allocated to kafka brokers, must not overlap with the
+    /// bootstrap port
+    #[arg(long, default_value_t = kafka_default_consumer_port_range())]
+    brokers_port_range: PortRange,
+    /// The route to another kafka consumer node
+    #[arg(long)]
+    consumer_route: Option<MultiAddr>,
+}
+
+impl CreateCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        let arg_opts = ArgOpts {
+            endpoint: "/node/services/kafka_direct".to_string(),
+            kafka_entity: "KafkaDirect".to_string(),
+            node_opts: self.node_opts,
+            addr: self.addr,
+            bind_address: self.bind_address,
+            brokers_port_range: self.brokers_port_range,
+            consumer_route: self.consumer_route,
+            bootstrap_server: self.bootstrap_server,
+        };
+        node_rpc(start, (opts, arg_opts));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
@@ -1,0 +1,52 @@
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
+use clap::Args;
+use colorful::Colorful;
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
+const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
+
+/// Delete a Kafka Consumer
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
+pub struct DeleteCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+
+    /// Kafka consumer service address
+    pub address: String,
+}
+
+impl DeleteCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> miette::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let req = Request::delete("/node/services/kafka_direct").body(
+        models::services::DeleteServiceRequest::new(cmd.address.clone()),
+    );
+    rpc.request(req).await?;
+    rpc.is_ok()?;
+
+    opts.terminal
+        .stdout()
+        .plain(fmt_ok!(
+            "Kafka consumer with address `{}` successfully deleted",
+            cmd.address
+        ))
+        .write_line()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
@@ -1,0 +1,68 @@
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
+use miette::miette;
+
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::nodes::models;
+
+use ockam_api::DefaultAddress;
+use ockam_core::api::Request;
+
+const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
+
+/// List Kafka Consumers
+#[derive(Args, Clone, Debug)]
+#[command(
+    before_help = docs::before_help(PREVIEW_TAG),
+    after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
+pub struct ListCommand {
+    #[command(flatten)]
+    node_opts: NodeOpts,
+}
+
+impl ListCommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        initialize_node_if_default(&opts, &self.node_opts.at_node);
+        node_rpc(run_impl, (opts, self))
+    }
+}
+
+async fn run_impl(
+    ctx: ockam::Context,
+    (opts, cmd): (CommandGlobalOpts, ListCommand),
+) -> miette::Result<()> {
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+
+    if !opts.state.nodes.get(&node_name)?.is_running() {
+        return Err(miette!("The node '{}' is not running", node_name));
+    }
+
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    rpc.request(Request::get(format!(
+        "/node/services/{}",
+        DefaultAddress::KAFKA_DIRECT
+    )))
+    .await?;
+    let services = rpc.parse_response_body::<models::services::ServiceList>()?;
+    if services.list.is_empty() {
+        opts.terminal
+            .stdout()
+            .plain(fmt_err!("No Kafka Direct Client found on this node"))
+            .write_line()?;
+    } else {
+        let mut buf = String::new();
+        buf.push_str("Kafka Direct Clients:\n");
+        for service in services.list {
+            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+        }
+        opts.terminal.stdout().plain(buf).write_line()?;
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/mod.rs
@@ -1,0 +1,36 @@
+use clap::{command, Args, Subcommand};
+
+use crate::kafka::direct::create::CreateCommand;
+use crate::kafka::direct::delete::DeleteCommand;
+use crate::kafka::direct::list::ListCommand;
+use crate::CommandGlobalOpts;
+
+mod create;
+mod delete;
+mod list;
+mod rpc;
+
+/// Manage Kafka Consumers
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
+pub struct KafkaDirectCommand {
+    #[command(subcommand)]
+    subcommand: KafkaDirectSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum KafkaDirectSubcommand {
+    Create(CreateCommand),
+    Delete(DeleteCommand),
+    List(ListCommand),
+}
+
+impl KafkaDirectCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            KafkaDirectSubcommand::Create(c) => c.run(options),
+            KafkaDirectSubcommand::Delete(c) => c.run(options),
+            KafkaDirectSubcommand::List(c) => c.run(options),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
@@ -1,0 +1,114 @@
+use std::net::SocketAddr;
+
+use colorful::Colorful;
+use tokio::{sync::Mutex, try_join};
+
+use ockam::{Context, TcpTransport};
+use ockam_api::nodes::models::services::{StartKafkaDirectRequest, StartServiceRequest};
+use ockam_api::port_range::PortRange;
+use ockam_core::api::Request;
+use ockam_multiaddr::MultiAddr;
+
+use crate::node::{get_node_name, NodeOpts};
+use crate::service::start::start_service_impl;
+use crate::terminal::OckamColor;
+use crate::util::process_nodes_multiaddr;
+use crate::{display_parse_logs, fmt_log, fmt_ok, CommandGlobalOpts};
+
+pub struct ArgOpts {
+    pub endpoint: String,
+    pub kafka_entity: String,
+    pub node_opts: NodeOpts,
+    pub addr: String,
+    pub bind_address: SocketAddr,
+    pub brokers_port_range: PortRange,
+    pub consumer_route: Option<MultiAddr>,
+    pub bootstrap_server: String,
+}
+
+pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> miette::Result<()> {
+    let ArgOpts {
+        endpoint,
+        kafka_entity,
+        node_opts,
+        addr,
+        bind_address,
+        brokers_port_range,
+        consumer_route,
+        bootstrap_server,
+    } = args;
+
+    opts.terminal
+        .write_line(&fmt_log!("Creating {} service...\n", kafka_entity))?;
+
+    display_parse_logs(&opts);
+
+    let consumer_route = if let Some(consumer_route) = consumer_route {
+        Some(process_nodes_multiaddr(&consumer_route, &opts.state)?)
+    } else {
+        None
+    };
+
+    let is_finished = Mutex::new(false);
+    let send_req = async {
+        let tcp = TcpTransport::create(&ctx).await?;
+        let node_name = get_node_name(&opts.state, &node_opts.at_node);
+
+        let payload = StartKafkaDirectRequest::new(
+            bind_address.to_owned(),
+            bootstrap_server,
+            brokers_port_range,
+            consumer_route,
+        );
+        let payload = StartServiceRequest::new(payload, &addr);
+        let req = Request::post(endpoint).body(payload);
+        start_service_impl(&ctx, &opts, &node_name, &kafka_entity, req, Some(&tcp)).await?;
+
+        *is_finished.lock().await = true;
+
+        Ok::<_, crate::Error>(())
+    };
+
+    let msgs = vec![
+        format!(
+            "Building {} service {}",
+            kafka_entity,
+            &addr.to_string().color(OckamColor::PrimaryResource.color())
+        ),
+        format!(
+            "Creating {} service at {}",
+            kafka_entity,
+            &bind_address
+                .to_string()
+                .color(OckamColor::PrimaryResource.color())
+        ),
+        format!(
+            "Setting brokers port range to {}",
+            &brokers_port_range
+                .to_string()
+                .color(OckamColor::PrimaryResource.color())
+        ),
+    ];
+    let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+    let (_, _) = try_join!(send_req, progress_output)?;
+
+    opts.terminal
+        .stdout()
+        .plain(
+            fmt_ok!(
+                "{} service started at {}\n",
+                kafka_entity,
+                &bind_address
+                    .to_string()
+                    .color(OckamColor::PrimaryResource.color())
+            ) + &fmt_log!(
+                "Brokers port range set to {}",
+                &brokers_port_range
+                    .to_string()
+                    .color(OckamColor::PrimaryResource.color())
+            ),
+        )
+        .write_line()?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/static/delete/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/static/delete/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To delete a kafka consumers on the default node
+$ ockam kafka-consumer delete kcaddr
+
+# To delete a kafka consumers on a specific node
+$ ockam kafka-consumer delete kcaddr --at n
+```

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/static/list/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/static/list/after_long_help.txt
@@ -1,0 +1,7 @@
+```sh
+# To list the kafka consumers on the default node
+$ ockam kafka-consumer list
+
+# To list the kafka consumers on a specific node
+$ ockam kafka-consumer list --at n
+```

--- a/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
@@ -4,6 +4,7 @@ use ockam_api::{port_range::PortRange, DefaultAddress};
 use ockam_multiaddr::MultiAddr;
 
 pub(crate) mod consumer;
+pub(crate) mod direct;
 pub(crate) mod outlet;
 pub(crate) mod producer;
 pub(crate) mod util;
@@ -21,6 +22,10 @@ fn kafka_default_outlet_addr() -> String {
 
 fn kafka_consumer_default_addr() -> String {
     DefaultAddress::KAFKA_CONSUMER.to_string()
+}
+
+fn kafka_direct_default_addr() -> String {
+    DefaultAddress::KAFKA_DIRECT.to_string()
 }
 
 fn kafka_producer_default_addr() -> String {

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -57,6 +57,7 @@ pub use crate::terminal::{OckamColor, Terminal, TerminalStream};
 use authenticated::AuthenticatedCommand;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
+use crate::kafka::direct::KafkaDirectCommand;
 use crate::kafka::outlet::KafkaOutletCommand;
 use colorful::Colorful;
 use completion::CompletionCommand;
@@ -282,6 +283,7 @@ pub enum OckamSubcommand {
 
     KafkaOutlet(KafkaOutletCommand),
     KafkaConsumer(KafkaConsumerCommand),
+    KafkaDirect(KafkaDirectCommand),
     KafkaProducer(KafkaProducerCommand),
 
     SecureChannelListener(SecureChannelListenerCommand),
@@ -405,6 +407,7 @@ impl OckamCommand {
 
             OckamSubcommand::KafkaConsumer(c) => c.run(options),
             OckamSubcommand::KafkaProducer(c) => c.run(options),
+            OckamSubcommand::KafkaDirect(c) => c.run(options),
 
             OckamSubcommand::SecureChannelListener(c) => c.run(options),
             OckamSubcommand::SecureChannel(c) => c.run(options),


### PR DESCRIPTION
Currently it's possible to use a local kafka but it requires a centralized relay node (outlet node), with this direct kafka mode, the sidecar will connect directly to the kafka broker, but only one consumer is allowed.

(needs to be enrolled in a project in order to work)

In this setup the client acts both as consumer and producer for itself (uses kafka as a local queue):
```
ockam  kafka-direct create  --consumer-route ""
```

In this one we spawn 2 sidecar, one referencing the other as a consumer:
```
ockam  kafka-direct create
ockam node create second
ockam  kafka-direct create  --bind-address 127.0.0.1:6092 --brokers-port-range 6001-6100 --consumer-route /node/default --at second
```