### PR TITLE
renamed nix_installer_and_cache to cache_nix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Install Nix
-        uses: ./.github/actions/nix_installer_and_cache
+        uses: ./.github/actions/cache_nix
         with:
           cache-unique-id: ${{ matrix.lint_projects }}
         id: nix-installer
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Install Nix
-        uses: ./.github/actions/nix_installer_and_cache
+        uses: ./.github/actions/cache_nix
         with:
           cache-unique-id: ${{ matrix.build_projects }}
         id: nix-installer
@@ -156,7 +156,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Install Nix
-        uses: ./.github/actions/nix_installer_and_cache
+        uses: ./.github/actions/cache_nix
         with:
           cache-unique-id: ${{ matrix.test_projects }}
         id: nix-installer
@@ -197,7 +197,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Install Nix
-        uses: ./.github/actions/nix_installer_and_cache
+        uses: ./.github/actions/cache_nix
         with:
           cache-unique-id: ${{ matrix.check_projects }}
         id: nix-installer
@@ -245,7 +245,7 @@ jobs:
           workspaces: "ockam_cli -> target"
 
       - name: Install Nix
-        uses: ./ockam_bats/.github/actions/nix_installer_and_cache
+        uses: ./ockam_bats/.github/actions/cache_nix
         with:
           cache-unique-id: test_ockam_command
         id: nix-installer
@@ -348,7 +348,7 @@ jobs:
           path: ockam_library
 
       - name: Install Nix
-        uses: ./ockam_library/.github/actions/nix_installer_and_cache
+        uses: ./ockam_library/.github/actions/cache_nix
         with:
           cache-unique-id: test_docs_rust_library_examples
         id: nix-installer
@@ -389,7 +389,7 @@ jobs:
           path: ockam-documentation
 
       - name: Install Nix
-        uses: ./ockam/.github/actions/nix_installer_and_cache
+        uses: ./ockam/.github/actions/cache_nix
         with:
           cache-unique-id: lint_docs_ockam_io_rust_examples
         id: nix-installer


### PR DESCRIPTION
Renaming Rust Workflow to Use "cache_nix" Composite Action

#6552 

## Current behavior
[rust workflow](https://github.com/build-trust/ockam/blob/develop/.github/workflows/rust.yml)  uses the old action which is in the directory .github/actions/nix_installer_and_cache 

## Proposed changes
Renamed the [rust workflow](https://github.com/build-trust/ockam/blob/develop/.github/workflows/rust.yml) that uses the old action which is in the directory .github/actions/nix_installer_and_cache to use the new action in directory ./.github/actions/cache_nix

## Checks


- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

