### PR TITLE
feat(rust): disable `backtrace` for errors by default

### DIFF
--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -54,7 +54,10 @@ alloc = [
 
 # Feature: "error-traces" cover whether not our errors capture
 # backtraces and/or spantraces by default.
-error-traces = ["backtrace", "tracing-error", "once_cell"]
+error-traces = [
+  "tracing-error",
+  "once_cell",
+] # "backtrace" is disabled by default since it slows down the code drastically
 
 # Feature: "debugger" enables functionality to trace addresses and
 # message flows within Ockam apps.

--- a/implementations/rust/ockam/ockam_core/src/error/inner/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/inner/mod.rs
@@ -79,12 +79,17 @@ impl ErrorData {
         #[allow(unused_mut)]
         let mut local: Vec<LocalPayloadEntry> = vec![];
 
-        #[cfg(all(feature = "std", feature = "error-traces"))]
+        #[cfg(all(feature = "std", feature = "backtrace"))]
         if trace_config::BACKTRACE_ENABLED.get() {
+            // This is called everytime an Error instance is created and takes up to 300ms
+            // on a fast CPU, which is way slower than expected from such type of operation.
+            // Therefore, this feature is disabled by default, but can be used.
+            // It's also possible to replace `Backtrace::new()` with `Backtrace::new_unresolved()`
+            // which is much faster.
             local.push(LocalPayloadEntry::Backtrace(backtrace::Backtrace::new()));
         }
 
-        #[cfg(all(feature = "std", feature = "error-traces"))]
+        #[cfg(all(feature = "std", feature = "tracing-error"))]
         if trace_config::SPANTRACE_ENABLED.get() {
             local.push(LocalPayloadEntry::Spantrace(
                 tracing_error::SpanTrace::capture(),


### PR DESCRIPTION
Disable backtraces by default