### PR TITLE
feat(rust): new sidecar to run inlet/outlet relay portal with one command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -34,6 +34,8 @@ mod secure_channel;
 mod service;
 #[cfg(feature = "orchestrator")]
 mod share;
+pub mod shutdown;
+mod sidecar;
 mod space;
 mod status;
 mod subscription;
@@ -59,6 +61,7 @@ use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 use crate::kafka::direct::KafkaDirectCommand;
 use crate::kafka::outlet::KafkaOutletCommand;
+use crate::sidecar::SidecarCommand;
 use colorful::Colorful;
 use completion::CompletionCommand;
 use configuration::ConfigurationCommand;
@@ -265,6 +268,7 @@ pub enum OckamSubcommand {
     Enroll(EnrollCommand),
     Space(SpaceCommand),
     Project(ProjectCommand),
+    Sidecar(SidecarCommand),
     Admin(AdminCommand),
     #[cfg(feature = "orchestrator")]
     Share(ShareCommand),
@@ -432,6 +436,7 @@ impl OckamCommand {
             OckamSubcommand::Environment(c) => c.run(),
 
             OckamSubcommand::FlowControl(c) => c.run(options),
+            OckamSubcommand::Sidecar(c) => c.run(options),
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -1,7 +1,7 @@
 mod addon;
 mod create;
 mod delete;
-mod enroll;
+pub(crate) mod enroll;
 mod info;
 mod list;
 mod show;
@@ -17,6 +17,7 @@ pub use crate::credential::get::GetCommand;
 pub use addon::AddonCommand;
 pub use create::CreateCommand;
 pub use delete::DeleteCommand;
+pub use enroll::EnrollCommand;
 pub use info::InfoCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
@@ -24,7 +25,6 @@ pub use ticket::TicketCommand;
 pub use version::VersionCommand;
 
 use crate::docs;
-use crate::project::enroll::EnrollCommand;
 use crate::CommandGlobalOpts;
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");

--- a/implementations/rust/ockam/ockam_command/src/run/parser.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser.rs
@@ -1,6 +1,7 @@
+use crate::{shutdown, CommandGlobalOpts};
 use duct::Expression;
 use miette::IntoDiagnostic;
-use ockam_api::cli_state::{CliState, StateDirTrait};
+use ockam_api::cli_state::StateDirTrait;
 use ockam_core::compat::collections::HashMap;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
@@ -19,6 +20,7 @@ pub struct ParsedCommand {
     pub id: String,
     pub depends_on: Option<String>,
     pub cmd: Expression,
+    pub block_on_node: Option<String>,
 }
 
 impl ConfigRunner {
@@ -29,16 +31,26 @@ impl ConfigRunner {
         }
     }
 
-    pub fn go(cli_state: &CliState, path: &Path) -> miette::Result<()> {
+    pub async fn go(opts: CommandGlobalOpts, path: &Path, blocking: bool) -> miette::Result<()> {
         let mut cr = Self::new();
-        cr.parse(cli_state, path)?;
-        cr.run()?;
+        let config = std::fs::read_to_string(path).into_diagnostic()?;
+        cr.parse(&config, blocking)?;
+        cr.run(opts).await?;
         Ok(())
     }
 
-    fn parse(&mut self, cli_state: &CliState, path: &Path) -> miette::Result<()> {
-        let config = std::fs::read_to_string(path).into_diagnostic()?;
-        let config: Config = serde_yaml::from_str(&config).into_diagnostic()?;
+    pub async fn go_inline(
+        opts: CommandGlobalOpts,
+        config: &str,
+        blocking: bool,
+    ) -> miette::Result<()> {
+        let mut cr = Self::new();
+        cr.parse(config, blocking)?;
+        cr.run(opts).await
+    }
+
+    fn parse(&mut self, config: &str, blocking: bool) -> miette::Result<()> {
+        let config: Config = serde_yaml::from_str(config).into_diagnostic()?;
         let mut visited = HashSet::new();
         let mut nodes = VecDeque::new();
         for (name, node) in config.nodes {
@@ -77,20 +89,67 @@ impl ConfigRunner {
             }
             // Remove it from the control vector and parse it.
             visited.remove(&name);
-            node.parse(cli_state, &name, self)?;
+            node.parse(&name, blocking, self)?;
         }
         Ok(())
     }
 
-    fn run(self) -> miette::Result<()> {
-        for c in self.commands_sorted.into_iter() {
-            debug!("Running command: {}", c.id);
+    async fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let mut spawned_nodes = vec![];
+        let mut handlers = vec![];
+
+        for command in self.commands_sorted.into_iter() {
+            debug!("Running command: {}: {:?}", command.id, command.cmd);
             // If a command fails it will show the appropriate error in its subshell.
             // No need to return an error here.
-            if c.cmd.run().is_err() {
+            if let Some(spawn_node) = command.block_on_node {
+                let result = command.cmd.start();
+                match result {
+                    Ok(handle) => {
+                        handlers.push(handle);
+                        spawned_nodes.push(spawn_node);
+                    }
+                    Err(_err) => {
+                        break;
+                    }
+                }
+
+                // the next command will expect the node to be up and running
+                //TODO: wait for the node availability rather than sleeping
+                tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            } else if command.cmd.run().is_err() {
                 break;
             }
         }
+
+        if !spawned_nodes.is_empty() {
+            // Create a channel for communicating back to the main thread
+            let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+
+            // Spawn a thread to trigger shutdown when all nodes are done
+            {
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    while let Some(handle) = handlers.pop() {
+                        let _ = handle.wait();
+                    }
+                    let _ = tx.send(()).await;
+                });
+            }
+
+            // Wait for CTRL+C or any other exit condition (like receiving a signal)
+            shutdown::wait(opts.terminal, true, true, tx, &mut rx).await?;
+
+            // Send a SIGTERM to all nodes if they are still running
+            for node_name in spawned_nodes {
+                if let Ok(node) = opts.state.nodes.get(node_name) {
+                    if node.is_running() {
+                        let _ = node.kill_process(false);
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -113,7 +172,7 @@ impl ConfigRunner {
 ///         from: /service/outlet
 ///         to: '127.0.0.1:8086'
 ///         access_control: '(= subject.component "telegraf")'
-///     forwarders:
+///     relays:
 ///       influxdb:
 ///         at: /project/default
 /// ```
@@ -127,57 +186,88 @@ pub struct Config {
 pub struct NodeConfig {
     #[serde(rename(deserialize = "depends-on"))]
     pub depends_on: Option<String>,
-    pub enrollment_token: Option<String>,
+    #[serde(rename(deserialize = "enroll-ticket"))]
+    pub enroll_ticket: Option<String>,
     #[serde(rename(deserialize = "tcp-inlets"))]
     pub tcp_inlets: Option<HashMap<String, InletConfig>>,
     #[serde(rename(deserialize = "tcp-outlets"))]
     pub tcp_outlets: Option<HashMap<String, OutletConfig>>,
-    pub forwarders: Option<HashMap<String, ForwarderConfig>>,
+    pub relays: Option<HashMap<String, RelayConfig>>,
 }
 
 impl NodeConfig {
-    fn parse(
-        self,
-        cli_state: &CliState,
-        node_name: &str,
-        cmds: &mut ConfigRunner,
-    ) -> miette::Result<()> {
-        let mut insert_command = |subject: &str, name: &str, depends_on, args: &[&str]| {
-            debug!("Parsed command: {} {}", binary_path(), args.join(" "));
-            let cmd = duct::cmd(binary_path(), args);
-            let id = format!("{subject}/{name}");
-            if cmds.commands_index.contains_key(&id) {
-                return Err(miette::miette!(
-                    "There can't be {}s with the same name: {}",
-                    subject,
-                    name
-                ));
-            }
-            cmds.commands_index
-                .insert(id.clone(), cmds.commands_sorted.len());
-            cmds.commands_sorted.push(ParsedCommand {
-                id,
-                depends_on,
-                cmd,
-            });
-            Ok(())
-        };
-
-        // Check if the node already exists. If it doesn't, create it.
-        if !cli_state.nodes.exists(node_name) {
-            let args = {
-                let mut args = vec!["node", "create", node_name];
-                if let Some(enrollment_token) = &self.enrollment_token {
-                    args.push("--enrollment-token");
-                    args.push(enrollment_token);
+    fn parse(self, node_name: &str, blocking: bool, cmds: &mut ConfigRunner) -> miette::Result<()> {
+        let mut insert_command =
+            |subject: &str, name: &str, depends_on, args: &[&str], blocks: bool| {
+                debug!("Parsed command: {} {}", binary_path(), args.join(" "));
+                let cmd = duct::cmd(binary_path(), args);
+                let id = format!("{subject}/{name}");
+                if cmds.commands_index.contains_key(&id) {
+                    return Err(miette::miette!(
+                        "There can't be {}s with the same name: {}",
+                        subject,
+                        name
+                    ));
                 }
-                args
+                cmds.commands_index
+                    .insert(id.clone(), cmds.commands_sorted.len());
+
+                let block_on_node = if blocks {
+                    Some(node_name.to_string())
+                } else {
+                    None
+                };
+
+                cmds.commands_sorted.push(ParsedCommand {
+                    id,
+                    depends_on,
+                    cmd,
+                    block_on_node,
+                });
+                Ok(())
             };
+
+        // always enroll since it's an idempotent operation
+        // the trust context is named after the node
+        if let Some(enroll_ticket) = &self.enroll_ticket {
+            insert_command(
+                "node",
+                &format!("{}/enroll", node_name),
+                None,
+                &[
+                    "project",
+                    "enroll",
+                    "--new-trust-context-name",
+                    node_name,
+                    enroll_ticket,
+                ],
+                false,
+            )?;
+        }
+
+        // Always create the node, if it already exists (but not running) it'll be-started.
+        if blocking {
             insert_command(
                 "node",
                 node_name,
                 self.depends_on.map(|s| format!("node/{s}")),
-                args.as_slice(),
+                &[
+                    "node",
+                    "create",
+                    node_name,
+                    "--foreground",
+                    "--trust-context",
+                    node_name,
+                ],
+                true,
+            )?;
+        } else {
+            insert_command(
+                "node",
+                node_name,
+                self.depends_on.map(|s| format!("node/{s}")),
+                &["node", "create", node_name, "--trust-context", node_name],
+                false,
             )?;
         }
 
@@ -198,7 +288,7 @@ impl NodeConfig {
                         "--expression",
                         exp,
                     ];
-                    insert_command("policy", name, None, args)?;
+                    insert_command("policy", name, None, args, false)?;
                 }
                 let args = &[
                     "tcp-inlet",
@@ -212,7 +302,7 @@ impl NodeConfig {
                     "--alias",
                     name,
                 ];
-                insert_command("inlet", name, None, args)?;
+                insert_command("inlet", name, None, args, false)?;
             }
         }
 
@@ -230,7 +320,7 @@ impl NodeConfig {
                         "--expression",
                         exp,
                     ];
-                    insert_command("policy", name, None, args)?;
+                    insert_command("policy", name, None, args, false)?;
                 }
                 let args = &[
                     "tcp-outlet",
@@ -244,23 +334,23 @@ impl NodeConfig {
                     "--alias",
                     name,
                 ];
-                insert_command("outlet", name, None, args)?;
+                insert_command("outlet", name, None, args, false)?;
             }
         }
 
-        if let Some(forwarders) = &self.forwarders {
-            for (name, forwarder) in forwarders {
-                // TODO: store forwarders in CliState; Then check if the forwarder already exists. If it doesn't, create it.
+        if let Some(relays) = &self.relays {
+            for (name, relay) in relays {
+                // TODO: store relays in CliState; Then check if the relay already exists. If it doesn't, create it.
                 let args = &[
-                    "forwarder",
+                    "relay",
                     "create",
                     name,
                     "--to",
                     &node_name_formatted,
                     "--at",
-                    &forwarder.at,
+                    &relay.at,
                 ];
-                insert_command("forwarder", name, None, args)?;
+                insert_command("relay", name, None, args, false)?;
             }
         }
 
@@ -284,9 +374,9 @@ pub struct OutletConfig {
     pub access_control: Option<String>,
 }
 
-/// Defines the structure of a forwarder in the config file.
+/// Defines the structure of a relay in the config file.
 #[derive(Debug, Deserialize)]
-pub struct ForwarderConfig {
+pub struct RelayConfig {
     pub at: String,
 }
 
@@ -314,7 +404,7 @@ mod tests {
                     from: /service/outlet
                     to: '127.0.0.1:8086'
                     access_control: '(= subject.component "telegraf")'
-                forwarders:
+                relays:
                   influxdb:
                     at: /project/default
 
@@ -326,18 +416,15 @@ mod tests {
                     to: /project/default/service/forward_to_influxdb/secure/api/service/outlet
                     access_control: '(= subject.component "influxdb")'
         "#;
-        let tmp_file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(tmp_file.path(), config).unwrap();
 
         let mut sut = ConfigRunner::new();
-        let cli_state = CliState::test().unwrap();
-        sut.parse(&cli_state, tmp_file.path()).unwrap();
+        sut.parse(config, false).unwrap();
 
         assert_eq!(sut.commands_sorted.len(), 7);
         assert_eq!(sut.commands_sorted[0].id, "node/influxdb");
         assert_eq!(sut.commands_sorted[1].id, "policy/influxdb");
         assert_eq!(sut.commands_sorted[2].id, "outlet/influxdb");
-        assert_eq!(sut.commands_sorted[3].id, "forwarder/influxdb");
+        assert_eq!(sut.commands_sorted[3].id, "relay/influxdb");
         assert_eq!(sut.commands_sorted[4].id, "node/telegraf");
         assert_eq!(
             sut.commands_sorted[4].depends_on.as_ref().unwrap(),
@@ -403,12 +490,9 @@ mod tests {
                 Ok(()),
             ),
         ];
-        let tmp_file = tempfile::NamedTempFile::new().unwrap();
         for (config, expected) in cases {
-            std::fs::write(tmp_file.path(), config).unwrap();
             let mut sut = ConfigRunner::new();
-            let cli_state = CliState::test().unwrap();
-            let result = sut.parse(&cli_state, tmp_file.path());
+            let result = sut.parse(config, false);
             match expected {
                 Ok(_) => assert!(result.is_ok()),
                 Err(_) => {

--- a/implementations/rust/ockam/ockam_command/src/shutdown.rs
+++ b/implementations/rust/ockam/ockam_command/src/shutdown.rs
@@ -1,0 +1,61 @@
+use crate::{Terminal, TerminalStream};
+use colorful::Colorful;
+use console::Term;
+use std::io;
+use std::io::Read;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+/// Waits for CTRL+C, EOF or a signal to exit, can provide extra shutdown events by
+/// sending a message through the channel
+pub async fn wait(
+    terminal: Terminal<TerminalStream<Term>>,
+    exit_on_eof: bool,
+    muted: bool,
+    tx: Sender<()>,
+    rx: &mut Receiver<()>,
+) -> miette::Result<bool> {
+    // Register a handler for SIGINT, SIGTERM, SIGHUP
+    {
+        let tx = tx.clone();
+        let terminal = terminal.clone();
+        // avoid printing CTRL+C multiple times
+        let first_time_handling_ctrl_c = Arc::new(AtomicBool::new(true));
+        ctrlc::set_handler(move || {
+            if first_time_handling_ctrl_c.load(std::sync::atomic::Ordering::Relaxed) {
+                let _ = tx.blocking_send(());
+                if !muted {
+                    let _ = terminal.write_line(
+                        format!("{} Ctrl+C signal received", "!".light_yellow()).as_str(),
+                    );
+                }
+                first_time_handling_ctrl_c.store(false, std::sync::atomic::Ordering::Relaxed);
+            }
+        })
+        .expect("Error setting Ctrl+C handler");
+    }
+
+    if exit_on_eof {
+        // Spawn a thread to monitor STDIN for EOF
+        {
+            let tx = tx.clone();
+            let terminal = terminal.clone();
+            std::thread::spawn(move || {
+                let mut buffer = Vec::new();
+                let mut handle = io::stdin().lock();
+                handle
+                    .read_to_end(&mut buffer)
+                    .expect("Error reading from stdin");
+                let _ = tx.blocking_send(());
+                if !muted {
+                    let _ = terminal
+                        .write_line(format!("{} EOF received", "!".light_yellow()).as_str());
+                }
+            });
+        }
+    }
+
+    // Shutdown on SIGINT, SIGTERM, SIGHUP or EOF
+    Ok(rx.recv().await.is_some())
+}

--- a/implementations/rust/ockam/ockam_command/src/sidecar/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/mod.rs
@@ -1,0 +1,38 @@
+use crate::sidecar::secure_relay_inlet::SecureRelayInlet;
+use crate::{docs, CommandGlobalOpts};
+use clap::{Args, Subcommand};
+
+mod secure_relay_inlet;
+mod secure_relay_outlet;
+use crate::sidecar::secure_relay_outlet::SecureRelayOutlet;
+
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+
+/// Manage nodes
+#[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+)]
+pub struct SidecarCommand {
+    #[command(subcommand)]
+    pub subcommand: SidecarSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum SidecarSubcommand {
+    #[command(display_order = 800)]
+    SecureRelayInlet(Box<SecureRelayInlet>),
+    #[command(display_order = 801)]
+    SecureRelayOutlet(Box<SecureRelayOutlet>),
+}
+
+impl SidecarCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            SidecarSubcommand::SecureRelayOutlet(c) => c.run(options),
+            SidecarSubcommand::SecureRelayInlet(c) => c.run(options),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -1,0 +1,114 @@
+use clap::Args;
+use colorful::Colorful;
+use indoc::formatdoc;
+use ockam_node::Context;
+use std::net::SocketAddr;
+
+use crate::run::ConfigRunner;
+use crate::tcp::inlet::create::default_from_addr;
+use crate::util::node_rpc;
+use crate::util::parsers::socket_addr_parser;
+use crate::{docs, fmt_info, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/secure_relay_inlet/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/secure_relay_inlet/after_long_help.txt");
+
+/// Create and setup a new relay node, idempotent
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
+pub struct SecureRelayInlet {
+    /// The name of the service
+    #[arg(value_name = "SERVICE NAME")]
+    pub service_name: String,
+
+    /// Address on which to accept tcp connections.
+    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", default_value_t = default_from_addr(), value_parser = socket_addr_parser)]
+    from: SocketAddr,
+
+    /// Just print the recipe and exit
+    #[arg(long)]
+    dry_run: bool,
+
+    #[command(flatten)]
+    enroll: Enroll,
+}
+
+#[derive(Clone, Debug, Args)]
+#[group(required = true, multiple = false)]
+struct Enroll {
+    /// Enrollment ticket to use
+    #[arg(
+        long,
+        value_name = "ENROLLMENT TICKET PATH",
+        group = "authentication_method"
+    )]
+    pub enroll_ticket: Option<String>,
+
+    /// If using Okta enrollment
+    #[arg(long = "okta", group = "authentication_method")]
+    pub okta: bool,
+}
+
+impl SecureRelayInlet {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(rpc, (opts, self))
+    }
+}
+
+async fn rpc(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, SecureRelayInlet),
+) -> miette::Result<()> {
+    cmd.create_config_and_start(opts).await
+}
+
+impl SecureRelayInlet {
+    pub async fn create_config_and_start(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let stdout = opts.terminal.clone().stdout();
+
+        let enroll: String = if let Some(enroll_ticket) = self.enroll.enroll_ticket.as_ref() {
+            format! {
+                "enroll-ticket: {enroll_ticket}",
+                enroll_ticket = enroll_ticket
+            }
+        } else {
+            "okta: true".to_string()
+        };
+
+        let recipe: String = formatdoc! {
+            r#"
+            nodes:
+              secure_relay_inlet:
+                {enroll}
+                tcp-inlets:
+                  {service_name}:
+                    from: {from}
+                    to: /project/default/service/forward_to_{service_name}/secure/api/service/outlet_{service_name}
+            "#,
+            enroll = enroll,
+            from = self.from.to_string(),
+            service_name = self.service_name,
+        };
+
+        if self.dry_run {
+            stdout.plain(recipe.as_str()).write_line()?;
+            return Ok(());
+        }
+
+        stdout
+            .plain(fmt_info!(
+                r#"Creating new inlet relay node using this configuration:
+```
+{}```
+       You can copy and customize the above recipe and launch it with `ockam run`.
+"#,
+                recipe.as_str().dark_gray()
+            ))
+            .write_line()?;
+
+        ConfigRunner::go_inline(opts, &recipe, true).await
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -1,0 +1,117 @@
+use clap::Args;
+use colorful::Colorful;
+use indoc::formatdoc;
+use ockam_node::Context;
+use std::net::SocketAddr;
+
+use crate::run::ConfigRunner;
+use crate::util::node_rpc;
+use crate::util::parsers::socket_addr_parser;
+use crate::{docs, fmt_info, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("./static/secure_relay_outlet/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/secure_relay_outlet/after_long_help.txt");
+
+/// Create and setup a new relay node, idempotent
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
+pub struct SecureRelayOutlet {
+    /// The name of the service
+    #[arg(value_name = "SERVICE NAME")]
+    pub service_name: String,
+
+    /// TCP address to send raw tcp traffic.
+    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS", value_parser = socket_addr_parser)]
+    to: SocketAddr,
+
+    /// Just print the recipe and exit
+    #[arg(long)]
+    dry_run: bool,
+
+    #[command(flatten)]
+    enroll: Enroll,
+}
+
+#[derive(Clone, Debug, Args)]
+#[group(required = true, multiple = false)]
+struct Enroll {
+    /// Enrollment ticket to use
+    #[arg(
+        long,
+        value_name = "ENROLLMENT TICKET PATH",
+        group = "authentication_method"
+    )]
+    pub enroll_ticket: Option<String>,
+
+    /// If using Okta enrollment
+    #[arg(long = "okta", group = "authentication_method")]
+    pub okta: bool,
+}
+
+impl SecureRelayOutlet {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(rpc, (opts, self))
+    }
+}
+
+async fn rpc(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, SecureRelayOutlet),
+) -> miette::Result<()> {
+    cmd.create_config_and_start(opts).await
+}
+
+impl SecureRelayOutlet {
+    pub async fn create_config_and_start(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let stdout = opts.terminal.clone().stdout();
+
+        let enroll: String = if let Some(enroll_ticket) = self.enroll.enroll_ticket.as_ref() {
+            format! {
+                "enroll-ticket: {enroll_ticket}",
+                enroll_ticket = enroll_ticket
+            }
+        } else {
+            "okta: true".to_string()
+        };
+
+        let recipe: String = formatdoc! {
+            r#"
+            nodes:
+              secure_relay_outlet:
+                {enroll}
+                tcp-outlets:
+                  {service_name}:
+                    from: '/service/outlet_{service_name}'
+                    to: {to}
+                    access_control: '(= subject.component "{service_name}")'
+                relays:
+                  {service_name}:
+                    at: /project/default
+            "#,
+            enroll = enroll,
+            to = self.to.to_string(),
+            service_name = self.service_name,
+        };
+
+        if self.dry_run {
+            stdout.plain(recipe.as_str()).write_line()?;
+            return Ok(());
+        }
+
+        stdout
+            .plain(fmt_info!(
+                r#"Creating new outlet relay node using this configuration:
+```
+{}```
+       You can copy and customize the above recipe and launch it with `ockam run`.
+"#,
+                recipe.as_str().dark_gray()
+            ))
+            .write_line()?;
+
+        ConfigRunner::go_inline(opts, &recipe, true).await
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/sidecar/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/static/long_about.txt
@@ -1,0 +1,3 @@
+This command starts sidecar, every sidecar is thought to be standalone and can be executed locally or within a docker container.
+You can also customize recipes to fit your needs by running the sidecar with `--dry-run` parameter and then editing the generated recipe.
+To execute a recipe, use `ockam run`.

--- a/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_inlet/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_inlet/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# Starts the inlet relay listening in port 5432 with a service called `postgresql-production`
+ockam sidecar secure-relay-inlet --from 127.0.0.1:5432 --enroll-ticket ./ticket postgresql-production
+
+# Prints the recipe without executing any command, can be used with `ockam run`
+ockam sidecar secure-relay-inlet --from 127.0.0.1:5432 --enroll-ticket ./ticket --dry-run postgresql-production
+
+# Starts an inlet relay service called `my-http-service` listening on port 6000 inside a docker container
+docker run --name my-http-service -ti -p 6000:6000 --volume /tmp/ticket_for_docker:/ticket ockam sidecar secure-relay-inlet --from 0.0.0.0:6000 --enroll-ticket /ticket my-http-service
+```

--- a/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_inlet/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_inlet/long_about.txt
@@ -1,0 +1,1 @@
+This sidecar starts a TCP inlet listening in the provided port. It requires a valid enrollment mechanism. The portal will be named and inlet and outlet name must match.

--- a/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_outlet/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_outlet/after_long_help.txt
@@ -1,0 +1,10 @@
+```sh
+# Starts the outlet connecting to localhost port 5432, with a named service `postgresql-production`
+ockam sidecar secure-relay-outlet --to 127.0.0.1:5432 --enroll-ticket ./ticket postgresql-production
+
+# Prints the recipe without executing any command, can be used with `ockam run`
+ockam sidecar secure-relay-outlet --to 127.0.0.1:5432 --enroll-ticket ./ticket --dry-run postgresql-production
+
+# Starts an outlet relay service called `my-http-service` listening connecting to port 5000 inside a docker container
+docker run --name my-http-service -ti --volume /tmp/ticket_for_docker:/ticket ockam sidecar secure-relay-outlet --to 127.0.0.1:5000 --enroll-ticket /ticket my-http-service
+```

--- a/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_outlet/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/static/secure_relay_outlet/long_about.txt
@@ -1,0 +1,1 @@
+This sidecar starts a TCP outlet connecting to the provided address. It requires a valid enrollment mechanism. The portal will be named and inlet and outlet name must match.

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -64,7 +64,7 @@ pub struct CreateCommand {
     retry_wait: Duration,
 }
 
-fn default_from_addr() -> SocketAddr {
+pub(crate) fn default_from_addr() -> SocketAddr {
     let port = find_available_port().expect("Failed to find available port");
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
@@ -1,4 +1,4 @@
-mod create;
+pub(crate) mod create;
 mod delete;
 mod list;
 mod show;

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -60,12 +60,12 @@ teardown() {
   run "$OCKAM" project ticket --identity enroller --project-path "$PROJECT_JSON_PATH" --member $m2_identifier --attribute sample_attr=m2_member
   assert_success
 
-  run "$OCKAM" project enroll --project-path "$PROJECT_JSON_PATH" --identity m2
+  run "$OCKAM" project enroll --force --project-path "$PROJECT_JSON_PATH" --identity m2
   assert_success
   assert_output --partial "m2_member"
 
   token=$($OCKAM project ticket --identity enroller --project-path "$PROJECT_JSON_PATH" --attribute sample_attr=m3_member)
-  run "$OCKAM" project enroll $token --identity m3
+  run "$OCKAM" project enroll --force $token --identity m3
   assert_success
   assert_output --partial "m3_member"
 }


### PR DESCRIPTION
New standalone commands class called `sidecar`, these command create `ockam run` configurations, now called `recipes`.
The sidecar commands are thought to be standalone and idempotent, so they can be easily used inside a docker environment (or any other executor).

To achieve this, `ockam run` was adjusted to allow for a blocking mode where every node started is started in foreground mode. 
Project enrollment is now idempotent, and it's a no-op if the ticket authority is the same as the current trust-context (there is a force parameter to bypass the check).
Moreover, `ockam run` will always call `ockam node create` rather than restarting the node, to achieve idempotence.