### PR TITLE
Fix the building of the desktop application

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -1,3 +1,19 @@
+//! This crate contains the implementation of the Ockam desktop application.
+//!
+//! In order to run the application in development you need to execute:
+//! ```sh
+//! # to build the `ockam` executable in the target/debug directory
+//! cargo build
+//!
+//! # to build the `ockam_desktop` executable in the target/debug directory and start it
+//! # the overridden tauri configuration renames the package.productName value from "Ockam" to
+//! # "OckamDesktop" so that we don't get any conflict with the command line executable name.
+//! # However when the application is published we keep "Ockam" as a name since this will be the
+//! # MacOS bundle name
+//! cd implementations/rust/ockam/ockam_app; cargo tauri dev -c tauri.conf.dev.json; cd -
+//!
+//! ```
+
 #[cfg(feature = "log")]
 use crate::app::configure_tauri_plugin_log;
 #[cfg(all(not(feature = "log"), feature = "tracing"))]

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -1,6 +1,8 @@
 #[cfg(all(debug_assertions, feature = "invitations"))]
 use tauri::Manager;
-use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, SystemTraySubmenu, Wry};
+#[cfg(debug_assertions)]
+use tauri::SystemTraySubmenu;
+use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 #[cfg(target_os = "macos")]
 use tauri_runtime::menu::NativeImage;
 use tracing::log::error;
@@ -41,6 +43,7 @@ pub(crate) async fn build_options_section(
     }
 }
 
+#[cfg(debug_assertions)]
 fn build_developer_submenu(app_state: &AppState, tray_menu: SystemTrayMenu) -> SystemTrayMenu {
     let submenu = SystemTrayMenu::new()
         .add_item(CustomMenuItem::new(REFRESH_MENU_ID, "Refresh Data"))

--- a/implementations/rust/ockam/ockam_app/tauri.conf.dev.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.dev.json
@@ -1,0 +1,6 @@
+{
+  "package": {
+    "productName": "OckamDesktop",
+    "version": "0.1.0"
+  }
+}

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -12,7 +12,7 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "OckamDesktop",
+    "productName": "Ockam",
     "version": "0.1.0"
   },
   "tauri": {

--- a/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_addr]/+page.ts
+++ b/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_addr]/+page.ts
@@ -1,3 +1,14 @@
+/** @type {import('./$types').EntryGenerator}
+ * Since this page has a dynamic address we need to specify the entries function
+ * so that it can be pre-rendered.
+ * See: https://kit.svelte.dev/docs/page-options#prerender-troubleshooting
+ */
+export function entries() {
+  return [
+    { outlet_addr: '12345' },
+  ];
+}
+
 export const load = ({ params }) => {
   return {
     outlet_addr: params.outlet_addr,


### PR DESCRIPTION
This PR fixes the execution of `cargo tauri build`

 - there was a compilation error with a feature flag for develop
 - there was a pre-rendering error with a Svelte route for the `/invite/[outlet_addr]` dynamic route

In addition this PR brings another solution to [the overlap of executable names when testing the desktop application during development](https://github.com/build-trust/ockam/pull/5723).

Our objective is to:

 1. be able to create a `.dmg` bundle with the name `Ockam`. This name is defined by the `package.productName` property in `tauri.conf.json`
 
 2. be able to run both `cargo build` and `cd implementations/rust/ockam/ockam_app; cargo tauri dev;` in development to produce both the desktop application executable and the command-line executable in the `target/debug` directory. Since the desktop executable uses the command-line executable we need different names. Unfortunately the `cargo tauri dev` command reuses `package.productName` to define the desktop executable name.

The solution adopted in #5723 contradicts objective 1. I tried to use the possibility to [override the `Info.plist` file](https://jonaskruckenberg.github.io/tauri-docs-wip/building/macos-bundle.html) when bundling the Mac application but that didn't work (at least not for the `.dmg` file).

This PR proposes another solution: override the `tauri.conf.json` file at development time:
```
cd implementations/rust/ockam/ockam_app; cargo tauri dev -c tauri.conf.dev.json; cd -
```
With the command above we can run the desktop application in development and not get a name conflict for our executables.