### PR TITLE
fix(rust): `project enroll` now can read the enrollment ticket from the passed path

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -58,13 +58,18 @@ pub struct EnrollCommand {
     pub force: bool,
 }
 
-pub fn parse_enroll_ticket(input: &str) -> Result<EnrollmentTicket> {
-    let decoded = match std::fs::read_to_string(input) {
-        Ok(s) => hex::decode(s)?,
-        Err(_) => hex::decode(input)?,
+pub fn parse_enroll_ticket(hex_encoded_data_or_path: &str) -> Result<EnrollmentTicket> {
+    let decoded = match std::fs::read_to_string(hex_encoded_data_or_path) {
+        Ok(data) => hex::decode(data.trim())
+            .into_diagnostic()
+            .context("Failed to decode enrollment ticket from file")?,
+        Err(_) => hex::decode(hex_encoded_data_or_path)
+            .into_diagnostic()
+            .context("Failed to decode enrollment ticket from file")?,
     };
-
-    Ok(serde_json::from_slice(&decoded)?)
+    Ok(serde_json::from_slice(&decoded)
+        .into_diagnostic()
+        .context("Failed to parse enrollment ticket from decoded data")?)
 }
 
 impl EnrollCommand {

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
@@ -24,6 +24,18 @@ teardown() {
   run_success "$OCKAM" project version
 }
 
+@test "project - enrollment from file - parse check" {
+  run_success bash -c "$OCKAM project ticket >$OCKAM_HOME/p.ticket"
+
+  # From file
+  run_success "$OCKAM" project enroll "$OCKAM_HOME/p.ticket" --test-argument-parser
+  run_failure "$OCKAM" project enroll "$OCKAM_HOME/p.t" --test-argument-parser
+
+  # From contents
+  run_success "$OCKAM" project enroll $(cat "$OCKAM_HOME/p.ticket") --test-argument-parser
+  run_failure "$OCKAM" project enroll "INVALID_TICKET" --test-argument-parser
+}
+
 @test "projects - enrollment" {
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
 


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/5978