### PR TITLE
feat(rust): on desktop enroll, wait until project is ready

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -17,6 +17,7 @@ CLI Behavior
 - OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node.
 
 Devs Usage
+- OCKAM: a `string` that defines the path to the ockam binary to use.
 - OCKAM_HELP_SHOW_HIDDEN: a `boolean` to control the visibility of hidden commands.
 - OCKAM_CONTROLLER_ADDR: a `string` that overrides the default address of the controller.
 - OCKAM_CONTROLLER_IDENTITY_ID: a `string` that overrides the default identifier of the controller.


### PR DESCRIPTION
## Current

When the user runs the application with no projects created previously, the app crashes.

## Proposed

Wait until the project is fully created, as we do in the CLI.