### PR TITLE
chore(rust): move `error.rs` of `ockam_identity` one level up

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials.rs
@@ -1,6 +1,7 @@
 use crate::credential::{Credential, CredentialData, Timestamp, Verified};
 use crate::identities::{AttributesEntry, Identities};
-use crate::identity::{Identity, IdentityError, IdentityIdentifier};
+use crate::identity::{Identity, IdentityIdentifier};
+use crate::IdentityError;
 use async_trait::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::errcode::{Kind, Origin};

--- a/implementations/rust/ockam/ockam_identity/src/error.rs
+++ b/implementations/rust/ockam/ockam_identity/src/error.rs
@@ -8,8 +8,6 @@ use ockam_core::{
 pub enum IdentityError {
     /// Bare serialization error
     BareError = 1,
-    /// `IdentityChangeHistory` verification failed
-    VerifyFailed,
     /// Invalid internal state of the `Identity`
     InvalidInternalState,
     /// Consistency check failed
@@ -18,32 +16,22 @@ pub enum IdentityError {
     SecureChannelVerificationFailed,
     /// SecureChannel `TrustPolicy` check failed
     SecureChannelTrustCheckFailed,
-    /// Custom payload wasn't provided where required
-    NoCustomPayload,
     /// Unknown channel message destination
     UnknownChannelMsgDestination,
     /// Invalid `LocalInfo` type
     InvalidLocalInfoType,
-    /// Internal Secure Channel error
-    InvalidSecureChannelInternalState,
     /// `Identity` verification error
     IdentityVerificationFailed,
     /// Invalid `IdentityIdentifier` format
     InvalidIdentityId,
-    /// Invalid `Credential` format
-    InvalidCredentialFormat,
     /// Unknown Authority
     UnknownAuthority,
-    /// `Credential` verification failed
-    CredentialVerificationFailed,
     /// SecureChannel with this address already exists
     DuplicateSecureChannel,
     /// Invalid nonce format
     InvalidNonce,
     /// Nonce overflow
     NonceOverflow,
-    /// SecureChannel was not found in the Registry
-    SecureChannelNotFound,
 }
 
 impl ockam_core::compat::error::Error for IdentityError {}

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -4,7 +4,7 @@ use ockam_core::Result;
 use ockam_vault::{KeyId, Secret, SecretAttributes};
 
 use crate::alloc::string::ToString;
-use crate::identity::IdentityError;
+use crate::IdentityError;
 use crate::{
     IdentitiesKeys, IdentitiesRepository, IdentitiesVault, Identity, IdentityChangeConstants,
     IdentityChangeHistory, IdentityIdentifier, KeyAttributes,

--- a/implementations/rust/ockam/ockam_identity/src/identities/identity_keys.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identity_keys.rs
@@ -1,12 +1,13 @@
 use crate::alloc::string::ToString;
 use crate::identities::IdentitiesVault;
 use crate::identity::IdentityChange::{CreateKey, RotateKey};
-use crate::identity::IdentityError::InvalidInternalState;
 use crate::identity::{
     ChangeIdentifier, CreateKeyChangeData, Identity, IdentityChangeConstants,
-    IdentityChangeHistory, IdentityError, IdentitySignedChange, KeyAttributes, RotateKeyChangeData,
-    Signature, SignatureType,
+    IdentityChangeHistory, IdentitySignedChange, KeyAttributes, RotateKeyChangeData, Signature,
+    SignatureType,
 };
+use crate::IdentityError;
+use crate::IdentityError::InvalidInternalState;
 use ockam_core::compat::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{Encodable, Result};

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository.rs
@@ -10,8 +10,8 @@ use crate::alloc::string::ToString;
 use crate::credential::Timestamp;
 use crate::identities::storage::storage::{InMemoryStorage, Storage};
 use crate::identity::IdentityHistoryComparison;
-use crate::identity::{Identity, IdentityChangeConstants, IdentityError, IdentityIdentifier};
-use crate::AttributesEntry;
+use crate::identity::{Identity, IdentityChangeConstants, IdentityIdentifier};
+use crate::{AttributesEntry, IdentityError};
 
 /// Repository for data related to identities: key changes and attributes
 #[async_trait]

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_change_history.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_change_history.rs
@@ -3,7 +3,7 @@ use crate::identity::identity_change::IdentityChange::CreateKey;
 use crate::identity::identity_change::{
     ChangeIdentifier, IdentityChangeConstants, IdentitySignedChange,
 };
-use crate::identity::IdentityError;
+use crate::IdentityError;
 use core::cmp::Ordering;
 use core::fmt;
 use minicbor::{Decode, Encode};

--- a/implementations/rust/ockam/ockam_identity/src/identity/identity_identifier.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/identity_identifier.rs
@@ -1,4 +1,4 @@
-use crate::identity::IdentityError;
+use crate::IdentityError;
 use core::fmt::{Display, Formatter};
 use core::str::FromStr;
 use minicbor::decode::{self, Decoder};

--- a/implementations/rust/ockam/ockam_identity/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identity/mod.rs
@@ -1,5 +1,3 @@
-mod error;
-
 #[allow(clippy::module_inception)]
 mod identity;
 /// List of key changes associated to an identity
@@ -7,7 +5,6 @@ pub mod identity_change;
 mod identity_change_history;
 mod identity_identifier;
 
-pub use error::*;
 pub use identity::*;
 pub use identity_change::*;
 pub use identity_change_history::*;

--- a/implementations/rust/ockam/ockam_identity/src/lib.rs
+++ b/implementations/rust/ockam/ockam_identity/src/lib.rs
@@ -50,11 +50,15 @@ pub mod secure_channel;
 /// Service supporting the creation of secure channel listener and connection to a listener
 pub mod secure_channels;
 
+/// Errors
+mod error;
+
 ///
 /// Exports
 ///
 pub use credential::*;
 pub use credentials::*;
+pub use error::*;
 pub use identities::*;
 pub use identity::*;
 pub use secure_channel::*;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor.rs
@@ -1,4 +1,4 @@
-use crate::identity::IdentityError;
+use crate::IdentityError;
 use crate::XXInitializedVault;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/encryptor_worker.rs
@@ -1,7 +1,7 @@
-use crate::identity::IdentityError;
 use crate::secure_channel::addresses::Addresses;
 use crate::secure_channel::api::{EncryptionRequest, EncryptionResponse};
 use crate::secure_channel::encryptor::Encryptor;
+use crate::IdentityError;
 use ockam_core::compat::boxed::Box;
 use ockam_core::{async_trait, Decodable, Encodable, Route};
 use ockam_core::{Any, Result, Routed, TransportMessage, Worker};

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/local_info.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/local_info.rs
@@ -1,4 +1,5 @@
-use crate::identity::{IdentityError, IdentityIdentifier};
+use crate::identity::IdentityIdentifier;
+use crate::IdentityError;
 use ockam_core::compat::vec::Vec;
 use ockam_core::{Decodable, Encodable, LocalInfo, LocalMessage, Result};
 use serde::{Deserialize, Serialize};

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/registry.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/registry.rs
@@ -1,4 +1,5 @@
-use crate::identity::{IdentityError, IdentityIdentifier};
+use crate::identity::IdentityIdentifier;
+use crate::IdentityError;
 use ockam_core::compat::collections::BTreeMap;
 use ockam_core::compat::sync::{Arc, RwLock};
 use ockam_core::compat::vec::Vec;


### PR DESCRIPTION
`error.rs` is meant to contain errors of the whole module (or even crate). In this case, it's the error file used for the whole crate, therefore, I'm moving it to the root of the crate. Also, deleting unused errors