### PR TITLE
refactor(rust): return Err when secret size doesn't match the expected one

### DIFF
--- a/implementations/rust/ockam/ockam_vault/src/vault/vault_kms/vault_kms.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/vault_kms/vault_kms.rs
@@ -147,8 +147,9 @@ impl VaultSecurityModule {
                     return Err(VaultError::InvalidSecretLength(
                         SecretType::X25519,
                         stored_secret.secret().length(),
-                        CURVE25519_SECRET_LENGTH_U32)
-                        .into());
+                        CURVE25519_SECRET_LENGTH_U32,
+                    )
+                    .into());
                 };
                 let secret = *array_ref![
                     stored_secret.secret().as_ref(),
@@ -165,8 +166,9 @@ impl VaultSecurityModule {
                     return Err(VaultError::InvalidSecretLength(
                         SecretType::Ed25519,
                         stored_secret.secret().length(),
-                        SECRET_KEY_LENGTH as u32)
-                        .into());
+                        SECRET_KEY_LENGTH as u32,
+                    )
+                    .into());
                 };
                 let secret = array_ref![stored_secret.secret().as_ref(), 0, SECRET_KEY_LENGTH];
                 let sk = ed25519_dalek::SigningKey::from_bytes(secret);
@@ -190,8 +192,9 @@ impl VaultSecurityModule {
                     return Err(VaultError::InvalidSecretLength(
                         SecretType::Ed25519,
                         stored_secret.secret().length(),
-                        SECRET_KEY_LENGTH as u32)
-                        .into());
+                        SECRET_KEY_LENGTH as u32,
+                    )
+                    .into());
                 }
                 let secret = array_ref![stored_secret.secret().as_ref(), 0, SECRET_KEY_LENGTH];
                 let sk = SigningKey::from_bytes(secret);
@@ -223,8 +226,9 @@ impl VaultSecurityModule {
                     return Err(VaultError::InvalidSecretLength(
                         SecretType::X25519,
                         secret.length(),
-                        CURVE25519_SECRET_LENGTH_U32)
-                        .into());
+                        CURVE25519_SECRET_LENGTH_U32,
+                    )
+                    .into());
                 };
                 let secret = *array_ref![secret.as_ref(), 0, CURVE25519_SECRET_LENGTH_U32 as usize];
                 let sk = x25519_dalek::StaticSecret::from(secret);
@@ -241,8 +245,9 @@ impl VaultSecurityModule {
                     return Err(VaultError::InvalidSecretLength(
                         SecretType::Ed25519,
                         secret.length(),
-                        SECRET_KEY_LENGTH as u32)
-                        .into());
+                        SECRET_KEY_LENGTH as u32,
+                    )
+                    .into());
                 }
                 let secret = array_ref![secret.as_ref(), 0, SECRET_KEY_LENGTH];
                 let sk = SigningKey::from_bytes(secret);

--- a/implementations/rust/ockam/ockam_vault/src/vault/vault_kms/vault_kms.rs
+++ b/implementations/rust/ockam/ockam_vault/src/vault/vault_kms/vault_kms.rs
@@ -6,7 +6,6 @@ use crate::{
     StoredSecret, VaultError,
 };
 use arrayref::array_ref;
-use ed25519_dalek::SECRET_KEY_LENGTH;
 use ockam_core::compat::rand::{thread_rng, RngCore};
 use ockam_core::compat::sync::Arc;
 use ockam_core::errcode::{Kind, Origin};
@@ -145,7 +144,11 @@ impl VaultSecurityModule {
         match attributes.secret_type() {
             SecretType::X25519 => {
                 if stored_secret.secret().length() != CURVE25519_SECRET_LENGTH_U32 as usize {
-                    return Err(VaultError::InvalidX25519SecretLength.into());
+                    return Err(VaultError::InvalidSecretLength(
+                        SecretType::X25519,
+                        stored_secret.secret().length(),
+                        CURVE25519_SECRET_LENGTH_U32)
+                        .into());
                 };
                 let secret = *array_ref![
                     stored_secret.secret().as_ref(),
@@ -217,7 +220,11 @@ impl VaultSecurityModule {
         Ok(match attributes.secret_type() {
             SecretType::X25519 => {
                 if secret.length() != CURVE25519_SECRET_LENGTH_U32 as usize {
-                    return Err(VaultError::InvalidX25519SecretLength.into());
+                    return Err(VaultError::InvalidSecretLength(
+                        SecretType::X25519,
+                        secret.length(),
+                        CURVE25519_SECRET_LENGTH_U32)
+                        .into());
                 };
                 let secret = *array_ref![secret.as_ref(), 0, CURVE25519_SECRET_LENGTH_U32 as usize];
                 let sk = x25519_dalek::StaticSecret::from(secret);


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request is applied. -->
Currently, as described in #5631, in `vault_kms.rs` secrets are casted to fixed-length array using the `array_ref` macro, without checking for length mismatches.
This affects the following methods:
* `compute_public_key_from_secret`
* `sign_with_secret`
* `compute_key_id`

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
As suggested in #5631, we can implement the check as the [verify method](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_vault/src/vault/vault_kms/vault_kms.rs#L80) already does, e.g.:

```rust
    pub(crate) fn compute_public_key_from_secret(
        stored_secret: StoredSecret,
    ) -> Result<PublicKey, Error> {
        let attributes = stored_secret.attributes();
        match attributes.secret_type() {
            SecretType::X25519 => {
                if stored_secret.secret().length() != CURVE25519_SECRET_LENGTH_U32 as usize {
                    return Err(VaultError::InvalidSecretLength(
                        SecretType::X25519,
                        stored_secret.secret().length(),
                        CURVE25519_SECRET_LENGTH_U32)
                        .into());
                };
                let secret = *array_ref![
                    stored_secret.secret().as_ref(),
                    0,
                    CURVE25519_SECRET_LENGTH_U32 as usize
                ];
                let sk = x25519_dalek::StaticSecret::from(secret);
                let pk = x25519_dalek::PublicKey::from(&sk);
                Ok(PublicKey::new(pk.to_bytes().to_vec(), SecretType::X25519))
            }
            SecretType::Ed25519 => {
                use ed25519_dalek::SECRET_KEY_LENGTH;
                if stored_secret.secret().length() != SECRET_KEY_LENGTH {
                    return Err(VaultError::InvalidSecretLength(
                        SecretType::Ed25519,
                        stored_secret.secret().length(),
                        SECRET_KEY_LENGTH as u32)
                        .into());
                };
                let secret = array_ref![stored_secret.secret().as_ref(), 0, SECRET_KEY_LENGTH];
                let sk = ed25519_dalek::SigningKey::from_bytes(secret);
                let pk = sk.verifying_key();
                Ok(PublicKey::new(pk.to_bytes().to_vec(), SecretType::Ed25519))
            }
            SecretType::NistP256 => Self::public_key(stored_secret.secret().as_ref()),
            SecretType::Buffer | SecretType::Aes => Err(VaultError::InvalidKeyType.into()),
        }
    }
```

The check has to be implemented in each match branch, since the returned `Err` must contain the `SecretType`, the actual length and the expected one.

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->