### PR TITLE
fix(rust): restored app's outlets were not using the previous alias

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/tcp_outlet/state.rs
@@ -4,7 +4,7 @@ use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::NodeManagerWorker;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{debug, error};
 
 impl ModelState {
     pub fn add_tcp_outlet(&mut self, status: OutletStatus) {
@@ -31,19 +31,21 @@ pub(crate) async fn load_model_state(
     }
     let mut node_manager = node_manager_worker.inner().write().await;
     for tcp_outlet in model_state.get_tcp_outlets() {
+        debug!(worker_addr = %tcp_outlet.worker_addr, "Restoring outlet");
         let _ = node_manager
             .create_outlet(
                 &context,
                 tcp_outlet.socket_addr,
                 tcp_outlet.worker_addr.clone(),
-                None,
+                Some(tcp_outlet.alias.clone()),
                 true,
             )
             .await
             .map_err(|e| {
                 error!(
                     ?e,
-                    "failed to create outlet with tcp addr {}", tcp_outlet.socket_addr
+                    worker_addr = %tcp_outlet.worker_addr,
+                    "Failed to restore outlet"
                 );
             });
     }


### PR DESCRIPTION
When an outlet is created from the app, it's stored in the app state given its alias, so we can restore them when restarting it.

The problem was that, when restarting the app, the restored outlets where being created with a random alias.