### PR TITLE
Add human-writable duration support (Closes: #5255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,6 +3707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "libp2p-identity"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4304,6 +4325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4563,6 +4585,7 @@ dependencies = [
  "once_cell",
  "open",
  "pem-rfc7468",
+ "proptest",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -5428,6 +5451,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5882,6 +5931,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -7613,6 +7674,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -118,6 +118,7 @@ which = "4.4.0"
 assert_cmd = "2"
 ockam_api = { path = "../ockam_api", version = "0.33.0", features = ["std", "authenticators"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.30.0" }
+proptest = "1.2.0"
 tempfile = "3.7.1"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -11,6 +11,7 @@ use ockam_multiaddr::MultiAddr;
 use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::{CloudOpts, TrustContextOpts};
+use crate::util::duration::duration_parser;
 use crate::util::{clean_nodes_multiaddr, extract_address_value, node_rpc, RpcBuilder};
 
 use crate::{docs, CommandGlobalOpts};
@@ -38,9 +39,9 @@ pub struct SendCommand {
     #[arg(long)]
     pub hex: bool,
 
-    /// Override default timeout (in seconds)
-    #[arg(long, value_name = "TIMEOUT", default_value = "10")]
-    pub timeout: u64,
+    /// Override default timeout
+    #[arg(long, value_name = "TIMEOUT", default_value = "10s", value_parser = duration_parser)]
+    pub timeout: Duration,
 
     pub message: String,
 
@@ -113,7 +114,7 @@ async fn rpc(
             cmd.message.as_bytes().to_vec()
         };
 
-        rpc.request_with_timeout(req(&to, msg_bytes), Duration::from_secs(cmd.timeout))
+        rpc.request_with_timeout(req(&to, msg_bytes), cmd.timeout)
             .await?;
         let res = {
             let res = rpc.parse_response_body::<Vec<u8>>()?;

--- a/implementations/rust/ockam/ockam_command/src/util/duration.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/duration.rs
@@ -1,0 +1,59 @@
+use clap::error::{Error, ErrorKind};
+use once_cell::sync::OnceCell;
+use regex::Regex;
+use std::time::Duration;
+
+static DURATION_REGEX: OnceCell<Regex> = OnceCell::new();
+
+pub(crate) fn duration_parser(arg: &str) -> Result<Duration, clap::Error> {
+    let needles = DURATION_REGEX
+        .get_or_init(|| {
+            Regex::new(r"(?P<numeric_duration>[0-9]+)(?P<length_sigil>m|s|ms)?$").unwrap()
+        })
+        .captures(arg)
+        .ok_or(Error::raw(ErrorKind::InvalidValue, "Invalid duration."))?;
+    let time = needles["numeric_duration"]
+        .parse::<u64>()
+        .map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))?;
+
+    match needles.name("length_sigil") {
+        Some(n) => match n.as_str() {
+            "ms" => Ok(Duration::from_millis(time)),
+            "m" => Ok(Duration::from_secs(60 * time)),
+            "s" => Ok(Duration::from_secs(time)),
+            _ => unreachable!("Alternatives excluded by regex."),
+        },
+        None => Ok(Duration::from_secs(time)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use std::time::Duration;
+
+    use crate::util::duration::duration_parser;
+
+    const ONE_YEAR_MILLIS: u64 = 31_536_000_000;
+
+    proptest! {
+        #[test]
+        fn test_reverse_duration(arg in 0..ONE_YEAR_MILLIS) {
+            let millis = Duration::from_millis(arg);
+            let milli_str = format!("{}ms", millis.as_millis());
+            prop_assert_eq!(duration_parser(milli_str.as_str()).unwrap(), millis);
+
+            // We need to truncate the value before calculating seconds,
+            // so pass it through Duration
+            let secs = Duration::from_secs(millis.as_secs());
+            let secs_str_s = format!("{}s", secs.as_secs());
+            let secs_str = format!("{}", secs.as_secs());
+            prop_assert_eq!(duration_parser(secs_str_s.as_str()).unwrap(), secs);
+            prop_assert_eq!(duration_parser(secs_str.as_str()).unwrap(), secs);
+
+            let mins = Duration::from_secs(secs.as_secs() / 60 * 60);
+            let mins_str = format!("{}m", mins.as_secs() / 60);
+            prop_assert_eq!(duration_parser(mins_str.as_str()).unwrap(), mins)
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -30,6 +30,7 @@ use crate::{node::util::start_embedded_node, EncodeFormat};
 use crate::{CommandGlobalOpts, OutputFormat, Result};
 
 pub mod api;
+pub mod duration;
 pub mod exitcode;
 pub mod orchestrator_api;
 pub mod parsers;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently, durations are supplied to the ockam command with a fixed unit attached (e.g., timeout in ms).  This PR adds support for specifying "human-writable" durations, such as "10s", "1m", or "150ms". 

## Proposed changes

This PR only supports milliseconds, seconds, and minutes, as was discussed in #5255.  Note, I'm not 100% sure that the test here provides juice that's worth the squeeze; it's a pretty close reimplementation that I can't see catching a lot of errors, with an additional library on top for testing to boot.  That being said, it's at least simple enough to read through.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
