### PR TITLE
fix(rust): persist the in-memory node used by the ockam app

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app/src/app/state/mod.rs
@@ -317,7 +317,7 @@ pub(crate) async fn make_node_manager(
 
     let node_manager = InMemoryNode::new(
         &ctx,
-        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), None, true, false),
+        NodeManagerGeneralOptions::new(cli_state.clone(), NODE_NAME.to_string(), None, true, true),
         NodeManagerTransportOptions::new(listener.flow_control_id().clone(), tcp),
         NodeManagerTrustOptions::new(trust_context_config),
     )


### PR DESCRIPTION
Otherwise we get this message when sharing a service
```
"Unable to find node named ockam_app (origin: Application, kind: Internal, source location: implementations/rust/ockam/ockam_api/src/cli_state/mod.rs:93:18)"
```