### PR TITLE
feat(rust): update the accepted invitation menu with the tcp-inlet socket address

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/cli/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use crate::error::Error::Generic;
+use crate::error::Error::App;
 use crate::Result;
 use ockam_core::env::get_env_with_default;
 use tracing::{error, info};
@@ -19,7 +19,7 @@ pub(crate) fn check_ockam_executable() -> Result<()> {
     if ockam_path != *"ockam" && !ockam_path.starts_with('/') {
         let message = format!("The OCKAM environment variable must be defined with an absolute path. The current value is: {ockam_path}");
         error!(message);
-        return Err(Generic(message));
+        return Err(App(message));
     };
 
     // Check that the executable can be found on the path
@@ -30,7 +30,7 @@ pub(crate) fn check_ockam_executable() -> Result<()> {
         Err(e) => {
             let message = format!("The ockam path could not be found: {e}");
             error!(message);
-            return Err(Generic(message));
+            return Err(App(message));
         }
         Ok(v) => info!(
             "The ockam command was found at {:?}",
@@ -47,7 +47,7 @@ pub(crate) fn check_ockam_executable() -> Result<()> {
         Err(e) => {
             let message = format!("The ockam command could not be executed correctly: {e}. Please execute $OCKAM --version or ockam --version");
             error!(message);
-            return Err(Generic(message));
+            return Err(App(message));
         }
         Ok(v) => info!(
             "The ockam command is available {:?}",

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -2,6 +2,7 @@ use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 #[cfg(target_os = "macos")]
 use tauri_runtime::menu::NativeImage;
 use tauri_runtime::menu::SystemTrayMenuItem;
+use tracing::error;
 
 use crate::app::events::SystemTrayOnUpdatePayload;
 use crate::app::AppState;
@@ -61,6 +62,10 @@ pub(crate) async fn build_enroll_section(
 /// Enroll the user and show that it has been enrolled
 pub fn on_enroll(app: &AppHandle<Wry>) -> tauri::Result<()> {
     let app_handle = app.clone();
-    tauri::async_runtime::spawn(async move { enroll_user(&app_handle).await });
+    tauri::async_runtime::spawn(async move {
+        enroll_user(&app_handle)
+            .await
+            .map_err(|e| error!(%e, "Failed to enroll user"))
+    });
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -6,7 +6,7 @@ use tauri::{
     plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 
 use super::commands::*;
 use super::events::{REFRESHED_INVITATIONS, REFRESH_INVITATIONS};
@@ -24,7 +24,11 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             let handle = app.clone();
             app.listen_global(REFRESH_INVITATIONS, move |_event| {
                 let handle = handle.clone();
-                spawn(async move { refresh_invitations(handle.clone()).await });
+                spawn(async move {
+                    refresh_invitations(handle.clone())
+                        .await
+                        .map_err(|e| error!(%e, "Failed to refresh invitations"))
+                });
             });
 
             let handle = app.clone();

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -61,7 +61,7 @@ fn add_manage_submenu(
 }
 
 fn add_pending_menu(submenu: SystemTrayMenu, sent: &[SentInvitation]) -> SystemTrayMenu {
-    debug!(?sent, "adding pending invitations menu");
+    trace!(?sent, "adding pending invitations menu");
     let header_text = if sent.is_empty() {
         "No Pending Invitations"
     } else {
@@ -109,7 +109,7 @@ fn pending_invitation_menu(invitation: &SentInvitation) -> SystemTraySubmenu {
 }
 
 fn add_received_menu(tray_menu: SystemTrayMenu, received: &[ReceivedInvitation]) -> SystemTrayMenu {
-    debug!(?received, "adding received invitations menu");
+    trace!(?received, "adding received invitations menu");
     let header_text = if received.is_empty() {
         "No Received Invitations"
     } else {
@@ -160,7 +160,7 @@ fn received_invite_menu(invitation: &ReceivedInvitation) -> SystemTraySubmenu {
 }
 
 fn add_accepted_menu(submenu: SystemTrayMenu, accepted: &AcceptedInvitations) -> SystemTrayMenu {
-    debug!(?accepted, "adding accepted invitations menu");
+    trace!(?accepted, "adding accepted invitations menu");
     let header_text = if accepted.invitations.is_empty() {
         "No Accepted Invitations"
     } else {

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -4,7 +4,7 @@ use tauri::SystemTraySubmenu;
 use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
 #[cfg(target_os = "macos")]
 use tauri_runtime::menu::NativeImage;
-use tracing::log::error;
+use tracing::error;
 
 use crate::app::events::system_tray_on_update;
 use crate::app::AppState;
@@ -74,7 +74,11 @@ pub fn on_refresh(app: &AppHandle<Wry>) -> tauri::Result<()> {
 /// Reset the persistent state
 pub fn on_reset(app: &AppHandle<Wry>) -> tauri::Result<()> {
     let app = app.clone();
-    tauri::async_runtime::spawn(async move { reset(&app).await });
+    tauri::async_runtime::spawn(async move {
+        reset(&app)
+            .await
+            .map_err(|e| error!(%e, "Failed to reset app"))
+    });
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -6,7 +6,7 @@ use tauri::{
     plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 
 use super::{
     commands::*,
@@ -26,7 +26,11 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             let handle = app.clone();
             app.listen_global(REFRESH_PROJECTS, move |_event| {
                 let handle = handle.clone();
-                spawn(async move { refresh_projects(handle.clone()).await });
+                spawn(async move {
+                    refresh_projects(handle.clone())
+                        .await
+                        .map_err(|e| error!(%e, "Failed to refresh projects"))
+                });
             });
             let handle = app.clone();
             spawn(async move {

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -58,13 +58,11 @@ async fn tcp_outlet_create_impl(
             system_tray_on_update(&app);
             Ok(())
         }
-        Err(_) => Err(Error::Generic("Failed to create outlet".to_string())),
+        Err(_) => Err(Error::App("Failed to create outlet".to_string())),
     }?;
 
     if let Some(email) = email {
-        create_service_invitation(email, socket_addr.to_string(), app)
-            .await
-            .map_err(Error::Generic)?;
+        create_service_invitation(email, socket_addr.to_string(), app).await?;
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/unit.bats
@@ -462,10 +462,9 @@ teardown() {
   sleep 1
 
   # Check that inlet is available for deletion and delete it
-  run $OCKAM tcp-inlet show test-inlet --at /node/n2
-  assert_output --partial "Alias: test-inlet"
-  assert_output --partial "TCP Address: 127.0.0.1:$inlet_port"
-  assert_output --regexp "To Outlet Address: /service/.*/service/outlet"
+  run $OCKAM tcp-inlet show test-inlet --at /node/n2 --output json
+  assert_output --partial "\"alias\":\"test-inlet\""
+  assert_output --partial "\"bind_addr\":\"127.0.0.1:$inlet_port\""
   assert_success
 
   run $OCKAM tcp-inlet delete "test-inlet" --at /node/n2 --yes


### PR DESCRIPTION
It also contains multiple changes mainly related to improving error management and logging, as well as changes that enhance error propagation rather than silent ignoring, for enroll, reset.

Most of the complexity of the tcp-inlet creation/management will be reduced once we are able to refactor that to stop using the CLI directly.