### PR TITLE
refactor(rust): new menu design for invitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arboard"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac57f2b058a76363e357c056e4f74f1945bf734d37b8b3ef49066c4787dde0fc"
+dependencies = [
+ "clipboard-win",
+ "core-graphics 0.22.3",
+ "image",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "parking_lot",
+ "thiserror",
+ "winapi",
+ "x11rb",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +2966,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3489,8 @@ dependencies = [
  "color_quant",
  "num-rational",
  "num-traits",
+ "png",
+ "tiff",
 ]
 
 [[package]]
@@ -3700,6 +3731,12 @@ dependencies = [
  "static_assertions",
  "uuid",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
@@ -4046,6 +4083,15 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -4358,6 +4404,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -4678,6 +4736,7 @@ dependencies = [
 name = "ockam_app"
 version = "0.1.0"
 dependencies = [
+ "arboard",
  "duct",
  "hex",
  "indoc",
@@ -7504,6 +7563,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
+]
+
+[[package]]
 name = "time"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8372,6 +8442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8403,6 +8479,15 @@ name = "winapi-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
  "winapi",
 ]
@@ -8730,6 +8815,28 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507"
+dependencies = [
+ "gethostname",
+ "nix 0.24.3",
+ "winapi",
+ "winapi-wsapoll",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67"
+dependencies = [
+ "nix 0.24.3",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/mod.rs
@@ -10,6 +10,7 @@ mod create;
 mod list;
 mod show;
 
+use crate::address::extract_address_value;
 use crate::error::ApiError;
 use crate::identity::EnrollmentTicket;
 pub use accept::*;
@@ -169,6 +170,10 @@ impl ServiceAccessDetails {
         let as_json = serde_json::from_slice(&hex_decoded)
             .map_err(|_| ApiError::core("Invalid enrollment ticket"))?;
         Ok(as_json)
+    }
+
+    pub fn service_name(&self) -> Result<String, ApiError> {
+        extract_address_value(&self.shared_node_route)
     }
 }
 

--- a/implementations/rust/ockam/ockam_app/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app/Cargo.toml
@@ -34,6 +34,7 @@ path = "src/lib.rs"
 tauri-build = { version = "=2.0.0-alpha.8", features = [] }
 
 [dependencies]
+arboard = "3.2.1"
 duct = "0.13.6"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 indoc = "2.0.3"

--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -310,6 +310,7 @@ fn load_model_state(
     context: Arc<Context>,
     cli_state: &CliState,
 ) -> ModelState {
+    crate::shared_service::relay::load_model_state(context.clone(), node_manager_worker, cli_state);
     block_on(async {
         match model_state_repository.load().await {
             Ok(model_state) => {
@@ -318,12 +319,6 @@ fn load_model_state(
                     context.clone(),
                     node_manager_worker,
                     &model_state,
-                    cli_state,
-                )
-                .await;
-                crate::shared_service::relay::load_model_state(
-                    context.clone(),
-                    node_manager_worker,
                     cli_state,
                 )
                 .await;

--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -71,9 +71,9 @@ pub fn process_tray_menu_event<R: Runtime>(
 fn on_enroll<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
-        enroll_user(&app_handle)
+        let _ = enroll_user(&app_handle)
             .await
-            .map_err(|e| error!(%e, "Failed to enroll user"))
+            .map_err(|e| error!(%e, "Failed to enroll user"));
     });
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/commands.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use tauri::{AppHandle, Manager, Runtime, State};
 use tracing::{debug, info, trace, warn};
 
-use ockam_api::address::{extract_address_value, get_free_address};
+use ockam_api::address::get_free_address;
 use ockam_api::cli_state::{CliState, StateDirTrait};
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::share::{AcceptInvitation, CreateServiceInvitation, InvitationWithAccess};
@@ -215,7 +215,7 @@ async fn refresh_inlets<R: Runtime>(
                                 .push((invitation.invitation.id.clone(), inlet_socket_addr));
                         }
                         Err(err) => {
-                            warn!(%err, node = %i.local_node_name, "Failed to create tcp-inlet for accepted invitation");
+                            warn!(%err, node = %i.local_node_name, "Failed to create TCP inlet for accepted invitation");
                         }
                     }
                 }
@@ -296,6 +296,8 @@ async fn create_inlet(inlet_data: &InletDataFromInvitation) -> crate::Result<Soc
         &service_route,
         "--alias",
         &service_name,
+        "--retry-wait",
+        "0",
     )
     .stderr_null()
     .stdout_capture()
@@ -323,7 +325,7 @@ impl InletDataFromInvitation {
     ) -> crate::Result<Option<Self>> {
         match &invitation.service_access_details {
             Some(d) => {
-                let service_name = extract_address_value(&d.shared_node_route)?;
+                let service_name = d.service_name()?;
                 let mut enrollment_ticket = d.enrollment_ticket()?;
                 // The enrollment ticket contains the project data.
                 // We need to replace the project name on the enrollment ticket with the project id,

--- a/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod commands;
 pub(crate) mod events;
 pub(super) mod plugin;
-mod state;
+pub(crate) mod state;
 mod tray_menu;
 
 use std::net::SocketAddr;

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -25,9 +25,9 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             app.listen_global(REFRESH_INVITATIONS, move |_event| {
                 let handle = handle.clone();
                 spawn(async move {
-                    refresh_invitations(handle.clone())
+                    let _ = refresh_invitations(handle.clone())
                         .await
-                        .map_err(|e| error!(%e, "Failed to refresh invitations"))
+                        .map_err(|e| error!(%e, "Failed to refresh invitations"));
                 });
             });
 

--- a/implementations/rust/ockam/ockam_app/src/invitations/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/state.rs
@@ -37,13 +37,4 @@ pub struct AcceptedInvitations {
     pub(crate) inlets: HashMap<String, SocketAddr>,
 }
 
-impl AcceptedInvitations {
-    pub fn zip(&self) -> Vec<(&InvitationWithAccess, Option<&SocketAddr>)> {
-        self.invitations
-            .iter()
-            .map(|invitation| (invitation, self.inlets.get(&invitation.invitation.id)))
-            .collect::<Vec<_>>()
-    }
-}
-
 pub(crate) type SyncInvitationsState = Arc<RwLock<InvitationState>>;

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -86,13 +86,6 @@ pub(crate) fn pending_invitation_menu<R: Runtime>(
             &MenuItemBuilder::with_id(id.clone(), &invitation.recipient_email)
                 .enabled(false)
                 .build(app_handle),
-            // TODO: not supported yet
-            // &MenuItemBuilder::with_id(
-            //     format!("invitation-sent-cancel-{}", invitation.id),
-            //     "Cancel",
-            // )
-            // .enabled(false)
-            // .build(app_handle),
         ])
         .build()
         .expect("cannot build single invitation submenu")
@@ -142,13 +135,6 @@ fn received_invite_menu<R: Runtime>(
                 include_bytes!("../../icons/check-lg.png").to_vec(),
             ))
             .build(app_handle),
-            // TODO: not supported yet
-            // &IconMenuItemBuilder::with_id(
-            //     format!("invitation-received_decline_{}", invitation.id),
-            //     "Decline invite",
-            // )
-            // .icon(Icon::Raw(include_bytes!("../../icons/x-lg.png").to_vec()))
-            // .build(app_handle),
         ])
         .build()
         .expect("cannot build received invitation submenu")
@@ -228,15 +214,6 @@ fn accepted_invite_menu<R: Runtime>(
                 .build(app_handle),
         ),
     };
-    // TODO: not supported yet
-    // submenu_builder.item(
-    //     &MenuItemBuilder::with_id(
-    //         format!("invitation-accepted–leave-{invitation_id}"),
-    //         "Leave",
-    //     )
-    //     .enabled(false)
-    //     .build(app_handle),
-    // );
     submenu_builder
         .build()
         .expect("cannot build accepted invitation submenu")

--- a/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/options/tray_menu.rs
@@ -77,9 +77,9 @@ fn on_docs() -> tauri::Result<()> {
 fn on_reset<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
-        reset(&app)
+        let _ = reset(&app)
             .await
-            .map_err(|e| error!(%e, "Failed to reset app"))
+            .map_err(|e| error!(%e, "Failed to reset app"));
     });
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/projects/plugin.rs
@@ -26,9 +26,9 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
             app.listen_global(REFRESH_PROJECTS, move |_event| {
                 let handle = handle.clone();
                 spawn(async move {
-                    refresh_projects(handle.clone())
+                    let _ = refresh_projects(handle.clone())
                         .await
-                        .map_err(|e| error!(%e, "Failed to refresh projects"))
+                        .map_err(|e| error!(%e, "Failed to refresh projects"));
                 });
             });
 

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/state.rs
@@ -3,7 +3,7 @@ use ockam_api::cli_state::CliState;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
 
-pub(crate) async fn load_model_state(
+pub(crate) fn load_model_state(
     context: Arc<Context>,
     node_manager_worker: &NodeManagerWorker,
     cli_state: &CliState,

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -177,9 +177,14 @@ async fn rpc(
                         }
                     };
                     trace!("the inlet creation returned a non-OK status: {s:?}");
+
+                    if cmd.retry_wait.as_millis() == 0 {
+                        return Err(miette!("Failed to create TCP inlet"))?;
+                    }
+
                     if let Some(spinner) = progress_bar.as_ref() {
                         spinner.set_message(format!(
-                            "Waiting for outlet {} to be available... Retrying momentarily",
+                            "Waiting for inlet {} to be available... Retrying momentarily",
                             &cmd.to
                                 .to_string()
                                 .color(OckamColor::PrimaryResource.color())

--- a/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_socket_addr]/CreateServiceInvitation.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_socket_addr]/CreateServiceInvitation.svelte
@@ -32,8 +32,7 @@
     <div class="mx-auto max-w-md flex-1">
       <div class="font-bold">Email Address</div>
       <p class="text-sm text-gray-500">
-        Recipient will need to install the Ockam app,<br /> and enroll using this
-        address.
+        Recipient will need to install the Ockam app, and enroll using this address.
       </p>
     </div>
     <div class="flex-1">


### PR DESCRIPTION
## Current limitations

- I wanted to show the pending invites as a submenu of the shared service. Currently we can't do that because the pending invitation data we receive from the backend doesn't include the shared service name, only the invitation id, so we don't have a way to match them
- The backend doesn't return the accepted invitations to the sharer user, only the accepted invitations from the invited user perspective
- Related to the first point, the pending invitations can't show the service name, only the invitation id

## Shared services
![image](https://github.com/build-trust/ockam/assets/12375782/8b0db5de-1af8-4b30-a910-80ca2098c714)

## Pending invitations
![image](https://github.com/build-trust/ockam/assets/12375782/2e340fe1-fbf7-4665-a89b-2ad96b459ea1)

## Connected services
![image](https://github.com/build-trust/ockam/assets/12375782/f46d0313-2403-405e-ba82-b6edd504b607)

