### PR TITLE
feat(rust): support json output for tcp-outlet list

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -73,7 +73,23 @@ async fn run_impl(
         &format!("Outlets on Node {node_name}"),
         &format!("No TCP Outlets found on node {node_name}."),
     )?;
-    opts.terminal.stdout().plain(list).write_line()?;
+    let json: Vec<_> = outlets
+        .list
+        .iter()
+        .map(|outlet| {
+            Ok(serde_json::json!({
+                "alias": outlet.alias,
+                "from": outlet.worker_address()?,
+                "to": outlet.socket_addr,
+            }))
+        })
+        .flat_map(|res: Result<_, ockam_core::Error>| res.ok())
+        .collect();
+    opts.terminal
+        .stdout()
+        .plain(list)
+        .json(serde_json::json!(json))
+        .write_line()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Current behavior

`ockam tcp-outlet list` only supports plain-text output.

## Proposed changes

Add support for the global `--output json` flag value for this command.

![image](https://github.com/build-trust/ockam/assets/772507/7f2dd7be-378f-4f65-8fda-2771842216df)

Note: if `outlet.worker_address()` does not (reasonably) return an error, I can simply the map closure.

Fixes #6343

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.
