### PR TITLE
chore(elixir): simplify CI job for elixir

### DIFF
--- a/.github/actions/elixir_cache/action.yml
+++ b/.github/actions/elixir_cache/action.yml
@@ -14,6 +14,6 @@ runs:
         path: |
           **/deps
           **/_build
-        key: cache-elixir-${{ github.workflow }}-${{ inputs.job_name }}-${{ hashFiles('**/mix.lock') }}
+        key: cache-elixir-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          cache-elixir-${{ github.workflow }}-${{ inputs.job_name }}-
+          cache-elixir-${{ github.workflow }}-${{ github.job }}-

--- a/.github/workflows/elixir-ignored.yml
+++ b/.github/workflows/elixir-ignored.yml
@@ -21,55 +21,7 @@ on:
 
 jobs:
   lint:
-    name: Elixir - lint_${{ matrix.mix_project }}
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
+    name: Elixir - test
+    runs-on: ubuntu-22.04
     steps:
-      - run: 'echo "Elixir - lint_${{ matrix.mix_project }} - Ignored"'
-
-  build:
-    name: Elixir - build_${{ matrix.mix_project }}
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
-    steps:
-      - run: 'echo "Elixir - build_${{ matrix.mix_project }} - Ignored"'
-
-  test:
-    name: Elixir - test_${{ matrix.mix_project }}
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
-    steps:
-      - run: 'echo "Elixir - test_${{ matrix.mix_project }} - Ignored"'
+      - run: 'echo "Elixir - test - Ignored"'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -52,83 +52,16 @@ defaults:
     shell: nix develop ../../tools/nix#elixir --command bash {0}
 
 jobs:
-  lint:
-    name: Elixir - lint_${{ matrix.mix_project }}
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
-    steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-        with:
-          ref: ${{ github.event.inputs.commit_sha }}
-      - uses: ./.github/actions/nix_installer
-      - uses: ./.github/actions/elixir_cache
-        with:
-          job_name: lint_${{ matrix.mix_project }}
-      - run: make lint_${{ matrix.mix_project }}
-        working-directory: implementations/elixir
-
-  build:
-    name: Elixir - build_${{ matrix.mix_project }}
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
-    steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-        with:
-          ref: ${{ github.event.inputs.commit_sha }}
-      - uses: ./.github/actions/nix_installer
-      - uses: ./.github/actions/elixir_cache
-        with:
-          job_name: build_${{ matrix.mix_project }}
-      - run: make build_${{ matrix.mix_project }}
-        working-directory: implementations/elixir
-
   test:
-    name: Elixir - test_${{ matrix.mix_project }}
+    name: Elixir - test
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        mix_project:
-          - ockam
-          - ockam_abac
-          - ockam_cloud_node
-          - ockam_healthcheck
-          - ockam_kafka
-          - ockam_metrics
-          - ockam_services
-          - ockam_typed_cbor
-          - ockly
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/nix_installer
       - uses: ./.github/actions/elixir_cache
-        with:
-          job_name: test_${{ matrix.mix_project }}
-      - run: make test_${{ matrix.mix_project }}
+      - run: make test
+        working-directory: implementations/elixir
+      - run: make lint
         working-directory: implementations/elixir


### PR DESCRIPTION
We need to run the test suite and linter, a separate "build" step doesn't add anything. It takes way longer to setup the nix environment than to run the actual tests/linting, it doesn't make sense to have then split in parallel.
