### PR TITLE
docs(rust): updated as_identity value name on ockam credential issue

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -18,7 +18,8 @@ use ockam_api::cli_state::traits::{StateDirTrait, StateItemTrait};
 
 #[derive(Clone, Debug, Args)]
 pub struct IssueCommand {
-    #[arg(long = "as")]
+    /// Name of the Identity to be used as the credential issuer
+    #[arg(long = "as", value_name = "IDENTITY_NAME")]
     pub as_identity: Option<String>,
 
     #[arg(long = "for", value_name = "IDENTIFIER", value_parser = identity_identifier_parser)]


### PR DESCRIPTION
## Current behavior

This fixes https://github.com/build-trust/ockam/issues/6249, which asked for adding a value_name to the as_identity argument on ockam credential issue.

## Proposed changes

Fix #6249 by adding value_name and a docstring.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
