### PR TITLE
feat(elixir): bump tokio version on nif

### DIFF
--- a/implementations/elixir/ockam/ockly/native/ockly/Cargo.lock
+++ b/implementations/elixir/ockam/ockly/native/ockly/Cargo.lock
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7974062fdff17dbf4bcc0e2eb9939a056ab7aa393287422b33b965bb3281176a"
+checksum = "66c57e06dbdb216b03ff6045a2b19eef081d1bc1cbffe5bd684d2333d0ac22ae"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_core"
-version = "0.86.0"
+version = "0.88.0"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_executor"
-version = "0.54.0"
+version = "0.56.0"
 dependencies = [
  "crossbeam-queue",
  "futures",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_identity"
-version = "0.83.0"
+version = "0.85.0"
 dependencies = [
  "arrayref",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_node"
-version = "0.91.0"
+version = "0.93.0"
 dependencies = [
  "cfg-if",
  "fs2",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_transport_core"
-version = "0.59.0"
+version = "0.61.0"
 dependencies = [
  "ockam_core",
  "tracing",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault"
-version = "0.84.0"
+version = "0.86.0"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_vault_aws"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",
@@ -2124,9 +2124,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",

--- a/implementations/elixir/ockam/ockly/native/ockly/Cargo.toml
+++ b/implementations/elixir/ockam/ockly/native/ockly/Cargo.toml
@@ -20,4 +20,4 @@ ockam_vault = { path = "../../../../../rust/ockam/ockam_vault" }
 ockam_vault_aws = { path = "../../../../../rust/ockam/ockam_vault_aws" }
 # Enable credentials-sso feature in ockam_vault_aws for use on sso environments (like dev machines)
 rustler = "0.29.1"
-tokio = "1.31.0"
+tokio = "1.33.0"


### PR DESCRIPTION
update tokio to 1.33.0 on the NIF code. Required as it was done on the underling ockam libraries the nif depends on.
