### PR TITLE
fix(rust): app's window size on monitors with a scale factor > 1

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/invitations/tray_menu.rs
@@ -7,7 +7,6 @@ use tauri::menu::{
     SubmenuBuilder,
 };
 use tauri::{AppHandle, Icon, Manager, Runtime, State};
-use tauri_plugin_positioner::{Position, WindowExt};
 use tracing::{debug, error, trace, warn};
 
 use ockam_api::cloud::share::{ReceivedInvitation, SentInvitation, ServiceAccessDetails};
@@ -300,29 +299,13 @@ fn on_create<R: Runtime>(app: &AppHandle<R>, outlet_socket_addr: &str) -> tauri:
                 &PATH_ENCODING_SET,
             )
             .to_string();
-            let w = tauri::WindowBuilder::new(
+            let builder = tauri::WindowBuilder::new(
                 app,
                 INVITATIONS_WINDOW_ID,
                 tauri::WindowUrl::App(url_path.into()),
             )
-            .always_on_top(true)
-            .visible(false)
-            .title("Invite To Share")
-            .max_inner_size(450.0, 350.0)
-            .resizable(true)
-            .minimizable(false)
-            .build()?;
-            // TODO: ideally we should use Position::TrayCenter, but it's broken on the latest alpha
-            let _ = w.move_window(Position::TopRight);
-            w.show()?;
-
-            #[cfg(debug_assertions)]
-            {
-                let app_state: State<AppState> = app.state();
-                if app_state.browser_dev_tools() {
-                    w.open_devtools();
-                }
-            }
+            .title("Invite To Share");
+            crate::window::create(app, builder, 450.0, 350.0)?;
         }
         Some(w) => w.set_focus()?,
     }

--- a/implementations/rust/ockam/ockam_app/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app/src/lib.rs
@@ -33,6 +33,7 @@ mod options;
 mod platform;
 mod projects;
 mod shared_service;
+pub(crate) mod window;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tray_menu.rs
@@ -3,7 +3,6 @@ use tauri::menu::{
     SubmenuBuilder,
 };
 use tauri::{AppHandle, Icon, Manager, Runtime, State};
-use tauri_plugin_positioner::{Position, WindowExt};
 use tracing::error;
 
 use ockam_api::nodes::models::portal::OutletStatus;
@@ -129,29 +128,13 @@ pub fn process_tray_menu_event<R: Runtime>(
 fn on_create<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     match app.get_window(SHARED_SERVICE_WINDOW_ID) {
         None => {
-            let w = tauri::WindowBuilder::new(
+            let builder = tauri::WindowBuilder::new(
                 app,
                 SHARED_SERVICE_WINDOW_ID,
                 tauri::WindowUrl::App("service".into()),
             )
-            .always_on_top(true)
-            .visible(false)
-            .title("Share a service")
-            .max_inner_size(450.0, 350.0)
-            .resizable(false)
-            .minimizable(false)
-            .build()?;
-            // TODO: ideally we should use Position::TrayCenter, but it's broken on the latest alpha
-            let _ = w.move_window(Position::TopRight);
-            w.show()?;
-
-            #[cfg(debug_assertions)]
-            {
-                let app_state: State<AppState> = app.state();
-                if app_state.browser_dev_tools() {
-                    w.open_devtools();
-                }
-            }
+            .title("Share a service");
+            crate::window::create(app, builder, 450.0, 350.0)?;
         }
         Some(w) => w.set_focus()?,
     }

--- a/implementations/rust/ockam/ockam_app/src/window.rs
+++ b/implementations/rust/ockam/ockam_app/src/window.rs
@@ -1,0 +1,31 @@
+use crate::app::AppState;
+use tauri::{AppHandle, Manager, Runtime, State, WindowBuilder};
+use tauri_plugin_positioner::{Position, WindowExt};
+
+pub(crate) fn create<R: Runtime>(
+    app: &AppHandle<R>,
+    builder: WindowBuilder<'_, R>,
+    width: f64,
+    height: f64,
+) -> tauri::Result<()> {
+    let w = builder
+        .always_on_top(true)
+        .min_inner_size(width, height)
+        .max_inner_size(width, height)
+        .resizable(true)
+        .minimizable(false)
+        .build()?;
+    // TODO: ideally we should use Position::TrayCenter, but it's broken on the latest alpha
+    let _ = w.move_window(Position::TopRight);
+    w.show()?;
+
+    #[cfg(debug_assertions)]
+    {
+        let app_state: State<AppState> = app.state();
+        if app_state.browser_dev_tools() {
+            w.open_devtools();
+        }
+    }
+
+    Ok(())
+}

--- a/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_socket_addr]/CreateServiceInvitation.svelte
+++ b/implementations/typescript/ockam/ockam_app/src/routes/invite/[outlet_socket_addr]/CreateServiceInvitation.svelte
@@ -38,7 +38,7 @@
     <div class="flex-1">
       <input
         type="email"
-        class="w-full border-none bg-transparent px-4 text-right focus:outline-none"
+        class="w-full border-none bg-transparent px-4 text-right text-base focus:outline-none"
         placeholder="user@example.com"
         bind:value={email}
       />
@@ -53,11 +53,11 @@
 {/if}
 <div class="flex justify-end">
   <button
-    class="mr-2 rounded bg-gray-300 px-2 py-1 text-gray-700 hover:bg-gray-400"
+    class="mr-2 rounded bg-gray-300 px-2 py-1 text-base text-gray-700 hover:bg-gray-400"
     on:click={cancel}>Cancel</button
   >
   <button
-    class="rounded bg-blue-500 px-2 py-1 text-white hover:bg-blue-600"
+    class="rounded bg-blue-500 px-2 py-1 text-base text-white hover:bg-blue-600"
     on:click={submit}>Create</button
   >
 </div>


### PR DESCRIPTION
## How it looked

### Scale factor 1

Note the size differences in the placeholders and buttons.

![image](https://github.com/build-trust/ockam/assets/12375782/2ee6b072-4521-4d0d-acdd-5a70cd5bc7ea)

### Scale factor 2

Note the scrolling bar on the "Share a service" window.

![image](https://github.com/build-trust/ockam/assets/12375782/25ec8991-7ada-42ed-9f01-b714899a56ff)

## Solution

This is how it looks now in both scale factors.

<img width="902" alt="Screenshot 2023-09-21 at 10 06 37" src="https://github.com/build-trust/ockam/assets/12375782/6f53f967-7872-4c1e-bbeb-9fed1ae6615b">
