### PR TITLE
feat: Generate and attach enrollment tickets on service invitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,6 +4519,7 @@ name = "ockam_app"
 version = "0.1.0"
 dependencies = [
  "duct",
+ "hex",
  "log",
  "miette",
  "muda",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,6 +4518,7 @@ dependencies = [
 name = "ockam_app"
 version = "0.1.0"
 dependencies = [
+ "duct",
  "log",
  "miette",
  "muda",

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -16,6 +16,9 @@ pub struct ProjectState {
 }
 
 impl ProjectState {
+    pub fn id(&self) -> &str {
+        &self.config.id
+    }
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -35,6 +35,7 @@ path = "src/lib.rs"
 tauri-build = { version = "2.0.0-alpha.6", features = [] }
 
 [dependencies]
+duct = "0.13.6"
 log = { version = "0.4.19", optional = true }
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 muda = "0.8"

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -36,6 +36,7 @@ tauri-build = { version = "2.0.0-alpha.6", features = [] }
 
 [dependencies]
 duct = "0.13.6"
+hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 log = { version = "0.4.19", optional = true }
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 muda = "0.8"

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -29,6 +29,8 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
         .map(|i| info!("Enrolled a new user with identifier {}", i))
         .unwrap_or_else(|e| error!("{:?}", e));
     app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
     // Reset the node manager to include the project's setup, needed to create the relay.
     // This is necessary because the project data is used in the worker initialization,
     // which can't be rerun manually once the worker is started.

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod commands;
-mod events;
+pub(crate) mod events;
 pub(super) mod plugin;
 mod state;
 mod tray_menu;

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -10,12 +10,14 @@ use crate::app::{AppState, NODE_NAME};
 use crate::error::Error;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::cloud::share::CreateServiceInvitation;
+use ockam_api::identity::EnrollmentTicket;
 use tauri::{AppHandle, Manager, Runtime, State};
 
 pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
     app_handle: &AppHandle<R>,
     outlet_tcp_addr: &str,
     recipient_email: &str,
+    enrollment_ticket: EnrollmentTicket,
 ) -> crate::Result<CreateServiceInvitation> {
     let app_state: State<'_, AppState> = app_handle.state();
     let cli_state = app_state.state().await;
@@ -29,6 +31,7 @@ pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
         .await
         .ok_or::<Error>("outlet should exist".into())??;
     let project = cli_state.projects.default()?;
+
     Ok(CreateServiceInvitation::new(
         &cli_state,
         None,
@@ -36,6 +39,7 @@ pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
         recipient_email,
         NODE_NAME,
         service_route.to_string().as_str(),
+        enrollment_ticket,
     )
     .await?)
 }

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -6,6 +6,7 @@ use tracing::{debug, info};
 use ockam_api::{cli_state::StateDirTrait, cloud::project::Project};
 use ockam_command::util::api::CloudOpts;
 
+use super::error::{Error, Result};
 use super::State as ProjectState;
 use crate::app::AppState;
 
@@ -14,7 +15,7 @@ type SyncState = Arc<RwLock<ProjectState>>;
 // At time of writing, tauri::command requires pub not pub(crate)
 
 #[tauri::command]
-pub async fn list_projects<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>, String> {
+pub async fn list_projects<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>> {
     let state: State<'_, SyncState> = app.state();
     let reader = state.read().await;
     debug!(projects = ?reader);
@@ -22,21 +23,21 @@ pub async fn list_projects<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>
 }
 
 #[tauri::command]
-pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     info!("refreshing projects");
     let state: State<'_, AppState> = app.state();
     let node_manager_worker = state.node_manager_worker().await;
     let projects = node_manager_worker
         .list_projects(&state.context(), &CloudOpts::route())
         .await
-        .map_err(|e| e.to_string())?;
+        .map_err(Error::ListingFailed)?;
     debug!(?projects);
 
     let cli_projects = state.state().await.projects;
     for project in &projects {
         cli_projects
             .overwrite(&project.name, project.clone())
-            .map_err(|e| format!("could not save project in cli state: {e}"))?;
+            .map_err(|_| Error::StateSaveFailed)?;
     }
 
     let project_state: State<'_, SyncState> = app.state();

--- a/implementations/rust/ockam/ockam_app/src/projects/error.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/error.rs
@@ -1,0 +1,18 @@
+use serde::Serialize;
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error, Serialize)]
+pub enum Error {
+    #[error("listing projects failed: {0:?}")]
+    ListingFailed(ockam::Error),
+    #[error("failed to save local project state")]
+    StateSaveFailed,
+}
+
+impl From<Error> for String {
+    fn from(e: Error) -> Self {
+        e.to_string()
+    }
+}

--- a/implementations/rust/ockam/ockam_app/src/projects/error.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/error.rs
@@ -5,8 +5,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error, Serialize)]
 pub enum Error {
+    #[error("creating enrollment ticket failed")]
+    EnrollmentTicketFailed,
+    #[error("decoding enrollment ticket failed")]
+    EnrollmentTicketDecodeFailed,
     #[error("listing projects failed: {0:?}")]
     ListingFailed(ockam::Error),
+    #[error("binary for ockam command is invalid")]
+    OckamCommandInvalid,
+    #[error("project {0} not found")]
+    ProjectNotFound(String),
     #[error("failed to save local project state")]
     StateSaveFailed,
 }

--- a/implementations/rust/ockam/ockam_app/src/projects/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/mod.rs
@@ -1,6 +1,7 @@
 use ockam_api::cloud::project::Project;
 
 mod commands;
+mod error;
 pub(crate) mod events;
 pub(super) mod plugin;
 

--- a/implementations/rust/ockam/ockam_app/src/projects/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/mod.rs
@@ -1,6 +1,6 @@
 use ockam_api::cloud::project::Project;
 
-mod commands;
+pub(crate) mod commands;
 mod error;
 pub(crate) mod events;
 pub(super) mod plugin;

--- a/implementations/rust/ockam/ockam_app/src/projects/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/mod.rs
@@ -1,7 +1,7 @@
 use ockam_api::cloud::project::Project;
 
 mod commands;
-mod events;
+pub(crate) mod events;
 pub(super) mod plugin;
 
 pub(crate) type State = Vec<Project>;

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -32,6 +32,8 @@ pub struct ServiceCreateCommand {
     pub shared_node_identity: String,
     pub shared_node_route: String,
 
+    pub enrollment_ticket: String,
+
     #[arg(long, short = 'x')]
     pub expires_at: Option<String>,
 }
@@ -55,6 +57,8 @@ impl From<ServiceCreateCommand> for CreateServiceInvitation {
             project_authority_route,
             shared_node_identity,
             shared_node_route,
+
+            enrollment_ticket,
             ..
         } = val;
         Self {
@@ -68,6 +72,8 @@ impl From<ServiceCreateCommand> for CreateServiceInvitation {
             project_authority_route,
             shared_node_identity,
             shared_node_route,
+
+            enrollment_ticket,
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Service Invitations do not include credentials needed to contact a Project authority node to retrieve credentials.

## Proposed changes

- [x] When creating a Service invitation in the Desktop app, automatically create a Project enrollment ticket to attach to that invitation

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
