### PR TITLE
fix(rust): drop the in memory node and delete its node manager

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -275,6 +275,7 @@ pub struct NodeManagerGeneralOptions {
     node_name: String,
     pre_trusted_identities: Option<PreTrustedIdentities>,
     start_default_services: bool,
+    persistent: bool,
 }
 
 impl NodeManagerGeneralOptions {
@@ -283,12 +284,14 @@ impl NodeManagerGeneralOptions {
         node_name: String,
         pre_trusted_identities: Option<PreTrustedIdentities>,
         start_default_services: bool,
+        persistent: bool,
     ) -> Self {
         Self {
             cli_state,
             node_name,
             pre_trusted_identities,
             start_default_services,
+            persistent,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -475,7 +475,7 @@ pub mod test_utils {
 
         let node_manager = InMemoryNode::new(
             context,
-            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, None, true),
+            NodeManagerGeneralOptions::new(cli_state.clone(), node_name, None, true, false),
             NodeManagerTransportOptions::new(
                 FlowControls::generate_flow_control_id(), // FIXME
                 tcp.async_try_clone().await?,

--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -186,7 +186,7 @@ impl AppState {
     /// Return a client to access the Controller
     pub async fn controller(&self) -> Result<Controller> {
         let node_manager = self.node_manager.read().await;
-        Ok(node_manager.controller().await?)
+        Ok(node_manager.create_controller().await?)
     }
 
     pub async fn is_enrolled(&self) -> Result<bool> {
@@ -317,7 +317,7 @@ pub(crate) async fn make_node_manager(
 
     let node_manager = InMemoryNode::new(
         &ctx,
-        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), None, true),
+        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), None, true, false),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -142,7 +142,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
 ) -> miette::Result<()> {
-    let controller = InMemoryNode::create_controller(&ctx, &opts.state).await?;
+    let node = InMemoryNode::start(&ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     match cmd.subcommand {
         SubscriptionSubcommand::Attach {

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -112,7 +112,7 @@ async fn run_impl(
         .overwrite(&user_info.email, user_info.clone())?;
 
     let node = InMemoryNode::start(ctx, &opts.state).await?;
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     enroll_with_node(&controller, ctx, token)
         .await
@@ -135,7 +135,7 @@ pub async fn retrieve_user_project(
     ctx: &Context,
     node: &InMemoryNode,
 ) -> Result<Identifier> {
-    let space = default_space(opts, ctx, &node.controller().await?)
+    let space = default_space(opts, ctx, &node.create_controller().await?)
         .await
         .wrap_err("Unable to retrieve and set a space as default")?;
     info!("Retrieved the user default space {:?}", space);
@@ -270,7 +270,7 @@ async fn default_project(
     node: &InMemoryNode,
     space: &Space,
 ) -> Result<Project> {
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     // Get available project for the given space
     opts.terminal.write_line(&fmt_log!(

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -313,6 +313,7 @@ async fn run_foreground_node(
             cmd.node_name.clone(),
             pre_trusted_identities,
             cmd.launch_config.is_none(),
+            true,
         ),
         NodeManagerTransportOptions::new(
             listener.flow_control_id().clone(),

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_confluent.rs
@@ -58,7 +58,7 @@ async fn run_impl(
     let config = ConfluentConfig::new(bootstrap_server);
 
     let node = InMemoryNode::start(&ctx, &opts.state).await?;
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     let response = controller
         .configure_confluent_addon(&ctx, project_id.clone(), config)

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_influxdb.rs
@@ -156,7 +156,7 @@ async fn run_impl(
     );
 
     let node = InMemoryNode::start(&ctx, &opts.state).await?;
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     let response = controller
         .configure_influxdb_addon(&ctx, project_id.clone(), config)

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -119,7 +119,7 @@ async fn run_impl(
 
     // Do request
     let node = InMemoryNode::start(&ctx, &opts.state).await?;
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     let response = controller
         .configure_okta_addon(&ctx, project_id.clone(), okta_config)

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -48,7 +48,8 @@ async fn run_impl(
         addon_id,
     } = cmd;
     let project_id = get_project_id(&opts.state, project_name.as_str())?;
-    let controller = InMemoryNode::create_controller(&ctx, &opts.state).await?;
+    let node = InMemoryNode::start(&ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let response = controller.disable_addon(&ctx, project_id, addon_id).await?;
     let operation_id = response.operation_id;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -35,7 +35,9 @@ async fn run_impl(
     let project_name = cmd.project_name;
     let project_id = get_project_id(&opts.state, project_name.as_str())?;
 
-    let controller = InMemoryNode::create_controller(&ctx, &opts.state).await?;
+    let node = InMemoryNode::start(&ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
+
     let addons = controller.list_addons(&ctx, project_id).await?;
 
     opts.println(&addons)?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -122,7 +122,7 @@ async fn check_configuration_completion(
     project_id: String,
     operation_id: String,
 ) -> Result<()> {
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
     check_for_completion(opts, ctx, &controller, &operation_id).await?;
     let project = controller.get_project(ctx, project_id).await?;
     let _ = check_project_readiness(opts, ctx, node, project).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -52,7 +52,7 @@ async fn run_impl(
 ) -> miette::Result<()> {
     let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
     let node = InMemoryNode::start(ctx, &opts.state).await?;
-    let controller = node.controller().await?;
+    let controller = node.create_controller().await?;
 
     let project = controller
         .create_project(ctx, space_id, cmd.project_name, vec![])

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -58,7 +58,8 @@ async fn run_impl(
         .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this project?")?
     {
         let space_id = opts.state.spaces.get(&cmd.space_name)?.config().id.clone();
-        let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
+        let controller = node.create_controller().await?;
 
         // Lookup project
         let project_id = match opts.state.projects.get(&cmd.project_name) {

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -35,7 +35,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, InfoCommand)) -> mie
 }
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: InfoCommand) -> miette::Result<()> {
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     // Lookup project
     let id = match opts.state.projects.get(&cmd.name) {

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -40,7 +40,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
 }
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, _cmd: ListCommand) -> miette::Result<()> {
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_projects = async {

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -42,7 +42,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> mie
 }
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ShowCommand) -> miette::Result<()> {
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     // Lookup project
     let id = match &opts.state.projects.get(&cmd.name) {

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -121,7 +121,7 @@ pub async fn check_project_readiness(
     let spinner_option = opts.terminal.progress_spinner();
     let project = check_project_ready(
         ctx,
-        &node.controller().await?,
+        &node.create_controller().await?,
         project,
         retry_strategy.clone(),
         spinner_option.clone(),

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -36,7 +36,8 @@ async fn rpc(ctx: Context, opts: CommandGlobalOpts) -> miette::Result<()> {
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
     // Send request
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
     let project_version = controller.get_project_version(ctx).await?;
 
     let json = serde_json::to_string(&project_version).into_diagnostic()?;

--- a/implementations/rust/ockam/ockam_command/src/share/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/accept.rs
@@ -40,7 +40,8 @@ async fn run_impl(
     cmd: AcceptCommand,
 ) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_accepted_invitation = async {
         let invitation = controller.accept_invitation(ctx, cmd.id).await?;

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -49,7 +49,8 @@ async fn run_impl(
     cmd: CreateCommand,
 ) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_sent_invitation = async {
         let invitation = controller

--- a/implementations/rust/ockam/ockam_command/src/share/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/list.rs
@@ -37,7 +37,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, _cmd: ListCommand) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_invitations = async {
         let invitations = controller

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -93,7 +93,8 @@ async fn run_impl(
     cmd: ServiceCreateCommand,
 ) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_sent_invitation = async {
         let invitation = controller

--- a/implementations/rust/ockam/ockam_command/src/share/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/show.rs
@@ -37,7 +37,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> mie
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ShowCommand) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_invitation_with_access = async {
         let invitation_with_access = controller.show_invitation(ctx, cmd.invitation_id).await?;

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -57,7 +57,8 @@ async fn run_impl(
         "To learn more about production ready spaces in Ockam Orchestrator, contact us at: hello@ockam.io".light_magenta()
     ))?;
 
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
     let space = controller.create_space(ctx, cmd.name, cmd.admins).await?;
 
     opts.println(&space)?;

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -54,7 +54,8 @@ async fn run_impl(
         .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this space?")?
     {
         let space_id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
-        let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
+        let controller = node.create_controller().await?;
         controller.delete_space(ctx, space_id).await?;
 
         let _ = opts.state.spaces.delete(&cmd.name);

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -41,7 +41,8 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> mie
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, _cmd: ListCommand) -> miette::Result<()> {
     let is_finished: Mutex<bool> = Mutex::new(false);
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     let get_spaces = async {
         let spaces = controller.list_spaces(ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -44,7 +44,8 @@ async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ShowCommand) -> m
     let id = opts.state.spaces.get(&cmd.name)?.config().id.clone();
 
     // Send request
-    let controller = InMemoryNode::create_controller(ctx, &opts.state).await?;
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
     let space: Space = controller.get_space(ctx, id).await?;
     opts.println(&space)?;
     opts.state

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -57,7 +57,8 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, SubscriptionCommand),
 ) -> miette::Result<()> {
-    let controller = InMemoryNode::create_controller(&ctx, &opts.state).await?;
+    let node = InMemoryNode::start(&ctx, &opts.state).await?;
+    let controller = node.create_controller().await?;
 
     match cmd.subcommand {
         SubscriptionSubcommand::Show {


### PR DESCRIPTION
The code dropping the `InMemoryNode` has possibly disappeared during a rebase or one of the later refactorings to try to slim down some code. In particular the `InMemoryNode::create_controller` function would not allow to use a `Drop` instance for the `InMemoryNode` since it does not return one.

This PR:

 - adds a `Drop` instance for the `InMemoryNode` deleting its `NodeManager` when the `InMemoryNode` is used in a command
 - moves the `create_controller` function to an instance of `InMemoryMode` so that the usage pattern in a command is

```rust
fn run_cmd(ctx: Context, opts: CommandGlobalOpts) {
    let node = InMemoryNode::start(&ctx, &opts.state).await?;
    let controller = node.create_controller().await?;
    // use the controller client
    ...

    // at the end the InMemoryNode resources are deleted
}
```
