### PR TITLE
fix(rust):Breaking changes in upgrading dialoguer crate from 0.10.4 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,13 +2120,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "thiserror",
  "zeroize",
 ]
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -64,7 +64,7 @@ colorful = "0.2"
 colors-transform = "0.2.11"
 console = "0.15.7"
 ctrlc = { version = "3.4.1", features = ["termination"] }
-dialoguer = "0.10"
+dialoguer = "0.11.0"
 duct = "0.13"
 flate2 = "1.0.27"
 hex = "0.4"

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -180,3 +180,4 @@ gen_from_impl!(ockam_api::error::ApiError, SOFTWARE);
 gen_from_impl!(ockam_multiaddr::Error, SOFTWARE);
 gen_from_impl!(miette::ErrReport, SOFTWARE);
 gen_from_impl!(time::error::Parse, DATAERR);
+gen_from_impl!(dialoguer::Error, DATAERR);


### PR DESCRIPTION
Fixes #6062  Investigate and fix breaking changes in upgrading dialoguer crate from 0.10.4 to 0.11.0