### PR TITLE
feat(rust): added new cli command to retrieve the project's version

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -95,7 +95,7 @@ impl Project {
     }
 }
 
-#[derive(Decode, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Decode, Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 #[cbor(map)]
 pub struct ProjectVersion {
     #[cfg(feature = "tag")]
@@ -103,9 +103,11 @@ pub struct ProjectVersion {
     #[cbor(n(0))]
     pub tag: TypeTag<9116532>,
 
+    /// The version of the Orchestrator Controller
     #[cbor(n(1))]
     pub version: Option<String>,
 
+    /// The version of the Projects
     #[cbor(n(2))]
     pub project_version: Option<String>,
 }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -7,6 +7,7 @@ mod list;
 mod show;
 mod ticket;
 pub mod util;
+mod version;
 
 pub use info::ProjectInfo;
 
@@ -20,6 +21,7 @@ pub use info::InfoCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 pub use ticket::TicketCommand;
+pub use version::VersionCommand;
 
 use crate::docs;
 use crate::project::enroll::EnrollCommand;
@@ -45,6 +47,7 @@ pub enum ProjectSubcommand {
     Delete(DeleteCommand),
     List(ListCommand),
     Show(ShowCommand),
+    Version(VersionCommand),
     Information(InfoCommand),
     Ticket(TicketCommand),
     Addon(AddonCommand),
@@ -58,6 +61,7 @@ impl ProjectCommand {
             ProjectSubcommand::Delete(c) => c.run(options),
             ProjectSubcommand::List(c) => c.run(options),
             ProjectSubcommand::Show(c) => c.run(options),
+            ProjectSubcommand::Version(c) => c.run(options),
             ProjectSubcommand::Ticket(c) => c.run(options),
             ProjectSubcommand::Information(c) => c.run(options),
             ProjectSubcommand::Addon(c) => c.run(options),

--- a/implementations/rust/ockam/ockam_command/src/project/static/version/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/version/after_long_help.txt
@@ -1,0 +1,4 @@
+```sh
+# To retrieve the version of the projects
+$ ockam project version
+```

--- a/implementations/rust/ockam/ockam_command/src/project/static/version/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/static/version/long_about.txt
@@ -1,0 +1,1 @@
+This command will return the version of the projects.

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -1,0 +1,57 @@
+use clap::Args;
+use colorful::Colorful;
+use miette::IntoDiagnostic;
+use ockam::Context;
+use ockam_api::cloud::project::ProjectVersion;
+
+use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::util::api::{self, CloudOpts};
+use crate::util::{node_rpc, RpcBuilder};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/version/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/version/after_long_help.txt");
+
+/// Return the version of the Orchestrator Controller and the Projects
+#[derive(Clone, Debug, Args)]
+#[command(
+    long_about=docs::about(LONG_ABOUT),
+    after_long_help=docs::about(AFTER_LONG_HELP)
+)]
+pub struct VersionCommand {
+    #[command(flatten)]
+    pub cloud_opts: CloudOpts,
+}
+
+impl VersionCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, options);
+    }
+}
+
+async fn rpc(mut ctx: Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    run_impl(&mut ctx, opts).await
+}
+
+async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    let controller_route = &CloudOpts::route();
+    let node_name = start_embedded_node(ctx, &opts, None).await?;
+
+    // Send request
+    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
+    rpc.request(api::project::version(controller_route)).await?;
+    let res = rpc.parse_response_body::<ProjectVersion>()?;
+    delete_embedded_node(&opts, rpc.node_name()).await;
+
+    let json = serde_json::to_string(&res).into_diagnostic()?;
+    let project_version = res.project_version.unwrap_or("unknown".to_string());
+    let plain = fmt_ok!("The version of the Projects is '{project_version}'");
+
+    opts.terminal
+        .stdout()
+        .plain(plain)
+        .machine(project_version)
+        .json(json)
+        .write_line()?;
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -306,6 +306,10 @@ pub(crate) mod project {
         Request::get(format!("v0/projects/{id}")).body(CloudRequestWrapper::bare(cloud_route))
     }
 
+    pub(crate) fn version(cloud_route: &MultiAddr) -> RequestBuilder<BareCloudRequestWrapper> {
+        Request::get("v0/projects/version_info").body(CloudRequestWrapper::bare(cloud_route))
+    }
+
     pub(crate) fn delete(
         space_id: &str,
         project_id: &str,

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -20,6 +20,10 @@ teardown() {
 }
 
 # ===== TESTS
+@test "projects - version" {
+  run_success "$OCKAM" project version
+}
+
 @test "projects - enrollment" {
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
 

--- a/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_project.rs
@@ -17,6 +17,10 @@ fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(prefix_args).arg("version");
+    cmd.assert().success();
+
+    let mut cmd = Command::cargo_bin("ockam")?;
     cmd.args(prefix_args).arg("show").arg("project-id");
     cmd.assert().success();
 


### PR DESCRIPTION
https://github.com/build-trust/ockam/issues/4050

ockam project version v0.90.0

## Current behavior

There is no CLI command to get project version details

## Proposed changes

Added a new command that retrieves the version of a given project.

1.  Added new command in [ockam_command::project](https://github.com/build-trust/ockam/tree/develop/implementations/rust/ockam/ockam_command/src/project) named ockam project version {name} that sends a request to the API developed at 
https://github.com/build-trust/ockam/issues/4062 that outputs the project version

2. Added test in the [commands.bats](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_command/tests/commands.bats) file

-------

Hi @etorreborre ,

Request you to review.

Thanks
