### PR TITLE
Changed vault argument value name to VAULT_NAME

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -93,7 +93,7 @@ pub struct CreateCommand {
     foreground: bool,
 
     /// Vault that authority will use
-    #[arg(long = "vault", value_name = "VAULT")]
+    #[arg(long = "vault", value_name = "VAULT_NAME")]
     vault: Option<String>,
 
     /// Name of the Identity that the authority will use


### PR DESCRIPTION
closes #6383 