### PR TITLE
Fix: tcp-listener create command using Terminal to output

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -1,16 +1,18 @@
+use crate::util::{node_rpc, parse_node_name};
+use crate::{docs, fmt_log, CommandGlobalOpts};
+use crate::{
+    fmt_ok,
+    node::{get_node_name, initialize_node_if_default},
+};
 use clap::Args;
+use colorful::Colorful;
 use miette::IntoDiagnostic;
-
 use ockam_api::nodes::models::transport::{CreateTcpListener, TransportStatus};
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 use ockam_multiaddr::proto::{DnsAddr, Tcp};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
-
-use crate::node::{get_node_name, initialize_node_if_default};
-use crate::util::{node_rpc, parse_node_name};
-use crate::{docs, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -54,7 +56,14 @@ async fn run_impl(
         .push_back(DnsAddr::new("localhost"))
         .into_diagnostic()?;
     multiaddr.push_back(Tcp::new(port)).into_diagnostic()?;
-    println!("Tcp listener created! You can send messages to it via this route:\n`{multiaddr}`");
+
+    opts.terminal
+        .stdout()
+        .plain(
+            fmt_ok!("Tcp listener created! You can send messages to it via this route:\n")
+                + &fmt_log!("{multiaddr}"),
+        )
+        .write_line()?;
 
     Ok(())
 }


### PR DESCRIPTION
### Adding Terminal Struct for Output

Fixes #6570 

## Current behavior

The tcp-listener create command is using println to print the command's output, which is a strategy that is being deprecated.

## Proposed changes

Instead, the Terminal struct should be used to handle the output of every command.

## Checks


- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
