### PR TITLE
fix(rust): reset cli state if it can't be parsed

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/credentials.rs
@@ -58,6 +58,7 @@ mod traits {
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for CredentialsState {
@@ -66,8 +67,10 @@ mod traits {
         const DIR_NAME: &'static str = "credentials";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -223,8 +223,10 @@ mod traits {
         const DIR_NAME: &'static str = "identities";
         const HAS_DATA_DIR: bool = true;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
@@ -198,7 +198,7 @@ impl CliState {
 
     pub fn delete_at(root_path: &PathBuf) -> Result<()> {
         // Delete nodes' state and processes, if possible
-        let nodes_state = NodesState::new(root_path.clone());
+        let nodes_state = NodesState::new(root_path);
         let _ = nodes_state.list().map(|nodes| {
             nodes.iter().for_each(|n| {
                 let _ = n.delete_sigkill(true);
@@ -208,13 +208,13 @@ impl CliState {
         // Delete all other state directories
         for dir in &[
             nodes_state.dir(),
-            IdentitiesState::new(root_path.clone()).dir(),
-            VaultsState::new(root_path.clone()).dir(),
-            SpacesState::new(root_path.clone()).dir(),
-            ProjectsState::new(root_path.clone()).dir(),
-            CredentialsState::new(root_path.clone()).dir(),
-            TrustContextsState::new(root_path.clone()).dir(),
-            UsersInfoState::new(root_path.clone()).dir(),
+            IdentitiesState::new(root_path).dir(),
+            VaultsState::new(root_path).dir(),
+            SpacesState::new(root_path).dir(),
+            ProjectsState::new(root_path).dir(),
+            CredentialsState::new(root_path).dir(),
+            TrustContextsState::new(root_path).dir(),
+            UsersInfoState::new(root_path).dir(),
             &root_path.join("defaults"),
         ] {
             let _ = std::fs::remove_dir_all(dir);

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -451,8 +451,10 @@ mod traits {
         const DIR_NAME: &'static str = "nodes";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {
@@ -719,7 +721,7 @@ mod tests {
         std::fs::write(&tmp_file, v1_json_json).unwrap();
 
         // Run migration
-        let nodes_state = NodesState::new(tmp_dir.path().to_path_buf());
+        let nodes_state = NodesState::new(tmp_dir.path());
         nodes_state.migrate(&node_dir).await.unwrap();
 
         // Check migration was done correctly

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -124,6 +124,7 @@ mod traits {
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for ProjectsState {
@@ -132,8 +133,10 @@ mod traits {
         const DIR_NAME: &'static str = "projects";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
@@ -51,6 +51,7 @@ mod traits {
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for SpacesState {
@@ -59,8 +60,10 @@ mod traits {
         const DIR_NAME: &'static str = "spaces";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/traits.rs
@@ -19,7 +19,7 @@ pub trait StateDirTrait: Sized + Send + Sync {
     const DIR_NAME: &'static str;
     const HAS_DATA_DIR: bool;
 
-    fn new(dir: PathBuf) -> Self;
+    fn new(root_path: &Path) -> Self;
 
     fn default_filename() -> &'static str {
         Self::DEFAULT_FILENAME
@@ -47,8 +47,8 @@ pub trait StateDirTrait: Sized + Send + Sync {
     }
 
     fn load(root_path: &Path) -> Result<Self> {
-        let dir = Self::create_dirs(root_path)?;
-        Ok(Self::new(dir))
+        Self::create_dirs(root_path)?;
+        Ok(Self::new(root_path))
     }
 
     /// Recreate all the state directories
@@ -267,11 +267,11 @@ pub trait StateItemTrait: Sized + Send {
 #[cfg(test)]
 mod tests {
     use crate::cli_state::{StateDirTrait, StateItemTrait};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn test_is_item_path() {
-        let config = TestConfig::new("dir".into());
+        let config = TestConfig::new(Path::new("dir"));
         let path = config.path("name");
         assert!(config.is_item_path(&path).unwrap())
     }
@@ -286,8 +286,10 @@ mod tests {
         const DIR_NAME: &'static str = "";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
@@ -33,6 +33,7 @@ mod traits {
     use crate::cli_state::file_stem;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for TrustContextsState {
@@ -41,8 +42,10 @@ mod traits {
         const DIR_NAME: &'static str = "trust_contexts";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/user_info.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/user_info.rs
@@ -27,6 +27,7 @@ mod traits {
     use super::*;
     use crate::cli_state::traits::*;
     use ockam_core::async_trait;
+    use std::path::Path;
 
     #[async_trait]
     impl StateDirTrait for UsersInfoState {
@@ -35,8 +36,10 @@ mod traits {
         const DIR_NAME: &'static str = "users_info";
         const HAS_DATA_DIR: bool = false;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -128,8 +128,10 @@ mod traits {
         const DIR_NAME: &'static str = "vaults";
         const HAS_DATA_DIR: bool = true;
 
-        fn new(dir: PathBuf) -> Self {
-            Self { dir }
+        fn new(root_path: &Path) -> Self {
+            Self {
+                dir: Self::build_dir(root_path),
+            }
         }
 
         fn dir(&self) -> &PathBuf {

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -379,9 +379,7 @@ pub mod test_utils {
 
     impl Drop for NodeManagerHandle {
         fn drop(&mut self) {
-            self.cli_state
-                .delete(true)
-                .expect("cannot delete cli state");
+            CliState::delete_at(&self.cli_state.dir).expect("cannot delete cli state");
         }
     }
 

--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -65,8 +65,11 @@ impl Default for AppState {
 impl AppState {
     /// Create a new AppState
     pub fn new() -> AppState {
-        let cli_state =
-            CliState::initialize().expect("Failed to load the local Ockam configuration");
+        let cli_state = CliState::initialize().unwrap_or_else(|_| {
+            CliState::backup_and_reset().expect(
+                "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
+            )
+        });
         let (context, mut executor) = NodeBuilder::new().no_logging().build();
         let context = Arc::new(context);
 

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -238,7 +238,11 @@ pub struct CommandGlobalOpts {
 
 impl CommandGlobalOpts {
     pub fn new(global_args: GlobalArgs) -> Self {
-        let state = CliState::initialize().expect("Failed to load the local Ockam configuration");
+        let state = CliState::initialize().unwrap_or_else(|_| {
+            CliState::backup_and_reset().expect(
+                "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
+            )
+        });
         let terminal = Terminal::new(
             global_args.quiet,
             global_args.no_color,

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -239,9 +239,15 @@ pub struct CommandGlobalOpts {
 impl CommandGlobalOpts {
     pub fn new(global_args: GlobalArgs) -> Self {
         let state = CliState::initialize().unwrap_or_else(|_| {
-            CliState::backup_and_reset().expect(
+            let state = CliState::backup_and_reset().expect(
                 "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
-            )
+            );
+            let dir = &state.dir;
+            let backup_dir = CliState::backup_default_dir().unwrap();
+            eprintln!(
+                "The {dir:?} directory has been reset and has been backed up to {backup_dir:?}"
+            );
+            state
         });
         let terminal = Terminal::new(
             global_args.quiet,

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -4,6 +4,7 @@ use crate::{fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
+use ockam_api::cli_state::CliState;
 
 /// Removes the local Ockam configuration including all Identities and Nodes
 #[derive(Clone, Debug, Args)]
@@ -34,7 +35,7 @@ fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> miette::Result<()> {
             }
         }
     }
-    opts.state.delete(true)?;
+    CliState::delete()?;
     opts.terminal
         .stdout()
         .plain(fmt_ok!("Local Ockam configuration deleted"))


### PR DESCRIPTION
## Problem description

In out last release (0.93.0, 0.94.0) introduced some breaking changes related to identities with no possible migration strategy. This leads to the following UX problems:

1. The user is forced to run `ockam reset` to remove any previous configuration, so that it can be regenerated with the new format
2. The `ockam reset` will try to parse the previous configuration, but, because there is no migration, it will fail, forcing the user to manually delete the ockam directory (`$OCKAM_HOME`, `~/.ockam`)

## Proposed solution

1. The `CliState`'s `delete` method has been refactored to be static, so that we don't need to initialize it first before removing it.

2. In both the CLI and the App, when it fails to initialize the CliState (this will happen if the configuration has been tampered or if we introduced breaking changes without migrations), it will backup the current configuration and do an automatic reset. In the CLI, a message will be written to stderr to inform them of such operation.

## How to test

From `develop` run:

```
ockam identity create
```

Now, tamper the identity config json file. For example, change the `identifier` field to `identifier2`. Now run:

```
ockam status
```

It should fail with the error described at https://github.com/build-trust/ockam/issues/6069. Switch to this PR's branch and run the same command again. You should see a message like the following and everything should work as expected:

```
The ".ockam" directory has been reset and has been backed up to ".ockam.bak"
```