### PR TITLE
fix(rust): tcp-inlet handling on desktop app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "tauri-runtime",
  "thiserror",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-subscriber",
 ]

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -182,7 +182,7 @@ mod test {
 
         let non_expired = now + time::Duration::days(1);
         let non_expired_str = non_expired.format(&Iso8601::DEFAULT).unwrap();
-        assert!(is_expired(&non_expired_str).unwrap());
+        assert!(!is_expired(&non_expired_str).unwrap());
 
         let expired = now - time::Duration::days(1);
         let expired_str = expired.format(&Iso8601::DEFAULT).unwrap();

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -55,6 +55,7 @@ tauri-plugin-window = "2.0.0-alpha.0"
 tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
 thiserror = "1.0.47"
 tokio = { version = "1.31.0", features = ["full"] }
+tokio-retry = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"], optional = true }
 

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -28,12 +28,12 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
         .await
         .unwrap_or_else(|e| error!(?e, "Failed to enroll user"));
     system_tray_on_update(app);
-    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
-    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
     // Reset the node manager to include the project's setup, needed to create the relay.
     // This is necessary because the project data is used in the worker initialization,
     // which can't be rerun manually once the worker is started.
     app_state.reset_node_manager().await?;
+    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
     shared_service::relay::create_relay(&app_state).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -14,14 +14,8 @@ use crate::app::{AppState, NODE_NAME, PROJECT_NAME};
 use crate::cli::cli_bin;
 use crate::projects::commands::{create_enrollment_ticket, list_projects_with_admin};
 
-use super::{
-    events::REFRESHED_INVITATIONS,
-    state::{InvitationState, SyncState},
-};
+use super::{events::REFRESHED_INVITATIONS, state::SyncState};
 
-// At time of writing, tauri::command requires pub not pub(crate)
-
-#[tauri::command]
 pub async fn accept_invitation<R: Runtime>(id: String, app: AppHandle<R>) -> Result<(), String> {
     accept_invitation_impl(id, &app)
         .await
@@ -109,14 +103,6 @@ async fn send_invitation<R: Runtime>(
     Ok(())
 }
 
-#[tauri::command]
-pub async fn list_invitations<R: Runtime>(app: AppHandle<R>) -> tauri::Result<InvitationState> {
-    let state: State<'_, SyncState> = app.state();
-    let reader = state.read().await;
-    Ok((*reader).clone())
-}
-
-#[tauri::command]
 pub async fn refresh_invitations<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
     debug!("refreshing invitations");
     let state: State<'_, AppState> = app.state();

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -16,12 +16,7 @@ const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("invitations")
-        .invoke_handler(tauri::generate_handler![
-            accept_invitation,
-            create_service_invitation,
-            list_invitations,
-            refresh_invitations
-        ])
+        .invoke_handler(tauri::generate_handler![create_service_invitation,])
         .setup(|app, _api| {
             debug!("Initializing the invitations plugin");
             app.manage(Arc::new(RwLock::new(InvitationState::default())));
@@ -34,7 +29,6 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
 
             let handle = app.clone();
             spawn(async move {
-                handle.trigger_global(REFRESH_INVITATIONS, None);
                 let mut interval = tokio::time::interval(DEFAULT_POLL_INTERVAL);
                 loop {
                     interval.tick().await;

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -30,7 +30,6 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             });
             let handle = app.clone();
             spawn(async move {
-                handle.trigger_global(REFRESH_PROJECTS, None);
                 let mut interval = tokio::time::interval(DEFAULT_POLL_INTERVAL);
                 loop {
                     interval.tick().await;

--- a/implementations/rust/ockam/ockam_app/src/shared_service/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/events.rs
@@ -1,1 +1,0 @@
-pub const CHECK_RELAY: &str = "shared_service/relay/check";

--- a/implementations/rust/ockam/ockam_app/src/shared_service/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/mod.rs
@@ -1,4 +1,3 @@
-mod events;
 pub(crate) mod plugin;
 pub(crate) mod relay;
 pub(crate) mod tcp_outlet;

--- a/implementations/rust/ockam/ockam_app/src/shared_service/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/plugin.rs
@@ -1,44 +1,12 @@
-use std::time::Duration;
-
-use crate::app::AppState;
-use crate::shared_service::relay::create_relay;
 use crate::shared_service::tcp_outlet::*;
 
 use tauri::{
-    async_runtime::spawn,
     plugin::{Builder, TauriPlugin},
-    Manager, Wry,
+    Wry,
 };
-use tracing::{debug, info, trace};
-
-use super::events::CHECK_RELAY;
-
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(120);
 
 pub(crate) fn init() -> TauriPlugin<Wry> {
     Builder::new("shared_service")
         .invoke_handler(tauri::generate_handler![tcp_outlet_create])
-        .setup(|app, _api| {
-            debug!("Initializing the shared service plugin");
-            let handle = app.clone();
-            app.listen_global(CHECK_RELAY, move |_event| {
-                let handle = handle.clone();
-                spawn(async move {
-                    let app_state = handle.state::<AppState>();
-                    let _ = create_relay(&app_state).await;
-                });
-            });
-            let handle = app.clone();
-            spawn(async move {
-                let mut interval = tokio::time::interval(DEFAULT_POLL_INTERVAL);
-                loop {
-                    interval.tick().await;
-                    trace!("checking relay via background poll");
-                    handle.trigger_global(CHECK_RELAY, None);
-                }
-            });
-            info!("Shared service plugin initialized");
-            Ok(())
-        })
         .build()
 }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
@@ -2,6 +2,8 @@ use ockam::Context;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
+use tokio_retry::strategy::FixedInterval;
+use tokio_retry::Retry;
 use tracing::error;
 
 pub(crate) async fn load_model_state(
@@ -12,8 +14,11 @@ pub(crate) async fn load_model_state(
     let node_manager_worker = node_manager_worker.clone();
     let cli_state = cli_state.clone();
     tauri::async_runtime::spawn(async move {
-        let _ = super::create_relay_impl(&context, &cli_state, &node_manager_worker)
-            .await
-            .map_err(|e| error!(?e, "failed to create relay at the default project"));
+        let retry_strategy = FixedInterval::from_millis(60_000).take(10);
+        let _ = Retry::spawn(retry_strategy.clone(), || async {
+            super::create_relay_impl(&context, &cli_state, &node_manager_worker).await
+        })
+        .await
+        .map_err(|e| error!(?e, "failed to create relay at the default project"));
     });
 }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -86,7 +86,7 @@ pub fn on_create(app: &AppHandle<Wry>) -> tauri::Result<()> {
             let _ = w.move_window(Position::TopRight);
             w.show()?;
         }
-        Some(w) => w.show()?,
+        Some(w) => w.set_focus()?,
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -139,6 +139,14 @@ pub async fn project_enroll(
         }
     }
 
+    opts.state
+        .projects
+        .overwrite(&project.name, project.clone())?;
+
+    opts.state
+        .trust_contexts
+        .overwrite(trust_context_name, project.clone().try_into()?)?;
+
     // Create secure channel to the project's authority node
     // RPC is in embedded mode
     let secure_channel_addr = {
@@ -200,18 +208,8 @@ pub async fn project_enroll(
     .await
     .into_diagnostic()?;
 
-    opts.state
-        .projects
-        .overwrite(&project.name, project.clone())?;
-
-    opts.state
-        .trust_contexts
-        .overwrite(trust_context_name, project.clone().try_into()?)?;
-
     let credential = client2.credential().await.into_diagnostic()?;
-    println!("---");
-    println!("{credential}");
-    println!("---");
+    opts.terminal.stdout().plain(credential).write_line()?;
     Ok(project.name)
 }
 


### PR DESCRIPTION
- refactor(rust): invitation state to store the inlet data, so we can show it in the menu
- fix(rust): create tcp-inlet for invitation using separate commands instead of `run`
- fix(rust): don't use expired enrollment tokens when creating the tcp-inlet
- refactor(rust): relay is created using a retry strategy instead of using an event listener

There is a pending TODO that I'll address in a separate PR, as it needs changes on the `tcp-inlet create` command and it would complicate this PR too much.
