### PR TITLE
chore: format frontend ockam_app with prettier and plugins

### DIFF
--- a/implementations/typescript/ockam/ockam_app/.prettierrc
+++ b/implementations/typescript/ockam/ockam_app/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-svelte"]
+}

--- a/implementations/typescript/ockam/ockam_app/.prettierrc
+++ b/implementations/typescript/ockam/ockam_app/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["prettier-plugin-svelte"]
+  "plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"]
 }

--- a/implementations/typescript/ockam/ockam_app/package.json
+++ b/implementations/typescript/ockam/ockam_app/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "prettier": "prettier --plugin prettier-plugin-svelte --write src/"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "2.0.3",

--- a/implementations/typescript/ockam/ockam_app/package.json
+++ b/implementations/typescript/ockam/ockam_app/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "prettier": "prettier --plugin prettier-plugin-svelte --write src/"
+    "prettier": "prettier --plugin prettier-plugin-svelte --plugin prettier-plugin-tailwindcss --write src/"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "2.0.3",

--- a/implementations/typescript/ockam/ockam_app/package.json
+++ b/implementations/typescript/ockam/ockam_app/package.json
@@ -17,6 +17,7 @@
     "postcss": "^8.4.27",
     "prettier": "^3.0.1",
     "prettier-plugin-svelte": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.4.1",
     "svelte": "^4.1.2",
     "svelte-check": "^3.4.6",
     "tailwindcss": "^3.3.3",

--- a/implementations/typescript/ockam/ockam_app/package.json
+++ b/implementations/typescript/ockam/ockam_app/package.json
@@ -14,6 +14,8 @@
     "@sveltejs/kit": "^1.22.4",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.27",
+    "prettier": "^3.0.1",
+    "prettier-plugin-svelte": "^3.0.3",
     "svelte": "^4.1.2",
     "svelte-check": "^3.4.6",
     "tailwindcss": "^3.3.3",

--- a/implementations/typescript/ockam/ockam_app/src/app.d.ts
+++ b/implementations/typescript/ockam/ockam_app/src/app.d.ts
@@ -1,12 +1,12 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
-    namespace App {
-        // interface Error {}
-        // interface Locals {}
-        // interface PageData {}
-        // interface Platform {}
-    }
+  namespace App {
+    // interface Error {}
+    // interface Locals {}
+    // interface PageData {}
+    // interface Platform {}
+  }
 }
 
 export {};

--- a/implementations/typescript/ockam/ockam_app/src/app.html
+++ b/implementations/typescript/ockam/ockam_app/src/app.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/implementations/typescript/ockam/ockam_app/src/app.html
+++ b/implementations/typescript/ockam/ockam_app/src/app.html
@@ -7,6 +7,6 @@
     %sveltekit.head%
   </head>
   <body class="font-brand" data-sveltekit-preload-data="hover">
-    <div class="max-w-md mx-auto mt-1 p-4">%sveltekit.body%</div>
+    <div class="mx-auto mt-1 max-w-md p-4">%sveltekit.body%</div>
   </body>
 </html>

--- a/implementations/typescript/ockam/ockam_app/src/routes/+layout.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/+layout.svelte
@@ -1,8 +1,8 @@
 <script>
-  import '../app.css'
-  import '../assets/fonts/Inter-Light.ttf'
-  import '../assets/fonts/Inter-Regular.ttf'
-  import '../assets/fonts/Inter-Thin.ttf'
+  import "../app.css";
+  import "../assets/fonts/Inter-Light.ttf";
+  import "../assets/fonts/Inter-Regular.ttf";
+  import "../assets/fonts/Inter-Thin.ttf";
 </script>
 
-<slot/>
+<slot />

--- a/implementations/typescript/ockam/ockam_app/src/routes/+layout.ts
+++ b/implementations/typescript/ockam/ockam_app/src/routes/+layout.ts
@@ -1,2 +1,2 @@
-export const prerender = true
-export const ssr = false
+export const prerender = true;
+export const ssr = false;

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/+page.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import ServiceCreate from './ServiceCreate.svelte'
+  import ServiceCreate from "./ServiceCreate.svelte";
 </script>
 
-<ServiceCreate/>
+<ServiceCreate />

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
@@ -1,5 +1,5 @@
 <script>
-  import {invoke} from '@tauri-apps/api/tauri';
+  import { invoke } from "@tauri-apps/api/tauri";
 
   let service = "/service/outlet";
   let port = "10000";
@@ -7,15 +7,17 @@
 
   async function submit() {
     error_message = "";
-    await invoke('tcp_outlet_create', {service: service, port: port}).then(() => {
-      invoke('tcp_outlet_close_window');
-    }).catch((error) => {
-      error_message = error;
-    });
+    await invoke("tcp_outlet_create", { service: service, port: port })
+      .then(() => {
+        invoke("tcp_outlet_close_window");
+      })
+      .catch((error) => {
+        error_message = error;
+      });
   }
 
   function cancel() {
-    invoke('tcp_outlet_close_window');
+    invoke("tcp_outlet_close_window");
   }
 </script>
 
@@ -27,7 +29,12 @@
       <p class="text-sm text-gray-500">Name of the service you want to share</p>
     </div>
     <div class="flex-1">
-      <input type="text" class="w-full px-4 bg-transparent border-none focus:outline-none text-right" placeholder="{service}" bind:value="{service}"/>
+      <input
+        type="text"
+        class="w-full px-4 bg-transparent border-none focus:outline-none text-right"
+        placeholder={service}
+        bind:value={service}
+      />
     </div>
   </div>
   <div class="flex items-start">
@@ -36,15 +43,26 @@
       <p class="text-sm text-gray-500">Choose a port for the service</p>
     </div>
     <div class="flex-1">
-      <input type="text" class="w-full px-4 bg-transparent border-none focus:outline-none text-right" placeholder="{port}" bind:value="{port}"/>
+      <input
+        type="text"
+        class="w-full px-4 bg-transparent border-none focus:outline-none text-right"
+        placeholder={port}
+        bind:value={port}
+      />
     </div>
   </div>
 </div>
-<hr class="my-4">
+<hr class="my-4" />
 {#if error_message}
   <div class="mb-2 text-red-500 text-sm">{error_message}</div>
 {/if}
 <div class="flex justify-end">
-  <button class="px-2 py-1 mr-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400" on:click="{cancel}">Cancel</button>
-  <button class="px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600" on:click="{submit}">Create</button>
+  <button
+    class="px-2 py-1 mr-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+    on:click={cancel}>Cancel</button
+  >
+  <button
+    class="px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
+    on:click={submit}>Create</button
+  >
 </div>

--- a/implementations/typescript/pnpm-lock.yaml
+++ b/implementations/typescript/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.0.3
         version: 3.0.3(prettier@3.0.1)(svelte@4.1.2)
+      prettier-plugin-tailwindcss:
+        specifier: ^0.4.1
+        version: 0.4.1(prettier-plugin-svelte@3.0.3)(prettier@3.0.1)
       svelte:
         specifier: ^4.1.2
         version: 4.1.2
@@ -2846,6 +2849,62 @@ packages:
     dependencies:
       prettier: 3.0.1
       svelte: 4.1.2
+    dev: true
+
+  /prettier-plugin-tailwindcss@0.4.1(prettier-plugin-svelte@3.0.3)(prettier@3.0.1):
+    resolution: {integrity: sha512-hwn2EiJmv8M+AW4YDkbjJ6HlZCTzLyz1QlySn9sMuKV/Px0fjwldlB7tol8GzdgqtkdPtzT3iJ4UzdnYXP25Ag==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: ^2.2 || ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 3.0.1
+      prettier-plugin-svelte: 3.0.3(prettier@3.0.1)(svelte@4.1.2)
     dev: true
 
   /prettier@3.0.1:

--- a/implementations/typescript/pnpm-lock.yaml
+++ b/implementations/typescript/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       postcss:
         specifier: ^8.4.27
         version: 8.4.27
+      prettier:
+        specifier: ^3.0.1
+        version: 3.0.1
+      prettier-plugin-svelte:
+        specifier: ^3.0.3
+        version: 3.0.3(prettier@3.0.1)(svelte@4.1.2)
       svelte:
         specifier: ^4.1.2
         version: 4.1.2
@@ -2830,6 +2836,16 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
+
+  /prettier-plugin-svelte@3.0.3(prettier@3.0.1)(svelte@4.1.2):
+    resolution: {integrity: sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==}
+    peerDependencies:
+      prettier: ^3.0.0
+      svelte: ^3.2.0 || ^4.0.0-next.0
+    dependencies:
+      prettier: 3.0.1
+      svelte: 4.1.2
     dev: true
 
   /prettier@3.0.1:


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

We're developing frontend content for ockam_app using Svelte/Sveltekit and TailwindCSS.

## Proposed changes

Add a (non-CI-enforced) Prettier configuration with plugins to apply automatic formatting to Svelte components and sort Tailwind utility classes in a consistent manner.

Both Prettier plugins are maintained by the upstream projects:
https://github.com/sveltejs/prettier-plugin-svelte
https://github.com/tailwindlabs/prettier-plugin-tailwindcss

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
