### PR TITLE
feat(rust): show progress message while the enroll process is running

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -84,6 +84,8 @@ impl AppState {
         self.reset_node_manager().await?;
 
         // recreate the model state repository since the cli state has changed
+        let mut writer = self.model_state.write().await;
+        *writer = ModelState::default();
         let identity_path = self
             .state()
             .await

--- a/implementations/rust/ockam/ockam_app/src/app/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/events.rs
@@ -1,1 +1,56 @@
+use tauri::{AppHandle, Manager, Runtime};
+
 pub const SYSTEM_TRAY_ON_UPDATE: &str = "app/system_tray/on_update";
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct SystemTrayOnUpdatePayload {
+    /// An optional status message that is shown when the application
+    /// is waiting until the enroll process is done.
+    pub enroll_status: Option<String>,
+}
+
+pub struct SystemTrayOnUpdatePayloadBuilder {
+    payload: SystemTrayOnUpdatePayload,
+}
+
+impl SystemTrayOnUpdatePayloadBuilder {
+    pub fn new() -> Self {
+        Self {
+            payload: SystemTrayOnUpdatePayload::default(),
+        }
+    }
+
+    pub fn enroll_status(mut self, status_message: &str) -> Self {
+        self.payload.enroll_status = Some(status_message.to_string());
+        self
+    }
+
+    pub fn build(self) -> SystemTrayOnUpdatePayload {
+        self.payload
+    }
+}
+
+impl TryFrom<&str> for SystemTrayOnUpdatePayload {
+    type Error = serde_json::Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+pub fn system_tray_on_update<R: Runtime>(app: &AppHandle<R>) {
+    app.trigger_global(SYSTEM_TRAY_ON_UPDATE, None);
+}
+
+pub fn system_tray_on_update_with_enroll_status<R: Runtime>(
+    app: &AppHandle<R>,
+    payload: &str,
+) -> crate::Result<()> {
+    let payload = Some(serde_json::to_string(
+        &SystemTrayOnUpdatePayloadBuilder::new()
+            .enroll_status(payload)
+            .build(),
+    )?);
+    app.trigger_global(SYSTEM_TRAY_ON_UPDATE, payload);
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_app/src/app/process.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/process.rs
@@ -1,4 +1,5 @@
-use tauri::{AppHandle, Manager, RunEvent, Wry};
+use crate::app::events::system_tray_on_update;
+use tauri::{AppHandle, RunEvent, Wry};
 
 /// This is the function dispatching application events
 pub fn process_application_event(app: &AppHandle<Wry>, event: RunEvent) {
@@ -7,7 +8,7 @@ pub fn process_application_event(app: &AppHandle<Wry>, event: RunEvent) {
             api.prevent_exit();
         }
         RunEvent::Ready => {
-            app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+            system_tray_on_update(app);
         }
         _ => {}
     }

--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -1,18 +1,23 @@
 use tauri::{AppHandle, Manager, State, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, Wry};
 use tracing::error;
 
+use crate::app::events::SystemTrayOnUpdatePayload;
 use crate::app::AppState;
-use crate::enroll::build_enroll_section;
+use crate::enroll::{build_enroll_section, build_user_info_section};
 #[cfg(feature = "invitations")]
 use crate::invitations::{self, build_invitations_section};
 use crate::options::build_options_section;
 use crate::shared_service::build_shared_services_section;
 use crate::{enroll, options, shared_service};
 
-pub async fn build_tray_menu(app_handle: &AppHandle) -> SystemTrayMenu {
+pub async fn build_tray_menu(
+    app_handle: &AppHandle,
+    payload: Option<SystemTrayOnUpdatePayload>,
+) -> SystemTrayMenu {
     let app_state: State<'_, AppState> = app_handle.state();
     let mut tray_menu = SystemTrayMenu::new();
-    tray_menu = build_enroll_section(&app_state, tray_menu).await;
+    tray_menu = build_user_info_section(&app_state, tray_menu).await;
+    tray_menu = build_enroll_section(&app_state, tray_menu, &payload).await;
     tray_menu = build_shared_services_section(&app_state, tray_menu).await;
     #[cfg(feature = "invitations")]
     {

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -1,7 +1,9 @@
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 #[cfg(target_os = "macos")]
 use tauri_runtime::menu::NativeImage;
+use tauri_runtime::menu::SystemTrayMenuItem;
 
+use crate::app::events::SystemTrayOnUpdatePayload;
 use crate::app::AppState;
 use crate::enroll::enroll_user::enroll_user;
 
@@ -10,25 +12,44 @@ pub const ENROLL_MENU_HEADER_ID: &str = "enroll-header";
 pub const ENROLL_MENU_ID: &str = "enroll";
 pub const ENROLL_MENU_USER_NAME: &str = "user-name";
 
-pub(crate) async fn build_enroll_section(
+pub(crate) async fn build_user_info_section(
     app_state: &AppState,
     tray_menu: SystemTrayMenu,
 ) -> SystemTrayMenu {
-    if app_state.is_enrolled().await.unwrap_or(false) {
-        match app_state.model(|m| m.get_user_info()).await {
-            Some(user_info) => {
-                let item = CustomMenuItem::new(
-                    ENROLL_MENU_USER_NAME,
-                    format!("{} ({})", user_info.name, user_info.nickname),
-                );
-                #[cfg(target_os = "macos")]
-                let item = item.native_image(NativeImage::User);
-                tray_menu
-                    .add_item(item)
-                    .add_item(CustomMenuItem::new(ENROLL_MENU_EMAIL, user_info.email).disabled())
-            }
-            None => tray_menu,
+    match app_state.model(|m| m.get_user_info()).await {
+        Some(user_info) => {
+            let item = CustomMenuItem::new(
+                ENROLL_MENU_USER_NAME,
+                format!("{} ({})", user_info.name, user_info.nickname),
+            );
+            #[cfg(target_os = "macos")]
+            let item = item.native_image(NativeImage::User);
+            tray_menu
+                .add_item(item)
+                .add_item(CustomMenuItem::new(ENROLL_MENU_EMAIL, user_info.email).disabled())
         }
+        None => tray_menu,
+    }
+}
+
+pub(crate) async fn build_enroll_section(
+    app_state: &AppState,
+    tray_menu: SystemTrayMenu,
+    payload: &Option<SystemTrayOnUpdatePayload>,
+) -> SystemTrayMenu {
+    if let Some(payload) = &payload {
+        if let Some(message) = &payload.enroll_status {
+            let tray_menu = match app_state.model(|m| m.get_user_info()).await {
+                None => tray_menu,
+                Some(_) => tray_menu.add_native_item(SystemTrayMenuItem::Separator),
+            };
+            return tray_menu
+                .add_item(CustomMenuItem::new(ENROLL_MENU_HEADER_ID, "Enrolling...").disabled())
+                .add_item(CustomMenuItem::new("status", message).disabled());
+        }
+    }
+    if app_state.is_enrolled().await.unwrap_or(false) {
+        tray_menu
     } else {
         tray_menu
             .add_item(CustomMenuItem::new(ENROLL_MENU_HEADER_ID, "Please enroll").disabled())

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use crate::app::events::system_tray_on_update;
 use tauri::{
     async_runtime::{spawn, RwLock},
     plugin::{Builder, TauriPlugin},
@@ -42,7 +43,7 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             });
             let handle = app.clone();
             app.listen_global(REFRESHED_INVITATIONS, move |_event| {
-                handle.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+                system_tray_on_update(&handle);
             });
             Ok(())
         })

--- a/implementations/rust/ockam/ockam_app/src/options/reset.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/reset.rs
@@ -2,6 +2,7 @@ use miette::miette;
 use tauri::{AppHandle, Manager, Wry};
 use tracing::log::info;
 
+use crate::app::events::system_tray_on_update;
 use crate::app::AppState;
 use crate::Result;
 
@@ -12,6 +13,6 @@ pub async fn reset(app: &AppHandle<Wry>) -> Result<()> {
     let app_state = app.state::<AppState>();
     let result = app_state.reset().await;
     info!("Application state recreated");
-    app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+    system_tray_on_update(app);
     result.map_err(|e| miette!(e).into())
 }

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use crate::app::events::system_tray_on_update;
 use tauri::{
     async_runtime::{spawn, RwLock},
     plugin::{Builder, TauriPlugin},
@@ -38,7 +39,7 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             });
             let handle = app.clone();
             app.listen_global(REFRESHED_PROJECTS, move |_event| {
-                handle.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+                system_tray_on_update(&handle);
             });
             Ok(())
         })

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 use tauri::{AppHandle, Manager, Wry};
 use tracing::{debug, error, info};
 
+use crate::app::events::system_tray_on_update;
 use crate::app::AppState;
 use crate::error::Error;
 #[cfg(feature = "invitations")]
@@ -55,7 +56,7 @@ async fn tcp_outlet_create_impl(
         Ok(status) => {
             info!(tcp_addr = status.tcp_addr, "Outlet created");
             app_state.model_mut(|m| m.add_tcp_outlet(status)).await?;
-            app.trigger_global(crate::app::events::SYSTEM_TRAY_ON_UPDATE, None);
+            system_tray_on_update(&app);
             Ok(())
         }
         Err(_) => Err(Error::Generic("Failed to create outlet".to_string())),


### PR DESCRIPTION
While enrolling, it shows a message with the current state of the process (waiting for token, retrieving space, retrieving project). Once the `user_info` is ready, it renders that section right away, even if the project is still being created.

![image](https://github.com/build-trust/ockam/assets/12375782/fc49fada-a082-4d5a-ae4a-ad0d6e998f30)
