### PR TITLE
refactor(rust): display more detailed error messages to the user when `create_outlet` fails

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -55,7 +55,7 @@ impl NodeManager {
 
         // Check that there is no entry in the registry with the same alias
         if self.registry.outlets.contains_key(&alias) {
-            let message = format!("A TCP outlet with alias '{alias}' already exists");
+            let message = format!("A service with alias '{alias}' already exists");
             return Err(ockam_core::Error::new(
                 Origin::Node,
                 Kind::AlreadyExists,
@@ -112,7 +112,7 @@ impl NodeManager {
             }
             Err(e) => {
                 warn!(at = %socket_addr, err = %e, "Failed to create TCP outlet");
-                let message = format!("Failed to create outlet: {}", e);
+                let message = format!("{}", e);
                 return Err(ockam_core::Error::new(
                     Origin::Node,
                     Kind::Internal,

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -58,7 +58,7 @@ async fn tcp_outlet_create_impl(
             system_tray_on_update(&app);
             Ok(())
         }
-        Err(_) => Err(Error::App("Failed to create outlet".to_string())),
+        Err(_) => Err(Error::App(format!("Failed to create service: {}", e))),
     }?;
 
     if let Some(email) = email {

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs
@@ -58,7 +58,7 @@ async fn tcp_outlet_create_impl(
             system_tray_on_update(&app);
             Ok(())
         }
-        Err(_) => Err(Error::App(format!("Failed to create service: {}", e))),
+        Err(e) => Err(Error::App(format!("Failed to create service: {}", e))),
     }?;
 
     if let Some(email) = email {


### PR DESCRIPTION


<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently, when `NodeManager.create_outlet` returns an error, `tcp_outlet_create_impl` (the caller) does not parse it and returns a generic error message instead and thus does not give the user enough information about what has caused the failure. Also, the error message use the term _outlet_ which is considered to not be consistent with the UI, that instead refers to it as _service_.

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Issue #5850 

Including the source error message from [`NodeManager.create_outlet`](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs#L37) in [`tcp_outlet_create_impl`](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/create.rs#L30) and replacing the term _outlet_ with _service_ in those error messages.


## Checks

<!-- To help us review and merge this pull request quickly, please confirm the following:  -->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
