### PR TITLE
chore: make the command line app the default application

### DIFF
--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -9,7 +9,6 @@ categories = [
   "network-programming",
   "embedded",
 ]
-default-run = "ockam_app"
 edition = "2021"
 homepage = "https://github.com/build-trust/ockam"
 keywords = [

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -9,6 +9,7 @@ categories = [
   "network-programming",
   "embedded",
 ]
+default-run = "ockam"
 edition = "2021"
 exclude = ["tests/**"]
 homepage = "https://github.com/build-trust/ockam"


### PR DESCRIPTION
This PR makes the command line application the default application, instead of the desktop application.
This allows `cargo run` to always work, even on systems where all the dependencies for `tauri` might not be installed.

Fixes #5594