### PR TITLE
fix(rust): fixes several papercuts in swift ockam app implementation

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/api/mock_data.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/mock_data.rs
@@ -1,3 +1,4 @@
+use crate::api::state::rust::Invitee;
 use crate::api::state::{c, convert_to_c, rust, OrchestratorStatus};
 
 /// This function serves to create a mock application state for the UI.
@@ -89,6 +90,16 @@ extern "C" fn mock_application_state() -> c::ApplicationState {
                         enabled: false,
                     },
                 ],
+            },
+        ],
+        sent_invitations: vec![
+            Invitee {
+                name: Some("Adrian Benavides".into()),
+                email: "adrian@ockam.io".into(),
+            },
+            Invitee {
+                name: None,
+                email: "eric.torreborre@ockam.io".into(),
             },
         ],
     };

--- a/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
@@ -137,6 +137,7 @@ pub mod rust {
         pub enrollment_github_user: Option<String>,
         pub local_services: Vec<LocalService>,
         pub groups: Vec<ServiceGroup>,
+        pub sent_invitations: Vec<Invitee>,
     }
 
     #[derive(Clone)]
@@ -229,6 +230,7 @@ pub mod c {
 
         pub(super) local_services: *const *const LocalService,
         pub(super) groups: *const *const ServiceGroup,
+        pub(super) sent_invitations: *const *const Invitee,
     }
 }
 
@@ -326,5 +328,12 @@ pub(crate) fn convert_to_c(state: rust::ApplicationState) -> c::ApplicationState
         ),
 
         groups: append_c_terminator(state.groups.into_iter().map(group_to_c).collect::<Vec<_>>()),
+        sent_invitations: append_c_terminator(
+            state
+                .sent_invitations
+                .into_iter()
+                .map(invitee_to_c)
+                .collect::<Vec<_>>(),
+        ),
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -348,6 +348,7 @@ impl AppState {
         let enrollment_github_user;
         let mut local_services: Vec<LocalService>;
         let mut groups: Vec<ServiceGroup>;
+        let mut sent_invitations: Vec<Invitee>;
         let invitation_state = self.invitations().read().await.clone();
 
         // we want to sort everything to avoid having to deal with ordering in the UI
@@ -361,27 +362,23 @@ impl AppState {
                     address: outlet.socket_addr.ip().to_string(),
                     port: outlet.socket_addr.port(),
                     scheme: None,
-                    shared_with: {
-                        let mut shared_with: Vec<Invitee> = invitation_state
-                            .sent
-                            .iter()
-                            .filter(|invitation| {
-                                invitation.target_id == *outlet.worker_addr.address()
-                            })
-                            .map(|invitation| Invitee {
-                                name: Some(invitation.recipient_email.clone()),
-                                email: invitation.recipient_email.clone(),
-                            })
-                            .collect();
-                        shared_with.sort();
-                        shared_with
-                    },
+                    shared_with: vec![],
                     available: true,
                 })
                 .collect();
 
             local_services.sort();
             let mut group_names = Vec::new();
+
+            sent_invitations = invitation_state
+                .sent
+                .iter()
+                .map(|invitation| Invitee {
+                    name: Some(invitation.recipient_email.clone()),
+                    email: invitation.recipient_email.clone(),
+                })
+                .collect();
+            sent_invitations.sort();
 
             invitation_state
                 .accepted
@@ -492,6 +489,7 @@ impl AppState {
             enrollment_github_user = None;
             local_services = vec![];
             groups = vec![];
+            sent_invitations = vec![];
         }
 
         Ok(api::state::rust::ApplicationState {
@@ -503,6 +501,7 @@ impl AppState {
             enrollment_github_user,
             local_services,
             groups,
+            sent_invitations,
         })
     }
 }

--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		782D5BAC2AC33EAD00D1B27F /* Bridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 782D5BAB2AC33EAD00D1B27F /* Bridge.h */; };
 		782D5BAF2AC33F9400D1B27F /* libockam_app_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 782D5B792AC1E36700D1B27F /* libockam_app_lib.a */; };
 		783B62722AC432B700880261 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783B62712AC432B700880261 /* Bridge.swift */; };
+		78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D520822ADD5CAE00F36B64 /* Helpers.swift */; };
 		78ED0DA12AD4354400574AE9 /* CreateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA02AD4354400574AE9 /* CreateService.swift */; };
 		78ED0DA32AD4501200574AE9 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA22AD4501200574AE9 /* ShareService.swift */; };
 		78F5F3042AD4127C00B8D18E /* EmailInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F5F3032AD4127C00B8D18E /* EmailInput.swift */; };
@@ -39,6 +40,7 @@
 		782D5BAD2AC33F7B00D1B27F /* libockam_app_lib.d */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.dtrace; name = libockam_app_lib.d; path = ../../../../target/debug/libockam_app_lib.d; sourceTree = "<group>"; };
 		783B62712AC432B700880261 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
 		785D8D372AD5369100DF5004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		78D520822ADD5CAE00F36B64 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		78ED0DA02AD4354400574AE9 /* CreateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateService.swift; sourceTree = "<group>"; };
 		78ED0DA22AD4501200574AE9 /* ShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
 		78F5F3032AD4127C00B8D18E /* EmailInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailInput.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 				78ED0DA22AD4501200574AE9 /* ShareService.swift */,
 				7827D5062AD93EE700F7A20F /* ProfilePicture.swift */,
 				7827D5082AD93F1700F7A20F /* ClickableMenuEntry.swift */,
+				78D520822ADD5CAE00F36B64 /* Helpers.swift */,
 			);
 			path = Ockam;
 			sourceTree = "<group>";
@@ -190,6 +193,7 @@
 				7827D5092AD93F1700F7A20F /* ClickableMenuEntry.swift in Sources */,
 				782D5B4B2AC1D3D700D1B27F /* MainView.swift in Sources */,
 				78ED0DA12AD4354400574AE9 /* CreateService.swift in Sources */,
+				78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */,
 				78F5F3042AD4127C00B8D18E /* EmailInput.swift in Sources */,
 				781D00042AD05D26009848FE /* Services.swift in Sources */,
 				7827D5072AD93EE700F7A20F /* ProfilePicture.swift in Sources */,

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
@@ -107,6 +107,7 @@ typedef struct C_ApplicationState {
   const char *enrollment_github_user;
   const struct C_LocalService *const *local_services;
   const struct C_ServiceGroup *const *groups;
+  const struct C_Invitee *const *sent_invitations;
 } C_ApplicationState;
 
 typedef struct C_Notification {

--- a/implementations/swift/ockam/ockam_app/Ockam/ClickableMenuEntry.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/ClickableMenuEntry.swift
@@ -6,8 +6,10 @@ struct ClickableMenuEntry: View {
     @State private var isHovered = false
 
     @State var text: String
+    @State var clicked: String = ""
     @State var icon: String = ""
     @State var action: (() -> Void)? = nil
+    @State var isDown = false
 
     var body: some View {
         HStack {
@@ -15,7 +17,7 @@ struct ClickableMenuEntry: View {
                 Image(systemName: icon)
                     .frame(minWidth: 16, maxWidth: 16)
             }
-            Text(verbatim: text)
+            Text(verbatim: isDown ? (clicked.isEmpty ? text : clicked) : text)
             Spacer()
         }
         .padding(.horizontal, 8)
@@ -24,13 +26,21 @@ struct ClickableMenuEntry: View {
         .buttonStyle(PlainButtonStyle())
         .cornerRadius(4)
         .contentShape(Rectangle())
+        .modifier(PressActions(
+            onPress: {
+                isDown = true
+            },
+            onRelease: {
+                if isDown {
+                    isDown = false
+                    if let action = action {
+                        action()
+                    }
+                }
+            }
+        ))
         .onHover { hover in
             isHovered = hover
-        }
-        .onTapGesture {
-            if let action = action {
-                action()
-            }
         }
     }
 }

--- a/implementations/swift/ockam/ockam_app/Ockam/CreateService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/CreateService.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 struct CreateServiceView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @FocusState private var isFocused: Bool
 
     @State var isProcessing = false
     @State var errorMessage = ""
     @State var serviceName = ""
     @State var serviceAddress = "localhost:10000"
     @State var emails = Set<String>()
-    @State var share = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -19,6 +19,10 @@ struct CreateServiceView: View {
                         Text(verbatim: "Name of the service you want to share").font(.caption)
                     }
                     TextField("Name", text: $serviceName)
+                        .focused($isFocused)
+                        .onAppear(perform: {
+                            isFocused = true
+                        })
                 }
                 GridRow{
                     VStack(alignment: .leading) {
@@ -32,13 +36,10 @@ struct CreateServiceView: View {
                         Text(verbatim: "Share")
                         Text(verbatim: "Optionally, send an invitation to share this service").font(.caption)
                     }
-
-                    Toggle(isOn: $share) {
-                    }.toggleStyle(SwitchToggleStyle())
                 }
             }
 
-            EmailListView(emailList: $emails).disabled(!self.share)
+            EmailListView(emailList: $emails)
 
             //use opacity to pre-allocate the space for this component
             Text("Error: \(errorMessage)")
@@ -55,11 +56,7 @@ struct CreateServiceView: View {
                 Button(action: {
                     let emails: String;
 
-                    if self.share {
-                        emails = Array(self.emails).joined(separator: ";")
-                    } else {
-                        emails = ""
-                    }
+                    emails = Array(self.emails).joined(separator: ";")
                     self.errorMessage = ""
 
                     isProcessing = true
@@ -74,14 +71,13 @@ struct CreateServiceView: View {
                         self.errorMessage = ""
                         self.serviceName = ""
                         self.emails = Set<String>()
-                        self.share = false
                         self.serviceAddress = "localhost:10000"
                         self.closeWindow()
                     } else {
                         self.errorMessage = String(cString: error.unsafelyUnwrapped)
                     }
                 }, label: {
-                    Text("Create")
+                    Text("Create and Share")
                 })
                 .disabled(!canCreateService() && !isProcessing)
             }

--- a/implementations/swift/ockam/ockam_app/Ockam/EmailInput.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/EmailInput.swift
@@ -10,7 +10,7 @@ struct EmailListView: View {
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
-                TextField("Enter email", text: $emailInput)
+                TextField("Type an email address, then press Enter to add it", text: $emailInput)
                     .onSubmit {
                         if validateEmail(email: self.emailInput) {
                             self.emailList.insert(self.emailInput)

--- a/implementations/swift/ockam/ockam_app/Ockam/Helpers.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Helpers.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+// Helper modifier to intercept the 'mouse down' event
+struct PressActions: ViewModifier {
+    var onPress: () -> Void
+    var onRelease: () -> Void
+    func body(content: Content) -> some View {
+        content
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged({ _ in
+                        onPress()
+                    })
+                    .onEnded({ _ in
+                        onRelease()
+                    })
+            )
+    }
+}
+
+// Helper function to move the application windows to the front
+func bringInFront() {
+    NSApplication.shared.activate(ignoringOtherApps: true)
+}
+
+// Helper function to copy the text into the clipboard
+func copyToClipboard(_ text: String) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.declareTypes([.string], owner: nil)
+    pasteboard.setString(text, forType: .string)
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -69,6 +69,13 @@ struct MainView: View {
             }
 
             if state.enrolled {
+                if !state.sent_invitations.isEmpty {
+                    Group {
+                        Divider()
+                        SentInvitations(state: self.state)
+                    }
+                }
+
                 Group {
                     Divider()
                     Text("Your services")

--- a/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
@@ -22,11 +22,12 @@ class StateContainer {
         enrollmentImage: nil,
         enrollmentGithubUser: nil,
         localServices: [],
-        groups: []
+        groups: [],
+        sent_invitations: []
     )
 
     func update(state: ApplicationState) {
-        print("update: \(state)")
+        debugPrint("update: ", state)
         self.state = state
         if let callback = self.callback {
             callback(state)
@@ -38,18 +39,6 @@ class StateContainer {
         self.callback = callback
         callback(state)
     }
-}
-
-// Helper function to move the application windows to the front
-func bringInFront() {
-    NSApplication.shared.activate(ignoringOtherApps: true)
-}
-
-// Helper function to copy the text into the clipboard
-func copyToClipboard(_ text: String) {
-    let pasteboard = NSPasteboard.general
-    pasteboard.declareTypes([.string], owner: nil)
-    pasteboard.setString(text, forType: .string)
 }
 
 @main
@@ -90,8 +79,8 @@ struct OckamApp: App {
         Window("Create a service", id: "create-service") {
             CreateServiceView()
         }
-        .commandsRemoved()
         .windowResizability(.contentSize)
+        .commandsRemoved()
 
         // Declare a "template" of windows, dependent on the LocalService.ID, not open by default
         WindowGroup("Share a service", id: "share-service", for: LocalService.ID.self) { $localServiceId in


### PR DESCRIPTION
Fixes:

- missing sent_invites (i kept the `shared_with` field within local services since we'll be likely to use them in a week or two)
- proper debug log of the status update
- showing feedback when clicking on "copy" by changing button text in "copied!" and by closing the window
- removed "share" toggle in the create service and added a better explanation for the email field
- grouped helper functions in a `Helper.swift`
- limited titles to 1 line to avoid graphical glitches