### PR TITLE
refactor(rust): drop dependency on termcolor for ockam_command crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,7 +4845,6 @@ dependencies = [
  "strip-ansi-escapes",
  "syntect",
  "tempfile",
- "termcolor",
  "termimad",
  "thiserror",
  "time",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -100,7 +100,6 @@ serde_json = "1"
 serde_yaml = "0.9"
 strip-ansi-escapes = "0.2.0"
 syntect = "5"
-termcolor = "1.3.0"
 termimad = "0.25"
 thiserror = "1"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -2,7 +2,6 @@ use crate::terminal::TerminalBackground;
 use colorful::Colorful;
 use ockam_core::env::get_env_with_default;
 use once_cell::sync::Lazy;
-use std::io::{Read, Write};
 use syntect::highlighting::Theme;
 use syntect::{
     easy::HighlightLines,
@@ -11,7 +10,6 @@ use syntect::{
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},
 };
-use termcolor::WriteColor;
 
 const FOOTER: &str = "
 Learn More:
@@ -159,20 +157,6 @@ impl FencedCodeBlockHighlighter<'_> {
             false
         }
     }
-}
-
-#[allow(unused)]
-fn to_bold_and_underline(mut b: String, s: &str) -> String {
-    let mut buffer = termcolor::Buffer::ansi();
-    let mut color = termcolor::ColorSpec::new();
-    color.set_bold(true);
-    color.set_underline(true);
-    let err_msg = "Failed to create styled text";
-    buffer.set_color(&color).expect(err_msg);
-    buffer.write_all(s.as_bytes()).expect(err_msg);
-    buffer.reset().expect(err_msg);
-    buffer.as_slice().read_to_string(&mut b).expect(err_msg);
-    b
 }
 
 const PREVIEW_TOOLTIP_TEXT: &str = include_str!("./static/preview_tooltip.txt");


### PR DESCRIPTION
Remove dep `termcolor` since we are not using it. Also remove unused function that was calling a function from this crate.