### PR TITLE
refactor: create outlets using worker address instead of tcp address

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -15,7 +15,7 @@ use tauri::{AppHandle, Manager, Runtime, State};
 
 pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
     app_handle: &AppHandle<R>,
-    outlet_tcp_addr: &str,
+    outlet_worker_addr: &str,
     recipient_email: &str,
     enrollment_ticket: EnrollmentTicket,
 ) -> crate::Result<CreateServiceInvitation> {
@@ -25,7 +25,7 @@ pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
         .model(|m| {
             m.tcp_outlets
                 .iter()
-                .find(|o| o.tcp_addr == outlet_tcp_addr)
+                .find(|o| o.worker_addr == outlet_worker_addr)
                 .map(|o| o.worker_address())
         })
         .await

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -223,7 +223,7 @@ pub(crate) fn dispatch_click_event(app: &AppHandle<Wry>, id: &str) -> tauri::Res
         .collect::<Vec<&str>>();
     match segments.as_slice() {
         ["accepted", "connect", id] => on_connect(app, id),
-        ["create", "for", outlet_tcp_addr] => on_create(app, outlet_tcp_addr),
+        ["create", "for", outlet_worker_addr] => on_create(app, outlet_worker_addr),
         ["received", "accept", id] => on_accept(app, id),
         ["received", "decline", id] => on_decline(app, id),
         ["sent", "cancel", id] => on_cancel(app, id),
@@ -251,13 +251,13 @@ fn on_cancel(_app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
     todo!()
 }
 
-fn on_create(app: &AppHandle<Wry>, outlet_tcp_addr: &str) -> tauri::Result<()> {
-    debug!(?outlet_tcp_addr, "creating invite via menu");
+fn on_create(app: &AppHandle<Wry>, outlet_worker_addr: &str) -> tauri::Result<()> {
+    debug!(?outlet_worker_addr, "creating invite via menu");
 
     match app.get_window(INVITATIONS_WINDOW_ID) {
         None => {
             let url_path = percent_encode(
-                format!("invite/{outlet_tcp_addr}").as_bytes(),
+                format!("invite/{outlet_worker_addr}").as_bytes(),
                 &PATH_ENCODING_SET,
             )
             .to_string();

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -44,7 +44,7 @@ fn shared_service_submenu(outlet: &OutletStatus) -> SystemTraySubmenu {
         // NOTE: Event handler for dynamic ID is defined in crate::invitations::tray_menu module,
         // and reached via crate::app::tray_menu::fallback_for_id
         submenu = submenu.add_item(CustomMenuItem::new(
-            format!("invitation-create-for-{}", outlet.tcp_addr),
+            format!("invitation-create-for-{}", outlet.worker_addr),
             "Share".to_string(),
         ));
     }


### PR DESCRIPTION
Display change to worker_address was already part of c8fd964bf4536a42f7f020342851df28bc2c1d56

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The menu IDs and function arguments around the app's use of outlets currently are focused on the worker's TCP address.

## Proposed changes

Replace argument names and values to use the outlet's worker address instead per #5600.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
