### PR TITLE
Improves macOS Swift Application responsiveness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4960,6 +4960,7 @@ version = "0.1.0"
 dependencies = [
  "cbindgen",
  "duct",
+ "futures 0.3.28",
  "hex",
  "libc",
  "miette",

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/invitation.rs
@@ -89,7 +89,7 @@ impl PartialEq for InvitationWithAccess {
 
 impl Eq for InvitationWithAccess {}
 
-#[derive(Clone, Debug, Decode, Encode, Deserialize, Serialize)]
+#[derive(Clone, Debug, Decode, Encode, Deserialize, Serialize, PartialEq)]
 #[cbor(map)]
 #[rustfmt::skip]
 pub struct ReceivedInvitation {
@@ -107,7 +107,7 @@ impl ReceivedInvitation {
     }
 }
 
-#[derive(Clone, Debug, Decode, Encode, Deserialize, Serialize)]
+#[derive(Clone, Debug, Decode, Encode, Deserialize, Serialize, PartialEq)]
 #[cbor(map)]
 #[rustfmt::skip]
 pub struct SentInvitation {

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 duct = "0.13.6"
+futures = { version = "0.3.28", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 libc = "0.2"
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }

--- a/implementations/rust/ockam/ockam_app_lib/src/api/functions.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/functions.rs
@@ -90,12 +90,14 @@ extern "C" fn accept_invitation(id: *const c_char) {
     });
 }
 
-/// Initiate and wait for graceful shutdown of the application.
+/// Initiate graceful shutdown of the application, exit process when complete.
 #[no_mangle]
 extern "C" fn shutdown_application() {
     let app_state = unsafe { APPLICATION_STATE.take() };
     if let Some(app_state) = app_state {
         app_state.shutdown();
+    } else {
+        std::process::exit(0);
     }
 }
 

--- a/implementations/rust/ockam/ockam_app_lib/src/api/mock_data.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/mock_data.rs
@@ -38,6 +38,18 @@ extern "C" fn mock_application_state() -> c::ApplicationState {
         ],
         groups: vec![
             rust::ServiceGroup {
+                email: "mrinal@ockam.io".to_string(),
+                name: Some("Mrinal Wadhwa".into()),
+                image_url: Some("https://avatars.githubusercontent.com/u/159583?v=4".into()),
+                invitations: vec![rust::Invitation {
+                    id: "5373".into(),
+                    service_name: "New Concept".into(),
+                    service_scheme: Some("http".into()),
+                    accepting: false,
+                }],
+                incoming_services: vec![],
+            },
+            rust::ServiceGroup {
                 name: Some("Adrian Benavides".into()),
                 email: "adrian@ockam.io".into(),
                 image_url: Some("https://avatars.githubusercontent.com/u/12375782?v=4".into()),

--- a/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
@@ -6,7 +6,7 @@
 //! When the rust structure needs to be send to the C API, it is converted to the C structure
 //! through the `convert_to_c` function.
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[repr(C)]
 pub enum OrchestratorStatus {
     #[default]
@@ -127,7 +127,7 @@ pub mod rust {
         }
     }
 
-    #[derive(Default, Clone, Debug)]
+    #[derive(Default, Clone, Debug, PartialEq)]
     pub struct ApplicationState {
         pub enrolled: bool,
         pub orchestrator_status: OrchestratorStatus,

--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -1,6 +1,7 @@
 use crate::cli::cli_bin;
 use crate::error::Error;
 use crate::Result;
+use ockam::compat::tokio::task::spawn_blocking;
 use ockam_api::nodes::models::portal::InletStatus;
 use ockam_core::async_trait;
 use std::net::SocketAddr;
@@ -85,37 +86,42 @@ impl BackgroundNodeClient for Cli {
 #[async_trait]
 impl Nodes for Cli {
     async fn create(&mut self, node_name: &str) -> Result<()> {
-        duct::cmd!(
-            &self.bin,
-            "--no-input",
-            "node",
-            "create",
-            node_name,
-            "--trust-context",
-            node_name
-        )
-        .before_spawn(log_command)
-        .stderr_null()
-        .stdout_capture()
-        .run()?;
-        debug!(node = %node_name, "Node created");
+        let bin = self.bin.clone();
+        let node_name = node_name.to_string();
+        spawn_blocking(move || {
+            let _ = duct::cmd!(
+                &bin,
+                "--no-input",
+                "node",
+                "create",
+                &node_name,
+                "--trust-context",
+                &node_name
+            )
+            .before_spawn(log_command)
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            .map(|_| debug!(node = %node_name, "Node created"));
+        })
+        .await?;
+
         Ok(())
     }
 
     async fn delete(&mut self, node_name: &str) -> Result<()> {
         debug!(node = %node_name, "Deleting node");
-        let _ = duct::cmd!(
-            &self.bin,
-            "--no-input",
-            "node",
-            "delete",
-            "--yes",
-            node_name
-        )
-        .before_spawn(log_command)
-        .stderr_null()
-        .stdout_capture()
-        .run();
+        let bin = self.bin.clone();
+        let node_name = node_name.to_string();
+        spawn_blocking(move || {
+            let _ = duct::cmd!(&bin, "--no-input", "node", "delete", "--yes", &node_name)
+                .before_spawn(log_command)
+                .stderr_null()
+                .stdout_capture()
+                .run();
+        })
+        .await?;
+
         Ok(())
     }
 }
@@ -130,133 +136,171 @@ impl Inlets for Cli {
         service_name: &str,
     ) -> Result<()> {
         let from_str = from.to_string();
-        duct::cmd!(
-            &self.bin,
-            "--no-input",
-            "tcp-inlet",
-            "create",
-            "--at",
-            node_name,
-            "--from",
-            &from_str,
-            "--to",
-            service_route,
-            "--alias",
-            service_name,
-            "--retry-wait",
-            "0",
-        )
-        .before_spawn(log_command)
-        .stderr_null()
-        .stdout_capture()
-        .run()?;
-        info!(
-            from = from_str,
-            to = service_route,
-            "Created TCP inlet for accepted invitation"
-        );
-        Ok(())
+        let bin = self.bin.clone();
+        let node_name = node_name.to_string();
+        let service_route = service_route.to_string();
+        let service_name = service_name.to_string();
+        spawn_blocking(move || {
+            duct::cmd!(
+                &bin,
+                "--no-input",
+                "tcp-inlet",
+                "create",
+                "--at",
+                &node_name,
+                "--from",
+                &from_str,
+                "--to",
+                &service_route,
+                "--alias",
+                &service_name,
+                "--retry-wait",
+                "0",
+            )
+            .before_spawn(log_command)
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            .map(|_| {
+                info!(
+                    from = from_str,
+                    to = service_route,
+                    "Created TCP inlet for accepted invitation"
+                );
+            })
+        })
+        .await?
+        .map_err(|err| err.into())
     }
 
     async fn show(&self, node_name: &str, inlet_name: &str) -> Result<InletStatus> {
         debug!(node = %node_name, "Checking TCP inlet status");
-        match duct::cmd!(
-            &self.bin,
-            "--no-input",
-            "tcp-inlet",
-            "show",
-            inlet_name,
-            "--at",
-            node_name,
-            "--output",
-            "json"
-        )
-        .before_spawn(log_command)
-        .env("OCKAM_LOG", "off")
-        .stderr_null()
-        .stdout_capture()
-        .run()
-        {
-            Ok(cmd) => {
-                trace!(output = ?String::from_utf8_lossy(&cmd.stdout), "TCP inlet status");
-                let inlet: InletStatus = serde_json::from_slice(&cmd.stdout)?;
-                debug!(
-                    at = ?inlet.bind_addr,
-                    alias = inlet.alias,
-                    "TCP inlet running"
-                );
-                Ok(inlet)
+        let inlet_name = inlet_name.to_string();
+        let node_name = node_name.to_string();
+        let bin = self.bin.clone();
+        spawn_blocking(move || {
+            match duct::cmd!(
+                &bin,
+                "--no-input",
+                "tcp-inlet",
+                "show",
+                &inlet_name,
+                "--at",
+                &node_name,
+                "--output",
+                "json"
+            )
+            .before_spawn(log_command)
+            .env("OCKAM_LOG", "off")
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            {
+                Ok(cmd) => {
+                    trace!(output = ?String::from_utf8_lossy(&cmd.stdout), "TCP inlet status");
+                    let inlet: InletStatus = serde_json::from_slice(&cmd.stdout)?;
+                    debug!(
+                        at = ?inlet.bind_addr,
+                        alias = inlet.alias,
+                        "TCP inlet running"
+                    );
+                    Ok(inlet)
+                }
+                Err(_) => Err(Error::App(format!(
+                    "TCP inlet {} is not running",
+                    inlet_name
+                ))),
             }
-            Err(_) => Err(Error::App(format!(
-                "TCP inlet {} is not running",
-                inlet_name
-            ))),
-        }
+        })
+        .await?
     }
 
     async fn delete(&mut self, node_name: &str, alias: &str) -> Result<()> {
         debug!(node = %node_name, %alias, "Deleting TCP inlet");
-        let _ = duct::cmd!(
-            &cli_bin()?,
-            "--no-input",
-            "tcp-inlet",
-            "delete",
-            alias,
-            "--at",
-            node_name,
-            "--yes"
-        )
-        .before_spawn(log_command)
-        .stderr_null()
-        .stdout_capture()
-        .run()
-        .map_err(|e| warn!(%e, node = %node_name, alias = %alias, "Failed to delete TCP inlet"));
-        info!(
-            node = %node_name, alias = %alias,
-            "Disconnected TCP inlet for accepted invitation"
-        );
-        Ok(())
+        let bin = self.bin.clone();
+        let node_name = node_name.to_string();
+        let alias = alias.to_string();
+        spawn_blocking(move || {
+            let _ = duct::cmd!(
+                &bin,
+                "--no-input",
+                "tcp-inlet",
+                "delete",
+                &alias,
+                "--at",
+                &node_name,
+                "--yes"
+            )
+            .before_spawn(log_command)
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            .map(|_| {
+                info!(
+                    node = %node_name, alias = %alias,
+                    "Disconnected TCP inlet for accepted invitation"
+                );
+            })
+            .map_err(
+                |e| warn!(%e, node = %node_name, alias = %alias, "Failed to delete TCP inlet"),
+            );
+        })
+        .await
+        .map_err(|err| err.into())
     }
 }
 
 #[async_trait]
 impl Projects for Cli {
     async fn enroll(&self, node_name: &str, hex_encoded_ticket: &str) -> Result<()> {
-        let _ = duct::cmd!(
-            &self.bin,
-            "--no-input",
-            "project",
-            "enroll",
-            "--new-trust-context-name",
-            node_name,
-            hex_encoded_ticket,
-        )
-        .before_spawn(log_command)
-        .stderr_null()
-        .stdout_capture()
-        .run();
-        debug!(node = %node_name, "Node enrolled using enrollment ticket");
-        Ok(())
+        let node_name = node_name.to_string();
+        let hex_encoded_ticket = hex_encoded_ticket.to_string();
+        let bin = self.bin.clone();
+        spawn_blocking(move || {
+            let _ = duct::cmd!(
+                &bin,
+                "--no-input",
+                "project",
+                "enroll",
+                "--new-trust-context-name",
+                &node_name,
+                &hex_encoded_ticket,
+            )
+            .before_spawn(log_command)
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            .map(|_| {
+                debug!(node = %node_name, "Node enrolled using enrollment ticket");
+            });
+        })
+        .await
+        .map_err(|err| err.into())
     }
 
     async fn ticket(&self, project_name: &str) -> Result<String> {
-        Ok(duct::cmd!(
-            &self.bin,
-            "project",
-            "ticket",
-            "--quiet",
-            "--project",
-            project_name,
-            "--expires-in",
-            DEFAULT_ENROLLMENT_TICKET_EXPIRY.to_string(),
-            "--to",
-            &format!("/project/{project_name}")
-        )
-        .before_spawn(log_command)
-        .read()
-        .map_err(|err| {
-            error!(?err, "Could not create enrollment ticket");
-            Error::App("Could not create enrollment ticket".to_string())
-        })?)
+        let bin = self.bin.clone();
+        let project_name = project_name.to_string();
+        spawn_blocking(move || {
+            duct::cmd!(
+                &bin,
+                "project",
+                "ticket",
+                "--quiet",
+                "--project",
+                &project_name,
+                "--expires-in",
+                DEFAULT_ENROLLMENT_TICKET_EXPIRY.to_string(),
+                "--to",
+                &format!("/project/{project_name}")
+            )
+            .before_spawn(log_command)
+            .read()
+            .map_err(|err| {
+                error!(?err, "Could not create enrollment ticket");
+                Error::App("Could not create enrollment ticket".to_string())
+            })
+        })
+        .await?
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/error.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/error.rs
@@ -1,4 +1,5 @@
 use miette::Diagnostic;
+use ockam::compat::tokio::task::JoinError;
 use thiserror::Error;
 
 pub type Result<T> = miette::Result<T, Error>;
@@ -22,6 +23,12 @@ pub enum Error {
 
     #[error(transparent)]
     CliState(#[from] ockam_api::cli_state::CliStateError),
+}
+
+impl From<JoinError> for Error {
+    fn from(e: JoinError) -> Self {
+        Error::Internal(e.into())
+    }
 }
 
 impl From<miette::Report> for Error {

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/state.rs
@@ -22,11 +22,27 @@ pub struct InvitationState {
 }
 
 impl InvitationState {
-    pub fn replace_by(&mut self, list: InvitationList) {
+    pub fn replace_by(&mut self, list: InvitationList) -> bool {
         debug!("Updating invitations state");
-        self.sent = list.sent.unwrap_or_default();
-        self.received.invitations = list.received.unwrap_or_default();
-        self.accepted.invitations = list.accepted.unwrap_or_default();
+        let mut changed = false;
+
+        let new_sent = list.sent.unwrap_or_default();
+        if self.sent != new_sent {
+            self.sent = new_sent;
+            changed = true;
+        }
+        let new_received = list.received.unwrap_or_default();
+        if self.received.invitations != new_received {
+            self.received.invitations = new_received;
+            changed = true;
+        }
+        let new_accepted = list.accepted.unwrap_or_default();
+        if self.accepted.invitations != new_accepted {
+            self.accepted.invitations = new_accepted;
+            changed = true;
+        }
+
+        changed
     }
 }
 
@@ -79,10 +95,6 @@ impl Inlet {
     pub(crate) fn disable(&mut self) {
         self.enabled = false;
     }
-
-    pub(crate) fn enable(&mut self) {
-        self.enabled = true;
-    }
 }
 
 #[cfg(test)]
@@ -127,7 +139,8 @@ mod tests {
                 service_access_details: None,
             }]),
         };
-        state.replace_by(list);
+        assert!(state.replace_by(list.clone()));
+        assert!(!state.replace_by(list));
         assert_eq!(state.sent.len(), 1);
         assert_eq!(state.received.invitations.len(), 1);
         assert_eq!(state.accepted.invitations.len(), 1);

--- a/implementations/rust/ockam/ockam_app_lib/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/lib.rs
@@ -13,6 +13,7 @@ mod enroll;
 mod error;
 mod invitations;
 mod projects;
+mod scheduler;
 mod shared_service;
 mod state;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
@@ -1,4 +1,4 @@
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use ockam_api::cloud::project::Projects;
 use ockam_api::{cli_state::StateDirTrait, cloud::project::Project, identity::EnrollmentTicket};
@@ -39,7 +39,7 @@ impl AppState {
     }
 
     pub(crate) async fn refresh_projects(&self) -> Result<()> {
-        debug!("Refreshing projects");
+        info!("Refreshing projects");
         if !self.is_enrolled().await.unwrap_or(false) {
             return Ok(());
         }

--- a/implementations/rust/ockam/ockam_app_lib/src/scheduler.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/scheduler.rs
@@ -1,0 +1,66 @@
+//! Scheduler
+//! The scheduler is responsible for running operations in the background.
+//! It is implemented as a Tokio task that waits for a notification to run an operation.
+//! The notification can be triggered by the user or by a timeout.
+
+use ockam_core::async_trait;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::time::{timeout, Duration};
+
+#[async_trait]
+pub(crate) trait ScheduledTask: Send + Sync + 'static {
+    async fn run(&self);
+}
+
+#[derive(Clone)]
+pub(crate) struct Scheduler {
+    task: Arc<dyn ScheduledTask>,
+    interval: Duration,
+    tx: Sender<()>,
+}
+
+impl Scheduler {
+    /// Create a new scheduler instance and spawn a Tokio task to run it
+    pub(crate) fn create(
+        task: Arc<dyn ScheduledTask>,
+        interval: Duration,
+        runtime: &Handle,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel::<()>(1);
+        let instance = Self { tx, task, interval };
+        {
+            let instance = instance.clone();
+            runtime.spawn(async move {
+                instance.start(rx).await;
+            });
+        }
+
+        instance
+    }
+
+    /// Schedule the task to run immediately
+    pub(crate) fn schedule_now(&self) {
+        // try to send the event, ignore if the channel is full (already scheduled)
+        let _ = self.tx.try_send(());
+    }
+
+    async fn start(self, mut rx: Receiver<()>) {
+        loop {
+            // run the task at right away to avoid extra delays in initialization phase
+            self.task.run().await;
+
+            // resets notification right after execution to avoid running the task twice
+            let _ = rx.try_recv();
+
+            // either we received an event or timed out
+            let _ = timeout(self.interval, rx.recv()).await;
+
+            // sometimes we want to refresh a state that was just updated and we end up
+            // fetching the previous status instead, this is a workaround to avoid that
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_app_lib/src/state/tasks.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/tasks.rs
@@ -1,0 +1,64 @@
+use crate::scheduler::ScheduledTask;
+use crate::state::AppState;
+use ockam_core::async_trait;
+use tracing::warn;
+
+pub(crate) struct RefreshProjectsTask {
+    state: AppState,
+}
+
+impl RefreshProjectsTask {
+    pub(crate) fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for RefreshProjectsTask {
+    async fn run(&self) {
+        let result = self.state.refresh_projects().await;
+        if let Err(e) = result {
+            warn!(%e, "Failed to refresh projects");
+        }
+    }
+}
+
+pub(crate) struct RefreshInvitationsTask {
+    state: AppState,
+}
+
+impl RefreshInvitationsTask {
+    pub(crate) fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for RefreshInvitationsTask {
+    async fn run(&self) {
+        let result = self.state.refresh_invitations().await;
+        if let Err(e) = result {
+            warn!(%e, "Failed to refresh invitations");
+        }
+    }
+}
+
+pub(crate) struct RefreshInletsTask {
+    state: AppState,
+}
+
+impl RefreshInletsTask {
+    pub(crate) fn new(state: AppState) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl ScheduledTask for RefreshInletsTask {
+    async fn run(&self) {
+        let result = self.state.refresh_inlets().await;
+        if let Err(e) = result {
+            warn!(%e, "Failed to refresh inlets");
+        }
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
@@ -128,7 +128,7 @@ void initialize_application(void (*application_state_callback)(struct C_Applicat
 void accept_invitation(const char *id);
 
 /**
- * Initiate and wait for graceful shutdown of the application.
+ * Initiate graceful shutdown of the application, exit process when complete.
  */
 void shutdown_application(void);
 

--- a/implementations/swift/ockam/ockam_app/Ockam/CreateService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/CreateService.swift
@@ -38,6 +38,7 @@ struct CreateServiceView: View {
                     }
                 }
             }
+            .padding(10)
 
             EmailListView(emailList: $emails)
 
@@ -45,6 +46,7 @@ struct CreateServiceView: View {
             Text("Error: \(errorMessage)")
                 .opacity(errorMessage.isEmpty ? 0 : 1)
                 .foregroundColor(.red)
+                .padding(10)
 
             HStack {
                 Spacer()
@@ -80,10 +82,12 @@ struct CreateServiceView: View {
                     Text("Create and Share")
                 })
                 .disabled(!canCreateService() && !isProcessing)
+                .keyboardShortcut(.defaultAction)
+                .padding(10)
             }
+            .background(.black.opacity(0.1))
         }
         .frame(width: 600)
-        .padding(10)
     }
 
     func closeWindow(){

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -8,6 +8,7 @@ struct MainView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     @Binding var state : ApplicationState
     @Environment(\.openWindow) var openWindow
+    @State private var selectedGroup: String = ""
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -84,28 +85,36 @@ struct MainView: View {
                         openWindow(id: "create-service")
                         self.closeWindow()
                         bringInFront()
-                    })
+                    })        .buttonStyle(PlainButtonStyle())
                     ForEach(state.localServices){ localService in
                         LocalServiceView(localService: localService)
                     }
                 }
 
                 if !state.groups.isEmpty {
-
                     Divider()
                     Text("Services shared with you")
                         .font(.body).bold().foregroundColor(.primary.opacity(0.7))
 
-                    NavigationStack {
-                        ForEach(state.groups) { group in
-                            NavigationLink {
-                                ServiceGroupView(group: group)
-                                    .padding([.top], 5)
-                            } label: {
-                                ServiceGroupButton(group: group)
+                    ForEach(state.groups) { group in
+                        if selectedGroup == group.id {
+                            ServiceGroupView(group: group, back: {
+                                selectedGroup = ""
+                            })
+                            .padding([.top], 5)
+                        }
+                    }
+
+                    if selectedGroup == "" {
+                        VStack {
+                            ForEach(state.groups) { group in
+                                ServiceGroupButton(group: group, action: {
+                                    selectedGroup = group.id
+                                })
                             }
                         }
-                    }.buttonStyle(.plain)
+                        .padding([.top], 5)
+                    }
                 }
             }
 
@@ -129,7 +138,6 @@ struct MainView: View {
                         //by closing the window first
                         self.closeWindow()
                         shutdown_application();
-                        NSApplication.shared.terminate(self);
                     })
                 }
             }

--- a/implementations/swift/ockam/ockam_app/Ockam/Services.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Services.swift
@@ -6,10 +6,17 @@ import SwiftUI
 
 struct ServiceGroupView: View {
     @ObservedObject var group: ServiceGroup
+    @State var back: (() -> Void)? = nil
+    @State private var isPictureHovered = false
 
     var body: some View {
         VStack {
             HStack {
+                Image(systemName: "chevron.backward")
+                    .frame(width: 32, height: 32)
+                    //use opacity to account for space
+                    .opacity(isPictureHovered ? 1 : 0)
+
                 Spacer()
                 ProfilePicture(url: group.imageUrl, size: 32)
                 VStack(alignment: .leading) {
@@ -19,7 +26,23 @@ struct ServiceGroupView: View {
                     Text(verbatim: group.email)
                 }
                 Spacer()
+                // to match the 32px icon on the left and keep the content centered
+                Spacer().frame(width: 32, height: 32)
             }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isPictureHovered ? Color.gray.opacity(0.25) : Color.clear)
+            .buttonStyle(PlainButtonStyle())
+            .cornerRadius(4)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if let back = self.back {
+                    back()
+                }
+            }
+            .onHover(perform: { hovering in
+                isPictureHovered = hovering
+            })
             ForEach(group.invitations) { invite in
                 IncomingInvite(invite: invite)
             }
@@ -33,23 +56,33 @@ struct ServiceGroupView: View {
 struct ServiceGroupButton: View {
     @State private var isHovered = false
     @ObservedObject var group: ServiceGroup
+    @State var action: (() -> Void)? = nil
 
     var body: some View {
         HStack {
             ProfilePicture(url: group.imageUrl, size: 32)
             VStack(alignment: .leading) {
                 if let name = group.name {
-                    Text(verbatim: name)
+                    Text(verbatim: name).lineLimit(1)
                 }
-                Text(verbatim: group.email)
+                Text(verbatim: group.email).lineLimit(1)
             }
             Spacer()
             Image(systemName: "chevron.right")
+                .frame(width: 32, height: 32)
         }.onHover { hover in
             isHovered = hover
         }
         .padding(3)
         .background(isHovered ? Color.gray.opacity(0.25) : Color.clear)
+        .onTapGesture {
+            if let action = self.action {
+                action()
+            }
+            // for some reason hover doesn't change back to false
+            // when out of view
+            isHovered = false
+        }
         .contentShape(Rectangle())
         .cornerRadius(4)
     }
@@ -80,7 +113,7 @@ struct RemoteServiceView: View {
                         } else {
                             service.address.unsafelyUnwrapped + ":" + String(service.port.unsafelyUnwrapped)
                         }
-                        Text(verbatim: address).font(.caption)
+                        Text(verbatim: address).font(.caption).lineLimit(1)
                     } else {
                         Text(verbatim: "Connecting...").font(.caption)
                     }
@@ -88,6 +121,7 @@ struct RemoteServiceView: View {
                 Spacer()
                 if service.available {
                     Image(systemName: "chevron.right")
+                        .frame(width: 32, height: 32)
                         .rotationEffect(isOpen ? Angle.degrees(90.0) : Angle.degrees(0), anchor: .center)
                 }
             }
@@ -163,10 +197,11 @@ struct LocalServiceView: View {
                     } else {
                         localService.address + ":" + String(localService.port)
                     }
-                    Text(verbatim: address).font(.caption)
+                    Text(verbatim: address).font(.caption).lineLimit(1)
                 }
                 Spacer()
                 Image(systemName: "chevron.right")
+                    .frame(width: 32, height: 32)
                     .rotationEffect(isOpen ? Angle.degrees(90.0) : Angle.degrees(0), anchor: .center)
             }
             .padding(3)
@@ -235,6 +270,7 @@ struct IncomingInvite: View {
                 if !invite.accepting {
                     Image(systemName: "chevron.right")
                         .rotationEffect(isOpen ? Angle.degrees(90.0) : Angle.degrees(0), anchor: .center)
+                        .padding([.trailing], 10)
                 }
             }
             .padding(3)
@@ -278,13 +314,15 @@ struct SentInvitations: View {
                 Spacer()
                 Image(systemName: "chevron.right")
                     .rotationEffect(isOpen ? Angle.degrees(90.0) : Angle.degrees(0), anchor: .center)
+                    .padding([.trailing], 10)
             }
             .padding(3)
             .contentShape(Rectangle())
             .onTapGesture {
                 withAnimation {
                     isOpen = !isOpen
-                }            }
+                }
+            }
             .onHover { hover in
                 isHovered = hover
             }

--- a/implementations/swift/ockam/ockam_app/Ockam/ShareService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/ShareService.swift
@@ -44,10 +44,12 @@ struct ShareServiceView: View {
                     Text("Share")
                 })
                 .disabled(!canShareService() && !isProcessing)
+                .keyboardShortcut(.defaultAction)
+                .padding(10)
             }
+            .background(.black.opacity(0.1))
         }
         .frame(width: 600)
-        .padding(10)
     }
 
     func closeWindow(){


### PR DESCRIPTION
Improved responsiveness by having a parallel inlet refresh and status reporting for each
Added a scheduler for refresh operations instead of a timed loop
Trigger refresh only when states change (for both `ApplicationState` and internal refresh of inlets re-triggered only when invites changes)
`NodeManager` is now reachable and `ockam_app`can be viewed from CLI (ockam node show ockam_app)
On exit, every app-related node is deleted.
A connection bug was also fixed: duct cmd was executing in blocking mode inside an async context, this could trigger several issues such as timeouts or stalls.

On the UI side, the sub-menu of groups was rewritten to match the current U. Also minor stylistic touch ups on the create/share service.

