### PR TITLE
fix: Filter projects for admin role during app interactions

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -9,7 +9,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::error::ApiError;
 
-use self::share::RoleInShare;
+use self::share::{RoleInShare, ShareScope};
 
 pub mod addon;
 pub mod enroll;
@@ -42,6 +42,7 @@ pub struct ProjectUserRole {
     #[n(1)] pub email: String,
     #[n(2)] pub id: usize,
     #[n(3)] pub role: RoleInShare,
+    #[n(4)] pub scope: ShareScope,
 }
 
 /// A wrapper around a cloud request with extra fields.

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -47,7 +47,7 @@ impl FromStr for RoleInShare {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Decode, Deserialize, Encode, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Deserialize, Encode, Serialize)]
 #[cbor(index_only)]
 #[rustfmt::skip]
 pub enum ShareScope {

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -194,6 +194,10 @@ impl AppState {
         node_manager.list_outlets().await.list
     }
 
+    pub async fn user_email(&self) -> Option<String> {
+        self.model(|m| m.get_user_info()).await.map(|ui| ui.email)
+    }
+
     pub async fn model_mut(&self, f: impl FnOnce(&mut ModelState)) -> Result<()> {
         let mut model_state = self.model_state.write().await;
         f(&mut model_state);

--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -23,6 +23,7 @@ use crate::app::model_state_repository::{LmdbModelStateRepository, ModelStateRep
 use crate::Result;
 
 pub const NODE_NAME: &str = "ockam_app";
+// TODO: static project name of "default" is an unsafe default behavior due to backend uniqueness requirements
 pub const PROJECT_NAME: &str = "default";
 
 /// The AppState struct contains all the state managed by `tauri`.

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -124,7 +124,14 @@ async fn retrieve_project(app_state: &AppState, space: &Space) -> Result<Project
             .await
             .map_err(|e| miette!(e))?
     };
-    let project = match projects.iter().find(|p| p.name == *PROJECT_NAME) {
+
+    let email = app_state.user_email().await.unwrap_or_default();
+
+    let project = match projects
+        .iter()
+        .filter(|p| p.has_admin_with_email(&email))
+        .find(|p| p.name == *PROJECT_NAME)
+    {
         Some(project) => project.clone(),
         None => {
             let ctx = &app_state.context();

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -61,7 +61,9 @@ pub async fn create_enrollment_ticket<R: Runtime>(
     })
 }
 
-async fn list_projects_with_admin<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>> {
+pub(crate) async fn list_projects_with_admin<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Vec<Project>> {
     let app_state: State<'_, AppState> = app.state();
     let user_email = app_state.user_email().await.unwrap_or_default();
     let state: State<'_, SyncState> = app.state();


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Orchestrator users may be members of multiple Spaces, multiple Projects, and hold varying roles within each. In order to share an invitation for another user to connect through a project, the inviter must hold an Admin role in either the parent Space or in the Project itself.

## Proposed changes

Pre-filter the list of projects for Admin roles when choosing a Project for an app interaction, such as creating an Enrollment Ticket or service invitation. This will prevent most classes of backend 401 under the existing logic, where the inference may select a Project you have no rights to.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [X] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [X] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [X] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
