### PR TITLE
refactor(rust): move common code to `api` so we can remove `command` from `app`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ version = "0.33.0"
 dependencies = [
  "anyhow",
  "aws-config",
+ "base64-url",
  "bytes 1.4.0",
  "cddl-cat",
  "either",
@@ -4652,6 +4653,7 @@ dependencies = [
  "ockam_vault",
  "ockam_vault_aws",
  "once_cell",
+ "open",
  "quickcheck",
  "rand 0.8.5",
  "reqwest",
@@ -4661,6 +4663,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
+ "tiny_http",
  "tinyvec",
  "tokio",
  "tokio-retry",
@@ -4681,10 +4684,8 @@ dependencies = [
  "muda",
  "ockam",
  "ockam_api",
- "ockam_command",
  "ockam_core",
  "ockam_multiaddr",
- "open",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -4707,9 +4708,7 @@ version = "0.90.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "async-recursion",
  "async-trait",
- "base64-url",
  "clap 4.4.0",
  "clap_complete",
  "clap_mangen",
@@ -7545,9 +7544,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
  "backtrace",
  "bytes 1.4.0",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -33,6 +33,7 @@ direct-authenticator = ["std"]
 [dependencies]
 anyhow = "1"
 aws-config = { version = "0.56.1", default-features = false, features = ["rustls"] }
+base64-url = "2.0.0"
 bytes = { version = "1.4.0", default-features = false, features = ["serde"] }
 cddl-cat = { version = "0.6.1", optional = true }
 either = { version = "1.9.0", default-features = false }
@@ -44,6 +45,7 @@ miette = "5.10.0"
 minicbor = { version = "0.19.0", features = ["alloc", "derive"] }
 nix = "0.26"
 once_cell = { version = "1", optional = true, default-features = false }
+open = "5.0.0"
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.187", features = ["derive"] }
@@ -52,7 +54,9 @@ sysinfo = "0.29"
 tempfile = "3.8.0"
 thiserror = "1.0"
 time = { version = "0.3.27", default-features = false }
+tiny_http = "0.12.0"
 tinyvec = { version = "1.6.0", features = ["rustc_1_57"] }
+tokio = { version = "1.31.0", features = ["full"] }
 tokio-retry = "0.3.0"
 tracing = { version = "0.1", default-features = false }
 url = "2.4.0"

--- a/implementations/rust/ockam/ockam_api/src/address.rs
+++ b/implementations/rust/ockam/ockam_api/src/address.rs
@@ -1,0 +1,73 @@
+use crate::error::{ApiError, ParseError};
+use ockam_core::env::{get_env_with_default, FromString};
+use ockam_core::Result;
+use ockam_multiaddr::proto::{Node, Project, Service};
+use ockam_multiaddr::{MultiAddr, Protocol};
+use std::net::{SocketAddr, TcpListener};
+use std::str::FromStr;
+
+pub const OCKAM_CONTROLLER_ADDR: &str = "OCKAM_CONTROLLER_ADDR";
+pub const DEFAULT_CONTROLLER_ADDRESS: &str = "/dnsaddr/orchestrator.ockam.io/tcp/6252/service/api";
+
+pub fn controller_route() -> MultiAddr {
+    let default_addr = MultiAddr::from_string(DEFAULT_CONTROLLER_ADDRESS)
+        .unwrap_or_else(|_| panic!("invalid Controller route: {DEFAULT_CONTROLLER_ADDRESS}"));
+
+    let route = get_env_with_default::<MultiAddr>(OCKAM_CONTROLLER_ADDR, default_addr).unwrap();
+    trace!(%route, "Controller route");
+
+    route
+}
+
+/// Get address value from a string.
+///
+/// The input string can be either a plain address of a MultiAddr formatted string.
+/// Examples: `/node/<name>`, `<name>`
+pub fn extract_address_value(input: &str) -> Result<String, ApiError> {
+    // we default to the `input` value
+    let mut addr = input.to_string();
+    // if input has "/", we process it as a MultiAddr
+    if input.contains('/') {
+        let maddr = MultiAddr::from_str(input)?;
+        if let Some(p) = maddr.iter().next() {
+            match p.code() {
+                Node::CODE => {
+                    addr = p
+                        .cast::<Node>()
+                        .ok_or(ApiError::message("Failed to parse `node` protocol"))?
+                        .to_string();
+                }
+                Service::CODE => {
+                    addr = p
+                        .cast::<Service>()
+                        .ok_or(ApiError::message("Failed to parse `service` protocol"))?
+                        .to_string();
+                }
+                Project::CODE => {
+                    addr = p
+                        .cast::<Project>()
+                        .ok_or(ApiError::message("Failed to parse `project` protocol"))?
+                        .to_string();
+                }
+                code => return Err(ApiError::message(format!("Protocol {code} not supported"))),
+            }
+        } else {
+            return Err(ApiError::message("invalid address protocol"));
+        }
+    }
+    if addr.is_empty() {
+        return Err(ApiError::message(format!(
+            "Empty address in input: {input}"
+        )));
+    }
+    Ok(addr)
+}
+
+pub fn get_free_address() -> Result<SocketAddr, ApiError> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let res = format!("127.0.0.1:{port}")
+        .parse()
+        .map_err(ParseError::from)?;
+    Ok(res)
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
@@ -66,6 +66,10 @@ pub enum CliStateError {
 
     #[error("{0}")]
     #[diagnostic(code("OCK500"))]
+    InvalidData(String),
+
+    #[error("{0}")]
+    #[diagnostic(code("OCK500"))]
     InvalidOperation(String),
 
     #[error("Invalid configuration version '{0}'")]

--- a/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
@@ -50,6 +50,25 @@ mod traits {
         }
     }
 
+    impl TrustContextsState {
+        pub fn read_config_from_path(&self, path: &str) -> Result<TrustContextConfig> {
+            let tcc = match std::fs::read_to_string(path) {
+                Ok(contents) => {
+                    let mut tc = serde_json::from_str::<TrustContextConfig>(&contents)?;
+                    tc.set_path(PathBuf::from(path));
+                    tc
+                }
+                Err(_) => {
+                    let state = self.get(path)?;
+                    let mut tcc = state.config().clone();
+                    tcc.set_path(state.path().clone());
+                    tcc
+                }
+            };
+            Ok(tcc)
+        }
+    }
+
     #[async_trait]
     impl StateItemTrait for TrustContextState {
         type Config = TrustContextConfig;

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -161,7 +161,7 @@ mod node {
                     self.configure_addon_impl::<ConfluentConfig>(ctx, dec, project_id, addon_id)
                         .await
                 }
-                _ => Err(ApiError::generic(&format!("Unknown addon: {addon_id}"))),
+                _ => Err(ApiError::core(format!("Unknown addon: {addon_id}"))),
             }
         }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -71,7 +71,7 @@ impl<T> CloudRequestWrapper<T> {
 
     pub fn multiaddr(&self) -> Result<MultiAddr> {
         MultiAddr::from_str(self.route.as_ref())
-            .map_err(|_err| ApiError::generic(&format!("Invalid route: {}", self.route)))
+            .map_err(|_err| ApiError::core(format!("Invalid route: {}", self.route)))
     }
 }
 
@@ -176,7 +176,7 @@ mod node {
             let sc = {
                 let cloud_route = crate::multiaddr_to_route(cloud_multiaddr, &self.tcp_transport)
                     .await
-                    .ok_or_else(|| ApiError::generic("Invalid Multiaddr"))?;
+                    .ok_or_else(|| ApiError::core("Invalid Multiaddr"))?;
 
                 let options = SecureChannelOptions::new()
                     .with_trust_policy(TrustIdentifierPolicy::new(self.controller_identifier()));

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -75,7 +75,7 @@ pub struct Project {
 
 impl Project {
     pub fn access_route(&self) -> Result<MultiAddr> {
-        MultiAddr::from_str(&self.access_route).map_err(|e| ApiError::generic(&e.to_string()))
+        MultiAddr::from_str(&self.access_route).map_err(|e| ApiError::core(e.to_string()))
     }
 
     pub fn has_admin_with_email(&self, email: &str) -> bool {
@@ -103,7 +103,7 @@ impl Project {
     fn access_route_socket_addr(&self) -> Result<String> {
         let ma = self.access_route()?;
         ma.to_socket_addr()
-            .map_err(|e| ApiError::generic(&e.to_string()))
+            .map_err(|e| ApiError::core(e.to_string()))
     }
 }
 
@@ -382,7 +382,7 @@ mod node {
             let operation_id = match &project.operation_id {
                 Some(operation_id) => operation_id,
                 None => {
-                    return Err(ApiError::generic("Project has no operation id"));
+                    return Err(ApiError::core("Project has no operation id"));
                 }
             };
             let retry_strategy =
@@ -397,15 +397,13 @@ mod node {
                         }
                     }
                 }
-                Err(ApiError::generic(
-                    "Project is not reachable yet. Retrying...",
-                ))
+                Err(ApiError::core("Project is not reachable yet. Retrying..."))
             })
             .await?;
             if operation.is_successful() {
                 self.get_project(ctx, route, &project.id).await
             } else {
-                Err(ApiError::generic("Operation failed. Please try again."))
+                Err(ApiError::core("Operation failed. Please try again."))
             }
         }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
@@ -53,13 +53,13 @@ impl CreateServiceInvitation {
         let project = cli_state.projects.get(&project_name)?.config().clone();
         let project_authority_route = project
             .authority_access_route
-            .ok_or(ApiError::generic("Project authority route is missing"))?;
+            .ok_or(ApiError::core("Project authority route is missing"))?;
         let project_authority_identifier = {
             let identity = project
                 .authority_identity
-                .ok_or(ApiError::generic("Project authority identifier is missing"))?;
+                .ok_or(ApiError::core("Project authority identifier is missing"))?;
             let as_hex = hex::decode(identity.as_str()).map_err(|_| {
-                ApiError::generic("Project authority identifier is not a valid hex string")
+                ApiError::core("Project authority identifier is not a valid hex string")
             })?;
             identities()
                 .identities_creation()
@@ -70,7 +70,7 @@ impl CreateServiceInvitation {
         // see also: ockam_command::project::ticket
         let enrollment_ticket = hex::encode(
             serde_json::to_vec(&enrollment_ticket)
-                .map_err(|_| ApiError::generic("Could not encode enrollment ticket"))?,
+                .map_err(|_| ApiError::core("Could not encode enrollment ticket"))?,
         );
         Ok(CreateServiceInvitation {
             enrollment_ticket,
@@ -79,7 +79,7 @@ impl CreateServiceInvitation {
             recipient_email: recipient_email.as_ref().to_string(),
             project_identity: project
                 .identity
-                .ok_or(ApiError::generic("Project identity is missing"))?
+                .ok_or(ApiError::core("Project identity is missing"))?
                 .to_string(),
             project_route: project.access_route,
             project_authority_identity: project_authority_identifier.to_string(),

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -137,9 +137,9 @@ pub struct ServiceAccessDetails {
 impl ServiceAccessDetails {
     pub fn enrollment_ticket(&self) -> ockam_core::Result<EnrollmentTicket> {
         let hex_decoded = hex::decode(&self.enrollment_ticket)
-            .map_err(|_| ApiError::generic("Invalid hex-encoded enrollment ticket"))?;
+            .map_err(|_| ApiError::core("Invalid hex-encoded enrollment ticket"))?;
         let as_json = serde_json::from_slice(&hex_decoded)
-            .map_err(|_| ApiError::generic("Invalid enrollment ticket"))?;
+            .map_err(|_| ApiError::core("Invalid enrollment ticket"))?;
         Ok(as_json)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/config/cli.rs
+++ b/implementations/rust/ockam/ockam_api/src/config/cli.rs
@@ -107,7 +107,7 @@ impl TrustContextConfig {
     pub fn authority(&self) -> Result<&TrustAuthorityConfig> {
         self.authority
             .as_ref()
-            .ok_or_else(|| ApiError::generic("Missing authority on trust context config"))
+            .ok_or_else(|| ApiError::core("Missing authority on trust context config"))
     }
 
     pub async fn to_trust_context(
@@ -183,7 +183,7 @@ impl TryFrom<Project> for TrustContextConfig {
         ) {
             (Some(route), Some(identity)) => {
                 let authority_route = MultiAddr::from_str(route)
-                    .map_err(|_| ApiError::generic("incorrect multi address"))?;
+                    .map_err(|_| ApiError::core("incorrect multi address"))?;
                 let retriever = CredentialRetrieverConfig::FromCredentialIssuer(
                     CredentialIssuerConfig::new(identity.to_string(), authority_route),
                 );
@@ -246,7 +246,7 @@ impl TrustAuthorityConfig {
             .identities_creation()
             .decode_identity(
                 &hex::decode(&self.identity)
-                    .map_err(|_| ApiError::generic("unable to decode authority identity"))?,
+                    .map_err(|_| ApiError::core("unable to decode authority identity"))?,
             )
             .await
     }
@@ -254,7 +254,7 @@ impl TrustAuthorityConfig {
     pub fn own_credential(&self) -> Result<&CredentialRetrieverConfig> {
         self.own_credential
             .as_ref()
-            .ok_or_else(|| ApiError::generic("Missing own credential on trust authority config"))
+            .ok_or_else(|| ApiError::core("Missing own credential on trust authority config"))
     }
 }
 
@@ -283,7 +283,7 @@ impl CredentialRetrieverConfig {
                 CredentialsMemoryRetriever::new(state.config().credential()?),
             )),
             CredentialRetrieverConfig::FromCredentialIssuer(issuer_config) => {
-                let _ = tcp_transport.ok_or_else(|| ApiError::generic("TCP Transport was not provided when credential retriever was defined as an issuer."))?;
+                let _ = tcp_transport.ok_or_else(|| ApiError::core("TCP Transport was not provided when credential retriever was defined as an issuer."))?;
                 let credential_issuer_info = RemoteCredentialsRetrieverInfo::new(
                     issuer_config.resolve_identity().await?.identifier(),
                     issuer_config.resolve_route().await?,
@@ -374,14 +374,14 @@ impl CredentialIssuerConfig {
         let Some(route) = multiaddr_to_transport_route(&self.multiaddr) else {
             let err_msg = format!("Invalid route within trust context: {}", &self.multiaddr);
             error!("{err_msg}");
-            return Err(ApiError::generic(&err_msg));
+            return Err(ApiError::core(&err_msg));
         };
         Ok(route)
     }
 
     async fn resolve_identity(&self) -> Result<Identity> {
-        let encoded = hex::decode(&self.identity)
-            .map_err(|_| ApiError::generic("Invalid project authority"))?;
+        let encoded =
+            hex::decode(&self.identity).map_err(|_| ApiError::core("Invalid project authority"))?;
         identities()
             .identities_creation()
             .decode_identity(&encoded)

--- a/implementations/rust/ockam/ockam_api/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/mod.rs
@@ -1,0 +1,4 @@
+pub mod ockam_oidc_provider;
+pub mod oidc_provider;
+pub mod oidc_service;
+pub mod okta_oidc_provider;

--- a/implementations/rust/ockam/ockam_api/src/enroll/ockam_oidc_provider.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/ockam_oidc_provider.rs
@@ -1,4 +1,4 @@
-use miette::Result;
+use ockam_core::Result;
 use std::time::Duration;
 use url::Url;
 

--- a/implementations/rust/ockam/ockam_api/src/enroll/oidc_provider.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/oidc_provider.rs
@@ -1,4 +1,4 @@
-use miette::Result;
+use ockam_core::Result;
 use std::time::Duration;
 use url::Url;
 

--- a/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
@@ -1,0 +1,380 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use miette::miette;
+use reqwest::{StatusCode, Url};
+use serde::de::DeserializeOwned;
+use tiny_http::{Header, Response, Server};
+use tokio::time::Duration;
+use tokio_retry::{strategy::ExponentialBackoff, Retry};
+use tracing::{error, info};
+
+use crate::cloud::enroll::auth0::{AuthorizationCode, DeviceCode, OidcToken, UserInfo};
+use crate::enroll::ockam_oidc_provider::OckamOidcProvider;
+use crate::enroll::oidc_provider::OidcProvider;
+use crate::error::ApiError;
+use ockam::compat::fmt::Debug;
+use ockam_core::compat::rand::{thread_rng, RngCore};
+use ockam_core::Result;
+use ockam_node::callback::{new_callback, CallbackSender};
+use ockam_vault::Vault;
+
+/// This service supports various flows of authentication with an OIDC Provider
+///
+/// The OidcProvider trait is currently implemented for:
+///   - Ockam: uses Github and account creation with an email
+///   - Okta
+///
+/// The main purpose of the OidcService is to authenticate a user and get
+/// back an OidcToken allowing the user to connect to the Orchestrator
+///
+pub struct OidcService(Arc<dyn OidcProvider + Send + Sync + 'static>);
+
+impl Default for OidcService {
+    fn default() -> Self {
+        OidcService::new(Arc::new(OckamOidcProvider::default()))
+    }
+}
+
+impl OidcService {
+    /// Create an OIDC service using a specific OIDC provider
+    pub fn new(provider: Arc<dyn OidcProvider + Send + Sync + 'static>) -> Self {
+        Self(provider)
+    }
+
+    /// Create an OIDC service using the Ockam provider with a specific timeout for redirects
+    pub fn default_with_redirect_timeout(timeout: Duration) -> Self {
+        Self::new(Arc::new(OckamOidcProvider::new(timeout)))
+    }
+
+    /// Request an authorization token with a PKCE flow
+    /// See the full protocol here: https://datatracker.ietf.org/doc/html/rfc7636
+    pub async fn get_token_with_pkce(&self) -> Result<OidcToken> {
+        let code_verifier = self.create_code_verifier();
+        let authorization_code = self.authorization_code(&code_verifier).await?;
+        self.retrieve_token_with_authorization_code(authorization_code, &code_verifier)
+            .await
+    }
+
+    pub async fn validate_provider_config(&self) -> miette::Result<()> {
+        if let Err(e) = self.device_code().await {
+            return Err(miette!("Invalid OIDC configuration: {}", e));
+        }
+        Ok(())
+    }
+}
+
+/// Implementation methods for the OidcService
+impl OidcService {
+    /// Return the OIDC provider
+    pub fn provider(&self) -> Arc<dyn OidcProvider + Send + Sync + 'static> {
+        self.0.clone()
+    }
+
+    /// Request a device code for the current client
+    pub async fn device_code(&self) -> Result<DeviceCode<'_>> {
+        self.request_code(
+            self.provider().device_code_url(),
+            &[("scope", self.scopes())],
+        )
+        .await
+    }
+
+    /// Request an authorization code for the PKCE OIDC flow
+    async fn authorization_code(&self, code_verifier: &str) -> Result<AuthorizationCode> {
+        // Hash and base64 encode the random bytes
+        // to obtain a code challenge
+        let hashed = Vault::sha256(code_verifier.as_bytes());
+        let code_challenge = base64_url::encode(&hashed);
+
+        // Start a local server to get back the authorization code after redirect
+        let (authorization_code_receiver, authorization_code_sender) = new_callback();
+        self.wait_for_authorization_code(authorization_code_sender)
+            .await?;
+
+        let redirect_url = self.provider().redirect_url();
+        let query_parameters = vec![
+            ("code_challenge_method", "S256".to_string()),
+            ("response_type", "code".to_string()),
+            ("code_challenge", code_challenge),
+            ("redirect_uri", redirect_url.to_string()),
+        ];
+
+        let parameters = {
+            let mut ps = vec![
+                ("client_id", self.provider().client_id()),
+                ("scope", self.scopes()),
+            ];
+            ps.extend_from_slice(query_parameters.as_slice());
+            ps
+        };
+
+        let url = Url::parse_with_params(self.provider().authorization_url().as_str(), parameters)
+            .unwrap();
+
+        // Send a request to get an authentication code
+        if open::that(url.as_str()).is_err() {
+            error!(
+                "Couldn't open activation url automatically [url={}]",
+                url.to_string()
+            );
+        };
+
+        // Wait for the authorization code to be received
+        authorization_code_receiver
+            .receive_timeout(self.provider().redirect_timeout())
+            .await
+    }
+
+    /// Retrieve a token given an authorization code obtained
+    /// with a specific code verifier
+    pub async fn retrieve_token_with_authorization_code(
+        &self,
+        authorization_code: AuthorizationCode,
+        code_verifier: &str,
+    ) -> Result<OidcToken> {
+        info!(
+            "getting an OIDC token using the authorization code {}",
+            authorization_code.code
+        );
+        self.request_code(
+            Url::parse("https://account.ockam.io/oauth/token").unwrap(),
+            vec![
+                ("code", authorization_code.code),
+                ("code_verifier", code_verifier.to_string()),
+                ("grant_type", "authorization_code".to_string()),
+                ("redirect_uri", self.provider().redirect_url().to_string()),
+            ]
+            .as_slice(),
+        )
+        .await
+    }
+
+    /// Request a code from a given OIDC Provider URL
+    /// This code can be a device code or an authorization code depending on the URL
+    /// and the query parameters
+    async fn request_code<T: DeserializeOwned + Debug>(
+        &self,
+        url: Url,
+        query_parameters: &[(&str, String)],
+    ) -> Result<T> {
+        let client = self.provider().build_http_client()?;
+
+        let parameters = {
+            let mut ps = vec![("client_id", self.provider().client_id())];
+            ps.extend_from_slice(query_parameters);
+            ps
+        };
+
+        let req = || {
+            client
+                .post(url.clone())
+                .header("content-type", "application/x-www-form-urlencoded")
+                .form(&parameters)
+        };
+        let retry_strategy = ExponentialBackoff::from_millis(10).take(3);
+        let res = Retry::spawn(retry_strategy, move || req().send())
+            .await
+            .map_err(|e| ApiError::core(e.to_string()))?;
+
+        match res.status() {
+            StatusCode::OK => {
+                let res = res
+                    .json::<T>()
+                    .await
+                    .map_err(|e| ApiError::core(e.to_string()))?;
+                info!(?res, "code received: {res:#?}");
+                Ok(res)
+            }
+            _ => {
+                let res = res
+                    .text()
+                    .await
+                    .map_err(|e| ApiError::core(e.to_string()))?;
+                let err_msg = format!("couldn't get code: {:?}", res);
+                error!(err_msg);
+                Err(ApiError::core(err_msg))
+            }
+        }
+    }
+
+    /// Wait for an authorization code after a redirect
+    /// by starting temporarily a local web server
+    /// Use the provided callback channel sender to return the authorization code asynchronously
+    async fn wait_for_authorization_code(
+        &self,
+        authorization_code: CallbackSender<AuthorizationCode>,
+    ) -> Result<()> {
+        let server_url = self.provider().redirect_url();
+        let host_and_port = format!(
+            "{}:{}",
+            server_url.host().unwrap(),
+            server_url.port().unwrap()
+        );
+        let server = Arc::new(
+            Server::http(host_and_port).map_err(|_| ApiError::core("failed to set up server"))?,
+        );
+        info!(
+            "server is started at {} and waiting for an authorization code",
+            server_url
+        );
+
+        let redirect_timeout = self.provider().redirect_timeout();
+
+        // Start a background thread which will wait for a request sending the authorization code
+        tokio::task::spawn_blocking(move || {
+            match server.recv_timeout(redirect_timeout) {
+                Ok(Some(request)) => {
+                    let code = Self::get_code(request.url())?;
+                    authorization_code.send(AuthorizationCode::new(code))?;
+
+                    // Note that a code 303 does not properly redirect to the success page
+                    let response = Response::empty(302).with_header(
+                        Header::from_str("Location: https://account.ockam.io/device/success")
+                            .unwrap(),
+                    );
+
+                    request.respond(response).map_err(|e| {
+                        ApiError::message(
+                            format!("error while trying to send a response to a request on {server_url}: {e}"),
+                        )
+                    })
+                }
+                Ok(None) => Err(ApiError::message(
+                    format!("timeout while trying to receive a request on {server_url} (waited for {redirect_timeout:?})"),
+                )),
+                Err(e) => Err(ApiError::message(
+                    format!("error while trying to receive a request on {server_url}: {e}"),
+                )),
+            }
+        });
+        Ok(())
+    }
+
+    // Generate 32 random bytes as a code verifier
+    // to prove that this client was really the one requesting an authorization code
+    /// See the full PKCE flow here: https://datatracker.ietf.org/doc/html/rfc7636
+    fn create_code_verifier(&self) -> String {
+        let mut code_verifier = [0u8; 32];
+        let mut rng = thread_rng();
+        rng.fill_bytes(&mut code_verifier);
+        base64_url::encode(&code_verifier)
+    }
+
+    /// Return the list of scopes for the authorization requests
+    fn scopes(&self) -> String {
+        "profile openid email".to_string()
+    }
+
+    /// Extract the `code` query parameter from the callback request
+    fn get_code(request_url: &str) -> Result<String> {
+        // The local url is retrieved as a path associated to the tiny-http request
+        // In order to parse it with the Url parser we need to first recover a full URL
+        let url = Url::parse(format!("http://0.0.0.0:0{}", request_url).as_str())
+            .map_err(|e| ApiError::core(e.to_string()))?;
+
+        // Check the URL path
+        if !url.path().starts_with("/callback") {
+            return Err(ApiError::core(format!(
+                "the query path should be of the form '/callback?code=xxxx'. Got: {request_url})"
+            )));
+        };
+
+        // Extract the 'code' query parameter
+        if let Some((name, value)) = url.query_pairs().next() {
+            if name == "code" {
+                return Ok(value.to_string());
+            };
+        };
+        Err(ApiError::core(format!(
+            "could not extract the 'code' query parameter from the path {request_url})",
+        )))
+    }
+
+    pub async fn get_user_info(&self, token: &OidcToken) -> Result<UserInfo> {
+        let client = self.provider().build_http_client()?;
+        let access_token = token.access_token.0.clone();
+        let req = || {
+            client
+                .get("https://account.ockam.io/userinfo")
+                .header("Authorization", format!("Bearer {}", access_token.clone()))
+        };
+        let retry_strategy = ExponentialBackoff::from_millis(10).take(3);
+        let res = Retry::spawn(retry_strategy, move || req().send())
+            .await
+            .map_err(|e| ApiError::core(e.to_string()))?;
+        res.json().await.map_err(|e| ApiError::core(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
+    async fn test_user_info() -> Result<()> {
+        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
+        let token = oidc_service.get_token_with_pkce().await?;
+        let user_info = oidc_service.get_user_info(&token).await;
+        assert!(user_info.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
+    async fn test_get_token_with_pkce() -> Result<()> {
+        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
+        let token = oidc_service.get_token_with_pkce().await;
+        assert!(token.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
+    async fn test_authorization_code() -> Result<()> {
+        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
+        let code_verifier = oidc_service.create_code_verifier();
+        let authorization_code = oidc_service
+            .authorization_code(code_verifier.as_str())
+            .await;
+        assert!(authorization_code.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_authorization_code() -> Result<()> {
+        let oidc_service = OidcService::default();
+
+        let (authorization_code_receiver, authorization_code_sender) = new_callback();
+        oidc_service
+            .wait_for_authorization_code(authorization_code_sender)
+            .await?;
+
+        let client_thread = tokio::spawn(async move {
+            let client = reqwest::ClientBuilder::new().build().unwrap();
+            client
+                .get(oidc_service.provider().redirect_url().as_str())
+                .query(&[("code", "12345")])
+                .send()
+                .await
+        });
+
+        let res = client_thread.await.unwrap();
+        assert!(res.is_ok());
+
+        let authorization_code = authorization_code_receiver
+            .receive_timeout(Duration::from_secs(1))
+            .await?;
+        assert_eq!(authorization_code, AuthorizationCode::new("12345"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_path_query_parameters() {
+        let code = OidcService::get_code("/callback?code=12345");
+        assert!(code.is_ok());
+        assert_eq!(code.unwrap(), "12345".to_string())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/enroll/okta_oidc_provider.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/okta_oidc_provider.rs
@@ -1,11 +1,10 @@
+use crate::cloud::project::OktaAuth0;
+use ockam_core::Result;
 use std::time::Duration;
-
-use miette::{miette, Result};
 use url::Url;
 
-use ockam_api::cloud::project::OktaAuth0;
-
 use crate::enroll::oidc_provider::OidcProvider;
+use crate::error::ApiError;
 
 pub struct OktaOidcProvider {
     okta: OktaAuth0,
@@ -49,12 +48,12 @@ impl OidcProvider for OktaOidcProvider {
 
     fn build_http_client(&self) -> Result<reqwest::Client> {
         let certificate = reqwest::Certificate::from_pem(self.okta.certificate.as_bytes())
-            .map_err(|e| miette!("Error parsing certificate: {}", e))?;
+            .map_err(|e| ApiError::core(format!("Error parsing certificate: {}", e)))?;
 
         reqwest::ClientBuilder::new()
             .tls_built_in_root_certs(false)
             .add_root_certificate(certificate)
             .build()
-            .map_err(|e| miette!("Error building http client: {}", e))
+            .map_err(|e| ApiError::core(e.to_string()))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/error.rs
@@ -1,77 +1,51 @@
 use core::fmt;
+use miette::Diagnostic;
 
-use ockam_core::compat::io;
 use ockam_core::errcode::{Kind, Origin};
 
 /// Potential API errors
-#[derive(Debug)]
-pub struct ApiError(ErrorImpl);
+#[derive(Debug, thiserror::Error, Diagnostic)]
+pub enum ApiError {
+    #[error(transparent)]
+    Core(#[from] ockam_core::Error),
+
+    #[error(transparent)]
+    MultiAddr(#[from] ockam_multiaddr::Error),
+
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+}
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+pub enum ParseError {
+    #[error(transparent)]
+    Addr(#[from] std::net::AddrParseError),
+
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+
+    #[error(transparent)]
+    CborDecode(#[from] minicbor::decode::Error),
+
+    #[error(transparent)]
+    CborEncode(#[from] minicbor::encode::Error<std::io::Error>),
+
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+}
 
 impl ApiError {
-    pub fn generic(cause: &str) -> ockam_core::Error {
-        ockam_core::Error::new(Origin::Application, Kind::Unknown, cause)
+    pub fn message<T: fmt::Display>(m: T) -> ApiError {
+        ockam_core::Error::new(Origin::Application, Kind::Unknown, m.to_string()).into()
     }
 
-    pub fn message<T: fmt::Display>(m: T) -> ockam_core::Error {
+    pub fn core<T: fmt::Display>(m: T) -> ockam_core::Error {
         ockam_core::Error::new(Origin::Application, Kind::Unknown, m.to_string())
-    }
-
-    pub fn wrap<E>(e: E) -> ockam_core::Error
-    where
-        E: ockam_core::compat::error::Error + Send + Sync + 'static,
-    {
-        ockam_core::Error::new(Origin::Application, Kind::Unknown, e)
-    }
-}
-
-#[derive(Debug)]
-enum ErrorImpl {
-    CborDecode(minicbor::decode::Error),
-    CborEncode(minicbor::encode::Error<io::Error>),
-    SerdeJson(serde_json::Error),
-}
-
-impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            ErrorImpl::CborEncode(e) => e.fmt(f),
-            ErrorImpl::CborDecode(e) => e.fmt(f),
-            ErrorImpl::SerdeJson(e) => e.fmt(f),
-        }
-    }
-}
-
-impl ockam_core::compat::error::Error for ApiError {
-    #[cfg(feature = "std")]
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.0 {
-            ErrorImpl::CborDecode(e) => Some(e),
-            ErrorImpl::CborEncode(e) => Some(e),
-            ErrorImpl::SerdeJson(e) => Some(e),
-        }
-    }
-}
-
-impl From<minicbor::decode::Error> for ApiError {
-    fn from(e: minicbor::decode::Error) -> Self {
-        ApiError(ErrorImpl::CborDecode(e))
-    }
-}
-
-impl From<minicbor::encode::Error<io::Error>> for ApiError {
-    fn from(e: minicbor::encode::Error<io::Error>) -> Self {
-        ApiError(ErrorImpl::CborEncode(e))
-    }
-}
-
-impl From<serde_json::Error> for ApiError {
-    fn from(e: serde_json::Error) -> Self {
-        ApiError(ErrorImpl::SerdeJson(e))
-    }
-}
-
-impl From<ApiError> for ockam_core::Error {
-    fn from(e: ApiError) -> Self {
-        ockam_core::Error::new(Origin::Application, Kind::Invalid, e)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -123,6 +123,7 @@
 //! file per vault. A vault contains secrets which are generally used during the creation of secure
 //! channels to sign or encrypt data involved in the handshake.
 //!
+pub mod address;
 pub mod auth;
 pub mod authenticator;
 pub mod bootstrapped_identities_store;
@@ -130,6 +131,7 @@ pub mod cli_state;
 pub mod cloud;
 pub mod config;
 pub mod echoer;
+pub mod enroll;
 pub mod error;
 pub mod hop;
 pub mod identity;
@@ -139,6 +141,7 @@ pub mod nodes;
 pub mod okta;
 pub mod port_range;
 pub mod rpc_proxy_service;
+pub mod trust_context;
 pub mod uppercase;
 pub mod verifier;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/plain_tcp.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/plain_tcp.rs
@@ -38,10 +38,10 @@ impl Instantiator for PlainTcpInstantiator {
 
         let mut tcp = multiaddr_to_route(&tcp_piece, &self.tcp_transport)
             .await
-            .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
+            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
 
         let multiaddr =
-            route_to_multiaddr(&tcp.route).ok_or_else(|| ApiError::generic("invalid tcp route"))?;
+            route_to_multiaddr(&tcp.route).ok_or_else(|| ApiError::core("invalid tcp route"))?;
 
         let current_multiaddr = ConnectionInstanceBuilder::combine(before, multiaddr, after)?;
 
@@ -50,7 +50,7 @@ impl Instantiator for PlainTcpInstantiator {
         let tcp_connection = tcp
             .tcp_connection
             .take()
-            .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
+            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
 
         Ok(Changes {
             current_multiaddr,

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -56,11 +56,11 @@ impl Instantiator for ProjectInstantiator {
 
         let project_protocol_value = project_piece
             .first()
-            .ok_or_else(|| ApiError::message("missing project protocol in multiaddr"))?;
+            .ok_or_else(|| ApiError::core("missing project protocol in multiaddr"))?;
 
         let project = project_protocol_value
             .cast::<Project>()
-            .ok_or_else(|| ApiError::message("invalid project protocol in multiaddr"))?;
+            .ok_or_else(|| ApiError::core("invalid project protocol in multiaddr"))?;
 
         let mut node_manager = self.node_manager.write().await;
         let (project_multiaddr, project_identifier) =
@@ -69,7 +69,7 @@ impl Instantiator for ProjectInstantiator {
         debug!(addr = %project_multiaddr, "creating secure channel");
         let tcp = multiaddr_to_route(&project_multiaddr, &node_manager.tcp_transport)
             .await
-            .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
+            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
 
         let sc = node_manager
             .create_secure_channel_impl(

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
@@ -56,7 +56,7 @@ impl Instantiator for SecureChannelInstantiator {
 
         debug!(%secure_piece, %transport_route, "creating secure channel");
         let route = local_multiaddr_to_route(&secure_piece)
-            .ok_or_else(|| ApiError::generic("invalid multiaddr"))?;
+            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
 
         let mut node_manager = self.node_manager.write().await;
         let sc = node_manager

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/forwarder.rs
@@ -104,12 +104,12 @@ impl ForwarderInfo {
 
     pub fn remote_address_ma(&self) -> Result<MultiAddr, ockam_core::Error> {
         route_to_multiaddr(&route![self.remote_address.to_string()])
-            .ok_or_else(|| ApiError::generic("Invalid Remote Address"))
+            .ok_or_else(|| ApiError::core("Invalid Remote Address"))
     }
 
     pub fn worker_address_ma(&self) -> Result<MultiAddr, ockam_core::Error> {
         route_to_multiaddr(&route![self.worker_address.to_string()])
-            .ok_or_else(|| ApiError::generic("Invalid Worker Address"))
+            .ok_or_else(|| ApiError::core("Invalid Worker Address"))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -250,7 +250,7 @@ impl OutletStatus {
 
     pub fn worker_address(&self) -> Result<MultiAddr, ockam_core::Error> {
         route_to_multiaddr(&route![self.worker_addr.to_string()])
-            .ok_or_else(|| ApiError::generic("Invalid Worker Address"))
+            .ok_or_else(|| ApiError::core("Invalid Worker Address"))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -87,7 +87,7 @@ impl CreateSecureChannelResponse {
 
     pub fn multiaddr(&self) -> Result<MultiAddr> {
         route_to_multiaddr(&route![self.addr.to_string()])
-            .ok_or_else(|| ApiError::generic(&format!("Invalid route: {}", self.addr)))
+            .ok_or_else(|| ApiError::core(format!("Invalid route: {}", self.addr)))
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -241,7 +241,7 @@ impl NodeManager {
     pub(crate) fn trust_context(&self) -> Result<&TrustContext> {
         self.trust_context
             .as_ref()
-            .ok_or_else(|| ApiError::generic("Trust context doesn't exist"))
+            .ok_or_else(|| ApiError::core("Trust context doesn't exist"))
     }
 }
 
@@ -503,21 +503,21 @@ impl NodeManager {
     ) -> Result<(MultiAddr, IdentityIdentifier)> {
         let projects = ProjectLookup::from_state(self.cli_state.projects.list()?)
             .await
-            .map_err(|e| ApiError::message(format!("Cannot load projects: {:?}", e)))?;
+            .map_err(|e| ApiError::core(format!("Cannot load projects: {:?}", e)))?;
         if let Some(info) = projects.get(name) {
             let node_route = info
                 .node_route
                 .as_ref()
-                .ok_or_else(|| ApiError::generic("Project should have node route set"))?
+                .ok_or_else(|| ApiError::core("Project should have node route set"))?
                 .clone();
             let identity_id = info
                 .identity_id
                 .as_ref()
-                .ok_or_else(|| ApiError::generic("Project should have identity set"))?
+                .ok_or_else(|| ApiError::core("Project should have identity set"))?
                 .clone();
             Ok((node_route, identity_id))
         } else {
-            Err(ApiError::message(format!("project {name} not found")))
+            Err(ApiError::core(format!("project {name} not found")))
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -69,7 +69,7 @@ impl NodeManagerWorker {
         let route = MultiAddr::from_str(&request.route).map_err(map_multiaddr_err)?;
         let route = match local_multiaddr_to_route(&route) {
             Some(route) => route,
-            None => return Err(ApiError::generic("Invalid credentials service route").into()),
+            None => return Err(ApiError::core("Invalid credentials service route").into()),
         };
 
         let credential = node_manager

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -65,7 +65,7 @@ impl NodeManagerWorker {
         let options = RemoteForwarderOptions::new();
 
         let route = local_multiaddr_to_route(&connection_instance.normalized_addr)
-            .ok_or_else(|| ApiError::message("invalid address: {addr}"))?;
+            .ok_or_else(|| ApiError::core("invalid address: {addr}"))?;
 
         let forwarder = if req.at_rust_node() {
             if let Some(alias) = req.alias() {
@@ -258,7 +258,7 @@ fn replacer(
 
                 let route = local_multiaddr_to_route(&new_connection_instance.normalized_addr)
                     .ok_or_else(|| {
-                        ApiError::message(format!(
+                        ApiError::core(format!(
                             "invalid multiaddr: {}",
                             &new_connection_instance.normalized_addr
                         ))
@@ -276,7 +276,7 @@ fn replacer(
             match timeout(MAX_RECOVERY_TIME, f).await {
                 Err(_) => {
                     warn!(%addr, "timeout creating new remote forwarder");
-                    Err(ApiError::generic("timeout"))
+                    Err(ApiError::core("timeout"))
                 }
                 Ok(Err(e)) => {
                     warn!(%addr, err = %e, "error creating new remote forwarder");

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -32,7 +32,7 @@ impl SendMessage {
 
     pub fn multiaddr(&self) -> Result<MultiAddr> {
         MultiAddr::from_str(self.route.as_ref())
-            .map_err(|_err| ApiError::generic(&format!("Invalid route: {}", self.route)))
+            .map_err(|_err| ApiError::core(format!("Invalid route: {}", self.route)))
     }
 }
 
@@ -68,7 +68,7 @@ mod node {
                 NodeManager::connect(self.node_manager.clone(), connection).await?;
 
             let route = local_multiaddr_to_route(&connection_instance.normalized_addr)
-                .ok_or_else(|| ApiError::generic("Invalid route"))?;
+                .ok_or_else(|| ApiError::core("Invalid route"))?;
 
             trace!(target: TARGET, route = %route, msg_l = %msg_length, "sending message");
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -52,7 +52,7 @@ impl NodeManager {
         addr: Address,
     ) -> Result<()> {
         if self.registry.identity_services.contains_key(&addr) {
-            return Err(ApiError::generic("Identity service exists at this address"));
+            return Err(ApiError::core("Identity service exists at this address"));
         }
 
         let service = IdentityService::new(self.node_identities()).await?;
@@ -77,9 +77,7 @@ impl NodeManager {
         oneway: bool,
     ) -> Result<()> {
         if self.registry.credentials_services.contains_key(&addr) {
-            return Err(ApiError::generic(
-                "Credentials service exists at this address",
-            ));
+            return Err(ApiError::core("Credentials service exists at this address"));
         }
 
         self.credentials_service()
@@ -99,7 +97,7 @@ impl NodeManager {
         addr: Address,
     ) -> Result<()> {
         if self.registry.authenticated_services.contains_key(&addr) {
-            return Err(ApiError::generic(
+            return Err(ApiError::core(
                 "Authenticated service exists at this address",
             ));
         }
@@ -120,9 +118,7 @@ impl NodeManager {
         addr: Address,
     ) -> Result<()> {
         if self.registry.uppercase_services.contains_key(&addr) {
-            return Err(ApiError::generic(
-                "Uppercase service exists at this address",
-            ));
+            return Err(ApiError::core("Uppercase service exists at this address"));
         }
 
         ctx.start_worker(addr.clone(), Uppercase).await?;
@@ -140,7 +136,7 @@ impl NodeManager {
         addr: Address,
     ) -> Result<()> {
         if self.registry.echoer_services.contains_key(&addr) {
-            return Err(ApiError::generic("Echoer service exists at this address"));
+            return Err(ApiError::core("Echoer service exists at this address"));
         }
 
         let maybe_trust_context_id = self.trust_context.as_ref().map(|c| c.id());
@@ -173,7 +169,7 @@ impl NodeManager {
         addr: Address,
     ) -> Result<()> {
         if self.registry.hop_services.contains_key(&addr) {
-            return Err(ApiError::generic("Hop service exists at this address"));
+            return Err(ApiError::core("Hop service exists at this address"));
         }
 
         ctx.flow_controls()
@@ -219,9 +215,7 @@ impl NodeManager {
         project: String,
     ) -> Result<()> {
         if self.registry.authenticator_service.contains_key(&addr) {
-            return Err(ApiError::generic(
-                "Credential issuer service already started",
-            ));
+            return Err(ApiError::core("Credential issuer service already started"));
         }
         let action = actions::HANDLE_MESSAGE;
         let resource = Resource::new(&addr.to_string());
@@ -249,7 +243,7 @@ impl NodeManager {
         project: String,
     ) -> Result<()> {
         if self.registry.authenticator_service.contains_key(&addr) {
-            return Err(ApiError::generic(
+            return Err(ApiError::core(
                 "Direct Authenticator  service already started",
             ));
         }
@@ -300,7 +294,7 @@ impl NodeManager {
                 .authenticator_service
                 .contains_key(&acceptor_addr)
         {
-            return Err(ApiError::generic(
+            return Err(ApiError::core(
                 "Enrollment token Authenticator service already started",
             ));
         }
@@ -348,7 +342,7 @@ impl NodeManager {
             .okta_identity_provider_services
             .contains_key(&addr)
         {
-            return Err(ApiError::generic(
+            return Err(ApiError::core(
                 "Okta Identity Provider service already started",
             ));
         }
@@ -444,7 +438,7 @@ impl NodeManagerWorker {
     ) -> Result<ResponseBuilder, ResponseBuilder<Error>> {
         let mut node_manager = self.node_manager.write().await;
         #[cfg(not(feature = "direct-authenticator"))]
-        return Err(ApiError::generic("Direct authenticator not available"));
+        return Err(ApiError::core("Direct authenticator not available"));
 
         #[cfg(feature = "direct-authenticator")]
         {
@@ -511,7 +505,7 @@ impl NodeManagerWorker {
         let addr: Address = body.address().into();
 
         if node_manager.registry.verifier_services.contains_key(&addr) {
-            return Err(ApiError::generic("Verifier service exists at this address").into());
+            return Err(ApiError::core("Verifier service exists at this address").into());
         }
 
         ctx.flow_controls()
@@ -541,7 +535,7 @@ impl NodeManagerWorker {
         let encoded_identity = body.public_identity();
 
         let decoded_identity =
-            &hex::decode(encoded_identity).map_err(|_| ApiError::generic("Unable to decode trust context's public identity when starting credential service."))?;
+            &hex::decode(encoded_identity).map_err(|_| ApiError::core("Unable to decode trust context's public identity when starting credential service."))?;
         let i = identities()
             .identities_creation()
             .decode_identity(decoded_identity)
@@ -576,7 +570,7 @@ impl NodeManagerWorker {
             .flow_controls()
             .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
             .ok_or_else(|| {
-                ApiError::generic("Unable to get flow control for secure channel listener")
+                ApiError::core("Unable to get flow control for secure channel listener")
             })?;
 
         PrefixForwarderService::create(
@@ -673,7 +667,7 @@ impl NodeManagerWorker {
             .flow_controls()
             .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
             .ok_or_else(|| {
-                ApiError::generic("Unable to get flow control for secure channel listener")
+                ApiError::core("Unable to get flow control for secure channel listener")
             })?;
 
         {
@@ -717,7 +711,7 @@ impl NodeManagerWorker {
             route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
             bind_ip,
             PortRange::try_from(brokers_port_range)
-                .map_err(|_| ApiError::message("invalid port range"))?,
+                .map_err(|_| ApiError::core("invalid port range"))?,
         );
 
         // since we cannot call APIs of node manager via message due to the read/write lock
@@ -872,7 +866,7 @@ impl NodeManagerWorker {
             route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
             bind_ip,
             PortRange::try_from(brokers_port_range)
-                .map_err(|_| ApiError::message("invalid port range"))?,
+                .map_err(|_| ApiError::core("invalid port range"))?,
         );
 
         // since we cannot call APIs of node manager via message due to the read/write lock

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -592,7 +592,7 @@ fn replacer(
                 let normalized_route = route![
                     prefix_route,
                     local_multiaddr_to_route(&new_connection_instance.normalized_addr.clone())
-                        .ok_or_else(|| ApiError::generic("invalid normalized address"))?,
+                        .ok_or_else(|| ApiError::core("invalid normalized address"))?,
                     suffix_route
                 ];
 
@@ -615,7 +615,7 @@ fn replacer(
             match timeout(MAX_RECOVERY_TIME, f).await {
                 Err(_) => {
                     warn!(%addr, "timeout creating new tcp inlet");
-                    Err(ApiError::generic("timeout"))
+                    Err(ApiError::core("timeout"))
                 }
                 Ok(Err(e)) => {
                     warn!(%addr, err = %e, "error creating new tcp inlet");

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -50,7 +50,7 @@ impl Server {
         attributes: &[String],
     ) -> Result<Self> {
         let certificate = reqwest::Certificate::from_pem(certificate.as_bytes())
-            .map_err(|err| ApiError::generic(&err.to_string()))?;
+            .map_err(|err| ApiError::core(err.to_string()))?;
         Ok(Server {
             attributes_writer,
             project,
@@ -124,7 +124,7 @@ impl Server {
             .tls_built_in_root_certs(false)
             .add_root_certificate(self.certificate.clone())
             .build()
-            .map_err(|err| ApiError::generic(&err.to_string()))?;
+            .map_err(|err| ApiError::core(err.to_string()))?;
         let res = client
             .get(format!("{}/v1/userinfo", &self.tenant_base_url))
             .header("Authorization", format!("Bearer {token}"))
@@ -138,7 +138,7 @@ impl Server {
                     let doc: HashMap<String, serde_json::Value> = res
                         .json()
                         .await
-                        .map_err(|_err| ApiError::generic("Failed to authenticate with Okta"))?;
+                        .map_err(|_err| ApiError::core("Failed to authenticate with Okta"))?;
                     debug!("userinfo received: {doc:?}");
                     let mut custom_attrs = HashMap::new();
                     for a in self.attributes.iter() {

--- a/implementations/rust/ockam/ockam_api/src/trust_context.rs
+++ b/implementations/rust/ockam/ockam_api/src/trust_context.rs
@@ -1,0 +1,111 @@
+use crate::cli_state::{CliState, ProjectConfigCompact, StateDirTrait, StateItemTrait};
+use crate::cloud::project::Project;
+use crate::config::cli::TrustContextConfig;
+use miette::{IntoDiagnostic, WrapErr};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct TrustContextConfigBuilder {
+    pub cli_state: CliState,
+    pub project_path: Option<PathBuf>,
+    pub trust_context: Option<TrustContextConfig>,
+    pub project: Option<String>,
+    pub authority_identity: Option<String>,
+    pub credential_name: Option<String>,
+    pub use_default_trust_context: bool,
+}
+
+impl TrustContextConfigBuilder {
+    pub fn new(cli_state: &CliState) -> Self {
+        Self {
+            cli_state: cli_state.clone(),
+            project_path: None,
+            trust_context: None,
+            project: None,
+            authority_identity: None,
+            credential_name: None,
+            use_default_trust_context: false,
+        }
+    }
+
+    pub fn with_authority_identity(&mut self, authority_identity: Option<&String>) -> &mut Self {
+        self.authority_identity = authority_identity.map(|s| s.to_string());
+        self
+    }
+
+    pub fn with_credential_name(&mut self, credential_name: Option<&String>) -> &mut Self {
+        self.credential_name = credential_name.map(|s| s.to_string());
+        self
+    }
+
+    pub fn use_default_trust_context(&mut self, use_default_trust_context: bool) -> &mut Self {
+        self.use_default_trust_context = use_default_trust_context;
+        self
+    }
+
+    pub fn build(&self) -> Option<TrustContextConfig> {
+        self.trust_context
+            .clone()
+            .or_else(|| self.get_from_project_path(self.project_path.as_ref()?))
+            .or_else(|| self.get_from_project_name())
+            .or_else(|| self.get_from_authority_identity())
+            .or_else(|| self.get_from_credential())
+            .or_else(|| self.get_from_default_trust_context())
+            .or_else(|| self.get_from_default_project())
+    }
+
+    fn get_from_project_path(&self, path: &PathBuf) -> Option<TrustContextConfig> {
+        let s = std::fs::read_to_string(path)
+            .into_diagnostic()
+            .context("Failed to read project file")
+            .ok()?;
+        let proj_info = serde_json::from_str::<ProjectConfigCompact>(&s)
+            .into_diagnostic()
+            .context("Failed to parse project info")
+            .ok()?;
+        let proj: Project = (&proj_info).into();
+        proj.try_into().ok()
+    }
+
+    fn get_from_project_name(&self) -> Option<TrustContextConfig> {
+        let project = self.cli_state.projects.get(self.project.as_ref()?).ok()?;
+        project.config().clone().try_into().ok()
+    }
+
+    fn get_from_authority_identity(&self) -> Option<TrustContextConfig> {
+        let authority_identity = self.authority_identity.clone();
+        let credential = match &self.credential_name {
+            Some(c) => Some(self.cli_state.credentials.get(c).ok()?),
+            None => None,
+        };
+
+        TrustContextConfig::from_authority_identity(&authority_identity?, credential).ok()
+    }
+
+    fn get_from_credential(&self) -> Option<TrustContextConfig> {
+        let cred_name = self.credential_name.clone()?;
+        let cred_state = self.cli_state.credentials.get(cred_name).ok()?;
+
+        cred_state.try_into().ok()
+    }
+
+    fn get_from_default_trust_context(&self) -> Option<TrustContextConfig> {
+        if !self.use_default_trust_context {
+            return None;
+        }
+
+        let tc = self
+            .cli_state
+            .trust_contexts
+            .default()
+            .ok()?
+            .config()
+            .clone();
+        Some(tc)
+    }
+
+    fn get_from_default_project(&self) -> Option<TrustContextConfig> {
+        let proj = self.cli_state.projects.default().ok()?;
+        self.get_from_project_path(proj.path())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -232,7 +232,7 @@ pub fn multiaddr_to_addr(ma: &MultiAddr) -> Option<Address> {
 
 pub fn try_multiaddr_to_addr(ma: &MultiAddr) -> Result<Address, Error> {
     multiaddr_to_addr(ma)
-        .ok_or_else(|| ApiError::message(format!("could not convert {ma} to address")))
+        .ok_or_else(|| ApiError::core(format!("could not convert {ma} to address")))
 }
 
 /// Try to convert an Ockam Route into a MultiAddr.
@@ -251,9 +251,7 @@ pub fn try_address_to_multiaddr(a: &Address) -> Result<MultiAddr, Error> {
         LOCAL => ma.push_back(Service::new(a.address()))?,
         other => {
             error!(target: "ockam_api", transport = %other, "unsupported transport type");
-            return Err(ApiError::message(format!(
-                "unknown transport type: {other}"
-            )));
+            return Err(ApiError::core(format!("unknown transport type: {other}")));
         }
     }
     Ok(ma)
@@ -325,7 +323,7 @@ pub fn local_worker(code: &Code) -> Result<bool> {
         | Secure::CODE => Ok(false),
         Worker::CODE | Service::CODE => Ok(true),
 
-        _ => Err(ApiError::message(format!("unknown transport type: {code}"))),
+        _ => Err(ApiError::core(format!("unknown transport type: {code}"))),
     }
 }
 

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -42,10 +42,8 @@ miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 muda = "0.8"
 ockam = { path = "../ockam", version = "^0.90.0", features = ["software_vault"] }
 ockam_api = { path = "../ockam_api", version = "0.33.0", features = ["std", "authenticators"] }
-ockam_command = { path = "../ockam_command", version = "^0.90.0" }
 ockam_core = { path = "../ockam_core", version = "^0.83.0" }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.24.0", features = ["cbor", "serde"] }
-open = "5"
 percent-encoding = "2.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -56,7 +54,7 @@ tauri-plugin-positioner = { version = "2.0.0-alpha.0", features = ["system-tray"
 tauri-plugin-window = "2.0.0-alpha.0"
 tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
 thiserror = "1.0.47"
-tokio = { version = "1.31.0", features = ["time"] }
+tokio = { version = "1.31.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional = true }
 

--- a/implementations/rust/ockam/ockam_app/src/error.rs
+++ b/implementations/rust/ockam/ockam_app/src/error.rs
@@ -12,10 +12,10 @@ pub enum Error {
     Ockam(#[from] ockam_core::Error),
 
     #[error(transparent)]
-    Command(#[from] ockam_command::error::Error),
+    Api(#[from] ockam_api::error::ApiError),
 
     #[error(transparent)]
-    CommandState(#[from] ockam_api::cli_state::CliStateError),
+    CliState(#[from] ockam_api::cli_state::CliStateError),
 
     #[error(transparent)]
     Tauri(#[from] tauri::Error),

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -1,6 +1,7 @@
 use tauri::{AppHandle, Manager, Runtime, State};
 use tracing::{debug, error, info, warn};
 
+use ockam_api::address::{extract_address_value, get_free_address};
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::share::{AcceptInvitation, InvitationWithAccess};
@@ -8,7 +9,6 @@ use ockam_api::{
     cloud::share::{InvitationListKind, ListInvitations},
     nodes::models::portal::OutletStatus,
 };
-use ockam_command::util::{extract_address_value, get_free_address};
 
 use crate::app::{AppState, NODE_NAME, PROJECT_NAME};
 use crate::cli::cli_bin;

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use tauri::{async_runtime::RwLock, AppHandle, Manager, Runtime, State};
 use tracing::{debug, error, info};
 
+use ockam_api::address::controller_route;
 use ockam_api::{cli_state::StateDirTrait, cloud::project::Project, identity::EnrollmentTicket};
-use ockam_command::util::api::CloudOpts;
 
 use super::error::{Error, Result};
 use super::State as ProjectState;
@@ -91,7 +91,7 @@ pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     }
     let node_manager_worker = state.node_manager_worker().await;
     let projects = node_manager_worker
-        .list_projects(&state.context(), &CloudOpts::route())
+        .list_projects(&state.context(), &controller_route())
         .await
         .map_err(Error::ListingFailed)?;
     debug!(?projects);

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -1,5 +1,5 @@
 use miette::{IntoDiagnostic, WrapErr};
-use ockam_command::util::extract_address_value;
+use ockam_api::address::extract_address_value;
 use std::net::SocketAddr;
 use tauri::{AppHandle, Manager, Wry};
 use tracing::{debug, error, info};

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -54,9 +54,7 @@ path = "src/bin/ockam.rs"
 
 [dependencies]
 anyhow = "1"
-async-recursion = { version = "1.0.0" }
 async-trait = "0.1"
-base64-url = "2.0.0"
 clap = { version = "4.4.0", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.4.0"
 clap_mangen = "0.2.13"
@@ -88,7 +86,7 @@ ockam_node = { path = "../ockam_node", version = "^0.86.0" }
 ockam_vault = { path = "../ockam_vault", version = "^0.79.0", features = ["storage"] }
 ockam_vault_aws = { path = "../ockam_vault_aws", version = "^0.4.0" }
 once_cell = "1.18"
-open = "5"
+open = "5.0.0"
 pem-rfc7468 = { version = "0.7.0", features = ["std"] }
 rand = "0.8"
 regex = "1.9.3"

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -1,4 +1,3 @@
-use crate::node::util::init_node_state;
 use crate::node::util::run_ockam;
 use crate::util::{embedded_node_that_is_not_stopped, exitcode};
 use crate::util::{local_cmd, node_rpc};
@@ -8,6 +7,7 @@ use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
 use ockam::Context;
 use ockam_api::bootstrapped_identities_store::PreTrustedIdentities;
+use ockam_api::cli_state::init_node_state;
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::authority_node;
 use ockam_api::nodes::authority_node::{OktaConfiguration, TrustedIdentity};
@@ -109,7 +109,7 @@ async fn spawn_background_node(
 ) -> miette::Result<()> {
     // Create node state, including the vault and identity if they don't exist
     init_node_state(
-        opts,
+        &opts.state,
         &cmd.node_name,
         cmd.vault.as_deref(),
         cmd.identity.as_deref(),
@@ -262,7 +262,7 @@ async fn start_authority_node(
     // Create node state, including the vault and identity if they don't exist
     if !opts.state.nodes.exists(&cmd.node_name) {
         init_node_state(
-            &opts,
+            &opts.state,
             &cmd.node_name,
             cmd.vault.as_deref(),
             cmd.identity.as_deref(),

--- a/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/mod.rs
@@ -1,10 +1,5 @@
 pub use command::*;
-pub use ockam_oidc_provider::*;
 pub use oidc_service::*;
-pub use okta_oidc_provider::*;
 
 mod command;
-mod ockam_oidc_provider;
-mod oidc_provider;
 mod oidc_service;
-mod okta_oidc_provider;

--- a/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
@@ -1,61 +1,54 @@
+use async_trait::async_trait;
 use std::borrow::Borrow;
 use std::io::stdin;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use colorful::Colorful;
+use console::Term;
 use miette::{miette, IntoDiagnostic};
-use reqwest::{StatusCode, Url};
-use serde::de::DeserializeOwned;
-use tiny_http::{Header, Response, Server};
+use reqwest::StatusCode;
 use tokio::time::{sleep, Duration};
-use tokio_retry::{strategy::ExponentialBackoff, Retry};
-use tracing::{debug, error, info};
+use tracing::debug;
 
-use ockam::compat::fmt::Debug;
 use ockam_api::cloud::enroll::auth0::*;
-use ockam_core::compat::rand::{thread_rng, RngCore};
-use ockam_node::callback::{new_callback, CallbackSender};
-use ockam_vault::Vault;
+use ockam_api::enroll::oidc_service::OidcService;
 
-use crate::enroll::oidc_provider::OidcProvider;
-use crate::enroll::OckamOidcProvider;
 use crate::terminal::OckamColor;
-use crate::{fmt_err, fmt_log, fmt_para, CommandGlobalOpts, Result};
+use crate::{fmt_err, fmt_log, fmt_para, CommandGlobalOpts, Result, Terminal, TerminalStream};
 
-/// This service supports various flows of authentication with an OIDC Provider
-///
-/// The OidcProvider trait is currently implemented for:
-///   - Ockam: uses Github and account creation with an email
-///   - Okta
-///
-/// The main purpose of the OidcService is to authenticate a user and get
-/// back an OidcToken allowing the user to connect to the Orchestrator
-///
-pub struct OidcService(Arc<dyn OidcProvider + Send + Sync + 'static>);
-
-impl Default for OidcService {
-    fn default() -> Self {
-        OidcService::new(Arc::new(OckamOidcProvider::default()))
-    }
-}
-
-impl OidcService {
-    /// Create an OIDC service using a specific OIDC provider
-    pub fn new(provider: Arc<dyn OidcProvider + Send + Sync + 'static>) -> Self {
-        Self(provider)
-    }
-
-    /// Create an OIDC service using the Ockam provider with a specific timeout for redirects
-    pub fn default_with_redirect_timeout(timeout: Duration) -> Self {
-        Self::new(Arc::new(OckamOidcProvider::new(timeout)))
-    }
-
+#[async_trait]
+pub trait OidcServiceExt {
     /// Retrieve a token by having the user copy and paste a device code in their browser
-    pub(crate) async fn get_token_interactively(
+    async fn get_token_interactively(&self, opts: &CommandGlobalOpts) -> Result<OidcToken>;
+
+    /// Retrieve a token using the device code get a token from the OIDC service
+    async fn get_token(&self, opts: &CommandGlobalOpts) -> Result<OidcToken>;
+
+    async fn wait_for_email_verification(
+        &self,
+        token: &OidcToken,
+        terminal: Option<&Terminal<TerminalStream<Term>>>,
+    ) -> Result<UserInfo>;
+
+    /// Open a browser from one of the URIs returned by a device code
+    /// in order to authenticate and poll the OIDC token url to get a token back
+    async fn get_token_from_browser<'a>(
         &self,
         opts: &CommandGlobalOpts,
-    ) -> Result<OidcToken> {
+        dc: DeviceCode<'a>,
+        uri: String,
+    ) -> Result<OidcToken>;
+
+    /// Poll for an OidcToken until it's ready
+    async fn poll_token<'a>(
+        &'a self,
+        dc: DeviceCode<'a>,
+        opts: &CommandGlobalOpts,
+    ) -> Result<OidcToken>;
+}
+
+#[async_trait]
+impl OidcServiceExt for OidcService {
+    async fn get_token_interactively(&self, opts: &CommandGlobalOpts) -> Result<OidcToken> {
         let dc = self.device_code().await?;
 
         opts.terminal
@@ -101,53 +94,25 @@ impl OidcService {
         self.get_token_from_browser(opts, dc, uri).await
     }
 
-    /// Retrieve a token using the device code get a token from the OIDC service
-    /// The device code is directly pasted to the currently opened browser window
-    pub async fn get_token(&self, opts: &CommandGlobalOpts) -> Result<OidcToken> {
+    async fn get_token(&self, opts: &CommandGlobalOpts) -> Result<OidcToken> {
         let dc = self.device_code().await?;
         let uri = dc.verification_uri_complete.to_string();
         self.get_token_from_browser(opts, dc, uri).await
     }
 
-    /// Request an authorization token with a PKCE flow
-    /// See the full protocol here: https://datatracker.ietf.org/doc/html/rfc7636
-    pub async fn get_token_with_pkce(&self) -> Result<OidcToken> {
-        let code_verifier = self.create_code_verifier();
-        let authorization_code = self.authorization_code(&code_verifier).await?;
-        self.retrieve_token_with_authorization_code(authorization_code, &code_verifier)
-            .await
-    }
-
-    /// Return the information about a user once authenticated
-    pub async fn get_user_info(&self, token: &OidcToken) -> Result<UserInfo> {
-        let client = self.provider().build_http_client()?;
-        let access_token = token.access_token.0.clone();
-        let req = || {
-            client
-                .get("https://account.ockam.io/userinfo")
-                .header("Authorization", format!("Bearer {}", access_token.clone()))
-        };
-        let retry_strategy = ExponentialBackoff::from_millis(10).take(3);
-        let res = Retry::spawn(retry_strategy, move || req().send())
-            .await
-            .into_diagnostic()?;
-        res.json().await.map_err(|e| miette!(e).into())
-    }
-
-    pub async fn wait_for_email_verification(
+    async fn wait_for_email_verification(
         &self,
         token: &OidcToken,
-        opts: &CommandGlobalOpts,
+        terminal: Option<&Terminal<TerminalStream<Term>>>,
     ) -> Result<UserInfo> {
-        let spinner_option = opts.terminal.progress_spinner();
+        let spinner_option = terminal.and_then(|t| t.progress_spinner());
         loop {
             let user_info = self.get_user_info(token).await?;
             if user_info.email_verified {
                 if let Some(spinner) = spinner_option.as_ref() {
                     spinner.finish_and_clear();
                 }
-                opts.terminal
-                    .write_line(&fmt_para!("Email <{}> verified\n", user_info.email))?;
+                terminal.map(|t| t.write_line(fmt_para!("Email <{}> verified\n", user_info.email)));
                 return Ok(user_info);
             } else {
                 if let Some(spinner) = spinner_option.as_ref() {
@@ -159,203 +124,6 @@ impl OidcService {
                 sleep(Duration::from_secs(5)).await;
             }
         }
-    }
-
-    pub(crate) async fn validate_provider_config(&self) -> miette::Result<()> {
-        if let Err(e) = self.device_code().await {
-            return Err(miette!("Invalid OIDC configuration: {}", e));
-        }
-        Ok(())
-    }
-}
-
-/// Implementation methods for the OidcService
-impl OidcService {
-    /// Return the OIDC provider
-    fn provider(&self) -> Arc<dyn OidcProvider + Send + Sync + 'static> {
-        self.0.clone()
-    }
-
-    /// Request a device code for the current client
-    pub async fn device_code(&self) -> Result<DeviceCode<'_>> {
-        self.request_code(
-            self.provider().device_code_url(),
-            &[("scope", self.scopes())],
-        )
-        .await
-    }
-
-    /// Request an authorization code for the PKCE OIDC flow
-    async fn authorization_code(&self, code_verifier: &str) -> Result<AuthorizationCode> {
-        // Hash and base64 encode the random bytes
-        // to obtain a code challenge
-        let hashed = Vault::sha256(code_verifier.as_bytes());
-        let code_challenge = base64_url::encode(&hashed);
-
-        // Start a local server to get back the authorization code after redirect
-        let (authorization_code_receiver, authorization_code_sender) = new_callback();
-        self.wait_for_authorization_code(authorization_code_sender)
-            .await?;
-
-        let redirect_url = self.provider().redirect_url();
-        let query_parameters = vec![
-            ("code_challenge_method", "S256".to_string()),
-            ("response_type", "code".to_string()),
-            ("code_challenge", code_challenge),
-            ("redirect_uri", redirect_url.to_string()),
-        ];
-
-        let parameters = {
-            let mut ps = vec![
-                ("client_id", self.provider().client_id()),
-                ("scope", self.scopes()),
-            ];
-            ps.extend_from_slice(query_parameters.as_slice());
-            ps
-        };
-
-        let url = Url::parse_with_params(self.provider().authorization_url().as_str(), parameters)
-            .unwrap();
-
-        // Send a request to get an authentication code
-        if open::that(url.as_str()).is_err() {
-            error!(
-                "Couldn't open activation url automatically [url={}]",
-                url.to_string()
-            );
-        };
-
-        // Wait for the authorization code to be received
-        authorization_code_receiver
-            .receive_timeout(self.provider().redirect_timeout())
-            .await
-            .map_err(|e| {
-                miette!(
-                    "could not retrieve an authorization code in {:?} (cause: {:?})",
-                    self.provider().redirect_timeout(),
-                    e
-                )
-                .into()
-            })
-    }
-
-    /// Retrieve a token given an authorization code obtained
-    /// with a specific code verifier
-    pub async fn retrieve_token_with_authorization_code(
-        &self,
-        authorization_code: AuthorizationCode,
-        code_verifier: &str,
-    ) -> Result<OidcToken> {
-        info!(
-            "getting an OIDC token using the authorization code {}",
-            authorization_code.code
-        );
-        self.request_code(
-            Url::parse("https://account.ockam.io/oauth/token").unwrap(),
-            vec![
-                ("code", authorization_code.code),
-                ("code_verifier", code_verifier.to_string()),
-                ("grant_type", "authorization_code".to_string()),
-                ("redirect_uri", self.provider().redirect_url().to_string()),
-            ]
-            .as_slice(),
-        )
-        .await
-    }
-
-    /// Request a code from a given OIDC Provider URL
-    /// This code can be a device code or an authorization code depending on the URL
-    /// and the query parameters
-    async fn request_code<T: DeserializeOwned + Debug>(
-        &self,
-        url: Url,
-        query_parameters: &[(&str, String)],
-    ) -> Result<T> {
-        let client = self.provider().build_http_client()?;
-
-        let parameters = {
-            let mut ps = vec![("client_id", self.provider().client_id())];
-            ps.extend_from_slice(query_parameters);
-            ps
-        };
-
-        let req = || {
-            client
-                .post(url.clone())
-                .header("content-type", "application/x-www-form-urlencoded")
-                .form(&parameters)
-        };
-        let retry_strategy = ExponentialBackoff::from_millis(10).take(3);
-        let res = Retry::spawn(retry_strategy, move || req().send())
-            .await
-            .into_diagnostic()?;
-
-        match res.status() {
-            StatusCode::OK => {
-                let res = res.json::<T>().await.into_diagnostic()?;
-                info!(?res, "code received: {res:#?}");
-                Ok(res)
-            }
-            _ => {
-                let res = res.text().await.into_diagnostic()?;
-                let err_msg = format!("couldn't get code: {:?}", res);
-                error!(err_msg);
-                Err(miette!(err_msg).into())
-            }
-        }
-    }
-
-    /// Wait for an authorization code after a redirect
-    /// by starting temporarily a local web server
-    /// Use the provided callback channel sender to return the authorization code asynchronously
-    async fn wait_for_authorization_code(
-        &self,
-        authorization_code: CallbackSender<AuthorizationCode>,
-    ) -> Result<()> {
-        let server_url = self.provider().redirect_url();
-        let host_and_port = format!(
-            "{}:{}",
-            server_url.host().unwrap(),
-            server_url.port().unwrap()
-        );
-        let server = Arc::new(Server::http(host_and_port).map_err(|e| miette!(e))?);
-        info!(
-            "server is started at {} and waiting for an authorization code",
-            server_url
-        );
-
-        let redirect_timeout = self.provider().redirect_timeout();
-
-        // Start a background thread which will wait for a request sending the authorization code
-        tokio::task::spawn_blocking(move || {
-            match server.recv_timeout(redirect_timeout) {
-                Ok(Some(request)) => {
-                    let code = Self::get_code(request.url())?;
-                    authorization_code
-                        .send(AuthorizationCode::new(code))
-                        .into_diagnostic()?;
-
-                    // Note that a code 303 does not properly redirect to the success page
-                    let response = Response::empty(302).with_header(
-                        Header::from_str("Location: https://account.ockam.io/device/success")
-                            .unwrap(),
-                    );
-
-                    request.respond(response).into_diagnostic()
-                }
-                Ok(None) => Err(miette!(
-                    "timeout while trying to receive a request on {} (waited for {:?})",
-                    server_url,
-                    redirect_timeout
-                )),
-                Err(e) => Err(miette!(
-                    "error while trying to receive a request on {}: {}",
-                    server_url,
-                    e
-                )),
-            }
-        });
-        Ok(())
     }
 
     /// Open a browser from one of the URIs returned by a device code
@@ -430,121 +198,5 @@ impl OidcService {
                 }
             }
         }
-    }
-
-    // Generate 32 random bytes as a code verifier
-    // to prove that this client was really the one requesting an authorization code
-    /// See the full PKCE flow here: https://datatracker.ietf.org/doc/html/rfc7636
-    fn create_code_verifier(&self) -> String {
-        let mut code_verifier = [0u8; 32];
-        let mut rng = thread_rng();
-        rng.fill_bytes(&mut code_verifier);
-        base64_url::encode(&code_verifier)
-    }
-
-    /// Return the list of scopes for the authorization requests
-    fn scopes(&self) -> String {
-        "profile openid email".to_string()
-    }
-
-    /// Extract the `code` query parameter from the callback request
-    fn get_code(request_url: &str) -> Result<String> {
-        // The local url is retrieved as a path associated to the tiny-http request
-        // In order to parse it with the Url parser we need to first recover a full URL
-        let url =
-            Url::parse(format!("http://0.0.0.0:0{}", request_url).as_str()).into_diagnostic()?;
-
-        // Check the URL path
-        if !url.path().starts_with("/callback") {
-            return Err(miette!(
-                "the query path should be of the form '/callback?code=xxxx'. Got: {})",
-                request_url
-            )
-            .into());
-        };
-
-        // Extract the 'code' query parameter
-        if let Some((name, value)) = url.query_pairs().next() {
-            if name == "code" {
-                return Ok(value.to_string());
-            };
-        };
-        Err(miette!(
-            "could not extract the 'code' query parameter from the path {})",
-            request_url
-        )
-        .into())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
-    async fn test_user_info() -> Result<()> {
-        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
-        let token = oidc_service.get_token_with_pkce().await?;
-        let user_info = oidc_service.get_user_info(&token).await;
-        assert!(user_info.is_ok());
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
-    async fn test_get_token_with_pkce() -> Result<()> {
-        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
-        let token = oidc_service.get_token_with_pkce().await;
-        assert!(token.is_ok());
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[ignore = "this test can only run with an open browser in order to authenticate the user"]
-    async fn test_authorization_code() -> Result<()> {
-        let oidc_service = OidcService::default_with_redirect_timeout(Duration::from_secs(15));
-        let code_verifier = oidc_service.create_code_verifier();
-        let authorization_code = oidc_service
-            .authorization_code(code_verifier.as_str())
-            .await;
-        assert!(authorization_code.is_ok());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_wait_for_authorization_code() -> Result<()> {
-        let oidc_service = OidcService::default();
-
-        let (authorization_code_receiver, authorization_code_sender) = new_callback();
-        oidc_service
-            .wait_for_authorization_code(authorization_code_sender)
-            .await?;
-
-        let client_thread = tokio::spawn(async move {
-            let client = reqwest::ClientBuilder::new().build().unwrap();
-            client
-                .get(oidc_service.provider().redirect_url().as_str())
-                .query(&[("code", "12345")])
-                .send()
-                .await
-        });
-
-        let res = client_thread.await.unwrap();
-        assert!(res.is_ok());
-
-        let authorization_code = authorization_code_receiver
-            .receive_timeout(Duration::from_secs(1))
-            .await?;
-        assert_eq!(authorization_code, AuthorizationCode::new("12345"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_path_query_parameters() {
-        let code = OidcService::get_code("/callback?code=12345");
-        assert!(code.is_ok());
-        assert_eq!(code.unwrap(), "12345".to_string())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -176,6 +176,7 @@ gen_from_impl!(minicbor::encode::Error<std::convert::Infallible>, DATAERR);
 gen_from_impl!(minicbor::decode::Error, DATAERR);
 gen_from_impl!(ockam::Error, SOFTWARE);
 gen_from_impl!(ockam_api::cli_state::CliStateError, SOFTWARE);
+gen_from_impl!(ockam_api::error::ApiError, SOFTWARE);
 gen_from_impl!(ockam_multiaddr::Error, SOFTWARE);
 gen_from_impl!(miette::ErrReport, SOFTWARE);
 gen_from_impl!(time::error::Parse, DATAERR);

--- a/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
+++ b/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
@@ -2,11 +2,12 @@ use clap::Args;
 use miette::IntoDiagnostic;
 
 use ockam::{Context, TcpTransport};
+use ockam_api::address::extract_address_value;
 use ockam_core::flow_control::FlowControlId;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::{get_node_name, NodeOpts};
-use crate::util::{api, extract_address_value, node_rpc, RpcBuilder};
+use crate::util::{api, node_rpc, RpcBuilder};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -3,6 +3,7 @@ use miette::{Context as _, IntoDiagnostic};
 
 use core::time::Duration;
 use ockam::{Context, TcpTransport};
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
 use ockam_api::nodes::service::message::SendMessage;
 use ockam_core::api::{Request, RequestBuilder};
@@ -12,7 +13,7 @@ use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::duration::duration_parser;
-use crate::util::{clean_nodes_multiaddr, extract_address_value, node_rpc, RpcBuilder};
+use crate::util::{clean_nodes_multiaddr, node_rpc, RpcBuilder};
 
 use crate::{docs, CommandGlobalOpts};
 
@@ -77,7 +78,7 @@ async fn rpc(
             let identity = get_identity_name(&opts.state, &cmd.cloud_opts.identity);
             let api_node = start_embedded_node_with_vault_and_identity(
                 ctx,
-                &opts,
+                &opts.state,
                 None,
                 Some(identity),
                 Some(&cmd.trust_context_opts),

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -1,9 +1,10 @@
 use crate::policy::policy_path;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use clap::Args;
 use ockam::Context;
 use ockam_abac::{Action, Resource};
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::policy::Policy;
 use ockam_core::api::Request;
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -13,10 +13,11 @@ use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::cloud::operation::CreateOperationResponse;
 use ockam_api::cloud::project::{OktaConfig, Project};
 use ockam_api::cloud::CloudRequestWrapper;
+use ockam_api::enroll::oidc_service::OidcService;
+use ockam_api::enroll::okta_oidc_provider::OktaOidcProvider;
 use ockam_api::minicbor_url::Url;
 use ockam_core::api::Request;
 
-use crate::enroll::{OidcService, OktaOidcProvider};
 use crate::node::util::delete_embedded_node;
 use crate::operation::util::check_for_completion;
 use crate::project::addon::configure_addon_endpoint;

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -9,8 +9,6 @@ mod ticket;
 pub mod util;
 mod version;
 
-pub use info::ProjectInfo;
-
 use clap::{Args, Subcommand};
 
 pub use crate::credential::get::GetCommand;

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -20,7 +20,7 @@ use ockam_node::RpcClient;
 use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::node::util::{delete_embedded_node, start_embedded_node};
 use crate::project::util::create_secure_channel_to_authority;
-use crate::util::api::{parse_trust_context, CloudOpts, TrustContextOpts};
+use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::node_rpc;
 use crate::{docs, CommandGlobalOpts, Result};
 
@@ -95,7 +95,7 @@ impl Runner {
         let mut trust_context: Option<TrustContextConfig> = None;
 
         let base_addr = if let Some(tc) = self.cmd.trust_opts.trust_context.as_ref() {
-            let tc = parse_trust_context(&self.opts.state, tc)?;
+            let tc = &self.opts.state.trust_contexts.read_config_from_path(tc)?;
             trust_context = Some(tc.clone());
             let cred_retr = tc
                 .authority()

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -8,6 +8,7 @@ use ockam::identity::IdentityIdentifier;
 use ockam_multiaddr::proto::Project;
 
 use ockam::{Context, TcpTransport};
+use ockam_api::address::extract_address_value;
 use ockam_api::is_local_node;
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
 use ockam_core::api::Request;
@@ -18,7 +19,7 @@ use tokio::try_join;
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
-use crate::util::{extract_address_value, node_rpc, process_nodes_multiaddr, RpcBuilder};
+use crate::util::{node_rpc, process_nodes_multiaddr, RpcBuilder};
 use crate::{display_parse_logs, docs, fmt_ok, CommandGlobalOpts};
 use crate::{fmt_log, Result};
 

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
 use ockam::Context;
+use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
@@ -11,7 +12,7 @@ use tokio::try_join;
 
 use crate::node::get_node_name;
 use crate::terminal::OckamColor;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -2,11 +2,12 @@ use clap::Args;
 use miette::IntoDiagnostic;
 
 use ockam::Context;
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
 
 use crate::node::get_node_name;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     fmt_log, fmt_ok,
     terminal::OckamColor,
-    util::{exitcode, extract_address_value, node_rpc},
+    util::{exitcode, node_rpc},
     CommandGlobalOpts,
 };
 
@@ -18,6 +18,7 @@ use crate::identity::{get_identity_name, initialize_identity_if_default};
 use crate::util::api::CloudOpts;
 use crate::util::{clean_nodes_multiaddr, RpcBuilder};
 use ockam::{identity::IdentityIdentifier, route, Context, TcpTransport};
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models;
 use ockam_api::nodes::models::secure_channel::{
     CreateSecureChannelResponse, CredentialExchangeMode,

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -2,12 +2,13 @@ use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::is_tty;
 use crate::{
     docs,
-    util::{api, extract_address_value, node_rpc, Rpc},
+    util::{api, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models;
 use serde_json::json;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,12 +1,13 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
+use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models;
 use ockam_api::nodes::models::transport::TransportStatus;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::util::extract_address_value;
 use ockam::Context;
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,6 +1,6 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 use clap::Args;
@@ -11,6 +11,7 @@ use ockam_api::nodes::models;
 
 use ockam_core::api::Request;
 
+use ockam_api::address::extract_address_value;
 use tokio::sync::Mutex;
 use tokio::try_join;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,10 +1,11 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::Result;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use ockam::{Context, Route};
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::{Request, RequestBuilder};

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::util::extract_address_value;
 use ockam::Context;
+use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -4,7 +4,7 @@ use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
 
 use crate::util::parsers::{host_parser, HostPort};
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{display_parse_logs, fmt_log};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
@@ -13,6 +13,7 @@ use colorful::Colorful;
 use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_abac::Resource;
+use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::portal::{CreateOutlet, OutletStatus};
 use ockam_core::api::Request;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,7 +1,7 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
 
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 use clap::Args;
@@ -10,6 +10,7 @@ use miette::miette;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::portal::OutletList;
 
+use ockam_api::address::extract_address_value;
 use ockam_core::api::Request;
 use ockam_node::Context;
 use tokio::sync::Mutex;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,11 +1,12 @@
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
-use crate::util::{extract_address_value, node_rpc, Rpc};
+use crate::util::{node_rpc, Rpc};
 use crate::Result;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use miette::miette;
 use ockam::{route, Context};
+use ockam_api::address::extract_address_value;
 
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::route_to_multiaddr;

--- a/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
@@ -1,10 +1,7 @@
 use crate::util::local_cmd;
 use crate::{
     docs,
-    util::{
-        api::{TrustContextConfigBuilder, TrustContextOpts},
-        random_name,
-    },
+    util::{api::TrustContextOpts, random_name},
     CommandGlobalOpts,
 };
 use clap::Args;
@@ -42,7 +39,9 @@ impl CreateCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: CreateCommand) -> miette::Result<()> {
-    let config = TrustContextConfigBuilder::new(&opts.state, &cmd.trust_context_opts)?
+    let config = cmd
+        .trust_context_opts
+        .to_config(&opts.state)?
         .with_credential_name(cmd.credential.as_ref())
         .use_default_trust_context(false)
         .build();

--- a/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/orchestrator_api.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use ockam::identity::credential::{Credential, OneTimeCode};
 use ockam::Context;
-use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
+use ockam_api::cli_state::{ProjectConfigCompact, StateDirTrait, StateItemTrait};
 use ockam_api::{
     config::lookup::ProjectLookup, nodes::models::secure_channel::CredentialExchangeMode,
     DefaultAddress,
@@ -20,10 +20,7 @@ use ockam_multiaddr::MultiAddr;
 
 use crate::{
     node::util::{delete_node, start_embedded_node_with_vault_and_identity},
-    project::{
-        util::{create_secure_channel_to_authority, create_secure_channel_to_project},
-        ProjectInfo,
-    },
+    project::util::{create_secure_channel_to_authority, create_secure_channel_to_project},
     util::Rpc,
     CommandGlobalOpts, Result,
 };
@@ -83,7 +80,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
         // TODO: always use the default vault
         let node_name = start_embedded_node_with_vault_and_identity(
             self.ctx,
-            self.opts,
+            &self.opts.state,
             None,
             self.identity.clone(),
             Some(self.trust_context_opts),
@@ -100,7 +97,7 @@ impl<'a> OrchestratorApiBuilder<'a> {
     ) -> Result<&mut OrchestratorApiBuilder<'a>> {
         // Read (okta and authority) project parameters from project.json
         let s = tokio::fs::read_to_string(file_path).await?;
-        let proj_info: ProjectInfo = serde_json::from_str(&s)?;
+        let proj_info: ProjectConfigCompact = serde_json::from_str(&s)?;
         let project_lookup = ProjectLookup::from_project(&(&proj_info).into()).await?;
 
         self.project_lookup = Some(project_lookup);

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -6,7 +6,7 @@ use miette::miette;
 use miette::IntoDiagnostic;
 
 use ockam::identity::credential::Credential;
-use ockam_api::cli_state::{StateItemTrait, VaultState};
+use ockam_api::cli_state::{ProjectConfigCompact, StateItemTrait, VaultState};
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::space::Space;
 use ockam_api::nodes::models::portal::{InletStatus, OutletStatus};
@@ -16,7 +16,6 @@ use ockam_api::nodes::models::secure_channel::{
 use ockam_api::route_to_multiaddr;
 use ockam_core::{route, Route};
 
-use crate::project::ProjectInfo;
 use crate::terminal::OckamColor;
 use crate::util::comma_separated;
 use crate::Result;
@@ -156,7 +155,7 @@ Space {}"#,
     }
 }
 
-impl Output for ProjectInfo<'_> {
+impl Output for ProjectConfigCompact {
     fn output(&self) -> Result<String> {
         let pi = self
             .identity

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -1,12 +1,13 @@
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::terminal::OckamColor;
 use crate::util::output::Output;
-use crate::util::{api, extract_address_value, node_rpc, Rpc};
+use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 use ockam::Context;
+use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::workers::{WorkerList, WorkerStatus};
 use tokio::sync::Mutex;


### PR DESCRIPTION
Move all the `ockam_command` code that was used from `ockam_app` to `ockam_api`. All the moved code was related to either the `CliState` or the `Enroll` service, so it felt like the right move to take all that code to `ockam_api`, which acts as the common interface for both the Cli and the App.

After this refactor, the `ockam_app` doesn't depend anymore on the `ockam_command` crate, which gives us a big compilation time improvement.