### PR TITLE
Small node manager worker refactoring + relay renaming

### DIFF
--- a/examples/rust/file_transfer/examples/receiver.rs
+++ b/examples/rust/file_transfer/examples/receiver.rs
@@ -2,7 +2,7 @@
 
 use file_transfer::FileData;
 use ockam::identity::SecureChannelListenerOptions;
-use ockam::remote::RemoteForwarderOptions;
+use ockam::remote::RemoteRelayOptions;
 use ockam::{
     errcode::{Kind, Origin},
     node, Context, Error, Result, Routed, TcpConnectionOptions, Worker,
@@ -102,17 +102,15 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // To allow Sender and others to initiate an end-to-end secure channel with this program
     // we connect with 1.node.ockam.network:4000 as a TCP client and ask the forwarding
-    // service on that node to create a forwarder for us.
+    // service on that node to create a relay for us.
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
     let node_in_hub = tcp.connect("1.node.ockam.network:4000", tcp_options).await?;
-    let forwarder = node
-        .create_forwarder(node_in_hub, RemoteForwarderOptions::new())
-        .await?;
-    println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
+    let relay = node.create_relay(node_in_hub, RemoteRelayOptions::new()).await?;
+    println!("\n[✓] RemoteRelay was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Receiver is:");
-    println!("{}", forwarder.remote_address());
+    println!("{}", relay.remote_address());
 
     // Start a worker, of type FileReception, at address "receiver".
     node.start_worker("receiver", FileReception::default()).await?;

--- a/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
+++ b/examples/rust/get_started/examples/04-routing-over-transport-two-hops-middle.rs
@@ -1,9 +1,9 @@
 // This node creates a tcp connection to a node at 127.0.0.1:4000
-// Starts a forwarder worker to forward messages to 127.0.0.1:4000
+// Starts a relay worker to forward messages to 127.0.0.1:4000
 // Starts a tcp listener at 127.0.0.1:3000
 // It then runs forever waiting to route messages.
 
-use hello_ockam::Forwarder;
+use hello_ockam::Relay;
 use ockam::{node, Context, Result, TcpConnectionOptions, TcpListenerOptions, TcpTransportExtension};
 
 #[ockam::node]
@@ -17,14 +17,14 @@ async fn main(ctx: Context) -> Result<()> {
     // Create a TCP connection to the responder node.
     let connection_to_responder = tcp.connect("127.0.0.1:4000", TcpConnectionOptions::new()).await?;
 
-    // Create a Forwarder worker
-    node.start_worker("forward_to_responder", Forwarder(connection_to_responder.into()))
+    // Create a Relay worker
+    node.start_worker("forward_to_responder", Relay(connection_to_responder.into()))
         .await?;
 
     // Create a TCP listener and wait for incoming connections.
     let listener = tcp.listen("127.0.0.1:3000", TcpListenerOptions::new()).await?;
 
-    // Allow access to the Forwarder via TCP connections from the TCP listener
+    // Allow access to the Relay via TCP connections from the TCP listener
     node.flow_controls()
         .add_consumer("forward_to_responder", listener.flow_control_id());
 

--- a/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-middle.rs
+++ b/examples/rust/get_started/examples/05-secure-channel-over-two-transport-hops-middle.rs
@@ -1,9 +1,9 @@
 // This node creates a tcp connection to a node at 127.0.0.1:4000
-// Starts a forwarder worker to forward messages to 127.0.0.1:4000
+// Starts a relay worker to forward messages to 127.0.0.1:4000
 // Starts a tcp listener at 127.0.0.1:3000
 // It then runs forever waiting to route messages.
 
-use hello_ockam::Forwarder;
+use hello_ockam::Relay;
 use ockam::{node, Context, Result, TcpConnectionOptions, TcpListenerOptions, TcpTransportExtension};
 
 #[ockam::node]
@@ -17,8 +17,8 @@ async fn main(ctx: Context) -> Result<()> {
     // Create a TCP connection to Bob.
     let connection_to_bob = tcp.connect("127.0.0.1:4000", TcpConnectionOptions::new()).await?;
 
-    // Start a Forwarder to forward messages to Bob using the TCP connection.
-    node.start_worker("forward_to_bob", Forwarder(connection_to_bob.into()))
+    // Start a Relay to forward messages to Bob using the TCP connection.
+    node.start_worker("forward_to_bob", Relay(connection_to_bob.into()))
         .await?;
 
     // Create a TCP listener and wait for incoming connections.

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -5,7 +5,7 @@ use ockam::identity::{
     AuthorityService, RemoteCredentialsRetriever, RemoteCredentialsRetrieverInfo, SecureChannelListenerOptions,
     SecureChannelOptions, TrustContext, TrustMultiIdentifiersPolicy,
 };
-use ockam::remote::RemoteForwarderOptions;
+use ockam::remote::RemoteRelayOptions;
 use ockam::{node, route, Context, Result, TcpOutletOptions};
 use ockam_api::authenticator::enrollment_tokens::TokenAcceptor;
 use ockam_api::nodes::NodeManager;
@@ -16,14 +16,14 @@ use std::sync::Arc;
 
 /// This node supports a "control" server on which several "edge" devices can connect
 ///
-/// The connections go through the Ockam Orchestrator, via a Forwarder, and a secure channel
+/// The connections go through the Ockam Orchestrator, via a Relay, and a secure channel
 /// can be established to forward messages to an outlet going to a local Python webserver.
 ///
 ///
 /// This example shows how to:
 ///
 ///   - retrieve credentials from an authority
-///   - create a Forwarder on the Ockam Orchestrator
+///   - create a Relay on the Ockam Orchestrator
 ///   - create a TCP outlet with some access control checking the authenticated attributes of the caller
 ///
 /// The node needs to be started with:
@@ -118,7 +118,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     )
     .await?;
 
-    // 5. create a forwarder on the Ockam orchestrator
+    // 5. create a relay on the Ockam orchestrator
 
     let tcp_project_route = multiaddr_to_route(&project.route(), &tcp).await.unwrap(); // FIXME: Handle error
     let project_options =
@@ -140,11 +140,11 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         )
         .await?;
 
-    // finally create a forwarder using the secure channel to the project
-    let forwarder = node
-        .create_static_forwarder(secure_channel_address, "control_plane1", RemoteForwarderOptions::new())
+    // finally create a relay using the secure channel to the project
+    let relay = node
+        .create_static_relay(secure_channel_address, "control_plane1", RemoteRelayOptions::new())
         .await?;
-    println!("forwarder is {forwarder:?}");
+    println!("relay is {relay:?}");
 
     // 6. create a secure channel listener which will allow the edge node to
     //    start a secure channel when it is ready

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -17,7 +17,7 @@ use ockam_transport_tcp::{TcpInletOptions, TcpTransportExtension};
 /// This node supports an "edge" server which can connect to a "control" node
 /// in order to connect its TCP inlet to the "control" node TCP outlet
 ///
-/// The connections go through the Ockam Orchestrator, via the control node Forwarder.
+/// The connections go through the Ockam Orchestrator, via the control node Relay.
 ///
 /// This example shows how to:
 ///
@@ -131,7 +131,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         )
         .await?;
 
-    // 4.3 then create a secure channel to the control node (via its forwarder)
+    // 4.3 then create a secure channel to the control node (via its relay)
     let secure_channel_listener_route = route![secure_channel_address, "forward_to_control_plane1", "untrusted"];
     let secure_channel_to_control = node
         .create_secure_channel(

--- a/examples/rust/get_started/examples/11-attribute-based-authentication.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication.rs
@@ -45,7 +45,7 @@
 ///              |               +-------------------------------------+
 ///              |                   |                           |
 ///              |                   |                           | create secure channel to control
-///              |                   |                           | via the forwarder
+///              |                   |                           | via the relay
 ///              v                   v                           |
 ///      +--------------+        +-------------------------------+-------+
 ///      | Authority    |        |                               |       |
@@ -67,10 +67,10 @@
 ///   - we create initially some secure channels to the Authority in order to retrieve credential
 ///     based on a one-time token generated with `ockam project ticket --attribute component=<name of node>`
 ///
-///   - then the control node creates a forwarder on the Orchestrator in order to accept TCP traffic without
+///   - then the control node creates a relay on the Orchestrator in order to accept TCP traffic without
 ///     having to open a port to the internet. It also starts a channel listener ("untrusted", accept all incoming requests for now)
 ///
-///   - on its side the edge node starts a secure channel via forwarder (named "forward_to_control_plane1"), to the "untrusted" listener
+///   - on its side the edge node starts a secure channel via relay (named "forward_to_control_plane1"), to the "untrusted" listener
 ///     with the secure channel address it creates an Inlet which will direct TCP traffic via the secure channel to get to the
 ///     control node and then to the "outlet" worker to reach the Python webserver
 ///

--- a/examples/rust/get_started/examples/bob.rs
+++ b/examples/rust/get_started/examples/bob.rs
@@ -1,5 +1,5 @@
 use ockam::identity::SecureChannelListenerOptions;
-use ockam::remote::RemoteForwarderOptions;
+use ockam::remote::RemoteRelayOptions;
 use ockam::{node, Routed, TcpConnectionOptions, Worker};
 use ockam::{Context, Result};
 use ockam_transport_tcp::TcpTransportExtension;
@@ -48,19 +48,17 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // To allow Alice and others to initiate an end-to-end secure channel with this program
     // we connect with 1.node.ockam.network:4000 as a TCP client and ask the forwarding
-    // service on that node to create a forwarder for us.
+    // service on that node to create a relay for us.
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
     let node_in_hub = tcp
         .connect("1.node.ockam.network:4000", TcpConnectionOptions::new())
         .await?;
-    let forwarder = node
-        .create_forwarder(node_in_hub, RemoteForwarderOptions::new())
-        .await?;
-    println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
+    let relay = node.create_relay(node_in_hub, RemoteRelayOptions::new()).await?;
+    println!("\n[✓] RemoteRelay was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address for Bob is:");
-    println!("{}", forwarder.remote_address());
+    println!("{}", relay.remote_address());
 
     // We won't call ctx.stop() here, this program will run until you stop it with Ctrl-C
     Ok(())

--- a/examples/rust/get_started/src/lib.rs
+++ b/examples/rust/get_started/src/lib.rs
@@ -2,11 +2,11 @@ mod echoer;
 
 pub use echoer::*;
 
-mod forwarder;
 mod hop;
+mod relay;
 
-pub use forwarder::*;
 pub use hop::*;
+pub use relay::*;
 
 mod logger;
 mod project;

--- a/examples/rust/get_started/src/relay.rs
+++ b/examples/rust/get_started/src/relay.rs
@@ -1,9 +1,9 @@
 use ockam::{Address, Any, Context, LocalMessage, Result, Routed, Worker};
 
-pub struct Forwarder(pub Address);
+pub struct Relay(pub Address);
 
 #[ockam::worker]
-impl Worker for Forwarder {
+impl Worker for Relay {
     type Context = Context;
     type Message = Any;
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-inlet.rs
@@ -13,7 +13,7 @@ async fn main(ctx: Context) -> Result<()> {
     // TCP Transport Outlet.
     //
     // For this example, we know that the Outlet node is listening for Ockam Routing Messages
-    // through a Remote Forwarder at "1.node.ockam.network:4000" and its forwarder address
+    // through a Remote Relay at "1.node.ockam.network:4000" and its forwarder address
     // points to secure channel listener.
     let e = node.create_identity().await?;
 

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -1,5 +1,5 @@
 use ockam::identity::SecureChannelListenerOptions;
-use ockam::remote::RemoteForwarderOptions;
+use ockam::remote::RemoteRelayOptions;
 use ockam::{node, Context, Result, TcpConnectionOptions, TcpOutletOptions};
 use ockam_transport_tcp::TcpTransportExtension;
 
@@ -45,17 +45,15 @@ async fn main(ctx: Context) -> Result<()> {
 
     // To allow Inlet Node and others to initiate an end-to-end secure channel with this program
     // we connect with 1.node.ockam.network:4000 as a TCP client and ask the forwarding
-    // service on that node to create a forwarder for us.
+    // service on that node to create a relay for us.
     //
     // All messages that arrive at that forwarding address will be sent to this program
     // using the TCP connection we created as a client.
     let node_in_hub = tcp.connect("1.node.ockam.network:4000", tcp_options).await?;
-    let forwarder = node
-        .create_forwarder(node_in_hub, RemoteForwarderOptions::new())
-        .await?;
-    println!("\n[✓] RemoteForwarder was created on the node at: 1.node.ockam.network:4000");
+    let relay = node.create_relay(node_in_hub, RemoteRelayOptions::new()).await?;
+    println!("\n[✓] RemoteRelay was created on the node at: 1.node.ockam.network:4000");
     println!("Forwarding address in Hub is:");
-    println!("{}", forwarder.remote_address());
+    println!("{}", relay.remote_address());
 
     // We won't call ctx.stop() here,
     // so this program will keep running until you interrupt it with Ctrl-C.

--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -83,7 +83,7 @@ fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_hub() -> Resu
     let port = rand::thread_rng().gen_range(10000..65535);
     // Spawn outlet, wait for it to start up, grab dynamic forwarding address
     let outlet = CmdBuilder::new("cargo run --example 04-outlet ockam.io:80").spawn()?;
-    outlet.match_stdout(r"(?i)RemoteForwarder was created on the node")?;
+    outlet.match_stdout(r"(?i)RemoteRelay was created on the node")?;
     let fwd_address = outlet.match_stdout(r"(?m)^FWD_(\w+)$")?.swap_remove(0).unwrap();
     println!("Forwarding address: {fwd_address}");
 

--- a/implementations/rust/ockam/ockam/src/forwarding_service/mod.rs
+++ b/implementations/rust/ockam/ockam/src/forwarding_service/mod.rs
@@ -1,7 +1,0 @@
-mod forwarder;
-#[allow(clippy::module_inception)]
-mod forwarding_service;
-mod options;
-
-pub use forwarding_service::*;
-pub use options::*;

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -67,15 +67,15 @@ pub use ockam_node::{
 
 mod delay;
 mod error;
-mod forwarding_service;
 mod metadata;
 mod monotonic;
+mod relay_service;
 mod system;
 mod unique;
 
 pub use error::OckamError;
-pub use forwarding_service::{ForwardingService, ForwardingServiceOptions};
 pub use metadata::OckamMessage;
+pub use relay_service::{RelayService, RelayServiceOptions};
 pub use system::{SystemBuilder, SystemHandler, WorkerSystem};
 pub use unique::unique_with_prefix;
 

--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -17,7 +17,7 @@ use ockam_identity::{PurposeKeys, Vault, VaultStorage};
 use ockam_node::{Context, HasContext, MessageReceiveOptions, MessageSendReceiveOptions};
 use ockam_vault::KeyId;
 
-use crate::remote::{RemoteForwarder, RemoteForwarderInfo, RemoteForwarderOptions};
+use crate::remote::{RemoteRelay, RemoteRelayInfo, RemoteRelayOptions};
 use crate::stream::Stream;
 use crate::OckamError;
 
@@ -81,23 +81,23 @@ impl Node {
         Stream::new(self.get_context()).await
     }
 
-    /// Create a new forwarder
-    pub async fn create_forwarder(
+    /// Create a new relay
+    pub async fn create_relay(
         &self,
         orchestrator_route: impl Into<Route>,
-        options: RemoteForwarderOptions,
-    ) -> Result<RemoteForwarderInfo> {
-        RemoteForwarder::create(self.get_context(), orchestrator_route, options).await
+        options: RemoteRelayOptions,
+    ) -> Result<RemoteRelayInfo> {
+        RemoteRelay::create(self.get_context(), orchestrator_route, options).await
     }
 
-    /// Create a new static forwarder
-    pub async fn create_static_forwarder(
+    /// Create a new static relay
+    pub async fn create_static_relay(
         &self,
         orchestrator_route: impl Into<Route>,
         alias: impl Into<String>,
-        options: RemoteForwarderOptions,
-    ) -> Result<RemoteForwarderInfo> {
-        RemoteForwarder::create_static(self.get_context(), orchestrator_route, alias, options).await
+        options: RemoteRelayOptions,
+    ) -> Result<RemoteRelayInfo> {
+        RemoteRelay::create_static(self.get_context(), orchestrator_route, alias, options).await
     }
 
     /// Create an Identity

--- a/implementations/rust/ockam/ockam/src/relay_service/mod.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/mod.rs
@@ -1,0 +1,7 @@
+mod options;
+mod relay;
+#[allow(clippy::module_inception)]
+mod relay_service;
+
+pub use options::*;
+pub use relay_service::*;

--- a/implementations/rust/ockam/ockam/src/relay_service/options.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/options.rs
@@ -4,34 +4,34 @@ use ockam_core::flow_control::{FlowControlId, FlowControls};
 use ockam_core::{Address, AllowAll, IncomingAccessControl};
 
 /// Trust Options for a Forwarding Service
-pub struct ForwardingServiceOptions {
+pub struct RelayServiceOptions {
     pub(super) service_incoming_access_control: Arc<dyn IncomingAccessControl>,
-    pub(super) forwarders_incoming_access_control: Arc<dyn IncomingAccessControl>,
+    pub(super) relays_incoming_access_control: Arc<dyn IncomingAccessControl>,
     pub(super) consumer_service: Vec<FlowControlId>,
-    pub(super) consumer_forwarder: Vec<FlowControlId>,
+    pub(super) consumer_relay: Vec<FlowControlId>,
 }
 
-impl ForwardingServiceOptions {
+impl RelayServiceOptions {
     /// Default constructor without Access Control
     pub fn new() -> Self {
         Self {
             service_incoming_access_control: Arc::new(AllowAll),
-            forwarders_incoming_access_control: Arc::new(AllowAll),
+            relays_incoming_access_control: Arc::new(AllowAll),
             consumer_service: vec![],
-            consumer_forwarder: vec![],
+            consumer_relay: vec![],
         }
     }
 
-    /// Mark that this Forwarding service is a Consumer for to the given [`FlowControlId`]
+    /// Mark that this Relay service is a Consumer for to the given [`FlowControlId`]
     pub fn service_as_consumer(mut self, id: &FlowControlId) -> Self {
         self.consumer_service.push(id.clone());
 
         self
     }
 
-    /// Mark that spawned Forwarders are Consumers for to the given [`FlowControlId`]
-    pub fn forwarder_as_consumer(mut self, id: &FlowControlId) -> Self {
-        self.consumer_forwarder.push(id.clone());
+    /// Mark that spawned Relays are Consumers for to the given [`FlowControlId`]
+    pub fn relay_as_consumer(mut self, id: &FlowControlId) -> Self {
+        self.consumer_relay.push(id.clone());
 
         self
     }
@@ -54,25 +54,25 @@ impl ForwardingServiceOptions {
         self
     }
 
-    /// Set spawned forwarders Incoming Access Control
-    pub fn with_forwarders_incoming_access_control_impl(
+    /// Set spawned relays Incoming Access Control
+    pub fn with_relays_incoming_access_control_impl(
         mut self,
         access_control: impl IncomingAccessControl,
     ) -> Self {
-        self.forwarders_incoming_access_control = Arc::new(access_control);
+        self.relays_incoming_access_control = Arc::new(access_control);
         self
     }
 
-    /// Set spawned forwarders Incoming Access Control
-    pub fn with_forwarders_incoming_access_control(
+    /// Set spawned relays Incoming Access Control
+    pub fn with_relays_incoming_access_control(
         mut self,
         access_control: Arc<dyn IncomingAccessControl>,
     ) -> Self {
-        self.forwarders_incoming_access_control = access_control;
+        self.relays_incoming_access_control = access_control;
         self
     }
 
-    pub(super) fn setup_flow_control_for_forwarding_service(
+    pub(super) fn setup_flow_control_for_relay_service(
         &self,
         flow_controls: &FlowControls,
         address: &Address,
@@ -82,18 +82,18 @@ impl ForwardingServiceOptions {
         }
     }
 
-    pub(super) fn setup_flow_control_for_forwarder(
+    pub(super) fn setup_flow_control_for_relay(
         &self,
         flow_controls: &FlowControls,
         address: &Address,
     ) {
-        for id in &self.consumer_forwarder {
+        for id in &self.consumer_relay {
             flow_controls.add_consumer(address.clone(), id);
         }
     }
 }
 
-impl Default for ForwardingServiceOptions {
+impl Default for RelayServiceOptions {
     fn default() -> Self {
         Self::new()
     }

--- a/implementations/rust/ockam/ockam/src/relay_service/relay.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/relay.rs
@@ -8,7 +8,7 @@ use ockam_core::{
 use ockam_node::WorkerBuilder;
 use tracing::info;
 
-pub(super) struct Forwarder {
+pub(super) struct Relay {
     forward_route: Route,
     // this option will be `None` after this worker is initialized, because
     // while initializing, the worker will send the payload contained in this
@@ -16,7 +16,7 @@ pub(super) struct Forwarder {
     payload: Option<Vec<u8>>,
 }
 
-impl Forwarder {
+impl Relay {
     pub(super) async fn create(
         ctx: &Context,
         address: Address,
@@ -35,12 +35,12 @@ impl Forwarder {
             Arc::new(AllowOnwardAddress(next_hop))
         };
 
-        let forwarder = Self {
+        let relay = Self {
             forward_route,
             payload: Some(registration_payload.clone()),
         };
 
-        WorkerBuilder::new(forwarder)
+        WorkerBuilder::new(relay)
             .with_address(address)
             .with_incoming_access_control_arc(incoming_access_control)
             .with_outgoing_access_control_arc(outgoing_access_control)
@@ -52,7 +52,7 @@ impl Forwarder {
 }
 
 #[crate::worker]
-impl Worker for Forwarder {
+impl Worker for Relay {
     type Context = Context;
     type Message = Any;
 

--- a/implementations/rust/ockam/ockam/src/remote/addresses.rs
+++ b/implementations/rust/ockam/ockam/src/remote/addresses.rs
@@ -1,4 +1,4 @@
-use crate::remote::lifecycle::ForwardType;
+use crate::remote::lifecycle::RelayType;
 use ockam_core::Address;
 
 #[derive(Clone, Debug)]
@@ -14,15 +14,14 @@ pub(super) struct Addresses {
 }
 
 impl Addresses {
-    pub(super) fn generate(ftype: ForwardType) -> Self {
+    pub(super) fn generate(ftype: RelayType) -> Self {
         let type_str = ftype.str();
-        let main_remote =
-            Address::random_tagged(&format!("RemoteForwarder.{}.main_remote", type_str));
+        let main_remote = Address::random_tagged(&format!("RemoteRelay.{}.main_remote", type_str));
         let main_internal =
-            Address::random_tagged(&format!("RemoteForwarder.{}.main_internal", type_str));
-        let heartbeat = Address::random_tagged(&format!("RemoteForwarder.{}.heartbeat", type_str));
+            Address::random_tagged(&format!("RemoteRelay.{}.main_internal", type_str));
+        let heartbeat = Address::random_tagged(&format!("RemoteRelay.{}.heartbeat", type_str));
         let completion_callback =
-            Address::random_tagged(&format!("RemoteForwarder.{}.child", type_str));
+            Address::random_tagged(&format!("RemoteRelay.{}.child", type_str));
 
         Self {
             main_remote,

--- a/implementations/rust/ockam/ockam/src/remote/info.rs
+++ b/implementations/rust/ockam/ockam/src/remote/info.rs
@@ -6,14 +6,14 @@ use serde::{Deserialize, Serialize};
 
 /// Information about a remotely forwarded worker.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug, Message)]
-pub struct RemoteForwarderInfo {
+pub struct RemoteRelayInfo {
     forwarding_route: Route,
     remote_address: String,
     worker_address: Address,
     flow_control_id: Option<FlowControlId>,
 }
 
-impl RemoteForwarderInfo {
+impl RemoteRelayInfo {
     /// Constructor
     pub fn new(
         forwarding_route: Route,

--- a/implementations/rust/ockam/ockam/src/remote/mod.rs
+++ b/implementations/rust/ockam/ockam/src/remote/mod.rs
@@ -1,4 +1,4 @@
-//! [`RemoteForwarder`] allows registering node within a Cloud Node with dynamic or static alias,
+//! [`RemoteRelay`] allows registering node within a Cloud Node with dynamic or static alias,
 //! which allows other nodes forward messages to local workers on this node using that alias.
 
 mod addresses;
@@ -18,14 +18,14 @@ use ockam_core::Route;
 use ockam_node::DelayedEvent;
 
 /// This Worker is responsible for registering on Ockam Orchestrator and forwarding messages to local Worker
-pub struct RemoteForwarder {
+pub struct RemoteRelay {
     /// Address used from other node
     addresses: Addresses,
     completion_msg_sent: bool,
     registration_route: Route,
     registration_payload: String,
     flow_control_id: Option<FlowControlId>,
-    // We only use Heartbeat for static RemoteForwarder
+    // We only use Heartbeat for static RemoteRelay
     heartbeat: Option<DelayedEvent<Vec<u8>>>,
     heartbeat_interval: Duration,
 }

--- a/implementations/rust/ockam/ockam/src/remote/options.rs
+++ b/implementations/rust/ockam/ockam/src/remote/options.rs
@@ -3,16 +3,16 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::{FlowControlId, FlowControlOutgoingAccessControl, FlowControls};
 use ockam_core::{Address, AllowAll, OutgoingAccessControl};
 
-/// Trust options for [`RemoteForwarder`](super::RemoteForwarder)
-pub struct RemoteForwarderOptions {}
+/// Trust options for [`RemoteRelay`](super::RemoteRelay)
+pub struct RemoteRelayOptions {}
 
-impl RemoteForwarderOptions {
+impl RemoteRelayOptions {
     /// Usually [`FlowControlId`] should be shared with the Producer that was used to create this
-    /// forwarder (probably Secure Channel), since [`RemoteForwarder`](super::RemoteForwarder)
+    /// relay (probably Secure Channel), since [`RemoteRelay`](super::RemoteRelay)
     /// doesn't imply any new "trust" context, it's just a Message Routing helper.
     /// Therefore, workers that are allowed to receive messages from the corresponding
     /// Secure Channel should as well be allowed to receive messages
-    /// through the [`RemoteForwarder`](super::RemoteForwarder) through the same Secure Channel.
+    /// through the [`RemoteRelay`](super::RemoteRelay) through the same Secure Channel.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {}

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -13,7 +13,7 @@ mod secure_channel_map;
 
 pub(crate) use inlet_controller::KafkaInletController;
 use ockam_core::Address;
-pub(crate) use outlet_service::prefix_forwarder::PrefixForwarderService;
+pub(crate) use outlet_service::prefix_relay::PrefixRelayService;
 pub(crate) use outlet_service::OutletManagerService;
 pub(crate) use portal_listener::KafkaPortalListener;
 pub(crate) use secure_channel_map::ConsumerNodeAddr;

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/mod.rs
@@ -1,4 +1,4 @@
 mod interceptor_listener;
-pub(crate) mod prefix_forwarder;
+pub(crate) mod prefix_relay;
 
 pub(crate) use interceptor_listener::OutletManagerService;

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
@@ -108,7 +108,7 @@ impl InletInterceptorImpl {
         let request: FetchRequest = decode_body(buffer, header.request_api_version)?;
 
         //we intercept every partition interested by the kafka client
-        //and create a forwarder for each
+        //and create a relay for each
         for topic in &request.topics {
             let topic_id = if header.request_api_version <= 12 {
                 topic.topic.0.to_string()
@@ -135,7 +135,7 @@ impl InletInterceptorImpl {
                 .collect();
 
             self.secure_channel_controller
-                .start_forwarders_for(context, &topic_id, partitions)
+                .start_relays_for(context, &topic_id, partitions)
                 .await
                 .map_err(InterceptError::Ockam)?
         }

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -43,7 +43,7 @@ mod test {
             Ok(encrypted_content)
         }
 
-        async fn start_forwarders_for(
+        async fn start_relays_for(
             &self,
             _context: &mut Context,
             _topic_id: &str,

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -160,7 +160,7 @@ pub struct DefaultAddress;
 
 impl DefaultAddress {
     pub const AUTHENTICATED_SERVICE: &'static str = "authenticated";
-    pub const FORWARDING_SERVICE: &'static str = "forwarding_service";
+    pub const RELAY_SERVICE: &'static str = "forwarding_service";
     pub const UPPERCASE_SERVICE: &'static str = "uppercase";
     pub const ECHO_SERVICE: &'static str = "echo";
     pub const HOP_SERVICE: &'static str = "hop";
@@ -180,7 +180,7 @@ impl DefaultAddress {
         matches!(
             name,
             Self::AUTHENTICATED_SERVICE
-                | Self::FORWARDING_SERVICE
+                | Self::RELAY_SERVICE
                 | Self::UPPERCASE_SERVICE
                 | Self::ECHO_SERVICE
                 | Self::HOP_SERVICE
@@ -201,7 +201,7 @@ impl DefaultAddress {
     pub fn iter() -> impl Iterator<Item = &'static str> {
         [
             Self::AUTHENTICATED_SERVICE,
-            Self::FORWARDING_SERVICE,
+            Self::RELAY_SERVICE,
             Self::UPPERCASE_SERVICE,
             Self::ECHO_SERVICE,
             Self::HOP_SERVICE,
@@ -300,7 +300,7 @@ mod test {
         assert!(DefaultAddress::is_valid(
             DefaultAddress::AUTHENTICATED_SERVICE
         ));
-        assert!(DefaultAddress::is_valid(DefaultAddress::FORWARDING_SERVICE));
+        assert!(DefaultAddress::is_valid(DefaultAddress::RELAY_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::UPPERCASE_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::ECHO_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::HOP_SERVICE));

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/mod.rs
@@ -5,9 +5,9 @@
 pub mod base;
 pub mod credentials;
 pub mod flow_controls;
-pub mod forwarder;
 pub mod policy;
 pub mod portal;
+pub mod relay;
 pub mod secure_channel;
 pub mod services;
 pub mod transport;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
@@ -1,7 +1,7 @@
 use minicbor::{Decode, Encode};
 
 use ockam::identity::Identifier;
-use ockam::remote::RemoteForwarderInfo;
+use ockam::remote::RemoteRelayInfo;
 use ockam::route;
 use ockam_core::flow_control::FlowControlId;
 use ockam_multiaddr::MultiAddr;
@@ -9,14 +9,14 @@ use ockam_multiaddr::MultiAddr;
 use crate::error::ApiError;
 use crate::route_to_multiaddr;
 
-/// Request body when instructing a node to create a forwarder
+/// Request body when instructing a node to create a relay
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateForwarder {
-    /// Address to create forwarder at.
+pub struct CreateRelay {
+    /// Address to create relay at.
     #[n(1)] pub(crate) address: MultiAddr,
-    /// Forwarder alias.
+    /// Relay alias.
     #[n(2)] pub(crate) alias: Option<String>,
     /// Forwarding service is at rust node.
     #[n(3)] pub(crate) at_rust_node: bool,
@@ -26,7 +26,7 @@ pub struct CreateForwarder {
     #[n(4)] pub(crate) authorized: Option<Identifier>,
 }
 
-impl CreateForwarder {
+impl CreateRelay {
     pub fn new(
         address: MultiAddr,
         alias: Option<String>,
@@ -58,18 +58,18 @@ impl CreateForwarder {
     }
 }
 
-/// Response body when creating a forwarder
+/// Response body when creating a relay
 #[derive(Debug, Clone, Decode, Encode, serde::Serialize, serde::Deserialize)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct ForwarderInfo {
+pub struct RelayInfo {
     #[n(1)] forwarding_route: String,
     #[n(2)] remote_address: String,
     #[n(3)] worker_address: String,
     #[n(4)] flow_control_id: Option<FlowControlId>,
 }
 
-impl ForwarderInfo {
+impl RelayInfo {
     pub fn forwarding_route(&self) -> &str {
         &self.forwarding_route
     }
@@ -93,8 +93,8 @@ impl ForwarderInfo {
     }
 }
 
-impl From<RemoteForwarderInfo> for ForwarderInfo {
-    fn from(inner: RemoteForwarderInfo) -> Self {
+impl From<RemoteRelayInfo> for RelayInfo {
+    fn from(inner: RemoteRelayInfo) -> Self {
         Self {
             forwarding_route: inner.forwarding_route().to_string(),
             remote_address: inner.remote_address().into(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -1,7 +1,7 @@
 use crate::nodes::service::Alias;
 use ockam::identity::Identifier;
 use ockam::identity::{SecureChannel, SecureChannelListener};
-use ockam::remote::RemoteForwarderInfo;
+use ockam::remote::RemoteRelayInfo;
 use ockam_core::compat::collections::BTreeMap;
 use ockam_core::{Address, Route};
 use ockam_node::compat::asynchronous::RwLock;
@@ -205,7 +205,7 @@ pub(crate) struct Registry {
     pub(crate) kafka_services: RegistryOf<Address, KafkaServiceInfo>,
     pub(crate) hop_services: RegistryOf<Address, HopServiceInfo>,
     pub(crate) credentials_services: RegistryOf<Address, CredentialsServiceInfo>,
-    pub(crate) forwarders: RegistryOf<String, RemoteForwarderInfo>,
+    pub(crate) relays: RegistryOf<String, RemoteRelayInfo>,
     pub(crate) inlets: RegistryOf<Alias, InletInfo>,
     pub(crate) outlets: RegistryOf<Alias, OutletInfo>,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -720,7 +720,7 @@ impl NodeManagerWorker {
             (Get, ["node", "forwarder", remote_address]) => {
                 encode_request_result(self.show_forwarder(req, remote_address).await)?
             }
-            (Get, ["node", "forwarder"]) => self.get_forwarders_response(req).await.to_vec()?,
+            (Get, ["node", "forwarder"]) => encode_request_result(self.get_forwarders(req).await)?,
             (Delete, ["node", "forwarder", remote_address]) => {
                 encode_request_result(self.delete_forwarder(ctx, req, remote_address).await)?
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -75,7 +75,7 @@ fn random_alias() -> String {
     Address::random_local().without_type().to_owned()
 }
 
-pub(crate) fn encode_request_result<T: Encode<()>>(
+pub(crate) fn encode_response<T: Encode<()>>(
     res: std::result::Result<Response<T>, Response<ockam_core::api::Error>>,
 ) -> Result<Vec<u8>> {
     let v = match res {
@@ -608,25 +608,25 @@ impl NodeManagerWorker {
             // ==*== Tcp Connection ==*==
             (Get, ["node", "tcp", "connection"]) => self.get_tcp_connections(req).await.to_vec()?,
             (Get, ["node", "tcp", "connection", address]) => {
-                encode_request_result(self.get_tcp_connection(req, address.to_string()).await)?
+                encode_response(self.get_tcp_connection(req, address.to_string()).await)?
             }
             (Post, ["node", "tcp", "connection"]) => {
-                encode_request_result(self.create_tcp_connection(req, dec, ctx).await)?
+                encode_response(self.create_tcp_connection(req, dec, ctx).await)?
             }
             (Delete, ["node", "tcp", "connection"]) => {
-                encode_request_result(self.delete_tcp_connection(req, dec).await)?
+                encode_response(self.delete_tcp_connection(req, dec).await)?
             }
 
             // ==*== Tcp Listeners ==*==
             (Get, ["node", "tcp", "listener"]) => self.get_tcp_listeners(req).await.to_vec()?,
             (Get, ["node", "tcp", "listener", address]) => {
-                encode_request_result(self.get_tcp_listener(req, address.to_string()).await)?
+                encode_response(self.get_tcp_listener(req, address.to_string()).await)?
             }
             (Post, ["node", "tcp", "listener"]) => {
-                encode_request_result(self.create_tcp_listener(req, dec).await)?
+                encode_response(self.create_tcp_listener(req, dec).await)?
             }
             (Delete, ["node", "tcp", "listener"]) => {
-                encode_request_result(self.delete_tcp_listener(req, dec).await)?
+                encode_response(self.delete_tcp_listener(req, dec).await)?
             }
 
             // ==*== Credential ==*==
@@ -635,7 +635,7 @@ impl NodeManagerWorker {
                 .await?
                 .either(Response::to_vec, Response::to_vec)?,
             (Post, ["node", "credentials", "actions", "present"]) => {
-                encode_request_result(self.present_credential(req, dec, ctx).await)?
+                encode_response(self.present_credential(req, dec, ctx).await)?
             }
 
             // ==*== Secure channels ==*==
@@ -644,16 +644,16 @@ impl NodeManagerWorker {
                 self.list_secure_channel_listener(req).await.to_vec()?
             }
             (Post, ["node", "secure_channel"]) => {
-                encode_request_result(self.create_secure_channel(req, dec, ctx).await)?
+                encode_response(self.create_secure_channel(req, dec, ctx).await)?
             }
             (Delete, ["node", "secure_channel"]) => {
-                encode_request_result(self.delete_secure_channel(req, dec, ctx).await)?
+                encode_response(self.delete_secure_channel(req, dec, ctx).await)?
             }
             (Get, ["node", "show_secure_channel"]) => {
-                encode_request_result(self.show_secure_channel(req, dec).await)?
+                encode_response(self.show_secure_channel(req, dec).await)?
             }
             (Post, ["node", "secure_channel_listener"]) => {
-                encode_request_result(self.create_secure_channel_listener(req, dec, ctx).await)?
+                encode_response(self.create_secure_channel_listener(req, dec, ctx).await)?
             }
             (Delete, ["node", "secure_channel_listener"]) => self
                 .delete_secure_channel_listener(ctx, req, dec)
@@ -665,24 +665,24 @@ impl NodeManagerWorker {
 
             // ==*== Services ==*==
             (Post, ["node", "services", DefaultAddress::AUTHENTICATED_SERVICE]) => {
-                encode_request_result(self.start_authenticated_service(ctx, req, dec).await)?
+                encode_response(self.start_authenticated_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::UPPERCASE_SERVICE]) => {
-                encode_request_result(self.start_uppercase_service(ctx, req, dec).await)?
+                encode_response(self.start_uppercase_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::ECHO_SERVICE]) => {
-                encode_request_result(self.start_echoer_service(ctx, req, dec).await)?
+                encode_response(self.start_echoer_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::HOP_SERVICE]) => {
-                encode_request_result(self.start_hop_service(ctx, req, dec).await)?
+                encode_response(self.start_hop_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => {
-                encode_request_result(self.start_credentials_service(ctx, req, dec).await)?
+                encode_response(self.start_credentials_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => {
                 self.start_kafka_outlet_service(ctx, req, dec).await?
             }
-            (Delete, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_request_result(
+            (Delete, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Outlet)
                     .await,
             )?,
@@ -690,7 +690,7 @@ impl NodeManagerWorker {
                 self.start_kafka_consumer_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
-                encode_request_result(
+                encode_response(
                     self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Consumer)
                         .await,
                 )?
@@ -699,7 +699,7 @@ impl NodeManagerWorker {
                 self.start_kafka_producer_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => {
-                encode_request_result(
+                encode_response(
                     self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Producer)
                         .await,
                 )?
@@ -707,7 +707,7 @@ impl NodeManagerWorker {
             (Post, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => {
                 self.start_kafka_direct_service(ctx, req, dec).await?
             }
-            (Delete, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_request_result(
+            (Delete, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Direct)
                     .await,
             )?,
@@ -718,42 +718,42 @@ impl NodeManagerWorker {
 
             // ==*== Forwarder commands ==*==
             (Get, ["node", "forwarder", remote_address]) => {
-                encode_request_result(self.show_forwarder(req, remote_address).await)?
+                encode_response(self.show_forwarder(req, remote_address).await)?
             }
-            (Get, ["node", "forwarder"]) => encode_request_result(self.get_forwarders(req).await)?,
+            (Get, ["node", "forwarder"]) => encode_response(self.get_forwarders(req).await)?,
             (Delete, ["node", "forwarder", remote_address]) => {
-                encode_request_result(self.delete_forwarder(ctx, req, remote_address).await)?
+                encode_response(self.delete_forwarder(ctx, req, remote_address).await)?
             }
             (Post, ["node", "forwarder"]) => {
-                encode_request_result(self.create_forwarder(ctx, req, dec.decode()?).await)?
+                encode_response(self.create_forwarder(ctx, req, dec.decode()?).await)?
             }
 
             // ==*== Inlets & Outlets ==*==
             (Get, ["node", "inlet"]) => self.get_inlets(req).await.to_vec()?,
             (Get, ["node", "inlet", alias]) => {
-                encode_request_result(self.show_inlet(req, alias).await)?
+                encode_response(self.show_inlet(req, alias).await)?
             }
             (Get, ["node", "outlet"]) => self.get_outlets(req).await.to_vec()?,
             (Get, ["node", "outlet", alias]) => {
-                encode_request_result(self.show_outlet(req, alias).await)?
+                encode_response(self.show_outlet(req, alias).await)?
             }
             (Post, ["node", "inlet"]) => {
-                encode_request_result(self.create_inlet(req, dec, ctx).await)?
+                encode_response(self.create_inlet(req, dec, ctx).await)?
             }
             (Post, ["node", "outlet"]) => {
-                encode_request_result(self.create_outlet(ctx, req, dec.decode()?).await)?
+                encode_response(self.create_outlet(ctx, req, dec.decode()?).await)?
             }
             (Delete, ["node", "outlet", alias]) => {
-                encode_request_result(self.delete_outlet(req, alias).await)?
+                encode_response(self.delete_outlet(req, alias).await)?
             }
             (Delete, ["node", "inlet", alias]) => {
-                encode_request_result(self.delete_inlet(req, alias).await)?
+                encode_response(self.delete_inlet(req, alias).await)?
             }
             (Delete, ["node", "portal"]) => todo!(),
 
             // ==*== Flow Controls ==*==
             (Post, ["node", "flow_controls", "add_consumer"]) => {
-                encode_request_result(self.add_consumer(ctx, req, dec))?
+                encode_response(self.add_consumer(ctx, req, dec))?
             }
 
             // ==*== Workers ==*==
@@ -767,13 +767,13 @@ impl NodeManagerWorker {
 
                 Response::ok(req).body(WorkerList::new(list)).to_vec()?
             }
-            (Post, ["policy", resource, action]) => encode_request_result(
+            (Post, ["policy", resource, action]) => encode_response(
                 self.node_manager
                     .add_policy(resource, action, req, dec)
                     .await,
             )?,
             (Get, ["policy", resource]) => {
-                encode_request_result(self.node_manager.list_policies(req, resource).await)?
+                encode_response(self.node_manager.list_policies(req, resource).await)?
             }
             (Get, ["policy", resource, action]) => self
                 .node_manager
@@ -781,7 +781,7 @@ impl NodeManagerWorker {
                 .await?
                 .either(Response::to_vec, Response::to_vec)?,
             (Delete, ["policy", resource, action]) => {
-                encode_request_result(self.node_manager.del_policy(req, resource, action).await)?
+                encode_response(self.node_manager.del_policy(req, resource, action).await)?
             }
 
             // ==*== Messages ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -52,8 +52,8 @@ impl NodeManagerWorker {
         }
     }
 
-    pub(super) async fn delete_forwarder(
-        &mut self,
+    pub async fn delete_forwarder(
+        &self,
         ctx: &mut Context,
         req: &RequestHeader,
         remote_address: &str,
@@ -63,28 +63,27 @@ impl NodeManagerWorker {
             .await
     }
 
-    pub(super) async fn show_forwarder(
-        &mut self,
+    pub async fn show_forwarder(
+        &self,
         req: &RequestHeader,
         remote_address: &str,
     ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
         self.node_manager.show_forwarder(req, remote_address).await
     }
 
-    pub async fn get_forwarders(&self) -> Vec<ForwarderInfo> {
-        self.node_manager.get_forwarders().await
-    }
-
-    pub(super) async fn get_forwarders_response(
+    pub async fn get_forwarders(
         &self,
         req: &RequestHeader,
-    ) -> Response<Vec<ForwarderInfo>> {
+    ) -> Result<Response<Vec<ForwarderInfo>>, Response<Error>> {
         debug!("Handling ListForwarders request");
-        Response::ok(req).body(self.get_forwarders().await)
+        Ok(Response::ok(req).body(self.node_manager.get_forwarders().await))
     }
 }
 
 impl NodeManager {
+
+    /// This function returns a representation of the relays currently
+    /// registered on this node
     pub async fn get_forwarders(&self) -> Vec<ForwarderInfo> {
         let forwarders = self
             .registry

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/forwarder.rs
@@ -97,6 +97,10 @@ impl NodeManager {
         forwarders
     }
 
+    /// Create a new Relay
+    /// The Connection encapsulates the list of workers required on the relay route.
+    /// This route is monitored in the `InMemoryNode` and the workers are restarted if necessary
+    /// when the route is unresponsive
     pub async fn create_forwarder(
         &self,
         ctx: &Context,
@@ -143,9 +147,10 @@ impl NodeManager {
         }
     }
 
-    pub(super) async fn delete_forwarder(
+    /// This function removes an existing relay based on its remote address
+    pub async fn delete_forwarder(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         req: &RequestHeader,
         remote_address: &str,
     ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
@@ -180,6 +185,7 @@ impl NodeManager {
         }
     }
 
+    /// This function finds an existing relay and returns its configuration
     pub(super) async fn show_forwarder(
         &self,
         req: &RequestHeader,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -20,7 +20,7 @@ use crate::kafka::{
     ConsumerNodeAddr, KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
     KAFKA_OUTLET_BOOTSTRAP_ADDRESS, KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
 };
-use crate::kafka::{OutletManagerService, PrefixForwarderService};
+use crate::kafka::{OutletManagerService, PrefixRelayService};
 use crate::nodes::models::services::{
     DeleteServiceRequest, ServiceList, ServiceStatus, StartAuthenticatedServiceRequest,
     StartCredentialsService, StartEchoerServiceRequest, StartHopServiceRequest,
@@ -270,7 +270,7 @@ impl NodeManagerWorker {
                 ApiError::core("Unable to get flow control for secure channel listener")
             })?;
 
-        PrefixForwarderService::create(
+        PrefixRelayService::create(
             context,
             default_secure_channel_listener_flow_control_id.clone(),
         )

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -524,7 +524,7 @@ impl InMemoryNode {
     ) -> Result<InletStatus> {
         // The addressing scheme is very flexible. Typically the node connects to
         // the cloud via secure channel and the with another secure channel via
-        // forwarder to the actual outlet on the target node. However it is also
+        // relay to the actual outlet on the target node. However it is also
         // possible that there is just a single secure channel used to go directly
         // to another node.
         let duration = wait_for_outlet_duration.unwrap_or(Duration::from_secs(5));

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use ockam::compat::sync::Mutex;
 use ockam::identity::Identifier;
-use ockam::remote::{RemoteForwarder, RemoteForwarderOptions};
+use ockam::remote::{RemoteRelay, RemoteRelayOptions};
 use ockam::Result;
 use ockam_core::api::{Error, Request, RequestHeader, Response};
 use ockam_core::{async_trait, Address, AsyncTryClone};
@@ -15,7 +15,7 @@ use ockam_node::Context;
 
 use crate::error::ApiError;
 use crate::nodes::connection::Connection;
-use crate::nodes::models::forwarder::{CreateForwarder, ForwarderInfo};
+use crate::nodes::models::relay::{CreateRelay, RelayInfo};
 use crate::nodes::models::secure_channel::{
     CreateSecureChannelRequest, CreateSecureChannelResponse,
 };
@@ -27,194 +27,192 @@ use crate::session::sessions::{MAX_CONNECT_TIME, MAX_RECOVERY_TIME};
 use super::{NodeManager, NodeManagerWorker};
 
 impl NodeManagerWorker {
-    pub async fn create_forwarder(
+    pub async fn create_relay(
         &self,
         ctx: &Context,
         req: &RequestHeader,
-        create_forwarder: CreateForwarder,
-    ) -> Result<Response<ForwarderInfo>, Response<Error>> {
-        let CreateForwarder {
+        create_relay: CreateRelay,
+    ) -> Result<Response<RelayInfo>, Response<Error>> {
+        let CreateRelay {
             address,
             alias,
             at_rust_node,
             authorized,
-        } = create_forwarder;
+        } = create_relay;
         match self
             .node_manager
-            .create_forwarder(ctx, &address, alias, at_rust_node, authorized)
+            .create_relay(ctx, &address, alias, at_rust_node, authorized)
             .await
         {
             Ok(body) => Ok(Response::ok(req).body(body)),
             Err(err) => Err(Response::internal_error(
                 req,
-                &format!("Failed to create forwarder: {}", err),
+                &format!("Failed to create relay: {}", err),
             )),
         }
     }
 
-    pub async fn delete_forwarder(
+    pub async fn delete_relay(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         req: &RequestHeader,
         remote_address: &str,
-    ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
+    ) -> Result<Response<Option<RelayInfo>>, Response<Error>> {
         self.node_manager
-            .delete_forwarder(ctx, req, remote_address)
+            .delete_relay(ctx, req, remote_address)
             .await
     }
 
-    pub async fn show_forwarder(
+    pub async fn show_relay(
         &self,
         req: &RequestHeader,
         remote_address: &str,
-    ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
-        self.node_manager.show_forwarder(req, remote_address).await
+    ) -> Result<Response<Option<RelayInfo>>, Response<Error>> {
+        self.node_manager.show_relay(req, remote_address).await
     }
 
-    pub async fn get_forwarders(
+    pub async fn get_relays(
         &self,
         req: &RequestHeader,
-    ) -> Result<Response<Vec<ForwarderInfo>>, Response<Error>> {
-        debug!("Handling ListForwarders request");
-        Ok(Response::ok(req).body(self.node_manager.get_forwarders().await))
+    ) -> Result<Response<Vec<RelayInfo>>, Response<Error>> {
+        debug!("Handling GetRelays request");
+        Ok(Response::ok(req).body(self.node_manager.get_relays().await))
     }
 }
 
 impl NodeManager {
-
     /// This function returns a representation of the relays currently
     /// registered on this node
-    pub async fn get_forwarders(&self) -> Vec<ForwarderInfo> {
-        let forwarders = self
+    pub async fn get_relays(&self) -> Vec<RelayInfo> {
+        let relays = self
             .registry
-            .forwarders
+            .relays
             .entries()
             .await
             .iter()
-            .map(|(_, registry_info)| ForwarderInfo::from(registry_info.to_owned()))
+            .map(|(_, registry_info)| RelayInfo::from(registry_info.to_owned()))
             .collect();
-        trace!(?forwarders, "Forwarders retrieved");
-        forwarders
+        trace!(?relays, "Relays retrieved");
+        relays
     }
 
     /// Create a new Relay
     /// The Connection encapsulates the list of workers required on the relay route.
     /// This route is monitored in the `InMemoryNode` and the workers are restarted if necessary
     /// when the route is unresponsive
-    pub async fn create_forwarder(
+    pub async fn create_relay(
         &self,
         ctx: &Context,
         connection: Connection,
         at_rust_node: bool,
         alias: Option<String>,
-    ) -> Result<ForwarderInfo> {
+    ) -> Result<RelayInfo> {
         let route = connection.route(self.tcp_transport()).await?;
-        let options = RemoteForwarderOptions::new();
+        let options = RemoteRelayOptions::new();
 
-        let forwarder = if at_rust_node {
+        let relay = if at_rust_node {
             if let Some(alias) = alias {
-                RemoteForwarder::create_static_without_heartbeats(ctx, route, alias, options).await
+                RemoteRelay::create_static_without_heartbeats(ctx, route, alias, options).await
             } else {
-                RemoteForwarder::create(ctx, route, options).await
+                RemoteRelay::create(ctx, route, options).await
             }
         } else if let Some(alias) = alias {
-            RemoteForwarder::create_static(ctx, route, alias, options).await
+            RemoteRelay::create_static(ctx, route, alias, options).await
         } else {
-            RemoteForwarder::create(ctx, route, options).await
+            RemoteRelay::create(ctx, route, options).await
         };
 
-        match forwarder {
+        match relay {
             Ok(info) => {
                 let registry_info = info.clone();
                 let registry_remote_address = registry_info.remote_address().to_string();
-                let forwarder_info = ForwarderInfo::from(info);
+                let relay_info = RelayInfo::from(info);
                 self.registry
-                    .forwarders
+                    .relays
                     .insert(registry_remote_address, registry_info)
                     .await;
 
                 debug!(
-                    forwarding_route = %forwarder_info.forwarding_route(),
-                    remote_address = %forwarder_info.remote_address_ma()?,
-                    "CreateForwarder request processed, sending back response"
+                    forwarding_route = %relay_info.forwarding_route(),
+                    remote_address = %relay_info.remote_address_ma()?,
+                    "CreateRelay request processed, sending back response"
                 );
-                Ok(forwarder_info)
+                Ok(relay_info)
             }
             Err(err) => {
-                error!(?err, "Failed to create forwarder");
+                error!(?err, "Failed to create relay");
                 Err(err)
             }
         }
     }
 
     /// This function removes an existing relay based on its remote address
-    pub async fn delete_forwarder(
+    pub async fn delete_relay(
         &self,
         ctx: &Context,
         req: &RequestHeader,
         remote_address: &str,
-    ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
-        debug!(%remote_address , "Handling DeleteForwarder request");
+    ) -> Result<Response<Option<RelayInfo>>, Response<Error>> {
+        debug!(%remote_address , "Handling DeleteRelay request");
 
-        if let Some(forwarder_to_delete) = self.registry.forwarders.remove(remote_address).await {
-            debug!(%remote_address, "Successfully removed forwarder from node registry");
+        if let Some(relay_to_delete) = self.registry.relays.remove(remote_address).await {
+            debug!(%remote_address, "Successfully removed relay from node registry");
 
             match ctx
-                .stop_worker(forwarder_to_delete.worker_address().clone())
+                .stop_worker(relay_to_delete.worker_address().clone())
                 .await
             {
                 Ok(_) => {
-                    debug!(%remote_address, "Successfully stopped forwarder");
-                    Ok(Response::ok(req)
-                        .body(Some(ForwarderInfo::from(forwarder_to_delete.to_owned()))))
+                    debug!(%remote_address, "Successfully stopped relay");
+                    Ok(Response::ok(req).body(Some(RelayInfo::from(relay_to_delete.to_owned()))))
                 }
                 Err(err) => {
-                    error!(%remote_address, ?err, "Failed to delete forwarder from node registry");
+                    error!(%remote_address, ?err, "Failed to delete relay from node registry");
                     Err(Response::internal_error(
                         req,
-                        &format!("Failed to delete forwarder at {}: {}", remote_address, err),
+                        &format!("Failed to delete relay at {}: {}", remote_address, err),
                     ))
                 }
             }
         } else {
-            error!(%remote_address, "Forwarder not found in the node registry");
+            error!(%remote_address, "Relay not found in the node registry");
             Err(Response::not_found(
                 req,
-                &format!("Forwarder with address {} not found.", remote_address),
+                &format!("Relay with address {} not found.", remote_address),
             ))
         }
     }
 
     /// This function finds an existing relay and returns its configuration
-    pub(super) async fn show_forwarder(
+    pub(super) async fn show_relay(
         &self,
         req: &RequestHeader,
         remote_address: &str,
-    ) -> Result<Response<Option<ForwarderInfo>>, Response<Error>> {
-        debug!("Handling ShowForwarder request");
-        if let Some(forwarder_to_show) = self.registry.forwarders.get(remote_address).await {
-            debug!(%remote_address, "Forwarder not found in node registry");
-            Ok(Response::ok(req).body(Some(ForwarderInfo::from(forwarder_to_show.to_owned()))))
+    ) -> Result<Response<Option<RelayInfo>>, Response<Error>> {
+        debug!("Handling ShowRelay request");
+        if let Some(relay) = self.registry.relays.get(remote_address).await {
+            debug!(%remote_address, "Relay not found in node registry");
+            Ok(Response::ok(req).body(Some(RelayInfo::from(relay.to_owned()))))
         } else {
-            error!(%remote_address, "Forwarder not found in the node registry");
+            error!(%remote_address, "Relay not found in the node registry");
             Err(Response::not_found(
                 req,
-                &format!("Forwarder with address {} not found.", remote_address),
+                &format!("Relay with address {} not found.", remote_address),
             ))
         }
     }
 }
 
 impl InMemoryNode {
-    pub async fn create_forwarder(
+    pub async fn create_relay(
         &self,
         ctx: &Context,
         address: &MultiAddr,
         alias: Option<String>,
         at_rust_node: bool,
         authorized: Option<Identifier>,
-    ) -> Result<ForwarderInfo> {
-        debug!(addr = %address, alias = ?alias, at_rust_node = ?at_rust_node, "Handling CreateForwarder request");
+    ) -> Result<RelayInfo> {
+        debug!(addr = %address, alias = ?alias, at_rust_node = ?at_rust_node, "Handling CreateRelay request");
         let connection_ctx = Arc::new(ctx.async_try_clone().await?);
         let connection = self
             .make_connection(
@@ -234,9 +232,9 @@ impl InMemoryNode {
             connection.add_consumer(connection_ctx.clone(), &hop);
         }
 
-        let forwarder = self
+        let relay = self
             .node_manager
-            .create_forwarder(
+            .create_relay(
                 ctx,
                 connection.clone(),
                 at_rust_node,
@@ -258,7 +256,7 @@ impl InMemoryNode {
             session.set_replacer(repl);
             self.add_session(session);
         };
-        Ok(forwarder)
+        Ok(relay)
     }
 
     /// Create a session replacer.
@@ -286,7 +284,7 @@ impl InMemoryNode {
             let node_manager = node_manager.clone();
 
             Box::pin(async move {
-                debug!(%prev_route, %addr, "creating new remote forwarder");
+                debug!(%prev_route, %addr, "creating new remote relay");
 
                 let f = async {
                     for encryptor in &previous_connection.secure_channel_encryptors {
@@ -323,21 +321,21 @@ impl InMemoryNode {
 
                     let route = connection.route(node_manager.tcp_transport()).await?;
 
-                    let options = RemoteForwarderOptions::new();
+                    let options = RemoteRelayOptions::new();
                     if let Some(alias) = &alias {
-                        RemoteForwarder::create_static(&ctx, route, alias, options).await?;
+                        RemoteRelay::create_static(&ctx, route, alias, options).await?;
                     } else {
-                        RemoteForwarder::create(&ctx, route, options).await?;
+                        RemoteRelay::create(&ctx, route, options).await?;
                     }
                     Ok(connection.transport_route())
                 };
                 match timeout(MAX_RECOVERY_TIME, f).await {
                     Err(_) => {
-                        warn!(%addr, "timeout creating new remote forwarder");
+                        warn!(%addr, "timeout creating new remote relay");
                         Err(ApiError::core("timeout"))
                     }
                     Ok(Err(e)) => {
-                        warn!(%addr, err = %e, "error creating new remote forwarder");
+                        warn!(%addr, err = %e, "error creating new remote relay");
                         Err(e)
                     }
                     Ok(Ok(a)) => Ok(a),
@@ -355,7 +353,7 @@ pub trait Relays {
         address: &MultiAddr,
         alias: Option<String>,
         authorized: Option<Identifier>,
-    ) -> miette::Result<ForwarderInfo>;
+    ) -> miette::Result<RelayInfo>;
 }
 
 #[async_trait]
@@ -366,9 +364,9 @@ impl Relays for BackgroundNode {
         address: &MultiAddr,
         alias: Option<String>,
         authorized: Option<Identifier>,
-    ) -> miette::Result<ForwarderInfo> {
+    ) -> miette::Result<RelayInfo> {
         let at_rust_node = !address.starts_with(Project::CODE);
-        let body = CreateForwarder::new(address.clone(), alias, at_rust_node, authorized);
+        let body = CreateRelay::new(address.clone(), alias, at_rust_node, authorized);
         self.ask(ctx, Request::post("/node/forwarder").body(body))
             .await
     }

--- a/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app/src/shared_service/relay/create.rs
@@ -3,7 +3,7 @@ use crate::Result;
 use miette::IntoDiagnostic;
 use ockam::Context;
 use ockam_api::cli_state::{CliState, StateDirTrait};
-use ockam_api::nodes::models::forwarder::ForwarderInfo;
+use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
 use once_cell::sync::Lazy;
@@ -37,7 +37,7 @@ async fn create_relay_impl(
     context: &Context,
     cli_state: &CliState,
     node_manager: Arc<InMemoryNode>,
-) -> Result<Option<ForwarderInfo>> {
+) -> Result<Option<RelayInfo>> {
     trace!("Creating relay");
     if !cli_state.is_enrolled().unwrap_or(false) {
         trace!("Not enrolled, skipping relay creation");
@@ -53,7 +53,7 @@ async fn create_relay_impl(
                 let project_route = format!("/project/{}", project.name());
                 let project_address = MultiAddr::from_str(&project_route).into_diagnostic()?;
                 let relay = node_manager
-                    .create_forwarder(
+                    .create_relay(
                         context,
                         &project_address,
                         Some(NODE_NAME.to_string()),
@@ -73,9 +73,9 @@ async fn create_relay_impl(
     }
 }
 
-pub(crate) async fn get_relay(node_manager: Arc<InMemoryNode>) -> Option<ForwarderInfo> {
+pub(crate) async fn get_relay(node_manager: Arc<InMemoryNode>) -> Option<RelayInfo> {
     node_manager
-        .get_forwarders()
+        .get_relays()
         .await
         .into_iter()
         .find(|r| r.remote_address() == *RELAY_NAME)

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -12,7 +12,7 @@ use ockam_api::cloud::project::{Project, Projects};
 use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT_MS};
 use ockam_api::config::lookup::LookupMeta;
 use ockam_api::error::ApiError;
-use ockam_api::nodes::service::forwarder::SecureChannelsCreation;
+use ockam_api::nodes::service::relay::SecureChannelsCreation;
 use ockam_api::nodes::InMemoryNode;
 
 use ockam_api::route_to_multiaddr;

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -12,8 +12,8 @@ use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::is_local_node;
-use ockam_api::nodes::models::forwarder::ForwarderInfo;
-use ockam_api::nodes::service::forwarder::Relays;
+use ockam_api::nodes::models::relay::RelayInfo;
+use ockam_api::nodes::service::relay::Relays;
 use ockam_api::nodes::BackgroundNode;
 use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::{MultiAddr, Protocol};
@@ -43,7 +43,7 @@ pub struct CreateCommand {
     to: Option<String>,
 
     /// Route to the node at which to create the relay
-    #[arg(long, id = "ROUTE", display_order = 900, value_parser = parse_at, default_value_t = default_forwarder_at())]
+    #[arg(long, id = "ROUTE", display_order = 900, value_parser = parse_at, default_value_t = default_relay_at())]
     at: MultiAddr,
 
     /// Authorized identity for secure channel connection
@@ -69,7 +69,7 @@ fn parse_at(input: &str) -> Result<MultiAddr> {
     Ok(ma)
 }
 
-pub fn default_forwarder_at() -> MultiAddr {
+pub fn default_relay_at() -> MultiAddr {
     MultiAddr::from_str("/project/default").expect("Default relay address is invalid")
 }
 
@@ -107,7 +107,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
 
     let output_messages = vec![
         format!(
-            "Creating relay forwarding service at {}...",
+            "Creating relay relay service at {}...",
             &cmd.at
                 .to_string()
                 .color(OckamColor::PrimaryResource.color())
@@ -155,7 +155,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> m
     Ok(())
 }
 
-impl Output for ForwarderInfo {
+impl Output for RelayInfo {
     fn output(&self) -> Result<String> {
         let output = format!(
             r#"

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -63,7 +63,7 @@ pub async fn run_impl(
                 node_name
             ))
             .machine(&relay_name)
-            .json(serde_json::json!({ "forwarder": { "name": relay_name,
+            .json(serde_json::json!({ "relay": { "name": relay_name,
                 "node": node_name } }))
             .write_line()
             .unwrap();

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -8,7 +8,7 @@ use tracing::trace;
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::StateDirTrait;
-use ockam_api::nodes::models::forwarder::ForwarderInfo;
+use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 
@@ -54,8 +54,7 @@ async fn run_impl(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relays = async {
-        let relay_infos: Vec<ForwarderInfo> =
-            node.ask(&ctx, Request::get("/node/forwarder")).await?;
+        let relay_infos: Vec<RelayInfo> = node.ask(&ctx, Request::get("/node/forwarder")).await?;
         *is_finished.lock().await = true;
         Ok(relay_infos)
     };

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -3,7 +3,7 @@ use miette::IntoDiagnostic;
 
 use ockam::Context;
 use ockam_api::address::extract_address_value;
-use ockam_api::nodes::models::forwarder::ForwarderInfo;
+use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 
@@ -45,7 +45,7 @@ async fn run_impl(
     let node_name = extract_address_value(&at)?;
     let remote_address = &cmd.remote_address;
     let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
-    let relay_info: ForwarderInfo = node
+    let relay_info: RelayInfo = node
         .ask(
             &ctx,
             Request::get(format!("/node/forwarder/{remote_address}")),

--- a/implementations/rust/ockam/ockam_command/tests/bats/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/relay.bats
@@ -58,6 +58,6 @@ teardown() {
   assert_output --regexp "Worker Address: /service/.*"
 
   # Test showing non-existing with no relay
-  run_failure "$OCKAM" relay show forwarder_blank --at /node/n2
+  run_failure "$OCKAM" relay show relay_blank --at /node/n2
   assert_output --partial "not found"
 }


### PR DESCRIPTION
This PR aims at showing how the `NodeManagerWorker/NodeManager` relationship should be implemented.
Since the example taken is how `relays` requests are implemented I seized the opportunity of this PR to do a pass of renaming `Forwarder` to `Relay` so that we get a more align vocabulary across our crates.