### PR TITLE
refactor(rust): use `Terminal`'s `is_tty` function to using `termimad`'s

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -395,6 +395,7 @@ impl OckamCommand {
             let guard = setup_logging(
                 options.global_args.verbose,
                 options.global_args.no_color,
+                options.terminal.is_tty(),
                 log_path,
             );
             tracing::debug!("{}", Version::short());

--- a/implementations/rust/ockam/ockam_command/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/logs/mod.rs
@@ -4,7 +4,6 @@ use ockam_core::env::{get_env, get_env_with_default, FromString};
 use std::io::stdout;
 use std::path::PathBuf;
 use std::str::FromStr;
-use termimad::crossterm::tty::IsTty;
 use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt::layer;
@@ -58,6 +57,7 @@ impl std::fmt::Display for LogFormat {
 pub fn setup_logging(
     verbose: u8,
     no_color: bool,
+    is_tty: bool,
     log_path: Option<PathBuf>,
 ) -> Option<WorkerGuard> {
     let level = {
@@ -102,7 +102,7 @@ pub fn setup_logging(
     let (appender, guard) = match log_path {
         // If a log path is not provided, log to stdout.
         None => {
-            let color = !no_color && stdout().is_tty();
+            let color = !no_color && is_tty;
             let (n, guard) = tracing_appender::non_blocking(stdout());
             let appender = layer().with_ansi(color).with_writer(n);
             (Box::new(appender), guard)

--- a/implementations/rust/ockam/ockam_command/src/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/term.rs
@@ -3,7 +3,6 @@
 use std::io::Write;
 
 use console::Term;
-use termimad::crossterm::tty::IsTty;
 
 use crate::terminal::{TerminalStream, TerminalWriter};
 use crate::Result;
@@ -22,7 +21,7 @@ impl TerminalWriter for TerminalStream<Term> {
     }
 
     fn is_tty(&self) -> bool {
-        self.writer.is_tty()
+        self.writer.is_term()
     }
 
     fn write(&mut self, s: impl AsRef<str>) -> Result<()> {


### PR DESCRIPTION
First step to remove `termimad` dependency, which will help to avoid the problem its latest version: https://github.com/build-trust/ockam/pull/6672