### PR TITLE
Use the random_name function on the space_name argument of the space …

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -295,3 +295,4 @@ yes,jltorresm,Jose Torres,<jose.torres.tm@gmail.com>
 yes,Chandram-Dutta,Chandram Dutta,<chandramdutta2004@gmail.com>
 yes,volcov,Bruno Volcov,<volcov.bruno@gmail.com>
 yes,racnan,Rachit,<rachitdev45@gmail.com> <81706961+racnan@users.noreply.github.com>
+yes,dhruvmehtaaa,Dhruv Mehta,<dhruvmehtaalt@gmail.com>

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -8,6 +8,7 @@ use crate::util::{is_enrolled_guard, node_rpc};
 use crate::{docs, CommandGlobalOpts};
 use colorful::Colorful;
 use ockam_api::cli_state::{SpaceConfig, StateDirTrait};
+use ockam_api::cli_state::random_name;
 
 use ockam_api::nodes::InMemoryNode;
 
@@ -22,8 +23,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt"
 )]
 pub struct CreateCommand {
     /// Name of the space - must be unique across all Ockam Orchestrator users.
-    #[arg(display_order = 1001, value_name = "SPACE_NAME", default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true, value_parser = validate_space_name)]
-    pub name: String,
+    #[arg(display_order = 1001, value_name = "SPACE_NAME", default_value_t = hex::encode(&random::<[u8;4]>()), hide_default_value = true, value_parser = validate_space_name)] 
+    pub name: String, 
 
     /// Administrators for this space
     #[arg(display_order = 1100, last = true)]


### PR DESCRIPTION
Fixes Issue #6380 

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The space_name argument of the ockam space create command is calling hex::encode() to generate the random name in the default_value_t attribute.

## Proposed changes

Use the random_name function on the space_name argument of the space …

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
