### PR TITLE
feat(rust): added packages for ockam app for macos and ubuntu22.04

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -2,6 +2,12 @@ name: Build Ockam Binaries For Different Architechtures
 description: Build Ockam Binaries For Different Architechtures
 
 inputs:
+  build_command:
+    description: Indicate if building the ockam command
+    default: 'true'
+  build_app:
+    description: Indicate if we are also building ockam app
+    default: 'false'
   use_cross_build:
     description: Indicate If Cross Should Be Used To Build Binary Instead Of Cargo
     required: true
@@ -24,7 +30,17 @@ runs:
         profile: minimal
         override: true
         target: ${{ inputs.target }}
-
+    - name: setup node
+      if: inputs.build_app == 'true'
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598
+      if: inputs.build_app == 'true'
+      name: Install pnpm
+      with:
+        version: 8
+        run_install: false
     - shell: bash
       if: inputs.platform_operating_system == 'ubuntu-20.04'
       run: |
@@ -34,12 +50,24 @@ runs:
           cargo install --version 0.1.16 cross
         else
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+        fi
+    - shell: bash
+      if: inputs.platform_operating_system == 'ubuntu-22.04'
+      run: |
+        set -x
+        use_cross_build=${{ inputs.use_cross_build }}
+        if [[ $use_cross_build == true ]]; then
+          cargo install --version 0.1.16 cross
+        else
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
         fi
 
     ## TODO Cache for faster build for different targets
 
     - shell: bash
+      if: inputs.build_command == 'true'
       run: |
         set -x
         use_cross_build="${{ inputs.use_cross_build }}"
@@ -49,7 +77,16 @@ runs:
         fi
 
         if [[ $use_cross_build == "true" ]]; then
-          cross build --bin ockam --target ${{ inputs.target }} --verbose --release
+          cross build --bin ockam --target ${{ inputs.target }} --release
         else
-          cargo build --bin ockam --target ${{ inputs.target }} --verbose --release
+          cargo build --bin ockam --target ${{ inputs.target }} --release
         fi
+
+    - shell: bash
+      if: inputs.build_app == 'true'
+      run: |
+        set -x
+        cargo install --locked tauri-cli --version 2.0.0-alpha.10
+
+        cd implementations/rust/ockam/ockam_app/
+        cargo tauri build --target ${{ inputs.target }}

--- a/.github/actions/gradle_cache/action.yml
+++ b/.github/actions/gradle_cache/action.yml
@@ -6,9 +6,9 @@ runs:
     - uses: actions/cache@67b839edb68371cc5014f6cea11c9aa77238de78
       with:
         path: /root/.gradle/wrapper/dists
-        key: cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b
+        key: cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e
         restore-keys: |
-          cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b
+          cache-gradle-${{ github.workflow }}-${{ github.job }}-ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e
           cache-gradle-${{ github.workflow }}-${{ github.job }}-
           cache-gradle-${{ github.workflow }}-
           cache-gradle-

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,7 +43,7 @@ jobs:
     name: Gradle - full_build_in_release_mode
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b
+      image: ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -200,27 +200,39 @@ jobs:
           os: ubuntu-20.04
           toolchain: stable
           target: aarch64-unknown-linux-musl
+          build_app: false
           use-cross-build: true
         - build: linux_armv7
           os: ubuntu-20.04
           toolchain: stable
           target: armv7-unknown-linux-musleabihf
           use-cross-build: true
+          build_app: false
         - build: linux_86
           os: ubuntu-20.04
           toolchain: stable
           target: x86_64-unknown-linux-musl
           use-cross-build: true
+          build_app: false
+        - build: linux_86_gnu
+          os: ubuntu-22.04
+          toolchain: stable
+          target: x86_64-unknown-linux-gnu
+          use-cross-build: false
+          build_app: true
+          build_command: false
         - build: macos_silicon
           os: macos-latest
           toolchain: stable
           target: aarch64-apple-darwin
           use-cross-build: false
+          build_app: true
         - build: macos_86
           os: macos-latest
           toolchain: stable
           target: x86_64-apple-darwin
           use-cross-build: false
+          build_app: true
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository
@@ -237,12 +249,22 @@ jobs:
         toolchain: ${{ matrix.toolchain }}
         target: ${{ matrix.target }}
         platform_operating_system: ${{ matrix.os }}
+        build_app: ${{ matrix.build_app }}
 
-    - name: Build archive
+    - name: Copy Artifacts
       run: |
         set -x
+        find target/
         cp target/${{ matrix.target }}/release/ockam ockam.${{ matrix.target }}
-        echo "ASSET=ockam.${{ matrix.target }}" >> $GITHUB_ENV
+        echo "ASSET_OCKAM_CLI=ockam.${{ matrix.target }}" >> $GITHUB_ENV
+        if [ -e "target/${{ matrix.target }}/release/bundle/dmg/Ockam App"*dmg ]; then
+          cp "target/${{ matrix.target }}/release/bundle/dmg/Ockam App"*dmg "Ockam_App_${{ matrix.target }}.dmg"
+          echo "ASSET_OCKAM_APP_DMG=Ockam_App_${{ matrix.target }}.dmg" >> $GITHUB_ENV
+        fi
+        if [ -e "target/${{ matrix.target }}/release/bundle/deb/ockam-app"*.deb ]; then
+          cp "target/${{ matrix.target }}/release/bundle/deb/ockam-app"*.deb "ockam-app-${{ matrix.target }}.deb"
+          echo "ASSET_OCKAM_APP_DEB=ockam-app-${{ matrix.target }}.deb" >> $GITHUB_ENV
+        fi
         ls $GITHUB_WORKSPACE
 
     - name: Install Cosign
@@ -250,31 +272,81 @@ jobs:
       with:
         cosign-release: 'v2.0.0'
 
-    - name: Sign Binary
+    - name: Sign Binaries
       env:
         PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
         COSIGN_PASSWORD: '${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}'
       run: |
-        cosign sign-blob --yes --key env://PRIVATE_KEY ${{ env.ASSET }} > ${{ env.ASSET }}.sig
+        cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_CLI }}" > "${{ env.ASSET_OCKAM_CLI }}.sig"
+        if [ -n "${{ env.ASSET_OCKAM_APP_DMG }}" ]; then
+          cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_APP_DMG }}" > "${{ env.ASSET_OCKAM_APP_DMG }}.sig"
+        fi
+        if [ -n "${{ env.ASSET_OCKAM_APP_DEB }}" ]; then
+          cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_APP_DEB }}" > "${{ env.ASSET_OCKAM_APP_DEB }}.sig"
+        fi
 
-    - name: Upload release archive
+    - name: Upload CLI release archive
       uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
+        asset_path: ${{ env.ASSET_OCKAM_CLI }}
+        asset_name: ${{ env.ASSET_OCKAM_CLI }}
         asset_content_type: application/octet-stream
 
-    - name: Upload Signature
+    - name: Upload CLI Signature
       uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}.sig
-        asset_name: ${{ env.ASSET }}.sig
+        asset_path: ${{ env.ASSET_OCKAM_CLI }}.sig
+        asset_name: ${{ env.ASSET_OCKAM_CLI }}.sig
+        asset_content_type: application/octet-stream
+
+    - name: Upload MacOS App release
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_APP_DMG }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}
+        asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}
+        asset_content_type: application/octet-stream
+
+    - name: Upload MacOS App release Signature
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_APP_DMG }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
+        asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
+        asset_content_type: application/octet-stream
+
+    - name: Upload Debian App Package
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_APP_DEB }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_APP_DEB }}
+        asset_name: ${{ env.ASSET_OCKAM_APP_DEB }}
+        asset_content_type: application/octet-stream
+
+    - name: Upload Debian App Package Signature
+      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+      if: ${{ env.ASSET_OCKAM_APP_DEB }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ env.ASSET_OCKAM_APP_DEB }}.sig
+        asset_name: ${{ env.ASSET_OCKAM_APP_DEB }}.sig
         asset_content_type: application/octet-stream
 
   build_elixir_nifs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -196,7 +196,7 @@ jobs:
           os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-gnu
-          container: "ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b"
+          container: "ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
     steps:
@@ -289,7 +289,7 @@ jobs:
   test_docs_rust_library_examples:
     name: Rust - test_docs_rust_library_examples
     runs-on: ubuntu-20.04
-    container: ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b
+    container: ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e
     if: github.event_name == 'workflow_dispatch'
 
     steps:
@@ -320,7 +320,7 @@ jobs:
     name: Rust - lint_docs_ockam_io_rust_examples
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/build-trust/ockam-builder@sha256:9ee4558d834514e60a50c41bbf38c6ecae47d94dcfaa4df6a7256c262a7b0f4b
+      image: ghcr.io/build-trust/ockam-builder@sha256:65812150a60a114b1620f63dcf9f2380144985a213d54d3ef7978a0221bd147e
 
     steps:
       - name: Checkout Ockam Repository

--- a/implementations/rust/build.gradle
+++ b/implementations/rust/build.gradle
@@ -46,7 +46,7 @@ ext {
     command = ['cargo']
     command.addAll(arguments)
 
-    if (command.contains('build') && mode == 'release') {
+    if (command.contains('build') && !command.contains('tauri') && mode == 'release') {
       command.add('--release')
     }
 
@@ -147,6 +147,8 @@ task build {
     exec {
       environment environmentVars()
       commandLine cargo('--locked', 'build')
+      workingDir "ockam/ockam_app"
+      commandLine cargo('--locked', 'tauri', 'build')
     }
   }
 }

--- a/implementations/rust/ockam/ockam_app/src/cli/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/cli/mod.rs
@@ -22,6 +22,17 @@ pub(crate) fn check_ockam_executable() -> Result<()> {
         return Err(App(message));
     };
 
+    #[cfg(target_os = "macos")]
+    {
+        // HACK: ockam is not installed in a listed PATH on MacOS when installed with homebrew
+        // On MacOS, the ockam command is installed in /opt/homebrew/bin/ockam
+        // It won't work if the user installed homebrew in a different location
+        let mut paths = std::env::var_os("PATH").unwrap_or_default();
+        paths.push(":");
+        paths.push("/opt/homebrew/bin/");
+        std::env::set_var("PATH", &paths);
+    }
+
     // Check that the executable can be found on the path
     match duct::cmd!("which", ockam_path.clone())
         .stdout_capture()

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -2,7 +2,7 @@
   "build": {
     "beforeBuildCommand": {
       "cwd": "../../../typescript/ockam/ockam_app",
-      "script": "pnpm run build"
+      "script": "pnpm install . && pnpm run build"
     },
     "beforeDevCommand": {
       "cwd": "../../../typescript/ockam/ockam_app",
@@ -12,21 +12,21 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "Ockam",
-    "version": "0.1.0"
+    "productName": "Ockam App"
   },
   "tauri": {
     "systemTray": {
       "iconPath": "icons/icon.png",
       "iconAsTemplate": true
     },
+    "security": {
+      "csp": null
+    },
     "bundle": {
       "active": true,
       "category": "DeveloperTool",
-      "copyright": "",
-      "deb": {
-        "depends": []
-      },
+      "identifier": "io.ockam.app",
+      "publisher": "Ockam",
       "externalBin": [],
       "icon": [
         "icons/32x32.png",
@@ -35,27 +35,17 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "io.ockam.app",
-      "longDescription": "",
-      "macOS": {
-        "entitlements": null,
-        "exceptionDomain": "",
-        "frameworks": [],
-        "providerShortName": null,
-        "signingIdentity": null
-      },
       "resources": [],
-      "shortDescription": "",
-      "targets": "all",
-      "windows": {
-        "certificateThumbprint": null,
-        "digestAlgorithm": "sha256",
-        "timestampUrl": ""
+      "shortDescription": "Ockam App",
+      "longDescription": "End-to-end encryption and mutual authentication for distributed applications.",
+      "targets": [
+        "deb",
+        "dmg"
+      ],
+      "macOS": {
+      },
+      "deb": {
       }
-    },
-    "security": {
-      "csp": null
-    },
-    "windows": []
+    }
   }
 }


### PR DESCRIPTION
Added packages building for Ockam App via `cargo tauri build`, in `build_binaries/action.yml` I've added a parameter `build_app` populated within the matrix from `release-binaries.yml`.

MacOS .dmg package is built twice, for amd64 and for aarch64. The packages are not signed with Apple developer key, and can be installed via homebrew cask only with the `--no-quarantine` option. ([see related homebrew pr](https://github.com/build-trust/homebrew-ockam/pull/70))

to install it on mac:
`brew install --cask build-trust/ockam/ockam_app --no-quarantine`

The Ubuntu package is built against dynamic libraries, and supports only Ubuntu 22.04, a dedicated version for each version is needed.