### PR TITLE
feat: Use tracing-subscriber for ockam_app log output during development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4539,6 +4539,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -55,6 +55,7 @@ tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
 thiserror = "1.0.46"
 tokio = { version = "1.31.0", features = ["time"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional = true }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.
@@ -64,3 +65,4 @@ custom-protocol = ["tauri/custom-protocol"]
 default = ["invitations", "log"]
 invitations = []
 log = ["dep:log", "dep:tauri-plugin-log", "log/release_max_level_info", "tracing/log"]
+tracing = ["dep:tracing-subscriber", "tracing/log", "tracing/release_max_level_info"]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -62,7 +62,8 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional =
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
-default = ["invitations", "log"]
+default = ["invitations", "tracing"]
 invitations = []
 log = ["dep:log", "dep:tauri-plugin-log", "log/release_max_level_info", "tracing/log"]
+release = ["invitations", "log"]
 tracing = ["dep:tracing-subscriber", "tracing/log", "tracing/release_max_level_info"]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -48,7 +48,7 @@ percent-encoding = "2.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2.0.0-alpha.10", features = ["system-tray"] }
-tauri-plugin-log = "2.0.0-alpha.0"
+tauri-plugin-log = { version = "2.0.0-alpha.0", optional = true }
 tauri-plugin-positioner = { version = "2.0.0-alpha.0", features = ["system-tray"] }
 tauri-plugin-window = "2.0.0-alpha.0"
 tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
@@ -63,4 +63,4 @@ tracing = "0.1"
 custom-protocol = ["tauri/custom-protocol"]
 default = ["invitations", "log"]
 invitations = []
-log = ["dep:log", "log/release_max_level_info", "tracing/log"]
+log = ["dep:log", "dep:tauri-plugin-log", "log/release_max_level_info", "tracing/log"]

--- a/implementations/rust/ockam/ockam_app/src/app/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/mod.rs
@@ -2,6 +2,8 @@ use std::error::Error;
 
 use tauri::{App, Manager, SystemTray, Wry};
 
+#[cfg(all(not(feature = "log"), feature = "tracing"))]
+pub use self::tracing::configure_tracing_log;
 pub use app_state::*;
 #[cfg(feature = "log")]
 pub use logging::configure_tauri_plugin_log;
@@ -16,6 +18,8 @@ mod logging;
 mod model_state;
 mod model_state_repository;
 mod process;
+#[cfg(all(not(feature = "log"), feature = "tracing"))]
+mod tracing;
 mod tray_menu;
 
 /// Set up the Tauri application. This function is called once when the application starts.

--- a/implementations/rust/ockam/ockam_app/src/app/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/mod.rs
@@ -3,13 +3,15 @@ use std::error::Error;
 use tauri::{App, Manager, SystemTray, Wry};
 
 pub use app_state::*;
-pub use logging::*;
+#[cfg(feature = "log")]
+pub use logging::configure_tauri_plugin_log;
 pub use model_state::*;
 pub use process::*;
 pub use tray_menu::*;
 
 mod app_state;
 pub(crate) mod events;
+#[cfg(feature = "log")]
 mod logging;
 mod model_state;
 mod model_state_repository;

--- a/implementations/rust/ockam/ockam_app/src/app/tracing.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tracing.rs
@@ -1,0 +1,10 @@
+use tracing_subscriber::{filter::LevelFilter, EnvFilter};
+
+pub fn configure_tracing_log() {
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .with_env_var("OCKAM_LOG")
+        .from_env_lossy();
+
+    tracing_subscriber::fmt().with_env_filter(filter).init()
+}

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "log")]
 use crate::app::configure_tauri_plugin_log;
-#[cfg(feature = "tracing")]
+#[cfg(all(not(feature = "log"), feature = "tracing"))]
 use crate::app::configure_tracing_log;
 use crate::app::{process_application_event, setup_app, AppState};
 use crate::error::Result;
@@ -19,6 +19,9 @@ mod shared_service;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(all(feature = "tracing", not(feature = "log")))]
+    configure_tracing_log();
+
     // For now, the application only consists of a system tray with several menu items
     #[cfg_attr(not(feature = "invitations"), allow(unused_mut))]
     let mut builder = tauri::Builder::default()

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -1,4 +1,8 @@
-use crate::app::{configure_tauri_plugin_log, process_application_event, setup_app, AppState};
+#[cfg(feature = "log")]
+use crate::app::configure_tauri_plugin_log;
+#[cfg(feature = "tracing")]
+use crate::app::configure_tracing_log;
+use crate::app::{process_application_event, setup_app, AppState};
 use crate::error::Result;
 use shared_service::tcp_outlet::tcp_outlet_create;
 
@@ -18,12 +22,16 @@ pub fn run() {
     // For now, the application only consists of a system tray with several menu items
     #[cfg_attr(not(feature = "invitations"), allow(unused_mut))]
     let mut builder = tauri::Builder::default()
-        .plugin(configure_tauri_plugin_log())
         .plugin(tauri_plugin_window::init())
         .plugin(tauri_plugin_positioner::init())
         .setup(move |app| setup_app(app))
         .manage(AppState::new())
         .invoke_handler(tauri::generate_handler![tcp_outlet_create]);
+
+    #[cfg(feature = "log")]
+    {
+        builder = builder.plugin(configure_tauri_plugin_log());
+    }
 
     #[cfg(feature = "invitations")]
     {

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -6,6 +6,7 @@ use tracing::{debug, error, info};
 
 use crate::app::AppState;
 use crate::error::Error;
+#[cfg(feature = "invitations")]
 use crate::invitations::commands::create_service_invitation;
 
 /// Create a TCP outlet within the default node.
@@ -30,7 +31,7 @@ async fn tcp_outlet_create_impl(
     app: AppHandle<Wry>,
     service: String,
     port: String,
-    email: Option<String>,
+    #[cfg_attr(not(feature = "invitations"), allow(unused_variables))] email: Option<String>,
 ) -> crate::Result<()> {
     debug!(%service, %port, "Creating an outlet");
     let app_state = app.state::<AppState>();
@@ -59,6 +60,7 @@ async fn tcp_outlet_create_impl(
         }
         Err(_) => Err(Error::Generic("Failed to create outlet".to_string())),
     }?;
+    #[cfg(feature = "invitations")]
     if let Some(email) = email {
         create_service_invitation(email, tcp_addr.to_string(), app)
             .await


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

`tauri-plugin-log` does not seem to support coloring or trivially runtime-configurable filtering, so we get a full firehose of internal details' log emissions while running the app. `tauri-plugin-log`'s primary perceived advantage is that it lets us log to disk on end users' machines so that we could collect that info out of band when troubleshooting issues.

## Proposed changes

In development workflows, use `tracing-subscriber` to provide the more familiar and runtime-configurable log stream. In release artifacts, make sure to enable the `release` crate feature which will fall back to `tauri-plugin-log`.

My suggested starting point for using the tracing features to zoom in on logging statements that are just within our `ockam_app` code:

```shell
env OCKAM_LOG=ockam_app=trace,ockam_node=warn,ockam_identity=error,info cargo tauri dev
```

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
