### PR TITLE
fix(rust): Abort on ockam enroll --output json

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -25,6 +25,7 @@ use ockam_api::nodes::InMemoryNode;
 use crate::enroll::OidcServiceExt;
 use crate::identity::initialize_identity_if_default;
 use crate::operation::util::check_for_completion;
+use crate::output::OutputFormat;
 use crate::project::util::check_project_readiness;
 use crate::terminal::OckamColor;
 use crate::util::node_rpc;
@@ -57,6 +58,12 @@ impl EnrollCommand {
 }
 
 async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, EnrollCommand)) -> miette::Result<()> {
+    if opts.global_args.output_format == OutputFormat::Json {
+        return Err(miette::miette!(
+            "The flag --output json is invalid for this command."
+        ));
+    }
+
     run_impl(&ctx, opts, cmd).await
 }
 


### PR DESCRIPTION


<!-- Thank you for sending a pull request :heart: -->

## Current behavior

When you run ockam enroll --output json whether you have enrolled (using ockam enroll) or not, it looks like the following screenshot.

-  It does not show a one-time code
-  But it spawns a local browser
-  Since no code is shown there is no way to type in the correct code in the browser

## Proposed changes

Add an early exit to the command `ockam enroll` when used with the `--output json` flag as it's not admitted in this command.

Close #6119

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
