### PR TITLE
feat(elixir): explicit setup for aws kms in nif

### DIFF
--- a/implementations/elixir/ockam/ockly/lib/ockly.ex
+++ b/implementations/elixir/ockam/ockly/lib/ockly.ex
@@ -2,11 +2,4 @@ defmodule Ockly do
   @moduledoc """
   Documentation for `Ockly`.
   """
-
-  def nif_config do
-    case Application.fetch_env(:ockly, :aws_vault) do
-      {:ok, true} -> :aws_kms
-      _ -> nil
-    end
-  end
 end

--- a/implementations/elixir/ockam/ockly/lib/ockly/native.ex
+++ b/implementations/elixir/ockam/ockly/lib/ockly/native.ex
@@ -14,7 +14,7 @@ defmodule Ockly.Native do
   def verify_credential(_, _, _), do: error()
   def import_signing_secret(_), do: error()
 
-  def setup_aws_kms(), do: error()
+  def setup_aws_kms(_), do: error()
 
   def issue_credential(_, _, _, _), do: error()
 

--- a/implementations/elixir/ockam/ockly/lib/ockly/native.ex
+++ b/implementations/elixir/ockam/ockly/lib/ockly/native.ex
@@ -4,7 +4,6 @@ defmodule Ockly.Native do
   use Rustler,
     otp_app: :ockly,
     crate: "ockly",
-    load_data_fun: {Ockly, :nif_config},
     load_from: {:ockly, "priv/native/libockly"}
 
   def create_identity, do: create_identity(nil)
@@ -14,6 +13,8 @@ defmodule Ockly.Native do
   def verify_secure_channel_key_attestation(_, _, _), do: error()
   def verify_credential(_, _, _), do: error()
   def import_signing_secret(_), do: error()
+
+  def setup_aws_kms(), do: error()
 
   def issue_credential(_, _, _, _), do: error()
 

--- a/implementations/rust/ockam/ockam_vault_aws/src/aws_signing_vault.rs
+++ b/implementations/rust/ockam/ockam_vault_aws/src/aws_signing_vault.rs
@@ -30,16 +30,10 @@ impl AwsSigningVault {
     }
 
     /// Create a new AWS security module
-    async fn create_with_config(config: AwsKmsConfig) -> Result<Self> {
+    pub async fn create_with_config(config: AwsKmsConfig) -> Result<Self> {
         let client = AwsKmsClient::new(config).await?;
-
         let mut keys: Vec<AwsKeyPair> = vec![];
-
         // Fetch list of all keys, then fetch the public key for each key
-        // There shouldn't be more than 2-3 active keys in the KMS,
-        // however, technically we have a software limit of 100 keys here
-        // If there are more keys - `list_keys` will return an Error
-        // TODO: Make sure every Vault in AWS account gets its isolated scope
         let key_ids = client.list_keys().await?;
 
         for key_id in key_ids {


### PR DESCRIPTION
Elixir side: Instead of choosing between memory/aws vault at nif load time, use a memory vault by default and have an explicit call to switch to aws kms. This simplify some deployment scenarios, and make errors easier to debug.

Library side: so far it performs a `list()` request to aws at vault creation time to retrieve all the available keys on the kms,  and populate internal structure.  This is the only place and time where such request is done.    This PR introduces a new option at aws vault creation:

```
/// Defines how to populate the initial keys at vault startup
#[derive(Debug, Clone)]
pub enum InitialKeysDiscovery {
    /// Make a list() call to aws kms to obtain the entire set of keys this role as access to
    ListFromAwsKms,

    /// Use a specific set of key-ids
    Keys(Vec<String>),
}  
```

The default is to `ListFromAwsKms`  (existing behaviour),  but the caller can instead provide a list of key ids explicitly,  avoiding the call to list() entirely.
