### PR TITLE
feat(elixir): allow to compile nif library when desired

### DIFF
--- a/implementations/elixir/ockam/ockly/lib/ockly/native.ex
+++ b/implementations/elixir/ockam/ockly/lib/ockly/native.ex
@@ -5,7 +5,7 @@ defmodule Ockly.Native do
     otp_app: :ockly,
     crate: "ockly",
     load_data_fun: {Ockly, :nif_config},
-    skip_compilation?: true,
+    skip_compilation?: System.get_env("OCKLY_PRECOMPILED_LIB", "true") == "true",
     load_from: {:ockly, "priv/native/libockly"}
 
   def create_identity, do: create_identity(nil)

--- a/implementations/elixir/ockam/ockly/mix.exs
+++ b/implementations/elixir/ockam/ockly/mix.exs
@@ -47,8 +47,14 @@ defmodule Ockly.MixProject do
 
   defp check_native(args) do
     case prebuilt_lib_exists?() do
-      true -> :ok
-      false -> download_native(args)
+      true ->
+        :ok
+
+      false ->
+        case System.get_env("OCKLY_PRECOMPILED_LIB", "true") do
+          "true" -> download_native(args)
+          "false" -> :ok
+        end
     end
   end
 

--- a/implementations/elixir/ockam/ockly/native/ockly/Cargo.lock
+++ b/implementations/elixir/ockam/ockly/native/ockly/Cargo.lock
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.84.0"
+version = "0.85.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "crossbeam-queue",
  "futures",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_identity"
-version = "0.79.0"
+version = "0.80.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.87.0"
+version = "0.88.0"
 dependencies = [
  "cfg-if",
  "fs2",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "ockam_core",
  "tracing",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_aws"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",

--- a/tools/docker/healthcheck/Dockerfile
+++ b/tools/docker/healthcheck/Dockerfile
@@ -1,16 +1,31 @@
 # Stage 1 - Build elixir release of ockam_healthcheck elixir app
-FROM ghcr.io/build-trust/ockam-builder@sha256:5ab42598e35509cad3ea9c1e1bd0ed135ed1340c6ae44b762b1c8bbec31d5c68 as elixir-app-release-build
+FROM hexpm/elixir:1.14.5-erlang-24.3.4.11-debian-bullseye-20230227-slim@sha256:69a2436202ac4cd0078dff0758d11e0c55ed663fc8de8bdc9c7287a369912db4 AS elixir-app-release-build
+
+# install build dependencies
+# FIXME: we should use precompile .so instead of requiring the rust compiler
+RUN apt-get update; \
+  apt-get install -y --no-install-recommends \
+  ca-certificates \
+  openssl \
+  libncurses5 \
+  git \
+  curl \
+  g++
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.71.1 -y
+ENV PATH=/root/.cargo/bin:$PATH
+
 COPY . /work
 RUN set -xe; \
-    cd implementations/elixir; \
-    make build; \
-    cd ockam/ockam_healthcheck; \
-    MIX_ENV=prod mix release;
-
+    cd /work/implementations/elixir/ockam/ockam_healthcheck; \
+    MIX_ENV=prod OCKLY_PRECOMPILED_LIB=false mix local.hex --force; \
+    MIX_ENV=prod OCKLY_PRECOMPILED_LIB=false mix local.rebar --force; \
+    MIX_ENV=prod OCKLY_PRECOMPILED_LIB=false mix deps.get; \
+    MIX_ENV=prod OCKLY_PRECOMPILED_LIB=false mix release;
 
 # TODO: Use distroless container after https://github.com/elixir-lang/elixir/issues/11942 is closed
 # Stage 2 - Create container and copy executables in above step
-FROM debian:11.1-slim@sha256:312218c8dae688bae4e9d12926704fa9af6f7307a6edb4f66e479702a9af5a0c
+FROM debian:bullseye-20230227-slim@sha256:403e06393d6b9dcb506eeef2adba9e30a97139c54e4c90d55254049f7d224081 AS app
 
 COPY --from=elixir-app-release-build /work/implementations/elixir/ockam/ockam_healthcheck/_build/prod/rel/ockam_healthcheck /opt/ockam_healthcheck
 


### PR DESCRIPTION
Allow to optionally compile the nif from scratch, as the precompiled nif mechanism cause problems on some environments due to mismatched libc versions.

Real solution would be to compile the nif on the older libc version we want to support,  or perhaps with musl

