### PR TITLE
ci: rename ockam app package to just ockam

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -82,6 +82,8 @@ runs:
           cargo build --bin ockam --target ${{ inputs.target }} --release
         fi
 
+        cp target/${{ inputs.target }}/release/ockam target/${{ inputs.target }}/release/ockam_command
+
     - shell: bash
       if: inputs.build_app == 'true'
       run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -254,16 +254,16 @@ jobs:
     - name: Copy Artifacts
       run: |
         set -x
-        find target/
-        cp target/${{ matrix.target }}/release/ockam ockam.${{ matrix.target }}
+
+        cp target/${{ matrix.target }}/release/ockam_command ockam.${{ matrix.target }}
         echo "ASSET_OCKAM_CLI=ockam.${{ matrix.target }}" >> $GITHUB_ENV
-        if [ -e "target/${{ matrix.target }}/release/bundle/dmg/Ockam App"*dmg ]; then
-          cp "target/${{ matrix.target }}/release/bundle/dmg/Ockam App"*dmg "Ockam_App_${{ matrix.target }}.dmg"
-          echo "ASSET_OCKAM_APP_DMG=Ockam_App_${{ matrix.target }}.dmg" >> $GITHUB_ENV
+        if [ -e "target/${{ matrix.target }}/release/bundle/dmg/Ockam"*dmg ]; then
+          cp "target/${{ matrix.target }}/release/bundle/dmg/Ockam"*dmg "ockam.app.${{ matrix.target }}.dmg"
+          echo "ASSET_OCKAM_APP_DMG=ockam.app.${{ matrix.target }}.dmg" >> $GITHUB_ENV
         fi
-        if [ -e "target/${{ matrix.target }}/release/bundle/deb/ockam-app"*.deb ]; then
-          cp "target/${{ matrix.target }}/release/bundle/deb/ockam-app"*.deb "ockam-app-${{ matrix.target }}.deb"
-          echo "ASSET_OCKAM_APP_DEB=ockam-app-${{ matrix.target }}.deb" >> $GITHUB_ENV
+        if [ -e "target/${{ matrix.target }}/release/bundle/deb/ockam"*.deb ]; then
+          cp "target/${{ matrix.target }}/release/bundle/deb/ockam"*.deb "ockam.app.${{ matrix.target }}.deb"
+          echo "ASSET_OCKAM_APP_DEB=ockam.app.${{ matrix.target }}.deb" >> $GITHUB_ENV
         fi
         ls $GITHUB_WORKSPACE
 
@@ -471,7 +471,7 @@ jobs:
         run: gh release download ${{ needs.create_release.outputs.tag_name }} -R ${{ github.repository_owner }}/ockam
 
       - name: Generate File SHASum
-        run: shasum -a 256 ockam.* Ockam_* > sha256sums.txt
+        run: shasum -a 256 ockam.* > sha256sums.txt
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19

--- a/implementations/rust/ockam/ockam_app/tauri.conf.json
+++ b/implementations/rust/ockam/ockam_app/tauri.conf.json
@@ -12,7 +12,7 @@
     "distDir": "../../../typescript/ockam/ockam_app/build"
   },
   "package": {
-    "productName": "Ockam App"
+    "productName": "Ockam"
   },
   "tauri": {
     "security": {
@@ -32,7 +32,7 @@
         "icons/icon.ico"
       ],
       "resources": [],
-      "shortDescription": "Ockam App",
+      "shortDescription": "Ockam Desktop Application",
       "longDescription": "End-to-end encryption and mutual authentication for distributed applications.",
       "targets": [
         "deb",


### PR DESCRIPTION
Rename `Ockam App` package to `Ockam`. The file itself will keep the `.app.` suffix to differentiate it.

note that a naming conflict will arise if the developer builds both tauri package and `ockam` command, this issue is side-stepped in CI by renaming `ockam` to `ockam_command`. This should **not** impact day to day development since a simple `cargo build` will still build `ockam_app` and not `ockam`.
