### PR TITLE
Changed vault argument name to VAULT_NAME

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -12,7 +12,8 @@ use super::CredentialOutput;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {
-    #[arg()]
+    /// Name of the Vault from which to retrieve the credentials
+    #[arg(value_name = "VAULT_NAME")]
     pub vault: Option<String>,
 }
 


### PR DESCRIPTION
Closes #6387 
Added vault argument value name as "VAULT_NAME" and updated docs string.
