### PR TITLE
refactor(elixir): route from router.route/1 to worker.router/2 #3654

### DIFF
--- a/examples/elixir/get_started/echoer.exs
+++ b/examples/elixir/get_started/echoer.exs
@@ -2,12 +2,12 @@ defmodule Echoer do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def handle_message(message, %{address: address} = state) do
     IO.puts("Address: #{address}\t Received: #{inspect(message)}")
-    Router.route(Message.reply(message, address, Message.payload(message)))
+    Worker.route(Message.reply(message, address, Message.payload(message)), state)
 
     {:ok, state}
   end

--- a/examples/elixir/get_started/hop.exs
+++ b/examples/elixir/get_started/hop.exs
@@ -2,7 +2,7 @@ defmodule Hop do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def handle_message(message, %{address: address} = state) do
@@ -12,7 +12,7 @@ defmodule Hop do
     ## in return route.
     forwarded_message = Message.forward(message) |> Message.trace(address)
 
-    Router.route(forwarded_message)
+    Worker.route(forwarded_message, state)
 
     {:ok, state}
   end

--- a/implementations/elixir/README.md
+++ b/implementations/elixir/README.md
@@ -41,3 +41,14 @@ By default this repo provides pre-build NIF files for MacOS (universal) and Linu
 To build Ockam Elixir implementation on other architectures, Rust implementation should also be built.
 
 Please see `ockam_vault_software/README.md` for more information.
+
+## asdf
+
+If you happen to use asdf to control your elixir and erlang versions, there are some inconsistencies in this project (some mix.exs files use elixir 1.10, others have 1.12).
+
+Using the following to make sure everything builds correctly at the implementations level (`implementations/elixir`):
+```bash
+asdf install elixir 1.13.4
+asdf local elixir 1.13.4
+asdf install erlang 24.3.4.13
+asdf local erlang 24.3.4.13

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/echoer.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/echoer.ex
@@ -4,13 +4,13 @@ defmodule Ockam.Examples.Echoer do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def handle_message(message, state) do
     reply = Message.reply(message, state.address, Message.payload(message))
 
-    Router.route(reply)
+    Worker.route(reply, state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/hop.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/hop.ex
@@ -4,11 +4,11 @@ defmodule Ockam.Examples.Hop do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def handle_message(message, state) do
-    Router.route(Message.forward(message) |> Message.trace(state.address))
+    Worker.route(Message.forward(message) |> Message.trace(state.address), state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/shuffle.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/messaging/shuffle.ex
@@ -19,8 +19,8 @@ defmodule Ockam.Examples.Messaging.Shuffle do
     {:ok, state}
   end
 
-  def forward_message(message, _state) do
+  def forward_message(message, state) do
     :timer.sleep(10)
-    Ockam.Router.route(Message.forward(message))
+    Ockam.Worker.route(Message.forward(message), state)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/ping_pong.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/ping_pong.ex
@@ -2,7 +2,7 @@ defmodule Ockam.Examples.Ping do
   @moduledoc false
   use Ockam.Worker
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -34,7 +34,7 @@ defmodule Ockam.Examples.Ping do
           reply = Message.reply(message, state.address, "#{next}")
 
           Logger.info("\nSend ping #{inspect(next)}")
-          Router.route(reply)
+          Worker.route(reply, state)
           Map.put(state, :last, next)
       end
 
@@ -48,7 +48,7 @@ defmodule Ockam.Examples.Pong do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -65,7 +65,7 @@ defmodule Ockam.Examples.Pong do
     :timer.sleep(Map.get(state, :delay))
 
     Logger.info("\nPong\nMESSAGE: #{inspect(message)}\nREPLY: #{inspect(reply)}")
-    Router.route(reply)
+    Worker.route(reply, state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/session/count_to/data_worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/session/count_to/data_worker.ex
@@ -15,11 +15,14 @@ defmodule Ockam.Examples.Session.CountTo.DataWorker do
   def handle_message(message, state) do
     return_route = Message.return_route(message)
 
-    Ockam.Router.route(%{
-      onward_route: return_route,
-      return_route: [state.address],
-      payload: "#{state.count}"
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: return_route,
+        return_route: [state.address],
+        payload: "#{state.count}"
+      },
+      state
+    )
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/examples/session/routing/data_worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/examples/session/routing/data_worker.ex
@@ -14,7 +14,7 @@ defmodule Ockam.Examples.Session.Routing.DataWorker do
 
   @impl true
   def handle_inner_message(message, state) do
-    Ockam.Router.route(Message.forward(message))
+    Ockam.Worker.route(Message.forward(message), state)
 
     {:ok, Map.update(state, :messages, [message], fn messages -> [message | messages] end)}
   end
@@ -23,7 +23,7 @@ defmodule Ockam.Examples.Session.Routing.DataWorker do
   def handle_outer_message(message, state) do
     [_ | onward_route] = Message.onward_route(message)
     ## TODO: add forward_through?
-    Ockam.Router.route(Message.set_onward_route(message, state.route ++ onward_route))
+    Ockam.Worker.route(Message.set_onward_route(message, state.route ++ onward_route), state)
 
     {:ok, Map.update(state, :messages, [message], fn messages -> [message | messages] end)}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/receiver.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/confirm_pipe/receiver.ex
@@ -9,7 +9,7 @@ defmodule Ockam.Messaging.ConfirmPipe.Receiver do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   alias Ockam.Messaging.ConfirmPipe.Wrapper
 
@@ -22,7 +22,7 @@ defmodule Ockam.Messaging.ConfirmPipe.Receiver do
 
     case Wrapper.unwrap_message(wrapped_message) do
       {:ok, ref, message} ->
-        Router.route(message)
+        Worker.route(message, state)
         send_confirm(ref, return_route, state)
         {:ok, state}
 
@@ -33,11 +33,14 @@ defmodule Ockam.Messaging.ConfirmPipe.Receiver do
   end
 
   def send_confirm(ref, return_route, state) do
-    Router.route(%{
-      onward_route: return_route,
-      return_route: [state.address],
-      payload: ref_payload(ref)
-    })
+    Worker.route(
+      %{
+        onward_route: return_route,
+        return_route: [state.address],
+        payload: ref_payload(ref)
+      },
+      state
+    )
   end
 
   def ref_payload(ref) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/delivery/resend_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/delivery/resend_pipe.ex
@@ -100,11 +100,14 @@ defmodule Ockam.Messaging.Delivery.ResendPipe.Sender do
 
     receiver_route = Map.get(state, :receiver_route)
 
-    Ockam.Router.route(%{
-      onward_route: receiver_route,
-      return_route: [state.inner_address],
-      payload: wrapped_message
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: receiver_route,
+        return_route: [state.inner_address],
+        payload: wrapped_message
+      },
+      state
+    )
 
     {:ok, set_confirm_timeout(message, state)}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/sender.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/index_pipe/sender.ex
@@ -23,7 +23,7 @@ defmodule Ockam.Messaging.IndexPipe.Sender do
   @impl true
   def handle_message(message, state) do
     {indexed_message, state} = make_indexed_message(message, state)
-    Ockam.Router.route(indexed_message)
+    Ockam.Worker.route(indexed_message, state)
     {:ok, state}
   end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/monotonic/index_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/monotonic/index_pipe.ex
@@ -40,7 +40,7 @@ defmodule Ockam.Messaging.Ordering.Monotonic.IndexPipe.Receiver do
       {:ok, index, message} ->
         case index_valid?(index, state) do
           true ->
-            Ockam.Router.route(message)
+            Ockam.Worker.route(message, state)
             {:ok, Map.put(state, :current_index, index)}
 
           false ->

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/confirm_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/confirm_pipe.ex
@@ -103,11 +103,14 @@ defmodule Ockam.Messaging.Ordering.Strict.ConfirmPipe.Sender do
     {ref, state} = bump_send_ref(state)
     {:ok, wrapped_message} = Wrapper.wrap_message(forwarded_message, ref)
 
-    Ockam.Router.route(%{
-      onward_route: receiver_route,
-      return_route: [state.inner_address],
-      payload: wrapped_message
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: receiver_route,
+        return_route: [state.inner_address],
+        payload: wrapped_message
+      },
+      state
+    )
 
     {:ok, Map.put(state, :waiting_confirm, true)}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/index_pipe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/ordering/strict/index_pipe.ex
@@ -77,7 +77,7 @@ defmodule Ockam.Messaging.Ordering.Strict.IndexPipe.Receiver do
   end
 
   def send_message(index, message, state) do
-    Ockam.Router.route(message)
+    Ockam.Worker.route(message, state)
     state = Map.put(state, :current_index, index)
     process_queue(state)
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/simple.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/messaging/pipe_channel/simple.ex
@@ -18,7 +18,7 @@ defmodule Ockam.Messaging.PipeChannel.Simple do
 
   alias Ockam.Message
 
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def inner_setup(options, state) do
@@ -44,7 +44,7 @@ defmodule Ockam.Messaging.PipeChannel.Simple do
   ## Inner message is forwarded with outer address in return route
   def forward_inner(message, state) do
     message = Message.forward(message) |> Message.trace(state.address)
-    Router.route(message)
+    Worker.route(message, state)
   end
 
   @doc false
@@ -59,6 +59,6 @@ defmodule Ockam.Messaging.PipeChannel.Simple do
 
     message = Message.set_onward_route(message, [sender | channel_route ++ onward_route])
 
-    Router.route(message)
+    Worker.route(message, state)
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
@@ -38,6 +38,7 @@ defmodule Ockam.SecureChannel.Channel do
   alias Ockam.SecureChannel.ServiceMessage
   alias Ockam.Session.Spawner
   alias Ockam.Wire
+  alias Ockam.Worker
 
   alias __MODULE__
 
@@ -495,7 +496,7 @@ defmodule Ockam.SecureChannel.Channel do
         return_route: [state.inner_address]
       }
 
-      Router.route(msg)
+      Worker.route(msg, state)
       next_handshake_state(next, state)
     end
   end
@@ -546,7 +547,7 @@ defmodule Ockam.SecureChannel.Channel do
     message
     |> attach_metadata(state.additional_metadata, e)
     |> Message.trace(state.address)
-    |> Router.route()
+    |> Worker.route(state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable.ex
@@ -135,7 +135,7 @@ defmodule Ockam.Session.Pluggable do
       {:ok, data_state} ->
         case message do
           nil -> :ok
-          %{} -> Ockam.Router.route(message)
+          %{} -> Ockam.Worker.route(message, base_state)
         end
 
         state =

--- a/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/responder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/pluggable/responder.ex
@@ -123,7 +123,7 @@ defmodule Ockam.Session.Pluggable.Responder do
       {:next, response, handshake_state} ->
         case response do
           nil -> :ok
-          %{} -> Ockam.Router.route(response)
+          %{} -> Ockam.Worker.route(response, handshake_state)
         end
 
         {:ok, Session.update_handshake_state(state, handshake_state)}

--- a/implementations/elixir/ockam/ockam/lib/ockam/session/spawner.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/session/spawner.ex
@@ -23,7 +23,7 @@ defmodule Ockam.Session.Spawner do
   {:ok, spawner} = Ockam.Session.Spawner.create(worker_mod: MyWorker, worker_options: [key: "val"])
 
   ## Sending init message
-  Ockam.Router.route(%{onward_route: [spawner], return_route: ["me"], payload: "HI!"})
+  Ockam.Worker.route(%{onward_route: [spawner], return_route: ["me"], payload: "HI!"}, state)
 
   ## Is equivalent to calling:
   MyWorker.create(key: "val", init_message: %{onward_route: [spawner], return_route: ["me"], payload: "HI!"})
@@ -32,7 +32,7 @@ defmodule Ockam.Session.Spawner do
   {:ok, spawner} = Ockam.Session.Spawner.create(worker_mod: MyWorker, message_parser: fn(msg) -> [pl: Ockam.Message.payload(msg)] end)
 
   ## Sending init message
-  Ockam.Router.route(%{onward_route: [spawner], return_route: ["me"], payload: "HI!"})
+  Ockam.Worker.route(%{onward_route: [spawner], return_route: ["me"], payload: "HI!"}, state)
 
   ## Is equivalent to calling:
   MyWorker.create(pl: "HI!")

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional.ex
@@ -43,7 +43,7 @@ defmodule Ockam.Stream.Client.BiDirectional do
   Creates a return stream publisher id it doesn't exist
   Routes the message locally with return publisher address in return route
   """
-  def handle_message(data, consumer_stream, subscription_id, stream_options, _state) do
+  def handle_message(data, consumer_stream, subscription_id, stream_options, state) do
     with {:ok, %{return_stream: publisher_stream, message: message}} <-
            decode_message(data) do
       {:ok, publisher_address} =
@@ -56,7 +56,7 @@ defmodule Ockam.Stream.Client.BiDirectional do
 
       forwarded_message = Message.trace(message, publisher_address)
 
-      Ockam.Router.route(forwarded_message)
+      Ockam.Worker.route(forwarded_message, state)
       :ok
     end
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/publisher_proxy.ex
@@ -61,11 +61,14 @@ defmodule Ockam.Stream.Client.BiDirectional.PublisherProxy do
       Ockam.Protocol.encode_payload(Ockam.Protocol.Binary, :request, encoded_message)
 
     ## TODO: should we forward metadata here?
-    Ockam.Router.route(%{
-      payload: binary_message,
-      onward_route: [publisher_address],
-      return_route: []
-    })
+    Ockam.Worker.route(
+      %{
+        payload: binary_message,
+        onward_route: [publisher_address],
+        return_route: []
+      },
+      state
+    )
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/subscribe.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/bi_directional/subscribe.ex
@@ -86,7 +86,7 @@ defmodule Ockam.Stream.Client.BiDirectional.Subscribe do
             Map.fetch!(state, :stream_options)
           )
 
-        Ockam.Router.route(Message.reply(message, address, "irrelevant"))
+        Ockam.Worker.route(Message.reply(message, address, "irrelevant"), state)
 
       other ->
         Logger.error("Unexpected message: #{inspect(other)}")

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/consumer.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/consumer.ex
@@ -287,11 +287,14 @@ defmodule Ockam.Stream.Client.Consumer do
   end
 
   def route(payload, route, state, timeout \\ @request_timeout) do
-    Ockam.Router.route(%{
-      onward_route: route,
-      return_route: [Map.get(state, :address)],
-      payload: payload
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: route,
+        return_route: [Map.get(state, :address)],
+        payload: payload
+      },
+      state
+    )
 
     set_request_timeout(state, timeout)
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/client/publisher.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/client/publisher.ex
@@ -223,11 +223,14 @@ defmodule Ockam.Stream.Client.Publisher do
 
   @spec route(binary(), [Ockam.Address.t()], state()) :: state()
   def route(payload, route, state) do
-    Ockam.Router.route(%{
-      onward_route: route,
-      return_route: [Map.get(state, :address)],
-      payload: payload
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: route,
+        return_route: [Map.get(state, :address)],
+        payload: payload
+      },
+      state
+    )
 
     set_request_timeout(state)
   end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/index/service.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/index/service.ex
@@ -109,16 +109,19 @@ defmodule Ockam.Stream.Index.Service do
   end
 
   def reply_index(protocol, client_id, stream_name, partition, index, return_route, state) do
-    Ockam.Router.route(%{
-      onward_route: return_route,
-      return_route: [state.address],
-      payload:
-        encode_payload(protocol, %{
-          client_id: client_id,
-          stream_name: stream_name,
-          partition: partition,
-          index: index
-        })
-    })
+    Ockam.Worker.route(
+      %{
+        onward_route: return_route,
+        return_route: [state.address],
+        payload:
+          encode_payload(protocol, %{
+            client_id: client_id,
+            stream_name: stream_name,
+            partition: partition,
+            index: index
+          })
+      },
+      state
+    )
   end
 end

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/service.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/service.ex
@@ -69,12 +69,13 @@ defmodule Ockam.Stream.Workers.Service do
   def return_error(error, message, state) do
     Logger.error("Error creating stream: #{inspect(error)}")
 
-    Ockam.Router.route(
+    Ockam.Worker.route(
       Message.reply(
         message,
         state.address,
         encode_payload(Ockam.Protocol.Error, %{reason: "Invalid request"})
-      )
+      ),
+      state
     )
 
     state

--- a/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/stream.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/stream/workers/stream.ex
@@ -217,11 +217,14 @@ defmodule Ockam.Stream.Workers.Stream do
 
   defp send_reply(data, reply_route, state) do
     :ok =
-      Ockam.Router.route(%{
-        onward_route: reply_route,
-        return_route: [state.address],
-        payload: data
-      })
+      Ockam.Worker.route(
+        %{
+          onward_route: reply_route,
+          return_route: [state.address],
+          payload: data
+        },
+        state
+      )
   end
 
   ### Encode helpers

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/interceptor.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/interceptor.ex
@@ -34,8 +34,8 @@ defmodule Ockam.Transport.Portal.Interceptor do
   use Ockam.AsymmetricWorker
 
   alias Ockam.Message
-  alias Ockam.Router
   alias Ockam.Transport.Portal.TunnelProtocol
+  alias Ockam.Worker
 
   ## TODO: enforce that on inlet/outlet level
   @max_payload_size 48 * 1024
@@ -143,7 +143,7 @@ defmodule Ockam.Transport.Portal.Interceptor do
   defp send_disconnect(state) do
     case Map.fetch(state, :ping_route) do
       {:ok, route} ->
-        Router.route(TunnelProtocol.encode(:disconnect), route)
+        Worker.route(TunnelProtocol.encode(:disconnect), route, [], %{}, state)
 
       :error ->
         :ok
@@ -151,7 +151,7 @@ defmodule Ockam.Transport.Portal.Interceptor do
 
     case Map.fetch(state, :pong_route) do
       {:ok, route} ->
-        Router.route(TunnelProtocol.encode(:disconnect), route)
+        Worker.route(TunnelProtocol.encode(:disconnect), route, [], %{}, state)
 
       :error ->
         :ok
@@ -177,7 +177,7 @@ defmodule Ockam.Transport.Portal.Interceptor do
     |> Message.trace(return_address)
     |> Message.set_payload(new_payload)
     |> Message.set_local_metadata(%{})
-    |> Router.route()
+    |> Worker.route(state)
   end
 
   defp handle_tunnel_message(type, %Message{payload: payload} = message, state) do

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/client.ex
@@ -97,7 +97,7 @@ defmodule Ockam.Transport.TCP.Client do
           message
           |> Message.trace(state.address)
 
-        Ockam.Router.route(forwarded_message)
+        Ockam.Worker.route(forwarded_message, state)
 
       {:error, %Wire.DecodeError{} = e} ->
         raise e

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/tcp/recoverable_client.ex
@@ -16,7 +16,7 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
   alias Ockam.Transport.TCPAddress
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -46,7 +46,7 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
           |> Message.forward()
           |> Message.set_return_route([state.address | return_route])
 
-        Router.route(forwarded_message)
+        Worker.route(forwarded_message, state)
 
         {:ok, state}
 
@@ -61,9 +61,10 @@ defmodule Ockam.Transport.TCP.RecoverableClient do
     [_me | onward_route] = Message.onward_route(message)
 
     ## TODO: forward_through and trace
-    Router.route(
+    Worker.route(
       Message.set_onward_route(message, [client | onward_route])
-      |> Message.trace(state.inner_address)
+      |> Message.trace(state.inner_address),
+      state
     )
 
     {:ok, state}

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
@@ -8,6 +8,7 @@ defmodule Ockam.Transport.UDP.Listener do
   alias Ockam.Telemetry
   alias Ockam.Transport.UDPAddress
   alias Ockam.Wire
+  alias Ockam.Worker
 
   require Logger
 
@@ -97,7 +98,7 @@ defmodule Ockam.Transport.UDP.Listener do
           decoded
           |> Message.trace(UDPAddress.new(from_ip, from_port))
 
-        with :ok <- Router.route(message) do
+        with :ok <- Worker.route(message, state) do
           {:ok, state}
         end
 

--- a/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/worker.ex
@@ -1,6 +1,7 @@
 defmodule Ockam.Worker do
   @moduledoc false
 
+  alias Ockam.Message
   alias Ockam.Node
   alias Ockam.Telemetry
   alias Ockam.Worker.Authorization
@@ -415,6 +416,30 @@ defmodule Ockam.Worker do
       {:error, {:already_registered, _pid}} -> register_random_extra_address(module, state)
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  ## Add Worker Route with state data (https://github.com/build-trust/ockam/issues/3654)
+  def route(message) do
+    Ockam.Router.route(message)
+  end
+
+  def route(message, _state) do
+    route(message)
+  end
+
+  @doc """
+  Routes a message with given payload, onward_route and return_route
+  """
+  def route(payload, onward_route, return_route \\ [], local_metadata \\ %{}, state) do
+    route(
+      %Message{
+        onward_route: onward_route,
+        return_route: return_route,
+        payload: payload,
+        local_metadata: local_metadata
+      },
+      state
+    )
   end
 
   ## Metrics functions

--- a/implementations/elixir/ockam/ockam/lib/ockam/workers/pub_sub_subscriber.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/workers/pub_sub_subscriber.ex
@@ -18,7 +18,7 @@ defmodule Ockam.Workers.PubSubSubscriber do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -63,7 +63,7 @@ defmodule Ockam.Workers.PubSubSubscriber do
         :ok
 
       route ->
-        Router.route(Message.set_onward_route(message, route))
+        Worker.route(Message.set_onward_route(message, route), state)
     end
 
     {:ok, state}
@@ -80,11 +80,14 @@ defmodule Ockam.Workers.PubSubSubscriber do
     name = Map.fetch!(state, :name)
     interval = Map.fetch!(state, :interval)
 
-    Router.route(%{
-      onward_route: pub_sub_route,
-      return_route: [state.address],
-      payload: :bare.encode(name <> ":" <> topic, :string)
-    })
+    Worker.route(
+      %{
+        onward_route: pub_sub_route,
+        return_route: [state.address],
+        payload: :bare.encode(name <> ":" <> topic, :string)
+      },
+      state
+    )
 
     Process.send_after(self(), :refresh, interval)
     state

--- a/implementations/elixir/ockam/ockam/lib/ockam/workers/remote_forwarder.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/workers/remote_forwarder.ex
@@ -23,7 +23,7 @@ defmodule Ockam.Workers.RemoteForwarder do
   forwarder_address = RemoteForwarder.forwarder_address(forwarder)
 
   Send messages from another node:
-  Ockam.Router.route(%{onward_route: cloud_route ++ [forwarder_address], ...})
+  Ockam.Worker.route(%{onward_route: cloud_route ++ [forwarder_address], ...})
 
   Messages will be delivered through the cloud forwarder
   to the remote forwarder on the first node
@@ -34,6 +34,7 @@ defmodule Ockam.Workers.RemoteForwarder do
 
   alias Ockam.Message
   alias Ockam.Router
+  alias Ockam.Worker
 
   @doc """
   Get the remote forwarder address to send messages to this worker
@@ -67,7 +68,7 @@ defmodule Ockam.Workers.RemoteForwarder do
 
     forward_to = Map.get(state, :forward_to)
 
-    Router.route(Message.set_onward_route(message, forward_to ++ onward_route))
+    Worker.route(Message.set_onward_route(message, forward_to ++ onward_route), state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam/test/ockam/api/client_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/api/client_test.exs
@@ -5,13 +5,13 @@ defmodule Ockam.API.Tests.EchoAPI do
   alias Ockam.API.Request
   alias Ockam.API.Response
 
-  alias Ockam.Router
+  alias Ockam.Worker
 
   @impl true
   def handle_message(message, state) do
     {:ok, request} = Request.from_message(message)
     response = Response.reply_to(request, 200, request.body)
-    Router.route(Response.to_message(response, [state.address]))
+    Worker.route(Response.to_message(response, [state.address]), state)
     {:ok, state}
   end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/helpers/test_echoer.ex
+++ b/implementations/elixir/ockam/ockam/test/ockam/helpers/test_echoer.ex
@@ -3,7 +3,7 @@ defmodule Ockam.Tests.Helpers.Echoer do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -11,7 +11,7 @@ defmodule Ockam.Tests.Helpers.Echoer do
   def handle_message(message, state) do
     reply = Message.reply(message, state.address, Message.payload(message))
 
-    Router.route(reply)
+    Worker.route(reply, state)
     {:ok, state}
   end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
@@ -267,7 +267,7 @@ defmodule Ockam.SecureChannel.Tests do
              SecureChannel.get_remote_identity_with_id(channel)
 
     {:ok, me} = Ockam.Node.register_random_address()
-    Ockam.Router.route("PING!", [channel, me], [me])
+    Router.route("PING!", [channel, me], [me])
 
     assert_receive %Ockam.Message{
       onward_route: [^me],
@@ -284,7 +284,7 @@ defmodule Ockam.SecureChannel.Tests do
     receiver_pid = Ockam.Node.whereis(receiver_addr)
     ref2 = Process.monitor(receiver_pid)
 
-    Ockam.Router.route("PONG!", return_route, [me])
+    Router.route("PONG!", return_route, [me])
 
     assert_receive %Ockam.Message{
       onward_route: [^me],
@@ -313,7 +313,7 @@ defmodule Ockam.SecureChannel.Tests do
 
     {:ok, me} = Ockam.Node.register_random_address()
 
-    Ockam.Router.route("PING!", [bob_inner_address, me], [me])
+    Router.route("PING!", [bob_inner_address, me], [me])
 
     refute_receive %Ockam.Message{
       onward_route: [^me],
@@ -326,7 +326,7 @@ defmodule Ockam.SecureChannel.Tests do
     {:ok, channel} = create_secure_channel([listener], bob, %{bar: :foo})
 
     {:ok, me} = Ockam.Node.register_random_address()
-    Ockam.Router.route("PING!", [channel, me], [me])
+    Router.route("PING!", [channel, me], [me])
 
     assert_receive %Ockam.Message{
       onward_route: [^me],
@@ -340,7 +340,7 @@ defmodule Ockam.SecureChannel.Tests do
       }
     }
 
-    Ockam.Router.route("PONG!", return_route, [me])
+    Router.route("PONG!", return_route, [me])
 
     assert_receive %Ockam.Message{
       onward_route: [^me],
@@ -389,7 +389,7 @@ defmodule Ockam.SecureChannel.Tests do
     {:ok, channel} = create_secure_channel([listener], bob, %{bar: :foo})
 
     {:ok, me} = Ockam.Node.register_random_address()
-    Ockam.Router.route("PING!", [channel, me], [me])
+    Router.route("PING!", [channel, me], [me])
 
     refute_receive %Ockam.Message{
       onward_route: [^me],
@@ -439,7 +439,7 @@ defmodule Ockam.SecureChannel.Tests do
 
     {:ok, me} = Ockam.Node.register_random_address()
 
-    Ockam.Router.route("PING!", [channel, me], [me])
+    Router.route("PING!", [channel, me], [me])
 
     # This to make sure receiver end has fully completed the handshake, and so processes our
     # credentials.
@@ -476,7 +476,7 @@ defmodule Ockam.SecureChannel.Tests do
         1000
       )
 
-    # Ockam.Router.route("PING!", [channel, me], [me])
+    # Router.route("PING!", [channel, me], [me])
 
     # refute_receive %Ockam.Message{
     #  onward_route: [^me],
@@ -501,7 +501,7 @@ defmodule Ockam.SecureChannel.Tests do
         1000
       )
 
-    Ockam.Router.route("PING!", [channel, me], [me])
+    Router.route("PING!", [channel, me], [me])
 
     refute_receive %Ockam.Message{
       onward_route: [^me],

--- a/implementations/elixir/ockam/ockam_abac/test/helpers/echoer.ex
+++ b/implementations/elixir/ockam/ockam_abac/test/helpers/echoer.ex
@@ -3,7 +3,7 @@ defmodule Ockam.Tests.Helpers.Echoer do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -11,7 +11,7 @@ defmodule Ockam.Tests.Helpers.Echoer do
   def handle_message(message, state) do
     reply = Message.reply(message, state.address, Message.payload(message))
 
-    Router.route(reply)
+    Worker.route(reply, state)
     {:ok, state}
   end
 end

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
@@ -9,7 +9,7 @@ defmodule Ockam.Kafka.Interceptor.Test.FakeOutlet do
   alias Ockam.Kafka.Interceptor.Protocol.ResponseHeader
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   alias Ockam.Transport.Portal.TunnelProtocol
 
@@ -23,7 +23,7 @@ defmodule Ockam.Kafka.Interceptor.Test.FakeOutlet do
       {:ok, :ping} ->
         tunnel_message
         |> Message.reply(state.address, TunnelProtocol.encode(:pong))
-        |> Router.route()
+        |> Worker.route(state)
 
         {:ok, Map.put(state, :peer_route, Message.return_route(tunnel_message))}
 
@@ -33,10 +33,13 @@ defmodule Ockam.Kafka.Interceptor.Test.FakeOutlet do
       {:ok, {:payload, data}} ->
         response = make_response(data)
 
-        Router.route(%Message{
-          onward_route: Map.get(state, :peer_route),
-          payload: TunnelProtocol.encode({:payload, response})
-        })
+        Worker.route(
+          %Message{
+            onward_route: Map.get(state, :peer_route),
+            payload: TunnelProtocol.encode({:payload, response})
+          },
+          state
+        )
 
         {:ok, state}
     end

--- a/implementations/elixir/ockam/ockam_services/lib/services/echo.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/echo.ex
@@ -4,7 +4,7 @@ defmodule Ockam.Services.Echo do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -20,7 +20,7 @@ defmodule Ockam.Services.Echo do
 
     log_level = Map.get(state, :log_level, :info)
     Logger.log(log_level, "\nECHO\nMESSAGE: #{inspect(message)}\nREPLY: #{inspect(reply)}")
-    Router.route(reply)
+    Worker.route(reply, state)
 
     {:ok, state}
   end

--- a/implementations/elixir/ockam/ockam_services/lib/services/forwarding.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/forwarding.ex
@@ -12,7 +12,7 @@ defmodule Ockam.Services.Forwarding do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -58,7 +58,7 @@ defmodule Ockam.Services.Forwarding.Forwarder do
   use Ockam.Worker
 
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   require Logger
 
@@ -83,7 +83,7 @@ defmodule Ockam.Services.Forwarding.Forwarder do
     route_to_forward = route ++ onward_route
     Logger.info("Alias forward #{inspect(message)} to #{inspect(route_to_forward)}")
 
-    Router.route(Message.set_onward_route(message, route_to_forward))
+    Worker.route(Message.set_onward_route(message, route_to_forward), state)
 
     {:ok, state}
   end
@@ -96,6 +96,6 @@ defmodule Ockam.Services.Forwarding.Forwarder do
     }
 
     Logger.info("REGISTER OK: #{inspect(reply)}")
-    Router.route(reply)
+    Worker.route(reply, state)
   end
 end

--- a/implementations/elixir/ockam/ockam_services/lib/services/proxy.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/proxy.ex
@@ -33,7 +33,7 @@ defmodule Ockam.Services.Proxy do
 
   alias Ockam.Address
   alias Ockam.Message
-  alias Ockam.Router
+  alias Ockam.Worker
 
   alias Ockam.Transport.TCP.RecoverableClient
   alias Ockam.Transport.TCPAddress
@@ -61,7 +61,7 @@ defmodule Ockam.Services.Proxy do
             ## Only authorize inner address to accept messages from proxy client
             ## TODO: we need better authorization mechanism
             state =
-              Ockam.Worker.update_authorization_state(state, inner_address,
+              Worker.update_authorization_state(state, inner_address,
                 from_addresses: [:message, [client_address]]
               )
 
@@ -102,7 +102,7 @@ defmodule Ockam.Services.Proxy do
     forwarded_message =
       Message.set_onward_route(message, forward_route) |> Message.trace(inner_address)
 
-    Router.route(forwarded_message)
+    Worker.route(forwarded_message, state)
     {:ok, state}
   end
 
@@ -113,7 +113,7 @@ defmodule Ockam.Services.Proxy do
 
     forwarded_message = Message.forward(message) |> Map.put(:return_route, return_route)
 
-    Router.route(forwarded_message)
+    Worker.route(forwarded_message, state)
     {:ok, state}
   end
 end

--- a/implementations/elixir/ockam/ockam_services/test/services/forwarding_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/forwarding_test.exs
@@ -19,7 +19,7 @@ defmodule Test.Services.ForwardingTest do
       payload: ""
     }
 
-    Ockam.Router.route(register_message)
+    Router.route(register_message)
 
     assert_receive(%{onward_route: [^me], return_route: forwarder_route}, 5_000)
 


### PR DESCRIPTION
## Current behavior

All messages routed through Router.route/1.
```elixir
Router.route(%Ockam.Message{payload: pl, onward_route: o_r, return_route: r_r})
``` 

## Proposed Changes

Move the function to Worker.route/2 and add a state field for future usage.

```elixir
Router.route(%Ockam.Message{payload: pl, onward_route: o_r, return_route: r_r}, state: state)
``` 

All functions calling Router.route/1 will now call Worker.route/2 and pass `state` or `nil`

Set default `state` or `nil` when state unknown.

This is in reference to feature request #3654 

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.
