### PR TITLE
fix(rust): before sending the req to delete the TCP (outlet, inlet,listener) check that the target exists

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/delete.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
+use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 
@@ -41,24 +43,38 @@ pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> miette::Result<()> {
+    let alias_name = cmd.alias.clone();
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+    let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
+
+    // Check if alias exists
+    node.ask_and_get_reply::<_, InletStatus>(
+        &ctx,
+        Request::get(format!("/node/inlet/{alias_name}")),
+    )
+    .await?
+    .found()
+    .into_diagnostic()?
+    .ok_or(miette!(
+        "There's no TCP inlet with name/alias '{}'",
+        alias_name
+    ))?;
+    // Proceed with the deletion
     if opts
         .terminal
         .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this TCP inlet?")?
     {
-        let alias = cmd.alias.clone();
-        let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-        let node_name = parse_node_name(&node_name)?;
-        let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
-        node.tell(&ctx, Request::delete(format!("/node/inlet/{alias}")))
+        node.tell(&ctx, Request::delete(format!("/node/inlet/{alias_name}")))
             .await?;
 
         opts.terminal
             .stdout()
             .plain(fmt_ok!(
-                "TCP inlet with alias {alias} on Node {node_name} has been deleted."
+                "TCP inlet with alias {alias_name} on Node {node_name} has been deleted."
             ))
-            .machine(&alias)
-            .json(serde_json::json!({ "tcp-inlet": { "alias": alias, "node": node_name } }))
+            .machine(&alias_name)
+            .json(serde_json::json!({ "tcp-inlet": { "alias": alias_name, "node": node_name } }))
             .write_line()
             .unwrap();
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,7 +1,9 @@
 use clap::Args;
 use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
+use ockam_api::nodes::models::portal::OutletStatus;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 
@@ -41,24 +43,37 @@ pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> miette::Result<()> {
+    let alias_name = cmd.alias.clone();
+    let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
+    let node_name = parse_node_name(&node_name)?;
+    let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
+    // Check if there an outlet with the provided alias/name exists
+    node.ask_and_get_reply::<_, OutletStatus>(
+        &ctx,
+        Request::get(format!("/node/outlet/{alias_name}")),
+    )
+    .await?
+    .found()
+    .into_diagnostic()?
+    .ok_or(miette!(
+        "There's no Outlet with name/alias '{}'",
+        alias_name
+    ))?;
+    // Proceed with the deletion
     if opts.terminal.confirmed_with_flag_or_prompt(
         cmd.yes,
         "Are you sure you want to delete this TCP outlet?",
     )? {
-        let alias = cmd.alias.clone();
-        let node_name = get_node_name(&opts.state, &cmd.node_opts.at_node);
-        let node_name = parse_node_name(&node_name)?;
-        let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
-        node.tell(&ctx, Request::delete(format!("/node/outlet/{alias}")))
+        node.tell(&ctx, Request::delete(format!("/node/outlet/{alias_name}")))
             .await?;
 
         opts.terminal
             .stdout()
             .plain(fmt_ok!(
-                "TCP outlet with alias {alias} on node {node_name} has been deleted."
+                "TCP outlet with alias {alias_name} on node {node_name} has been deleted."
             ))
-            .machine(&alias)
-            .json(serde_json::json!({ "tcp-outlet": { "alias": alias, "node": node_name } }))
+            .machine(&alias_name)
+            .json(serde_json::json!({ "tcp-outlet": { "alias": alias_name, "node": node_name } }))
             .write_line()
             .unwrap();
     }


### PR DESCRIPTION
Before sending the req to delete the TCP (outlet, inlet, listener) check that the target exist

I'm still unable to figure out how to send a bodyless request to `/node/tcp/listener/` to just check if there is a TCP listener with the target address or not.  I'll appreciate it if someone can help me with this.

- Closes: #6347

<!-- Thank you for sending a pull request :heart: -->

## Current behavior
When a user runs `ockam tcp-outlet delete <ALIAS>` or `ockam tcp-inlet delete <ALIAS>` or `ockam tcp-listners delete <ALIAS>`  and ``<ALIAS>`` does not exist, then they get a prompt, asking them to confirm whether this command should proceed or not. Then they are shown an error stating that 404 NotFound.
 
## Proposed changes
- When the user tries to delete one (instance) of mentioned (resources) then send an `get` request to checks if the target are exist in the first place
- If not, then mention this in an error message and exit.
- If the target was exist then process the delete operation as normal

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. done via: build-trust/ockam-contributors/pull/266

<!-- We're looking forward to merging your contribution!! -->
