### PR TITLE
added ockam:// scheme association in app for linux and mac

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -88,7 +88,7 @@ runs:
       if: inputs.build_app == 'true'
       run: |
         set -x
-        cargo install --locked tauri-cli --version 2.0.0-alpha.10
+        cargo install tauri-cli --git https://github.com/build-trust/tauri.git --branch add-url-scheme
 
         cd implementations/rust/ockam/ockam_app/
         cargo tauri build --target ${{ inputs.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7150,8 +7150,7 @@ dependencies = [
 [[package]]
 name = "tauri-build"
 version = "2.0.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc47d3c84f4aeac397cd956267f3b8060c5a2dba78288a5ccf9a8b7a8c1e7025"
+source = "git+https://github.com/build-trust/tauri.git?branch=add-url-scheme#7856354fe16197b270dfa36bc095fec33bec4cff"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7317,8 +7316,7 @@ dependencies = [
 [[package]]
 name = "tauri-utils"
 version = "2.0.0-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06bcd7c6f67fd6371dcc22da7d7f26ec12c4eae26ad7bc54943bb9f35b5db302"
+source = "git+https://github.com/build-trust/tauri.git?branch=add-url-scheme#7856354fe16197b270dfa36bc095fec33bec4cff"
 dependencies = [
  "brotli",
  "ctor",
@@ -8917,3 +8915,8 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[patch.unused]]
+name = "tauri"
+version = "2.0.0-alpha.12"
+source = "git+https://github.com/build-trust/tauri.git?branch=add-url-scheme#7856354fe16197b270dfa36bc095fec33bec4cff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,9 @@ inherits = "test"
 opt-level = 2
 [profile.dev.package.adler]
 opt-level = 1
+
+[patch.crates-io]
+# temporary fork for url scheme - https://github.com/build-trust/ockam/issues/5667
+tauri = { git = "https://github.com/build-trust/tauri.git", branch = "add-url-scheme" }
+tauri-build = { git = "https://github.com/build-trust/tauri.git", branch = "add-url-scheme" }
+tauri-utils = { git = "https://github.com/build-trust/tauri.git", branch = "add-url-scheme" }

--- a/implementations/rust/ockam/ockam_app/src/app/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/events.rs
@@ -1,6 +1,7 @@
 use tauri::{AppHandle, Manager, Runtime};
 
 pub const SYSTEM_TRAY_ON_UPDATE: &str = "app/system_tray/on_update";
+pub const URL_OPEN: &str = "app/url/open";
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SystemTrayOnUpdatePayload {

--- a/implementations/rust/ockam/ockam_app/src/app/process.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/process.rs
@@ -4,6 +4,13 @@ use tauri::{AppHandle, RunEvent, Runtime};
 /// This is the function dispatching application events
 pub fn process_application_event<R: Runtime>(app: &AppHandle<R>, event: RunEvent) {
     match event {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        RunEvent::Opened { urls } => {
+            urls.into_iter().for_each(|url| {
+                use tauri::Manager;
+                app.trigger_global(crate::app::events::URL_OPEN, Some(url.into()));
+            });
+        }
         RunEvent::ExitRequested { api, .. } => {
             api.prevent_exit();
         }

--- a/implementations/rust/ockam/ockam_app/src/linux_url_plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/linux_url_plugin.rs
@@ -1,0 +1,69 @@
+use std::os::unix::fs::PermissionsExt;
+use std::time::Duration;
+
+use tauri::{
+    async_runtime::spawn,
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+use tokio::io::AsyncReadExt;
+use tokio::net::UnixListener;
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+pub(crate) fn open_url_sock_path() -> String {
+    let runtime_directory = std::env::var("XDG_RUNTIME_DIR").unwrap_or("/tmp".to_string());
+    format!("{runtime_directory}/ockam-open-url-sock")
+}
+const ONLY_WRITE_FROM_USER_PERMISSIONS: u32 = 0o200;
+
+pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("linux-url")
+        .setup(|app, _api| {
+            let handle = app.clone();
+            spawn(async move {
+                let sock_path = &open_url_sock_path();
+                //bind fails if the file already exists
+                let _ = std::fs::remove_file(sock_path);
+                let listener = UnixListener::bind(sock_path)
+                    .unwrap_or_else(|_| panic!("cannot listener on {sock_path}"));
+                //only allow the current user to write to the socket
+                std::fs::set_permissions(
+                    sock_path,
+                    std::fs::Permissions::from_mode(ONLY_WRITE_FROM_USER_PERMISSIONS),
+                )
+                .unwrap_or_else(|_| panic!("cannot set permissions on {sock_path}"));
+
+                //wait a bit to let the app start
+                sleep(Duration::from_millis(250)).await;
+
+                //check if we had an ockam:// argument passed to us
+                if let Some(url) = std::env::args().nth(1) {
+                    if url.starts_with("ockam:") {
+                        info!("received url: {}", url);
+                        handle.trigger_global(crate::app::events::URL_OPEN, Some(url));
+                    } else {
+                        warn!("ignored argument: {}", url);
+                    }
+                }
+
+                while let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buffer = [0; 4096];
+                    if let Ok(read_bytes) = stream.read(&mut buffer).await {
+                        if let Ok(url) = String::from_utf8(buffer[..read_bytes].to_vec()) {
+                            if url.starts_with("ockam:") {
+                                info!("received url: {}", url);
+                                handle.trigger_global(crate::app::events::URL_OPEN, Some(url));
+                            } else {
+                                warn!("ignored url: {}", url);
+                            }
+                        }
+                    }
+                    //every connection is used only once
+                    drop(stream);
+                }
+            });
+            Ok(())
+        })
+        .build()
+}

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -23,6 +23,12 @@
       "category": "DeveloperTool",
       "identifier": "io.ockam.app",
       "publisher": "Ockam",
+      "schemeAssociations": [
+        {
+          "scheme": ["ockam"],
+          "role": "Editor"
+        }
+      ],
       "externalBin": [],
       "icon": [
         "icons/32x32.png",

--- a/tools/docker/builder/Dockerfile
+++ b/tools/docker/builder/Dockerfile
@@ -104,7 +104,7 @@ RUN set -xe; \
     cargo install --locked cargo-deny; \
     cargo install --locked cargo-nextest; \
     cargo install --locked cargo-readme; \
-    cargo install --locked tauri-cli --version 2.0.0-alpha.10; \
+    cargo install tauri-cli --git https://github.com/build-trust/tauri.git --branch add-url-scheme; \
     chmod -R a+w "$RUSTUP_HOME" "$CARGO_HOME"; \
 # Setup erlang
     echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list; \

--- a/tools/nix/parts/tauri.nix
+++ b/tools/nix/parts/tauri.nix
@@ -15,7 +15,7 @@
         pname = "tauri-cli";
         # NOTE: Bumping version must always be accompanied by updating the two hashes below
         # https://github.com/tauri-apps/tauri/releases
-        version = "2.0.0-alpha.10";
+        version = "2.0.0-alpha.11";
       in
         # Need to make changes?
         # https://nixos.org/manual/nixpkgs/stable/#compiling-rust-applications-with-cargo
@@ -23,15 +23,15 @@
           inherit pname version;
 
           src = pkgs.fetchFromGitHub {
-            owner = "tauri-apps";
+            owner = "build-trust";
             repo = "tauri";
-            rev = "tauri-v${version}";
-            hash = "sha256-WOxl+hgzKmKXQryD5tH7SJ9YvZb9QA4R+YUYnarnhKA=";
+            rev = "7856354fe16197b270dfa36bc095fec33bec4cff";
+            hash = "sha256-UxWT5k3ZTbydy2iW9LXuSLIfQhSafN39g566J0xWDDs=";
           };
           sourceRoot = "source/tooling/cli";
 
           cargoDepsName = pname;
-          cargoHash = "sha256-MQmEOdQWyRbO+hogGQA2xjB9mezq21FClvscs1oWYLE=";
+          cargoHash = "sha256-4OKYj9rPB998JQTLi/k8ICBgYL/jcxXJT/4MAAR6wzU=";
 
           buildInputs =
             [pkgs.openssl]


### PR DESCRIPTION
This pr is based on alpha11 upgrade branch.

Added support for both linux and mac for the `ockam://` custom scheme.
Since tauri doesn't handle linux url passing I've recovered work [from previous pr](https://github.com/build-trust/ockam/pull/5587).
Both `.desktop` file and `pList` respectively for linux and mac, are now directly generated by tauri.

Note that to apply a patch, tauri **has been overridden to https://github.com/build-trust/tauri.git**
In order to start `cargo tauri build` the tauri-cli must be compiled and installed from the fork, for this reason the cli has been overridden in the build system. The docker build image wasn't changed because gradle build is deprecated and will be removed soon.