### PR TITLE
chore(rust): remove an unnecessary security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,9 +5828,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",

--- a/tools/cargo-deny/deny.toml
+++ b/tools/cargo-deny/deny.toml
@@ -65,11 +65,6 @@ ignore = [
   # CDDL schema conformance in tests.
   "RUSTSEC-2021-0127",
 
-  # `xml-rs` is unmaintained, pulled in from a transitive
-  # dependency `serde-xml`
-  # (https://rustsec.org/advisories/RUSTSEC-2022-0048.html)
-  "RUSTSEC-2022-0048",
-
   # `kuchiki` dependency of tauri, html/css parser, unmaintened
   # (https://rustsec.org/advisories/RUSTSEC-2023-0019.html)
   "RUSTSEC-2023-0019",


### PR DESCRIPTION
The rustsec website says that the advisory has been withdrawn now: https://rustsec.org/advisories/RUSTSEC-2022-0048.html. In any case we don't have a dependency on `xml-rs`.

