### PR TITLE
Remove the `skip_defaults` flag

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -153,13 +153,6 @@ impl PreTrustedIdentities {
         PreTrustedIdentities::Fixed(entries)
     }
 
-    pub fn get_trusted_identities(self) -> Result<HashMap<Identifier, AttributesEntry>> {
-        match self {
-            PreTrustedIdentities::Fixed(identities) => Ok(identities),
-            PreTrustedIdentities::ReloadFrom(path) => Self::parse_from_disk(&path),
-        }
-    }
-
     fn parse_from_disk(path: &PathBuf) -> Result<HashMap<Identifier, AttributesEntry>> {
         let contents = std::fs::read_to_string(path)
             .map_err(|e| ockam_core::Error::new(Origin::Other, Kind::Io, e))?;

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -444,7 +444,7 @@ pub mod test_utils {
 
         let node_manager = NodeManager::create(
             context,
-            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, false, None),
+            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, None, true),
             NodeManagerTransportOptions::new(
                 FlowControls::generate_flow_control_id(), // FIXME
                 tcp.async_try_clone().await?,

--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -314,7 +314,7 @@ pub(crate) async fn make_node_manager_worker(
 
     let node_manager = NodeManager::create(
         &ctx,
-        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), false, None),
+        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), None, true),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -307,8 +307,8 @@ async fn run_foreground_node(
         NodeManagerGeneralOptions::new(
             opts.state.clone(),
             cmd.node_name.clone(),
-            cmd.launch_config.is_some(),
             pre_trusted_identities,
+            cmd.launch_config.is_none(),
         ),
         NodeManagerTransportOptions::new(
             listener.flow_control_id().clone(),
@@ -318,8 +318,8 @@ async fn run_foreground_node(
     )
     .await
     .into_diagnostic()?;
-    let node_manager_worker = NodeManagerWorker::new(node_man);
 
+    let node_manager_worker = NodeManagerWorker::new(node_man);
     ctx.flow_controls()
         .add_consumer(NODEMANAGER_ADDR, listener.flow_control_id());
     ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -73,12 +73,7 @@ pub async fn start_embedded_node_with_vault_and_identity(
 
     let node_man = NodeManager::create(
         ctx,
-        NodeManagerGeneralOptions::new(
-            cli_state.clone(),
-            cmd.node_name.clone(),
-            cmd.launch_config.is_some(),
-            None,
-        ),
+        NodeManagerGeneralOptions::new(cli_state.clone(), cmd.node_name.clone(), None, true),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )


### PR DESCRIPTION
The `skip_defaults` flag used when creating a `NodeManager` does not need to be kept on the struct for its whole lifetime.
That flag is set to `true` when a launch config has been passed on the command line and is otherwise set to `false`.


