### PR TITLE
feat(rust): update rust api examples with colored output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "ockam_transport_uds",
  "ockam_transport_websocket",
  "ockam_vault",
+ "r3bl_ansi_color",
  "rand 0.8.5",
  "serde",
  "serde_bare",
@@ -5433,6 +5434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r3bl_ansi_color"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e10543981a8298abc7850a1a6392c0ab5d5b1a98db2c574a75e94815d7a14ab"
+dependencies = [
+ "is-terminal",
+ "is_ci",
 ]
 
 [[package]]

--- a/examples/rust/get_started/Cargo.toml
+++ b/examples/rust/get_started/Cargo.toml
@@ -43,6 +43,7 @@ ockam_transport_udp = { path = "../../../implementations/rust/ockam/ockam_transp
 ockam_transport_uds = { path = "../../../implementations/rust/ockam/ockam_transport_uds" }
 ockam_transport_websocket = { path = "../../../implementations/rust/ockam/ockam_transport_websocket", optional = true }
 ockam_vault = { path = "../../../implementations/rust/ockam/ockam_vault" }
+r3bl_ansi_color = "0.5.0"
 serde = { version = "1", default_features = false, features = ["derive"] }
 serde_bare = "0.5.0"
 serde_json = { version = "1.0", default_features = false }

--- a/examples/rust/get_started/examples/01-node.rs
+++ b/examples/rust/get_started/examples/01-node.rs
@@ -1,12 +1,47 @@
 // This program creates and then immediately stops a node.
 
 use ockam::{node, Context, Result};
+use r3bl_ansi_color::{AnsiStyledText, Color, Style};
 
+#[rustfmt::skip]
+const HELP_TEXT: &str =r#"
+┌───────────────────────┐
+│  Node 1               │
+├───────────────────────┤
+│  ┌─────────────────┐  │
+│  │ Worker Address: │  │
+│  │ 'app'           │  │
+│  └─────────────────┘  │
+└───────────────────────┘
+"#;
+
+/// Create and then immediately stop a node.
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    // Create a node with default implementations
+    AnsiStyledText {
+        text: HELP_TEXT,
+        style: &[Style::Foreground(Color::Rgb(100, 200, 0))],
+    }
+    .println();
+
+    print_title(vec!["Run a node & stop it right away"]);
+
+    // Create a node.
     let mut node = node(ctx);
 
     // Stop the node as soon as it starts.
     node.stop().await
+}
+
+fn print_title(title: Vec<&str>) {
+    let msg = format!("🚀 {}", title.join("\n  → "));
+    AnsiStyledText {
+        text: msg.as_str(),
+        style: &[
+            Style::Bold,
+            Style::Foreground(Color::Rgb(70, 70, 70)),
+            Style::Background(Color::Rgb(100, 200, 0)),
+        ],
+    }
+    .println();
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

Update Rust API examples so that they have nice colorized output that is easy for developers to read and understand.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
