### PR TITLE
docs(rust): improve documentation for `vault` argument of `credential show` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/credential/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/show.rs
@@ -15,7 +15,8 @@ pub struct ShowCommand {
     #[arg()]
     pub credential_name: String,
 
-    #[arg()]
+    /// Name of the Vault from which to retrieve the credential
+    #[arg(value_name = "VAULT_NAME")]
     pub vault: Option<String>,
 }
 


### PR DESCRIPTION
Closes #6388 
Added vault argument value name as 'VAULT_NAME' and updated the doc string.
