### PR TITLE
fix(rust): fix features to fix `ockam_identity` standalone build

### DIFF
--- a/implementations/rust/ockam/ockam_vault/Cargo.toml
+++ b/implementations/rust/ockam/ockam_vault/Cargo.toml
@@ -63,7 +63,7 @@ alloc = [
   "p256/pem",
 ]
 
-storage = ["ockam_node/storage", "std", "serde", "serde_cbor"]
+storage = ["ockam_node/storage", "std", "serde_cbor"]
 
 [dependencies]
 aes-gcm = { version = "0.9", default-features = false, features = ["aes"] }
@@ -81,7 +81,7 @@ ockam_node = { path = "../ockam_node", version = "^0.86.0", default_features = f
 p256 = { version = "0.13.2", default_features = false }
 rand = { version = "0.8", default-features = false }
 rand_pcg = { version = "0.3.1", default-features = false, optional = true }
-serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_cbor = { version = "0.11.2", optional = true }
 sha2 = { version = "0.10", default-features = false }
 thiserror = { version = "1.0.43", optional = true }

--- a/implementations/rust/ockam/ockam_vault/src/vault/vault.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/vault.rs
@@ -8,8 +8,6 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{async_trait, Result};
 use ockam_node::KeyValueStorage;
-#[cfg(feature = "std")]
-use std::path::Path;
 
 /// A Vault provides high-level interfaces to manage secrets:
 ///
@@ -80,8 +78,8 @@ impl Vault {
     }
 
     /// Create a new vault with a persistent storage
-    #[cfg(feature = "std")]
-    pub async fn create_with_persistent_storage_path(path: &Path) -> Result<Arc<Vault>> {
+    #[cfg(feature = "storage")]
+    pub async fn create_with_persistent_storage_path(path: &std::path::Path) -> Result<Arc<Vault>> {
         Ok(Vault::builder()
             .with_persistent_storage_path(path)
             .await?

--- a/implementations/rust/ockam/ockam_vault/src/vault/vault_builder.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/vault_builder.rs
@@ -9,8 +9,6 @@ use ockam_core::compat::sync::Arc;
 #[cfg(feature = "storage")]
 use ockam_core::Result;
 use ockam_node::InMemoryKeyValueStorage;
-#[cfg(feature = "std")]
-use std::path::Path;
 
 /// Builder for Vaults
 /// The `VaultBuilder` allows the setting of different implementations for the external interfaces of a Vault:
@@ -48,8 +46,11 @@ impl VaultBuilder {
 
     /// Set a persistent storage as a file storage with a specific path
     /// Note: this overrides all previously set implementations
-    #[cfg(feature = "std")]
-    pub async fn with_persistent_storage_path(&mut self, path: &Path) -> Result<&mut Self> {
+    #[cfg(feature = "storage")]
+    pub async fn with_persistent_storage_path(
+        &mut self,
+        path: &std::path::Path,
+    ) -> Result<&mut Self> {
         Ok(self.with_persistent_storage(PersistentStorage::create(path).await?))
     }
 


### PR DESCRIPTION
Currently, it's impossible to build `ockam_identity` crate with default features because of incorrect feature setup in some `Cargo.toml` files. I suspect we have a similar problem for other crates, for now fixing just `ockam_identity`.