### PR TITLE
refactor(rust): use project-id instead of project-name as the key to store projects state

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -204,7 +204,7 @@ impl NodeConfig {
         Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
     }
 
-    pub async fn identifier(&self) -> Result<IdentityIdentifier> {
+    pub fn identifier(&self) -> Result<IdentityIdentifier> {
         let state_path = std::fs::canonicalize(&self.default_identity)?;
         let state = IdentityState::load(state_path)?;
         Ok(state.identifier())

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -10,14 +10,17 @@ pub struct ProjectsState {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ProjectState {
-    name: String,
     path: PathBuf,
     config: ProjectConfig,
 }
 
 impl ProjectState {
+    pub fn id(&self) -> &str {
+        &self.config.id
+    }
+
     pub fn name(&self) -> &str {
-        &self.name
+        &self.config.name
     }
 }
 
@@ -54,6 +57,7 @@ mod traits {
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for ProjectsState {
@@ -69,6 +73,27 @@ mod traits {
         fn dir(&self) -> &PathBuf {
             &self.dir
         }
+
+        async fn migrate(&self, path: &Path) -> Result<()> {
+            // Rename the project file using the project id
+            let project = match ProjectState::load(path.to_path_buf()) {
+                Ok(p) => p,
+                Err(_) => {
+                    // Skip unexpected files
+                    return Ok(());
+                }
+            };
+            let filename = file_stem(path)?;
+            if filename.eq(project.name()) {
+                let new_filename = project.id();
+                let new_path = path
+                    .parent()
+                    .expect("projects dir should exist")
+                    .join(new_filename);
+                std::fs::rename(path, new_path)?;
+            }
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -78,15 +103,13 @@ mod traits {
         fn new(path: PathBuf, config: Self::Config) -> Result<Self> {
             let contents = serde_json::to_string(&config)?;
             std::fs::write(&path, contents)?;
-            let name = file_stem(&path)?;
-            Ok(Self { name, path, config })
+            Ok(Self { path, config })
         }
 
         fn load(path: PathBuf) -> Result<Self> {
-            let name = file_stem(&path)?;
             let contents = std::fs::read_to_string(&path)?;
             let config = serde_json::from_str(&contents)?;
-            Ok(Self { name, path, config })
+            Ok(Self { path, config })
         }
 
         fn path(&self) -> &PathBuf {
@@ -96,5 +119,36 @@ mod traits {
         fn config(&self) -> &Self::Config {
             &self.config
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli_state::random_name;
+    use crate::cli_state::traits::StateDirTrait;
+    use crate::cli_state::traits::StateItemTrait;
+    use ockam_core::compat::rand::random_string;
+
+    #[tokio::test]
+    async fn migrate_project_files_using_project_id_as_filename() {
+        let project_name = random_name();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let project_path = tmp_dir.path().join(&project_name);
+        let project_config = ProjectConfig {
+            name: project_name,
+            id: random_string(),
+            ..Default::default()
+        };
+        let project = ProjectState::new(project_path.clone(), project_config).unwrap();
+        assert!(project_path.exists());
+
+        // Run migration
+        let projects_state = ProjectsState::new(tmp_dir.path().to_path_buf());
+        projects_state.migrate(&project_path).await.unwrap();
+
+        // Check that the project file was renamed using the project id
+        let project_path = tmp_dir.path().join(project.id());
+        assert!(project_path.exists());
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
@@ -11,14 +11,13 @@ pub struct SpacesState {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SpaceState {
-    name: String,
     path: PathBuf,
     config: SpaceConfig,
 }
 
 impl SpaceState {
     pub fn name(&self) -> &str {
-        &self.name
+        &self.config.name
     }
 }
 
@@ -48,7 +47,6 @@ impl From<&Space> for SpaceConfig {
 
 mod traits {
     use super::*;
-    use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
 
@@ -75,15 +73,13 @@ mod traits {
         fn new(path: PathBuf, config: Self::Config) -> Result<Self> {
             let contents = serde_json::to_string(&config)?;
             std::fs::write(&path, contents)?;
-            let name = file_stem(&path)?;
-            Ok(Self { name, path, config })
+            Ok(Self { path, config })
         }
 
         fn load(path: PathBuf) -> Result<Self> {
-            let name = file_stem(&path)?;
             let contents = std::fs::read_to_string(&path)?;
             let config = serde_json::from_str(&contents)?;
-            Ok(Self { name, path, config })
+            Ok(Self { path, config })
         }
 
         fn path(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -371,7 +371,7 @@ impl NodeManager {
                     .unwrap()
                     .authority()
                     .is_ok(),
-            identifier: node_state.config().identifier().await?,
+            identifier: node_state.config().identifier()?,
             secure_channels,
             trust_context: None,
             registry: Default::default(),

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -134,7 +134,7 @@ async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project
         .state()
         .await
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     add_project_info_to_node_state(
         NODE_NAME,
         &app_state.options().await,

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -34,7 +34,7 @@ pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<(), Strin
     let cli_projects = state.state().await.projects;
     for project in &projects {
         cli_projects
-            .overwrite(&project.name, project.clone())
+            .overwrite(&project.id, project.clone())
             .map_err(|e| format!("could not save project in cli state: {e}"))?;
     }
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -309,7 +309,7 @@ async fn default_project(
         for project in &available_projects {
             opts.state
                 .projects
-                .overwrite(&project.name, project.clone())?;
+                .overwrite(&project.id, project.clone())?;
         }
         let p = match available_projects.iter().find(|ns| ns.name == "default") {
             None => available_projects
@@ -334,10 +334,10 @@ async fn default_project(
 
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     opts.state
         .trust_contexts
-        .overwrite(&project.name, project.clone().try_into()?)?;
+        .overwrite(&project.id, project.clone().try_into()?)?;
     Ok(project)
 }
 
@@ -348,7 +348,7 @@ pub async fn update_enrolled_identity(
     let identities = opts.state.identities.list()?;
 
     let node_state = opts.state.nodes.get(node_name)?;
-    let node_identifier = node_state.config().identifier().await?;
+    let node_identifier = node_state.config().identifier()?;
 
     for mut identity in identities {
         if node_identifier == identity.config().identifier() {

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -111,7 +111,7 @@ pub async fn add_project_info_to_node_state(
             state.set_setup(state.config().setup_mut().set_project(proj_lookup.clone()))?;
             opts.state
                 .projects
-                .overwrite(proj_lookup.name, proj_config)?;
+                .overwrite(&proj_lookup.id, proj_config)?;
             Ok(Some(proj_lookup.id))
         }
         None => {

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -68,10 +68,10 @@ async fn run_impl(
     let project = check_project_readiness(ctx, &opts, &node_name, None, project).await?;
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     opts.state
         .trust_contexts
-        .overwrite(&project.name, project.clone().try_into()?)?;
+        .overwrite(&project.id, project.clone().try_into()?)?;
     rpc.print_response(project)?;
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -167,10 +167,10 @@ async fn run_impl(
 
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     opts.state
         .trust_contexts
-        .overwrite(&project.name, project.clone().try_into()?)?;
+        .overwrite(&project.id, project.clone().try_into()?)?;
 
     let credential = client2.credential().await.into_diagnostic()?;
     println!("---");

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -73,7 +73,7 @@ async fn run_impl(
     for project in &projects {
         opts.state
             .projects
-            .overwrite(&project.name, project.clone())?;
+            .overwrite(&project.id, project.clone())?;
     }
     delete_embedded_node(&opts, rpc.node_name()).await;
 

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -67,7 +67,7 @@ async fn run_impl(
     let project = rpc.parse_and_print_response::<Project>()?;
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -180,7 +180,7 @@ pub async fn check_project_readiness(
     // Persist project config prior to checking readiness which might take a while
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
 
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {
@@ -303,7 +303,7 @@ pub async fn check_project_readiness(
     // Persist project config with all its fields
     opts.state
         .projects
-        .overwrite(&project.name, project.clone())?;
+        .overwrite(&project.id, project.clone())?;
     Ok(project)
 }
 
@@ -320,7 +320,7 @@ pub async fn refresh_projects(
     for project in projects {
         opts.state
             .projects
-            .overwrite(&project.name, project.clone())?;
+            .overwrite(&project.id, project.clone())?;
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -69,7 +69,7 @@ async fn get_nodes_details(
 
     for node_state in &node_states {
         let node_infos = NodeDetails {
-            identifier: node_state.config().identifier().await?,
+            identifier: node_state.config().identifier()?,
             state: node_state.clone(),
             status: get_node_status(ctx, opts, node_state, tcp).await?,
         };


### PR DESCRIPTION
When using the Desktop App, a user will have to access the data from their own projects as well as from other users. This will cause a collition where multiple projects will be named "default".

This PR refactors the project's CliState section so that the project files are stored using the project id as the file name, instead of the project name. 

## WIP status

This change would break the UX of passing project names in the CLI arguments. Should we explore the usage of random-human-readable names? (e.g. https://github.com/allenap/rust-petname or https://github.com/fnichol/names)
