### PR TITLE
chore(rust): Remove unused `Error` enum members

### DIFF
--- a/implementations/rust/ockam/ockam/src/error.rs
+++ b/implementations/rust/ockam/ockam/src/error.rs
@@ -12,21 +12,6 @@ use ockam_core::{
 // FIXME: Duplication from ockam_identity::IdentityError
 #[derive(Clone, Copy, Debug)]
 pub enum OckamError {
-    BareError = 1,
-    VerifyFailed,
-    InvalidInternalState,
-    InvalidProof,
-    ConsistencyError, // 5
-    ComplexEventsAreNotSupported,
-    EventIdDoesNotMatch,
-    IdentityIdDoesNotMatch,
-    EmptyChange,
-    ContactNotFound, // 10
-    EventNotFound,
-    InvalidChainSequence,
-    InvalidEventId,
-    AttestationRequesterDoesNotMatch,
-    AttestationNonceDoesNotMatch, // 15
     InvalidHubResponse,
     InvalidParameter,
     NoSuchProtocol,

--- a/implementations/rust/ockam/ockam_identity/src/v2/error.rs
+++ b/implementations/rust/ockam/ockam_identity/src/v2/error.rs
@@ -20,22 +20,10 @@ pub enum IdentityError {
     CredentialVerificationFailed,
     /// Error occurred while getting current UTC Timestamp
     UnknownTimestamp,
-    /// Attributes were already set
-    AttributesAlreadySet,
-    /// Attributes hasn't been set
-    AttributesNotSet,
-    /// Schema was not yet set
-    SchemaNotSet,
-    /// Maximum time for credential validity exceeded
-    CredentialTtlExceeded,
-    /// Credential ttl wasn't set
-    CredentialTtlNotSet,
     /// Unknown Authority
     UnknownAuthority,
     /// Unknown version of the Credential
     UnknownCredentialVersion,
-    /// Unknown version of the PurposeKeyAttestation
-    UnknownPurposeKeyVersion,
     /// Unknown version of the Identity
     UnknownIdentityVersion,
     /// SecureChannelVerificationFailed

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use ockam_core::{
     compat::error::Error as StdError,
     errcode::{Kind, Origin},
-    Address, Error, Route,
+    Address, Error,
 };
 
 /// Enumeration of error causes in ockam_node
@@ -14,8 +14,6 @@ pub enum NodeError {
     ///
     /// An address either refers to a Worker or a Processor
     Address(Address),
-    /// Sending a message to a recipient failed
-    Recipient(Route),
     /// A data retrieval operation failed
     Data,
     /// A failure occurred because of invalid node state
@@ -68,7 +66,6 @@ impl fmt::Display for NodeError {
             "{}",
             match self {
                 Self::Address(addr) => format!("operation failed for address {}", addr),
-                Self::Recipient(route) => format!("operation failed for recipient {}", route),
                 Self::Data => "failed to load data".into(),
                 Self::NodeState(reason) => format!("failed because node state: {}", reason),
                 Self::WorkerState(reason) => format!("failed because worker state: {}", reason),

--- a/implementations/rust/ockam/ockam_transport_ble/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/error.rs
@@ -19,7 +19,6 @@ pub enum BleError {
     ConfigurationFailed,
     /// Device failed to advertise itself
     AdvertisingFailure,
-    ConnectionClosed,
     ReadError,
     WriteError,
     UnexpectedCallback,
@@ -27,7 +26,6 @@ pub enum BleError {
     NoSuchCharacteristic,
     RuntimeError(String),
     Other(String),
-    Unknown,
 }
 
 impl ockam_core::compat::error::Error for BleError {}
@@ -42,7 +40,6 @@ impl core::fmt::Display for BleError {
             Self::NotConnected => write!(f, "not connected"),
             Self::ConfigurationFailed => write!(f, "configuration failed"),
             Self::AdvertisingFailure => write!(f, "ble advertising failed"),
-            Self::ConnectionClosed => write!(f, "connection closed"),
             Self::ReadError => write!(f, "read error"),
             Self::WriteError => write!(f, "write error"),
             Self::UnexpectedCallback => write!(f, "unexpected callback"),
@@ -50,7 +47,6 @@ impl core::fmt::Display for BleError {
             Self::NoSuchCharacteristic => write!(f, "no such characteristic"),
             Self::RuntimeError(s) => write!(f, "runtime error {:?}", s),
             Self::Other(s) => write!(f, "other error {:?}", s),
-            Self::Unknown => write!(f, "unknown error"),
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

There are a few `Error` enums with members that are never used. The compiler doesn't warn about these since these are `pub` enums.

## Proposed changes

Remove the unused enum members. This is not future-proof though, and more unused members can still creep in.

Fixes #5564

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
