### PR TITLE
feat(rust): cli's `random_name` function now returns human-readable two-word strings like 'fit-lark'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
  "ockam_vault_aws",
  "once_cell",
  "open",
+ "petname",
  "quickcheck",
  "rand 0.8.5",
  "reqwest",
@@ -5340,6 +5341,17 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "petname"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27039152ff4715ef8e4c40056ed5fd0152f362c662168906994182cde8b66232"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "phf"

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -44,6 +44,7 @@ minicbor = { version = "0.20.0", features = ["alloc", "derive"] }
 nix = { version = "0.27", features = ["signal"] }
 once_cell = { version = "1", optional = true, default-features = false }
 open = "5.0.0"
+petname = { version = "2.0.0-beta.2", default-features = false, features = ["default-rng", "default-words"] }
 rand = "0.8"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.188", features = ["derive"] }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
@@ -419,7 +419,7 @@ impl CliState {
 }
 
 pub fn random_name() -> String {
-    hex::encode(random::<[u8; 4]>())
+    petname::petname(2, "-").unwrap_or(hex::encode(random::<[u8; 4]>()))
 }
 
 fn file_stem(path: &Path) -> Result<String> {

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -357,7 +357,9 @@ pub mod test_utils {
     use ockam_node::Context;
     use ockam_transport_tcp::TcpTransport;
 
-    use crate::cli_state::{traits::*, CliState, IdentityConfig, NodeConfig, VaultConfig};
+    use crate::cli_state::{
+        random_name, traits::*, CliState, IdentityConfig, NodeConfig, VaultConfig,
+    };
     use crate::config::cli::{CredentialRetrieverConfig, TrustAuthorityConfig, TrustContextConfig};
     use crate::nodes::service::{
         NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
@@ -392,7 +394,7 @@ pub mod test_utils {
         let tcp = TcpTransport::create(context).await?;
         let cli_state = CliState::test()?;
 
-        let vault_name = hex::encode(rand::random::<[u8; 4]>());
+        let vault_name = random_name();
         let vault = cli_state
             .vaults
             .create_async(&vault_name.clone(), VaultConfig::default())
@@ -400,7 +402,7 @@ pub mod test_utils {
             .get()
             .await?;
 
-        let identity_name = hex::encode(rand::random::<[u8; 4]>());
+        let identity_name = random_name();
 
         // Premise: we need an identity and a credential before the node manager starts.
         // Since the LMDB can trigger some race conditions, we first use the memory storage
@@ -438,7 +440,7 @@ pub mod test_utils {
         let config = IdentityConfig::new(identity.identifier()).await;
         cli_state.identities.create(&identity_name, config).unwrap();
 
-        let node_name = hex::encode(rand::random::<[u8; 4]>());
+        let node_name = random_name();
         let node_config = NodeConfig::try_from(&cli_state).unwrap();
         cli_state.nodes.create(&node_name, node_config)?;
 

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -1,20 +1,15 @@
-use std::path::PathBuf;
-
+use crate::credential::{identities, identity};
 use crate::{
-    credential::validate_encoded_cred,
-    fmt_log, fmt_ok,
-    terminal::OckamColor,
-    util::{node_rpc, random_name},
-    vault::default_vault_name,
-    CommandGlobalOpts,
+    credential::validate_encoded_cred, fmt_log, fmt_ok, terminal::OckamColor, util::node_rpc,
+    vault::default_vault_name, CommandGlobalOpts,
 };
+use clap::Args;
 use colorful::Colorful;
 use miette::miette;
-
-use crate::credential::{identities, identity};
-use clap::Args;
 use ockam::Context;
+use ockam_api::cli_state::random_name;
 use ockam_api::cli_state::{CredentialConfig, StateDirTrait};
+use std::path::PathBuf;
 use tokio::{sync::Mutex, try_join};
 
 #[derive(Clone, Debug, Args)]

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -9,7 +9,7 @@ use tracing::log::warn;
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
-use ockam_api::cli_state::{update_enrolled_identity, SpaceConfig};
+use ockam_api::cli_state::{random_name, update_enrolled_identity, SpaceConfig};
 use ockam_api::cloud::enroll::auth0::*;
 use ockam_api::cloud::project::Project;
 use ockam_api::cloud::space::Space;
@@ -193,7 +193,7 @@ async fn default_space<'a>(opts: &CommandGlobalOpts, rpc: &mut Rpc) -> Result<Sp
         ))?;
 
         let is_finished = Mutex::new(false);
-        let name = crate::util::random_name();
+        let name = random_name();
         let create_space = async {
             let cmd = crate::space::CreateCommand {
                 name: name.to_string(),

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -13,7 +13,7 @@ use tokio::try_join;
 use ockam::{Address, AsyncTryClone, TcpListenerOptions};
 use ockam::{Context, TcpTransport};
 use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
-use ockam_api::cli_state::{add_project_info_to_node_state, init_node_state};
+use ockam_api::cli_state::{add_project_info_to_node_state, init_node_state, random_name};
 use ockam_api::nodes::models::transport::CreateTransportJson;
 use ockam_api::nodes::service::NodeManagerTrustOptions;
 use ockam_api::{
@@ -110,7 +110,7 @@ pub struct CreateCommand {
 impl Default for CreateCommand {
     fn default() -> Self {
         Self {
-            node_name: hex::encode(random::<[u8; 4]>()),
+            node_name: random_name(),
             exit_on_eof: false,
             tcp_listener_address: "127.0.0.1:0".to_string(),
             foreground: false,

--- a/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/trust_context/create.rs
@@ -1,13 +1,9 @@
 use crate::util::local_cmd;
-use crate::{
-    docs,
-    util::{api::TrustContextOpts, random_name},
-    CommandGlobalOpts,
-};
+use crate::{docs, util::api::TrustContextOpts, CommandGlobalOpts};
 use clap::Args;
 use indoc::formatdoc;
 use miette::{miette, IntoDiagnostic};
-use ockam_api::cli_state::StateDirTrait;
+use ockam_api::cli_state::{random_name, StateDirTrait};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -504,10 +504,6 @@ pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {
     s.is_terminal()
 }
 
-pub fn random_name() -> String {
-    hex::encode(rand::random::<[u8; 4]>())
-}
-
 #[cfg(test)]
 mod tests {
     use ockam_api::address::extract_address_value;


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/6096

Some commands must be updated to use this function. I'll create separate issues for that.