### PR TITLE
chore(rust): app long time usage debugging

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -176,7 +176,11 @@ mod node {
             let sc = {
                 let cloud_route = crate::multiaddr_to_route(cloud_multiaddr, &self.tcp_transport)
                     .await
-                    .ok_or_else(|| ApiError::core("Invalid Multiaddr"))?;
+                    .ok_or_else(|| {
+                        ApiError::core(format!(
+                            "Couldn't convert MultiAddr to route: cloud_multiaddr={cloud_multiaddr}"
+                        ))
+                    })?;
 
                 let options = SecureChannelOptions::new()
                     .with_trust_policy(TrustIdentifierPolicy::new(self.controller_identifier()));

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/list.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/list.rs
@@ -64,6 +64,8 @@ mod node {
         ) -> Result<Vec<u8>> {
             let cloud_multiaddr = req_wrapper.multiaddr()?;
             let req_body = req_wrapper.req;
+            debug!(req = ?req_body, "Sending request to list shares");
+
             let label = "list_shares";
             let req_builder = Request::get("/v0/invites").body(req_body);
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/plain_tcp.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/plain_tcp.rs
@@ -38,10 +38,18 @@ impl Instantiator for PlainTcpInstantiator {
 
         let mut tcp = multiaddr_to_route(&tcp_piece, &self.tcp_transport)
             .await
-            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
+            .ok_or_else(|| {
+                ApiError::core(format!(
+                    "Couldn't convert MultiAddr to route: tcp_piece={tcp_piece}"
+                ))
+            })?;
 
-        let multiaddr =
-            route_to_multiaddr(&tcp.route).ok_or_else(|| ApiError::core("invalid tcp route"))?;
+        let multiaddr = route_to_multiaddr(&tcp.route).ok_or_else(|| {
+            ApiError::core(format!(
+                "Couldn't convert route to MultiAddr: tcp_route={}",
+                &tcp.route
+            ))
+        })?;
 
         let current_multiaddr = ConnectionInstanceBuilder::combine(before, multiaddr, after)?;
 
@@ -50,7 +58,7 @@ impl Instantiator for PlainTcpInstantiator {
         let tcp_connection = tcp
             .tcp_connection
             .take()
-            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
+            .ok_or_else(|| ApiError::core("TCP connection should be set"))?;
 
         Ok(Changes {
             current_multiaddr,

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -69,7 +69,11 @@ impl Instantiator for ProjectInstantiator {
         debug!(addr = %project_multiaddr, "creating secure channel");
         let tcp = multiaddr_to_route(&project_multiaddr, &node_manager.tcp_transport)
             .await
-            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
+            .ok_or_else(|| {
+                ApiError::core(format!(
+                    "Couldn't convert MultiAddr to route: project_multiaddr={project_multiaddr}"
+                ))
+            })?;
 
         let sc = node_manager
             .create_secure_channel_impl(

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
@@ -55,8 +55,11 @@ impl Instantiator for SecureChannelInstantiator {
         let transport_route = builder.transport_route.clone();
 
         debug!(%secure_piece, %transport_route, "creating secure channel");
-        let route = local_multiaddr_to_route(&secure_piece)
-            .ok_or_else(|| ApiError::core("invalid multiaddr"))?;
+        let route = local_multiaddr_to_route(&secure_piece).ok_or_else(|| {
+            ApiError::core(format!(
+                "Couldn't convert local MultiAddr to route: secure_piece={secure_piece}"
+            ))
+        })?;
 
         let mut node_manager = self.node_manager.write().await;
         let sc = node_manager

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -20,8 +20,7 @@ use ockam::{
 use ockam_abac::expr::{and, eq, ident, str};
 use ockam_abac::{Action, Env, Expr, PolicyAccessControl, PolicyStorage, Resource};
 use ockam_core::api::{Error, Method, Request, Response, ResponseBuilder, Status};
-use ockam_core::compat::{boxed::Box, string::String, sync::Arc};
-use ockam_core::errcode::{Kind, Origin};
+use ockam_core::compat::{string::String, sync::Arc};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::IncomingAccessControl;
 use ockam_core::{AllowAll, AsyncTryClone};
@@ -71,16 +70,6 @@ pub(crate) type Alias = String;
 #[inline]
 fn random_alias() -> String {
     Address::random_local().without_type().to_owned()
-}
-
-// TODO: Move to multiaddr implementation
-pub(crate) fn invalid_multiaddr_error() -> ockam_core::Error {
-    ockam_core::Error::new(Origin::Core, Kind::Invalid, "Invalid multiaddr")
-}
-
-// TODO: Move to multiaddr implementation
-pub(crate) fn map_multiaddr_err(_err: ockam_multiaddr::Error) -> ockam_core::Error {
-    invalid_multiaddr_error()
 }
 
 pub(crate) fn encode_request_result<T: Encode<()>>(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -13,7 +13,6 @@ use crate::cli_state::traits::StateDirTrait;
 use crate::error::ApiError;
 use crate::local_multiaddr_to_route;
 use crate::nodes::models::credentials::{GetCredentialRequest, PresentCredentialRequest};
-use crate::nodes::service::map_multiaddr_err;
 
 use super::NodeManagerWorker;
 
@@ -66,7 +65,12 @@ impl NodeManagerWorker {
         let request: PresentCredentialRequest = dec.decode()?;
 
         // TODO: Replace with self.connect?
-        let route = MultiAddr::from_str(&request.route).map_err(map_multiaddr_err)?;
+        let route = MultiAddr::from_str(&request.route).map_err(|_| {
+            ApiError::core(format!(
+                "Couldn't convert String to MultiAddr: {}",
+                &request.route
+            ))
+        })?;
         let route = match local_multiaddr_to_route(&route) {
             Some(route) => route,
             None => return Err(ApiError::core("Invalid credentials service route").into()),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -290,6 +290,13 @@ impl NodeManagerWorker {
                     InletInfo::new(&listen_addr, Some(&worker_addr), &outlet_route),
                 );
                 if !connection_instance.normalized_addr.is_empty() {
+                    debug! {
+                        %alias,
+                        %listen_addr,
+                        %worker_addr,
+                        ping_addr = %connection_instance.transport_route,
+                        "Creating session for TCP inlet"
+                    };
                     let mut session = Session::new(connection_instance.transport_route.clone());
 
                     let ctx = Arc::new(ctx.async_try_clone().await?);

--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -34,7 +34,12 @@ pub async fn enroll_user(app: &AppHandle<Wry>) -> Result<()> {
     app_state.reset_node_manager().await?;
     app.trigger_global(crate::projects::events::REFRESH_PROJECTS, None);
     app.trigger_global(crate::invitations::events::REFRESH_INVITATIONS, None);
-    shared_service::relay::create_relay(&app_state).await?;
+    shared_service::relay::create_relay(
+        app_state.context(),
+        app_state.state().await,
+        app_state.node_manager_worker().await,
+    )
+    .await;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -123,7 +123,7 @@ pub async fn refresh_invitations<R: Runtime>(app: AppHandle<R>) -> Result<(), St
         )
         .await
         .map_err(|e| e.to_string())?;
-    trace!(?invitations);
+    trace!(?invitations, "Invitations fetched");
     {
         let invitation_state: State<'_, SyncState> = app.state();
         let mut writer = invitation_state.write().await;
@@ -166,10 +166,11 @@ async fn refresh_inlets<R: Runtime>(app: &AppHandle<R>) -> crate::Result<()> {
                                 "--output",
                                 "json"
                             )
-                            .stderr_to_stdout()
+                            .env("OCKAM_LOG", "off")
                             .stdout_capture()
                             .run()
                             {
+                                trace!(output = ?String::from_utf8_lossy(&cmd.stdout), "TCP inlet status");
                                 let inlet: InletStatus = serde_json::from_slice(&cmd.stdout)?;
                                 let inlet_socket_addr = SocketAddr::from_str(&inlet.bind_addr)?;
                                 inlet_is_running = true;

--- a/implementations/rust/ockam/ockam_app/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/commands.rs
@@ -16,10 +16,7 @@ type SyncState = Arc<RwLock<ProjectState>>;
 // Matches backend default of 14 days
 const DEFAULT_ENROLLMENT_TICKET_EXPIRY: &str = "14d";
 
-// At time of writing, tauri::command requires pub not pub(crate)
-
-#[tauri::command]
-pub async fn create_enrollment_ticket<R: Runtime>(
+pub(crate) async fn create_enrollment_ticket<R: Runtime>(
     project_id: String,
     app: AppHandle<R>,
 ) -> Result<EnrollmentTicket> {
@@ -74,16 +71,7 @@ pub(crate) async fn list_projects_with_admin<R: Runtime>(
         .collect())
 }
 
-#[tauri::command]
-pub async fn list_projects<R: Runtime>(app: AppHandle<R>) -> Result<Vec<Project>> {
-    let state: State<'_, SyncState> = app.state();
-    let reader = state.read().await;
-    debug!(projects = ?reader);
-    Ok((*reader).clone())
-}
-
-#[tauri::command]
-pub async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+pub(crate) async fn refresh_projects<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     info!("refreshing projects");
     let state: State<'_, AppState> = app.state();
     if !state.is_enrolled().await.unwrap_or(false) {

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -18,7 +18,6 @@ const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(60 * 5);
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
     Builder::new("projects")
-        .invoke_handler(tauri::generate_handler![list_projects])
         .setup(|app, _api| {
             debug!("Initializing the projects plugin");
             app.manage(Arc::new(RwLock::new(State::default())));

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
@@ -2,9 +2,6 @@ use ockam::Context;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
-use tokio_retry::strategy::FixedInterval;
-use tokio_retry::Retry;
-use tracing::error;
 
 pub(crate) async fn load_model_state(
     context: Arc<Context>,
@@ -13,12 +10,5 @@ pub(crate) async fn load_model_state(
 ) {
     let node_manager_worker = node_manager_worker.clone();
     let cli_state = cli_state.clone();
-    tauri::async_runtime::spawn(async move {
-        let retry_strategy = FixedInterval::from_millis(60_000).take(10);
-        let _ = Retry::spawn(retry_strategy.clone(), || async {
-            super::create_relay_impl(&context, &cli_state, &node_manager_worker).await
-        })
-        .await
-        .map_err(|e| error!(?e, "failed to create relay at the default project"));
-    });
+    super::create_relay(context, cli_state, node_manager_worker).await;
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -353,7 +353,14 @@ async fn run_foreground_node(
 
     // Create a channel for communicating back to the main thread
     let (tx, mut rx) = tokio::sync::mpsc::channel(2);
-    shutdown::wait(opts.terminal.clone(), cmd.exit_on_eof, false, tx, &mut rx).await?;
+    shutdown::wait(
+        opts.terminal.clone(),
+        cmd.exit_on_eof,
+        opts.global_args.quiet,
+        tx,
+        &mut rx,
+    )
+    .await?;
 
     // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
     if let Ok(state) = opts.state.nodes.get(&node_name) {

--- a/implementations/rust/ockam/ockam_command/src/shutdown.rs
+++ b/implementations/rust/ockam/ockam_command/src/shutdown.rs
@@ -6,13 +6,14 @@ use std::io::Read;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::info;
 
 /// Waits for CTRL+C, EOF or a signal to exit, can provide extra shutdown events by
 /// sending a message through the channel
 pub async fn wait(
     terminal: Terminal<TerminalStream<Term>>,
     exit_on_eof: bool,
-    muted: bool,
+    quiet: bool,
     tx: Sender<()>,
     rx: &mut Receiver<()>,
 ) -> miette::Result<bool> {
@@ -21,16 +22,17 @@ pub async fn wait(
         let tx = tx.clone();
         let terminal = terminal.clone();
         // avoid printing CTRL+C multiple times
-        let first_time_handling_ctrl_c = Arc::new(AtomicBool::new(true));
+        let flag = Arc::new(AtomicBool::new(true));
         ctrlc::set_handler(move || {
-            if first_time_handling_ctrl_c.load(std::sync::atomic::Ordering::Relaxed) {
+            if flag.load(std::sync::atomic::Ordering::Relaxed) {
                 let _ = tx.blocking_send(());
-                if !muted {
+                info!("Ctrl+C signal received");
+                if !quiet {
                     let _ = terminal.write_line(
                         format!("{} Ctrl+C signal received", "!".light_yellow()).as_str(),
                     );
                 }
-                first_time_handling_ctrl_c.store(false, std::sync::atomic::Ordering::Relaxed);
+                flag.store(false, std::sync::atomic::Ordering::Relaxed);
             }
         })
         .expect("Error setting Ctrl+C handler");
@@ -48,7 +50,8 @@ pub async fn wait(
                     .read_to_end(&mut buffer)
                     .expect("Error reading from stdin");
                 let _ = tx.blocking_send(());
-                if !muted {
+                info!("EOF received");
+                if !quiet {
                     let _ = terminal
                         .write_line(format!("{} EOF received", "!".light_yellow()).as_str());
                 }


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/5903. Check [this comment](https://github.com/build-trust/ockam/issues/5903#issuecomment-1710129183) for more context.

- fix(rust): disable logs when retrieving a node on `ockam_app` to properly capture the output
- chore(rust): add logs to shutdown events used in `ockam node create`
- chore(rust): add more context to `MultiAddr` errors caught at ockam_api
- refactor(rust): at app startup and after enrolling, try to create the relay until it succeeds