### PR TITLE
feat(rust): add menu items to connect to/disconnect from an invited service

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/invitations/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/state.rs
@@ -34,7 +34,71 @@ pub struct AcceptedInvitations {
 
     /// Inlets for accepted invitations, keyed by invitation id.
     #[serde(default)]
-    pub(crate) inlets: HashMap<String, SocketAddr>,
+    pub(crate) inlets: HashMap<String, TcpInlet>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TcpInlet {
+    pub(crate) socket_addr: SocketAddr,
+    pub(crate) enabled: bool,
+}
+
+impl TcpInlet {
+    pub fn new(socket_addr: SocketAddr) -> Self {
+        Self {
+            socket_addr,
+            enabled: true,
+        }
+    }
 }
 
 pub(crate) type SyncInvitationsState = Arc<RwLock<InvitationState>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_api::cloud::share::{RoleInShare, ShareScope};
+
+    #[test]
+    fn test_replace_by() {
+        let mut state = InvitationState::default();
+        assert!(state.sent.is_empty());
+        assert!(state.received.is_empty());
+        assert!(state.accepted.invitations.is_empty());
+        let list = InvitationList {
+            sent: Some(vec![SentInvitation {
+                id: "id".to_string(),
+                expires_at: "expires_at".to_string(),
+                grant_role: RoleInShare::Admin,
+                owner_id: 0,
+                recipient_email: "".to_string(),
+                remaining_uses: 0,
+                scope: ShareScope::Project,
+                target_id: "target_id".to_string(),
+            }]),
+            received: Some(vec![ReceivedInvitation {
+                id: "id".to_string(),
+                expires_at: "expires_at".to_string(),
+                grant_role: RoleInShare::Admin,
+                owner_email: "owner_email".to_string(),
+                scope: ShareScope::Project,
+                target_id: "target_id".to_string(),
+            }]),
+            accepted: Some(vec![InvitationWithAccess {
+                invitation: ReceivedInvitation {
+                    id: "id".to_string(),
+                    expires_at: "expires_at".to_string(),
+                    grant_role: RoleInShare::Admin,
+                    owner_email: "owner_email".to_string(),
+                    scope: ShareScope::Project,
+                    target_id: "target_id".to_string(),
+                },
+                service_access_details: None,
+            }]),
+        };
+        state.replace_by(list);
+        assert_eq!(state.sent.len(), 1);
+        assert_eq!(state.received.len(), 1);
+        assert_eq!(state.accepted.invitations.len(), 1);
+    }
+}

--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -170,8 +170,13 @@ fn add_accepted_menus<R: Runtime>(
         let mut submenu_builder = SubmenuBuilder::new(app_handle, owner_email);
         submenu_builder = invitations
             .into_iter()
-            .map(|(invitation_id, access_details, inlet_socket_addr)| {
-                accepted_invite_menu(app_handle, invitation_id, access_details, inlet_socket_addr)
+            .map(|(invitation_id, access_details, inlet)| {
+                accepted_invite_menu(
+                    app_handle,
+                    invitation_id,
+                    access_details,
+                    inlet.map(|i| &i.socket_addr),
+                )
             })
             .fold(submenu_builder, |menu, submenu| menu.item(&submenu));
         submenus.push(

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -45,7 +45,7 @@ pub struct CreateCommand {
     at: Option<String>,
 
     /// Address on which to accept tcp connections.
-    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", default_value_t = default_from_addr(), value_parser = socket_addr_parser)]
+    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", hide_default_value = true, default_value_t = default_from_addr(), value_parser = socket_addr_parser)]
     from: SocketAddr,
 
     /// Route to a tcp outlet.


### PR DESCRIPTION
Fixes https://github.com/build-trust/codebase/issues/576 and fixes https://github.com/build-trust/ockam/issues/5988

- persist tcp inlets data to reuse the same address when recreating them
- add menu items to manually connect/disconnect to/from an invited service
