### PR TITLE
Separate the Rcp data type into embedded and background

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -173,9 +173,7 @@ async fn run_impl(
             space_id,
         } => {
             let subscription_id = utils::subscription_id_from_cmd_args(
-                &ctx,
-                &opts,
-                rpc.node_name(),
+                &mut rpc,
                 controller_route,
                 subscription_id,
                 space_id,
@@ -198,9 +196,7 @@ async fn run_impl(
                         .into_diagnostic()
                         .context(format!("failed to read {:?}", &json))?;
                     let subscription_id = utils::subscription_id_from_cmd_args(
-                        &ctx,
-                        &opts,
-                        rpc.node_name(),
+                        &mut rpc,
                         controller_route,
                         subscription_id,
                         space_id,
@@ -217,9 +213,7 @@ async fn run_impl(
                     new_space_id,
                 } => {
                     let subscription_id = utils::subscription_id_from_cmd_args(
-                        &ctx,
-                        &opts,
-                        rpc.node_name(),
+                        &mut rpc,
                         controller_route,
                         subscription_id,
                         space_id,

--- a/implementations/rust/ockam/ockam_command/src/credential/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/get.rs
@@ -35,7 +35,7 @@ async fn run_impl(
     cmd: GetCommand,
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     rpc.tell(api::credentials::get_credential(
         cmd.overwrite,
         cmd.identity,

--- a/implementations/rust/ockam/ockam_command/src/credential/present.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/present.rs
@@ -40,7 +40,7 @@ async fn run_impl(
     cmd: PresentCommand,
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     rpc.tell(api::credentials::present_credential(&cmd.to, cmd.oneway))
         .await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -102,7 +102,7 @@ async fn run_impl(
 
 pub async fn retrieve_user_project<'a>(
     opts: &CommandGlobalOpts,
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
 ) -> Result<IdentityIdentifier> {
     let space = default_space(opts, rpc)
         .await
@@ -134,7 +134,7 @@ pub async fn retrieve_user_project<'a>(
 
 /// Enroll a user with a token, using a specific node to contact the controller
 pub async fn enroll_with_node<'a>(
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     route: &MultiAddr,
     token: OidcToken,
 ) -> miette::Result<()> {
@@ -161,7 +161,7 @@ pub async fn enroll_with_node<'a>(
     }
 }
 
-async fn default_space<'a>(opts: &CommandGlobalOpts, rpc: &mut Rpc<'a>) -> Result<Space> {
+async fn default_space<'a>(opts: &CommandGlobalOpts, rpc: &mut Rpc) -> Result<Space> {
     // Get available spaces for node's identity
     opts.terminal
         .write_line(&fmt_log!("Getting available spaces in your account..."))?;
@@ -246,7 +246,7 @@ async fn default_space<'a>(opts: &CommandGlobalOpts, rpc: &mut Rpc<'a>) -> Resul
 
 async fn default_project<'a>(
     opts: &CommandGlobalOpts,
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     space: &Space,
 ) -> Result<Project> {
     // Get available project for the given space

--- a/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
+++ b/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
@@ -42,7 +42,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     rpc.tell(api::add_consumer(cmd.flow_control_id, cmd.address))
         .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
+++ b/implementations/rust/ockam/ockam_command/src/flow_control/add_consumer.rs
@@ -1,13 +1,12 @@
 use clap::Args;
-use miette::IntoDiagnostic;
 
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_core::flow_control::FlowControlId;
 use ockam_multiaddr::MultiAddr;
 
 use crate::node::{get_node_name, NodeOpts};
-use crate::util::{api, node_rpc, RpcBuilder};
+use crate::util::{api, node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
@@ -43,9 +42,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
-    let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
-
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     rpc.tell(api::add_consumer(cmd.flow_control_id, cmd.address))
         .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
@@ -1,10 +1,12 @@
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
-use clap::Args;
-use colorful::Colorful;
-use ockam_api::nodes::models;
-use ockam_core::api::Request;
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -33,7 +35,7 @@ async fn run_impl(
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let req = Request::delete("/node/services/kafka_consumer").body(
         models::services::DeleteServiceRequest::new(cmd.address.clone()),
     );

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -1,16 +1,15 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{docs, fmt_err, CommandGlobalOpts};
-use miette::miette;
-
 use clap::Args;
 use colorful::Colorful;
+use miette::miette;
 
 use ockam_api::cli_state::StateDirTrait;
-
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::DefaultAddress;
 use ockam_core::api::Request;
+
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -44,7 +43,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let services: ServiceList = rpc
         .ask(Request::get(format!(
             "/node/services/{}",

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
@@ -1,10 +1,12 @@
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
-use clap::Args;
-use colorful::Colorful;
-use ockam_api::nodes::models;
-use ockam_core::api::Request;
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -33,7 +35,7 @@ async fn run_impl(
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let req = Request::delete("/node/services/kafka_direct").body(
         models::services::DeleteServiceRequest::new(cmd.address.clone()),
     );

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
@@ -1,16 +1,15 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{docs, fmt_err, CommandGlobalOpts};
-use miette::miette;
-
 use clap::Args;
 use colorful::Colorful;
+use miette::miette;
 
 use ockam_api::cli_state::StateDirTrait;
-
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::DefaultAddress;
 use ockam_core::api::Request;
+
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -44,7 +43,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let services: ServiceList = rpc
         .ask(Request::get(format!(
             "/node/services/{}",

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
@@ -52,7 +52,7 @@ pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> 
     let is_finished = Mutex::new(false);
     let send_req = async {
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
 
         let payload = StartKafkaDirectRequest::new(
             bind_address.to_owned(),

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/rpc.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use colorful::Colorful;
 use tokio::{sync::Mutex, try_join};
 
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::nodes::models::services::{StartKafkaDirectRequest, StartServiceRequest};
 use ockam_api::port_range::PortRange;
 use ockam_core::api::Request;
@@ -12,7 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use crate::node::{get_node_name, NodeOpts};
 use crate::service::start::start_service_impl;
 use crate::terminal::OckamColor;
-use crate::util::process_nodes_multiaddr;
+use crate::util::{process_nodes_multiaddr, Rpc};
 use crate::{display_parse_logs, fmt_log, fmt_ok, CommandGlobalOpts};
 
 pub struct ArgOpts {
@@ -51,8 +51,8 @@ pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> 
 
     let is_finished = Mutex::new(false);
     let send_req = async {
-        let tcp = TcpTransport::create(&ctx).await?;
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
 
         let payload = StartKafkaDirectRequest::new(
             bind_address.to_owned(),
@@ -62,7 +62,7 @@ pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> 
         );
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post(endpoint).body(payload);
-        start_service_impl(&ctx, &opts, &node_name, &kafka_entity, req, Some(&tcp)).await?;
+        start_service_impl(&mut rpc, &kafka_entity, req).await?;
 
         *is_finished.lock().await = true;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -1,12 +1,13 @@
+use std::net::SocketAddr;
+
 use clap::{command, Args};
 use colorful::Colorful;
+use tokio::{sync::Mutex, try_join};
+
 use ockam::Context;
 use ockam_api::nodes::models::services::StartKafkaOutletRequest;
 use ockam_api::nodes::models::services::StartServiceRequest;
 use ockam_core::api::Request;
-use std::net::SocketAddr;
-
-use tokio::{sync::Mutex, try_join};
 
 use crate::node::get_node_name;
 use crate::util::Rpc;
@@ -53,7 +54,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post("/node/services/kafka_outlet").body(payload);
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
 
         start_service_impl(&mut rpc, "KafkaOutlet", req).await?;
         *is_finished.lock().await = true;

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -1,7 +1,6 @@
 use clap::{command, Args};
 use colorful::Colorful;
-use miette::IntoDiagnostic;
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::nodes::models::services::StartKafkaOutletRequest;
 use ockam_api::nodes::models::services::StartServiceRequest;
 use ockam_core::api::Request;
@@ -10,6 +9,7 @@ use std::net::SocketAddr;
 use tokio::{sync::Mutex, try_join};
 
 use crate::node::get_node_name;
+use crate::util::Rpc;
 use crate::{
     fmt_log, fmt_ok,
     kafka::{kafka_default_outlet_addr, kafka_default_outlet_server},
@@ -49,14 +49,13 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
     } = cmd;
     let is_finished = Mutex::new(false);
     let send_req = async {
-        let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-
         let payload = StartKafkaOutletRequest::new(bootstrap_server);
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post("/node/services/kafka_outlet").body(payload);
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
 
-        start_service_impl(&ctx, &opts, &node_name, "KafkaOutlet", req, Some(&tcp)).await?;
+        start_service_impl(&mut rpc, "KafkaOutlet", req).await?;
         *is_finished.lock().await = true;
 
         Ok::<_, crate::Error>(())

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
@@ -1,10 +1,12 @@
+use clap::Args;
+use colorful::Colorful;
+
+use ockam_api::nodes::models;
+use ockam_core::api::Request;
+
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
-use clap::Args;
-use colorful::Colorful;
-use ockam_api::nodes::models;
-use ockam_core::api::Request;
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -33,7 +35,7 @@ async fn run_impl(
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let req = Request::delete("/node/services/kafka_producer").body(
         models::services::DeleteServiceRequest::new(cmd.address.clone()),
     );

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -1,16 +1,15 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{docs, fmt_err, CommandGlobalOpts};
-use miette::miette;
-
 use clap::Args;
 use colorful::Colorful;
+use miette::miette;
 
 use ockam_api::cli_state::StateDirTrait;
-
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::DefaultAddress;
 use ockam_core::api::Request;
+
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -44,7 +43,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let services: ServiceList = rpc
         .ask(Request::get(format!(
             "/node/services/{}",

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -46,7 +46,7 @@ pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> mi
     let is_finished = Mutex::new(false);
     let send_req = async {
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
 
         let payload = StartKafkaProducerRequest::new(
             bootstrap_server.to_owned(),

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use colorful::Colorful;
 use tokio::{sync::Mutex, try_join};
 
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::nodes::models::services::{StartKafkaProducerRequest, StartServiceRequest};
 use ockam_api::port_range::PortRange;
 use ockam_core::api::Request;
@@ -12,7 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use crate::node::{get_node_name, NodeOpts};
 use crate::service::start::start_service_impl;
 use crate::terminal::OckamColor;
-use crate::util::process_nodes_multiaddr;
+use crate::util::{process_nodes_multiaddr, Rpc};
 use crate::{display_parse_logs, fmt_log, fmt_ok, CommandGlobalOpts};
 
 pub struct ArgOpts {
@@ -45,8 +45,8 @@ pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> mi
 
     let is_finished = Mutex::new(false);
     let send_req = async {
-        let tcp = TcpTransport::create(&ctx).await?;
         let node_name = get_node_name(&opts.state, &node_opts.at_node);
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
 
         let payload = StartKafkaProducerRequest::new(
             bootstrap_server.to_owned(),
@@ -55,7 +55,7 @@ pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> mi
         );
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post(endpoint).body(payload);
-        start_service_impl(&ctx, &opts, &node_name, &kafka_entity, req, Some(&tcp)).await?;
+        start_service_impl(&mut rpc, &kafka_entity, req).await?;
 
         *is_finished.lock().await = true;
 

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -1,7 +1,8 @@
+use core::time::Duration;
+
 use clap::Args;
 use miette::{Context as _, IntoDiagnostic};
 
-use core::time::Duration;
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
@@ -14,7 +15,6 @@ use crate::node::util::delete_embedded_node;
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::duration::duration_parser;
 use crate::util::{clean_nodes_multiaddr, node_rpc, Rpc};
-
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/send/long_about.txt");
@@ -72,7 +72,7 @@ async fn rpc(
         // Setup environment depending on whether we are sending the message from an embedded node or a background node
         let mut rpc = if let Some(node) = &cmd.from {
             let api_node = extract_address_value(node)?;
-            Rpc::background(ctx, &opts, &api_node)?
+            Rpc::background(ctx, &opts, &api_node).await?
         } else {
             let identity = get_identity_name(&opts.state, &cmd.cloud_opts.identity);
             Rpc::embedded_with_vault_and_identity(ctx, &opts, identity, &cmd.trust_context_opts)

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use miette::{Context as _, IntoDiagnostic};
 
 use core::time::Duration;
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::secure_channel::CredentialExchangeMode;
 use ockam_api::nodes::service::message::SendMessage;
@@ -10,10 +10,10 @@ use ockam_core::api::{Request, RequestBuilder};
 use ockam_multiaddr::MultiAddr;
 
 use crate::identity::{get_identity_name, initialize_identity_if_default};
-use crate::node::util::{delete_embedded_node, start_embedded_node_with_vault_and_identity};
+use crate::node::util::delete_embedded_node;
 use crate::util::api::{CloudOpts, TrustContextOpts};
 use crate::util::duration::duration_parser;
-use crate::util::{clean_nodes_multiaddr, node_rpc, RpcBuilder};
+use crate::util::{clean_nodes_multiaddr, node_rpc, Rpc};
 
 use crate::{docs, CommandGlobalOpts};
 
@@ -70,21 +70,13 @@ async fn rpc(
         cmd: SendCommand,
     ) -> miette::Result<()> {
         // Setup environment depending on whether we are sending the message from an embedded node or a background node
-        let (api_node, tcp) = if let Some(node) = &cmd.from {
+        let mut rpc = if let Some(node) = &cmd.from {
             let api_node = extract_address_value(node)?;
-            let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
-            (api_node, Some(tcp))
+            Rpc::background(ctx, &opts, &api_node)?
         } else {
             let identity = get_identity_name(&opts.state, &cmd.cloud_opts.identity);
-            let api_node = start_embedded_node_with_vault_and_identity(
-                ctx,
-                &opts.state,
-                None,
-                Some(identity),
-                Some(&cmd.trust_context_opts),
-            )
-            .await?;
-            (api_node, None)
+            Rpc::embedded_with_vault_and_identity(ctx, &opts, identity, &cmd.trust_context_opts)
+                .await?
         };
 
         // Process `--to` Multiaddr
@@ -93,19 +85,13 @@ async fn rpc(
 
         // Replace `/project/<name>` occurrences with their respective secure channel addresses
         let projects_sc = crate::project::util::get_projects_secure_channels_from_config_lookup(
-            ctx,
             &opts,
+            &mut rpc,
             &meta,
-            &api_node,
-            tcp.as_ref(),
             CredentialExchangeMode::Oneway,
         )
         .await?;
         let to = crate::project::util::clean_projects_multiaddr(to, projects_sc)?;
-        // Send request
-        let mut rpc = RpcBuilder::new(ctx, &opts, &api_node)
-            .tcp(tcp.as_ref())?
-            .build();
 
         let msg_bytes = if cmd.hex {
             hex::decode(cmd.message)
@@ -115,6 +101,7 @@ async fn rpc(
             cmd.message.as_bytes().to_vec()
         };
 
+        // Send request
         let response: Vec<u8> = rpc
             .set_timeout(cmd.timeout)
             .ask(req(&to, msg_bytes))
@@ -131,9 +118,7 @@ async fn rpc(
         if cmd.from.is_none() {
             delete_embedded_node(&opts, rpc.node_name()).await;
         }
-
         opts.terminal.stdout().plain(&result).write_line()?;
-
         Ok(())
     }
     go(&mut ctx, opts, cmd).await

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -17,7 +17,6 @@ use ockam_api::cli_state::{add_project_info_to_node_state, init_node_state};
 use ockam_api::nodes::authority_node;
 use ockam_api::nodes::models::transport::CreateTransportJson;
 use ockam_api::nodes::service::NodeManagerTrustOptions;
-
 use ockam_api::{
     bootstrapped_identities_store::PreTrustedIdentities,
     nodes::models::transport::{TransportMode, TransportType},
@@ -201,7 +200,7 @@ pub(crate) async fn background_mode(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let send_req = async {
-        let mut rpc = Rpc::background(&ctx, &opts, node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, node_name).await?;
         spawn_background_node(&opts, cmd.clone()).await?;
         let is_node_up = is_node_up(&mut rpc, opts.state.clone(), true).await?;
         *is_finished.lock().await = true;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -34,7 +34,7 @@ use crate::secure_channel::listener::create as secure_channel_listener;
 use crate::service::config::Config;
 use crate::terminal::OckamColor;
 use crate::util::api::TrustContextOpts;
-use crate::util::{api, parse_node_name, RpcBuilder};
+use crate::util::{api, parse_node_name, Rpc};
 use crate::util::{embedded_node_that_is_not_stopped, exitcode};
 use crate::util::{local_cmd, node_rpc};
 use crate::{docs, identity, shutdown, CommandGlobalOpts, Result};
@@ -201,8 +201,7 @@ pub(crate) async fn background_mode(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let send_req = async {
-        let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-        let mut rpc = RpcBuilder::new(&ctx, &opts, node_name).tcp(&tcp)?.build();
+        let mut rpc = Rpc::background(&ctx, &opts, node_name)?;
         spawn_background_node(&opts, cmd.clone()).await?;
         let is_node_up = is_node_up(&mut rpc, opts.state.clone(), true).await?;
         *is_finished.lock().await = true;

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -1,17 +1,18 @@
-use crate::output::Output;
-use crate::terminal::OckamColor;
-use crate::util::{api, node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts, Result};
 use clap::Args;
 use colorful::Colorful;
 use indoc::formatdoc;
 use miette::Context as _;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::base::NodeStatus;
 
-use tokio::sync::Mutex;
-use tokio::try_join;
+use crate::output::Output;
+use crate::terminal::OckamColor;
+use crate::util::{api, node_rpc, Rpc};
+use crate::{docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -54,7 +55,7 @@ async fn run_impl(
 
     let mut nodes: Vec<NodeListOutput> = Vec::new();
     for node_name in node_names {
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
 
         let is_finished: Mutex<bool> = Mutex::new(false);
 

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,11 +1,9 @@
 use crate::node::get_node_name;
 use crate::node::util::check_default;
-use crate::util::{api, node_rpc, Rpc, RpcBuilder};
+use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, OutputFormat, Result};
 use clap::Args;
 use colorful::Colorful;
-use miette::IntoDiagnostic;
-use ockam::TcpTransport;
 use ockam_api::cli_state::{CliState, StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::portal::{InletList, OutletList};
 use ockam_api::nodes::models::secure_channel::SecureChannelListenersList;
@@ -49,8 +47,7 @@ async fn run_impl(
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_name);
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-    let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let is_default = check_default(&opts, &node_name);
     print_query_status(&opts, &mut rpc, &node_name, false, is_default).await?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,6 +1,6 @@
 use clap::Args;
-
 use colorful::Colorful;
+
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
 use crate::node::show::print_query_status;
@@ -76,7 +76,7 @@ async fn run_impl(
     )?;
 
     // Print node status
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let is_default = check_default(&opts, &node_name);
     print_query_status(&opts, &mut rpc, &node_name, true, is_default).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,14 +1,12 @@
 use clap::Args;
 
 use colorful::Colorful;
-use miette::IntoDiagnostic;
-use ockam::TcpTransport;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
 use crate::node::show::print_query_status;
 use crate::node::util::{check_default, spawn_node};
 use crate::node::{get_node_name, initialize_node_if_default};
-use crate::util::{node_rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
@@ -78,8 +76,7 @@ async fn run_impl(
     )?;
 
     // Print node status
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-    let mut rpc = RpcBuilder::new(&ctx, &opts, &node_name).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let is_default = check_default(&opts, &node_name);
     print_query_status(&opts, &mut rpc, &node_name, true, is_default).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -6,14 +6,13 @@ use ockam_api::cloud::operation::Operation;
 use ockam_api::cloud::ORCHESTRATOR_AWAIT_TIMEOUT_MS;
 
 use crate::util::api::CloudOpts;
-use crate::util::{api, RpcBuilder};
+use crate::util::{api, Rpc};
 use crate::CommandGlobalOpts;
 use crate::Result;
 
 pub async fn check_for_completion<'a>(
-    ctx: &ockam::Context,
     opts: &CommandGlobalOpts,
-    api_node: &str,
+    rpc: &Rpc<'a>,
     operation_id: &str,
 ) -> miette::Result<()> {
     let retry_strategy =
@@ -25,11 +24,12 @@ pub async fn check_for_completion<'a>(
     }
     let route = CloudOpts::route();
     let operation = Retry::spawn(retry_strategy.clone(), || async {
-        let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
-
+        let mut rpc_clone = rpc.clone();
         // Handle the operation show request result
         // so we can provide better errors in the case orchestrator does not respond timely
-        let result: Result<Operation> = rpc.ask(api::operation::show(operation_id, &route)).await;
+        let result: Result<Operation> = rpc_clone
+            .ask(api::operation::show(operation_id, &route))
+            .await;
         result.and_then(|o| {
             if o.is_completed() {
                 Ok(o)

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -1,12 +1,14 @@
-use crate::node::get_node_name;
-use crate::policy::policy_path;
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::CommandGlobalOpts;
 use clap::Args;
+
 use ockam::Context;
 use ockam_abac::{Action, Expr, Resource};
 use ockam_api::nodes::models::policy::Policy;
 use ockam_core::api::Request;
+
+use crate::node::get_node_name;
+use crate::policy::policy_path;
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
@@ -45,7 +47,7 @@ async fn run_impl(
     let node_name = parse_node_name(&at)?;
     let bdy = Policy::new(cmd.expression);
     let req = Request::post(policy_path(&cmd.resource, &cmd.action)).body(bdy);
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     rpc.tell(req).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/delete.rs
@@ -1,12 +1,14 @@
+use clap::Args;
+use colorful::Colorful;
+
+use ockam::Context;
+use ockam_abac::{Action, Resource};
+use ockam_core::api::Request;
+
 use crate::node::get_node_name;
 use crate::policy::policy_path;
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{fmt_ok, CommandGlobalOpts};
-use clap::Args;
-use colorful::Colorful;
-use ockam::Context;
-use ockam_abac::{Action, Resource};
-use ockam_core::api::Request;
 
 #[derive(Clone, Debug, Args)]
 pub struct DeleteCommand {
@@ -50,7 +52,7 @@ async fn run_impl(
     {
         let policy_path = policy_path(&cmd.resource, &cmd.action);
         let req = Request::delete(&policy_path);
-        let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
         rpc.tell(req).await?;
 
         opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/policy/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/list.rs
@@ -1,19 +1,22 @@
-use crate::node::get_node_name;
-use crate::output::Output;
-use crate::terminal::OckamColor;
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{CommandGlobalOpts, Result};
+use std::fmt::Write;
+
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam::Context;
 use ockam_abac::Resource;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::policy::{Expression, PolicyList};
 use ockam_core::api::Request;
-use std::fmt::Write;
-use tokio::sync::Mutex;
-use tokio::try_join;
+
+use crate::node::get_node_name;
+use crate::output::Output;
+use crate::terminal::OckamColor;
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
@@ -51,7 +54,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", &node_name));
     }
 
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_policies = async {

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -1,19 +1,22 @@
-mod create;
-mod delete;
-mod list;
-mod show;
-use crate::policy::delete::DeleteCommand;
-use crate::policy::list::ListCommand;
-use crate::policy::show::ShowCommand;
-use crate::{policy::create::CreateCommand, util::Rpc};
-use crate::{CommandGlobalOpts, Result};
 use clap::{Args, Subcommand};
+
 use ockam::Context;
 use ockam_abac::expr::{eq, ident, str};
 use ockam_abac::{Action, Resource};
 use ockam_api::nodes::models::policy::PolicyList;
 use ockam_api::{config::lookup::ProjectLookup, nodes::models::policy::Policy};
 use ockam_core::api::Request;
+
+use crate::policy::delete::DeleteCommand;
+use crate::policy::list::ListCommand;
+use crate::policy::show::ShowCommand;
+use crate::{policy::create::CreateCommand, util::Rpc};
+use crate::{CommandGlobalOpts, Result};
+
+mod create;
+mod delete;
+mod list;
+mod show;
 
 #[derive(Clone, Debug, Args)]
 pub struct PolicyCommand {
@@ -52,7 +55,7 @@ pub(crate) async fn has_policy(
     resource: &Resource,
 ) -> Result<bool> {
     let req = Request::get(format!("/policy/{resource}"));
-    let mut rpc = Rpc::background(ctx, opts, node)?;
+    let mut rpc = Rpc::background(ctx, opts, node).await?;
     let policies: PolicyList = rpc.ask(req).await?;
     Ok(!policies.expressions().is_empty())
 }
@@ -68,7 +71,7 @@ pub(crate) async fn add_default_project_policy(
     let bdy = Policy::new(expr);
     let req = Request::post(policy_path(resource, &Action::new("handle_message"))).body(bdy);
 
-    let mut rpc = Rpc::background(ctx, opts, node)?;
+    let mut rpc = Rpc::background(ctx, opts, node).await?;
     rpc.tell(req).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -1,12 +1,14 @@
-use crate::policy::policy_path;
-use crate::util::{node_rpc, Rpc};
-use crate::CommandGlobalOpts;
 use clap::Args;
+
 use ockam::Context;
 use ockam_abac::{Action, Resource};
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::policy::Policy;
 use ockam_core::api::Request;
+
+use crate::policy::policy_path;
+use crate::util::{node_rpc, Rpc};
+use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ShowCommand {
@@ -40,7 +42,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node = extract_address_value(&cmd.at)?;
     let req = Request::get(policy_path(&cmd.resource, &cmd.action));
-    let mut rpc = Rpc::background(ctx, &opts, &node)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node).await?;
     let policy: Policy = rpc.ask(req).await?;
     println!("{}", policy.expression());
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -76,13 +76,13 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&opts, &mut rpc, &operation_id).await?;
+    check_for_completion(&opts, &rpc, &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let project: Project = rpc
         .ask(api::project::show(&project_id, controller_route))
         .await?;
-    check_project_readiness(&opts, &mut rpc, project).await?;
+    check_project_readiness(&opts, &rpc, project).await?;
 
     opts.terminal
         .write_line(&fmt_ok!("Confluent addon configured successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -76,14 +76,13 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
+    check_for_completion(&opts, &mut rpc, &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
-    let mut rpc = rpc.clone();
     let project: Project = rpc
         .ask(api::project::show(&project_id, controller_route))
         .await?;
-    check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
+    check_project_readiness(&opts, &mut rpc, project).await?;
 
     opts.terminal
         .write_line(&fmt_ok!("Confluent addon configured successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -174,14 +174,14 @@ async fn run_impl(
     let operation_id = response.operation_id;
 
     // Wait until project is ready again
-    check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
+    check_for_completion(&opts, &mut rpc, &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let mut rpc = rpc.clone();
     let project: Project = rpc
         .ask(api::project::show(&project_id, controller_route))
         .await?;
-    check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
+    check_project_readiness(&opts, &mut rpc, project).await?;
 
     opts.terminal
         .write_line(&fmt_ok!("InfluxDB addon configured successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -137,13 +137,13 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
+    check_for_completion(&opts, &mut rpc, &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let project: Project = rpc
         .ask(api::project::show(&project_id, controller_route))
         .await?;
-    check_project_readiness(&ctx, &opts, rpc.node_name(), None, project).await?;
+    check_project_readiness(&opts, &mut rpc, project).await?;
 
     opts.terminal
         .write_line(&fmt_ok!("Okta addon configured successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -137,13 +137,13 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&opts, &mut rpc, &operation_id).await?;
+    check_for_completion(&opts, &rpc, &operation_id).await?;
 
     let project_id = opts.state.projects.get(&project_name)?.config().id.clone();
     let project: Project = rpc
         .ask(api::project::show(&project_id, controller_route))
         .await?;
-    check_project_readiness(&opts, &mut rpc, project).await?;
+    check_project_readiness(&opts, &rpc, project).await?;
 
     opts.terminal
         .write_line(&fmt_ok!("Okta addon configured successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -61,7 +61,7 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&opts, &mut rpc, &operation_id).await?;
+    check_for_completion(&opts, &rpc, &operation_id).await?;
     opts.terminal
         .write_line(&fmt_ok!("Addon disabled successfully"))?;
     delete_embedded_node(&opts, rpc.node_name()).await;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -61,11 +61,9 @@ async fn run_impl(
     let response: CreateOperationResponse = rpc.ask(req).await?;
     let operation_id = response.operation_id;
 
-    check_for_completion(&ctx, &opts, rpc.node_name(), &operation_id).await?;
-
+    check_for_completion(&opts, &mut rpc, &operation_id).await?;
     opts.terminal
         .write_line(&fmt_ok!("Addon disabled successfully"))?;
-
     delete_embedded_node(&opts, rpc.node_name()).await;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -63,8 +63,8 @@ async fn run_impl(
         ))
         .await?;
     let operation_id = project.operation_id.clone().unwrap();
-    check_for_completion(&opts, &mut rpc, &operation_id).await?;
-    let project = check_project_readiness(&opts, &mut rpc, project).await?;
+    check_for_completion(&opts, &rpc, &operation_id).await?;
+    let project = check_project_readiness(&opts, &rpc, project).await?;
     opts.state
         .projects
         .overwrite(&project.name, project.clone())?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -5,11 +5,11 @@ use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::cloud::project::Project;
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::operation::util::check_for_completion;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
-use crate::util::{api, node_rpc, RpcBuilder};
+use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
@@ -54,8 +54,7 @@ async fn run_impl(
     cmd: CreateCommand,
 ) -> miette::Result<()> {
     let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
-    let node_name = start_embedded_node(ctx, &opts, None).await?;
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
+    let mut rpc = Rpc::embedded(ctx, &opts).await?;
     let project: Project = rpc
         .ask(api::project::create(
             &cmd.project_name,
@@ -64,8 +63,8 @@ async fn run_impl(
         ))
         .await?;
     let operation_id = project.operation_id.clone().unwrap();
-    check_for_completion(ctx, &opts, rpc.node_name(), &operation_id).await?;
-    let project = check_project_readiness(ctx, &opts, &node_name, None, project).await?;
+    check_for_completion(&opts, &mut rpc, &operation_id).await?;
+    let project = check_project_readiness(&opts, &mut rpc, project).await?;
     opts.state
         .projects
         .overwrite(&project.name, project.clone())?;

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
+
 use clap::Args;
 use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
-use std::sync::Arc;
 
 use ockam::Context;
 use ockam_api::authenticator::direct::TokenAcceptorClient;
@@ -86,7 +87,7 @@ async fn run_impl(
 pub async fn project_enroll<'a>(
     ctx: &Context,
     opts: &CommandGlobalOpts,
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     cmd: EnrollCommand,
 ) -> miette::Result<String> {
     let project_as_string: String;
@@ -218,7 +219,7 @@ pub async fn project_enroll<'a>(
 
 async fn authenticate_through_okta<'a>(
     opts: &CommandGlobalOpts,
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     p: ProjectConfigCompact,
     secure_channel_addr: MultiAddr,
 ) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -20,10 +20,10 @@ use ockam_node::RpcClient;
 
 use crate::enroll::{enroll_with_node, OidcServiceExt};
 use crate::identity::{get_identity_name, initialize_identity_if_default};
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{CloudOpts, TrustContextOpts};
-use crate::util::node_rpc;
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/enroll/long_about.txt");
@@ -77,16 +77,17 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, EnrollCommand),
 ) -> miette::Result<()> {
-    let node_name = start_embedded_node(&ctx, &opts, Some(&cmd.trust_opts)).await?;
-    let result = project_enroll(&ctx, (opts.clone(), cmd), &node_name).await;
-    delete_embedded_node(&opts, &node_name).await;
+    let mut rpc = Rpc::embedded_with_trust_options(&ctx, &opts, &cmd.trust_opts).await?;
+    let result = project_enroll(&ctx, &opts, &mut rpc, cmd).await;
+    delete_embedded_node(&opts, rpc.node_name()).await;
     result.map(|_| ())
 }
 
-pub async fn project_enroll(
+pub async fn project_enroll<'a>(
     ctx: &Context,
-    (opts, cmd): (CommandGlobalOpts, EnrollCommand),
-    node_name: &str,
+    opts: &CommandGlobalOpts,
+    rpc: &mut Rpc<'a>,
+    cmd: EnrollCommand,
 ) -> miette::Result<String> {
     let project_as_string: String;
 
@@ -156,9 +157,7 @@ pub async fn project_enroll(
                 .ok_or_else(|| miette!("Authority details not configured"))?;
         let identity = get_identity_name(&opts.state, &cmd.cloud_opts.identity);
         create_secure_channel_to_authority(
-            ctx,
-            &opts,
-            node_name,
+            rpc,
             authority.identity_id().clone(),
             authority.address(),
             Some(identity),
@@ -189,7 +188,7 @@ pub async fn project_enroll(
             .await
             .into_diagnostic()?
     } else if cmd.okta {
-        authenticate_through_okta(ctx, &opts, node_name, proj, secure_channel_addr.clone()).await?
+        authenticate_through_okta(opts, rpc, proj, secure_channel_addr.clone()).await?
     }
 
     let credential_issuer_route = {
@@ -209,14 +208,17 @@ pub async fn project_enroll(
     .into_diagnostic()?;
 
     let credential = client2.credential().await.into_diagnostic()?;
-    opts.terminal.stdout().plain(credential).write_line()?;
+    opts.terminal
+        .clone()
+        .stdout()
+        .plain(credential)
+        .write_line()?;
     Ok(project.name)
 }
 
-async fn authenticate_through_okta(
-    ctx: &Context,
+async fn authenticate_through_okta<'a>(
     opts: &CommandGlobalOpts,
-    node_name: &str,
+    rpc: &mut Rpc<'a>,
     p: ProjectConfigCompact,
     secure_channel_addr: MultiAddr,
 ) -> miette::Result<()> {
@@ -243,7 +245,7 @@ async fn authenticate_through_okta(
         addr
     };
 
-    enroll_with_node(ctx, opts, &okta_authenticator_addr, node_name, token)
+    enroll_with_node(rpc, &okta_authenticator_addr, token)
         .await
         .wrap_err("Failed to enroll your local identity with Ockam Orchestrator")
 }

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -4,10 +4,10 @@ use ockam::Context;
 
 use ockam_api::cloud::project::Project;
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::project::util::refresh_projects;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::CommandGlobalOpts;
 use ockam_api::cli_state::{ProjectConfigCompact, StateDirTrait, StateItemTrait};
 
@@ -43,19 +43,18 @@ async fn run_impl(
     cmd: InfoCommand,
 ) -> miette::Result<()> {
     let controller_route = &CloudOpts::route();
-    let node_name = start_embedded_node(ctx, &opts, None).await?;
+    let mut rpc = Rpc::embedded(ctx, &opts).await?;
 
     // Lookup project
     let id = match opts.state.projects.get(&cmd.name) {
         Ok(state) => state.config().id.clone(),
         Err(_) => {
-            refresh_projects(ctx, &opts, &node_name, &CloudOpts::route(), None).await?;
+            refresh_projects(&opts, &mut rpc, &CloudOpts::route()).await?;
             opts.state.projects.get(&cmd.name)?.config().id.clone()
         }
     };
 
     // Send request
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
     let project: Project = rpc.ask(api::project::show(&id, controller_route)).await?;
     let info: ProjectConfigCompact = project.into();
     opts.println(&info)?;

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -18,10 +18,10 @@ use ockam_multiaddr::{proto, MultiAddr, Protocol};
 use ockam_node::RpcClient;
 
 use crate::identity::{get_identity_name, initialize_identity_if_default};
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::project::util::create_secure_channel_to_authority;
 use crate::util::api::{CloudOpts, TrustContextOpts};
-use crate::util::node_rpc;
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/ticket/long_about.txt");
@@ -88,8 +88,8 @@ impl Runner {
     }
 
     async fn run(self) -> miette::Result<()> {
-        let node_name =
-            start_embedded_node(&self.ctx, &self.opts, Some(&self.cmd.trust_opts)).await?;
+        let mut rpc =
+            Rpc::embedded_with_trust_options(&self.ctx, &self.opts, &self.cmd.trust_opts).await?;
 
         let mut project: Option<ProjectLookup> = None;
         let mut trust_context: Option<TrustContextConfig> = None;
@@ -114,9 +114,7 @@ impl Runner {
             };
             let identity = get_identity_name(&self.opts.state, &self.cmd.cloud_opts.identity);
             create_secure_channel_to_authority(
-                &self.ctx,
-                &self.opts,
-                &node_name,
+                &mut rpc,
                 tc.authority()
                     .into_diagnostic()?
                     .identity()
@@ -131,9 +129,7 @@ impl Runner {
         } else if let (Some(p), Some(a)) = get_project(&self.opts.state, &self.cmd.to).await? {
             let identity = get_identity_name(&self.opts.state, &self.cmd.cloud_opts.identity);
             let sc_addr = create_secure_channel_to_authority(
-                &self.ctx,
-                &self.opts,
-                &node_name,
+                &mut rpc,
                 a.identity_id().clone(),
                 a.address(),
                 Some(identity),
@@ -211,7 +207,7 @@ impl Runner {
                 .write_line()?;
         }
 
-        delete_embedded_node(&self.opts, &node_name).await;
+        delete_embedded_node(&self.opts, rpc.node_name()).await;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -4,9 +4,9 @@ use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_api::cloud::project::ProjectVersion;
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/version/long_about.txt");
@@ -35,10 +35,9 @@ async fn rpc(mut ctx: Context, opts: CommandGlobalOpts) -> miette::Result<()> {
 
 async fn run_impl(ctx: &mut Context, opts: CommandGlobalOpts) -> miette::Result<()> {
     let controller_route = &CloudOpts::route();
-    let node_name = start_embedded_node(ctx, &opts, None).await?;
 
     // Send request
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
+    let mut rpc = Rpc::embedded(ctx, &opts).await?;
     let project_version: ProjectVersion = rpc.ask(api::project::version(controller_route)).await?;
     delete_embedded_node(&opts, rpc.node_name()).await;
 

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -7,7 +7,7 @@ use miette::{miette, IntoDiagnostic};
 use ockam::identity::IdentityIdentifier;
 use ockam_multiaddr::proto::Project;
 
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::is_local_node;
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
@@ -19,7 +19,7 @@ use tokio::try_join;
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::output::Output;
 use crate::terminal::OckamColor;
-use crate::util::{node_rpc, process_nodes_multiaddr, RpcBuilder};
+use crate::util::{node_rpc, process_nodes_multiaddr, Rpc};
 use crate::{display_parse_logs, docs, fmt_ok, CommandGlobalOpts};
 use crate::{fmt_log, Result};
 
@@ -76,7 +76,6 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
 
     display_parse_logs(&opts);
 
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
     let to = get_node_name(&opts.state, &cmd.to);
     let api_node = extract_address_value(&to)?;
     let at_rust_node = is_local_node(&cmd.at).wrap_err("Argument --at is not valid")?;
@@ -88,7 +87,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
         cmd.relay_name.clone()
     };
 
-    let mut rpc = RpcBuilder::new(&ctx, &opts, &api_node).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(&ctx, &opts, &api_node)?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relay_info = async {

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -4,17 +4,17 @@ use clap::Args;
 use colorful::Colorful;
 use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
-use ockam::identity::IdentityIdentifier;
-use ockam_multiaddr::proto::Project;
+use tokio::sync::Mutex;
+use tokio::try_join;
 
+use ockam::identity::IdentityIdentifier;
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::is_local_node;
 use ockam_api::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
 use ockam_core::api::Request;
+use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::{MultiAddr, Protocol};
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::output::Output;
@@ -87,7 +87,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
         cmd.relay_name.clone()
     };
 
-    let mut rpc = Rpc::background(&ctx, &opts, &api_node)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &api_node).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relay_info = async {

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,13 +1,12 @@
-use crate::node::get_node_name;
-
-use crate::util::{node_rpc, parse_node_name, Rpc};
-
-use crate::{docs, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
 use ockam_core::api::Request;
+
+use crate::node::get_node_name;
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -48,7 +47,7 @@ pub async fn run_impl(
         let relay_name = cmd.relay_name.clone();
         let at = get_node_name(&opts.state, &cmd.at);
         let node = parse_node_name(&at)?;
-        let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
         rpc.tell(Request::delete(format!("/node/forwarder/{relay_name}",)))
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -1,15 +1,15 @@
 use clap::Args;
-
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
+use tokio::sync::Mutex;
+use tokio::try_join;
+use tracing::trace;
+
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::forwarder::ForwarderInfo;
 use ockam_core::api::Request;
-use tokio::sync::Mutex;
-use tokio::try_join;
-use tracing::trace;
 
 use crate::node::get_node_name;
 use crate::terminal::OckamColor;
@@ -49,7 +49,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relays = async {

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -43,7 +43,7 @@ async fn run_impl(
     let at = get_node_name(&opts.state, &cmd.at);
     let node_name = extract_address_value(&at)?;
     let remote_address = &cmd.remote_address;
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let relay_info: ForwarderInfo = rpc
         .ask(Request::get(format!("/node/forwarder/{remote_address}")))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -1,19 +1,20 @@
-use crate::docs;
+use std::str::FromStr;
 
+use clap::Parser;
+use colorful::Colorful;
+use serde_json::json;
+
+use ockam::{route, Context};
+use ockam_api::{nodes::models::secure_channel::DeleteSecureChannelResponse, route_to_multiaddr};
+use ockam_core::{Address, AddressParseError};
+
+use crate::docs;
+use crate::node::get_node_name;
 use crate::util::{is_tty, parse_node_name};
 use crate::{
     util::{api, exitcode, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
-use clap::Parser;
-use colorful::Colorful;
-
-use crate::node::get_node_name;
-use ockam::{route, Context};
-use ockam_api::{nodes::models::secure_channel::DeleteSecureChannelResponse, route_to_multiaddr};
-use ockam_core::{Address, AddressParseError};
-use serde_json::json;
-use std::str::FromStr;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -153,7 +154,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> m
         let at = get_node_name(&opts.state, &cmd.at);
         let node_name = parse_node_name(&at)?;
         let address = &cmd.address;
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
         let response: DeleteSecureChannelResponse =
             rpc.ask(api::delete_secure_channel(address)).await?;
         cmd.print_output(&node_name, address, &opts, response);

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -1,16 +1,16 @@
+use std::fmt::Write;
+
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
-use ockam_api::cli_state::StateDirTrait;
-use std::fmt::Write;
+use tokio::sync::Mutex;
+use tokio::try_join;
 
 use ockam::Context;
+use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::secure_channel::ShowSecureChannelResponse;
 use ockam_api::route_to_multiaddr;
 use ockam_core::{route, Address};
-
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 use crate::node::get_node_name;
 use crate::output::Output;
@@ -91,7 +91,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
     }
 
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
 
     let get_secure_channel_identifiers = async {
         let secure_channel_identifiers: Vec<String> = rpc.ask(api::list_secure_channels()).await?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -58,7 +58,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = parse_node_name(&at)?;
-    let mut rpc = Rpc::background(ctx, &opts, &node)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node).await?;
     let req = Request::post("/node/secure_channel_listener").body(
         CreateSecureChannelListenerRequest::new(
             &cmd.address,

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -44,7 +44,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let at = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&at)?;
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let req = api::delete_secure_channel_listener(&cmd.address);
     let response: DeleteSecureChannelListenerResponse = rpc.ask(req).await?;
     let addr = response.addr;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -1,6 +1,9 @@
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::secure_channel::{
@@ -8,8 +11,6 @@ use ockam_api::nodes::models::secure_channel::{
 };
 use ockam_api::route_to_multiaddr;
 use ockam_core::route;
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::output::Output;
@@ -62,7 +63,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_listeners = async {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/show.rs
@@ -46,7 +46,7 @@ async fn run_impl(
     let node_name = parse_node_name(&at)?;
     let address = &cmd.address;
 
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let req = api::show_secure_channel_listener(address);
     rpc.tell(req).await?;
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -1,15 +1,16 @@
+use clap::Args;
+
+use ockam::Context;
+use ockam_api::nodes::models::secure_channel::ShowSecureChannelResponse;
+use ockam_core::Address;
+
+use crate::node::get_node_name;
+use crate::util::parse_node_name;
 use crate::{
     docs,
     util::{api, node_rpc, Rpc},
     CommandGlobalOpts,
 };
-use clap::Args;
-
-use crate::node::get_node_name;
-use crate::util::parse_node_name;
-use ockam::Context;
-use ockam_api::nodes::models::secure_channel::ShowSecureChannelResponse;
-use ockam_core::Address;
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -44,7 +45,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> mie
     let node_name = parse_node_name(&at)?;
     let address = &cmd.address;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let response: ShowSecureChannelResponse = rpc.ask(api::show_secure_channel(address)).await?;
     opts.println(&response)?;
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 use miette::IntoDiagnostic;
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::services::{ServiceList, ServiceStatus};
@@ -14,7 +14,7 @@ use tokio::try_join;
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::output::Output;
 use crate::terminal::OckamColor;
-use crate::util::{api, node_rpc, parse_node_name, RpcBuilder};
+use crate::util::{api, node_rpc, parse_node_name, Rpc};
 use crate::CommandGlobalOpts;
 
 /// List service(s) of a given node
@@ -50,8 +50,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_services = async {

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -4,12 +4,12 @@ use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 use miette::IntoDiagnostic;
-use ockam::Context;
-
-use ockam_api::cli_state::StateDirTrait;
-use ockam_api::nodes::models::services::{ServiceList, ServiceStatus};
 use tokio::sync::Mutex;
 use tokio::try_join;
+
+use ockam::Context;
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::nodes::models::services::{ServiceList, ServiceStatus};
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::output::Output;
@@ -50,7 +50,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_services = async {

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -96,7 +96,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, StartCommand)) -> mi
 
 async fn run_impl(ctx: Context, opts: CommandGlobalOpts, cmd: StartCommand) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let mut is_hop_service = false;
     let addr = match cmd.create_subcommand {
         StartSubCommand::Hop { addr, .. } => {
@@ -149,7 +149,7 @@ async fn run_impl(ctx: Context, opts: CommandGlobalOpts, cmd: StartCommand) -> m
 
 /// Helper function.
 pub(crate) async fn start_service_impl<'a, T>(
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     serv_name: &str,
     req: RequestBuilder<T>,
 ) -> Result<()>
@@ -162,19 +162,19 @@ where
 }
 
 /// Public so `ockam_command::node::create` can use it.
-pub async fn start_hop_service<'a>(rpc: &mut Rpc<'a>, serv_addr: &str) -> Result<()> {
+pub async fn start_hop_service<'a>(rpc: &mut Rpc, serv_addr: &str) -> Result<()> {
     let req = api::start_hop_service(serv_addr);
     start_service_impl(rpc, "Hop", req).await
 }
 
 /// Public so `ockam_command::node::create` can use it.
-pub async fn start_identity_service<'a>(rpc: &mut Rpc<'a>, serv_addr: &str) -> Result<()> {
+pub async fn start_identity_service<'a>(rpc: &mut Rpc, serv_addr: &str) -> Result<()> {
     let req = api::start_identity_service(serv_addr);
     start_service_impl(rpc, "Identity", req).await
 }
 
 /// Public so `ockam_command::node::create` can use it.
-pub async fn start_verifier_service<'a>(rpc: &mut Rpc<'a>, serv_addr: &str) -> Result<()> {
+pub async fn start_verifier_service<'a>(rpc: &mut Rpc, serv_addr: &str) -> Result<()> {
     let req = api::start_verifier_service(serv_addr);
     start_service_impl(rpc, "Verifier", req).await
 }
@@ -182,7 +182,7 @@ pub async fn start_verifier_service<'a>(rpc: &mut Rpc<'a>, serv_addr: &str) -> R
 /// Public so `ockam_command::node::create` can use it.
 #[allow(clippy::too_many_arguments)]
 pub async fn start_authenticator_service<'a>(
-    rpc: &mut Rpc<'a>,
+    rpc: &mut Rpc,
     serv_addr: &str,
     project: &str,
 ) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -4,10 +4,10 @@ use colorful::Colorful;
 use ockam::Context;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
@@ -56,8 +56,7 @@ async fn run_impl(
         .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this space?")?
     {
         let space_id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
-        let node_name = start_embedded_node(ctx, &opts, None).await?;
-        let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
+        let mut rpc = Rpc::embedded(ctx, &opts).await?;
         rpc.tell(api::space::delete(&space_id, &CloudOpts::route()))
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -4,9 +4,9 @@ use ockam::Context;
 use ockam_api::cli_state::{SpaceConfig, StateDirTrait, StateItemTrait};
 use ockam_api::cloud::space::Space;
 
-use crate::node::util::{delete_embedded_node, start_embedded_node};
+use crate::node::util::delete_embedded_node;
 use crate::util::api::{self, CloudOpts};
-use crate::util::{node_rpc, RpcBuilder};
+use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
@@ -50,11 +50,10 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
 
-    let node_name = start_embedded_node(ctx, &opts, None).await?;
     let controller_route = &CloudOpts::route();
 
     // Send request
-    let mut rpc = RpcBuilder::new(ctx, &opts, &node_name).build();
+    let mut rpc = Rpc::embedded(ctx, &opts).await?;
     let space: Space = rpc.ask(api::space::show(&id, controller_route)).await?;
     opts.println(&space)?;
     opts.state

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -88,7 +88,7 @@ pub mod utils {
     use super::*;
 
     pub async fn subscription_id_from_cmd_args<'a>(
-        rpc: &mut Rpc<'a>,
+        rpc: &mut Rpc,
         controller_route: &MultiAddr,
         subscription_id: Option<String>,
         space_id: Option<String>,
@@ -103,7 +103,7 @@ pub mod utils {
     }
 
     async fn subscription_id_from_space_id<'a>(
-        rpc: &mut Rpc<'a>,
+        rpc: &mut Rpc,
         controller_route: &MultiAddr,
         space_id: &str,
     ) -> crate::Result<String> {

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -64,9 +64,7 @@ async fn run_impl(
             space_id,
         } => {
             let subscription_id = utils::subscription_id_from_cmd_args(
-                &ctx,
-                &opts,
-                rpc.node_name(),
+                &mut rpc,
                 controller_route,
                 subscription_id,
                 space_id,
@@ -87,36 +85,28 @@ pub mod utils {
 
     use ockam_multiaddr::MultiAddr;
 
-    use crate::util::RpcBuilder;
-
     use super::*;
 
-    pub async fn subscription_id_from_cmd_args(
-        ctx: &Context,
-        opts: &CommandGlobalOpts,
-        api_node: &str,
+    pub async fn subscription_id_from_cmd_args<'a>(
+        rpc: &mut Rpc<'a>,
         controller_route: &MultiAddr,
         subscription_id: Option<String>,
         space_id: Option<String>,
     ) -> crate::Result<String> {
         match (subscription_id, space_id) {
             (_, Some(space_id)) => {
-                subscription_id_from_space_id(ctx, opts, api_node, controller_route, &space_id)
-                    .await
+                subscription_id_from_space_id(rpc, controller_route, &space_id).await
             }
             (Some(subscription_id), _) => Ok(subscription_id),
             _ => unreachable!(),
         }
     }
 
-    async fn subscription_id_from_space_id(
-        ctx: &Context,
-        opts: &CommandGlobalOpts,
-        api_node: &str,
+    async fn subscription_id_from_space_id<'a>(
+        rpc: &mut Rpc<'a>,
         controller_route: &MultiAddr,
         space_id: &str,
     ) -> crate::Result<String> {
-        let mut rpc = RpcBuilder::new(ctx, opts, api_node).build();
         let req = Request::get("subscription").body(CloudRequestWrapper::bare(controller_route));
         let subscriptions: Vec<Subscription> = rpc.ask(req).await?;
         let subscription = subscriptions

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,3 +1,11 @@
+use clap::Args;
+use colorful::Colorful;
+use miette::IntoDiagnostic;
+use serde_json::json;
+
+use ockam_api::address::extract_address_value;
+use ockam_api::nodes::models::transport::TransportStatus;
+
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::util::is_tty;
 use crate::{
@@ -5,12 +13,6 @@ use crate::{
     util::{api, node_rpc, Rpc},
     CommandGlobalOpts, OutputFormat,
 };
-use clap::Args;
-use colorful::Colorful;
-use miette::IntoDiagnostic;
-use ockam_api::address::extract_address_value;
-use ockam_api::nodes::models::transport::TransportStatus;
-use serde_json::json;
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -89,7 +91,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let from = get_node_name(&opts.state, &cmd.node_opts.from);
     let node_name = extract_address_value(&from)?;
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let request = api::create_tcp_connection(&cmd);
     let transport_status: TransportStatus = rpc.ask(request).await?;
     cmd.print_output(&opts, &transport_status)

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/delete.rs
@@ -1,12 +1,12 @@
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::util::{node_rpc, Rpc};
-use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 use clap::Args;
-
 use colorful::Colorful;
 
 use ockam_api::nodes::models;
 use ockam_core::api::Request;
+
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::{node_rpc, Rpc};
+use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -42,7 +42,7 @@ async fn run_impl(
     )? {
         let address = cmd.address;
         let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-        let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
         let req = Request::delete("/node/tcp/connection")
             .body(models::transport::DeleteTransport::new(address.clone()));
         rpc.tell(req).await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -1,19 +1,21 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::terminal::OckamColor;
-use crate::util::{node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts};
+use std::fmt::Write;
 
-use crate::output::Output;
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::transport::{TransportList, TransportStatus};
 use ockam_core::api::Request;
-use std::fmt::Write;
-use tokio::sync::Mutex;
-use tokio::try_join;
+
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::output::Output;
+use crate::terminal::OckamColor;
+use crate::util::{node_rpc, Rpc};
+use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -46,7 +48,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_transports = async {

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,11 +1,11 @@
 use clap::Args;
 
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_core::api::Request;
 
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -38,7 +38,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
     let transport_status: TransportStatus = rpc
         .ask(Request::get(format!(
             "/node/tcp/connection/{}",

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -6,14 +6,14 @@ use crate::util::duration::duration_parser;
 use crate::util::parsers::socket_addr_parser;
 use crate::util::{
     find_available_port, node_rpc, parse_node_name, port_is_free_guard, process_nodes_multiaddr,
-    RpcBuilder,
+    Rpc,
 };
 use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
 use ockam::identity::IdentityIdentifier;
-use ockam::{Context, TcpTransport};
+use ockam::Context;
 use ockam_abac::Resource;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::portal::CreateInlet;
@@ -100,8 +100,7 @@ async fn rpc(
     let node_name = get_node_name(&opts.state, &cmd.at);
     let node = parse_node_name(&node_name)?;
 
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-    let mut rpc = RpcBuilder::new(&ctx, &opts, &node).tcp(&tcp)?.build();
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
     let is_finished: Mutex<bool> = Mutex::new(false);
     let progress_bar = opts.terminal.progress_spinner();
     let create_inlet = async {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,17 +1,15 @@
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::policy::{add_default_project_policy, has_policy};
-use crate::tcp::util::alias_parser;
-use crate::terminal::OckamColor;
-use crate::util::duration::duration_parser;
-use crate::util::parsers::socket_addr_parser;
-use crate::util::{
-    find_available_port, node_rpc, parse_node_name, port_is_free_guard, process_nodes_multiaddr,
-    Rpc,
-};
-use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::str::FromStr;
+use std::thread::sleep;
+use std::time::Duration;
+
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
+use tokio::sync::Mutex;
+use tokio::try_join;
+use tracing::log::trace;
+
 use ockam::identity::IdentityIdentifier;
 use ockam::Context;
 use ockam_abac::Resource;
@@ -23,13 +21,18 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{route, Error};
 use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::{MultiAddr, Protocol as _};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::str::FromStr;
-use std::thread::sleep;
-use std::time::Duration;
-use tokio::sync::Mutex;
-use tokio::try_join;
-use tracing::log::trace;
+
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::policy::{add_default_project_policy, has_policy};
+use crate::tcp::util::alias_parser;
+use crate::terminal::OckamColor;
+use crate::util::duration::duration_parser;
+use crate::util::parsers::socket_addr_parser;
+use crate::util::{
+    find_available_port, node_rpc, parse_node_name, port_is_free_guard, process_nodes_multiaddr,
+    Rpc,
+};
+use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -100,7 +103,7 @@ async fn rpc(
     let node_name = get_node_name(&opts.state, &cmd.at);
     let node = parse_node_name(&node_name)?;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
     let progress_bar = opts.terminal.progress_spinner();
     let create_inlet = async {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,14 +1,14 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::tcp::util::alias_parser;
-
-use crate::fmt_ok;
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
 use ockam_core::api::Request;
+
+use crate::fmt_ok;
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::tcp::util::alias_parser;
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -47,7 +47,7 @@ pub async fn run_impl(
         let alias = cmd.alias.clone();
         let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
         let node = parse_node_name(&node_name)?;
-        let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
         rpc.tell(Request::delete(format!("/node/inlet/{alias}")))
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -1,19 +1,18 @@
+use clap::Args;
+use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
+use tokio::sync::Mutex;
+use tokio::try_join;
+
+use ockam_api::address::extract_address_value;
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::nodes::models::portal::InletList;
+use ockam_core::api::Request;
+
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
 use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
-
-use clap::Args;
-use colorful::Colorful;
-use miette::{miette, IntoDiagnostic};
-use ockam_api::cli_state::StateDirTrait;
-
-use ockam_core::api::Request;
-
-use ockam_api::address::extract_address_value;
-use ockam_api::nodes::models::portal::InletList;
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -46,7 +45,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_inlets = async {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,15 +1,17 @@
+use clap::Args;
+use colorful::Colorful;
+use indoc::formatdoc;
+use miette::IntoDiagnostic;
+
+use ockam::Context;
+use ockam_api::nodes::models::portal::InletStatus;
+use ockam_core::api::{Request, RequestBuilder};
+
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{node_rpc, parse_node_name, Rpc};
 use crate::{docs, CommandGlobalOpts};
 use crate::{fmt_ok, Result};
-use clap::Args;
-use colorful::Colorful;
-use indoc::formatdoc;
-use miette::IntoDiagnostic;
-use ockam::Context;
-use ockam_api::nodes::models::portal::InletStatus;
-use ockam_core::api::{Request, RequestBuilder};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
@@ -43,7 +45,7 @@ pub async fn run_impl(
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = parse_node_name(&node_name)?;
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let inlet_status: InletStatus = rpc.ask(make_api_request(cmd)?).await?;
 
     let json = serde_json::to_string(&inlet_status).into_diagnostic()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,13 +1,15 @@
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::util::Rpc;
-use crate::util::{node_rpc, parse_node_name};
-use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use miette::IntoDiagnostic;
+
 use ockam_api::nodes::models::transport::{CreateTcpListener, TransportStatus};
 use ockam_core::api::Request;
 use ockam_multiaddr::proto::{DnsAddr, Tcp};
 use ockam_multiaddr::MultiAddr;
+
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::util::Rpc;
+use crate::util::{node_rpc, parse_node_name};
+use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -36,7 +38,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.at);
     let node_name = parse_node_name(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let transport_status: TransportStatus = rpc
         .ask(Request::post("/node/tcp/listener").body(CreateTcpListener::new(cmd.address)))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -6,7 +6,6 @@ use ockam_api::nodes::models;
 use ockam_core::api::Request;
 
 use crate::node::{get_node_name, initialize_node_if_default};
-
 use crate::util::parse_node_name;
 use crate::util::{node_rpc, Rpc};
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
@@ -45,7 +44,7 @@ async fn run_impl(
     )? {
         let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
         let node = parse_node_name(&node_name)?;
-        let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
         let req = Request::delete("/node/tcp/listener")
             .body(models::transport::DeleteTransport::new(cmd.address.clone()));
         rpc.tell(req).await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -1,12 +1,12 @@
 use clap::Args;
-
 use colorful::Colorful;
 use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam::Context;
 use ockam_api::cli_state::StateDirTrait;
 use ockam_api::nodes::models::transport::TransportList;
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::terminal::OckamColor;
@@ -52,7 +52,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_transports = async {

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/show.rs
@@ -1,11 +1,11 @@
 use clap::Args;
 
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_core::api::Request;
 
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::util::{node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
 
@@ -38,7 +38,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
     let transport_status: TransportStatus = rpc
         .ask(Request::get(format!("/node/tcp/listener/{}", &cmd.address)))
         .await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -1,25 +1,26 @@
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::policy::{add_default_project_policy, has_policy};
-use crate::tcp::util::alias_parser;
-use crate::terminal::OckamColor;
 use std::net::SocketAddr;
-
-use crate::util::parsers::socket_addr_parser;
-use crate::util::{node_rpc, Rpc};
-use crate::{display_parse_logs, fmt_log};
-use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
 use ockam::Context;
 use ockam_abac::Resource;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::portal::{CreateOutlet, OutletStatus};
 use ockam_core::api::Request;
-use tokio::sync::Mutex;
-use tokio::try_join;
+
+use crate::node::{get_node_name, initialize_node_if_default};
+use crate::policy::{add_default_project_policy, has_policy};
+use crate::tcp::util::alias_parser;
+use crate::terminal::OckamColor;
+use crate::util::parsers::socket_addr_parser;
+use crate::util::{node_rpc, Rpc};
+use crate::{display_parse_logs, fmt_log};
+use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -149,7 +150,7 @@ pub async fn send_request(
     to_node: impl Into<Option<String>>,
 ) -> crate::Result<OutletStatus> {
     let to_node = get_node_name(&opts.state, &to_node.into());
-    let mut rpc = Rpc::background(ctx, opts, &to_node)?;
+    let mut rpc = Rpc::background(ctx, opts, &to_node).await?;
     let req = Request::post("/node/outlet").body(payload);
     rpc.ask(req).await
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,14 +1,14 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::tcp::util::alias_parser;
-
-use crate::fmt_ok;
-use crate::util::{node_rpc, parse_node_name, Rpc};
-use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 
 use ockam::Context;
 use ockam_core::api::Request;
+
+use crate::fmt_ok;
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::tcp::util::alias_parser;
+use crate::util::{node_rpc, parse_node_name, Rpc};
+use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -47,7 +47,7 @@ pub async fn run_impl(
         let alias = cmd.alias.clone();
         let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
         let node = parse_node_name(&node_name)?;
-        let mut rpc = Rpc::background(&ctx, &opts, &node)?;
+        let mut rpc = Rpc::background(&ctx, &opts, &node).await?;
         rpc.tell(Request::delete(format!("/node/outlet/{alias}")))
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -1,20 +1,19 @@
-use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
-use crate::terminal::OckamColor;
-
-use crate::util::{node_rpc, Rpc};
-use crate::{docs, CommandGlobalOpts};
-
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
-use ockam_api::cli_state::StateDirTrait;
-use ockam_api::nodes::models::portal::OutletList;
-
-use ockam_api::address::extract_address_value;
-use ockam_core::api::Request;
-use ockam_node::Context;
 use tokio::sync::Mutex;
 use tokio::try_join;
+
+use ockam_api::address::extract_address_value;
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::nodes::models::portal::OutletList;
+use ockam_core::api::Request;
+use ockam_node::Context;
+
+use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::terminal::OckamColor;
+use crate::util::{node_rpc, Rpc};
+use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/list/after_long_help.txt");
@@ -84,6 +83,6 @@ pub async fn send_request(
     to_node: impl Into<Option<String>>,
 ) -> crate::Result<OutletList> {
     let to_node = get_node_name(&opts.state, &to_node.into());
-    let mut rpc = Rpc::background(ctx, opts, &to_node)?;
+    let mut rpc = Rpc::background(ctx, opts, &to_node).await?;
     rpc.ask(Request::get("/node/outlet")).await
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,16 +1,17 @@
+use clap::Args;
+use miette::miette;
+
+use ockam::{route, Context};
+use ockam_api::address::extract_address_value;
+use ockam_api::nodes::models::portal::OutletStatus;
+use ockam_api::route_to_multiaddr;
+use ockam_core::api::{Request, RequestBuilder};
+
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
 use crate::tcp::util::alias_parser;
 use crate::util::{node_rpc, Rpc};
 use crate::Result;
 use crate::{docs, CommandGlobalOpts};
-use clap::Args;
-use miette::miette;
-use ockam::{route, Context};
-use ockam_api::address::extract_address_value;
-
-use ockam_api::nodes::models::portal::OutletStatus;
-use ockam_api::route_to_multiaddr;
-use ockam_core::api::{Request, RequestBuilder};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
@@ -43,7 +44,7 @@ pub async fn run_impl(
 ) -> miette::Result<()> {
     let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
     let node_name = extract_address_value(&node_name)?;
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let outlet_status: OutletStatus = rpc.ask(make_api_request(cmd)?).await?;
 
     println!("Outlet:");

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -1,12 +1,13 @@
 use core::time::Duration;
+use std::sync::Arc;
 use std::{
     net::{SocketAddr, TcpListener},
     path::Path,
     str::FromStr,
 };
 
-use miette::{IntoDiagnostic, miette};
 use miette::Context as _;
+use miette::{miette, IntoDiagnostic};
 use minicbor::{Decode, Encode};
 use tracing::{debug, error};
 
@@ -18,16 +19,17 @@ use ockam_api::cli_state::{CliState, StateDirTrait, StateItemTrait};
 use ockam_api::config::lookup::{InternetAddress, LookupMeta};
 use ockam_api::nodes::NODEMANAGER_ADDR;
 use ockam_core::api::{Reply, RequestBuilder, Response, Status};
+use ockam_core::AsyncTryClone;
 use ockam_core::DenyAll;
-use ockam_multiaddr::{
-    MultiAddr,
-    proto::{self, Node}, Protocol,
-};
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Project, Space, Tcp};
+use ockam_multiaddr::{
+    proto::{self, Node},
+    MultiAddr, Protocol,
+};
 
-use crate::{CommandGlobalOpts, Result};
 use crate::node::util::{start_embedded_node, start_embedded_node_with_vault_and_identity};
 use crate::util::api::TrustContextOpts;
+use crate::{CommandGlobalOpts, Result};
 
 pub mod api;
 pub mod duration;
@@ -36,68 +38,32 @@ pub mod orchestrator_api;
 pub mod parsers;
 
 #[derive(Clone)]
-pub enum RpcMode<'a> {
+pub enum RpcMode {
     Embedded,
-    Background { tcp: Option<&'a TcpTransport> },
+    Background(Arc<TcpTransport>),
 }
 
-pub struct RpcBuilder<'a> {
-    ctx: &'a Context,
-    opts: &'a CommandGlobalOpts,
-    node_name: String,
-    to: Route,
-    mode: RpcMode<'a>,
-}
-
-impl<'a> RpcBuilder<'a> {
-    pub fn new(ctx: &'a Context, opts: &'a CommandGlobalOpts, node_name: &str) -> Self {
-        RpcBuilder {
-            ctx,
-            opts,
-            node_name: node_name.to_string(),
-            to: NODEMANAGER_ADDR.into(),
-            mode: RpcMode::Embedded,
-        }
-    }
-
-    pub fn to(mut self, to: &MultiAddr) -> Result<Self> {
-        self.to = ockam_api::local_multiaddr_to_route(to)
-            .ok_or_else(|| miette!("failed to convert {} to route", to))?;
-        Ok(self)
-    }
-
-    pub fn build(self) -> Rpc<'a> {
-        Rpc {
-            ctx: self.ctx,
-            buf: Vec::new(),
-            opts: self.opts,
-            node_name: self.node_name,
-            to: self.to,
-            timeout: None,
-            mode: self.mode,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct Rpc<'a> {
-    ctx: &'a Context,
+#[derive(AsyncTryClone)]
+#[async_try_clone(crate = "ockam_core")]
+pub struct Rpc {
+    ctx: Context,
     buf: Vec<u8>,
-    pub opts: &'a CommandGlobalOpts,
+    pub opts: CommandGlobalOpts,
     node_name: String,
     to: Route,
     pub timeout: Option<Duration>,
-    mode: RpcMode<'a>,
+    mode: RpcMode,
 }
 
-impl<'a> Rpc<'a> {
+impl Rpc {
     /// Creates a new RPC to send a request to an embedded node.
-    pub async fn embedded(ctx: &'a Context, opts: &'a CommandGlobalOpts) -> Result<Rpc<'a>> {
+    pub async fn embedded(ctx: &Context, opts: &CommandGlobalOpts) -> Result<Rpc> {
         let node_name = start_embedded_node(ctx, opts, None).await?;
+        let ctx_clone = ctx.async_try_clone().await?;
         Ok(Rpc {
-            ctx,
+            ctx: ctx_clone,
             buf: Vec::new(),
-            opts,
+            opts: opts.clone(),
             node_name,
             to: NODEMANAGER_ADDR.into(),
             timeout: None,
@@ -107,15 +73,16 @@ impl<'a> Rpc<'a> {
 
     /// Creates a new RPC to send a request to an embedded node.
     pub async fn embedded_with_trust_options(
-        ctx: &'a Context,
-        opts: &'a CommandGlobalOpts,
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
         trust_context_opts: &TrustContextOpts,
-    ) -> Result<Rpc<'a>> {
+    ) -> Result<Rpc> {
         let node_name = start_embedded_node(ctx, opts, Some(trust_context_opts)).await?;
+        let ctx_clone = ctx.async_try_clone().await?;
         Ok(Rpc {
-            ctx,
+            ctx: ctx_clone,
             buf: Vec::new(),
-            opts,
+            opts: opts.clone(),
             node_name,
             to: NODEMANAGER_ADDR.into(),
             timeout: None,
@@ -125,11 +92,11 @@ impl<'a> Rpc<'a> {
 
     /// Creates a new RPC to send a request to an embedded node.
     pub async fn embedded_with_vault_and_identity(
-        ctx: &'a Context,
-        opts: &'a CommandGlobalOpts,
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
         identity: String,
         trust_context_opts: &TrustContextOpts,
-    ) -> Result<Rpc<'a>> {
+    ) -> Result<Rpc> {
         let node_name = start_embedded_node_with_vault_and_identity(
             ctx,
             &opts.state,
@@ -139,10 +106,11 @@ impl<'a> Rpc<'a> {
         )
         .await?;
 
+        let ctx_clone = ctx.async_try_clone().await?;
         Ok(Rpc {
-            ctx,
+            ctx: ctx_clone,
             buf: Vec::new(),
-            opts,
+            opts: opts.clone(),
             node_name,
             to: NODEMANAGER_ADDR.into(),
             timeout: None,
@@ -151,19 +119,21 @@ impl<'a> Rpc<'a> {
     }
 
     /// Creates a new RPC to send a request to a running background node.
-    pub fn background(
-        ctx: &'a Context,
-        opts: &'a CommandGlobalOpts,
+    pub async fn background(
+        ctx: &Context,
+        opts: &CommandGlobalOpts,
         node_name: &str,
-    ) -> Result<Rpc<'a>> {
+    ) -> Result<Rpc> {
+        let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
+        let ctx_clone = ctx.async_try_clone().await?;
         Ok(Rpc {
-            ctx,
+            ctx: ctx_clone,
             buf: Vec::new(),
-            opts,
+            opts: opts.clone(),
             node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
             timeout: None,
-            mode: RpcMode::Background { tcp: None },
+            mode: RpcMode::Background(Arc::new(tcp)),
         })
     }
 
@@ -180,6 +150,12 @@ impl<'a> Rpc<'a> {
     pub fn set_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.timeout = Some(timeout);
         self
+    }
+
+    pub fn set_to(&mut self, to: &MultiAddr) -> Result<&Self> {
+        self.to = ockam_api::local_multiaddr_to_route(to)
+            .ok_or_else(|| miette!("failed to convert {} to route", to))?;
+        Ok(self)
     }
 
     /// Send a request
@@ -236,7 +212,7 @@ impl<'a> Rpc<'a> {
     where
         T: Encode<()>,
     {
-        let route = self.route_impl(self.ctx).await?;
+        let route = self.route_impl().await?;
         let options = self
             .timeout
             .map(|t| MessageSendReceiveOptions::new().with_timeout(t))
@@ -252,30 +228,19 @@ impl<'a> Rpc<'a> {
         Ok(())
     }
 
-    async fn route_impl(&self, ctx: &Context) -> Result<Route> {
+    async fn route_impl(&self) -> Result<Route> {
         let mut to = self.to.clone();
-        let route = match self.mode {
+        let route = match &self.mode {
             RpcMode::Embedded => to,
-            RpcMode::Background { ref tcp } => {
+            RpcMode::Background(tcp) => {
                 let node_state = self.opts.state.nodes.get(&self.node_name)?;
                 let port = node_state.config().setup().api_transport()?.addr.port();
                 let addr_str = format!("localhost:{port}");
-                let addr = match tcp {
-                    None => {
-                        let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
-                        tcp.connect(addr_str, TcpConnectionOptions::new())
-                            .await?
-                            .sender_address()
-                            .clone()
-                    }
-                    Some(tcp) => {
-                        // Create a new connection anyway
-                        tcp.connect(addr_str, TcpConnectionOptions::new())
-                            .await?
-                            .sender_address()
-                            .clone()
-                    }
-                };
+                let addr = tcp
+                    .connect(addr_str, TcpConnectionOptions::new())
+                    .await?
+                    .sender_address()
+                    .clone();
                 to.modify().prepend(addr);
                 to
             }
@@ -547,9 +512,9 @@ pub fn random_name() -> String {
 mod tests {
     use ockam_api::address::extract_address_value;
     use ockam_api::cli_state;
-    use ockam_api::cli_state::{NodeConfig, VaultConfig};
     use ockam_api::cli_state::identities::IdentityConfig;
     use ockam_api::cli_state::traits::StateDirTrait;
+    use ockam_api::cli_state::{NodeConfig, VaultConfig};
     use ockam_api::nodes::models::transport::{CreateTransportJson, TransportMode, TransportType};
 
     use super::*;

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -1,17 +1,19 @@
+use clap::Args;
+use colorful::Colorful;
+use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+
+use ockam::Context;
+use ockam_api::address::extract_address_value;
+use ockam_api::cli_state::StateDirTrait;
+use ockam_api::nodes::models::workers::{WorkerList, WorkerStatus};
+
 use crate::node::{get_node_name, initialize_node_if_default};
 use crate::output::Output;
 use crate::terminal::OckamColor;
 use crate::util::{api, node_rpc, Rpc};
 use crate::{docs, CommandGlobalOpts};
-use clap::Args;
-use colorful::Colorful;
-use miette::miette;
-use ockam::Context;
-use ockam_api::address::extract_address_value;
-use ockam_api::cli_state::StateDirTrait;
-use ockam_api::nodes::models::workers::{WorkerList, WorkerStatus};
-use tokio::sync::Mutex;
-use tokio::try_join;
 
 const LONG_ABOUT: &str = include_str!("./static/list/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -48,7 +50,7 @@ async fn run_impl(
         return Err(miette!("The node '{}' is not running", node_name));
     }
 
-    let mut rpc = Rpc::background(&ctx, &opts, &node_name)?;
+    let mut rpc = Rpc::background(&ctx, &opts, &node_name).await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_workers = async {


### PR DESCRIPTION
This PR is preparing further work for simplifying `Rpc` calls:

 - all the creation of `Rpc` have been reduced to either `Rpc::embedded` or `Rpc::background`
 - a `&mut Rpc` is passed around instead of `Context + CommandGlobalOpts` and have `Rpc` recreated in different places
 - this allows a simplification of the `Rpc` type which doesn't need a lifetime parameter anymore, nor to to embark an optional `TcpTransport`

This goes towards implementing [this story](https://github.com/build-trust/ockam/issues/5902).