### PR TITLE
feat(rust): `space create` fails gracefully if no identity is enrolled

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -4,7 +4,7 @@ use ockam_api::cloud::space::Spaces;
 use rand::prelude::random;
 
 use crate::util::api::{self};
-use crate::util::node_rpc;
+use crate::util::{is_enrolled_guard, node_rpc};
 use crate::{docs, CommandGlobalOpts};
 use colorful::Colorful;
 use ockam_api::cli_state::{SpaceConfig, StateDirTrait};
@@ -32,15 +32,6 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, options: CommandGlobalOpts) {
-        println!(
-            "\n{}",
-            "Creating a trial space for you (everything in it will be deleted in 15 days) ..."
-                .light_magenta()
-        );
-        println!(
-            "{}",
-            "To learn more about production ready spaces in Ockam Orchestrator, contact us at: hello@ockam.io".light_magenta()
-        );
         node_rpc(rpc, (options, self));
     }
 }
@@ -54,6 +45,18 @@ async fn run_impl(
     opts: CommandGlobalOpts,
     cmd: CreateCommand,
 ) -> miette::Result<()> {
+    is_enrolled_guard(&opts.state, None)?;
+
+    opts.terminal.write_line(format!(
+        "\n{}",
+        "Creating a trial space for you (everything in it will be deleted in 15 days) ..."
+            .light_magenta(),
+    ))?;
+    opts.terminal.write_line(format!(
+        "{}",
+        "To learn more about production ready spaces in Ockam Orchestrator, contact us at: hello@ockam.io".light_magenta()
+    ))?;
+
     let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
     let space = controller.create_space(ctx, cmd.name, cmd.admins).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -255,6 +255,20 @@ pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {
     s.is_terminal()
 }
 
+pub fn is_enrolled_guard(cli_state: &CliState, identity_name: Option<&str>) -> miette::Result<()> {
+    if !cli_state
+        .identities
+        .get_or_default(identity_name)
+        .map(|s| s.is_enrolled())
+        .unwrap_or(false)
+    {
+        return Err(miette!(
+            "Please enroll using 'ockam enroll' before using this command"
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use ockam_api::address::extract_address_value;

--- a/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/spaces.bats
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load load/base.bash
+  load_bats_ext
+  setup_home_dir
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "spaces - fail with human readable error if not enrolled" {
+  run_failure "$OCKAM" space create
+  assert_output --partial "Please enroll using 'ockam enroll' before using this command"
+}


### PR DESCRIPTION
Before attempting to send a request to the controller, check if the default identity is enrolled, so we can return a better error.

The error we were getting was:

```
OCK500

  × 401 (origin: Api, kind: Invalid, source location: /Users/adrian/projects/ockam/ockam/implementations/rust/ockam/ockam_core/src/api.rs:157:40)
  help: Please report this issue, with a copy of your logs, to https://github.com/build-trust/ockam/issues
```

Now, the error is:

```
  × Please enroll using 'ockam enroll' before using this command
```