### PR TITLE
feat(rust): Add JSON output to ockam identity list

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -9,6 +9,8 @@ use colorful::Colorful;
 use ockam_api::cli_state::traits::StateDirTrait;
 
 use ockam_node::Context;
+use serde::Serialize;
+use serde_json::json;
 use std::fmt::Write;
 use tokio::sync::Mutex;
 use tokio::try_join;
@@ -71,11 +73,16 @@ impl ListCommand {
             "No identities found on this system.",
         )?;
 
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal
+            .stdout()
+            .plain(list)
+            .json(json!({"identities": &identities}))
+            .write_line()?;
         Ok(())
     }
 }
 
+#[derive(Serialize)]
 pub struct IdentityListOutput {
     pub name: String,
     pub identifier: String,


### PR DESCRIPTION
## Current behavior

Currently running `ockam identity list --output json` produces an error instead of printing the list in JSON format 

## Proposed changes

Add JSON serialization to the output of `ockam identity list` so it supports `--output json`.

Closes #6122

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.
