### PR TITLE
feat: Increase app automatic refresh rate, add dev-only refresh menu

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -29,6 +29,8 @@ pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
         let result = match id.as_str() {
             enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
             shared_service::SHARED_SERVICE_CREATE_MENU_ID => shared_service::on_create(app),
+            #[cfg(debug_assertions)]
+            options::REFRESH_MENU_ID => options::on_refresh(app),
             options::RESET_MENU_ID => options::on_reset(app),
             options::QUIT_MENU_ID => options::on_quit(),
             id => fallback_for_id(app, id),

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -29,8 +29,11 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
         .map(|i| info!("Enrolled a new user with identifier {}", i))
         .unwrap_or_else(|e| error!("{:?}", e));
     app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
-    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
-    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
+    #[cfg(feature = "invitations")]
+    {
+        app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+        app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
+    }
     // Reset the node manager to include the project's setup, needed to create the relay.
     // This is necessary because the project data is used in the worker initialization,
     // which can't be rerun manually once the worker is started.

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -1,8 +1,12 @@
+#[cfg(all(debug_assertions, feature = "invitations"))]
+use tauri::Manager;
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 
 use crate::app::AppState;
 use crate::options::reset;
 
+#[cfg(debug_assertions)]
+pub const REFRESH_MENU_ID: &str = "refresh";
 pub const RESET_MENU_ID: &str = "reset";
 pub const QUIT_MENU_ID: &str = "quit";
 
@@ -11,11 +15,25 @@ pub(crate) async fn build_options_section(
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
     let tm = if app_state.is_enrolled().await {
+        #[cfg(debug_assertions)]
+        let tray_menu = tray_menu.add_item(CustomMenuItem::new(REFRESH_MENU_ID, "Dev: Refresh"));
         tray_menu.add_item(CustomMenuItem::new(RESET_MENU_ID, "Reset").accelerator("cmd+r"))
     } else {
         tray_menu
     };
     tm.add_item(CustomMenuItem::new(QUIT_MENU_ID, "Quit Ockam").accelerator("cmd+q"))
+}
+
+#[cfg(debug_assertions)]
+pub fn on_refresh(
+    #[cfg_attr(not(feature = "invitations"), allow(unused_variables))] app: &AppHandle<Wry>,
+) -> tauri::Result<()> {
+    #[cfg(feature = "invitations")]
+    {
+        app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+        app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
+    }
+    Ok(())
 }
 
 /// Event listener for the "Reset" menu item

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -13,7 +13,7 @@ use super::{
     State,
 };
 
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(300);
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("projects")


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The current polling period on `ockam_app` for projects data is a slow 5 minutes, triggered on startup and after enrollment then falling back to the timer cycle.

## Proposed changes

Sometimes while testing I make out-of-band changes to project membership, count, etc. and would like to have fresh data in the app without restarting or waiting for the polling interval.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
