### PR TITLE
feat(rust): rename the port field into address and support change the address and the port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "ockam_api",
  "ockam_core",
  "ockam_multiaddr",
+ "ockam_transport_tcp",
  "percent-encoding",
  "serde",
  "serde_json",

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -44,6 +44,7 @@ ockam = { path = "../ockam", version = "^0.91.0", features = ["software_vault"] 
 ockam_api = { path = "../ockam_api", version = "0.34.0", features = ["std", "authenticators"] }
 ockam_core = { path = "../ockam_core", version = "^0.84.0" }
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.25.0", features = ["cbor", "serde"] }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.85.0" }
 percent-encoding = "2.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -1,6 +1,6 @@
 use miette::{IntoDiagnostic, WrapErr};
 use ockam_api::address::extract_address_value;
-use std::net::SocketAddr;
+use ockam_transport_tcp::resolve_peer;
 use tauri::{AppHandle, Manager, Wry};
 use tracing::{debug, error, info};
 
@@ -9,16 +9,19 @@ use crate::app::AppState;
 use crate::error::Error;
 use crate::invitations::commands::create_service_invitation;
 
+/// The default host to use when creating a TCP outlet if the user doesn't specify one.
+const DEFAULT_HOST: &str = "localhost";
+
 /// Create a TCP outlet within the default node.
 #[tauri::command]
 pub async fn tcp_outlet_create(
     app: AppHandle<Wry>,
     service: String,
-    port: String,
+    address: String,
     email: String,
 ) -> Result<(), String> {
     let email = if email.is_empty() { None } else { Some(email) };
-    tcp_outlet_create_impl(app, service, port, email)
+    tcp_outlet_create_impl(app, service, address, email)
         .await
         .map_err(|e| {
             error!("{:?}", e);
@@ -30,15 +33,19 @@ pub async fn tcp_outlet_create(
 async fn tcp_outlet_create_impl(
     app: AppHandle<Wry>,
     service: String,
-    port: String,
+    address: String,
     email: Option<String>,
 ) -> crate::Result<()> {
-    debug!(%service, %port, "Creating an outlet");
+    debug!(%service, %address, "Creating an outlet");
     let app_state = app.state::<AppState>();
-    let socket_addr: SocketAddr = format!("127.0.0.1:{port}")
-        .parse()
+    let addr = if let Some((host, port)) = address.split_once(':') {
+        format!("{host}:{port}")
+    } else {
+        format!("{DEFAULT_HOST}:{address}")
+    };
+    let socket_addr = resolve_peer(addr)
         .into_diagnostic()
-        .wrap_err("Invalid port")?;
+        .wrap_err("Invalid address. The expected formats are 'host:port', 'ip:port' or 'port'")?;
     let worker_addr = extract_address_value(&service).wrap_err("Invalid service address")?;
     let node_manager_worker = app_state.node_manager_worker().await;
     let mut node_manager = node_manager_worker.inner().write().await;

--- a/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/service/ServiceCreate.svelte
@@ -3,7 +3,7 @@
   import { invoke } from "@tauri-apps/api/tauri";
 
   let service = "";
-  let port = "10000";
+  let address = "localhost:10000";
   let email = "";
   let error_message = "";
 
@@ -11,7 +11,7 @@
     error_message = "";
     await invoke("plugin:shared_service|tcp_outlet_create", {
       service: service,
-      port: port,
+      address: address,
       email: email,
     })
       .then(close)
@@ -47,15 +47,15 @@
   </div>
   <div class="flex items-start">
     <div class="flex-1">
-      <div class="font-bold">Port</div>
-      <p class="text-sm text-gray-500">Choose a port for the service</p>
+      <div class="font-bold">Address</div>
+      <p class="text-sm text-gray-500">Choose an address for the service</p>
     </div>
     <div class="flex-1">
       <input
         type="text"
         class="w-full border-none bg-transparent px-4 text-right text-base focus:outline-none"
-        placeholder={port}
-        bind:value={port}
+        placeholder={address}
+        bind:value={address}
       />
     </div>
   </div>


### PR DESCRIPTION
Sorry for the late PR, I had to take some time to parse the project structure tree.

## Current behavior

The Share a service window only allows the user to define the service port and the host address it always defaults to `127.0.0.1`

## Proposed changes

* Replace the Port field name to Address
* Support the formats `Host:Port`,  `IP:Port` and Port (defaulting to 127.0.0.1)
* Adapt the app backend to parse the address correctly.

> - Closes: #5685

## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. done via https://github.com/build-trust/ockam-contributors/pull/266

<!-- Looking forward to merging your contribution!! -->
