### PR TITLE
fix(rust): read default values for GlobalArgs from env variables

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -144,7 +144,7 @@ pub struct GlobalArgs {
     help: Option<bool>,
 
     /// Do not print any log messages
-    #[arg(global = true, long, short)]
+    #[arg(global = true, long, short, default_value_t = quiet_default_value())]
     quiet: bool,
 
     /// Increase verbosity of trace messages
@@ -157,11 +157,11 @@ pub struct GlobalArgs {
     verbose: u8,
 
     /// Output without any colors
-    #[arg(hide = docs::hide(), global = true, long)]
+    #[arg(hide = docs::hide(), global = true, long, default_value_t = no_color_default_value())]
     no_color: bool,
 
     /// Disable tty functionality
-    #[arg(hide = docs::hide(), global = true, long)]
+    #[arg(hide = docs::hide(), global = true, long, default_value_t = no_input_default_value())]
     no_input: bool,
 
     /// Output format
@@ -180,17 +180,26 @@ pub struct GlobalArgs {
     test_argument_parser: bool,
 }
 
+fn quiet_default_value() -> bool {
+    get_env_with_default("QUIET", false).unwrap_or(false)
+}
+
+fn no_color_default_value() -> bool {
+    get_env_with_default("NO_COLOR", false).unwrap_or(false)
+}
+
+fn no_input_default_value() -> bool {
+    get_env_with_default("NO_INPUT", false).unwrap_or(false)
+}
+
 impl Default for GlobalArgs {
     fn default() -> Self {
-        let quiet = get_env_with_default("QUIET", false).unwrap_or(false);
-        let no_color = get_env_with_default("NO_COLOR", false).unwrap_or(false);
-        let no_input = get_env_with_default("NO_INPUT", false).unwrap_or(false);
         Self {
             help: None,
-            quiet,
+            quiet: quiet_default_value(),
             verbose: 0,
-            no_color,
-            no_input,
+            no_color: no_color_default_value(),
+            no_input: no_input_default_value(),
             output_format: OutputFormat::Plain,
             test_argument_parser: false,
         }

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -34,6 +34,12 @@ pub struct Terminal<T: TerminalWriter, WriteMode = ToStdErr> {
     mode: WriteMode,
 }
 
+impl<T: TerminalWriter, W> Terminal<T, W> {
+    pub fn is_quiet(&self) -> bool {
+        self.quiet
+    }
+}
+
 impl<W: TerminalWriter> Default for Terminal<W> {
     fn default() -> Self {
         Terminal::new(false, false, false, OutputFormat::Plain)

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -3,6 +3,9 @@
 # Unset OCKAM_LOG so it doesn't interfere in the CLI input/output
 unset OCKAM_LOG
 
+# Set QUIET to 1 to suppress user-facing logging
+export QUIET=1
+
 # Ockam binary to use
 if [[ -z $OCKAM ]]; then
   export OCKAM=ockam

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -3,7 +3,7 @@
 # Unset OCKAM_LOG so it doesn't interfere in the CLI input/output
 unset OCKAM_LOG
 
-# Set QUIET to 1 to suppress user-facing logging
+# Set QUIET to 1 to suppress user-facing logging written at stderr
 export QUIET=1
 
 # Ockam binary to use

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes_unit.bats
@@ -114,7 +114,7 @@ force_kill_node() {
 
 @test "node - background node logs to file" {
   n="$(random_str)"
-  $OCKAM node create $n
+  QUIET=0 $OCKAM node create $n
 
   log_file="$($OCKAM node logs $n)"
   if [ ! -s $log_file ]; then


### PR DESCRIPTION
- refactor(rust): print at least the code when enrolling with `QUIET=1`
- fix(rust): read default values for `GlobalArgs` from env variables
- test(rust): enable `QUIET` env var on bats tests to remove unnecessary noise on ci