### PR TITLE
style: remove ANSI color codes from unsupported environments during i…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ heading() {
     # shellcheck disable=SC2059
     printf "${_orange}   $1${_no_color}\n"
   else
-    echo "${_orange}   $1${_no_color}"
+    echo "   $1"
   fi
 }
 


### PR DESCRIPTION
This commit updates the heading function in the install script to prevent that raw output.

## Current behavior

Currently when installing ockam on environments that don't support ansi color codes (specifically the SGR sequences used here), the raw code is output to the terminal like so:
```
\033[0;33m   GET STARTED:\033[0m
```

## Proposed changes

This simply removes the code from the conditional check to reflect the behavior of other items with color codes.

## Checks

- [x ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ x] There are no Merge commits in this Pull Request. The Ockam repo maintains a linear commit history so we merge PRs by rebasing them to the develop branch. Rebasing to the latest develop branch and force pushing to your PR branch is okay.
- [ x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.
