### PR TITLE
chore(rust): improve reset ouput when not enrolled

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -1,6 +1,6 @@
 use crate::terminal::ConfirmResult;
 use crate::util::local_cmd;
-use crate::{fmt_ok, CommandGlobalOpts};
+use crate::{fmt_info, fmt_ok, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use miette::miette;
@@ -20,6 +20,19 @@ impl ResetCommand {
 }
 
 fn run_impl(opts: CommandGlobalOpts, cmd: ResetCommand) -> miette::Result<()> {
+    match opts.state.is_enrolled() {
+        Ok(true) => {}
+        _ => {
+            opts.terminal
+                .stdout()
+                .plain(
+                    fmt_info!("There's no local Ockam configuration to delete. You can enroll using: ockam enroll")
+				)
+				.write_line()?;
+            return Ok(());
+        }
+    }
+
     if !cmd.yes {
         match opts
             .terminal


### PR DESCRIPTION
## Current behavior

Currently if a user has not enrolled (ie, they have not run ockam enroll yet) and they run ockam reset or ockam reset -y they get a prompt confirming that their local state information has been deleted.

## Proposed changes

When a user has not enrolled, and they run  `ockam reset` or `ockam reset -y`, instead of displaying information indicating that the command successfully ran, it should instead:

- Display information letting the user know that there is no local state to delete, since enrollment has not happened yet.
- And also ask them if they want to enroll by running ockam enroll in the prompt.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. The Ockam repo maintains a linear commit history so we merge PRs by rebasing them to the develop branch. Rebasing to the latest develop branch and force pushing to your PR branch is okay.
- [x] I accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/ockam-contributors/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/blob/main/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam-contributors](https://github.com/build-trust/ockam-contributors) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam-contributors/edit/main/CONTRIBUTORS.csv) file in the github web UI and create a PR, this will mark the commit as verified.

<!-- Looking forward to merging your contribution!! -->
