### PR TITLE
feat(rust): optionally share service when creating the tcp-outlet

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -204,7 +204,7 @@ impl NodeConfig {
         Ok(serde_json::from_str(&std::fs::read_to_string(path)?)?)
     }
 
-    pub async fn identifier(&self) -> Result<IdentityIdentifier> {
+    pub fn identifier(&self) -> Result<IdentityIdentifier> {
         let state_path = std::fs::canonicalize(&self.default_identity)?;
         let state = IdentityState::load(state_path)?;
         Ok(state.identifier())

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -371,7 +371,7 @@ impl NodeManager {
                     .unwrap()
                     .authority()
                     .is_ok(),
-            identifier: node_state.config().identifier().await?,
+            identifier: node_state.config().identifier()?,
             secure_channels,
             trust_context: None,
             registry: Default::default(),

--- a/implementations/rust/ockam/ockam_app/src/error.rs
+++ b/implementations/rust/ockam/ockam_app/src/error.rs
@@ -9,6 +9,9 @@ pub enum Error {
     Generic(String),
 
     #[error(transparent)]
+    Ockam(#[from] ockam_core::Error),
+
+    #[error(transparent)]
     Command(#[from] ockam_command::error::Error),
 
     #[error(transparent)]
@@ -26,6 +29,12 @@ pub enum Error {
 
 impl From<miette::Report> for Error {
     fn from(e: miette::Report) -> Self {
+        Error::Generic(e.to_string())
+    }
+}
+
+impl From<&str> for Error {
+    fn from(e: &str) -> Self {
         Error::Generic(e.to_string())
     }
 }

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -42,14 +42,14 @@ pub async fn create_service_invitation<R: Runtime>(
     invite_args: CreateServiceInvitation,
     app: AppHandle<R>,
 ) -> Result<(), String> {
-    info!("creating service invitation");
+    info!(?invite_args, "creating service invitation");
     let state: State<'_, AppState> = app.state();
     let node_manager_worker = state.node_manager_worker().await;
     let res = node_manager_worker
         .create_service_invitation(&state.context(), invite_args, &CloudOpts::route(), None)
         .await
         .map_err(|e| e.to_string())?;
-    debug!(?res);
+    debug!(?res, "invitation sent");
     app.trigger_global(super::events::REFRESH_INVITATIONS, None);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -1,7 +1,41 @@
-mod commands;
+pub(crate) mod commands;
 mod events;
 pub(super) mod plugin;
 mod state;
 mod tray_menu;
 
 pub(crate) use tray_menu::*;
+
+use crate::app::{AppState, NODE_NAME};
+use crate::error::Error;
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::cloud::share::CreateServiceInvitation;
+use tauri::{AppHandle, Manager, State, Wry};
+
+pub(crate) async fn build_args_for_create_service_invitation(
+    app_handle: &AppHandle<Wry>,
+    outlet_tcp_addr: &str,
+    recipient_email: &str,
+) -> crate::Result<CreateServiceInvitation> {
+    let app_state: State<'_, AppState> = app_handle.state();
+    let cli_state = app_state.state().await;
+    let service_route = app_state
+        .model(|m| {
+            m.tcp_outlets
+                .iter()
+                .find(|o| o.tcp_addr == outlet_tcp_addr)
+                .map(|o| o.worker_address())
+        })
+        .await
+        .ok_or::<Error>("outlet should exist".into())??;
+    let project = cli_state.projects.default()?;
+    Ok(CreateServiceInvitation::new(
+        &cli_state,
+        None,
+        project.name(),
+        recipient_email,
+        NODE_NAME,
+        service_route.to_string().as_str(),
+    )
+    .await?)
+}

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -6,9 +6,8 @@ use tracing::{debug, trace, warn};
 
 use ockam_api::cloud::share::{InvitationWithAccess, ReceivedInvitation, SentInvitation};
 
-use crate::app::AppState;
-
 use super::state::SyncState;
+use crate::app::AppState;
 
 pub const INVITATIONS_PENDING_HEADER_MENU_ID: &str = "sent_invitations_header";
 pub const INVITATIONS_RECEIVED_HEADER_MENU_ID: &str = "received_invitations_header";
@@ -185,6 +184,7 @@ pub(crate) fn dispatch_click_event(app: &AppHandle<Wry>, id: &str) -> tauri::Res
         .skip_while(|segment| segment == &"invitation")
         .collect::<Vec<&str>>();
     match segments.as_slice() {
+        ["create", "for", outlet_tcp_addr] => on_create(app, outlet_tcp_addr),
         ["accepted", "connect", id] => on_connect(app, id),
         ["received", "accept", id] => on_accept(app, id),
         ["received", "decline", id] => on_decline(app, id),
@@ -194,6 +194,11 @@ pub(crate) fn dispatch_click_event(app: &AppHandle<Wry>, id: &str) -> tauri::Res
             Ok(())
         }
     }
+}
+
+fn on_create(_app: &AppHandle<Wry>, outlet_tcp_addr: &str) -> tauri::Result<()> {
+    trace!(?outlet_tcp_addr, "create service invitation");
+    todo!("open window to ask the user for the recipient email address");
 }
 
 fn on_accept(app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/model_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/model_state.rs
@@ -2,13 +2,14 @@ use ockam::Context;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
+use tracing::error;
 
 pub(crate) async fn load_model_state(
     context: Arc<Context>,
     node_manager_worker: &NodeManagerWorker,
     cli_state: &CliState,
 ) {
-    super::create_relay_impl(&context, cli_state, node_manager_worker)
+    let _ = super::create_relay_impl(&context, cli_state, node_manager_worker)
         .await
-        .unwrap_or_else(|_| panic!("failed to create relay at the default project"));
+        .map_err(|e| error!(?e, "failed to create relay at the default project"));
 }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
@@ -3,6 +3,7 @@ use ockam::Context;
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
+use tracing::error;
 
 impl ModelState {
     pub fn add_tcp_outlet(&mut self, status: OutletStatus) {
@@ -21,7 +22,7 @@ pub(crate) async fn load_model_state(
 ) {
     let mut node_manager = node_manager_worker.inner().write().await;
     for tcp_outlet in model_state.get_tcp_outlets() {
-        node_manager
+        let _ = node_manager
             .create_outlet(
                 &context,
                 tcp_outlet.tcp_addr.clone(),
@@ -30,11 +31,11 @@ pub(crate) async fn load_model_state(
                 true,
             )
             .await
-            .unwrap_or_else(|_| {
-                panic!(
-                    "failed to create outlet with tcp addr {}",
-                    tcp_outlet.tcp_addr
-                )
+            .map_err(|e| {
+                error!(
+                    ?e,
+                    "failed to create outlet with tcp addr {}", tcp_outlet.tcp_addr
+                );
             });
     }
 }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -44,7 +44,7 @@ fn shared_service_submenu(outlet: &OutletStatus) -> SystemTraySubmenu {
         // NOTE: Event handler for dynamic ID is defined in crate::invitations::tray_menu module,
         // and reached via crate::app::tray_menu::fallback_for_id
         submenu = submenu.add_item(CustomMenuItem::new(
-            format!("invitation-create-for-{}", outlet.alias),
+            format!("invitation-create-for-{}", outlet.tcp_addr),
             "Share".to_string(),
         ));
     }
@@ -89,7 +89,7 @@ pub fn on_create(app: &AppHandle<Wry>) -> tauri::Result<()> {
             .always_on_top(true)
             .visible(false)
             .title("Share a service")
-            .max_inner_size(400.0, 400.0)
+            .max_inner_size(450.0, 350.0)
             .resizable(false)
             .minimizable(false)
             .build()?;

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -348,7 +348,7 @@ pub async fn update_enrolled_identity(
     let identities = opts.state.identities.list()?;
 
     let node_state = opts.state.nodes.get(node_name)?;
-    let node_identifier = node_state.config().identifier().await?;
+    let node_identifier = node_state.config().identifier()?;
 
     for mut identity in identities {
         if node_identifier == identity.config().identifier() {

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -69,7 +69,7 @@ async fn get_nodes_details(
 
     for node_state in &node_states {
         let node_infos = NodeDetails {
-            identifier: node_state.config().identifier().await?,
+            identifier: node_state.config().identifier()?,
             state: node_state.clone(),
             status: get_node_status(ctx, opts, node_state, tcp).await?,
         };

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
@@ -4,11 +4,16 @@
 
   let service = "/service/outlet";
   let port = "10000";
+  let email = "";
   let error_message = "";
 
   async function submit() {
     error_message = "";
-    await invoke("tcp_outlet_create", { service: service, port: port })
+    await invoke("tcp_outlet_create", {
+      service: service,
+      port: port,
+      email: email,
+    })
       .then(close)
       .catch((error) => {
         error_message = error;
@@ -34,7 +39,7 @@
     <div class="flex-1">
       <input
         type="text"
-        class="w-full px-4 bg-transparent border-none focus:outline-none text-right"
+        class="w-full px-4 text-base bg-transparent border-none focus:outline-none text-right"
         placeholder={service}
         bind:value={service}
       />
@@ -48,9 +53,25 @@
     <div class="flex-1">
       <input
         type="text"
-        class="w-full px-4 bg-transparent border-none focus:outline-none text-right"
+        class="w-full px-4 text-base bg-transparent border-none focus:outline-none text-right"
         placeholder={port}
         bind:value={port}
+      />
+    </div>
+  </div>
+  <div class="flex items-start">
+    <div class="flex-1">
+      <div class="font-bold">Share</div>
+      <p class="text-sm text-gray-500">
+        Optionally, send an invitation to share this service
+      </p>
+    </div>
+    <div class="flex-1 min-w-[60%]">
+      <input
+        type="email"
+        class="w-full px-4 text-base bg-transparent border-none focus:outline-none text-right"
+        placeholder="recipient@mail.com"
+        bind:value={email}
       />
     </div>
   </div>
@@ -61,11 +82,11 @@
 {/if}
 <div class="flex justify-end">
   <button
-    class="px-2 py-1 mr-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
+    class="px-2 py-1 text-base mr-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400"
     on:click={cancel}>Cancel</button
   >
   <button
-    class="px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
+    class="px-2 py-1 text-base bg-blue-500 text-white rounded hover:bg-blue-600"
     on:click={submit}>Create</button
   >
 </div>

--- a/implementations/typescript/ockam/ockam_app/tailwind.config.cjs
+++ b/implementations/typescript/ockam/ockam_app/tailwind.config.cjs
@@ -2,5 +2,13 @@
 export default {
   content: ['./src/**/*.{html,js,svelte,ts}'],
   plugins: [],
+  theme: {
+    fontSize: {
+      sm: ['0.688rem'], // 11px
+      base: ['0.813rem'], // 13px
+      lg: ['1rem'], // 16px
+      xl: ['1.25rem'], // 20px
+    }
+  }
 }
 


### PR DESCRIPTION
Add a new field to the "Share a service" form to optionally send the invitation to the given email. I've also included some modifications to make the font smaller to match the system sizes.

![image](https://github.com/build-trust/ockam/assets/12375782/65baa999-086f-4bcb-b310-5fc4affc688e)