### PR TITLE
fix(rust): on `project enroll` do not exit early if a trust context with same name exists

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -1,5 +1,4 @@
 use clap::Args;
-use colorful::Colorful;
 use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
 use std::sync::Arc;
@@ -24,7 +23,7 @@ use crate::project::util::create_secure_channel_to_authority;
 use crate::project::ProjectInfo;
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::node_rpc;
-use crate::{docs, fmt_ok, CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/enroll/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/enroll/after_long_help.txt");
@@ -130,18 +129,12 @@ pub async fn project_enroll(
 
     if !cmd.force {
         if let Ok(trust_context) = opts.state.trust_contexts.get(trust_context_name) {
-            return if trust_context.config().id() == project.id {
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("Already enrolled"))
-                    .write_line()?;
-                Ok(project.name)
-            } else {
-                Err(miette!(
+            if trust_context.config().id() != project.id {
+                return Err(miette!(
                     "A trust context with the name {} already exists and is associated with a different project. Please choose a different name.",
                     trust_context_name
-                ))
-            };
+                ));
+            }
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Unset OCKAM_LOG so it doesn't interfere in the CLI input/output
+unset OCKAM_LOG
+
 # Ockam binary to use
 if [[ -z $OCKAM ]]; then
   export OCKAM=ockam

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -180,28 +180,3 @@ teardown() {
   run "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$node_port/secure/api/service/echo --trust-context $msg
   assert_failure
 }
-
-@test "trust context - trust context with an id and authority using orchestrator; orchestrator enrollment and connection is performed, orchestrator" {
-  skip_if_orchestrator_tests_not_enabled
-  copy_local_orchestrator_data
-
-  $OCKAM trust-context create orchestrator-test
-
-  run "$OCKAM" identity create m1
-  $OCKAM project ticket >"$OCKAM_HOME/m1.token"
-  run "$OCKAM" project enroll $OCKAM_HOME/m1.token --identity m1
-
-  run "$OCKAM" identity create m2
-  $OCKAM project ticket >"$OCKAM_HOME/m2.token"
-  run "$OCKAM" project enroll $OCKAM_HOME/m2.token --identity m2
-
-  run "$OCKAM" node create n1 --identity m1 --trust-context orchestrator-test
-  assert_success
-
-  run "$OCKAM" node create n2 --identity m2 --trust-context orchestrator-test
-  assert_success
-
-  run bash -c "$OCKAM secure-channel create --from /node/n1 --to /node/n2/service/api \
-        | $OCKAM message send hello --from /node/n1 --to -/service/echo"
-  assert_success
-}


### PR DESCRIPTION
- on `project enroll` do not exit early if a trust context with same name exists
- remove local redundant trust-context test
- unset OCKAM_LOG in bats tests