### PR TITLE
fix(rust): fix the check done in `relay create` when targeting a project

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -76,12 +76,6 @@ pub fn default_relay_at() -> MultiAddr {
 async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> miette::Result<()> {
     opts.terminal.write_line(&fmt_log!("Creating Relay...\n"))?;
 
-    if cmd.at == default_relay_at() && !opts.state.is_enrolled().unwrap_or(false) {
-        return Err(miette!(
-            "Without being enrolled, it is not possible to create a Relay in the default project in Orchestrator. \
-             To enroll please run 'ockam enroll'"));
-    }
-
     display_parse_logs(&opts);
 
     let to = get_node_name(&opts.state, &cmd.to);


### PR DESCRIPTION
Fix a bug where the `relay create` project was failing when a non-enrolled user was trying to create a relay at a project that has access to.

I've removed that check because there is no easy way to check if a user has access to a particular project that is part of a MultiAddr easily. That is, the user was invited to a project via a one time token, never got enrolled, but it still has access to the project.