### PR TITLE
refactor: Invitation arguments require email, don't require or pass remaining uses

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
@@ -11,7 +11,7 @@ use super::{RoleInShare, SentInvitation, ShareScope};
 pub struct CreateInvitation {
     #[n(1)] pub expires_at: Option<String>,
     #[n(2)] pub grant_role: RoleInShare,
-    #[n(3)] pub recipient_email: Option<String>,
+    #[n(3)] pub recipient_email: String,
     #[n(4)] pub remaining_uses: Option<usize>,
     #[n(5)] pub scope: ShareScope,
     #[n(6)] pub target_id: String,

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -106,7 +106,7 @@ pub struct SentInvitation {
     #[n(2)] pub expires_at: String,
     #[n(3)] pub grant_role: RoleInShare,
     #[n(4)] pub owner_id: usize,
-    #[n(5)] pub recipient_email: Option<String>,
+    #[n(5)] pub recipient_email: String,
     #[n(6)] pub remaining_uses: usize,
     #[n(7)] pub scope: ShareScope,
     #[n(8)] pub target_id: String,

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -25,12 +25,11 @@ pub struct CreateCommand {
     #[arg(value_parser = clap::value_parser!(ShareScope))]
     pub scope: ShareScope,
     pub target_id: String,
+    pub recipient_email: String,
     #[arg(default_value_t = RoleInShare::Admin, long, short = 'R', value_parser = clap::value_parser!(RoleInShare))]
     pub grant_role: RoleInShare,
     #[arg(long, short = 'x')]
     pub expires_at: Option<String>,
-    #[arg(long, short = 'e')]
-    pub recipient_email: Option<String>,
     #[arg(default_value = "3", long, short = 'u')]
     pub remaining_uses: Option<usize>,
 }
@@ -101,16 +100,13 @@ async fn run_impl(
     delete_embedded_node(&opts, rpc.node_name()).await;
 
     let plain = fmt_ok!(
-        "Invite {} to {} {} created, with {} remaining uses and expiring at {}.{}",
+        "Invite {} to {} {} created, with {} remaining uses and expiring at {}. {} will be notified via email.",
         sent.id,
         sent.scope,
         sent.target_id,
         sent.remaining_uses,
         sent.expires_at,
         sent.recipient_email
-            .as_ref()
-            .map(|e| format!(" {e} will be notified via email."))
-            .unwrap_or("".to_string())
     );
     let json = serde_json::to_string_pretty(&sent).into_diagnostic()?;
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -30,8 +30,6 @@ pub struct CreateCommand {
     pub grant_role: RoleInShare,
     #[arg(long, short = 'x')]
     pub expires_at: Option<String>,
-    #[arg(default_value = "3", long, short = 'u')]
-    pub remaining_uses: Option<usize>,
 }
 
 impl CreateCommand {
@@ -46,7 +44,6 @@ impl From<CreateCommand> for CreateInvitation {
             expires_at,
             grant_role,
             recipient_email,
-            remaining_uses,
             scope,
             target_id,
             ..
@@ -55,7 +52,7 @@ impl From<CreateCommand> for CreateInvitation {
             expires_at,
             grant_role,
             recipient_email,
-            remaining_uses,
+            remaining_uses: None,
             scope,
             target_id,
         }
@@ -100,11 +97,10 @@ async fn run_impl(
     delete_embedded_node(&opts, rpc.node_name()).await;
 
     let plain = fmt_ok!(
-        "Invite {} to {} {} created, with {} remaining uses and expiring at {}. {} will be notified via email.",
+        "Invite {} to {} {} created, expiring at {}. {} will be notified via email.",
         sent.id,
         sent.scope,
         sent.target_id,
-        sent.remaining_uses,
         sent.expires_at,
         sent.recipient_email
     );

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -114,16 +114,13 @@ async fn run_impl(
     delete_embedded_node(&opts, rpc.node_name()).await;
 
     let plain = fmt_ok!(
-        "Invitation {} to {} {} created, with {} remaining uses and expiring at {}.{}",
+        "Invitation {} to {} {} created, with {} remaining uses and expiring at {}. {} will be notified via email.",
         sent.id,
         sent.scope,
         sent.target_id,
         sent.remaining_uses,
         sent.expires_at,
         sent.recipient_email
-            .as_ref()
-            .map(|e| format!(" {e} will be notified via email."))
-            .unwrap_or("".to_string())
     );
     let json = serde_json::to_string_pretty(&sent).into_diagnostic()?;
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -114,11 +114,10 @@ async fn run_impl(
     delete_embedded_node(&opts, rpc.node_name()).await;
 
     let plain = fmt_ok!(
-        "Invitation {} to {} {} created, with {} remaining uses and expiring at {}. {} will be notified via email.",
+        "Invitation {} to {} {} created, expiring at {}. {} will be notified via email.",
         sent.id,
         sent.scope,
         sent.target_id,
-        sent.remaining_uses,
         sent.expires_at,
         sent.recipient_email
     );


### PR DESCRIPTION
- refactor: consider recipient_email required for all invitations
- refactor: remove remaining_uses from invitation cli arguments

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Current CLI arguments under `ockam share [create|service]` treat `recipient_email` as `Option<String>`, and `remaining_uses` as `Option<usize>` with default value of 3.

## Proposed changes

Recent backend iterations have now deemed `recipient_email` a required field. As such, `remaining_uses` will also only ever have values of 0 or 1, because having multiple uses for a single recipient is no longer conceptually coherent. The `remaining_uses` argument can be omitted in the backend creation requests from now on. Most likely this field will be dropped altogether from backend and clients in another future iteration.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
