### PR TITLE
feat(rust): support json output for tcp-outlet show

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,5 +1,9 @@
+use std::net::SocketAddr;
+
 use clap::Args;
+use core::fmt::Write;
 use miette::miette;
+use serde::Serialize;
 
 use ockam::{route, Context};
 use ockam_api::address::extract_address_value;
@@ -7,8 +11,10 @@ use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::BackgroundNode;
 use ockam_api::route_to_multiaddr;
 use ockam_core::api::Request;
+use ockam_multiaddr::MultiAddr;
 
 use crate::node::{get_node_name, initialize_node_if_default, NodeOpts};
+use crate::output::Output;
 use crate::tcp::util::alias_parser;
 use crate::util::node_rpc;
 use crate::Result;
@@ -39,6 +45,24 @@ impl ShowCommand {
     }
 }
 
+#[derive(Debug, Serialize)]
+struct OutletInformation {
+    alias: String,
+    addr: MultiAddr,
+    socket_addr: SocketAddr,
+}
+
+impl Output for OutletInformation {
+    fn output(&self) -> Result<String> {
+        let mut w = String::new();
+        write!(w, "Outlet")?;
+        write!(w, "\n  Alias: {}", self.alias)?;
+        write!(w, "\n  From Outlet: {}", self.addr)?;
+        write!(w, "\n  To TCP: {}", self.socket_addr)?;
+        Ok(w)
+    }
+}
+
 pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
@@ -47,13 +71,18 @@ pub async fn run_impl(
     let node_name = extract_address_value(&node_name)?;
     let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
     let outlet_status: OutletStatus = node.ask(&ctx, make_api_request(cmd)?).await?;
+    let info = OutletInformation {
+        alias: outlet_status.alias,
+        addr: route_to_multiaddr(&route![outlet_status.worker_addr.to_string()])
+            .ok_or_else(|| miette!("Invalid Outlet Address"))?,
+        socket_addr: outlet_status.socket_addr,
+    };
 
-    println!("Outlet:");
-    println!("  Alias: {}", outlet_status.alias);
-    let addr = route_to_multiaddr(&route![outlet_status.worker_addr.to_string()])
-        .ok_or_else(|| miette!("Invalid Outlet Address"))?;
-    println!("  From Outlet: {addr}");
-    println!("  To TCP: {}", outlet_status.socket_addr);
+    opts.terminal
+        .stdout()
+        .plain(info.output()?)
+        .json(serde_json::json!(info))
+        .write_line()?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -56,9 +56,9 @@ teardown() {
   run_success $OCKAM tcp-outlet create --at /node/n2 --to $only_port
 
   run_success $OCKAM tcp-outlet show test-outlet --at /node/n1
-  assert_output --partial "Alias: test-outlet"
-  assert_output --partial "From Outlet: /service/outlet"
-  assert_output --regexp "To TCP: 127.0.0.1:$port"
+  assert_output --partial "\"alias\":\"test-outlet\""
+  assert_output --partial "\"addr\":\"/service/outlet\""
+  assert_output --partial "\"socket_addr\":\"127.0.0.1:$port\""
 
   run_success $OCKAM tcp-outlet delete "test-outlet" --yes
 


### PR DESCRIPTION
## Current behavior

`ockam tcp-outlet show <alias>` only supports plain-text output.

## Proposed changes

Add support for the global `--output json` flag value for this command.

![image](https://github.com/build-trust/ockam/assets/772507/a5565651-feb7-4e3c-b7c4-aeb098c19b43)

Note: I can eschew the new struct and use `serde_json::json!` if desired.

Fixes #6344

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.
