### PR TITLE
Refactor attributes types

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -51,12 +51,12 @@ async fn main(ctx: Context) -> Result<()> {
         node.identities().repository(),
         node.credentials(),
         &issuer,
-        "trust_context".into(),
+        "trust_context",
     );
     for identifier in known_identifiers.iter() {
         node.identities()
             .repository()
-            .put_attribute_value(identifier, b"cluster".to_vec(), b"production".to_vec())
+            .put_attribute_value(identifier, "cluster".into(), "production".into())
             .await?;
     }
 

--- a/implementations/elixir/ockam/ockly/native/ockly/src/lib.rs
+++ b/implementations/elixir/ockam/ockly/native/ockly/src/lib.rs
@@ -301,7 +301,7 @@ fn issue_credential<'a>(
             .map_err(|_| atoms::identity_import_error())?;
         let mut attr_builder = AttributesBuilder::with_schema(CredentialSchemaIdentifier(0));
         for (key, value) in attrs {
-            attr_builder = attr_builder.with_attribute(key, value)
+            attr_builder = attr_builder.with_attribute(key.as_str(), value.as_str())
         }
         identities_ref
             .credentials()
@@ -361,10 +361,7 @@ fn verify_credential(
             .subject_attributes
             .map
         {
-            attr_map.insert(
-                String::from_utf8(k.to_vec()).map_err(|_| atoms::utf8_error())?,
-                String::from_utf8(v.to_vec()).map_err(|_| atoms::utf8_error())?,
-            );
+            attr_map.insert(k.to_string(), v.to_string());
         }
         Ok((
             *credential_and_purpose_key_data

--- a/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
+++ b/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
@@ -1,4 +1,3 @@
-use core::str::from_utf8;
 use ockam_core::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::fmt;
@@ -10,7 +9,7 @@ use ockam_core::Result;
 use ockam_core::{IncomingAccessControl, RelayMessage};
 use tracing as log;
 
-use crate::expr::str;
+use crate::expr::{attribute_value, str};
 use crate::Expr::*;
 use crate::{eval, Env, Expr};
 use ockam_core::compat::format;
@@ -74,48 +73,28 @@ impl AbacAccessControl {
 
         // Get identity attributes and populate the environment:
         if let Some(attrs) = self.repository.get_attributes(&id).await? {
-            for (key, value) in attrs.attrs() {
-                let key = match from_utf8(key) {
-                    Ok(key) => key,
-                    Err(_) => {
-                        log::warn! {
-                            policy = %self.expression,
-                            id     = %id,
-                            "attribute key is not utf-8"
-                        }
-                        continue;
-                    }
-                };
-                if key.find(|c: char| c.is_whitespace()).is_some() {
+            for (key, value) in attrs.iter() {
+                if key.to_string().find(|c: char| c.is_whitespace()).is_some() {
                     log::warn! {
                         policy = %self.expression,
                         id     = %id,
-                        key    = %key,
+                        key    = ?key,
                         "attribute key with whitespace ignored"
                     }
                 }
-                match str::from_utf8(value) {
-                    Ok(s) => {
-                        if environment.contains(key) {
-                            log::debug! {
-                                policy = %self.expression,
-                                id     = %id,
-                                key    = %key,
-                                "attribute already present"
-                            }
-                        } else {
-                            environment.put(format!("subject.{key}"), str(s.to_string()));
-                        }
+
+                if environment.contains(key.to_string().as_str()) {
+                    log::debug! {
+                        policy = %self.expression,
+                        id     = %id,
+                        key    = ?key,
+                        "attribute already present"
                     }
-                    Err(e) => {
-                        log::warn! {
-                            policy = %self.expression,
-                            id     = %id,
-                            key    = %key,
-                            err    = %e,
-                            "failed to interpret attribute as string"
-                        }
-                    }
+                } else {
+                    environment.put(
+                        format!("subject.{}", key.to_string()),
+                        attribute_value(value.clone()),
+                    );
                 }
             }
         };

--- a/implementations/rust/ockam/ockam_abac/src/expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/expr.rs
@@ -9,6 +9,7 @@ use core::fmt;
 use minicbor::{Decode, Encode};
 use ockam_core::compat::string::String;
 use ockam_core::compat::vec::{vec, Vec};
+use ockam_identity::AttributeValue;
 
 #[derive(Debug, Clone, Encode, Decode)]
 #[rustfmt::skip]
@@ -195,6 +196,16 @@ pub fn seq<T: IntoIterator<Item = Expr>>(xs: T) -> Expr {
 
 pub fn str<S: Into<String>>(s: S) -> Expr {
     Expr::Str(s.into())
+}
+
+pub fn attribute_value(s: AttributeValue) -> Expr {
+    match s {
+        AttributeValue::Str(v) => Expr::Str(v),
+        AttributeValue::Int(v) => Expr::Int(v),
+        AttributeValue::Float(v) => Expr::Float(v),
+        AttributeValue::Bool(v) => Expr::Bool(v),
+        AttributeValue::Seq(v) => Expr::Seq(v.into_iter().map(attribute_value).collect()),
+    }
 }
 
 pub fn and<I>(exprs: I) -> Expr

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -26,6 +26,7 @@ pub use env::Env;
 pub use error::{EvalError, ParseError};
 pub use eval::eval;
 pub use expr::Expr;
+pub use expr::Val;
 pub use policy::PolicyAccessControl;
 pub use traits::PolicyStorage;
 pub use types::{Action, Resource, Subject};

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/authenticator.rs
@@ -5,7 +5,7 @@ use ockam::identity::{AttributesEntry, IdentityAttributesReader, IdentityAttribu
 use ockam::identity::{Identifier, IdentitySecureChannelLocalInfo};
 use ockam_core::api::{Method, RequestHeader, Response};
 use ockam_core::compat::sync::Arc;
-use ockam_core::{CowStr, Result, Routed, Worker};
+use ockam_core::{Result, Routed, Worker};
 use ockam_node::Context;
 use std::collections::HashMap;
 use tracing::trace;
@@ -31,22 +31,16 @@ impl DirectAuthenticator {
         })
     }
 
-    async fn add_member<'a>(
+    async fn add_member(
         &self,
         enroller: &Identifier,
         id: &Identifier,
-        attrs: &HashMap<CowStr<'a>, CowStr<'a>>,
+        attrs: &HashMap<String, String>,
     ) -> Result<()> {
         let auth_attrs = attrs
             .iter()
-            .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
-            .chain(
-                [(
-                    TRUST_CONTEXT_ID.to_owned(),
-                    self.trust_context.as_bytes().to_vec(),
-                )]
-                .into_iter(),
-            )
+            .map(|(k, v)| (k.clone().into(), v.clone().into()))
+            .chain([(TRUST_CONTEXT_ID.into(), self.trust_context.clone().into())].into_iter())
             .collect();
         let entry = AttributesEntry::new(auth_attrs, now()?, None, Some(enroller.clone()));
         self.attributes_writer.put_attributes(id, entry).await

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/types.rs
@@ -1,18 +1,17 @@
 use minicbor::{Decode, Encode};
 use ockam::identity::Identifier;
-use ockam_core::CowStr;
 use std::collections::HashMap;
 use std::time::Duration;
 
 #[derive(Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct AddMember<'a> {
+pub struct AddMember {
     #[n(1)] member: Identifier,
-    #[b(2)] attributes: HashMap<CowStr<'a>, CowStr<'a>>,
+    #[b(2)] attributes: HashMap<String, String>,
 }
 
-impl<'a> AddMember<'a> {
+impl AddMember {
     pub fn new(member: Identifier) -> Self {
         AddMember {
             member,
@@ -20,11 +19,8 @@ impl<'a> AddMember<'a> {
         }
     }
 
-    pub fn with_attributes<S: Into<CowStr<'a>>>(mut self, attributes: HashMap<S, S>) -> Self {
-        self.attributes = attributes
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+    pub fn with_attributes(mut self, attributes: HashMap<String, String>) -> Self {
+        self.attributes = attributes;
         self
     }
 
@@ -32,7 +28,7 @@ impl<'a> AddMember<'a> {
         &self.member
     }
 
-    pub fn attributes(&self) -> &HashMap<CowStr, CowStr> {
+    pub fn attributes(&self) -> &HashMap<String, String> {
         &self.attributes
     }
 }
@@ -40,13 +36,13 @@ impl<'a> AddMember<'a> {
 #[derive(Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct CreateToken<'a> {
-    #[b(1)] attributes: HashMap<CowStr<'a>, CowStr<'a>>,
+pub struct CreateToken {
+    #[b(1)] attributes: HashMap<String, String>,
     #[n(2)] ttl_secs: Option<u64>,
     #[n(3)] ttl_count: Option<u64>,
 }
 
-impl<'a> CreateToken<'a> {
+impl CreateToken {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         CreateToken {
@@ -56,11 +52,8 @@ impl<'a> CreateToken<'a> {
         }
     }
 
-    pub fn with_attributes<S: Into<CowStr<'a>>>(mut self, attributes: HashMap<S, S>) -> Self {
-        self.attributes = attributes
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+    pub fn with_attributes(mut self, attributes: HashMap<String, String>) -> Self {
+        self.attributes = attributes;
         self
     }
 
@@ -74,11 +67,8 @@ impl<'a> CreateToken<'a> {
         self
     }
 
-    pub fn into_owned_attributes(self) -> HashMap<String, String> {
+    pub fn attributes(self) -> HashMap<String, String> {
         self.attributes
-            .into_iter()
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect()
     }
 
     pub fn ttl_count(&self) -> Option<u64> {

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -56,12 +56,12 @@ impl EnrollmentTokenAcceptor {
         };
 
         //TODO: fixme:  unify use of hashmap vs btreemap
-        let trust_context = self.0.trust_context.as_bytes().to_vec();
+        let trust_context = self.0.trust_context.clone();
         let attrs = token
             .attrs
             .iter()
-            .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
-            .chain([(TRUST_CONTEXT_ID.to_owned(), trust_context)])
+            .map(|(k, v)| (k.clone().into(), v.clone().into()))
+            .chain([(TRUST_CONTEXT_ID.into(), trust_context.into())])
             .collect();
         let entry =
             AttributesEntry::new(attrs, now().unwrap(), None, Some(token.issued_by.clone()));

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -81,7 +81,7 @@ impl Worker for EnrollmentTokenIssuer {
                     let ttl_count = att.ttl_count();
                     // TODO: Use ttl_duration
                     match self
-                        .issue_token(&from, att.into_owned_attributes(), duration, ttl_count)
+                        .issue_token(&from, att.attributes(), duration, ttl_count)
                         .await
                     {
                         Ok(otc) => Response::ok(&req).body(&otc).to_vec()?,
@@ -105,7 +105,7 @@ pub trait Members {
         &self,
         ctx: &Context,
         identifier: Identifier,
-        attributes: HashMap<&str, &str>,
+        attributes: HashMap<String, String>,
     ) -> miette::Result<()>;
 
     async fn delete_member(&self, ctx: &Context, identifier: Identifier) -> miette::Result<()>;
@@ -124,7 +124,7 @@ impl Members for AuthorityNode {
         &self,
         ctx: &Context,
         identifier: Identifier,
-        attributes: HashMap<&str, &str>,
+        attributes: HashMap<String, String>,
     ) -> miette::Result<()> {
         let req = Request::post("/").body(AddMember::new(identifier).with_attributes(attributes));
         self.secure_client
@@ -174,7 +174,7 @@ pub trait TokenIssuer {
     async fn create_token(
         &self,
         ctx: &Context,
-        attributes: HashMap<&str, &str>,
+        attributes: HashMap<String, String>,
         duration: Option<Duration>,
         ttl_count: Option<u64>,
     ) -> miette::Result<OneTimeCode>;
@@ -185,7 +185,7 @@ impl TokenIssuer for AuthorityNode {
     async fn create_token(
         &self,
         ctx: &Context,
-        attributes: HashMap<&str, &str>,
+        attributes: HashMap<String, String>,
         duration: Option<Duration>,
         ttl_count: Option<u64>,
     ) -> miette::Result<OneTimeCode> {

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -195,7 +195,7 @@ impl Authority {
             self.secure_channels.identities().repository(),
             self.secure_channels.identities().credentials(),
             &self.identifier,
-            configuration.project_identifier(),
+            configuration.project_identifier().as_str(),
         );
 
         let address = DefaultAddress::CREDENTIAL_ISSUER.to_string();

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -2,7 +2,9 @@ use crate::bootstrapped_identities_store::PreTrustedIdentities;
 use crate::DefaultAddress;
 
 use ockam::identity::utils::now;
-use ockam::identity::{AttributesEntry, Identifier, TRUST_CONTEXT_ID};
+use ockam::identity::{
+    AttributeName, AttributeValue, AttributesEntry, Identifier, TRUST_CONTEXT_ID,
+};
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::fmt;
 use ockam_core::compat::fmt::{Display, Formatter};
@@ -144,14 +146,14 @@ impl TrustedIdentity {
         project_identifier: String,
         authority_identifier: &Identifier,
     ) -> AttributesEntry {
-        let mut map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
+        let mut map: BTreeMap<AttributeName, AttributeValue> = BTreeMap::new();
         for (name, value) in self.attributes.clone().iter() {
-            map.insert(name.as_bytes().to_vec(), value.as_bytes().to_vec());
+            map.insert(name.clone().into(), value.clone().into());
         }
 
         map.insert(
-            TRUST_CONTEXT_ID.to_vec(),
-            project_identifier.as_bytes().to_vec(),
+            TRUST_CONTEXT_ID.into(),
+            project_identifier.to_string().into(),
         );
         AttributesEntry::new(
             map,

--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -1,8 +1,8 @@
 use ockam::identity::models::ChangeHistory;
 use ockam::identity::utils::now;
 use ockam::identity::{
-    AttributesEntry, Identifier, IdentitiesReader, IdentitiesRepository, IdentitiesWriter,
-    IdentityAttributesReader, IdentityAttributesWriter,
+    AttributeName, AttributeValue, AttributesEntry, Identifier, IdentitiesReader,
+    IdentitiesRepository, IdentitiesWriter, IdentityAttributesReader, IdentityAttributesWriter,
 };
 use ockam_core::async_trait;
 use ockam_core::compat::sync::Arc;
@@ -76,8 +76,8 @@ impl IdentityAttributesWriter for BootstrapedIdentityStore {
     async fn put_attribute_value(
         &self,
         subject: &Identifier,
-        attribute_name: Vec<u8>,
-        attribute_value: Vec<u8>,
+        attribute_name: AttributeName,
+        attribute_value: AttributeValue,
     ) -> Result<()> {
         self.repository
             .put_attribute_value(subject, attribute_name, attribute_value)
@@ -168,7 +168,7 @@ impl PreTrustedIdentities {
             .map(|(identity_id, raw_attrs)| {
                 let attrs = raw_attrs
                     .into_iter()
-                    .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                    .map(|(k, v)| (k.into(), v.into()))
                     .collect();
                 (identity_id, AttributesEntry::new(attrs, now, None, None))
             })

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
@@ -2,7 +2,7 @@ use crate::kafka::outlet_controller::KafkaOutletController;
 use crate::kafka::portal_worker::KafkaPortalWorker;
 use crate::kafka::protocol_aware::OutletInterceptorImpl;
 use crate::kafka::{KAFKA_OUTLET_BOOTSTRAP_ADDRESS, KAFKA_OUTLET_INTERCEPTOR_ADDRESS};
-use ockam::identity::{SecureChannels, TRUST_CONTEXT_ID_UTF8};
+use ockam::identity::{SecureChannels, TRUST_CONTEXT_ID};
 use ockam::{Any, Context, Result, Routed, Worker};
 use ockam_abac::AbacAccessControl;
 use ockam_core::flow_control::{FlowControlId, FlowControlOutgoingAccessControl, FlowControls};
@@ -49,7 +49,7 @@ impl OutletManagerService {
             outlet_controller: KafkaOutletController::new(),
             incoming_access_control: Arc::new(AbacAccessControl::create(
                 secure_channels.identities().repository(),
-                TRUST_CONTEXT_ID_UTF8,
+                TRUST_CONTEXT_ID,
                 trust_context_id,
             )),
             flow_control_id: flow_control_id.clone(),

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -9,7 +9,7 @@ use crate::DefaultAddress;
 use minicbor::Decoder;
 use ockam::identity::{
     DecryptionRequest, DecryptionResponse, EncryptionRequest, EncryptionResponse,
-    SecureChannelRegistryEntry, SecureChannels, TRUST_CONTEXT_ID_UTF8,
+    SecureChannelRegistryEntry, SecureChannels, TRUST_CONTEXT_ID,
 };
 use ockam_abac::AbacAccessControl;
 use ockam_core::api::{Request, ResponseHeader, Status};
@@ -203,7 +203,7 @@ impl<F: RelayCreator> KafkaSecureChannelControllerImpl<F> {
     ) -> KafkaSecureChannelControllerImpl<F> {
         let access_control = AbacAccessControl::create(
             secure_channels.identities().repository(),
-            TRUST_CONTEXT_ID_UTF8,
+            TRUST_CONTEXT_ID,
             &trust_context_id,
         );
 

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -89,13 +89,10 @@ impl Server {
                         let entry = AttributesEntry::new(
                             attrs
                                 .into_iter()
-                                .map(|(k, v)| (k.as_bytes().to_vec(), v.as_bytes().to_vec()))
+                                .map(|(k, v)| (k.into(), v.into()))
                                 .chain(
-                                    [(
-                                        TRUST_CONTEXT_ID.to_owned(),
-                                        self.project.as_bytes().to_vec(),
-                                    )]
-                                    .into_iter(),
+                                    [(TRUST_CONTEXT_ID.into(), self.project.as_str().into())]
+                                        .into_iter(),
                                 )
                                 .collect(),
                             now().unwrap(),

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -452,7 +452,7 @@ pub mod test_utils {
             .export()?;
 
         let attributes = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA)
-            .with_attribute(TRUST_CONTEXT_ID.to_vec(), b"test_trust_context_id".to_vec())
+            .with_attribute(TRUST_CONTEXT_ID, "test_trust_context_id")
             .build();
 
         let credential = secure_channels

--- a/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
@@ -29,10 +29,7 @@ async fn auth_smoke(ctx: &mut Context) -> Result<()> {
         .await
         .unwrap()
         .expect("found");
-    assert_eq!(
-        Some(&b"value"[..].to_vec()),
-        entry.attrs().get("attr".as_bytes())
-    );
+    assert_eq!(Some(&"value".into()), entry.get(&"attr".into()));
     assert_eq!(None, entry.attested_by());
     assert_eq!(None, entry.expires());
 

--- a/implementations/rust/ockam/ockam_api/tests/authority.rs
+++ b/implementations/rust/ockam/ockam_api/tests/authority.rs
@@ -48,8 +48,7 @@ async fn controlling_authority_by_member_times_out(ctx: &mut Context) -> Result<
         .create_identity()
         .await?;
 
-    let mut attributes = HashMap::<&str, &str>::default();
-    attributes.insert("key", "value");
+    let attributes = HashMap::from([("key".to_string(), "value".to_string())]);
 
     admin
         .client
@@ -139,8 +138,7 @@ async fn test_one_admin_one_member(ctx: &mut Context) -> Result<()> {
         .create_identity()
         .await?;
 
-    let mut attributes = HashMap::<&str, &str>::default();
-    attributes.insert("key", "value");
+    let attributes = HashMap::from([("key".to_string(), "value".to_string())]);
 
     admin
         .client
@@ -160,15 +158,12 @@ async fn test_one_admin_one_member(ctx: &mut Context) -> Result<()> {
 
     let attrs = members.get(&member).unwrap();
 
-    assert_eq!(attrs.attrs().len(), 2);
+    assert_eq!(attrs.len(), 2);
     assert_eq!(
-        attrs.attrs().get("trust_context_id".as_bytes()),
-        Some(&b"123456".to_vec())
+        attrs.get(&"trust_context_id".into()),
+        Some(&"123456".into())
     );
-    assert_eq!(
-        attrs.attrs().get("key".as_bytes()),
-        Some(&b"value".to_vec())
-    );
+    assert_eq!(attrs.get(&"key".into()), Some(&"value".into()));
 
     assert!(attrs.added().abs_diff(now) < 5.into());
     assert!(attrs.expires().is_none());
@@ -215,11 +210,8 @@ async fn two_admins_two_members_exist_in_one_global_scope(ctx: &mut Context) -> 
         .create_identity()
         .await?;
 
-    let mut attributes1 = HashMap::<&str, &str>::default();
-    attributes1.insert("key1", "value1");
-
-    let mut attributes2 = HashMap::<&str, &str>::default();
-    attributes2.insert("key2", "value2");
+    let attributes1 = HashMap::from([("key1".to_string(), "value1".to_string())]);
+    let attributes2 = HashMap::from([("key2".to_string(), "value2".to_string())]);
 
     let now = now()?;
 
@@ -255,29 +247,23 @@ async fn two_admins_two_members_exist_in_one_global_scope(ctx: &mut Context) -> 
     assert!(members1.get(&admin1.identifier).is_some());
     assert!(members1.get(&admin2.identifier).is_some());
     let attrs = members1.get(&member1).unwrap();
-    assert_eq!(attrs.attrs().len(), 2);
+    assert_eq!(attrs.len(), 2);
     assert_eq!(
-        attrs.attrs().get("trust_context_id".as_bytes()),
-        Some(&b"123456".to_vec())
+        attrs.get(&"trust_context_id".into()),
+        Some(&"123456".into())
     );
-    assert_eq!(
-        attrs.attrs().get("key1".as_bytes()),
-        Some(&b"value1".to_vec())
-    );
+    assert_eq!(attrs.get(&"key1".into()), Some(&"value1".into()));
     assert!(attrs.added().abs_diff(now) < 5.into());
     assert!(attrs.expires().is_none());
     assert_eq!(attrs.attested_by(), Some(admin1.identifier.clone()));
 
     let attrs = members1.get(&member2).unwrap();
-    assert_eq!(attrs.attrs().len(), 2);
+    assert_eq!(attrs.len(), 2);
     assert_eq!(
-        attrs.attrs().get("trust_context_id".as_bytes()),
-        Some(&b"123456".to_vec())
+        attrs.get(&"trust_context_id".into()),
+        Some(&"123456".into())
     );
-    assert_eq!(
-        attrs.attrs().get("key2".as_bytes()),
-        Some(&b"value2".to_vec())
-    );
+    assert_eq!(attrs.get(&"key2".into()), Some(&"value2".into()));
     assert!(attrs.added().abs_diff(now) < 5.into());
     assert!(attrs.expires().is_none());
     assert_eq!(attrs.attested_by(), Some(admin2.identifier.clone()));
@@ -375,9 +361,10 @@ async fn setup(
 
     let mut trusted_identities = HashMap::<Identifier, AttributesEntry>::new();
 
-    let mut attrs = BTreeMap::<Vec<u8>, Vec<u8>>::new();
-    attrs.insert(b"ockam-role".to_vec(), b"enroller".to_vec());
-    attrs.insert(b"trust_context_id".to_vec(), b"123456".to_vec());
+    let attrs = BTreeMap::from([
+        ("ockam-role".into(), "enroller".into()),
+        ("trust_context_id".into(), "123456".into()),
+    ]);
 
     for _ in 0..number_of_admins {
         let admin = secure_channels

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -1,4 +1,3 @@
-use minicbor::bytes::ByteSlice;
 use ockam::identity::models::CredentialAndPurposeKey;
 use ockam::identity::utils::now;
 use ockam::identity::{identities, AttributesEntry};
@@ -31,7 +30,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
     let pre_trusted = HashMap::from([(
         member_identifier.clone(),
         AttributesEntry::new(
-            BTreeMap::from([(b"attr".to_vec(), b"value".to_vec())]),
+            BTreeMap::from([("attr".into(), "value".into())]),
             now,
             None,
             None,
@@ -68,7 +67,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         identities.repository(),
         identities.credentials(),
         &auth_identifier,
-        "project42".into(),
+        "project42",
     );
     ctx.start_worker(auth_worker_addr.clone(), auth).await?;
 
@@ -99,18 +98,18 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         .verify_credential(Some(&imported), &[auth_identifier.clone()], &credential)
         .await?;
     assert_eq!(
-        Some(&b"project42".to_vec().into()),
+        Some(&"project42".into()),
         data.credential_data
             .subject_attributes
             .map
-            .get::<ByteSlice>(b"trust_context_id".as_slice().into())
+            .get(&"trust_context_id".into())
     );
     assert_eq!(
-        Some(&b"value".to_vec().into()),
+        Some(&"value".into()),
         data.credential_data
             .subject_attributes
             .map
-            .get::<ByteSlice>(b"attr".as_slice().into())
+            .get(&"attr".into())
     );
     ctx.stop().await
 }

--- a/implementations/rust/ockam/ockam_command/src/authenticated.rs
+++ b/implementations/rust/ockam/ockam_command/src/authenticated.rs
@@ -93,15 +93,8 @@ impl Output for IdentifierWithAttributes {
         let mut output = String::new();
         let attrs: Vec<String> = self
             .entry
-            .attrs()
             .iter()
-            .map(|(k, v)| {
-                format!(
-                    "{}: {}",
-                    String::from_utf8_lossy(k),
-                    String::from_utf8_lossy(v)
-                )
-            })
+            .map(|(k, v)| format!("{}: {}", k.to_string(), v.to_string()))
             .collect();
         let attrs_str = attrs.join(", ");
         writeln!(output, "Identifier: {}", self.identifier)?;

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -78,12 +78,11 @@ async fn run_impl(
 
     let mut attributes_builder = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA)
         .with_attribute(
-            TRUST_CONTEXT_ID.to_vec(),
-            auth_identity_identifier.to_string(),
+            TRUST_CONTEXT_ID,
+            auth_identity_identifier.to_string().as_str(),
         );
     for (key, value) in cmd.attributes()? {
-        attributes_builder =
-            attributes_builder.with_attribute(key.as_bytes().to_vec(), value.as_bytes().to_vec());
+        attributes_builder = attributes_builder.with_attribute(&key, value.as_str());
     }
 
     let credential = identities

--- a/implementations/rust/ockam/ockam_command/src/output/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/output/output.rs
@@ -520,12 +520,13 @@ impl fmt::Display for CredentialDisplay {
         )?;
 
         f.debug_map()
-            .entries(credential_data.subject_attributes.map.iter().map(|(k, v)| {
-                (
-                    std::str::from_utf8(k).unwrap_or("**binary**"),
-                    std::str::from_utf8(v).unwrap_or("**binary**"),
-                )
-            }))
+            .entries(
+                credential_data
+                    .subject_attributes
+                    .map
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string())),
+            )
             .finish()?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -65,13 +65,13 @@ impl TicketCommand {
         node_rpc(run_impl, (opts, self));
     }
 
-    fn attributes(&self) -> Result<HashMap<&str, &str>> {
+    fn attributes(&self) -> Result<HashMap<String, String>> {
         let mut attributes = HashMap::new();
         for attr in &self.attributes {
             let mut parts = attr.splitn(2, '=');
             let key = parts.next().ok_or(miette!("key expected"))?;
             let value = parts.next().ok_or(miette!("value expected)"))?;
-            attributes.insert(key, value);
+            attributes.insert(key.to_string(), value.to_string());
         }
         Ok(attributes)
     }

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials.rs
@@ -6,7 +6,7 @@ use ockam_vault::{VaultForSigning, VaultForVerifyingSignatures};
 
 /// Structure with both [`CredentialData`] and [`PurposeKeyAttestationData`] that we get
 /// after parsing and verifying corresponding [`Credential`] and [`super::super::models::PurposeKeyAttestation`]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CredentialAndPurposeKeyData {
     /// [`CredentialData`]
     pub credential_data: CredentialData,
@@ -72,9 +72,7 @@ impl Credentials {
 mod tests {
     use crate::identities::identities;
     use crate::models::CredentialSchemaIdentifier;
-    use crate::Attributes;
-    use minicbor::bytes::ByteVec;
-    use ockam_core::compat::collections::BTreeMap;
+    use crate::utils::AttributesBuilder;
     use ockam_core::Result;
     use std::time::Duration;
 
@@ -87,12 +85,9 @@ mod tests {
         let subject = creation.create_identity().await?;
         let credentials = identities.credentials();
 
-        let mut map: BTreeMap<ByteVec, ByteVec> = Default::default();
-        map.insert(b"key".to_vec().into(), b"value".to_vec().into());
-        let subject_attributes = Attributes {
-            schema: CredentialSchemaIdentifier(1),
-            map,
-        };
+        let subject_attributes = AttributesBuilder::with_schema(CredentialSchemaIdentifier(1))
+            .with_attribute("key", "value")
+            .build();
 
         let credential = credentials
             .credentials_creation()

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
@@ -4,7 +4,6 @@ use crate::{Credentials, IdentitiesRepository, IdentitySecureChannelLocalInfo};
 
 use ockam_core::api::{Method, RequestHeader, Response};
 use ockam_core::compat::boxed::Box;
-use ockam_core::compat::string::String;
 use ockam_core::compat::string::ToString;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
@@ -17,10 +16,7 @@ use tracing::trace;
 
 /// Name of the attribute identifying the trust context for that attribute, meaning
 /// from which set of trusted authorities the attribute comes from
-pub const TRUST_CONTEXT_ID: &[u8] = b"trust_context_id";
-
-/// The same as above but in string format
-pub const TRUST_CONTEXT_ID_UTF8: &str = "trust_context_id";
+pub const TRUST_CONTEXT_ID: &str = "trust_context_id";
 
 /// Identifier for the schema of a project credential
 pub const PROJECT_MEMBER_SCHEMA: CredentialSchemaIdentifier = CredentialSchemaIdentifier(1);
@@ -42,10 +38,10 @@ impl CredentialsIssuer {
         identities_repository: Arc<dyn IdentitiesRepository>,
         credentials: Arc<Credentials>,
         issuer: &Identifier,
-        trust_context: String,
+        trust_context: &str,
     ) -> Self {
         let subject_attributes = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA)
-            .with_attribute(TRUST_CONTEXT_ID.to_vec(), trust_context.as_bytes().to_vec())
+            .with_attribute(TRUST_CONTEXT_ID, trust_context)
             .build();
 
         Self {
@@ -71,10 +67,8 @@ impl CredentialsIssuer {
         };
 
         let mut subject_attributes = self.subject_attributes.clone();
-        for (key, value) in entry.attrs().iter() {
-            subject_attributes
-                .map
-                .insert(key.clone().into(), value.clone().into());
+        for (key, value) in entry.iter() {
+            subject_attributes.map.insert(key.clone(), value.clone());
         }
 
         let credential = self

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_verification.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_verification.rs
@@ -6,9 +6,7 @@ use crate::{
     TimestampInSeconds,
 };
 
-use ockam_core::compat::collections::BTreeMap;
 use ockam_core::compat::sync::Arc;
-use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_vault::VaultForVerifyingSignatures;
 
@@ -177,12 +175,7 @@ impl CredentialsVerification {
                 credential_and_purpose_key_attestation,
             )
             .await?;
-
         let map = credential_data.credential_data.subject_attributes.map;
-        let map: BTreeMap<_, _> = map
-            .into_iter()
-            .map(|(k, v)| (Vec::<u8>::from(k), Vec::<u8>::from(v)))
-            .collect();
 
         self.identities_repository
             .put_attributes(

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/attribute_name.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/attribute_name.rs
@@ -1,0 +1,34 @@
+use minicbor::{Decode, Encode};
+use ockam_core::compat::string::String;
+use ockam_core::compat::string::ToString;
+use serde::{Deserialize, Serialize};
+
+/// This enum represents the type of attributes names which can be associated to an Identity
+/// We currently support only String names at the moment but this type opens the possibility
+/// of introducing more compact representations of attribute names in the future
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encode, Decode, Serialize, Deserialize)]
+#[rustfmt::skip]
+pub enum AttributeName {
+    /// String name
+    #[n(1)] Str(#[n(0)] String),
+}
+
+impl ToString for AttributeName {
+    fn to_string(&self) -> String {
+        match self {
+            AttributeName::Str(v) => v.to_string(),
+        }
+    }
+}
+
+impl From<&str> for AttributeName {
+    fn from(value: &str) -> Self {
+        AttributeName::Str(value.to_string())
+    }
+}
+
+impl From<String> for AttributeName {
+    fn from(value: String) -> Self {
+        AttributeName::Str(value)
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/attribute_value.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/attribute_value.rs
@@ -1,0 +1,51 @@
+use minicbor::{Decode, Encode};
+use ockam_core::compat::string::String;
+use ockam_core::compat::string::ToString;
+use ockam_core::compat::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+/// This enum represents the type of values which can be associated to an Identity
+/// The `ockam_abac` crate is able to use those attributes in policies to check if an identity
+/// is allowed to access a resource
+#[derive(Debug, Clone, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[rustfmt::skip]
+pub enum AttributeValue {
+    /// String value
+    #[n(1)] Str   (#[n(0)] String),
+    /// Int value
+    #[n(2)] Int   (#[n(0)] i64),
+    /// Float value
+    #[n(3)] Float (#[n(0)] f64),
+    /// Bool value
+    #[n(4)] Bool  (#[n(0)] bool),
+    /// Sequence of other attribute values
+    #[n(5)] Seq   (#[n(0)] Vec<AttributeValue>)
+}
+
+impl ToString for AttributeValue {
+    fn to_string(&self) -> String {
+        match self {
+            AttributeValue::Str(v) => v.to_string(),
+            AttributeValue::Int(v) => v.to_string(),
+            AttributeValue::Float(v) => v.to_string(),
+            AttributeValue::Bool(v) => v.to_string(),
+            AttributeValue::Seq(v) => v
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        }
+    }
+}
+
+impl From<&str> for AttributeValue {
+    fn from(value: &str) -> Self {
+        AttributeValue::Str(value.to_string())
+    }
+}
+
+impl From<String> for AttributeValue {
+    fn from(value: String) -> Self {
+        AttributeValue::Str(value)
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
@@ -1,16 +1,21 @@
 use crate::models::{Identifier, TimestampInSeconds};
+use crate::utils::now;
+use crate::AttributeName;
+use crate::AttributeValue;
+use alloc::collections::btree_map::Iter;
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::ToOwned;
-use ockam_core::compat::{collections::BTreeMap, vec::Vec};
+use ockam_core::compat::collections::BTreeMap;
+use ockam_core::Result;
 use serde::{Deserialize, Serialize};
 
 /// An entry on the AuthenticatedIdentities table.
-#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Serialize, Deserialize)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct AttributesEntry {
     // TODO: Check how it looks serialized with both serde and minicbor
-    #[b(1)] attrs: BTreeMap<Vec<u8>, Vec<u8>>,
+    #[n(1)] attrs: BTreeMap<AttributeName, AttributeValue>,
     #[n(2)] added: TimestampInSeconds,
     #[n(3)] expires: Option<TimestampInSeconds>,
     #[n(4)] attested_by: Option<Identifier>,
@@ -23,7 +28,7 @@ impl AttributesEntry {
 
     /// Constructor
     pub fn new(
-        attrs: BTreeMap<Vec<u8>, Vec<u8>>,
+        attrs: BTreeMap<AttributeName, AttributeValue>,
         added: TimestampInSeconds,
         expires: Option<TimestampInSeconds>,
         attested_by: Option<Identifier>,
@@ -36,9 +41,44 @@ impl AttributesEntry {
         }
     }
 
+    /// Create an empty set of attributes with no dates or attestor
+    pub fn empty() -> Result<Self> {
+        Ok(Self::new(BTreeMap::default(), now()?, None, None))
+    }
+
+    /// Create an empty set of attributes with an identity which will attest additional attributes
+    pub fn empty_attested_by(identifier: Identifier) -> Result<Self> {
+        Ok(Self::new(
+            BTreeMap::default(),
+            now()?,
+            None,
+            Some(identifier),
+        ))
+    }
+
+    /// Get the number of attributes
+    pub fn len(&self) -> usize {
+        self.attrs.len()
+    }
+
+    /// Return true if there are no attributes
+    pub fn is_empty(&self) -> bool {
+        self.attrs.is_empty()
+    }
+
+    /// Get an attribute value by name
+    pub fn get(&self, name: &AttributeName) -> Option<&AttributeValue> {
+        self.attrs.get(name)
+    }
+
+    /// Get an attribute value by name
+    pub fn insert(&mut self, name: AttributeName, value: AttributeValue) -> Option<AttributeValue> {
+        self.attrs.insert(name, value)
+    }
+
     /// The entry attributes
-    pub fn attrs(&self) -> &BTreeMap<Vec<u8>, Vec<u8>> {
-        &self.attrs
+    pub fn iter(&self) -> Iter<AttributeName, AttributeValue> {
+        self.attrs.iter()
     }
 
     /// Expiration time for this entry

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository_trait.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identities_repository_trait.rs
@@ -6,7 +6,7 @@ use ockam_core::Result;
 use ockam_core::{async_trait, Error};
 
 use crate::models::{ChangeHistory, Identifier};
-use crate::AttributesEntry;
+use crate::{AttributeName, AttributeValue, AttributesEntry};
 
 /// Repository for data related to identities: key changes and attributes
 #[async_trait]
@@ -47,8 +47,8 @@ pub trait IdentityAttributesWriter: Send + Sync + 'static {
     async fn put_attribute_value(
         &self,
         subject: &Identifier,
-        attribute_name: Vec<u8>,
-        attribute_value: Vec<u8>,
+        attribute_name: AttributeName,
+        attribute_value: AttributeValue,
     ) -> Result<()>;
 
     /// Remove all attributes for a given identity identifier

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/mod.rs
@@ -1,7 +1,11 @@
+mod attribute_name;
+mod attribute_value;
 mod attributes_entry;
 mod identities_repository_impl;
 mod identities_repository_trait;
 
+pub use attribute_name::*;
+pub use attribute_value::*;
 pub use attributes_entry::*;
 pub use identities_repository_impl::*;
 pub use identities_repository_trait::*;

--- a/implementations/rust/ockam/ockam_identity/src/models/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/credential.rs
@@ -1,6 +1,10 @@
 use crate::models::{ChangeHash, Identifier, TimestampInSeconds};
+use crate::{AttributeName, AttributeValue};
+use core::str::{from_utf8, Utf8Error};
 use minicbor::bytes::ByteVec;
-use minicbor::{Decode, Encode};
+use minicbor::encode::Write;
+use minicbor::{Decode, Decoder, Encode, Encoder};
+use ockam_core::compat::string::ToString;
 use ockam_core::compat::{collections::BTreeMap, vec::Vec};
 use ockam_vault::{ECDSASHA256CurveP256Signature, EdDSACurve25519Signature};
 
@@ -28,7 +32,7 @@ pub enum CredentialSignature {
 }
 
 /// Data inside a [`Credential`]
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Encode, Decode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct CredentialData {
@@ -52,12 +56,75 @@ pub struct CredentialData {
 pub struct CredentialSchemaIdentifier(#[n(0)] pub u64);
 
 /// Set a keys&values that an Authority (issuer) attests about the Subject
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Encode, Decode)]
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct Attributes {
     /// [`CredentialSchemaIdentifier`] that determines which keys&values to expect in the [`Attributes`]
     #[n(1)] pub schema: CredentialSchemaIdentifier,
-    /// Set of keys&values
-    #[n(2)] pub map: BTreeMap<ByteVec, ByteVec>,
+    /// Set of keys & values
+    /// The values exchanged with the Controller are actually UTF-8 encoded strings
+    /// so we use the 2 functions below to do the decoding
+    #[cbor(decode_with = "decode_attributes")]
+    #[cbor(encode_with = "encode_attributes")]
+    #[n(2)] pub map: BTreeMap<AttributeName, AttributeValue>,
+}
+
+fn decode_attributes<Ctx>(
+    d: &mut Decoder,
+    _ctx: &mut Ctx,
+) -> Result<BTreeMap<AttributeName, AttributeValue>, minicbor::decode::Error> {
+    let attributes: BTreeMap<ByteVec, ByteVec> = d.decode()?;
+    let attributes: Result<BTreeMap<AttributeName, AttributeValue>, Utf8Error> = attributes
+        .iter()
+        .map(|(k, v)| decode_key_value(k, v))
+        .collect();
+    attributes.map_err(|e| minicbor::decode::Error::message(e.to_string()))
+}
+
+fn decode_key_value(
+    k: &Vec<u8>,
+    v: &Vec<u8>,
+) -> Result<(AttributeName, AttributeValue), Utf8Error> {
+    let key = from_utf8(k.as_slice())?.into();
+    let value = from_utf8(v.as_slice())?.into();
+    Ok((key, value))
+}
+
+fn encode_attributes<Ctx, W: Write>(
+    v: &BTreeMap<AttributeName, AttributeValue>,
+    e: &mut Encoder<W>,
+    _ctx: &mut Ctx,
+) -> Result<(), minicbor::encode::Error<W::Error>> {
+    let attributes: BTreeMap<ByteVec, ByteVec> = v
+        .iter()
+        .map(|(k, v)| {
+            (
+                From::from(k.to_string().as_bytes().to_vec()),
+                From::from(v.to_string().as_bytes().to_vec()),
+            )
+        })
+        .collect();
+    e.encode(attributes)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::AttributesBuilder;
+
+    /// decoding what has been encoded should work ok if values are strings
+    #[test]
+    fn test_round_trip() {
+        let attributes = AttributesBuilder::with_schema(CredentialSchemaIdentifier(1))
+            .with_attribute("key1", "value2")
+            .with_attribute("key2", "value2")
+            .build();
+
+        let result = minicbor::decode(&minicbor::to_vec(attributes.clone()).unwrap());
+        assert!(result.is_ok());
+
+        assert_eq!(result.ok(), Some(attributes));
+    }
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/access_control/credential_access_control.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/access_control/credential_access_control.rs
@@ -1,3 +1,4 @@
+use crate::{AttributeName, AttributeValue};
 use core::fmt::{Debug, Formatter};
 use ockam_core::access_control::IncomingAccessControl;
 use ockam_core::compat::{boxed::Box, sync::Arc, vec::Vec};
@@ -10,14 +11,14 @@ use crate::secure_channel::local_info::IdentitySecureChannelLocalInfo;
 /// Access control checking that message senders have a specific set of attributes
 #[derive(Clone)]
 pub struct CredentialAccessControl {
-    required_attributes: Vec<(Vec<u8>, Vec<u8>)>,
+    required_attributes: Vec<(AttributeName, AttributeValue)>,
     storage: Arc<dyn IdentitiesRepository>,
 }
 
 impl CredentialAccessControl {
     /// Create a new credential access control
     pub fn new(
-        required_attributes: &[(Vec<u8>, Vec<u8>)],
+        required_attributes: &[(AttributeName, AttributeValue)],
         storage: Arc<dyn IdentitiesRepository>,
     ) -> Self {
         Self {
@@ -53,7 +54,7 @@ impl IncomingAccessControl for CredentialAccessControl {
             };
 
             for required_attribute in self.required_attributes.iter() {
-                let attr_val = match attributes.attrs().get(&required_attribute.0) {
+                let attr_val = match attributes.get(&required_attribute.0) {
                     Some(v) => v,
                     None => return Ok(false), // No required key
                 };

--- a/implementations/rust/ockam/ockam_identity/src/utils.rs
+++ b/implementations/rust/ockam/ockam_identity/src/utils.rs
@@ -1,10 +1,8 @@
-use minicbor::bytes::ByteVec;
 use ockam_core::compat::collections::BTreeMap;
-use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 
 use crate::models::{Attributes, CredentialSchemaIdentifier, TimestampInSeconds};
-use crate::IdentityError;
+use crate::{AttributeName, AttributeValue, IdentityError};
 
 /// Create a new timestamp using the system time
 #[cfg(feature = "std")]
@@ -30,7 +28,7 @@ pub fn add_seconds(timestamp: &TimestampInSeconds, seconds: u64) -> TimestampInS
 /// Convenient builder for the [`Attributes`] struct
 pub struct AttributesBuilder {
     schema_id: CredentialSchemaIdentifier,
-    map: BTreeMap<ByteVec, ByteVec>,
+    map: BTreeMap<AttributeName, AttributeValue>,
 }
 
 impl AttributesBuilder {
@@ -43,9 +41,8 @@ impl AttributesBuilder {
     }
 
     /// Add an attributes to the [`Attributes`]
-    pub fn with_attribute(mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
-        self.map.insert(key.into().into(), value.into().into());
-
+    pub fn with_attribute(mut self, key: &str, value: &str) -> Self {
+        self.map.insert(key.into(), value.into());
         self
     }
 

--- a/implementations/rust/ockam/ockam_identity/tests/aws.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/aws.rs
@@ -100,7 +100,7 @@ async fn create_credential_aws_key() -> Result<()> {
         .await?;
 
     let attributes = AttributesBuilder::with_schema(CredentialSchemaIdentifier(1))
-        .with_attribute(*b"key", *b"value")
+        .with_attribute("key", "value")
         .build();
 
     let credential = identities

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -190,14 +190,14 @@ async fn test_channel_send_credentials(context: &mut Context) -> Result<()> {
     //FIXME: only the last credential is kept around in the storage
     // assert_eq!(
     //     "true".as_bytes(),
-    //     alice_attributes.attrs().get("is_alice").unwrap()
+    //     alice_attributes.attrs().get(&"is_alice").unwrap()
     // );
     assert_eq!(
-        "true".as_bytes(),
-        alice_attributes.attrs().get("alice_2".as_bytes()).unwrap()
+        alice_attributes.get(&"alice_2".into()).unwrap(),
+        &"true".into()
     );
-    assert!(alice_attributes.attrs().get("is_bob".as_bytes()).is_none());
-    assert!(alice_attributes.attrs().get("bob_2".as_bytes()).is_none());
+    assert!(alice_attributes.get(&"is_bob".into()).is_none());
+    assert!(alice_attributes.get(&"bob_2".into()).is_none());
 
     let bob_attributes = secure_channels
         .identities()
@@ -206,17 +206,14 @@ async fn test_channel_send_credentials(context: &mut Context) -> Result<()> {
         .await?
         .unwrap();
 
-    assert!(bob_attributes.attrs().get("is_alice".as_bytes()).is_none());
-    assert!(bob_attributes.attrs().get("alice_2".as_bytes()).is_none());
+    assert!(bob_attributes.get(&"is_alice".into()).is_none());
+    assert!(bob_attributes.get(&"alice_2".into()).is_none());
     //FIXME: only the last credential is kept around in the storage
     // assert_eq!(
     //     "true".as_bytes(),
-    //     bob_attributes.attrs().get("is_bob").unwrap()
+    //     bob_attributes.attrs().get(&"is_bob").unwrap()
     // );
-    assert_eq!(
-        "true".as_bytes(),
-        bob_attributes.attrs().get("bob_2".as_bytes()).unwrap()
-    );
+    assert_eq!(bob_attributes.get(&"bob_2".into()).unwrap(), &"true".into());
 
     context.stop().await
 }

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -87,9 +87,9 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
         .await?
         .unwrap();
 
-    let val = attrs.attrs().get("is_superuser".as_bytes()).unwrap();
+    let val = attrs.get(&"is_superuser".into()).unwrap();
 
-    assert_eq!(val.as_slice(), b"true");
+    assert_eq!(val, &"true".into());
 
     ctx.stop().await
 }
@@ -183,24 +183,14 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         .await?
         .unwrap();
 
-    assert_eq!(
-        attrs1
-            .attrs()
-            .get("is_admin".as_bytes())
-            .unwrap()
-            .as_slice(),
-        b"true"
-    );
+    assert_eq!(attrs1.get(&"is_admin".into()).unwrap(), &"true".into());
 
     let attrs2 = identities_repository
         .get_attributes(&client2)
         .await?
         .unwrap();
 
-    assert_eq!(
-        attrs2.attrs().get("is_user".as_bytes()).unwrap().as_slice(),
-        b"true"
-    );
+    assert_eq!(attrs2.get(&"is_user".into()).unwrap(), &"true".into());
 
     ctx.stop().await
 }
@@ -273,7 +263,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
         msgs_count: counter.clone(),
     };
 
-    let required_attributes = vec![(b"is_superuser".to_vec(), b"true".to_vec())];
+    let required_attributes = vec![("is_superuser".into(), "true".into())];
     let access_control =
         CredentialAccessControl::new(&required_attributes, identities_repository.clone());
 


### PR DESCRIPTION
[NOTE]: the `ockam_documentation` update [PR is ready to be merged](https://github.com/build-trust/ockam-documentation/pull/74).

Attributes are used to create credentials for a given identity. When a credential is received and validated, its attributes are stored by a node. Then resources can have associated policies declaring that an identity can access it only if the attributes associated to that identity satisfies a logic expression.

The `ockam_abac` crate defines the exact type of values which can be used in expressions: string, bool, int, float, and a sequence of such values. Moreover, throughout the code attributes names are always expected to be strings (which is reasonable).

Yet we model attributes in our code as `name: Vec<u8>` and `value: Vec<u8>`. This is unnecessarily general. By having proper types for attribute names and values we signal to the library what can be really used and we avoid making mistakes by passing incompatible values.

This PR changes the type of `AttributesEntry` so that it contains a map of `String` -> `AttributeValue` pairs.

### Notes

 - the actual encoding / decoding of data exchanged with the Controller is still left as a pair of `Vec<u8>` where effectively those bytes only ever represent UTF-8 encoded strings at the moment (even for values)

 - the `AttributeValue` data type has been introduced to separate the declarations / persistence of attributes in the `ockam_identity` repository from their potential use as `Expr`essions in the `ockam_abac` crate (since there is a dependency from `ockam_abac` to `ockam_identity`)

