### PR TITLE
add rust cache composite action

### DIFF
--- a/.github/actions/cache_rust/action.yml
+++ b/.github/actions/cache_rust/action.yml
@@ -1,0 +1,16 @@
+name: Rust Cache
+description: Rust Cache
+
+inputs:
+  job_name:
+    description: Extra key to use for restoring and saving the cache
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
+      with:
+        prefix-key: ${{ inputs.job_name }}
+        # Only save if the workflow is running on the develop branch (cron job)
+        save-if: ${{ github.event_name == 'schedule' }}

--- a/.github/actions/cache_rust/action.yml
+++ b/.github/actions/cache_rust/action.yml
@@ -5,6 +5,9 @@ inputs:
   job_name:
     description: Extra key to use for restoring and saving the cache
     required: true
+  directory_to_cache:
+    description: Directory to cache
+    required: false
 
 runs:
   using: composite
@@ -14,3 +17,4 @@ runs:
         prefix-key: ${{ inputs.job_name }}
         # Only save if the workflow is running on the develop branch (cron job)
         save-if: ${{ github.event_name == 'schedule' }}
+        workspaces: "${{ inputs.directory_to_cache != '' && format('{0} -> target', inputs.directory_to_cache) || '' }}"


### PR DESCRIPTION
Add a composite action that only save rust dependency if it's run as a cron job so that we do not exceed github cache storage limit