### PR TITLE
#5707 make sure that we can execute the ockam command from the desktop application

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/cli/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/cli/mod.rs
@@ -15,7 +15,7 @@ pub(crate) fn cli_bin() -> Result<String> {
 /// its version
 pub(crate) fn check_ockam_executable() -> Result<()> {
     let ockam_path = cli_bin()?;
-    if ockam_path != "ockam".to_string() && !ockam_path.starts_with("/") {
+    if ockam_path != *"ockam" && !ockam_path.starts_with('/') {
         let message = format!("The OCKAM environment variable must be defined with an absolute path. The current value is: {ockam_path}");
         error!(message);
         return Err(Generic(message));
@@ -31,7 +31,7 @@ pub(crate) fn check_ockam_executable() -> Result<()> {
             "The ockam command is available {:?}",
             std::str::from_utf8(&v.stdout)
                 .unwrap_or("can't decode the ockam version")
-                .split("\n")
+                .split('\n')
                 .collect::<Vec<&str>>()
                 .join(" ")
         ),

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -3,8 +3,10 @@ use crate::app::configure_tauri_plugin_log;
 #[cfg(all(not(feature = "log"), feature = "tracing"))]
 use crate::app::configure_tracing_log;
 use crate::app::{process_application_event, setup_app, AppState};
+use crate::cli::check_ockam_executable;
 use crate::error::Result;
 use shared_service::tcp_outlet::tcp_outlet_create;
+use std::process::exit;
 
 mod app;
 mod cli;
@@ -22,6 +24,12 @@ mod shared_service;
 pub fn run() {
     #[cfg(all(feature = "tracing", not(feature = "log")))]
     configure_tracing_log();
+
+    // Exit if there is any issue with the ockam command
+    // The log messages should explain what went wrong
+    if check_ockam_executable().is_err() {
+        exit(-1)
+    }
 
     // For now, the application only consists of a system tray with several menu items
     #[cfg_attr(not(feature = "invitations"), allow(unused_mut))]

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -34,7 +34,7 @@ pub async fn create_enrollment_ticket<R: Runtime>(
     debug!(?project_id, "creating enrollment ticket via CLI");
     // TODO: Issue enrollment ticket using in-memory code instead of subshell
     // TODO: How might this degrade for users who have multiple spaces and projects?
-    let bin = cli_bin().map_err(|_| Error::OckamCommandInvalid)?;
+    let bin = cli_bin().map_err(|e| Error::OckamCommandInvalid(e.to_string()))?;
     let hex_encoded_ticket = duct::cmd!(
         bin,
         "project",

--- a/implementations/rust/ockam/ockam_app/src/projects/error.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/error.rs
@@ -11,8 +11,8 @@ pub enum Error {
     EnrollmentTicketDecodeFailed,
     #[error("listing projects failed: {0:?}")]
     ListingFailed(ockam::Error),
-    #[error("binary for ockam command is invalid")]
-    OckamCommandInvalid,
+    #[error("binary for ockam command is invalid: {0}")]
+    OckamCommandInvalid(String),
     #[error("project {0} not found")]
     ProjectNotFound(String),
     #[error("failed to save local project state")]

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -12,7 +12,7 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "Ockam",
+    "productName": "OckamDesktop",
     "version": "0.1.0"
   },
   "tauri": {


### PR DESCRIPTION
## Description

This PR checks the availability of the `ockam` command (used to start inlets) and exits the desktop application if the command can not be executed.

## Tests

It can be tested by:

1. running `cargo build`
2. running `cd implementations/rust/ockam/ockam_app; cargo tauri dev; cd -`
3. => the application should start and show the `ockam` version in the logs

Then, stop the desktop application and:

1. run `export OCKAM=target/debug/ockam`
2. run `cd implementations/rust/ockam/ockam_app; cargo tauri dev; cd -`
3. the application should exit

Then, stop the desktop application and:

1. run `export OCKAM=/<your ockam root directory>/target/debug/ockam`
2. run `cd implementations/rust/ockam/ockam_app; cargo tauri dev; cd -`
3. the application should start and show the `ockam` version in the logs

----
Fixes #5707 