### PR TITLE
fix(elixir): fix format on list_member_ids response

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/authenticator/direct/client.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/authenticator/direct/client.ex
@@ -95,7 +95,7 @@ defmodule Ockam.Credential.Authenticator.Direct.Client do
   def list_member_ids(api_route) do
     case ApiClient.sync_request(:get, "/member_ids", "", api_route) do
       {:ok, %ApiResponse{status: 200, body: response}} ->
-        Ockam.TypedCBOR.decode_strict({:list, :string}, response)
+        Ockam.TypedCBOR.decode_strict({:list, :binary}, response)
 
       {:ok, %ApiResponse{status: status, body: body}} ->
         {:error, {:api_error, status, body}}


### PR DESCRIPTION
Fix response parsing for list_members_ids call.
Allow creation of new identities from aws keys.