### PR TITLE
feat(rust): specify enrollment ticket ttl on desktop app

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -15,6 +15,9 @@ type SyncState = Arc<RwLock<ProjectState>>;
 
 // At time of writing, tauri::command requires pub not pub(crate)
 
+// 30 days
+const MONTH_IN_SECS : &str = "2592000";
+
 #[tauri::command]
 pub async fn create_enrollment_ticket<R: Runtime>(
     project_id: String,
@@ -39,6 +42,8 @@ pub async fn create_enrollment_ticket<R: Runtime>(
         "--quiet",
         "--project",
         project.name.clone(),
+        "--ticket-ttl",
+        MONTH_IN_SECS,
         "--to",
         &format!("/project/{}", project.name)
     )


### PR DESCRIPTION
set to to expire in 30 days.   Mostly as a workaround,  a better approach is likely needed to either
* don't use enrollment ticket and rely on email verification
* use enrollment ticket,  but with unlimited use (instead of one-time),  and likely unlimited ttl as well?,  with it managed by the inviter.

This need a bit more tough,  the extension to 30 days allows for using the feature in the general case meantime 

