### PR TITLE
ci: Configure GPG signing for Nix flake.lock workflow

### DIFF
--- a/.github/workflows/nix-flake-lock.yml
+++ b/.github/workflows/nix-flake-lock.yml
@@ -39,3 +39,22 @@ jobs:
             Type: Dependencies
           pr-title: 'chore: Update tools/nix/flake.lock'
           sign-commits: true
+          # see also: /.github/PULL_REQUEST_TEMPLATE.md
+          pr-body: |
+            ## Current behavior
+
+            N/A
+
+            ## Proposed changes
+
+            This is an automated change that has performed the equivalent of
+            `nix flake update --commit-lock-file` against `/tools/nix`. An Ockam
+            employee familiar with Nix should exercise the local Nix content,
+            such as `devShells`, using this branch.
+
+            ## Checks
+
+            - [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
+            - [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
+            - [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
+            - [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

--- a/.github/workflows/nix-flake-lock.yml
+++ b/.github/workflows/nix-flake-lock.yml
@@ -30,5 +30,7 @@ jobs:
           gpg-passphrase: '${{ secrets.GPG_PASSPHRASE }}'
           gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
           path-to-flake-dir: 'tools/nix'
+          pr-labels: |
+            Type: Dependencies
           pr-title: 'chore: Update tools/nix/flake.lock'
           sign-commits: true

--- a/.github/workflows/nix-flake-lock.yml
+++ b/.github/workflows/nix-flake-lock.yml
@@ -23,9 +23,12 @@ jobs:
         # https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v19
         uses: DeterminateSystems/update-flake-lock@dec3bc3c9b11c3b9d547f47dfb579b91a6051603
         with:
-          git-author-name: 'ockam[bot]'
-          git-author-email: 'ockam[bot]@users.noreply.ockam.io'
-          git-committer-name: 'ockam[bot]'
-          git-committer-email: 'ockam[bot]@users.noreply.ockam.io'
+          git-author-name: '${{ secrets.GPG_USER_NAME }}'
+          git-author-email: '${{ secrets.GPG_EMAIL }}'
+          git-committer-name: '${{ secrets.GPG_USER_NAME }}'
+          git-committer-email: '${{ secrets.GPG_EMAIL }}'
+          gpg-passphrase: '${{ secrets.GPG_PASSPHRASE }}'
+          gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
           path-to-flake-dir: 'tools/nix'
           pr-title: 'chore: Update tools/nix/flake.lock'
+          sign-commits: true

--- a/.github/workflows/nix-flake-lock.yml
+++ b/.github/workflows/nix-flake-lock.yml
@@ -30,6 +30,10 @@ jobs:
           gpg-passphrase: '${{ secrets.GPG_PASSPHRASE }}'
           gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
           path-to-flake-dir: 'tools/nix'
+          pr-assignees: shanesveller
+          pr-reviewers: |
+            etorreborre
+            shanesveller
           pr-labels: |
             Type: Dependencies
           pr-title: 'chore: Update tools/nix/flake.lock'

--- a/.github/workflows/nix-flake-lock.yml
+++ b/.github/workflows/nix-flake-lock.yml
@@ -23,6 +23,7 @@ jobs:
         # https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v19
         uses: DeterminateSystems/update-flake-lock@dec3bc3c9b11c3b9d547f47dfb579b91a6051603
         with:
+          commit-msg: "build: update tools/nix/flake.lock"
           git-author-name: '${{ secrets.GPG_USER_NAME }}'
           git-author-email: '${{ secrets.GPG_EMAIL }}'
           git-committer-name: '${{ secrets.GPG_USER_NAME }}'


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Our branch protection rules require signed commits, and the Nix workflow introduced during #5473 did not account for this.

## Proposed changes

Import a GPG private key during this workflow to produce appropriately signed commits.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
