### PR TITLE
feat(rust): add support for additional kafka addons

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -628,7 +628,7 @@ mod tests {
             authority_access_route: None,
             authority_identity: None,
             okta_config: None,
-            confluent_config: None,
+            kafka_config: None,
             version: None,
             running: None,
             operation_id: None,

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -28,11 +28,12 @@ pub struct Addon {
 #[derive(Encode, Decode, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ConfluentConfig {
+pub struct KafkaConfig {
+    #[serde(skip)]
     #[cbor(n(1))] pub bootstrap_server: String,
 }
 
-impl ConfluentConfig {
+impl KafkaConfig {
     pub fn new<S: Into<String>>(bootstrap_server: S) -> Self {
         Self {
             bootstrap_server: bootstrap_server.into(),
@@ -40,23 +41,8 @@ impl ConfluentConfig {
     }
 }
 
-#[derive(Encode, Decode, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct ConfluentConfigResponse {
-    #[cbor(n(1))] pub bootstrap_server: String,
-}
-
-impl ConfluentConfigResponse {
-    pub fn new<S: ToString>(bootstrap_server: S) -> Self {
-        Self {
-            bootstrap_server: bootstrap_server.to_string(),
-        }
-    }
-}
-
 #[cfg(test)]
-impl quickcheck::Arbitrary for ConfluentConfig {
+impl quickcheck::Arbitrary for KafkaConfig {
     fn arbitrary(g: &mut quickcheck::Gen) -> Self {
         Self {
             bootstrap_server: String::arbitrary(g),
@@ -87,7 +73,7 @@ pub trait Addons {
         &self,
         ctx: &Context,
         project_id: &str,
-        config: ConfluentConfig,
+        config: KafkaConfig,
     ) -> miette::Result<CreateOperationResponse>;
 
     async fn configure_okta_addon(
@@ -129,9 +115,9 @@ impl Addons for ControllerClient {
         &self,
         ctx: &Context,
         project_id: &str,
-        config: ConfluentConfig,
+        config: KafkaConfig,
     ) -> miette::Result<CreateOperationResponse> {
-        trace!(target: TARGET, project_id, "configuring confluent addon");
+        trace!(target: TARGET, project_id, "configuring kafka addon");
         let req = Request::post(format!(
             "/v1/projects/{project_id}/configure_addon/confluent"
         ))

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -14,7 +14,7 @@ use ockam_core::{async_trait, Error, Result};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::{tokio, Context};
 
-use crate::cloud::addon::ConfluentConfig;
+use crate::cloud::addon::KafkaConfig;
 use crate::cloud::email_address::EmailAddress;
 use crate::cloud::enroll::auth0::UserInfo;
 use crate::cloud::operation::{Operation, Operations};
@@ -64,7 +64,7 @@ pub struct Project {
 
     #[cbor(n(12))]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub confluent_config: Option<ConfluentConfig>,
+    pub kafka_config: Option<KafkaConfig>,
 
     #[cbor(n(13))]
     pub version: Option<String>,
@@ -648,7 +648,7 @@ mod tests {
                 authority_identity: bool::arbitrary(g)
                     .then(|| hex::encode(<Vec<u8>>::arbitrary(g))),
                 okta_config: bool::arbitrary(g).then(|| OktaConfig::arbitrary(g)),
-                confluent_config: bool::arbitrary(g).then(|| ConfluentConfig::arbitrary(g)),
+                kafka_config: bool::arbitrary(g).then(|| KafkaConfig::arbitrary(g)),
                 version: Some(String::arbitrary(g)),
                 running: bool::arbitrary(g).then(|| bool::arbitrary(g)),
                 operation_id: bool::arbitrary(g).then(|| String::arbitrary(g)),

--- a/implementations/rust/ockam/ockam_api/src/schema/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/src/schema/schema.cddl
@@ -49,7 +49,7 @@ project = {
     ?9: authority_access_route, ; optional, it can be missing if the authority hasn't started yet
     ?10: authority_identity, ; optional, hex encoded authority identity
     ?11: project_okta_config,
-    ?12: project_confluent_config,
+    ?12: project_kafka_config,
     ?13: project_version,
     ?14: project_running,
     ?15: project_operation_id,
@@ -102,12 +102,12 @@ okta_certificate     = text
 okta_client_id       = text
 okta_tenant_base_url = text
 
-project_confluent_config = {
+project_kafka_config = {
   ?0: 6434816,
-  1: confluent_bootstrap_server
+  1: kafka_bootstrap_server
 }
 
-confluent_bootstrap_server = text
+kafka_bootstrap_server = text
 
 ;;; Identity ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
@@ -383,7 +383,7 @@ mod tests {
                     authority_access_route: Some("/project/authority_route".to_string()),
                     authority_identity: Some("81a201583ba20101025835a4028201815820afbca9cf5d440147450f9f0d0a038a337b3fe5c17086163f2c54509558b62ef403f4041a64dd404a051a77a9434a0282018158407754214545cda6e7ff49136f67c9c7973ec309ca4087360a9f844aac961f8afe3f579a72c0c9530f3ff210f02b7c5f56e96ce12ee256b01d7628519800723805".to_string()),
                     okta_config: None,
-                    confluent_config: None,
+                    kafka_config: None,
                     version: None,
                     running: None,
                     operation_id: None,

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/aiven.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/aiven.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+
+use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
+use crate::util::node_rpc;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("../static/configure_aiven/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("../static/configure_aiven/after_long_help.txt");
+
+/// Configure the Aiven addon for a project
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
+)]
+pub struct AddonConfigureAivenSubcommand {
+    #[command(flatten)]
+    config: KafkaCommandConfig,
+}
+
+impl AddonConfigureAivenSubcommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, "Aiven (Kafka)", self.config));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/confluent.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+
+use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
+use crate::util::node_rpc;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("../static/configure_confluent/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("../static/configure_confluent/after_long_help.txt");
+
+/// Configure the Confluent addon for a project
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
+)]
+pub struct AddonConfigureConfluentSubcommand {
+    #[command(flatten)]
+    config: KafkaCommandConfig,
+}
+
+impl AddonConfigureConfluentSubcommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, "Confluent", self.config));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/instaclustr.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/instaclustr.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+
+use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
+use crate::util::node_rpc;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("../static/configure_instaclustr/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("../static/configure_instaclustr/after_long_help.txt");
+
+/// Configure the Instaclustr addon for a project
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
+)]
+pub struct AddonConfigureInstaclustrSubcommand {
+    #[command(flatten)]
+    config: KafkaCommandConfig,
+}
+
+impl AddonConfigureInstaclustrSubcommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, "Instaclustr (Kafka)", self.config));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/redpanda.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/redpanda.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+
+use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
+use crate::util::node_rpc;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("../static/configure_redpanda/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("../static/configure_redpanda/after_long_help.txt");
+
+/// Configure the Redpanda addon for a project
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
+)]
+pub struct AddonConfigureRedpandaSubcommand {
+    #[command(flatten)]
+    config: KafkaCommandConfig,
+}
+
+impl AddonConfigureRedpandaSubcommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, "Redpanda", self.config));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/warpstream.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/warpstream.rs
@@ -1,0 +1,25 @@
+use clap::Args;
+
+use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
+use crate::util::node_rpc;
+use crate::{docs, CommandGlobalOpts};
+
+const LONG_ABOUT: &str = include_str!("../static/configure_warpstream/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("../static/configure_warpstream/after_long_help.txt");
+
+/// Configure the WarpStream addon for a project
+#[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP),
+)]
+pub struct AddonConfigureWarpstreamSubcommand {
+    #[command(flatten)]
+    config: KafkaCommandConfig,
+}
+
+impl AddonConfigureWarpstreamSubcommand {
+    pub fn run(self, opts: CommandGlobalOpts) {
+        node_rpc(run_impl, (opts, "WarpStream", self.config));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -9,8 +9,12 @@ use ockam_node::Context;
 
 use crate::operation::util::check_for_operation_completion;
 use crate::output::Output;
-use crate::project::addon::configure_confluent::AddonConfigureConfluentSubcommand;
 use crate::project::addon::configure_influxdb::AddonConfigureInfluxdbSubcommand;
+use crate::project::addon::configure_kafka::{
+    AddonConfigureAivenSubcommand, AddonConfigureConfluentSubcommand,
+    AddonConfigureInstaclustrSubcommand, AddonConfigureKafkaSubcommand,
+    AddonConfigureRedpandaSubcommand, AddonConfigureWarpstreamSubcommand,
+};
 use crate::project::addon::configure_okta::AddonConfigureOktaSubcommand;
 use crate::project::addon::disable::AddonDisableSubcommand;
 use crate::project::addon::list::AddonListSubcommand;
@@ -18,8 +22,8 @@ use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 use crate::{CommandGlobalOpts, Result};
 
-mod configure_confluent;
 mod configure_influxdb;
+mod configure_kafka;
 mod configure_okta;
 mod disable;
 mod list;
@@ -52,11 +56,17 @@ impl AddonCommand {
     }
 }
 
+/// Configure an addon for a project
 #[derive(Clone, Debug, Subcommand)]
 pub enum ConfigureAddonCommand {
     Okta(AddonConfigureOktaSubcommand),
     Influxdb(AddonConfigureInfluxdbSubcommand),
     Confluent(AddonConfigureConfluentSubcommand),
+    InstaclustrKafka(AddonConfigureInstaclustrSubcommand),
+    AivenKafka(AddonConfigureAivenSubcommand),
+    Redpanda(AddonConfigureRedpandaSubcommand),
+    Warpstream(AddonConfigureWarpstreamSubcommand),
+    Kafka(AddonConfigureKafkaSubcommand),
 }
 
 impl ConfigureAddonCommand {
@@ -65,6 +75,11 @@ impl ConfigureAddonCommand {
             ConfigureAddonCommand::Okta(cmd) => cmd.run(opts),
             ConfigureAddonCommand::Influxdb(cmd) => cmd.run(opts),
             ConfigureAddonCommand::Confluent(cmd) => cmd.run(opts),
+            ConfigureAddonCommand::InstaclustrKafka(cmd) => cmd.run(opts),
+            ConfigureAddonCommand::AivenKafka(cmd) => cmd.run(opts),
+            ConfigureAddonCommand::Redpanda(cmd) => cmd.run(opts),
+            ConfigureAddonCommand::Warpstream(cmd) => cmd.run(opts),
+            ConfigureAddonCommand::Kafka(cmd) => cmd.run(opts),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_aiven/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_aiven/after_long_help.txt
@@ -1,0 +1,3 @@
+Examples of how to configure and use the Aiven (Kafka) addon can be found within the example documentation:
+
+- https://docs.ockam.io/guides/examples/end-to-end-encrypted-kafka

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_aiven/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_aiven/long_about.txt
@@ -1,0 +1,1 @@
+Aiven (Kafka) addon allows you to enable end-to-end encryption with your Kafka Consumers and Kafka Producers.

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_instaclustr/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_instaclustr/after_long_help.txt
@@ -1,0 +1,3 @@
+Examples of how to configure and use the Instaclustr (Kafka) addon can be found within the example documentation:
+
+- https://docs.ockam.io/guides/examples/end-to-end-encrypted-kafka

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_instaclustr/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_instaclustr/long_about.txt
@@ -1,0 +1,1 @@
+Instaclustr (Kafka) addon allows you to enable end-to-end encryption with your Kafka Consumers and Kafka Producers.

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_kafka/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_kafka/after_long_help.txt
@@ -1,0 +1,3 @@
+Examples of how to configure and use the Apache Kafka addon can be found within the example documentation:
+
+- https://docs.ockam.io/guides/examples/end-to-end-encrypted-kafka

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_kafka/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_kafka/long_about.txt
@@ -1,0 +1,1 @@
+Apache Kafka addon allows you to enable end-to-end encryption with your Kafka Consumers and Kafka Producers.

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_redpanda/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_redpanda/after_long_help.txt
@@ -1,0 +1,3 @@
+Examples of how to configure and use the Redpanda addon can be found within the example documentation:
+
+- https://docs.ockam.io/guides/examples/end-to-end-encrypted-kafka

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_redpanda/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_redpanda/long_about.txt
@@ -1,0 +1,1 @@
+Redpanda addon allows you to enable end-to-end encryption with your Kafka Consumers and Kafka Producers.

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_warpstream/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_warpstream/after_long_help.txt
@@ -1,0 +1,3 @@
+Examples of how to configure and use the WarpStream addon can be found within the example documentation:
+
+- https://docs.ockam.io/guides/examples/end-to-end-encrypted-kafka

--- a/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_warpstream/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/static/configure_warpstream/long_about.txt
@@ -1,0 +1,1 @@
+WarpSteam addon allows you to enable end-to-end encryption with your Kafka Consumers and Kafka Producers.

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231006100000_create_database.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231006100000_create_database.sql
@@ -241,7 +241,7 @@ CREATE TABLE okta_config
     attributes      TEXT           -- Comma-separated list of attribute names
 );
 
--- This table stores the data necessary to configure the Confluent addon
+-- This table stores the data necessary to configure the Kafka addons
 CREATE TABLE confluent_config
 (
     project_id       TEXT NOT NULL, -- Project id of the project using the addon

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20240108100000_rename_confluent_config_table.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20240108100000_rename_confluent_config_table.sql
@@ -1,0 +1,2 @@
+-- Rename the `confluent_config` table to `kafka_config`
+ALTER TABLE confluent_config RENAME TO kafka_config;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
@@ -121,7 +121,8 @@ impl SqlxDatabase {
 
     async fn migrate(&self) -> Result<()> {
         Self::migrate_tables(&self.pool).await?;
-        self.migrate_attributes_node_name().await
+        self.migrate_attributes_node_name().await?;
+        Ok(())
     }
 
     pub(crate) async fn migrate_tables(pool: &SqlitePool) -> Result<()> {


### PR DESCRIPTION
## Current behavior

The current support for Apache Kafka is configured via an add-on named `confluent`. 

## Proposed changes

I've been testing support for other Apache Kafka compatible brokers and many of them work, but it's a bit weird to configure them by configuring `confluent` when you're actually using a completely different product. These changes are adding the following subcommands:

* `ockam project addon configure aiven-kafka`
* `ockam project addon configure instaclustr`
* `ockam project addon configure redpanda`
* `ockam project addon configure kafka`
