### PR TITLE
feat(rust): app event debouncer

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/tray_menu.rs
@@ -13,6 +13,9 @@ pub(crate) async fn build_user_info_section<'a, R: Runtime, M: Manager<R>>(
     mut builder: MenuBuilder<'a, R, M>,
 ) -> MenuBuilder<'a, R, M> {
     let app_state: State<AppState> = app_handle.state();
+    if !app_state.is_enrolled().await.unwrap_or(false) {
+        return builder;
+    }
     if let Ok(user_info) = app_state.user_info().await {
         builder = builder.items(&[
             &MenuItemBuilder::new(format!("{} ({})", user_info.name, user_info.nickname))

--- a/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/plugin.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use crate::app::events::system_tray_on_update;
+use crate::app::AppState;
 use tauri::{
     async_runtime::{spawn, RwLock},
     plugin::{Builder, TauriPlugin},
@@ -23,8 +24,14 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
 
             let handle = app.clone();
             app.listen_global(REFRESH_INVITATIONS, move |_event| {
+                let app_state = handle.state::<AppState>();
+                let event_tracker = app_state.debounce_event(&handle, REFRESH_INVITATIONS);
+                if event_tracker.is_processing() {
+                    return;
+                }
                 let handle = handle.clone();
                 spawn(async move {
+                    let _event_tracker = event_tracker;
                     let _ = refresh_invitations(handle.clone())
                         .await
                         .map_err(|e| error!(%e, "Failed to refresh invitations"));

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -36,7 +36,7 @@ pub(crate) async fn build_invitations_section<'a, R: Runtime, M: Manager<R>>(
 ) -> MenuBuilder<'a, R, M> {
     let app_state: State<'_, AppState> = app_handle.state();
     if !app_state.is_enrolled().await.unwrap_or(false) {
-        trace!("not enrolled, skipping invitations menu");
+        trace!("Not enrolled, skipping invitations menu");
         return builder;
     };
 

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
@@ -40,7 +40,7 @@ async fn create_relay_impl(
 ) -> Result<Option<ForwarderInfo>> {
     trace!("Creating relay");
     if !cli_state.is_enrolled().unwrap_or(false) {
-        trace!("User is not enrolled, skipping...");
+        trace!("Not enrolled, skipping relay creation");
         return Ok(None);
     }
     match cli_state.projects.default() {


### PR DESCRIPTION
If I understand [Tauri's docs](https://tauri.app/v1/references/architecture/process-model/#the-core-process) correctly, the backend (rust part) runs as a single process (core process). Even though we `spawn` tasks to process background operations, some times the core process gets stuck if one of those background tasks takes longer than expected (couldn't reach the orchestrator, for example). 

Also, since we process most of the events as spawned tasks, multiple events can get processed concurrently, and some times, the same event gets fired up multiple times in a short period of time. 

This PR implements an event debouncer to prevent the same event from being processed multiple times concurrently and free up the core process from useless background tasks.

Here's a non sintetic example of debounced events while going through the enrolling process:

![Screenshot 2023-09-19 at 15 00 05](https://github.com/build-trust/ockam/assets/12375782/d14d6fb3-6472-4b2d-bd70-98e35f2ea4e6)

