### PR TITLE
fix(rust): do not return error for no relays

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use colorful::Colorful;
-use miette::{miette, IntoDiagnostic};
+use miette::IntoDiagnostic;
 use tokio::sync::Mutex;
 use tokio::try_join;
 use tracing::trace;
@@ -48,7 +48,10 @@ async fn run_impl(
     let node_name = extract_address_value(&to)?;
 
     if !opts.state.nodes.get(&node_name)?.is_running() {
-        return Err(miette!("The node '{}' is not running", node_name));
+        opts.terminal
+            .write_line("There are no relays available. Create one with 'ockam relay create'.")?;
+
+        return Ok(());
     }
 
     let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;


### PR DESCRIPTION
## Current behavior

In a fresh environment, running `ockam relay list` shows an error.

![image](https://github.com/build-trust/ockam/assets/772507/cacdecce-a016-47c4-a8e0-e7f99840da39)

## Proposed changes

Replaces the error that's returned by `ockam relay list` with normal stdout text and return code.

![image](https://github.com/build-trust/ockam/assets/772507/6a69a4dd-423b-4591-8d7b-c8e53dc1a280)

Is this sufficient? Is there a condition in which there are no nodes for the passed `node_name` and the error should be returned? Any preference on the text printed?

Fixes #6298

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.