### PR TITLE
fix(rust): increase timeout rust test

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -110,7 +110,7 @@ mod test {
     }
 
     #[allow(non_snake_case)]
-    #[ockam_macros::test(timeout = 5_000)]
+    #[ockam_macros::test(timeout = 60_000)]
     async fn producer__flow_with_mock_kafka__content_encryption_and_decryption(
         context: &mut Context,
     ) -> ockam::Result<()> {


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior
rust test timeout = 5s
<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->

## Proposed changes
rust test timeout = 1min
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
