### PR TITLE
feat(rust): support inline "recipe" on `ockam run` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -14,8 +14,13 @@ use std::path::PathBuf;
 #[command(hide = docs::hide())]
 pub struct RunCommand {
     /// Path to the recipe file
-    #[arg(long)]
+    #[arg(long, conflicts_with = "inline")]
     pub recipe: Option<PathBuf>,
+
+    /// Inlined recipe contents
+    #[arg(long, conflicts_with = "recipe")]
+    pub inline: Option<String>,
+
     /// If true, block until all the created node exits it also
     /// propagate signals to created nodes.
     /// To be used with docker or kubernetes.
@@ -34,30 +39,36 @@ async fn rpc(_ctx: Context, (opts, cmd): (CommandGlobalOpts, RunCommand)) -> mie
 }
 
 async fn run_impl(opts: CommandGlobalOpts, cmd: RunCommand) -> miette::Result<()> {
-    let path = match cmd.recipe {
-        Some(path) => path,
+    let config = match cmd.inline {
+        Some(config) => config,
         None => {
-            let mut path = std::env::current_dir()
-                .into_diagnostic()
-                .context("Failed to get current directory")?;
-            let default_file_names = ["ockam.yml", "ockam.yaml"];
-            let mut found = false;
-            for file_name in default_file_names.iter() {
-                path.push(file_name);
-                if path.exists() {
-                    found = true;
-                    break;
+            let path = match cmd.recipe {
+                Some(path) => path,
+                None => {
+                    let mut path = std::env::current_dir()
+                        .into_diagnostic()
+                        .context("Failed to get current directory")?;
+                    let default_file_names = ["ockam.yml", "ockam.yaml"];
+                    let mut found = false;
+                    for file_name in default_file_names.iter() {
+                        path.push(file_name);
+                        if path.exists() {
+                            found = true;
+                            break;
+                        }
+                        path.pop();
+                    }
+                    if !found {
+                        return Err(miette!(
+                            "No default configuration file found in current directory.\n\
+                    Try passing the path to the config file with the --recipe flag."
+                        ));
+                    }
+                    path
                 }
-                path.pop();
-            }
-            if !found {
-                return Err(miette!(
-                    "No default configuration file found in current directory.\n\
-                    Try passing the path to the config file with the --config-path flag."
-                ));
-            }
-            path
+            };
+            std::fs::read_to_string(path).into_diagnostic()?
         }
     };
-    ConfigRunner::go(opts, &path, cmd.blocking).await
+    ConfigRunner::go(opts, &config, cmd.blocking).await
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -109,6 +109,6 @@ impl SecureRelayInlet {
             ))
             .write_line()?;
 
-        ConfigRunner::go_inline(opts, &recipe, true).await
+        ConfigRunner::go(opts, &recipe, true).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -112,6 +112,6 @@ impl SecureRelayOutlet {
             ))
             .write_line()?;
 
-        ConfigRunner::go_inline(opts, &recipe, true).await
+        ConfigRunner::go(opts, &recipe, true).await
     }
 }


### PR DESCRIPTION
We can now use the command as follows:

```sh
 ockam run --inline "                                
        nodes:
          mynode:
            tcp-outlets:
              mynode:
                from: /service/outlet
                to: 127.0.0.1:10001"
```

Or from rust code:

```rust
let run_cmd_template = r#"
nodes:
  mynode:
    tcp-outlets:
      mynode:
        from: /service/outlet
        to: 127.0.0.1:10001
"#;
duct::cmd!("ockam", "run", "--inline", run_cmd_template).run()?;
```