### PR TITLE
fix(rust): Add the --identity flag to the ockam space create command...

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -3,7 +3,7 @@ use ockam::Context;
 use ockam_api::cloud::space::Spaces;
 use rand::prelude::random;
 
-use crate::util::api::{self};
+use crate::util::api::{self, CloudOpts};
 use crate::util::{is_enrolled_guard, node_rpc};
 use crate::{docs, CommandGlobalOpts};
 use colorful::Colorful;
@@ -28,6 +28,9 @@ pub struct CreateCommand {
     /// Administrators for this space
     #[arg(display_order = 1100, last = true)]
     pub admins: Vec<String>,
+
+    #[command(flatten)]
+    pub cloud_opts: CloudOpts,
 }
 
 impl CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -197,6 +197,7 @@ pub(crate) fn parse_create_secure_channel_listener_response(resp: &[u8]) -> Resu
 
 #[derive(Clone, Debug, Args)]
 pub struct CloudOpts {
+    /// Run the command as the given identity name
     #[arg(global = true, value_name = "IDENTITY_NAME", long)]
     pub identity: Option<String>,
 }


### PR DESCRIPTION
Fixes #6125

This keeps 'create' in line with the other subcommands ('delete', 'list', 'show'). The --identity flag is added via the CloudOpts struct. Also added the help text on the CloudOpts struct.

<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The `--identity` option is not available for the ockam space `create` sub-command.

```
$ockam space create -h
Create a new space

Usage: ockam space create [OPTIONS] [SPACE_NAME] [-- <ADMINS>...]

Arguments:
  [SPACE_NAME]  Name of the space - must be unique across all Ockam Orchestrator users
  [ADMINS]...   Administrators for this space

Global Options:
  -h, --help        Print help information (-h compact, --help extensive)
  -q, --quiet       Do not print any log messages
  -v, --verbose...  Increase verbosity of trace messages

```

<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

The `--identity` option is available on the space `create` sub-command.
The `--identity` option provide some help text (`Run the command as the given identity name`)
This identity  help text is now also visible when using the other space sub-commands (delete, list, show)

```
$ ockam space create -h
Create a new space

Usage: ockam space create [OPTIONS] [SPACE_NAME] [-- <ADMINS>...]

Arguments:
  [SPACE_NAME]  Name of the space - must be unique across all Ockam Orchestrator users
  [ADMINS]...   Administrators for this space

Options:
      --identity <IDENTITY_NAME>  Run the command as the given identity name

Global Options:
  -h, --help        Print help information (-h compact, --help extensive)
  -q, --quiet       Do not print any log messages
  -v, --verbose...  Increase verbosity of trace messages

```

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x ] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [ x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [ x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
