### PR TITLE
fail gracefully if docs script can't find a file specified in markdown

### DIFF
--- a/tools/docs/verify_md.sh
+++ b/tools/docs/verify_md.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 FILE=$1
 TMP=$(mktemp)
 example_blocks "$FILE" >"$TMP"


### PR DESCRIPTION
When checking a markdown file with the docs checker script, we check all markdown files as below
```rust
// full_path_of_rust_code_in_the_ockam_repo.rs
fn some_rust_code() {
}
```
we cd to `full_path_of_rust_code_in_the_ockam_repo` and then compare the code in the markdown file with that specified in the rust code, if `full_path_of_rust_code_in_the_ockam_repo` doesn't exists, the script errors but doesn't exit gracefully giving unintended behaviour, this PR ensures that if a file is not found that the script exits with a failure.