### PR TITLE
fix(rust): check that the node exists before creating a `BackgroundNode`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
@@ -43,6 +43,7 @@ impl BackgroundNode {
         cli_state: &CliState,
         node_name: &str,
     ) -> miette::Result<BackgroundNode> {
+        cli_state.nodes.get(node_name)?;
         Ok(BackgroundNode {
             cli_state: cli_state.clone(),
             node_name: node_name.to_string(),

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -204,8 +204,8 @@ pub(crate) async fn background_mode(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let send_req = async {
-        let mut node = BackgroundNode::create(&ctx, &opts.state, node_name).await?;
         spawn_background_node(&opts, cmd.clone()).await?;
+        let mut node = BackgroundNode::create(&ctx, &opts.state, node_name).await?;
         let is_node_up = is_node_up(&ctx, node_name, &mut node, opts.state.clone(), true).await?;
         *is_finished.lock().await = true;
         Ok(is_node_up)


### PR DESCRIPTION
When creating a `BackgroundNode` from the CLI, we were able to create the instance for a non-existing node, which would result in an error down the road.