### PR TITLE
Remove service prefix

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -44,21 +44,13 @@ fn shared_service_submenu(outlet: &OutletStatus) -> SystemTraySubmenu {
         "Share".to_string(),
     ));
 
-    submenu = submenu
-        .add_item(
-            CustomMenuItem::new(
-                "outlet-tcp-address".to_string(),
-                format!("TCP Address: {}", outlet.socket_addr),
-            )
-            .disabled(),
+    submenu = submenu.add_item(
+        CustomMenuItem::new(
+            "outlet-tcp-address".to_string(),
+            format!("TCP Address: {}", outlet.socket_addr),
         )
-        .add_item(
-            CustomMenuItem::new(
-                "outlet-worker-address".to_string(),
-                format!("Worker Address: {}", worker_address),
-            )
-            .disabled(),
-        );
+        .disabled(),
+    );
 
     let outlet_info = String::from_utf8(worker_address.last().unwrap().data().to_vec())
         .unwrap_or_else(|_| worker_address.to_string());

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
@@ -2,7 +2,7 @@
   import { getCurrent } from "@tauri-apps/plugin-window";
   import { invoke } from "@tauri-apps/api/tauri";
 
-  let service = "/service/outlet";
+  let service = "";
   let port = "10000";
   let email = "";
   let error_message = "";
@@ -40,7 +40,7 @@
       <input
         type="text"
         class="w-full border-none bg-transparent px-4 text-right text-base focus:outline-none"
-        placeholder={service}
+        placeholder="service"
         bind:value={service}
       />
     </div>


### PR DESCRIPTION
This PR removes the `/service` prefix when creating a service
<img width="415" alt="image" src="https://github.com/build-trust/ockam/assets/10988/3d921375-c46e-453c-bfe5-12af8019911c">

And also removes the `Worker address` field for a shared service, since this has no meaning for an application user
<img width="493" alt="image" src="https://github.com/build-trust/ockam/assets/10988/7564a645-1170-4fa1-a6f1-612718e45574">

