### PR TITLE
build: Include optional support for Nix-managed pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ vendor
 # nix build
 /result*
 .home
+# managed via nix flake
+/.pre-commit-config.yaml

--- a/tools/nix/flake.lock
+++ b/tools/nix/flake.lock
@@ -23,6 +23,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -56,6 +72,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -93,17 +130,63 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1691397944,
+        "narHash": "sha256-4fa4bX3kPYKpEssgrFRxRCPVXczidArDeSWaUMSzQAU=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "e5588ddffd4c3578547a86ef40ec9a6fbdae2986",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "beam-flakes": "beam-flakes",
         "flake-parts": "flake-parts",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "pre-commit": "pre-commit",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -6,8 +6,15 @@
     beam-flakes.inputs.flake-parts.follows = "flake-parts";
     beam-flakes.inputs.nixpkgs.follows = "nixpkgs";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    pre-commit = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.flake-utils.follows = "flake-utils";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -20,7 +20,7 @@
 
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      imports = [inputs.beam-flakes.flakeModule ./parts/all.nix];
+      imports = [inputs.beam-flakes.flakeModule inputs.pre-commit.flakeModule ./parts/all.nix];
       systems = ["aarch64-darwin" "x86_64-darwin" "x86_64-linux"];
 
       # see /tools/docker/builder/Dockerfile

--- a/tools/nix/parts/all.nix
+++ b/tools/nix/parts/all.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./overlays.nix
+    ./checks.nix
     ./elixir.nix
     ./examples.nix
     ./rust.nix

--- a/tools/nix/parts/checks.nix
+++ b/tools/nix/parts/checks.nix
@@ -24,6 +24,12 @@
               types = [];
             };
 
+            mix-format = {
+              enable = true;
+              entry = lib.mkForce "${config.packages.elixir}/bin/mix format";
+              excludes = ["^examples/elixir"];
+            };
+
             statix.enable = true;
           };
 

--- a/tools/nix/parts/checks.nix
+++ b/tools/nix/parts/checks.nix
@@ -32,6 +32,13 @@
 
             rustfmt.enable = true;
 
+            shellcheck.enable = true;
+            shellcheck.excludes = [
+              "^demos/"
+              "^gradlew$"
+              "^implementations/rust/ockam/ockam_command/tests/bats/.+\.(bats|bash)$"
+            ];
+
             statix.enable = true;
           };
 

--- a/tools/nix/parts/checks.nix
+++ b/tools/nix/parts/checks.nix
@@ -30,6 +30,8 @@
               excludes = ["^examples/elixir"];
             };
 
+            rustfmt.enable = true;
+
             statix.enable = true;
           };
 

--- a/tools/nix/parts/checks.nix
+++ b/tools/nix/parts/checks.nix
@@ -1,6 +1,11 @@
 {
   config = {
-    perSystem = {config, ...}: {
+    perSystem = {
+      config,
+      lib,
+      pkgs,
+      ...
+    }: {
       devShells.pre-commit = config.pre-commit.devShell;
 
       # https://flake.parts/options/pre-commit-hooks-nix.html
@@ -9,6 +14,16 @@
         settings = {
           hooks = {
             alejandra.enable = true;
+
+            # not implemented upstream in pre-commit-hooks.nix
+            commitlint = {
+              enable = true;
+              entry = "${lib.getExe pkgs.commitlint} --config ${../../commitlint/commitlint.config.js} --edit";
+              name = "commitlint";
+              stages = ["commit-msg"];
+              types = [];
+            };
+
             statix.enable = true;
           };
 

--- a/tools/nix/parts/checks.nix
+++ b/tools/nix/parts/checks.nix
@@ -1,0 +1,20 @@
+{
+  config = {
+    perSystem = {config, ...}: {
+      devShells.pre-commit = config.pre-commit.devShell;
+
+      # https://flake.parts/options/pre-commit-hooks-nix.html
+      pre-commit = {
+        check.enable = true;
+        settings = {
+          hooks = {
+            alejandra.enable = true;
+            statix.enable = true;
+          };
+
+          settings = {statix.ignore = [".direnv/*"];};
+        };
+      };
+    };
+  };
+}

--- a/tools/nix/parts/elixir.nix
+++ b/tools/nix/parts/elixir.nix
@@ -46,6 +46,8 @@ in {
         inherit (config.devShells.rust) OCKAM_DISABLE_UPGRADE_CHECK RUSTFLAGS RUST_SRC_PATH;
         inherit (config.devShells.tooling) BATS_LIB;
       };
+
+      packages = {inherit (pkgset) elixir erlang;};
     };
   };
 }

--- a/tools/nix/parts/typescript.nix
+++ b/tools/nix/parts/typescript.nix
@@ -31,9 +31,8 @@ in {
 
       packages = {
         nodejs =
-          if pkgs ? "nodejs-${cfg.nodeVersion}"
-          then pkgs."nodejs-${cfg.nodeVersion}"
-          else throw "unsupported nodejs version for nixpkgs: ${cfg.nodeVersion}";
+          pkgs."nodejs-${cfg.nodeVersion}"
+          or (throw "unsupported nodejs version for nixpkgs: ${cfg.nodeVersion}");
         pnpm = pkgs.nodePackages.pnpm.override {
           node = config.packages.nodejs;
         };


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

A number of the CI requirements in this repository are amenable to [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).

## Proposed changes

Managing Git hooks is something of a personal choice and I don't believe should be enacted unilaterally, so this design is currently opt-in. For contributors who use Nix and especially nix-direnv, a pre-configured set of Git hooks can be managed with syntax like so:

`.envrc`

```
use flake ./tools/nix
use flake ./tools/nix#pre-commit
```

This makes a clever use of `mkShell`'s `shellHook`, automatically detecting when the definitions have changed and regenerating the `.pre-commit-config.yaml` file.

The [upstream Nix library](https://github.com/cachix/pre-commit-hooks.nix) supports a number of likely tools, and has compatible support for integration via [flake-parts](https://flake.parts/options/pre-commit-hooks-nix) which was used here.

Prior to adopting some of its features that involve actual project compilation, steps need to be taken to ensure that the toolchain contributors use is correctly honored by these commit hooks. You can see a small example of this within this PR for `mix-format` hook.

They can be tested or run in one-off fashion using `nix develop ./tools/nix#pre-commit --command pre-commit run --all-files`;

By integrating the features this way, this will also be verified when running `nix flake check ./tools/nix` or `nix build ./tools/nix#checks.aarch64-darwin.pre-commit`. Both of these are sensitive to what changes have been staged/committed and **will ignore unstaged changes** that may either introduce new warnings or resolve existing warnings.

If the functionality is no longer desired, you can use `nix develop ./tools/nix#pre-commit --command pre-commit uninstall`.

At this time, I do not encourage that anyone attempt to migrate existing GitHub Actions CI flows to build directly upon this logic, as there are more consistent and lightweight flows that are possible instead.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
