### PR TITLE
disable unused rust packages

### DIFF
--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -1,12 +1,19 @@
 name: Elixir Cache
 description: Elixir Cache
 
+inputs:
+  job_name:
+    description: Extra key to use for restoring and saving the cache
+    required: true
+
 runs:
   using: composite
   steps:
     - uses: actions/cache@67b839edb68371cc5014f6cea11c9aa77238de78
       with:
-        path: '**/deps'
-        key: cache-elixir-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/mix.lock') }}
+        path: |
+          **/deps
+          **/_build
+        key: cache-elixir-${{ github.workflow }}-${{ inputs.job_name }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          cache-elixir-${{ github.workflow }}-${{ github.job }}-
+          cache-elixir-${{ github.workflow }}-${{ inputs.job_name }}-

--- a/.github/actions/nix_installer/action.yml
+++ b/.github/actions/nix_installer/action.yml
@@ -6,5 +6,3 @@ runs:
   steps:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@3ebd1aebb47f95493b62de6eec0cac3cd74e50a9
-
-    - uses: DeterminateSystems/magic-nix-cache-action@749fc5bbc9fa49d60c2b93f6c4bc867b82e1d295

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -74,6 +74,8 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/nix_installer
       - uses: ./.github/actions/elixir_cache
+        with:
+          job_name: lint_${{ matrix.mix_project }}
       - run: make lint_${{ matrix.mix_project }}
         working-directory: implementations/elixir
 
@@ -99,6 +101,8 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/nix_installer
       - uses: ./.github/actions/elixir_cache
+        with:
+          job_name: build_${{ matrix.mix_project }}
       - run: make build_${{ matrix.mix_project }}
         working-directory: implementations/elixir
 
@@ -124,5 +128,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/nix_installer
       - uses: ./.github/actions/elixir_cache
+        with:
+          job_name: test_${{ matrix.mix_project }}
       - run: make test_${{ matrix.mix_project }}
         working-directory: implementations/elixir

--- a/implementations/elixir/.gitignore
+++ b/implementations/elixir/.gitignore
@@ -1,0 +1,3 @@
+_build
+deps
+priv

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -20,6 +20,7 @@
       # 24.1.7 stipulated by Dockerfile does not build successfully with current nixpkgs input
       ockam.elixir.erlangVersion = "24.3.4.10";
       ockam.elixir.version = "1.13.0";
-      ockam.rust.suggestedCargoPlugins = true;
+      ockam.rust.suggestedCargoPlugins = false;
+      ockam.rust.rustAnalyzer = false;
     };
 }


### PR DESCRIPTION
Disables unused rust packages as they increase runtime in CI. Reduces Elixir runtime from 54min to 38min https://github.com/build-trust/ockam/actions/runs/6262368265?pr=6010