### PR TITLE
fix(rust): set the quit menu item label back to "Quit Ockam"

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -15,7 +15,7 @@ pub(crate) async fn build_options_section(
     } else {
         tray_menu
     };
-    tm.add_item(CustomMenuItem::new(QUIT_MENU_ID, "Quit").accelerator("cmd+q"))
+    tm.add_item(CustomMenuItem::new(QUIT_MENU_ID, "Quit Ockam").accelerator("cmd+q"))
 }
 
 /// Event listener for the "Reset" menu item


### PR DESCRIPTION
This PR addresses the regression found in https://github.com/build-trust/ockam/issues/5363.

Fixes #5363