### PR TITLE
docs(rust): improve feedback section of the help text

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -21,8 +21,8 @@ Learn more at https://docs.ockam.io/reference/command
 
 Feedback:
 
-If you have any questions or feedback, please start a discussion
-on Github https://github.com/build-trust/ockam/discussions/new
+If you have questions, as you explore, join us on the contributors
+discord channel https://discord.gg/bewvnm6zqS
 ";
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -23,7 +23,7 @@ pub struct ShowCommand {
     #[arg()]
     name: Option<String>,
 
-    /// Show the full identity history, and not just the identifier or the nameq
+    /// Show the full identity history, and not just the identifier or the name
     #[arg(short, long)]
     full: bool,
 


### PR DESCRIPTION
changed the feedback paragraph

Fixes https://github.com/build-trust/ockam/issues/6057