### PR TITLE
feat(elixir): add customizable wrapper around tcp calls

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -23,6 +23,7 @@ defmodule Ockam.Transport.TCP.Client do
   def setup(options, state) do
     with {:ok, {host, port}} <- get_destination(options) do
       heartbeat = Keyword.get(options, :heartbeat)
+      tcp_wrapper = Keyword.get(options, :tcp_wrapper, Ockam.Transport.TCP.DefaultWrapper)
 
       {protocol, inet_address} =
         case host do
@@ -55,7 +56,8 @@ defmodule Ockam.Transport.TCP.Client do
               socket: socket,
               inet_address: inet_address,
               port: port,
-              heartbeat: heartbeat
+              heartbeat: heartbeat,
+              tcp_wrapper: tcp_wrapper
             })
 
           schedule_heartbeat(state)
@@ -171,7 +173,7 @@ defmodule Ockam.Transport.TCP.Client do
     end
   end
 
-  defp send_over_tcp(data, %{socket: socket}) do
-    :gen_tcp.send(socket, data)
+  defp send_over_tcp(data, %{tcp_wrapper: tcp_wrapper, socket: socket}) do
+    tcp_wrapper.wrap_tcp_call(:gen_tcp, :send, [socket, data])
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/default_wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/default_wrapper.ex
@@ -1,0 +1,11 @@
+defmodule Ockam.Transport.TCP.DefaultWrapper do
+  @moduledoc """
+  Default implementation of a TCP wrapper behaviour.
+  """
+  @behaviour Ockam.Transport.TCP.Wrapper
+
+  @impl true
+  def wrap_tcp_call(transport_module, function, args \\ []) when is_list(args) do
+    apply(transport_module, function, args)
+  end
+end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/wrapper.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/wrapper.ex
@@ -1,0 +1,9 @@
+defmodule Ockam.Transport.TCP.Wrapper do
+  @moduledoc """
+  Behaviour definition for a TCP call wrapper.
+  Allows performing additional work around TCP calls, like
+  emitting telemetry events.
+  """
+  @callback wrap_tcp_call(transport_module :: module(), function :: atom(), args :: list()) ::
+              any()
+end

--- a/implementations/elixir/ockam/ockam_kafka/lib/interceptor/kafka_interceptor.ex
+++ b/implementations/elixir/ockam/ockam_kafka/lib/interceptor/kafka_interceptor.ex
@@ -73,7 +73,7 @@ defmodule Ockam.Kafka.Interceptor do
 
   defp process_kafka_packet(type, packet, %{read_buffer: <<>>} = state, replies) do
     case packet do
-      <<size::signed-big-integer-size(32), data::binary-size(size), rest::binary()>> ->
+      <<size::signed-big-integer-size(32), data::binary-size(size), rest::binary>> ->
         ## There is enough data in the packet to read the message
         case process_kafka_message(type, data, state) do
           {:ok, new_data, state} ->
@@ -94,7 +94,7 @@ defmodule Ockam.Kafka.Interceptor do
         ## We finished reading the packet
         {:ok, replies, state}
 
-      <<_size::signed-big-integer-size(32), _rest::binary()>> ->
+      <<_size::signed-big-integer-size(32), _rest::binary>> ->
         ## There is not enough data in the packed
         ## return replies and wait for the next packet
         {:ok, replies, %{state | read_buffer: packet}}

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/inlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/inlet_manager_test.exs
@@ -9,7 +9,15 @@ defmodule Ockam.Kafka.Interceptor.InletManager.Test do
     base_route = ["outlets"]
     outlet_prefix = "outlet_"
 
-    start_supervised!({InletManager, [base_port, allowed_ports, base_route, outlet_prefix]})
+    start_supervised!(
+      {InletManager,
+       [
+         base_port: base_port,
+         allowed_ports: allowed_ports,
+         base_route: base_route,
+         outlet_prefix: outlet_prefix
+       ]}
+    )
 
     inlets = InletManager.list_inlets()
 
@@ -38,7 +46,15 @@ defmodule Ockam.Kafka.Interceptor.InletManager.Test do
     base_route = ["outlets"]
     outlet_prefix = "outlet_"
 
-    start_supervised!({InletManager, [base_port, allowed_ports, base_route, outlet_prefix]})
+    start_supervised!(
+      {InletManager,
+       [
+         base_port: base_port,
+         allowed_ports: allowed_ports,
+         base_route: base_route,
+         outlet_prefix: outlet_prefix
+       ]}
+    )
 
     :ok = InletManager.set_inlets([1])
     inlets = InletManager.list_inlets()

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
@@ -133,14 +133,16 @@ defmodule Ockam.Kafka.Interceptor.Test do
     start_supervised!(
       {InletManager,
        [
-         base_port,
-         allowed_ports,
-         outlet_route,
-         outlet_prefix
+         base_port: base_port,
+         allowed_ports: allowed_ports,
+         base_route: outlet_route,
+         outlet_prefix: outlet_prefix
        ]}
     )
 
-    start_supervised!({OutletManager, [outlet_prefix, false, []]})
+    start_supervised!(
+      {OutletManager, [outlet_prefix: outlet_prefix, ssl: false, ssl_options: []]}
+    )
 
     {:ok, _pid, "kafka_interceptor"} =
       Ockam.Transport.Portal.Interceptor.start_link(

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
@@ -10,7 +10,9 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = false
     ssl_options = []
 
-    start_supervised!({OutletManager, [outlet_prefix, ssl, ssl_options]})
+    start_supervised!(
+      {OutletManager, [outlet_prefix: outlet_prefix, ssl: ssl, ssl_options: ssl_options]}
+    )
 
     [] = OutletManager.get_existing_outlets(outlet_prefix)
     [] = OutletManager.get_outlets()
@@ -42,7 +44,9 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     ssl = true
     ssl_options = []
 
-    start_supervised!({OutletManager, [outlet_prefix, ssl, ssl_options]})
+    start_supervised!(
+      {OutletManager, [outlet_prefix: outlet_prefix, ssl: ssl, ssl_options: ssl_options]}
+    )
 
     to_create = [
       %Outlet{
@@ -71,8 +75,19 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
     allowed_ports = 10
     base_route = []
 
-    start_supervised!({InletManager, [base_port, allowed_ports, base_route, outlet_prefix]})
-    start_supervised!({OutletManager, [outlet_prefix, ssl, ssl_options]})
+    start_supervised!(
+      {InletManager,
+       [
+         base_port: base_port,
+         allowed_ports: allowed_ports,
+         base_route: base_route,
+         outlet_prefix: outlet_prefix
+       ]}
+    )
+
+    start_supervised!(
+      {OutletManager, [outlet_prefix: outlet_prefix, ssl: ssl, ssl_options: ssl_options]}
+    )
 
     Ockam.Transport.TCP.start(listen: [port: 12_000])
 

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/protocol/header_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/protocol/header_test.exs
@@ -35,7 +35,7 @@ defmodule Ockam.Kafka.Interceptor.Protocol.HeaderTest do
     {:ok, v1_formatted} = Formatter.format_request_header(v1)
 
     <<3::signed-big-integer-size(16), 1::signed-big-integer-size(16),
-      10::signed-big-integer-size(32), _client_id::binary()>> = v1_formatted
+      10::signed-big-integer-size(32), _client_id::binary>> = v1_formatted
 
     {:ok, ^v1, <<>>} = Parser.parse_request_header(1, v1_formatted)
 
@@ -51,7 +51,7 @@ defmodule Ockam.Kafka.Interceptor.Protocol.HeaderTest do
     {:ok, v2_formatted} = Formatter.format_request_header(v2)
 
     <<3::signed-big-integer-size(16), 1::signed-big-integer-size(16),
-      10::signed-big-integer-size(32), _rest::binary()>> = v2_formatted
+      10::signed-big-integer-size(32), _rest::binary>> = v2_formatted
 
     {:ok, ^v2, <<>>} = Parser.parse_request_header(2, v2_formatted)
   end
@@ -69,7 +69,7 @@ defmodule Ockam.Kafka.Interceptor.Protocol.HeaderTest do
     v1 = %ResponseHeader{header_version: 1, correlation_id: 10, tagged_fields: %{1 => "foo"}}
 
     {:ok, v1_formatted} = Formatter.format_response_header(v1)
-    <<10::signed-big-integer-size(32), _fields::binary()>> = v1_formatted
+    <<10::signed-big-integer-size(32), _fields::binary>> = v1_formatted
 
     {:ok, ^v1, <<>>} = Parser.parse_response_header(1, request_header, v1_formatted)
   end


### PR DESCRIPTION
## Current behavior
<!-- Thank you for sending a pull request :heart: -->

Currently our TCP calls are made directly using transport modules like `:gen_tcp`, `:ranch_tcp` and `:ssl`.

## Proposed changes

We'd like to wrap TCP calls in a customizable wrapper, that would allow for performing actions around TCP calls, for example emitting metrics.

Default wrapper wouldn't perform any actions, and would simply execute a transport module call.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
