### PR TITLE
Renamed the vault parameter to vault_name In CreateSecureChannelListenerRequest

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -76,7 +76,7 @@ impl CreateSecureChannelResponse {
 pub struct CreateSecureChannelListenerRequest {
     #[n(1)] pub addr: String,
     #[n(2)] pub authorized_identifiers: Option<Vec<String>>,
-    #[n(3)] pub vault: Option<String>,
+    #[n(3)] pub vault_name: Option<String>,
     #[n(4)] pub identity_name: Option<String>,
 }
 
@@ -84,14 +84,14 @@ impl CreateSecureChannelListenerRequest {
     pub fn new(
         addr: &Address,
         authorized_identifiers: Option<Vec<Identifier>>,
-        vault: Option<String>,
+        vault_name: Option<String>,
         identity_name: Option<String>,
     ) -> Self {
         Self {
             addr: addr.to_string(),
             authorized_identifiers: authorized_identifiers
                 .map(|x| x.into_iter().map(|y| y.to_string()).collect()),
-            vault,
+            vault_name,
             identity_name,
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -148,7 +148,7 @@ impl NodeManagerWorker {
         let CreateSecureChannelListenerRequest {
             addr,
             authorized_identifiers,
-            vault,
+            vault_name,
             identity_name,
             ..
         } = dec.decode()?;
@@ -174,7 +174,13 @@ impl NodeManagerWorker {
         }
 
         self.node_manager
-            .create_secure_channel_listener(addr, authorized_identifiers, vault, identity_name, ctx)
+            .create_secure_channel_listener(
+                addr,
+                authorized_identifiers,
+                vault_name,
+                identity_name,
+                ctx,
+            )
             .await?;
 
         Ok(Response::ok(req))


### PR DESCRIPTION
Closes #6391 
Changed the 'vault' parameter to 'vault_name'
