### PR TITLE
Fix the creation of an outlet when sharing a service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,6 +4738,7 @@ dependencies = [
  "ockam_macros",
  "ockam_multiaddr",
  "ockam_node",
+ "ockam_transport_tcp",
  "ockam_vault",
  "ockam_vault_aws",
  "once_cell",

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -12,6 +12,7 @@ mod protocol_aware;
 mod secure_channel_map;
 
 pub(crate) use inlet_controller::KafkaInletController;
+use ockam_core::Address;
 pub(crate) use outlet_service::prefix_forwarder::PrefixForwarderService;
 pub(crate) use outlet_service::OutletManagerService;
 pub(crate) use portal_listener::KafkaPortalListener;
@@ -22,6 +23,6 @@ pub const KAFKA_OUTLET_CONSUMERS: &str = "kafka_consumers";
 pub const KAFKA_OUTLET_INTERCEPTOR_ADDRESS: &str = "kafka_interceptor";
 pub const KAFKA_OUTLET_BOOTSTRAP_ADDRESS: &str = "kafka_bootstrap";
 
-pub fn kafka_outlet_address(broker_id: i32) -> String {
-    format!("kafka_outlet_{}", broker_id)
+pub fn kafka_outlet_address(broker_id: i32) -> Address {
+    format!("kafka_outlet_{}", broker_id).into()
 }

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
@@ -13,7 +13,10 @@ use ockam_core::compat::sync::Mutex;
 use ockam_node::Context;
 use std::convert::TryFrom;
 use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+use std::str::FromStr;
 
+use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::FlowControlId;
 use tinyvec::alloc;
 use tracing::warn;
@@ -154,13 +157,19 @@ impl KafkaMessageInterceptor for OutletInterceptorImpl {
                     decode_body(&mut buffer, request_info.request_api_version)?;
 
                 for (broker_id, metadata) in response.brokers {
+                    let socket_addr = SocketAddr::from_str(
+                        format!("{}:{}", metadata.host, metadata.port).as_str(),
+                    )
+                    .map_err(|e| {
+                        InterceptError::Ockam(ockam_core::Error::new(
+                            Origin::Ockam,
+                            Kind::Invalid,
+                            format!("cannot parse a socket address from the broker {broker_id:?} metadata {e:?}"),
+                        ))
+                    })?;
                     let outlet_address = self
                         .outlet_controller
-                        .assert_outlet_for_broker(
-                            context,
-                            broker_id.0,
-                            format!("{}:{}", metadata.host, metadata.port),
-                        )
+                        .assert_outlet_for_broker(context, broker_id.0, socket_addr)
                         .await
                         .map_err(InterceptError::Ockam)?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -1,5 +1,6 @@
 //! Inlets and outlet request/response types
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 use minicbor::{Decode, Encode};
@@ -7,7 +8,7 @@ use ockam::route;
 use ockam_core::compat::borrow::Cow;
 #[cfg(feature = "tag")]
 use ockam_core::TypeTag;
-use ockam_core::{CowStr, Route};
+use ockam_core::{Address, CowStr, Route};
 use ockam_identity::IdentityIdentifier;
 use ockam_multiaddr::MultiAddr;
 use serde::{Deserialize, Serialize};
@@ -129,9 +130,9 @@ pub struct CreateOutlet {
     #[cfg(feature = "tag")]
     #[n(0)] tag: TypeTag<5351558>,
     /// The address the portal should connect or bind to
-    #[n(1)] pub tcp_addr: String,
+    #[n(1)] pub socket_addr: SocketAddr,
     /// The address the portal should connect or bind to
-    #[n(2)] pub worker_addr: String,
+    #[n(2)] pub worker_addr: Address,
     /// A human-friendly alias for this portal endpoint
     #[n(3)] pub alias: Option<String>,
     /// Allow the outlet to be reachable from the default secure channel, useful when we want to
@@ -141,16 +142,16 @@ pub struct CreateOutlet {
 
 impl CreateOutlet {
     pub fn new(
-        tcp_addr: impl Into<String>,
-        worker_addr: impl Into<String>,
+        socket_addr: SocketAddr,
+        worker_addr: Address,
         alias: impl Into<Option<String>>,
         reachable_from_default_secure_channel: bool,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            tcp_addr: tcp_addr.into(),
-            worker_addr: worker_addr.into(),
+            socket_addr,
+            worker_addr,
             alias: alias.into(),
             reachable_from_default_secure_channel,
         }
@@ -213,8 +214,8 @@ pub struct OutletStatus {
     #[cfg(feature = "tag")]
     #[serde(skip)]
     #[n(0)] tag: TypeTag<4012569>,
-    #[n(1)] pub tcp_addr: String,
-    #[n(2)] pub worker_addr: String,
+    #[n(1)] pub socket_addr: SocketAddr,
+    #[n(2)] pub worker_addr: Address,
     #[n(3)] pub alias:String,
     /// An optional status payload
     #[n(4)] pub payload: Option<String>,
@@ -225,7 +226,7 @@ impl OutletStatus {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            tcp_addr: "".into(),
+            socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 80),
             worker_addr: "".into(),
             alias: "".into(),
             payload: Some(reason.into()),
@@ -233,16 +234,16 @@ impl OutletStatus {
     }
 
     pub fn new(
-        tcp_addr: impl Into<String>,
-        worker_addr: impl Into<String>,
+        socket_addr: SocketAddr,
+        worker_addr: Address,
         alias: impl Into<String>,
         payload: impl Into<Option<String>>,
     ) -> Self {
         Self {
             #[cfg(feature = "tag")]
             tag: TypeTag,
-            tcp_addr: tcp_addr.into(),
-            worker_addr: worker_addr.into(),
+            socket_addr,
+            worker_addr,
             alias: alias.into(),
             payload: payload.into(),
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -64,17 +64,17 @@ impl DeleteServiceRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaOutletRequest {
-    #[n(1)] pub bootstrap_server_addr: String,
+    #[n(1)] pub bootstrap_server_addr: SocketAddr,
 }
 
 impl StartKafkaOutletRequest {
-    pub fn new(bootstrap_server_addr: impl Into<String>) -> Self {
+    pub fn new(bootstrap_server_addr: SocketAddr) -> Self {
         Self {
-            bootstrap_server_addr: bootstrap_server_addr.into(),
+            bootstrap_server_addr,
         }
     }
 
-    pub fn bootstrap_server_addr(&self) -> &str {
+    pub fn bootstrap_server_addr(&self) -> &SocketAddr {
         &self.bootstrap_server_addr
     }
 }
@@ -150,7 +150,7 @@ impl StartKafkaProducerRequest {
 #[cbor(map)]
 pub struct StartKafkaDirectRequest {
     #[n(1)] bind_address: SocketAddr,
-    #[n(2)] bootstrap_server_addr: String,
+    #[n(2)] bootstrap_server_addr: SocketAddr,
     #[n(3)] brokers_port_range: (u16, u16),
     #[n(4)] consumer_route: Option<String>,
 }
@@ -158,7 +158,7 @@ pub struct StartKafkaDirectRequest {
 impl StartKafkaDirectRequest {
     pub fn new(
         bind_address: SocketAddr,
-        bootstrap_server_addr: String,
+        bootstrap_server_addr: SocketAddr,
         brokers_port_range: impl Into<(u16, u16)>,
         consumer_route: Option<MultiAddr>,
     ) -> Self {
@@ -173,7 +173,7 @@ impl StartKafkaDirectRequest {
     pub fn bind_address(&self) -> SocketAddr {
         self.bind_address
     }
-    pub fn bootstrap_server_addr(&self) -> &str {
+    pub fn bootstrap_server_addr(&self) -> &SocketAddr {
         &self.bootstrap_server_addr
     }
     pub fn brokers_port_range(&self) -> (u16, u16) {

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -5,6 +5,7 @@ use ockam_core::compat::collections::BTreeMap;
 use ockam_core::{Address, Route};
 use ockam_identity::{SecureChannel, SecureChannelListener};
 use std::fmt::Display;
+use std::net::SocketAddr;
 
 #[derive(Default)]
 pub(crate) struct SecureChannelRegistry {
@@ -173,18 +174,18 @@ impl InletInfo {
 
 #[derive(Clone)]
 pub(crate) struct OutletInfo {
-    pub(crate) tcp_addr: String,
+    pub(crate) socket_addr: SocketAddr,
     pub(crate) worker_addr: Address,
 }
 
 impl OutletInfo {
-    pub(crate) fn new(tcp_addr: &str, worker_addr: Option<&Address>) -> Self {
+    pub(crate) fn new(socket_addr: &SocketAddr, worker_addr: Option<&Address>) -> Self {
         let worker_addr = match worker_addr {
             Some(addr) => addr.clone(),
             None => Address::from_string(""),
         };
         Self {
-            tcp_addr: tcp_addr.to_owned(),
+            socket_addr: *socket_addr,
             worker_addr,
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -150,7 +150,7 @@ impl NodeManager {
             outlets
                 .iter()
                 .map(|(alias, info)| {
-                    OutletStatus::new(&info.tcp_addr, info.worker_addr.to_string(), alias, None)
+                    OutletStatus::new(info.socket_addr, info.worker_addr.clone(), alias, None)
                 })
                 .collect(),
         )

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -594,8 +594,8 @@ impl NodeManagerWorker {
             .create_outlet_impl(
                 context,
                 request.id(),
-                body.request().bootstrap_server_addr.clone(),
-                KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string(),
+                body.request().bootstrap_server_addr,
+                KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
                 Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
                 false,
             )
@@ -640,7 +640,7 @@ impl NodeManagerWorker {
                 body_req.bind_address().ip(),
                 body_req.bind_address().port(),
                 body_req.brokers_port_range(),
-                body_req.bootstrap_server_addr().to_string(),
+                *body_req.bootstrap_server_addr(),
                 consumer_route,
             )
             .await
@@ -660,7 +660,7 @@ impl NodeManagerWorker {
         bind_ip: IpAddr,
         server_bootstrap_port: u16,
         brokers_port_range: (u16, u16),
-        bootstrap_server_addr: String,
+        bootstrap_server_addr: SocketAddr,
         consumer_route: Option<MultiAddr>,
     ) -> Result<(), ResponseBuilder<Error>> {
         let default_secure_channel_listener_flow_control_id = context
@@ -685,7 +685,7 @@ impl NodeManagerWorker {
             context,
             request.id(),
             bootstrap_server_addr,
-            KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string(),
+            KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
             Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
             false,
         )

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -63,8 +63,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional =
 # If you use cargo directly instead of tauri's cli you can use this feature flag to switch between tauri's `dev` and `build` modes.
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
-default = ["invitations", "tracing"]
-invitations = []
+default = ["tracing"]
 log = ["dep:log", "dep:tauri-plugin-log", "log/release_max_level_info", "tracing/log"]
-release = ["invitations", "log"]
+release = ["log"]
 tracing = ["dep:tracing-subscriber", "tracing/log", "tracing/release_max_level_info"]

--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -4,7 +4,6 @@ use tracing::error;
 use crate::app::events::SystemTrayOnUpdatePayload;
 use crate::app::AppState;
 use crate::enroll::{build_enroll_section, build_user_info_section};
-#[cfg(feature = "invitations")]
 use crate::invitations::{self, build_invitations_section};
 use crate::options::build_options_section;
 use crate::shared_service::build_shared_services_section;
@@ -19,10 +18,7 @@ pub async fn build_tray_menu(
     tray_menu = build_user_info_section(&app_state, tray_menu).await;
     tray_menu = build_enroll_section(&app_state, tray_menu, &payload).await;
     tray_menu = build_shared_services_section(&app_state, tray_menu).await;
-    #[cfg(feature = "invitations")]
-    {
-        tray_menu = build_invitations_section(app_handle, tray_menu).await;
-    }
+    tray_menu = build_invitations_section(app_handle, tray_menu).await;
     tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
     tray_menu = build_options_section(&app_state, tray_menu).await;
     tray_menu
@@ -46,16 +42,10 @@ pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
     }
 }
 
-#[cfg(feature = "invitations")]
 fn fallback_for_id(app: &AppHandle<Wry>, s: &str) -> tauri::Result<()> {
     if s.starts_with("invitation-") {
         invitations::dispatch_click_event(app, s)
     } else {
         Ok(())
     }
-}
-
-#[cfg(not(feature = "invitations"))]
-fn fallback_for_id(_app: &AppHandle<Wry>, _s: &str) -> tauri::Result<()> {
-    Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -28,11 +28,8 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
         .await
         .unwrap_or_else(|e| error!(?e, "Failed to enroll user"));
     system_tray_on_update(app);
-    #[cfg(feature = "invitations")]
-    {
-        app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
-        app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
-    }
+    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
     // Reset the node manager to include the project's setup, needed to create the relay.
     // This is necessary because the project data is used in the worker initialization,
     // which can't be rerun manually once the worker is started.

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -4,6 +4,7 @@ pub(super) mod plugin;
 mod state;
 mod tray_menu;
 
+use std::net::SocketAddr;
 pub(crate) use tray_menu::*;
 
 use crate::app::{AppState, NODE_NAME};
@@ -15,17 +16,18 @@ use tauri::{AppHandle, Manager, Runtime, State};
 
 pub(crate) async fn build_args_for_create_service_invitation<R: Runtime>(
     app_handle: &AppHandle<R>,
-    outlet_worker_addr: &str,
+    outlet_socket_addr: &SocketAddr,
     recipient_email: &str,
     enrollment_ticket: EnrollmentTicket,
 ) -> crate::Result<CreateServiceInvitation> {
     let app_state: State<'_, AppState> = app_handle.state();
     let cli_state = app_state.state().await;
+
     let service_route = app_state
         .model(|m| {
             m.tcp_outlets
                 .iter()
-                .find(|o| o.worker_addr == outlet_worker_addr)
+                .find(|o| o.socket_addr == *outlet_socket_addr)
                 .map(|o| o.worker_address())
         })
         .await

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -28,11 +28,9 @@ mod app;
 mod cli;
 mod enroll;
 mod error;
-#[cfg(feature = "invitations")]
 mod invitations;
 mod options;
 mod platform;
-#[cfg(feature = "invitations")]
 mod projects;
 mod shared_service;
 
@@ -48,7 +46,6 @@ pub fn run() {
     }
 
     // For now, the application only consists of a system tray with several menu items
-    #[cfg_attr(not(feature = "invitations"), allow(unused_mut))]
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_window::init())
         .plugin(tauri_plugin_positioner::init())
@@ -61,12 +58,8 @@ pub fn run() {
     {
         builder = builder.plugin(configure_tauri_plugin_log());
     }
-
-    #[cfg(feature = "invitations")]
-    {
-        builder = builder.plugin(projects::plugin::init());
-        builder = builder.plugin(invitations::plugin::init());
-    }
+    builder = builder.plugin(projects::plugin::init());
+    builder = builder.plugin(invitations::plugin::init());
 
     let mut app = builder
         .build(tauri::generate_context!())

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -1,4 +1,3 @@
-#[cfg(all(debug_assertions, feature = "invitations"))]
 use tauri::Manager;
 #[cfg(debug_assertions)]
 use tauri::SystemTraySubmenu;
@@ -64,14 +63,9 @@ fn build_developer_submenu(app_state: &AppState, tray_menu: SystemTrayMenu) -> S
 }
 
 #[cfg(debug_assertions)]
-pub fn on_refresh(
-    #[cfg_attr(not(feature = "invitations"), allow(unused_variables))] app: &AppHandle<Wry>,
-) -> tauri::Result<()> {
-    #[cfg(feature = "invitations")]
-    {
-        app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
-        app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
-    }
+pub fn on_refresh(app: &AppHandle<Wry>) -> tauri::Result<()> {
+    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
     system_tray_on_update(app);
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -7,7 +7,6 @@ use tracing::{debug, error, info};
 use crate::app::events::system_tray_on_update;
 use crate::app::AppState;
 use crate::error::Error;
-#[cfg(feature = "invitations")]
 use crate::invitations::commands::create_service_invitation;
 
 /// Create a TCP outlet within the default node.
@@ -32,7 +31,7 @@ async fn tcp_outlet_create_impl(
     app: AppHandle<Wry>,
     service: String,
     port: String,
-    #[cfg_attr(not(feature = "invitations"), allow(unused_variables))] email: Option<String>,
+    email: Option<String>,
 ) -> crate::Result<()> {
     debug!(%service, %port, "Creating an outlet");
     let app_state = app.state::<AppState>();
@@ -61,7 +60,7 @@ async fn tcp_outlet_create_impl(
         }
         Err(_) => Err(Error::Generic("Failed to create outlet".to_string())),
     }?;
-    #[cfg(feature = "invitations")]
+
     if let Some(email) = email {
         create_service_invitation(email, tcp_addr.to_string(), app)
             .await

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -35,7 +35,7 @@ async fn tcp_outlet_create_impl(
 ) -> crate::Result<()> {
     debug!(%service, %port, "Creating an outlet");
     let app_state = app.state::<AppState>();
-    let tcp_addr: SocketAddr = format!("127.0.0.1:{port}")
+    let socket_addr: SocketAddr = format!("127.0.0.1:{port}")
         .parse()
         .into_diagnostic()
         .wrap_err("Invalid port")?;
@@ -45,15 +45,15 @@ async fn tcp_outlet_create_impl(
     match node_manager
         .create_outlet(
             &app_state.context(),
-            tcp_addr.to_string(),
-            worker_addr,
+            socket_addr,
+            worker_addr.into(),
             None,
             true,
         )
         .await
     {
         Ok(status) => {
-            info!(tcp_addr = status.tcp_addr, "Outlet created");
+            info!(socket_addr = socket_addr.to_string(), "Outlet created");
             app_state.model_mut(|m| m.add_tcp_outlet(status)).await?;
             system_tray_on_update(&app);
             Ok(())
@@ -62,7 +62,7 @@ async fn tcp_outlet_create_impl(
     }?;
 
     if let Some(email) = email {
-        create_service_invitation(email, tcp_addr.to_string(), app)
+        create_service_invitation(email, socket_addr.to_string(), app)
             .await
             .map_err(Error::Generic)?;
     }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/model_state.rs
@@ -30,7 +30,7 @@ pub(crate) async fn load_model_state(
         let _ = node_manager
             .create_outlet(
                 &context,
-                tcp_outlet.tcp_addr.clone(),
+                tcp_outlet.socket_addr,
                 tcp_outlet.worker_addr.clone(),
                 None,
                 true,
@@ -39,7 +39,7 @@ pub(crate) async fn load_model_state(
             .map_err(|e| {
                 error!(
                     ?e,
-                    "failed to create outlet with tcp addr {}", tcp_outlet.tcp_addr
+                    "failed to create outlet with tcp addr {}", tcp_outlet.socket_addr
                 );
             });
     }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -48,7 +48,7 @@ fn shared_service_submenu(outlet: &OutletStatus) -> SystemTraySubmenu {
         .add_item(
             CustomMenuItem::new(
                 "outlet-tcp-address".to_string(),
-                format!("TCP Address: {}", outlet.tcp_addr),
+                format!("TCP Address: {}", outlet.socket_addr),
             )
             .disabled(),
         )

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -36,18 +36,13 @@ pub(crate) async fn build_shared_services_section(
 fn shared_service_submenu(outlet: &OutletStatus) -> SystemTraySubmenu {
     let worker_address = outlet.worker_address().unwrap();
 
-    #[cfg_attr(not(feature = "invitations"), allow(unused_mut))]
     let mut submenu = SystemTrayMenu::new();
-
-    #[cfg(feature = "invitations")]
-    {
-        // NOTE: Event handler for dynamic ID is defined in crate::invitations::tray_menu module,
-        // and reached via crate::app::tray_menu::fallback_for_id
-        submenu = submenu.add_item(CustomMenuItem::new(
-            format!("invitation-create-for-{}", outlet.worker_addr),
-            "Share".to_string(),
-        ));
-    }
+    // NOTE: Event handler for dynamic ID is defined in crate::invitations::tray_menu module,
+    // and reached via crate::app::tray_menu::fallback_for_id
+    submenu = submenu.add_item(CustomMenuItem::new(
+        format!("invitation-create-for-{}", outlet.worker_addr),
+        "Share".to_string(),
+    ));
 
     submenu = submenu
         .add_item(

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -83,6 +83,7 @@ ockam_core = { path = "../ockam_core", version = "^0.83.0" }
 ockam_identity = { path = "../ockam_identity", version = "^0.78.0" }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.24.0", features = ["std"] }
 ockam_node = { path = "../ockam_node", version = "^0.86.0" }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.84.0" }
 ockam_vault = { path = "../ockam_vault", version = "^0.79.0", features = ["storage"] }
 ockam_vault_aws = { path = "../ockam_vault_aws", version = "^0.4.0" }
 once_cell = "1.18"

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
@@ -29,7 +29,7 @@ pub struct CreateCommand {
     bind_address: SocketAddr,
     /// The address of the kafka bootstrap broke
     #[arg(long, default_value_t = kafka_default_outlet_server())]
-    bootstrap_server: String,
+    bootstrap_server: SocketAddr,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
     #[arg(long, default_value_t = kafka_default_consumer_port_range())]

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
@@ -23,7 +23,7 @@ pub struct ArgOpts {
     pub bind_address: SocketAddr,
     pub brokers_port_range: PortRange,
     pub consumer_route: Option<MultiAddr>,
-    pub bootstrap_server: String,
+    pub bootstrap_server: SocketAddr,
 }
 
 pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod outlet;
 pub(crate) mod producer;
 pub(crate) mod util;
 
-const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: &str = "localhost:9092";
+const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: &str = "127.0.0.1:9092";
 const KAFKA_DEFAULT_PROJECT_ROUTE: &str = "/project/default";
 const KAFKA_DEFAULT_CONSUMER_SERVER: &str = "127.0.0.1:4000";
 const KAFKA_DEFAULT_CONSUMER_PORT_RANGE: &str = "4001-4100";
@@ -36,8 +36,9 @@ fn kafka_default_project_route() -> MultiAddr {
     MultiAddr::from_str(KAFKA_DEFAULT_PROJECT_ROUTE).expect("Failed to parse default project route")
 }
 
-fn kafka_default_outlet_server() -> String {
-    KAFKA_DEFAULT_BOOTSTRAP_ADDRESS.to_string()
+fn kafka_default_outlet_server() -> SocketAddr {
+    SocketAddr::from_str(KAFKA_DEFAULT_BOOTSTRAP_ADDRESS)
+        .expect("Failed to parse default bootstrap address")
 }
 
 fn kafka_default_consumer_server() -> SocketAddr {

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -5,6 +5,7 @@ use ockam::{Context, TcpTransport};
 use ockam_api::nodes::models::services::StartKafkaOutletRequest;
 use ockam_api::nodes::models::services::StartServiceRequest;
 use ockam_core::api::Request;
+use std::net::SocketAddr;
 
 use tokio::{sync::Mutex, try_join};
 
@@ -29,7 +30,7 @@ pub struct CreateCommand {
     addr: String,
     /// The address of the kafka bootstrap broker
     #[arg(long, default_value_t = kafka_default_outlet_server())]
-    bootstrap_server: String,
+    bootstrap_server: SocketAddr,
 }
 
 impl CreateCommand {
@@ -50,7 +51,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
     let send_req = async {
         let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
 
-        let payload = StartKafkaOutletRequest::new(bootstrap_server.clone());
+        let payload = StartKafkaOutletRequest::new(bootstrap_server);
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post("/node/services/kafka_outlet").body(payload);
         let node_name = get_node_name(&opts.state, &node_opts.at_node);

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -150,9 +150,9 @@ fn print_node_info(
         println!("  Outlets:");
         for e in &outlets.list {
             println!("    Outlet:");
-            println!("      Forward Address: {}", e.tcp_addr);
+            println!("      Forward Address: {}", e.socket_addr);
 
-            if let Some(ma) = addr_to_multiaddr(&e.worker_addr) {
+            if let Some(ma) = addr_to_multiaddr(e.worker_addr.to_string()) {
                 println!("      Address: {ma}");
             }
         }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -2,8 +2,9 @@ use crate::node::{get_node_name, initialize_node_if_default};
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
+use std::net::SocketAddr;
 
-use crate::util::parsers::{host_parser, HostPort};
+use crate::util::parsers::socket_addr_parser;
 use crate::util::{node_rpc, Rpc};
 use crate::{display_parse_logs, fmt_log};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
@@ -35,8 +36,8 @@ pub struct CreateCommand {
     from: String,
 
     /// TCP address to send raw tcp traffic.
-    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS", value_parser = host_parser)]
-    to: HostPort,
+    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS", value_parser = socket_addr_parser)]
+    to: SocketAddr,
 
     /// Assign a name to this outlet.
     #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser)]
@@ -87,8 +88,8 @@ pub async fn run_impl(
 
     let send_req = async {
         let payload = CreateOutlet::new(
-            cmd.to.to_string(),
-            extract_address_value(&cmd.from)?,
+            cmd.to,
+            extract_address_value(&cmd.from)?.into(),
             cmd.alias,
             true,
         );

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -54,7 +54,7 @@ pub async fn run_impl(
     let addr = route_to_multiaddr(&route![outlet_to_show.worker_addr.to_string()])
         .ok_or_else(|| miette!("Invalid Outlet Address"))?;
     println!("  From Outlet: {addr}");
-    println!("  To TCP: {}", outlet_to_show.tcp_addr);
+    println!("  To TCP: {}", outlet_to_show.socket_addr);
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/output.rs
@@ -256,7 +256,7 @@ Outlet {}:
     Worker Address: {}
 "#,
             self.alias,
-            self.tcp_addr,
+            self.socket_addr,
             self.worker_address()?
         );
 
@@ -273,7 +273,7 @@ From {} to {}"#,
             self.worker_address()?
                 .to_string()
                 .color(OckamColor::PrimaryResource.color()),
-            self.tcp_addr
+            self.socket_addr
                 .to_string()
                 .color(OckamColor::PrimaryResource.color()),
         );

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -27,6 +27,7 @@ use ockam_core::TransportType;
 pub use options::{TcpConnectionOptions, TcpListenerOptions};
 pub use portal::{PortalInternalMessage, PortalMessage, MAX_PAYLOAD_SIZE};
 pub use registry::*;
+pub use transport::common::*;
 pub use transport::*;
 
 mod workers;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
@@ -122,7 +122,7 @@ impl TcpListener {
 }
 
 /// Resolve the given peer to a [`SocketAddr`](std::net::SocketAddr)
-pub(super) fn resolve_peer(peer: String) -> Result<SocketAddr> {
+pub fn resolve_peer(peer: String) -> Result<SocketAddr> {
     // Try to parse as SocketAddr
     if let Ok(p) = parse_socket_addr(&peer) {
         return Ok(p);

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
@@ -1,4 +1,4 @@
-mod common;
+pub(crate) mod common;
 mod connection;
 mod lifecycle;
 mod listener;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/portals.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/portals.rs
@@ -96,6 +96,19 @@ impl TcpTransport {
         Ok(())
     }
 
+    /// Create Tcp Outlet Listener at address, that connects to peer using Tcp
+    pub async fn create_tcp_outlet(
+        &self,
+        address: Address,
+        peer: SocketAddr,
+        options: TcpOutletOptions,
+    ) -> Result<()> {
+        TcpOutletListenWorker::start(&self.ctx, self.registry.clone(), address, peer, options)
+            .await?;
+
+        Ok(())
+    }
+
     /// Stop outlet at addr
     /// ```rust
     /// use ockam_transport_tcp::{TcpOutletOptions, TcpTransport};


### PR DESCRIPTION
This PR fixes a bug where we are not able to create an outlet:

![image](https://github.com/build-trust/ockam/assets/10988/cc48f7c7-37fe-4f10-bdc2-3be7f3ad09d6).

The fix consists in using proper types to propagate:

 - the socket address for an outlet
 - the worker address for an outlet worker

The propagation of these types leads to a change in the parsing of a socket address for the command line as well.
This partially reverts some of the code done in https://github.com/build-trust/ockam/pull/5595 so please @adrianbenavides have a look at this part in particular. From my testing it looks that we can use any of these input arguments to create an outlet now:

 - `--to 8080`
 - `--to localhost:8080`
 - `--to 127.0.0.1:8080` (IP V4)
 - `--to [::1]:8080` (IP V6)


