### PR TITLE
feat(rust): ignore expired accepted invitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ dependencies = [
  "tauri-plugin-window",
  "tauri-runtime",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -87,6 +87,14 @@ pub struct InvitationWithAccess {
     #[n(2)] pub service_access_details: Option<ServiceAccessDetails>,
 }
 
+impl PartialEq for InvitationWithAccess {
+    fn eq(&self, other: &Self) -> bool {
+        self.invitation.id == other.invitation.id
+    }
+}
+
+impl Eq for InvitationWithAccess {}
+
 #[derive(Clone, Debug, Decode, Encode, Deserialize, Serialize)]
 #[cbor(map)]
 #[rustfmt::skip]

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -56,6 +56,7 @@ tauri-plugin-positioner = { version = "2.0.0-alpha.0", features = ["system-tray"
 tauri-plugin-window = "2.0.0-alpha.0"
 tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
 thiserror = "1.0.47"
+time = { version = "0.3.25", default-features = false }
 tokio = { version = "1.31.0", features = ["time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional = true }

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -1,4 +1,6 @@
 use tauri::{AppHandle, Manager, Runtime, State};
+use time::format_description::well_known::iso8601::Iso8601;
+use time::OffsetDateTime;
 use tracing::{debug, error, info, warn};
 
 use ockam_api::cli_state::{CliState, StateDirTrait};
@@ -144,8 +146,8 @@ async fn refresh_inlets<R: Runtime>(app: &AppHandle<R>) -> crate::Result<()> {
     let cli_bin = cli_bin()?;
     for invitation in &reader.accepted {
         match InletDataFromInvitation::new(&cli_state, invitation) {
-            Ok(i) => {
-                if let Some(i) = i {
+            Ok(i) => match i {
+                Some(i) => {
                     if let Ok(node) = cli_state.nodes.get(&i.local_node_name) {
                         if node.is_running() {
                             debug!(node = %i.local_node_name, "Node already running");
@@ -164,7 +166,11 @@ async fn refresh_inlets<R: Runtime>(app: &AppHandle<R>) -> crate::Result<()> {
                     .run();
                     create_inlet(&i).await?;
                 }
-            }
+                None => {
+                    warn!("Invalid invitation data");
+                    continue;
+                }
+            },
             Err(err) => {
                 warn!(%err, "Failed to parse invitation data");
                 continue;
@@ -223,6 +229,13 @@ impl InletDataFromInvitation {
         cli_state: &CliState,
         invitation: &InvitationWithAccess,
     ) -> crate::Result<Option<Self>> {
+        let expires_at =
+            OffsetDateTime::parse(&invitation.invitation.expires_at, &Iso8601::DEFAULT).unwrap();
+        if expires_at < OffsetDateTime::now_utc() {
+            let invitation = &invitation.invitation;
+            warn!(invitation = %invitation.id, at = %invitation.expires_at, "Invitation has expired");
+            return Ok(None);
+        }
         match &invitation.service_access_details {
             Some(d) => {
                 let service_name = extract_address_value(&d.shared_node_route)?;


### PR DESCRIPTION
Accepted invitations are filtered out on the backend, but the user could try to use an invitation right before the poll event that filters that invitation.

In order to give the user a specific error message, this PR's checks the `expires_at` field before contacting the backend.