### PR TITLE
increase cron job time for better caching

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,8 +36,12 @@ on:
     branches:
       - develop
   schedule:
-    # At 1 am.
-    - cron: "0 1 * * *"
+    # We only save cache when a cron job is started, this is to ensure
+    # that we don't save cache on every push causing excessive caching
+    # and github deleting useful caches we use in our workflows, we now
+    # run a cron job every 2 hours so as to update the cache store with the
+    # latest data so that we don't have stale cache.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -19,8 +19,12 @@ on:
     branches:
       - develop
   schedule:
-    # At 1 am.
-    - cron: '0 1 * * *'
+    # We only save cache when a cron job is started, this is to ensure
+    # that we don't save cache on every push causing excessive caching
+    # and github deleting useful caches we use in our workflows, we now
+    # run a cron job every 2 hours so as to update the cache store with the
+    # latest data so that we don't have stale cache.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,8 +28,12 @@ on:
     branches:
       - develop
   schedule:
-    # At 1 am.
-    - cron: "0 1 * * *"
+    # We only save cache when a cron job is started, this is to ensure
+    # that we don't save cache on every push causing excessive caching
+    # and github deleting useful caches we use in our workflows, we now
+    # run a cron job every 2 hours so as to update the cache store with the
+    # latest data so that we don't have stale cache.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -18,6 +18,13 @@ on:
       - "**.bash"
     branches:
       - develop
+  schedule:
+    # We only save cache when a cron job is started, this is to ensure
+    # that we don't save cache on every push causing excessive caching
+    # and github deleting useful caches we use in our workflows, we now
+    # run a cron job every 2 hours so as to update the cache store with the
+    # latest data so that we don't have stale cache.
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:


### PR DESCRIPTION
We now only cache data when workflows run as a cron job, this ensures that we only cache from the default branch and that we are not over-caching (which causes github to delete our relevant caches), this PR ensures that we run the cron-job (which uploads caches) every two hours so that we are using latest cache data across all workflows