### PR TITLE
fix(rust): do not create tcp-outlet and relay if user is not enrolled

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/app_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/app_state.rs
@@ -163,32 +163,8 @@ impl AppState {
         }
     }
 
-    /// Return true if the user is enrolled
-    /// At the moment this check only verifies that there is a default project.
-    /// This project should be the project that is created at the end of the enrollment procedure
     pub async fn is_enrolled(&self) -> Result<bool> {
-        let identity_state = self.state().await.identities.get_or_default(None)?;
-
-        if !identity_state.is_enrolled() {
-            return Ok(false);
-        }
-
-        let default_space_exists = self.state().await.spaces.default().is_ok();
-        if !default_space_exists {
-            return Err(
-                "There should be a default space set for the current user. Please re-enroll".into(),
-            );
-        }
-
-        let default_project_exists = self.state().await.projects.default().is_ok();
-        if !default_project_exists {
-            return Err(
-                "There should be a default project set for the current user. Please re-enroll"
-                    .into(),
-            );
-        }
-
-        Ok(true)
+        self.state().await.is_enrolled().map_err(|e| e.into())
     }
 
     /// Return the list of currently running outlets
@@ -315,6 +291,7 @@ fn load_model_state(
                     context.clone(),
                     node_manager_worker,
                     &model_state,
+                    cli_state,
                 )
                 .await;
                 crate::shared_service::relay::load_model_state(
@@ -326,7 +303,7 @@ fn load_model_state(
                 model_state
             }
             Err(e) => {
-                println!("cannot load the model state: {e:?}");
+                error!(?e, "cannot load the model state");
                 panic!("{}", e)
             }
         }

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -113,6 +113,9 @@ pub async fn list_outlets<R: Runtime>(app: AppHandle<R>) -> tauri::Result<Vec<Ou
 pub async fn refresh_invitations<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     info!("refreshing invitations");
     let state: State<'_, AppState> = app.state();
+    if !state.is_enrolled().await.unwrap_or(false) {
+        return Ok(());
+    }
     let node_manager_worker = state.node_manager_worker().await;
     let invitations = node_manager_worker
         .list_shares(

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -33,7 +33,7 @@ pub(crate) async fn build_options_section(
             let error_item = CustomMenuItem::new(
                 ERROR_MENU_ID,
                 "The application state is corrupted, please re-enroll, reset or quit the application",
-            );
+            ).disabled();
             #[cfg(target_os = "macos")]
             let error_item = error_item.native_image(NativeImage::Caution);
             tray_menu.add_item(error_item)

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
@@ -25,6 +25,9 @@ pub async fn create_relay_impl(
     cli_state: &CliState,
     node_manager_worker: &NodeManagerWorker,
 ) -> Result<Option<ForwarderInfo>> {
+    if !cli_state.is_enrolled().unwrap_or(false) {
+        return Ok(None);
+    }
     match cli_state.projects.default() {
         Ok(project) => {
             debug!(project = %project.name(), "Creating relay at project");

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
@@ -1,5 +1,6 @@
 use crate::app::ModelState;
 use ockam::Context;
+use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
@@ -19,7 +20,11 @@ pub(crate) async fn load_model_state(
     context: Arc<Context>,
     node_manager_worker: &NodeManagerWorker,
     model_state: &ModelState,
+    cli_state: &CliState,
 ) {
+    if !cli_state.is_enrolled().unwrap_or(false) {
+        return;
+    }
     let mut node_manager = node_manager_worker.inner().write().await;
     for tcp_outlet in model_state.get_tcp_outlets() {
         let _ = node_manager


### PR DESCRIPTION
Under some circumstances, the app won't be able to reach the project to create the relay, even if it's enrolled (e.g. the user deletes the default project and then tries to run the app).

This PR adds a check so that it doesn't try to create the tcp-outlets and realy if the user is not enrolled and has the default space/project properly set.