### PR TITLE
remove conditional import of used crate

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -1,7 +1,6 @@
 mod model;
 mod repository;
 
-#[cfg(debug_assertions)]
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;


### PR DESCRIPTION
We have a crate that's conditionally imported during debug https://github.com/build-trust/ockam/blob/63d710b6a38b865b5a950b480e20a9d8a7d8b506/implementations/rust/ockam/ockam_app/src/app/state/mod.rs#L4-L5 and is used in a non-debug attribute https://github.com/build-trust/ockam/blob/63d710b6a38b865b5a950b480e20a9d8a7d8b506/implementations/rust/ockam/ockam_app/src/app/state/mod.rs#L368 This PR remove the conditional import