### PR TITLE
ci: add ockam app .dmg packages to the `sha256sums.txt` file

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -471,7 +471,7 @@ jobs:
         run: gh release download ${{ needs.create_release.outputs.tag_name }} -R ${{ github.repository_owner }}/ockam
 
       - name: Generate File SHASum
-        run: shasum -a 256 ockam.* > sha256sums.txt
+        run: shasum -a 256 ockam.* Ockam_* > sha256sums.txt
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19


### PR DESCRIPTION
In latest release, the ockam app homebrew description wasn't correctly generated because Ockam*.dmg wasn't listed in the `sha256sums.txt` file, this small fix solve the issue for the next release.