### PR TITLE
Move CLA to the ockam repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Request reviews from the approvers team
 * @build-trust/approvers
-/.github/CONTRIBUTORS.csv @cla-pr-approvers
+/.github/CONTRIBUTORS.csv @build-trust/cla-pr-approvers
 
 # References on updating this file:
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Request reviews from the approvers team
 * @build-trust/approvers
+/.github/CONTRIBUTORS.csv @cla-pr-approvers
 
 # References on updating this file:
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -266,3 +266,4 @@ yes,snandam,Sanjeev Nithyanandam,<sanjeev.nandam@gmail.com>
 yes,hseeberger,Heiko Seeberger,<git@heikoseeberger.de>
 yes,adiSuper94,Aditya Subramanian,<aditarun2008@gmail.com>
 yes,halfbro,Matt Lagarenne,<mlagare22@gmail.com>
+yes,denisyao101,Denis YAO,<denisyao@outlook.com>

--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -264,3 +264,5 @@ yes,celeo,Matt Boulanger,<mattboulanger@fastmail.com>
 yes,CEMcNeill,Chris McNeill,<cmcneill@gmail.com>
 yes,snandam,Sanjeev Nithyanandam,<sanjeev.nandam@gmail.com>
 yes,hseeberger,Heiko Seeberger,<git@heikoseeberger.de>
+yes,adiSuper94,Aditya Subramanian,<aditarun2008@gmail.com>
+yes,halfbro,Matt Lagarenne,<mlagare22@gmail.com>

--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -1,0 +1,266 @@
+Accepted CLA,Github User,Name,Emails
+yes,mrinalwadhwa,Mrinal Wadhwa,<mrinal@ockam.io>
+yes,mattgreg,Matthew Gregory,<matt@ockam.io>
+yes,dependabot[bot],dependabot[bot],<49699333+dependabot[bot]@users.noreply.github.com> <support@github.com>
+yes,github,GitHub,<noreply@github.com>
+yes,mergify[bot],mergify[bot],<37929162+mergify[bot]@users.noreply.github.com>
+yes,ockam-team,Ockam Team,<dev@ockam.io>
+yes,github-actions[bot],github-actions[bot],
+yes,jagtek,Logan Jager,<logan@ockam.io>
+yes,brettnitschke,Brett Nitschke,<brett@ockam.io>
+,rkaiser0324,Rolf Kaiser,<1090569+rkaiser0324@users.noreply.github.com>
+,malnick,Jeff Malnick,<malnick@gmail.com>
+yes,mtm0183,Mark Mulrooney,<mark@ockam.io>
+yes,robinbudd,Robin Budd,<robin@ockam.io>
+yes,bitwalker,Paul Schoenfelder,<paulschoenfelder@fastmail.com> <paul@ockam.io>
+,carlosflrs,Carlos Flores,<sudocarlosflores@protonmail.com>
+,ercanersoy,Ercan Ersoy,<ercanersoy@ercanersoy.net>
+,gustin,gustin,<gustin@users.noreply.github.com>
+yes,sobi3ch,Piotr Sobieszczański,<piotr.s@masterborn.com> <piotr.sobieszczanski@gmail.com> <piotr@ockam.io>
+yes,sanjodeundiak,Oleksandr Deundiak,<deundiak@gmail.com> <olek@ockam.io> <oleksandr.d@masterborn.com> <Oleksandr Deundiak>
+yes,necromos,Przemysław Królik,<necromos@necroworks.net>
+yes,nilslice,Steve Manuel,<steve@ockam.io>
+yes,fkouteib,Faycel Kouteib,<faycel.kouteib@gmail.com>
+yes,mikelodder7,Michael Lodder,<mike@ockam.io> <redmike7@gmail.com>
+yes,vvv,Valery V. Vorotyntsev,<valery.vv@gmail.com>
+yes,jared-s,Jared Stanbrough,<jared@ockam.io>
+yes,mjc,Michael J. Cohen,<mjc@kernel.org> <mika@ockam.io>
+yes,bartekpospiech,Bartek,<bartek.codes@gmail.com>
+yes,lukegalbraithrussell,Luke Russell,<luke.galbraith.russell@gmail.com>
+yes,winmillwill,Will Milton,<wa.milton@gmail.com>
+yes,miedziak,miedziak,<miedziak@gmail.com>
+yes,surajphulara,Suraj Phulara,<68676996+surajphulara@users.noreply.github.com>
+yes,digikata,Alan C,<argot@digikata.com>
+yes,lorrin,Lorrin Nelson,<lorrin@lorrin.org>
+yes,njvrzm,Nathan Verzemnieks,<njvrzm@gmail.com>
+yes,ls4096,Lukas,<ls4096@8bitbyte.ca>
+yes,xtian,Christian Wesselhoeft,<hi@xtian.us>
+yes,IslandUsurper,Lyle Mantooth,<ashagua@gmail.com>
+yes,drahnr,Bernhard Schuster,<bernhard+ockam@ahoi.io> <bernhard@ahoi.io>
+yes,franziskuskiefer,Franziskus Kiefer,<franziskuskiefer@gmail.com>
+yes,gabhijit,Abhijit Gadgil,<gabhijit@iitbombay.org>
+yes,feniks65,Wojciech Wais,<wojciech.wais@gmail.com>
+yes,fmterrorf,Daven Casia,<77761194+fmterrorf@users.noreply.github.com>
+yes,adrianbenavides,Adrian Benavides,<adri.benavides312@gmail.com>
+yes,malvfr,Matheus Alvarenga França,<matheus.alvfr@gmail.com>
+yes,jjscheel,Jeff Scheel,<jjscheel68@gmail.com>
+yes,piiih,Philipe Paixao,<piihpi@gmail.com>
+yes,mendrugory,Gonzalo Gabriel Jiménez Fuentes,<iam@mendrugory.com>
+yes,bloomen,Christian Blume,<chr.blume@gmail.com>
+yes,kbeaulieu,Keven Beaulieu,<3943905+kbeaulieu@users.noreply.github.com>
+yes,psinghal20,Pratyush Singhal,<psinghal20@gmail.com>
+yes,dotdiddz,Dorothy Gay,<dorothy.r.gay@gmail.com>
+yes,Walter-Haydock,Walter Haydock,<41760518+Walter-Haydock@users.noreply.github.com>
+yes,sateeshkumarb,Sateesh Kumar B,<sateeshkumarb@yahoo.com>
+yes,cipherboy,Alexander Scheel,<alexander.m.scheel@gmail.com>
+yes,niklaslong,Niklas Long,<niklas@long.ch>
+yes,sveljko,Srdjan Veljkovic,<sr.veljkovic@gmail.com> <sveljko@gvs.rs>
+yes,thomcc,Thom Chiovoloni,<chiovolonit@gmail.com>
+yes,metaclips,Michael Uti,<utimichael@icloud.com> <utimichael9@gmail.com> <michaeluti6@gmail.com>
+yes,devalain,Alain Buisseret,<me@alain.dev>
+yes,lelloman,Domenico Cerasuolo,<cerasuolodomenico@gmail.com>
+yes,l3pereira,Luis Pereira,<151566465+l3pereira@users.noreply.github.com>
+yes,efx,Eli Flanagan,<eli@typedspace.com>
+yes,Stupremee,Justus K,<justus.k@protonmail.com>
+yes,Hraesvel,Martin Smith,<mcodesmith@gmail.com>
+yes,jim4067,James Mutuku,<jimmyimpulse2@gmail.com>
+yes,whereistejas, Tejas Sanap, <sanap.tejas@gmail.com>
+yes,plaxi0s,Pawan Dogra, <pawan.dogra99@gmail.com> <35614614+plaxi0s@users.noreply.github.com>
+yes,mattjperez,Matthew J Perez,<matt@mperez.io>
+yes,MichalDolata,Michał Dolata,<dev@dolata.me>
+yes,giladwo,Gilad Woloch,<25708271+giladwo@users.noreply.github.com>
+yes,fisherdarling,Fisher Darling,<fdarlingco@gmail.com>
+yes,wkk,Bin Wang,<wkk@users.noreply.github.com>
+yes,NOBLES5E,Xiangru Lian,<admin@mail.xrlian.com> <xiangru@yandex.com>
+yes,abhishekc-sharma,Abhishek Chandramouli Sharma,<abhishekcs@protonmail.com>
+yes,radiantly,Joshua T,<radiantly@users.noreply.github.com> <buildingsomethingfun@gmail.com>
+yes,tanoarfinetti,Tano Arfinetti,<tanoarfinetti@gmail.com>
+yes,Szymongib,Szymon Gibała,<szymongib@gmail.com>
+yes,frazar,Francesco Zardi,<frazar0@hotmail.it>
+yes,tcd156,Tyler Dennis,<tcd156@gmail.com>
+yes,selectiveduplicate,Abu Sakib,<mabusakib@gmail.com>
+yes,BlackHoleFox,BlackHoleFox,<blackholefoxdev@gmail.com>
+yes,dvermd,dvermd,<315743+dvermd@users.noreply.github.com>
+yes,totsteps,Gagandeep Singh,<totsteps.gs@gmail.com>
+yes,cohix,Connor Hicks,<connor@suborbital.dev>
+yes,conectado,Gabriel Steinberg,<gabrielalejandro7@gmail.com>
+yes,ade5h,Adesh Attavar,<adesh.attavar@gmail.com>
+yes,pro465,Proloy Mishra,<namitapro0987@gmail.com>
+yes,Genysys,Samuel Dare,<samuel.b.dare@gmail.com>
+yes,spacekookie,Katharina Fey,<kookie@spacekookie.de> <katharina@ockam.io>
+yes,antoinevg,Antoine van Gelder,<antoine@ockam.io>
+yes,hairyhum,Daniil Fedotov,<daniil@ockam.io> <fedotov.danil@gmail.com>
+yes,v0idpwn,Felipe Stival,<14948182+v0idpwn@users.noreply.github.com> <v0idpwn@gmail.com>
+yes,nk7608,Nayana,<nayana@ockam.io> <87853806+nk7608@users.noreply.github.com>
+yes,calebbourg,Caleb Bourg,<calebbourg2@gmail.com>
+yes,marpit19,Arpit Mohapatra,<arpit.mohapatra19@gmail.com>
+yes,neil2468,Neil Singh,<neil2468@users.noreply.github.com> <neil2468@gmail.com>
+yes,polvorin,Pablo Polvorin,<pablo@polvorin.com.ar> <pablo@ockam.io>
+yes,jackbaude,Jack Baude, <jackbaude@gmail.com>
+yes,twittner,Toralf Wittner,<tw@dtex.org>
+yes,TheBorsuk,Mateusz Witkowski,<mateusz.w@masterborn.com>
+yes,0x2b3bfa0,Helio Machado,<0x2b3bfa0+ockam@googlemail.com>
+yes,arbourd,Dylan Arbour,<arbourd@users.noreply.github.com>
+yes,manavsiddharthgupta,Manav Gupta,<2006468@kiit.ac.in>
+yes,0x00A5,Yuan Lyu,<lyuyuan92@gmail.com>
+yes,lukasztucholski,Łukasz Tucholski,<luk.tucholski@gmail.com>
+yes,beenzsyed,Sabeen Syed,<sabeen.kazmi@gmail.com> <sabeen@ockam.io>
+yes,alojzy231,Damian Kłos,<alojzy231@gmail.com>
+yes,mszpakowski,Michał Szpakowski,<michszpakowski@gmail.com> <michal.szpakowski@ockam.io>
+yes,adamd,Adam DuVander,<github@duvander.com>
+yes,justinvzyl,Justin van Zyl,<justinvzyl@users.noreply.github.com>
+yes,PrajwalBorkar,Prajwal Borkar,<prajwalborkar5075@gmail.com>
+yes,Handschrift,Elias Brenigmer,<cahit.kilinc@gmx.de>
+yes,Guileas,Gwénola ETHEVE,<guileas@etheve.eu> <ethevegwenola@gmail.com>
+yes,tmuro17,Tanner Muro,<tanner@tmuro17.dev> <tmuro17@gmail.com>
+yes,edbastelli,Edward Bastelli,<edbastelli@users.noreply.github.com>
+yes,Retamogordo,Yury Yukhananov,<yury.yukhananov@tutanota.com>
+yes,anuvratsingh,Anuvrat,<anuvrats06@gmail.com>
+yes,leonzchang,Li Chang,<bellerophon00530@gmail.com>
+yes,SkoogJacob,Jacob Skoog,<jacob.skoog@protonmail.com>
+yes,sanjayatpilcrow,Sanjay Sharma,<shosansharma@gmail.com>
+yes,zzztimbo,Tim Chan,<tim@chan.net>
+yes,raysonkoh,Rayson Koh,<rayson.rk.koh@gmail.com>
+yes,michealkeines,Micheal Keines,<keinesmicheal@gmail.com>
+yes,chrischiedo,Chrispine Chiedo,<chrispinechiedo@gmail.com> <8336086+chrischiedo@users.noreply.github.com>
+yes,datdhruv,Dhruv Jain,<dhruvjainstuff@gmail.com> <dhruvjain1952@gmail.com>
+yes,jlucktay,James Lucktaylor,<jlucktay@gmail.com> <jlucktay+github@gmail.com>
+yes,duttaANI,Aniruddha Amit Dutta,<duttaaniruddha31@gmail.com>
+yes,elbart,Tim Eggert,<tim@elbart.com>
+yes,rajivts,Rajiv Sharma,<rajshar.email@gmail.com> <rajiv.tilakraj.sharma@gmail.com> <81089088+RajivTS@users.noreply.github.com>
+yes,tacoda,Ian Johnson,<tacoda@hey.com>
+yes,VectorStrike,ElliottB,<elliottb@protonmail.com> <45875628+VectorStrike@users.noreply.github.com>
+yes,danieled-it,Daniele Delaria,<daniele.registrazioni@outlook.it> <19713668+danieled-it@users.noreply.github.com>
+yes,rtsuk,Rob Tsuk,<rob@tsuk.com>
+yes,hargut,Harald Gutmann,<harald@hargut.com>
+yes,sanjayts,Sanjay Sharma,<sanjay.t.sharma@gmail.com> <30881+sanjayts@users.noreply.github.com>
+yes,karl-cardenas-coding,Karl Cardenas,<cardenas88karl@gmail.com>
+yes,akki1306,Akshay Kulkarni,<akshayk.gj@gmail.com>
+yes,allenap,Gavin Panella,<gavinpanella@gmail.com>
+yes,goverdhan07,Goverdhan Biradar,<goverdhanbiradar@gmail.com> <66107302+goverdhan07@users.noreply.github.com>
+yes,AntoniosBarotsis,Antonios Barotsis,<antonios.barotsis@pm.me> <a.barotsis@student.tudelft.nl>
+yes,gybrish,Niall McDonagh,<niall.mcdonagh@gmail.com>
+yes,kriogenia,Ricardo Soto Estévez,<ricardo@sotoestevez.dev> <47500377+kriogenia@users.noreply.github.com> <esekriogenia@gmail.com>
+yes,Overflow0xFFFF,Joshua Ford,<joshua.ford@proton.me> <joshua.ford@protonmail.com>
+yes,elliotwutingfeng,Wu Tingfeng,<wutingfeng@outlook.com> <wu.tingfeng@u.nus.edu>
+yes,vijaykramesh,Vijay Krishna Ramesh,<vijay.krishna.ramesh@gmail.com>
+yes,vncsalencar,Vinicius Alencar,<viniciusale4@gmail.com>
+yes,windlessstorm,Vikrant Biswas,<vikrant.biswas@gmail.com>
+yes,galbwe,Wes Galbraith,<galbwe92@gmail.com>
+yes,constantinosgeorgiou,Constantinos Georgiou,<constantgeorgiou@gmail.com>
+yes,noyez,Bradley Noyes,<b@noyes.dev>
+yes,h3athen,Aryan Gurung,<gurungaryan73@gmail.com>
+yes,bahelms,Barrett Helms,<jimbonkgit@gmail.com> <barrett.helms@salesloft.com>
+yes,Rishav-12,Rishav Mitra,<rishavmitra10@gmail.com>
+yes,divyank-rs,Divyank Aggarwal,<divyank.aggarwal@remotestate.com> <80034854+divyank-rs@users.noreply.github.com>
+yes,ronaudinho,Audi P. Risa P.,<doelaudi@gmail.com>
+yes,mvisic,Marcus Visic,<mivisic@gmail.com>
+yes,memark,Magnus Markling,<magnus@markling.com>
+yes,HyperNova114,Hyper Nova,<hypernova114@gmail.com> <116303411+HyperNova114@users.noreply.github.com>
+yes,elpiel,Lachezar Lechev,<hi@lechev.space> <8925621+elpiel@users.noreply.github.com> <elpiel93@gmail.com>
+yes,Dark-Knight11,Vedant Bhamare,<vedantbhamare11@gmail.com> <55763604+Dark-Knight11@users.noreply.github.com>
+yes,wbadart,Will Badart,<wbadart@pm.me> <will@willbadart.com>
+yes,jtmoon79,James Thomas Moon,<815261+jtmoon79@users.noreply.github.com>
+yes,justinmmott,Justin Mott,<justinmmott@gmail.com>
+yes,miles170,Miles Liu,<miles@bung.cc>
+yes,tshepang,Tshepang Mbambo,<tshepang@gmail.com>
+yes,Sparrow1029,Alex Ray,<19390913+Sparrow1029@users.noreply.github.com>
+yes,ill1,Garth A,<15029874+Ill1@users.noreply.github.com>
+yes,Abhicodes-crypto,Abhishek Marrivagu,<abhi.codes10@gmail.com> <68317979+Abhicodes-crypto@users.noreply.github.com> <abhishek.marrivagu@juspay.in>
+yes,mushahidq,Mohammed Mushahid Qureshi,<mushahidq@gmail.com>
+yes,spazm,Andrew Grangaard,<granny-github@ofb.net>
+yes,phillyphil91,Philip Huels,<philip.huels@googlemail.com>
+yes,davidag,David Alfonso,<developer@davidalfonso.es>
+yes,Mo-Fatah,Mohamed Abdelfatah,<mohamedabdelfatah2027@gmail.com>
+yes,m-ata,Muhammad Ata,<muhammad_ata@outlook.com>
+yes,h20220145,Tarun Singh,<trnsingh21@gmail.com> <h20220145@goa.bits-pilani.ac.in>
+yes,ippolito72,Nick Ippolito,<nicholas@ockam.io> <67592293+Ippolito72@users.noreply.github.com>
+yes,etorreborre,Eric Torreborre,<etorreborre@yahoo.com> <etorreborre@users.noreply.github.com>
+yes,caoakleyii,Chris Oakley,<christopher.oakley@ockam.io> <caoakleyii@gmail.com>
+yes,elvanja,Vanja Radovanovic,<elvanja@gmail.com>
+yes,ebrightfield,Eric Brightfield,<ebrightfield@gmail.com>
+yes,brianmego,Brian Mego,<brianmego@gmail.com>
+yes,nidnogg,Henrique Vermelho,<henriquevt98@gmail.com>
+yes,NathanTarbert,Nathan Tarbert,<nate4t@hotmail.com> <66887028+nathantarbert@users.noreply.github.com>
+yes,dzvon,Dezhi Wu,<oo0bf659r@mozmail.com> <wu543065657@163.com>
+yes,rishikumarray,Rishi Kumar Ray,<rishirai760@gmail.com> <87641376+RishiKumarRay@users.noreply.github.com>
+yes,waqasraz,Waqas Razzaq,<waqasraz@yahoo.ca>
+yes,glenngillen,Glenn Gillen,<github@gln.io> <glenn@ockam.io> <glenngillen@users.noreply.github.com>
+yes,sriharshamajeti,Sri Harsha Majeti,<sriharshamajeti@gmail.com> <67218172+sriharshamajeti@users.noreply.github.com>
+yes,davide-baldo,Davide Baldo,<davide@baldo.me> <davide.baldo@ockam.io>
+yes,hweawer,Alexander Gusakovsky,<alexandergusakovsky@gmail.com>
+yes,MavenRain,Onyeka Obi,<Onyeka.Obi@gmail.com>
+yes,Miidoriya,Marcus Ojerinde-Ardalla,<99621562+Miidoriya@users.noreply.github.com>
+yes,sladyn98,Sladyn Nunes,<snunes@usc.edu>
+yes,murex971,Nupur Agrawal,<nupur202000@gmail.com>
+yes,p-gentili,Paolo Gentili,<gentilipaolo92@gmail.com>
+yes,andrescaroc,Andres Caro,<38670654+andrescaroc@users.noreply.github.com>
+yes,0xkelvin,Kelvin,<quocvm1@gmail.com>
+yes,hugoamalric,Hugo Amalric,<hugo.amalric01@etu.umontpellier.fr>
+yes,jungletryne,Dan Mishin,<danila.mishin.2001@gmail.com>
+yes,rghdrizzle,Luqmaan Hakeem,<luqmaan1hakeem@gmail.com> <rockgameplayhakeem@gmail.com>
+yes,quasiuslikecautious,Zach Quasius,<zach@quasius.dev> <zquasius@gmail.com>
+yes,mehsalhi,Mehdi Salhi,<mehsalhi@proton.me> <mehdi.salhi@heig-vd.ch>
+yes,chanman3388,Chris Chan,<cwtchan3388@gmail.com>
+yes,amdadulbari,Md. Amdadul Bari Imad,<amdadulbari@gmail.com>
+yes,shanesveller,Shane Sveller,<shane.sveller@ockam.io> <shane@sveller.dev> <shanesveller@users.noreply.github.com>
+yes,aareet,Aareet Mahadevan,<aareet@users.noreply.github.com>
+yes,sergey-melnychuk,Sergey Melnychuk,<serg.meln@gmail.com>
+yes,itsajay1029,Ajay Chowdhury,<ajaychowdhury1029@gmail.com>
+yes,zacck,Zacck Osiemo,<coderv63@gmail.com>
+yes,jamesneb,James Nebeker,<jnebeker@truckitapp.com>
+yes,tarunsamanta2k20,Tarun Samanta,<tarunsamanta77@gmail.com>
+yes,Guilospanck,Guilherme Pereira,<guilospanck@protonmail.com>
+yes,jjdoar,Jacob Doar,<jjdoar@gmail.com>
+yes,saputkin,Arthur Saputkin,<saputkin@users.noreply.github.com> <artsapu@gmail.com>
+yes,talir0drigues,Talita Rodrigues,<trsantos92@gmail.com> <talita.rodrigues@ockam.io>
+yes,utkarshgupta137,Utkarsh Gupta,<utkarshgupta137@gmail.com>
+yes,EliKalter,Eli Kalter,<02374elim@gmail.com>
+yes,fsmiamoto,Flavio Miamoto,<hello@dorayaki.co>
+yes,neruelin,Tyler McFadden,<neruelin@gmail.com>
+yes,leafoliage,Leif Yeh,<leafoliages@gmail.com>
+yes,kat-coding,Katherine Watkins,<katherine.watkins.programming@gmail.com> <katstanford@hotmail.com>
+yes,paul-w42,Paul Woods,<paul.n.woods@gmail.com>
+yes,i-b-o-t,Toby S,<sr.eebowt@gmail.com>
+yes,StreakInTheSky,Ross Baquir,<streakinthesky@gmail.com>
+yes,Alef-gabriel,Alef Gabriel,<alefgabrielr@gmail.com>
+yes,rjtch,Hergy Fongue,<tchuinkoufongue@gmail.com>
+yes,nazmulidris,Nazmul Idris,<nazmul.idris@ockam.io>
+yes,deebrecke,Deirdre Brecke,<deebrecke23@gmail.com>
+yes,lper1582,Loghi Perinpanayagam,<loghijiaha.16@cse.mrt.ac.lk> <loghijiaha@gmail.com> <lper1582@sysco.com>
+yes,queenkatherinecodes,Katherine Berger,<katherineroseberger@gmail.com>
+yes,seth-schroeder,Seth Schroeder,<seth.schroeder@gmail.com>
+yes,abhinavverma03,Abhinav Verma,<mudunuriabhi@gmail.com> <93146938+abhinavverma03@users.noreply.github.com>
+yes,bradlewis,Bradley Lewis,<bradley.lewis.dev@gmail.com> <22850972+BradLewis@users.noreply.github.com>
+yes,gautamprikshit1,Prikshit Gautam,<gautamprikshit1@gmail.com>
+yes,meysam81,Meysam,<MeysamAzad81@gmail.com>
+yes,SnowBiz,Alan Snow,<alan.snow@ockam.io> <mail@alansnow.dev>
+yes,crajcan,Carson Rajcan,<carajcan@gmail.com>
+yes,CaioPiccirillo,Caio Piccirillo,<caiopiccirillo@gmail.com>
+yes,postmeback,Arka Poddar,<poddararka27@gmail.com>
+yes,aleksandarskrbic,Aleksandar Skrbic,<skrbic.alexa@gmail.com>
+yes,alcolmenar,Al Colmenar,<aljcolmenar@gmail.com>
+yes,ankit8848,Ankit Kumar Jha,<ankitkumarjha@protonmail.com> <2100032609@kluniversity.in>
+yes,qxtaiba,Qutaiba Al-Nuaimy,<qan205@nyu.edu>
+yes,vivek-26,Vivek Kumar,<vivek.26@outlook.com>
+yes,bharattech,Bharat Tech,<bharattech@protonmail.com>
+yes,hlieberman,Harlan Lieberman-Berg,<hlieberman@setec.io>
+yes,0xphen,Aseme Kifen,<raph.kifen@gmail.com>
+yes,GabrielBarbosaGV,Gabriel Barbosa,<gabrielbgasparv@gmail.com>
+yes,9to1url,Jack Chiu,<9to1url@gmail.com>
+yes,jtfmumm,John Mumm,<jtfmumm@gmail.com>
+yes,SaketKaswa20,Saket Kaswa,<kaswasd21.mfg@coeptech.ac.in>
+yes,warpengineer,A. G. Madi,<WarpEngineer@users.noreply.github.com>
+yes,seve-martinez,Seve Martinez,<motorific@gmail.com> <20816697+seve-martinez@users.noreply.github.com>
+yes,jatinderjit,Jatinderjit Singh,<jatinderjit89@gmail.com>
+yes,DontPanicO,Andrea Tedeschi,<dontpanic.call0@gmail.com> <andry.teddy@gmail.com>
+yes,Lazzaretti,Fabrizio Lazzaretti,<fabrizio@lazzaretti.me>
+yes,0x61nas,Anas Elgarhy,<anas.elgarhy.dev@gmail.com>
+yes,iakev,Kevin Mwongera,<kirimikmwongera@gmail.com>
+yes,philosodad,Paul Daigle,<j.paul.daigle@gmail.com>
+yes,paulozulato,Paulo Zulato,<paulozulato@gmail.com>
+yes,outerwear,Michael Coates,<michaelcoates@protonmail.com>
+yes,celeo,Matt Boulanger,<mattboulanger@fastmail.com>
+yes,CEMcNeill,Chris McNeill,<cmcneill@gmail.com>
+yes,snandam,Sanjeev Nithyanandam,<sanjeev.nandam@gmail.com>
+yes,hseeberger,Heiko Seeberger,<git@heikoseeberger.de>

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -124,26 +124,27 @@ jobs:
               https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages
             ' && exit 1)
 
-      # - name: Check If PR Author Made Changes To CONTRIBUTORS.md
-      #   if: github.event_name == 'pull_request'
-      #   run: |
-      #     if ! git diff --name-only --exit-code ${FIRST_COMMIT}..HEAD $CONTRIBUTORS_CSV_PATH > /dev/null; then
-      #       # It is required that PR authors only make changes to CONTRIBUTORS.md when signing CLA
-      #     fi
+      - name: Check If PR Author Made Changes Only To CONTRIBUTORS.csv
+        run: |
+          paths_updated=$(git diff --name-only origin/develop..HEAD)
 
-      #     if git diff --name-only $FIRST_COMMIT..HEAD | grep -q -iF 'CONTRIBUTING.md'; then
-      #       echo "[✓] Pull Request Author has made changes to CONTRIBUTING.md"
-      #     else
-      #       echo "
-      #         Pull Request Author has not made any changes to CONTRIBUTING.md
-
-      #         Please read the Ockam Contributing Guide at:
+          if echo "$paths_updated" | grep $CONTRIBUTORS_CSV_PATH; then
+            # user has made changes to the CONTRIBUTORS.md file, we need to ensure that PR
+            # is only accepting the CLA
+            no_paths_updated=$(echo $paths_updated | wc -l)
+            if [[ $no_paths_updated -gt 1 ]]; then
+              echo "
+                We require that all contributors have accepted our Contributor License Agreement (CLA).
+                Please read the CLA and create a new pull request to accept the CLA by adding your Github details in a row at the end of the CONTRIBUTORS.csv file.
+                This new pull request must only change the CONTRIBUTORS.csv file.
+                CONTRIBUTORS.csv file is located at: $CONTRIBUTORS_CSV_PATH
+              " && exit 1
+            fi
+          fi
 
       - name: Get Contributors List
         run: |
-          curl --proto '=https' --tlsv1.2 --silent --show-error --fail \
-            https://raw.githubusercontent.com/build-trust/ockam-contributors/main/CONTRIBUTORS.csv \
-            > CONTRIBUTORS.csv
+          mv $CONTRIBUTORS_CSV_PATH CONTRIBUTORS.csv
 
       - name: Split Contributors List
         shell: python

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -248,9 +248,12 @@ jobs:
 
       - name: Get Developers List
         run: |
-          curl --proto '=https' --tlsv1.2 --silent --show-error --fail \
-            https://raw.githubusercontent.com/build-trust/ockam-contributors/main/DEVELOPERS.csv \
-            > DEVELOPERS.csv
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /orgs/build-trust/teams/developers/members | jq -r '.[].login' > DEVELOPERS.csv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check all commits in are Verified by Github (Pull Request)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -137,7 +137,8 @@ jobs:
                 We require that all contributors have accepted our Contributor License Agreement (CLA).
                 Please read the CLA and create a new pull request to accept the CLA by adding your Github details in a row at the end of the CONTRIBUTORS.csv file.
                 This new pull request must only change the CONTRIBUTORS.csv file.
-                CONTRIBUTORS.csv file is located at: $CONTRIBUTORS_CSV_PATH
+                CONTRIBUTORS.csv file is located at: $CONTRIBUTORS_CSV_PATH.
+                If you have any issues, please feel free to ask questions on this discussion thread https://github.com/build-trust/ockam/discussions/6112
               " && exit 1
             fi
           fi

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -32,6 +32,7 @@ jobs:
     # https://github.com/build-trust/ockam/commit/2fd0d36fe6ae0c2d527368683ec3a6352617b381
     env:
       FIRST_COMMIT: 2fd0d36fe6ae0c2d527368683ec3a6352617b381
+      CONTRIBUTORS_CSV_PATH: .github/CONTRIBUTORS.csv
 
     steps:
       - name: Checkout
@@ -122,6 +123,21 @@ jobs:
               More about the Ockam Commit Message Convention
               https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages
             ' && exit 1)
+
+      # - name: Check If PR Author Made Changes To CONTRIBUTORS.md
+      #   if: github.event_name == 'pull_request'
+      #   run: |
+      #     if ! git diff --name-only --exit-code ${FIRST_COMMIT}..HEAD $CONTRIBUTORS_CSV_PATH > /dev/null; then
+      #       # It is required that PR authors only make changes to CONTRIBUTORS.md when signing CLA
+      #     fi
+
+      #     if git diff --name-only $FIRST_COMMIT..HEAD | grep -q -iF 'CONTRIBUTING.md'; then
+      #       echo "[✓] Pull Request Author has made changes to CONTRIBUTING.md"
+      #     else
+      #       echo "
+      #         Pull Request Author has not made any changes to CONTRIBUTING.md
+
+      #         Please read the Ockam Contributing Guide at:
 
       - name: Get Contributors List
         run: |
@@ -251,7 +267,7 @@ jobs:
           gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/build-trust/teams/developers/members | jq -r '.[].login' > DEVELOPERS.csv
+            /orgs/build-trust/members | jq -r '.[].login' > DEVELOPERS.csv
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR moves CLA signing to the ockam repository, it also ensures that PRs that make changes to the CLA file, only makes changes to the CLA.