### PR TITLE
hide desktop ui from application dock

### DIFF
--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 				INFOPLIST_FILE = Ockam/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ockam;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -384,6 +385,7 @@
 				INFOPLIST_FILE = Ockam/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ockam;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This PR allows us to hide the ockam app from the application dock and make it only visible on the menubar. [We use the LSUIElement attribute from Swift](https://developer.apple.com/documentation/bundleresources/information_property_list/lsuielement)
- <h3>Before</h3>
<img width="1512" alt="Screenshot 2023-10-23 at 2 00 14 AM" src="https://github.com/build-trust/ockam/assets/31141573/830c960b-f711-48e9-8dcf-07f27b755b7a">

- <h3>After</h3>

<img width="1512" alt="Screenshot 2023-10-23 at 2 01 13 AM" src="https://github.com/build-trust/ockam/assets/31141573/e8fa587f-5614-4e22-bb7d-a41742f4cac6">
