### PR TITLE
feat: Desktop Tauri plugins for invitations/projects state/commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4517,6 +4517,7 @@ dependencies = [
  "tauri-plugin-positioner",
  "tauri-runtime",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -468,6 +468,15 @@ mod node {
                 .await
         }
 
+        pub async fn list_projects(
+            &self,
+            ctx: &Context,
+            route: &MultiAddr,
+        ) -> Result<Vec<Project>> {
+            let node_manager = self.inner().read().await;
+            node_manager.list_projects(ctx, route).await
+        }
+
         pub(crate) async fn list_projects_response(
             &self,
             ctx: &Context,

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -58,5 +58,6 @@ tracing = "0.1"
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
-default = ["log"]
+default = ["invitations", "log"]
+invitations = []
 log = ["dep:log", "log/release_max_level_info", "tracing/log"]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -51,6 +51,7 @@ tauri-plugin-log = "2.0.0-alpha.0"
 tauri-plugin-positioner = { version = "2.0.0-alpha.0", features = ["system-tray"] }
 tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
 thiserror = "1.0.40"
+tokio = { version = "1.29.1", features = ["time"] }
 tracing = "0.1"
 
 [features]

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -1,0 +1,46 @@
+use tauri::{AppHandle, Manager, Runtime, State};
+use tracing::{debug, info};
+
+use ockam_api::cloud::share::{InvitationListKind, ListInvitations};
+use ockam_command::util::api::CloudOpts;
+
+use crate::app::AppState;
+
+use super::{
+    events::REFRESHED_INVITATIONS,
+    state::{InvitationState, SyncState},
+};
+
+// At time of writing, tauri::command requires pub not pub(crate)
+#[tauri::command]
+pub async fn list_invitations<R: Runtime>(app: AppHandle<R>) -> tauri::Result<InvitationState> {
+    let state: State<'_, SyncState> = app.state();
+    let reader = state.read().await;
+    Ok((*reader).clone())
+}
+
+#[tauri::command]
+pub async fn refresh_invitations<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    info!("refreshing invitations");
+    let state: State<'_, AppState> = app.state();
+    let node_manager_worker = state.node_manager_worker().await;
+    let invitations = node_manager_worker
+        .list_shares(
+            &state.context(),
+            ListInvitations {
+                kind: InvitationListKind::All,
+            },
+            &CloudOpts::route(),
+            None,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    debug!(?invitations);
+    {
+        let invitation_state: State<'_, SyncState> = app.state();
+        let mut writer = invitation_state.write().await;
+        *writer = invitations.into();
+    }
+    app.trigger_global(REFRESHED_INVITATIONS, None);
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_app/src/invitations/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/events.rs
@@ -1,0 +1,2 @@
+pub const REFRESH_INVITATIONS: &str = "invitations/refresh";
+pub const REFRESHED_INVITATIONS: &str = "invitations/refreshed";

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -1,0 +1,4 @@
+mod commands;
+mod events;
+pub(super) mod plugin;
+mod state;

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -1,0 +1,46 @@
+use std::{sync::Arc, time::Duration};
+
+use tauri::{
+    async_runtime::{spawn, RwLock},
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+use tracing::trace;
+
+use super::commands::*;
+use super::events::{REFRESHED_INVITATIONS, REFRESH_INVITATIONS};
+use super::state::InvitationState;
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("sharing")
+        .invoke_handler(tauri::generate_handler![
+            list_invitations,
+            refresh_invitations
+        ])
+        .setup(|app, _api| {
+            app.manage(Arc::new(RwLock::new(InvitationState::default())));
+            let handle = app.clone();
+            app.listen_global(REFRESH_INVITATIONS, move |_event| {
+                let handle = handle.clone();
+                spawn(async move { refresh_invitations(handle.clone()).await });
+            });
+            let handle = app.clone();
+            spawn(async move {
+                handle.trigger_global(REFRESH_INVITATIONS, None);
+                let mut interval = tokio::time::interval(DEFAULT_POLL_INTERVAL);
+                loop {
+                    interval.tick().await;
+                    trace!("refreshing invitations via background poll");
+                    handle.trigger_global(REFRESH_INVITATIONS, None);
+                }
+            });
+            let handle = app.clone();
+            app.listen_global(REFRESHED_INVITATIONS, move |_event| {
+                handle.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+            });
+            Ok(())
+        })
+        .build()
+}

--- a/implementations/rust/ockam/ockam_app/src/invitations/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/state.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::async_runtime::RwLock;
+
+use ockam_api::cloud::share::{
+    InvitationList, InvitationWithAccess, ReceivedInvitation, SentInvitation,
+};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct InvitationState {
+    #[serde(default)]
+    pub(crate) sent: Vec<SentInvitation>,
+    #[serde(default)]
+    pub(crate) received: Vec<ReceivedInvitation>,
+    #[serde(default)]
+    pub(crate) accepted: Vec<InvitationWithAccess>,
+}
+
+impl From<InvitationList> for InvitationState {
+    fn from(val: InvitationList) -> Self {
+        let InvitationList {
+            sent,
+            received,
+            accepted,
+        } = val;
+        Self {
+            sent: sent.unwrap_or_default(),
+            received: received.unwrap_or_default(),
+            accepted: accepted.unwrap_or_default(),
+        }
+    }
+}
+
+pub(crate) type SyncState = Arc<RwLock<InvitationState>>;

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -9,6 +9,8 @@ mod error;
 mod invitations;
 mod options;
 mod platform;
+#[cfg(feature = "invitations")]
+mod projects;
 mod shared_service;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -27,6 +29,7 @@ pub fn run() {
 
     #[cfg(feature = "invitations")]
     {
+        builder = builder.plugin(projects::plugin::init());
         builder = builder.plugin(invitations::plugin::init());
     }
 

--- a/implementations/rust/ockam/ockam_app/src/platform.rs
+++ b/implementations/rust/ockam/ockam_app/src/platform.rs
@@ -1,6 +1,6 @@
 use tauri::App;
 
-#[allow(unused_variables)]
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 pub fn set_platform_activation_policy(app: &mut App) {
     #[cfg(target_os = "macos")]
     app.set_activation_policy(tauri::ActivationPolicy::Accessory);

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use tauri::{async_runtime::RwLock, AppHandle, Manager, Runtime, State};
+use tracing::{debug, info};
+
+use ockam_api::cloud::project::Project;
+use ockam_command::util::api::CloudOpts;
+
+use super::State as ProjectState;
+use crate::app::AppState;
+
+type SyncState = Arc<RwLock<ProjectState>>;
+
+// At time of writing, tauri::command requires pub not pub(crate)
+
+#[tauri::command]
+pub async fn list_projects<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>, String> {
+    let state: State<'_, SyncState> = app.state();
+    let reader = state.read().await;
+    Ok((*reader).clone())
+}
+
+#[tauri::command]
+pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    info!("refreshing projects");
+    let state: State<'_, AppState> = app.state();
+    let node_manager_worker = state.node_manager_worker().await;
+    let projects = node_manager_worker
+        .list_projects(&state.context(), &CloudOpts::route())
+        .await
+        .map_err(|e| e.to_string())?;
+    debug!(?projects);
+    {
+        let project_state: State<'_, SyncState> = app.state();
+        let mut writer = project_state.write().await;
+        *writer = projects;
+    }
+    app.trigger_global(super::events::REFRESHED_PROJECTS, None);
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_app/src/projects/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/events.rs
@@ -1,0 +1,2 @@
+pub const REFRESH_PROJECTS: &str = "projects/refresh";
+pub const REFRESHED_PROJECTS: &str = "projects/refreshed";

--- a/implementations/rust/ockam/ockam_app/src/projects/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/mod.rs
@@ -1,0 +1,7 @@
+use ockam_api::cloud::project::Project;
+
+mod commands;
+mod events;
+pub(super) mod plugin;
+
+pub(crate) type State = Vec<Project>;

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -1,0 +1,46 @@
+use std::{sync::Arc, time::Duration};
+
+use tauri::{
+    async_runtime::{spawn, RwLock},
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+use tracing::trace;
+
+use super::{
+    commands::*,
+    events::{REFRESHED_PROJECTS, REFRESH_PROJECTS},
+    State,
+};
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(300);
+
+pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("projects")
+        .invoke_handler(tauri::generate_handler![list_projects])
+        .setup(|app, _api| {
+            app.manage(Arc::new(RwLock::new(State::default())));
+
+            let handle = app.clone();
+            app.listen_global(REFRESH_PROJECTS, move |_event| {
+                let handle = handle.clone();
+                spawn(async move { refresh_projects(handle.clone()).await });
+            });
+            let handle = app.clone();
+            spawn(async move {
+                handle.trigger_global(REFRESH_PROJECTS, None);
+                let mut interval = tokio::time::interval(DEFAULT_POLL_INTERVAL);
+                loop {
+                    interval.tick().await;
+                    trace!("refreshing projects via background poll");
+                    handle.trigger_global(REFRESH_PROJECTS, None);
+                }
+            });
+            let handle = app.clone();
+            app.listen_global(REFRESHED_PROJECTS, move |_event| {
+                handle.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+            });
+            Ok(())
+        })
+        .build()
+}


### PR DESCRIPTION
This is an extraction from #5492 with smaller scope and hopefully less subjectivity.

## Current behavior

The Desktop app does not currently have local state for projects or invitations, nor module trees to hold functionality surrounding these ideas.

## Proposed changes

This adds the [Tauri plugin structure boilerplate](https://next--tauri.netlify.app/next/guides/features/plugin), along with some Tauri commands and a pair of Tokio intervals to perform refresh calls on a regular interval without user intervention/activity required.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
