### PR TITLE
chore: use a different name for the desktop application executable

### DIFF
--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -12,7 +12,7 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "Ockam",
+    "productName": "OckamDesktop",
     "version": "0.1.0"
   },
   "tauri": {


### PR DESCRIPTION
This will avoid conflicts with the ockam command line executable.

Fixes #5703.

