### PR TITLE
feat(rust): upgraded ockam app to tauri alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,9 +911,6 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "block"
@@ -3311,9 +3308,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
@@ -3623,9 +3620,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "javascriptcore-rs"
-version = "0.17.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110b9902c80c12bf113c432d0b71c7a94490b294a8234f326fd0abca2fac0b00"
+checksum = "4cfcc681b896b083864a4a3c3b3ea196f14ff66b8641a68fde209c6d84434056"
 dependencies = [
  "bitflags 1.3.2",
  "glib",
@@ -3634,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "javascriptcore-rs-sys"
-version = "0.5.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a216519a52cd941a733a0ad3f1023cfdb1cd47f3955e8e863ed56f558f916c"
+checksum = "b0983ba5b3ab9a0c0918de02c42dc71f795d6de08092f88a98ce9fdfdee4ba91"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -3660,16 +3657,18 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if",
  "combine",
  "jni-sys",
  "log",
  "thiserror",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3734,23 +3733,24 @@ dependencies = [
 
 [[package]]
 name = "keyboard-types"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+checksum = "0b7668b7cff6a51fe61cdde64cd27c8a220786f399501b57ebe36f7d8112fd68"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 1.3.2",
  "serde",
  "unicode-segmentation",
 ]
 
 [[package]]
-name = "kuchiki"
-version = "0.8.1"
+name = "kuchikiki"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+checksum = "f29e4755b7b995046f510a7520c42b2fed58b77bd94d5a87a8eb43d2fd126da8"
 dependencies = [
  "cssparser",
  "html5ever",
+ "indexmap 1.9.3",
  "matches",
  "selectors",
 ]
@@ -3868,25 +3868,6 @@ checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libxdo"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
-dependencies = [
- "libxdo-sys",
-]
-
-[[package]]
-name = "libxdo-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
-dependencies = [
- "libc",
- "x11",
 ]
 
 [[package]]
@@ -4012,13 +3993,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf 0.8.0",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -4254,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.9.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6112ff1d15dd7b53f26038bbaac8b481cbcb088c4b0eb0af28a4843c8b6c0cc"
+checksum = "41fe753ec4d3e8137a1d3ecb1aee1192b8f7661fe1247641968f5bf5f2e6ebbe"
 dependencies = [
  "cocoa 0.25.0",
  "crossbeam-channel",
@@ -4264,7 +4245,6 @@ dependencies = [
  "gdk-pixbuf",
  "gtk",
  "keyboard-types",
- "libxdo",
  "objc",
  "once_cell",
  "png",
@@ -4329,14 +4309,15 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "ndk"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
+checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -4348,9 +4329,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.3.0"
+version = "0.4.1+23.1.7779620"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
 dependencies = [
  "jni-sys",
 ]
@@ -4693,7 +4674,6 @@ dependencies = [
  "indoc",
  "log",
  "miette",
- "muda",
  "ockam",
  "ockam_api",
  "ockam_core",
@@ -5295,6 +5275,16 @@ checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -6266,7 +6256,7 @@ dependencies = [
  "log",
  "matches",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -6287,9 +6277,6 @@ name = "semver"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "semver-parser"
@@ -6727,9 +6714,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
  "loom",
 ]
@@ -6952,9 +6939,9 @@ dependencies = [
 
 [[package]]
 name = "swift-rs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e51d6f2b5fff4808614f429f8a7655ac8bcfe218185413f3a60c508482c2d6"
+checksum = "1bbdb58577b6301f8d17ae2561f32002a5bae056d444e0f69e611e504a276204"
 dependencies = [
  "base64 0.21.2",
  "serde",
@@ -7034,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.19.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746ae5d0ca57ae275a792f109f6e992e0b41a443abdf3f5c6eff179ef5b3443a"
+checksum = "9f76221bce9db3af6b2b9cca4e92d8ea46c4cc88d785bc4b1a5cbcaab06f0b56"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -7045,7 +7032,6 @@ dependencies = [
  "core-foundation",
  "core-graphics 0.22.3",
  "crossbeam-channel",
- "dirs-next",
  "dispatch",
  "gdk",
  "gdk-pixbuf",
@@ -7058,9 +7044,8 @@ dependencies = [
  "gtk",
  "image",
  "instant",
- "jni 0.20.0",
+ "jni 0.21.1",
  "lazy_static",
- "libappindicator",
  "libc",
  "log",
  "ndk",
@@ -7075,10 +7060,12 @@ dependencies = [
  "serde",
  "tao-macros",
  "unicode-segmentation",
+ "url",
  "uuid",
- "windows 0.44.0",
+ "windows 0.48.0",
  "windows-implement",
  "x11-dl",
+ "zbus",
 ]
 
 [[package]]
@@ -7100,13 +7087,13 @@ checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-alpha.10"
+version = "2.0.0-alpha.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e18377a75e314aa1d476896af881ed63f57a78ca84889fe63e69067f0de158d"
+checksum = "fad0a5c32ce9e3e9862fb8cd433abf63e65ffea9b80dcc44d3d991e6794ea9a6"
 dependencies = [
  "anyhow",
  "bytes 1.5.0",
- "cocoa 0.24.1",
+ "cocoa 0.25.0",
  "dirs-next",
  "embed_plist",
  "futures-util",
@@ -7115,16 +7102,17 @@ dependencies = [
  "gtk",
  "heck 0.4.1",
  "http",
- "jni 0.20.0",
+ "jni 0.21.1",
  "libc",
  "log",
+ "mime",
+ "muda",
  "objc",
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
  "reqwest",
- "semver 1.0.18",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7136,26 +7124,27 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "tempfile",
  "thiserror",
  "tokio",
+ "tray-icon",
  "url",
  "uuid",
  "webkit2gtk",
  "webview2-com",
- "windows 0.44.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52990870fd043f1d3bd6719ae713ef2e0c50431334d7249f6ae8509d1b8c326"
+checksum = "dc47d3c84f4aeac397cd956267f3b8060c5a2dba78288a5ccf9a8b7a8c1e7025"
 dependencies = [
  "anyhow",
  "cargo_toml",
  "heck 0.4.1",
  "json-patch",
+ "plist",
  "semver 1.0.18",
  "serde",
  "serde_json",
@@ -7167,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f1611ab0896f2693163ba4e8f3e39c02a1b70cdca4314286b5e365a5e08c6"
+checksum = "7f98a67c7ef3cb3c25de91fe1fa16cc3681997f6ec99da0a7496d6feae2ea91e"
 dependencies = [
  "base64 0.21.2",
  "brotli",
@@ -7193,9 +7182,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22752425c6dd6f3a058f376db7371f1d5bac250e340d40ba6c97ecf7182eef29"
+checksum = "b01cb5f945c71e040c5d191c32598565ae26cc266a9d5d4f7dd2dc324c5cfdd0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -7207,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-log"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a62d542a448bfd1905744f6ab4bc75c1af2cc100ba625e7b69099b0fd5730e3"
+checksum = "480b3f792fbcf0715d71ec4a987ec71cdade2d4260c493104b9b62f7f071bf4f"
 dependencies = [
  "android_logger",
  "byte-unit",
@@ -7228,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-notification"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcfe7e72c6c6e27ceb75d6a34f3e9ff9cd748fc0d0cb9288eafbef9a7d6b9cb"
+checksum = "d48386441f15145937754ce40d959fc556df3aab7c3ecdb81ac27035deb32c1e"
 dependencies = [
  "log",
  "notify-rust",
@@ -7247,9 +7236,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-positioner"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf78edfbd802cbd55f178edc2403865af02e13f09bd79ee1fd5b2a5dc1654a8"
+checksum = "cd0160d40ffed7ecd25511accc9c7f514a49b901ef203c639eb73166ec5d95df"
 dependencies = [
  "log",
  "serde",
@@ -7261,9 +7250,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-window"
-version = "2.0.0-alpha.0"
+version = "2.0.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209fef1a00a981949e2440924b4be267c7639daeba51b29179004fa1c6d74900"
+checksum = "06f3c1d40ae1a1b2b837e7f9b8db80aa2ee8c4594f63d729d2abd69f0741225a"
 dependencies = [
  "serde",
  "tauri",
@@ -7272,14 +7261,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.13.0-alpha.6"
+version = "1.0.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ce19f1309299bbc38ee9236307fad4943bd8fb09dd3fea5e9dd93c1d0898d6"
+checksum = "f5ba2ea1c0b7a2c3e53259edc3c78527e9f40fa7b45f73c52ab5165e42f9d18a"
 dependencies = [
  "gtk",
  "http",
  "http-range",
- "jni 0.20.0",
+ "jni 0.21.1",
  "rand 0.8.5",
  "raw-window-handle",
  "serde",
@@ -7288,18 +7277,18 @@ dependencies = [
  "thiserror",
  "url",
  "uuid",
- "windows 0.44.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.13.0-alpha.6"
+version = "1.0.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1231be42085f3a8b150e615601f8a070bd16bf579771a5dafe2931970a05b518"
+checksum = "095d8a6cb312211bd0ed6b51f078be2e5bba4e3244b5fdbe39fce2ebfc0d7a15"
 dependencies = [
  "cocoa 0.24.1",
  "gtk",
- "jni 0.20.0",
+ "jni 0.21.1",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
@@ -7308,15 +7297,15 @@ dependencies = [
  "uuid",
  "webkit2gtk",
  "webview2-com",
- "windows 0.44.0",
+ "windows 0.48.0",
  "wry",
 ]
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2812e0cdfffb892c654555b2f1b8c84a035b4c56eb1646cb3eb5a9d8164d8e"
+checksum = "06bcd7c6f67fd6371dcc22da7d7f26ec12c4eae26ad7bc54943bb9f35b5db302"
 dependencies = [
  "brotli",
  "ctor",
@@ -7326,7 +7315,7 @@ dependencies = [
  "html5ever",
  "infer",
  "json-patch",
- "kuchiki",
+ "kuchikiki",
  "memchr",
  "phf 0.10.1",
  "proc-macro2",
@@ -7338,7 +7327,7 @@ dependencies = [
  "thiserror",
  "url",
  "walkdir",
- "windows 0.44.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -7818,6 +7807,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tray-icon"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b164327e17101c78ba3dfdf879b977027ef1bd7855668ac30063de21fc02447"
+dependencies = [
+ "cocoa 0.25.0",
+ "core-graphics 0.23.1",
+ "crossbeam-channel",
+ "dirs-next",
+ "libappindicator",
+ "muda",
+ "objc",
+ "once_cell",
+ "png",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "treediff"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8269,9 +8277,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk"
-version = "0.19.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eea819afe15eb8dcdff4f19d8bfda540bae84d874c10e6f4b8faf2d6704bd1"
+checksum = "3ba4cce9085e0fb02575cfd45c328740dde78253cba516b1e8be2ca0f57bd8bf"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -8293,9 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk-sys"
-version = "0.19.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ac7a95ddd3fdfcaf83d8e513b4b1ad101b95b413b6aa6662ed95f284fc3d5b"
+checksum = "f4489eb24e8cf0a3d0555fd3a8f7adec2a5ece34c1e7b7c9a62da7822fd40a59"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -8313,38 +8321,39 @@ dependencies = [
 
 [[package]]
 name = "webview2-com"
-version = "0.22.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11296e5daf3a653b79bf47d66c380e4143d5b9c975818871179a3bda79499562"
+checksum = "79e563ffe8e84d42e43ffacbace8780c0244fc8910346f334613559d92e203ad"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.44.0",
+ "windows 0.48.0",
  "windows-implement",
+ "windows-interface",
 ]
 
 [[package]]
 name = "webview2-com-macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaebe196c01691db62e9e4ca52c5ef1e4fd837dcae27dae3ada599b5a8fd05ac"
+checksum = "ac1345798ecd8122468840bcdf1b95e5dc6d2206c5e4b0eafa078d061f59c9bc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.31",
 ]
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.22.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde542bed28058a5b028d459689ee57f1d06685bb6c266da3b91b1be6703952f"
+checksum = "19d39576804304cf9ead192467ef47f7859a1a12fec3bd459d5ba34b8cd65ed5"
 dependencies = [
  "regex",
  "serde",
  "serde_json",
  "thiserror",
- "windows 0.44.0",
+ "windows 0.48.0",
  "windows-bindgen",
  "windows-metadata",
 ]
@@ -8406,29 +8415,20 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
+ "windows-implement",
+ "windows-interface",
  "windows-targets 0.48.1",
 ]
 
 [[package]]
 name = "windows-bindgen"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222204ecf46521382a4d88b4a1bbefca9f8855697b4ab7d20803901425e061a3"
+checksum = "1fe21a77bc54b7312dbd66f041605e098990c98be48cd52967b85b5e60e75ae6"
 dependencies = [
  "windows-metadata",
  "windows-tokens",
@@ -8436,9 +8436,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
+checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8447,9 +8447,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
+checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8458,9 +8458,9 @@ dependencies = [
 
 [[package]]
 name = "windows-metadata"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee78911e3f4ce32c1ad9d3c7b0bd95389662ad8d8f1a3155688fed70bd96e2b6"
+checksum = "422ee0e5f0e2cc372bb6addbfff9a8add712155cd743df9c15f6ab000f31432d"
 
 [[package]]
 name = "windows-sys"
@@ -8512,9 +8512,9 @@ dependencies = [
 
 [[package]]
 name = "windows-tokens"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4251900975a0d10841c5d4bde79c56681543367ef811f3fabb8d1803b0959b"
+checksum = "b34c9a3b28cb41db7385546f7f9a8179348dffc89923dde66857b1ba5312f6b4"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8661,11 +8661,11 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d15f9f827d537cefe6d047be3930f5d89b238dfb85e08ba6a319153217635aa"
+checksum = "07bf838a5430184dfe0b1f568af7998a455c0df75a1df300a3894e0f181e7408"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "block",
  "cocoa 0.24.1",
  "core-graphics 0.22.3",
@@ -8678,7 +8678,7 @@ dependencies = [
  "html5ever",
  "http",
  "javascriptcore-rs",
- "kuchiki",
+ "kuchikiki",
  "libc",
  "log",
  "objc",
@@ -8694,7 +8694,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.44.0",
+ "windows 0.48.0",
  "windows-implement",
 ]
 

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 path = "src/lib.rs"
 
 [build-dependencies]
-tauri-build = { version = "2.0.0-alpha.6", features = [] }
+tauri-build = { version = "=2.0.0-alpha.8", features = [] }
 
 [dependencies]
 duct = "0.13.6"
@@ -39,7 +39,6 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde
 indoc = "2.0.3"
 log = { version = "0.4.20", optional = true }
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
-muda = "0.9"
 ockam = { path = "../ockam", version = "^0.91.0", features = ["software_vault"] }
 ockam_api = { path = "../ockam_api", version = "0.34.0", features = ["std", "authenticators"] }
 ockam_core = { path = "../ockam_core", version = "^0.84.0" }
@@ -48,13 +47,13 @@ ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.85.0" }
 percent-encoding = "2.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tauri = { version = "2.0.0-alpha.10", features = ["system-tray"] }
-tauri-plugin-log = { version = "2.0.0-alpha.0", optional = true }
-tauri-plugin-notification = "2.0.0-alpha"
-tauri-plugin-positioner = { version = "2.0.0-alpha.0", features = ["system-tray"] }
-tauri-plugin-window = "2.0.0-alpha.0"
-tauri-runtime = { version = "0.13.0-alpha.6", features = ["system-tray"] }
-thiserror = "1.0.48"
+tauri = { version = "=2.0.0-alpha.11", features = ["tray-icon"] }
+tauri-plugin-log = { version = "=2.0.0-alpha.1", optional = true }
+tauri-plugin-notification = "=2.0.0-alpha.2"
+tauri-plugin-positioner = { version = "=2.0.0-alpha.1", features = ["tray-icon"] }
+tauri-plugin-window = "=2.0.0-alpha.1"
+tauri-runtime = "=1.0.0-alpha.0"
+thiserror = "1.0.47 "
 tokio = { version = "1.31.0", features = ["full"] }
 tokio-retry = "0.3"
 tracing = "0.1"

--- a/implementations/rust/ockam/ockam_app/src/app/dev_tools.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/dev_tools.rs
@@ -1,0 +1,43 @@
+use crate::app::AppState;
+use crate::options::{DEV_MENU_ID, OPEN_DEV_TOOLS_ID, REFRESH_MENU_ID};
+use tauri::menu::{CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+use tauri::{AppHandle, Manager, Runtime, State};
+
+pub async fn build_developer_tools_section<'a, R: Runtime, M: Manager<R>>(
+    app_handle: &AppHandle<R>,
+    builder: MenuBuilder<'a, R, M>,
+) -> MenuBuilder<'a, R, M> {
+    let app_state: State<AppState> = app_handle.state();
+
+    builder.item(
+        &SubmenuBuilder::new(app_handle, "Developer Tools")
+            .items(&[
+                &MenuItemBuilder::with_id(REFRESH_MENU_ID, "Refresh Data").build(app_handle),
+                &CheckMenuItemBuilder::with_id(OPEN_DEV_TOOLS_ID, "Browser Dev Tools")
+                    .enabled(true)
+                    .checked(app_state.browser_dev_tools())
+                    .build(app_handle),
+                &MenuItemBuilder::with_id(
+                    DEV_MENU_ID,
+                    format!("Controller Address: {}", app_state.controller_address()),
+                )
+                .build(app_handle),
+            ])
+            .build()
+            .expect("developer submenu build failed"),
+    )
+}
+
+pub fn on_refresh<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
+    app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
+    use crate::app::events::system_tray_on_update;
+    system_tray_on_update(app);
+    Ok(())
+}
+
+pub(crate) fn toggle_dev_tools<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let state: State<AppState> = app.state();
+    state.set_browser_dev_tools(!state.browser_dev_tools());
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_app/src/app/events.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/events.rs
@@ -1,7 +1,6 @@
 use tauri::{AppHandle, Manager, Runtime};
 
 pub const SYSTEM_TRAY_ON_UPDATE: &str = "app/system_tray/on_update";
-
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SystemTrayOnUpdatePayload {
     /// An optional status message that is shown when the application

--- a/implementations/rust/ockam/ockam_app/src/app/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/mod.rs
@@ -7,6 +7,8 @@ pub use setup::*;
 pub use state::*;
 pub use tray_menu::*;
 
+#[cfg(debug_assertions)]
+mod dev_tools;
 pub(crate) mod events;
 #[cfg(feature = "log")]
 mod logging;

--- a/implementations/rust/ockam/ockam_app/src/app/process.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/process.rs
@@ -1,8 +1,8 @@
 use crate::app::events::system_tray_on_update;
-use tauri::{AppHandle, RunEvent, Wry};
+use tauri::{AppHandle, RunEvent, Runtime};
 
 /// This is the function dispatching application events
-pub fn process_application_event(app: &AppHandle<Wry>, event: RunEvent) {
+pub fn process_application_event<R: Runtime>(app: &AppHandle<R>, event: RunEvent) {
     match event {
         RunEvent::ExitRequested { api, .. } => {
             api.prevent_exit();

--- a/implementations/rust/ockam/ockam_app/src/app/setup.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/setup.rs
@@ -1,40 +1,64 @@
 use crate::app::events::{SystemTrayOnUpdatePayload, SYSTEM_TRAY_ON_UPDATE};
-use crate::app::{build_tray_menu, process_system_tray_event};
+use crate::app::{build_tray_menu, process_system_tray_menu_event};
 use std::error::Error;
-use tauri::{async_runtime::spawn, App, Manager, SystemTray, Wry};
+use std::mem::forget;
+use std::sync::{Arc, Mutex};
+use tauri::async_runtime::spawn;
+use tauri::menu::Menu;
+use tauri::tray::TrayIconBuilder;
+use tauri::{App, Manager, Runtime};
 use tracing::{debug, error, info};
 
 /// Create the initial version of the system tray menu and the event listeners to update it.
-pub fn setup(app: &mut App<Wry>) -> Result<(), Box<dyn Error>> {
+pub fn setup<R: Runtime>(app: &mut App<R>) -> Result<(), Box<dyn Error>> {
     debug!("Setting up app");
 
-    let handle = app.handle();
-    let tray_menu = tauri::async_runtime::block_on(build_tray_menu(&handle, None));
-    SystemTray::new()
-        .with_menu(tray_menu)
-        .on_event(move |event| process_system_tray_event(&handle, event))
+    // Building the tray here rather than using the `tauri.conf.json` mechanism
+    // to sidestep breaking changes the file format and consequent dependency
+    // on a specific version of tauri-cli.
+    TrayIconBuilder::with_id("tray")
+        .tooltip("Ockam")
+        .icon_as_template(true)
+        .icon(app.default_window_icon().unwrap().clone())
+        .on_menu_event(process_system_tray_menu_event)
         .build(app)
         .expect("Couldn't initialize the system tray menu");
 
-    let handle = app.handle();
-    app.listen_global(SYSTEM_TRAY_ON_UPDATE, move |event| {
-        let payload = match event.payload() {
-            Some(p) => match SystemTrayOnUpdatePayload::try_from(p) {
-                Ok(p) => Some(p),
-                Err(e) => {
-                    error!(?e, "Couldn't deserialize payload");
-                    None
-                }
-            },
-            None => None,
-        };
-        let handle = handle.clone();
-        spawn(async move {
-            handle
-                .tray_handle()
-                .set_menu(build_tray_menu(&handle, payload).await)
+    // by design we have to keep our own reference to keep the menu alive
+    let menu_holder = Arc::new(Mutex::new(None::<Menu<R>>));
+    {
+        let handle = app.handle().clone();
+        let menu_holder = menu_holder.clone();
+        app.listen_global(SYSTEM_TRAY_ON_UPDATE, move |event| {
+            let payload = match event.payload() {
+                Some(p) => match SystemTrayOnUpdatePayload::try_from(p) {
+                    Ok(p) => Some(p),
+                    Err(e) => {
+                        error!(?e, "Couldn't deserialize payload");
+                        None
+                    }
+                },
+                None => None,
+            };
+
+            let menu_holder = menu_holder.clone();
+            let handle = handle.clone();
+            spawn(async move {
+                debug!("Building system tray menu");
+                let tray = handle.tray().unwrap();
+                let menu = build_tray_menu(&handle, payload).await;
+
+                let old_menu = menu_holder.lock().unwrap().replace(menu.clone());
+                tray.set_menu(Some(menu.clone()))
+                    .expect("Couldn't update menu");
+
+                // HACK: leak the previous menu to avoid a crash on macOS
+                // TODO: remove me once tauri 2.0 stable is out
+                forget(old_menu);
+            });
         });
-    });
+    }
+
     info!("App setup complete");
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/tray_menu.rs
@@ -1,48 +1,54 @@
-use tauri::{AppHandle, Manager, State, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, Wry};
+use tauri::menu::{Menu, MenuBuilder, MenuEvent};
+use tauri::{AppHandle, Runtime};
 use tracing::error;
 
+#[cfg(debug_assertions)]
+use crate::app::dev_tools;
 use crate::app::events::SystemTrayOnUpdatePayload;
-use crate::app::AppState;
 use crate::enroll::{build_enroll_section, build_user_info_section};
 use crate::invitations::{self, build_invitations_section};
 use crate::options::build_options_section;
 use crate::shared_service::build_shared_services_section;
 use crate::{enroll, options, shared_service};
 
-pub async fn build_tray_menu(
-    app_handle: &AppHandle,
+pub async fn build_tray_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
     payload: Option<SystemTrayOnUpdatePayload>,
-) -> SystemTrayMenu {
-    let app_state: State<'_, AppState> = app_handle.state();
-    let mut tray_menu = SystemTrayMenu::new();
-    tray_menu = build_user_info_section(&app_state, tray_menu).await;
-    tray_menu = build_enroll_section(&app_state, tray_menu, &payload).await;
-    tray_menu = build_shared_services_section(&app_state, tray_menu).await;
-    tray_menu = build_invitations_section(app_handle, tray_menu).await;
-    tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
-    tray_menu = build_options_section(&app_state, tray_menu).await;
-    tray_menu
+) -> Menu<R> {
+    let mut builder = MenuBuilder::new(app_handle);
+
+    builder = build_user_info_section(app_handle, builder).await;
+    builder = build_enroll_section(app_handle, builder, &payload).await;
+    builder = build_shared_services_section(app_handle, builder).await;
+    builder = build_invitations_section(app_handle, builder).await;
+    builder = build_options_section(app_handle, builder).await;
+    #[cfg(debug_assertions)]
+    {
+        builder = dev_tools::build_developer_tools_section(app_handle, builder).await;
+    }
+
+    builder.build().expect("tray menu build failed")
 }
 
-/// This is the function dispatching events for the SystemTray
-pub fn process_system_tray_event(app: &AppHandle<Wry>, event: SystemTrayEvent) {
-    if let SystemTrayEvent::MenuItemClick { id, .. } = event {
-        let result = match id.as_str() {
-            enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
-            shared_service::SHARED_SERVICE_CREATE_MENU_ID => shared_service::on_create(app),
-            #[cfg(debug_assertions)]
-            options::REFRESH_MENU_ID => options::on_refresh(app),
-            options::RESET_MENU_ID => options::on_reset(app),
-            options::QUIT_MENU_ID => options::on_quit(),
-            id => fallback_for_id(app, id),
-        };
-        if let Err(e) = result {
-            error!("{:?}", e)
-        }
+/// This is the function dispatching events for the SystemTray Menu
+pub fn process_system_tray_menu_event<R: Runtime>(app: &AppHandle<R>, event: MenuEvent) {
+    let result = match event.id.as_ref() {
+        enroll::ENROLL_MENU_ID => enroll::on_enroll(app),
+        shared_service::SHARED_SERVICE_CREATE_MENU_ID => shared_service::on_create(app),
+        #[cfg(debug_assertions)]
+        options::REFRESH_MENU_ID => dev_tools::on_refresh(app),
+        #[cfg(debug_assertions)]
+        options::OPEN_DEV_TOOLS_ID => dev_tools::toggle_dev_tools(app),
+        options::RESET_MENU_ID => options::on_reset(app),
+        options::QUIT_MENU_ID => options::on_quit(),
+        id => fallback_for_id(app, id),
+    };
+    if let Err(e) = result {
+        error!("{:?}", e)
     }
 }
 
-fn fallback_for_id(app: &AppHandle<Wry>, s: &str) -> tauri::Result<()> {
+fn fallback_for_id<R: Runtime>(app: &AppHandle<R>, s: &str) -> tauri::Result<()> {
     if s.starts_with("invitation-") {
         invitations::dispatch_click_event(app, s)
     } else {

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -1,7 +1,7 @@
 use miette::{miette, IntoDiagnostic, WrapErr};
 
 use ockam_api::address::controller_route;
-use tauri::{AppHandle, Manager, State, Wry};
+use tauri::{AppHandle, Manager, Runtime, State};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info};
 
@@ -22,7 +22,7 @@ use crate::{shared_service, Result};
 ///  - creates a default node, with a default identity if it doesn't exist
 ///  - connects to the OIDC service to authenticate the user of the Ockam application to retrieve a token
 ///  - connects to the Orchestrator with the retrieved token to create a project
-pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
+pub async fn enroll_user<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     let app_state: State<AppState> = app.state::<AppState>();
     enroll_with_token(app, &app_state)
         .await
@@ -38,7 +38,7 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
     Ok(())
 }
 
-async fn enroll_with_token(app: &AppHandle<Wry>, app_state: &AppState) -> Result<()> {
+async fn enroll_with_token<R: Runtime>(app: &AppHandle<R>, app_state: &AppState) -> Result<()> {
     if app_state.is_enrolled().await.unwrap_or_default() {
         debug!("User is already enrolled");
         return Ok(());
@@ -132,8 +132,8 @@ async fn retrieve_space(app_state: &AppState) -> Result<Space> {
     Ok(space)
 }
 
-async fn retrieve_project(
-    app: &AppHandle<Wry>,
+async fn retrieve_project<R: Runtime>(
+    app: &AppHandle<R>,
     app_state: &AppState,
     space: &Space,
 ) -> Result<Project> {

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -1,7 +1,5 @@
-use tauri::{AppHandle, CustomMenuItem, SystemTrayMenu, Wry};
-#[cfg(target_os = "macos")]
-use tauri_runtime::menu::NativeImage;
-use tauri_runtime::menu::SystemTrayMenuItem;
+use tauri::menu::{IconMenuItemBuilder, MenuBuilder, MenuItemBuilder, NativeIcon};
+use tauri::{AppHandle, Manager, Runtime, State};
 use tracing::error;
 
 use crate::app::events::SystemTrayOnUpdatePayload;
@@ -13,54 +11,69 @@ pub const ENROLL_MENU_HEADER_ID: &str = "enroll-header";
 pub const ENROLL_MENU_ID: &str = "enroll";
 pub const ENROLL_MENU_USER_NAME: &str = "user-name";
 
-pub(crate) async fn build_user_info_section(
-    app_state: &AppState,
-    tray_menu: SystemTrayMenu,
-) -> SystemTrayMenu {
-    match app_state.user_info().await {
-        Ok(user_info) => {
-            let item = CustomMenuItem::new(
-                ENROLL_MENU_USER_NAME,
-                format!("{} ({})", user_info.name, user_info.nickname),
-            );
-            #[cfg(target_os = "macos")]
-            let item = item.native_image(NativeImage::User);
-            tray_menu
-                .add_item(item)
-                .add_item(CustomMenuItem::new(ENROLL_MENU_EMAIL, user_info.email).disabled())
-        }
-        Err(_) => tray_menu,
+pub(crate) async fn build_user_info_section<'a, R: Runtime, M: Manager<R>>(
+    app_handle: &AppHandle<R>,
+    mut builder: MenuBuilder<'a, R, M>,
+) -> MenuBuilder<'a, R, M> {
+    let app_state: State<AppState> = app_handle.state();
+    if let Ok(user_info) = app_state.user_info().await {
+        builder = builder.items(&[
+            &IconMenuItemBuilder::new(format!("{} ({})", user_info.name, user_info.nickname))
+                .id(ENROLL_MENU_USER_NAME)
+                .native_icon(NativeIcon::User)
+                .build(app_handle),
+            &MenuItemBuilder::new(user_info.email)
+                .id(ENROLL_MENU_EMAIL)
+                .enabled(false)
+                .build(app_handle),
+        ])
     }
+    builder
 }
 
-pub(crate) async fn build_enroll_section(
-    app_state: &AppState,
-    tray_menu: SystemTrayMenu,
+pub(crate) async fn build_enroll_section<'a, R: Runtime, M: Manager<R>>(
+    app_handle: &AppHandle<R>,
+    mut builder: MenuBuilder<'a, R, M>,
     payload: &Option<SystemTrayOnUpdatePayload>,
-) -> SystemTrayMenu {
+) -> MenuBuilder<'a, R, M> {
+    let app_state: State<AppState> = app_handle.state();
+
     if let Some(payload) = &payload {
         if let Some(message) = &payload.enroll_status {
-            let tray_menu = match app_state.user_info().await {
-                Err(_) => tray_menu,
-                Ok(_) => tray_menu.add_native_item(SystemTrayMenuItem::Separator),
-            };
-            return tray_menu
-                .add_item(CustomMenuItem::new(ENROLL_MENU_HEADER_ID, "Enrolling...").disabled())
-                .add_item(CustomMenuItem::new("status", message).disabled());
+            return builder.items(&[
+                &MenuItemBuilder::new("Enrolling...")
+                    .id(ENROLL_MENU_HEADER_ID)
+                    .enabled(false)
+                    .build(app_handle),
+                &IconMenuItemBuilder::new(message)
+                    .id("status")
+                    .native_icon(NativeIcon::StatusPartiallyAvailable)
+                    .enabled(false)
+                    .build(app_handle),
+            ]);
         }
     }
-    if app_state.is_enrolled().await.unwrap_or(false) {
-        tray_menu
-    } else {
-        tray_menu
-            .add_item(CustomMenuItem::new(ENROLL_MENU_HEADER_ID, "Please enroll").disabled())
-            .add_item(CustomMenuItem::new(ENROLL_MENU_ID, "Enroll...").accelerator("cmd+e"))
+
+    if !app_state.is_enrolled().await.unwrap_or(false) {
+        builder = builder.items(&[
+            &IconMenuItemBuilder::new("Please enroll")
+                .id(ENROLL_MENU_HEADER_ID)
+                .native_icon(NativeIcon::User)
+                .enabled(false)
+                .build(app_handle),
+            &MenuItemBuilder::new("Enroll...")
+                .id(ENROLL_MENU_ID)
+                .accelerator("cmd+e")
+                .build(app_handle),
+        ])
     }
+
+    builder
 }
 
 /// Event listener for the "Enroll" menu item
 /// Enroll the user and show that it has been enrolled
-pub fn on_enroll(app: &AppHandle<Wry>) -> tauri::Result<()> {
+pub fn on_enroll<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
         enroll_user(&app_handle)

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -12,7 +12,7 @@ use super::commands::*;
 use super::events::{REFRESHED_INVITATIONS, REFRESH_INVITATIONS};
 use super::state::InvitationState;
 
-const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60);
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("invitations")

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -1,15 +1,11 @@
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use std::net::SocketAddr;
-use tauri::{
-    AppHandle, CustomMenuItem, Manager, State, SystemTrayMenu, SystemTrayMenuItem,
-    SystemTraySubmenu, Wry,
-};
+use tauri::menu::{MenuBuilder, MenuItemBuilder, Submenu, SubmenuBuilder};
+use tauri::{AppHandle, Manager, Runtime, State};
 use tauri_plugin_positioner::{Position, WindowExt};
 use tracing::{debug, trace, warn};
 
-use ockam_api::cloud::share::{
-    InvitationWithAccess, ReceivedInvitation, SentInvitation, ShareScope,
-};
+use ockam_api::cloud::share::{InvitationWithAccess, ReceivedInvitation, SentInvitation};
 
 use super::state::SyncState;
 use crate::app::AppState;
@@ -32,206 +28,237 @@ const PATH_ENCODING_SET: AsciiSet = CONTROLS
     .add(b'{')
     .add(b'}');
 
-pub(crate) async fn build_invitations_section(
-    app_handle: &AppHandle,
-    tray_menu: SystemTrayMenu,
-) -> SystemTrayMenu {
+pub(crate) async fn build_invitations_section<'a, R: Runtime, M: Manager<R>>(
+    app_handle: &AppHandle<R>,
+    mut builder: MenuBuilder<'a, R, M>,
+) -> MenuBuilder<'a, R, M> {
     let app_state: State<'_, AppState> = app_handle.state();
     if !app_state.is_enrolled().await.unwrap_or(false) {
         trace!("not enrolled, skipping invitations menu");
-        return tray_menu;
+        return builder;
     };
 
     let state: State<'_, SyncState> = app_handle.state();
     let reader = state.read().await;
-    let mut tray_menu = tray_menu.add_native_item(SystemTrayMenuItem::Separator);
-    tray_menu = add_received_menu(tray_menu, &reader.received);
-    add_manage_submenu(&reader.accepted, &reader.sent, tray_menu)
+    builder = builder.item(&add_received_menu(app_handle, &reader.received));
+
+    builder.item(&add_manage_submenu(
+        app_handle,
+        &reader.accepted,
+        &reader.sent,
+    ))
 }
 
-fn add_manage_submenu(
+fn add_manage_submenu<R: Runtime>(
+    app_handle: &AppHandle<R>,
     accepted: &AcceptedInvitations,
     sent: &[SentInvitation],
-    tray_menu: SystemTrayMenu,
-) -> SystemTrayMenu {
-    let mut submenu = SystemTrayMenu::new();
-    submenu = add_pending_menu(submenu, sent);
-    submenu = add_accepted_menu(submenu, accepted);
-    tray_menu.add_submenu(SystemTraySubmenu::new("Manage Invitations...", submenu))
+) -> Submenu<R> {
+    SubmenuBuilder::new(app_handle, "Manage Invitations...")
+        .items(&[
+            &add_pending_menu(app_handle, sent),
+            &add_accepted_menu(app_handle, accepted),
+        ])
+        .build()
+        .expect("manage invitation menu build failed")
 }
 
-fn add_pending_menu(submenu: SystemTrayMenu, sent: &[SentInvitation]) -> SystemTrayMenu {
+fn add_pending_menu<R: Runtime>(app_handle: &AppHandle<R>, sent: &[SentInvitation]) -> Submenu<R> {
     trace!(?sent, "adding pending invitations menu");
     let header_text = if sent.is_empty() {
         "No Pending Invitations"
     } else {
         "Pending Invitations"
     };
-    sent.iter().map(pending_invitation_menu).fold(
-        submenu.add_item(
-            CustomMenuItem::new(INVITATIONS_PENDING_HEADER_MENU_ID, header_text).disabled(),
-        ),
-        |menu, submenu| menu.add_submenu(submenu),
-    )
+
+    let mut submenu_builder =
+        SubmenuBuilder::with_id(app_handle, INVITATIONS_PENDING_HEADER_MENU_ID, header_text);
+
+    submenu_builder = sent
+        .iter()
+        .map(|invitation| pending_invitation_menu(app_handle, invitation))
+        .fold(submenu_builder, |submenu_builder, submenu| {
+            submenu_builder.item(&submenu)
+        });
+
+    submenu_builder
+        .build()
+        .expect("cannot build pending submenu")
 }
 
-fn pending_invitation_menu(invitation: &SentInvitation) -> SystemTraySubmenu {
+fn pending_invitation_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    invitation: &SentInvitation,
+) -> Submenu<R> {
     let id = invitation.id.to_owned();
-    let target_label = match invitation.scope {
-        ShareScope::Project => "Project",
-        ShareScope::Service => "Service",
-        ShareScope::Space => "Space",
-    };
-    let submenu = SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new(id.clone(), id.clone()).disabled())
-        .add_item(
-            CustomMenuItem::new(
-                id.clone(),
-                format!("Sent to: {}", invitation.recipient_email),
-            )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
-                id.clone(),
-                format!("{}: {}", target_label, invitation.target_id),
-            )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+
+    SubmenuBuilder::with_id(app_handle, id.clone(), &id)
+        .items(&[
+            &MenuItemBuilder::with_id(id.clone(), id.clone())
+                .enabled(true)
+                .build(app_handle),
+            &MenuItemBuilder::with_id(id.clone(), &invitation.recipient_email)
+                .enabled(false)
+                .build(app_handle),
+            &MenuItemBuilder::with_id(
                 format!("invitation-sent-cancel-{}", invitation.id),
                 "Cancel",
             )
-            .disabled(),
-        );
-    SystemTraySubmenu::new(id, submenu)
+            .enabled(false)
+            .build(app_handle),
+        ])
+        .build()
+        .expect("cannot build single invitation submenu")
 }
 
-fn add_received_menu(tray_menu: SystemTrayMenu, received: &[ReceivedInvitation]) -> SystemTrayMenu {
-    trace!(?received, "adding received invitations menu");
+fn add_received_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    received: &[ReceivedInvitation],
+) -> Submenu<R> {
     let header_text = if received.is_empty() {
         "No Received Invitations"
     } else {
         "Received Invitations"
     };
-    received.iter().map(received_invite_menu).fold(
-        tray_menu.add_item(
-            CustomMenuItem::new(INVITATIONS_RECEIVED_HEADER_MENU_ID, header_text).disabled(),
-        ),
-        |menu, submenu| menu.add_submenu(submenu),
-    )
+
+    let mut submenu_builder =
+        SubmenuBuilder::with_id(app_handle, INVITATIONS_RECEIVED_HEADER_MENU_ID, header_text);
+
+    submenu_builder = received
+        .iter()
+        .map(|invitation| received_invite_menu(app_handle, invitation))
+        .fold(submenu_builder, |submenu_builder, submenu| {
+            submenu_builder.item(&submenu)
+        });
+
+    submenu_builder
+        .build()
+        .expect("cannot build received submenu")
 }
 
-fn received_invite_menu(invitation: &ReceivedInvitation) -> SystemTraySubmenu {
+fn received_invite_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    invitation: &ReceivedInvitation,
+) -> Submenu<R> {
     let id = invitation.id.to_owned();
-    let submenu = SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new(id.clone(), id.clone()).disabled())
-        .add_item(
-            CustomMenuItem::new(id.clone(), format!("Sent by: {}", invitation.owner_email))
-                .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+
+    SubmenuBuilder::with_id(app_handle, id.clone(), &id)
+        .items(&[
+            &MenuItemBuilder::with_id(id.clone(), id.clone())
+                .enabled(false)
+                .build(app_handle),
+            &MenuItemBuilder::with_id(id.clone(), format!("Sent by: {}", invitation.owner_email))
+                .enabled(false)
+                .build(app_handle),
+            &MenuItemBuilder::with_id(
                 id.clone(),
                 format!("Grants role: {}", invitation.grant_role),
             )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 id.clone(),
                 format!("Target: {} {}", invitation.scope, invitation.target_id),
             )
-            .disabled(),
-        )
-        .add_item(CustomMenuItem::new(
-            format!("invitation-received-accept-{}", invitation.id),
-            "Accept",
-        ))
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
+                format!("invitation-received-accept-{}", invitation.id),
+                "Accept",
+            )
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 format!("invitation-received-decline-{}", invitation.id),
                 "Decline",
             )
-            .disabled(),
-        );
-    SystemTraySubmenu::new(id, submenu)
+            .enabled(false)
+            .build(app_handle),
+        ])
+        .build()
+        .expect("cannot build received invitation submenu")
 }
 
-fn add_accepted_menu(submenu: SystemTrayMenu, accepted: &AcceptedInvitations) -> SystemTrayMenu {
-    trace!(?accepted, "adding accepted invitations menu");
+fn add_accepted_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    accepted: &AcceptedInvitations,
+) -> Submenu<R> {
     let header_text = if accepted.invitations.is_empty() {
         "No Accepted Invitations"
     } else {
         "Accepted Invitations"
     };
-    accepted
+
+    let mut submenu_builder =
+        SubmenuBuilder::with_id(app_handle, INVITATIONS_ACCEPTED_HEADER_MENU_ID, header_text);
+
+    submenu_builder = accepted
         .zip()
         .iter()
-        .map(|(i, s)| accepted_invite_menu(i, s))
-        .fold(
-            submenu.add_item(
-                CustomMenuItem::new(INVITATIONS_ACCEPTED_HEADER_MENU_ID, header_text).disabled(),
-            ),
-            |menu, submenu| menu.add_submenu(submenu),
-        )
+        .map(|(invitation, inlet_socket_addr)| {
+            accepted_invite_menu(app_handle, invitation, inlet_socket_addr)
+        })
+        .fold(submenu_builder, |menu, submenu| menu.item(&submenu));
+
+    submenu_builder
+        .build()
+        .expect("cannot build accepted submenu")
 }
 
-fn accepted_invite_menu(
+fn accepted_invite_menu<R: Runtime>(
+    app_handle: &AppHandle<R>,
     invitation: &InvitationWithAccess,
     inlet_socket_addr: &Option<&SocketAddr>,
-) -> SystemTraySubmenu {
-    debug!(invitation_id = %invitation.invitation.id, ?inlet_socket_addr, "adding accepted invitation menu");
+) -> Submenu<R> {
     let id = invitation.invitation.id.to_owned();
     let inlet_title = match inlet_socket_addr {
         Some(s) => format!("Listening at: {}", s),
         None => "Not connected".to_string(),
     };
-    let submenu = SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new(id.clone(), id.clone()).disabled())
-        .add_item(
-            CustomMenuItem::new(
+
+    SubmenuBuilder::with_id(app_handle, id.clone(), &id)
+        .items(&[
+            &MenuItemBuilder::with_id(id.clone(), id.clone())
+                .enabled(false)
+                .build(app_handle),
+            &MenuItemBuilder::with_id(
                 id.clone(),
                 format!("Sent by: {}", invitation.invitation.owner_email),
             )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 id.clone(),
                 format!("Grants role: {}", invitation.invitation.grant_role),
             )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 id.clone(),
                 format!(
                     "Target: {} {}",
                     invitation.invitation.scope, invitation.invitation.target_id
                 ),
             )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 format!("invitation-accepted-connect-{}", invitation.invitation.id),
                 inlet_title,
             )
-            .disabled(),
-        )
-        .add_item(
-            CustomMenuItem::new(
+            .enabled(false)
+            .build(app_handle),
+            &MenuItemBuilder::with_id(
                 format!("invitation-accepted-leave-{}", invitation.invitation.id),
                 "Leave",
             )
-            .disabled(),
-        );
-    SystemTraySubmenu::new(id, submenu)
+            .enabled(false)
+            .build(app_handle),
+        ])
+        .build()
+        .expect("cannot build accepted invitation submenu")
 }
 
-pub(crate) fn dispatch_click_event(app: &AppHandle<Wry>, id: &str) -> tauri::Result<()> {
+pub(crate) fn dispatch_click_event<R: Runtime>(app: &AppHandle<R>, id: &str) -> tauri::Result<()> {
     let segments = id
         .splitn(4, '-')
         .skip_while(|segment| segment == &"invitation")
@@ -249,7 +276,7 @@ pub(crate) fn dispatch_click_event(app: &AppHandle<Wry>, id: &str) -> tauri::Res
     }
 }
 
-fn on_accept(app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
+fn on_accept<R: Runtime>(app: &AppHandle<R>, invite_id: &str) -> tauri::Result<()> {
     trace!(?invite_id, "accepting invite via spawn");
 
     let app_handle = app.clone();
@@ -261,12 +288,12 @@ fn on_accept(app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
     Ok(())
 }
 
-fn on_cancel(_app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
+fn on_cancel<R: Runtime>(_app: &AppHandle<R>, invite_id: &str) -> tauri::Result<()> {
     trace!(?invite_id, "canceling invite via spawn");
     todo!()
 }
 
-fn on_create(app: &AppHandle<Wry>, outlet_socket_addr: &str) -> tauri::Result<()> {
+fn on_create<R: Runtime>(app: &AppHandle<R>, outlet_socket_addr: &str) -> tauri::Result<()> {
     debug!(?outlet_socket_addr, "creating invite via menu");
 
     match app.get_window(INVITATIONS_WINDOW_ID) {
@@ -291,18 +318,26 @@ fn on_create(app: &AppHandle<Wry>, outlet_socket_addr: &str) -> tauri::Result<()
             // TODO: ideally we should use Position::TrayCenter, but it's broken on the latest alpha
             let _ = w.move_window(Position::TopRight);
             w.show()?;
+
+            #[cfg(debug_assertions)]
+            {
+                let app_state: State<AppState> = app.state();
+                if app_state.browser_dev_tools() {
+                    w.open_devtools();
+                }
+            }
         }
         Some(w) => w.set_focus()?,
     }
     Ok(())
 }
 
-fn on_connect(_app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
+fn on_connect<R: Runtime>(_app: &AppHandle<R>, invite_id: &str) -> tauri::Result<()> {
     trace!(?invite_id, "connecting to service via spawn");
     todo!()
 }
 
-fn on_decline(_app: &AppHandle<Wry>, invite_id: &str) -> tauri::Result<()> {
+fn on_decline<R: Runtime>(_app: &AppHandle<R>, invite_id: &str) -> tauri::Result<()> {
     trace!(?invite_id, "declining invite via spawn");
     todo!()
 }

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -53,7 +53,7 @@ pub fn run() {
         .plugin(shared_service::plugin::init())
         .plugin(projects::plugin::init())
         .plugin(invitations::plugin::init())
-        .setup(|app| setup(app))
+        .setup(setup)
         .manage(AppState::new());
 
     #[cfg(feature = "log")]

--- a/implementations/rust/ockam/ockam_app/src/options/reset.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/reset.rs
@@ -1,5 +1,5 @@
 use miette::miette;
-use tauri::{AppHandle, Manager, Wry};
+use tauri::{AppHandle, Manager, Runtime};
 use tracing::log::info;
 
 use crate::app::events::system_tray_on_update;
@@ -9,7 +9,7 @@ use crate::Result;
 /// Reset the project.
 /// This function removes all persisted state
 /// So that the user must enroll again in order to be able to access a project
-pub async fn reset(app: &AppHandle<Wry>) -> Result<()> {
+pub async fn reset<'a, R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     let app_state = app.state::<AppState>();
     let result = app_state.reset().await;
     info!("Application state recreated");

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -15,10 +15,6 @@
     "productName": "Ockam App"
   },
   "tauri": {
-    "systemTray": {
-      "iconPath": "icons/icon.png",
-      "iconAsTemplate": true
-    },
     "security": {
       "csp": null
     },

--- a/implementations/typescript/ockam/ockam_app/package.json
+++ b/implementations/typescript/ockam/ockam_app/package.json
@@ -27,7 +27,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@tauri-apps/api": "2.0.0-alpha.5",
+    "@tauri-apps/api": "2.0.0-alpha.6",
     "@tauri-apps/plugin-window": "2.0.0-alpha.0"
   }
 }

--- a/implementations/typescript/pnpm-lock.yaml
+++ b/implementations/typescript/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
   ockam/ockam_app:
     dependencies:
       '@tauri-apps/api':
-        specifier: 2.0.0-alpha.5
-        version: 2.0.0-alpha.5
+        specifier: 2.0.0-alpha.6
+        version: 2.0.0-alpha.6
       '@tauri-apps/plugin-window':
         specifier: 2.0.0-alpha.0
         version: 2.0.0-alpha.0
@@ -1020,8 +1020,8 @@ packages:
     engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
     dev: false
 
-  /@tauri-apps/api@2.0.0-alpha.5:
-    resolution: {integrity: sha512-OqysC4c819itGxic50RoDMrmd+ofX+MMNkXKeRS0BV2rkKqrnuV17o3TrQXFI1xs/kXRmmPC+3Y42P9Y5uNvRg==}
+  /@tauri-apps/api@2.0.0-alpha.6:
+    resolution: {integrity: sha512-ZMOc3eu9amwvkC6M69h3hWt4/EsFaAXmtkiw4xd2LN59/lTb4ZQiVfq2QKlRcu1rj3n/Tcr7U30ZopvHwXBGIg==}
     engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
     dev: false
 


### PR DESCRIPTION
Tauri upgraded to 2.0.0.alpha.11 had to migrate the menu creation and adjust dependencies.
Currently, [separator menu item leads to crash](https://github.com/tauri-apps/tauri/issues/7760) and has been temporary removed.