### PR TITLE
feat(rust): interactive ockam node start

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -1,15 +1,16 @@
 use clap::Args;
 use colorful::Colorful;
 
-use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
+use ockam_api::cli_state::{NodeState, StateDirTrait, StateItemTrait};
 use ockam_api::nodes::BackgroundNode;
 use ockam_node::Context;
 
 use crate::node::show::print_query_status;
-use crate::node::util::{check_default, spawn_node};
-use crate::node::{get_node_name, initialize_node_if_default};
+use crate::node::util::spawn_node;
 use crate::util::node_rpc;
-use crate::{docs, fmt_err, CommandGlobalOpts};
+use crate::{docs, fmt_err, fmt_info, fmt_log, fmt_ok, CommandGlobalOpts, OckamColor};
+
+use super::util::check_default;
 
 const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -18,7 +19,6 @@ const AFTER_LONG_HELP: &str = include_str!("./static/start/after_long_help.txt")
 /// Start a node that was previously stopped
 #[derive(Clone, Debug, Args)]
 #[command(
-    arg_required_else_help = true,
     long_about = docs::about(LONG_ABOUT),
     before_help = docs::before_help(PREVIEW_TAG),
     after_long_help = docs::after_help(AFTER_LONG_HELP)
@@ -33,7 +33,6 @@ pub struct StartCommand {
 
 impl StartCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         node_rpc(run_impl, (opts, self))
     }
 }
@@ -42,28 +41,142 @@ async fn run_impl(
     ctx: Context,
     (mut opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> miette::Result<()> {
-    let node_name = get_node_name(&opts.state, &cmd.node_name);
+    //If a node is given
+    if let Some(node_name) = cmd.node_name {
+        let node_state = opts.state.nodes.get(&node_name)?;
 
-    let node_state = opts.state.nodes.get(&node_name)?;
-    // Abort if node is already running
-    if node_state.is_running() {
-        let n = node_state.name();
+        opts.global_args.verbose = node_state.config().setup().verbose;
+
+        // Abort if node is already running
+        if node_state.is_running() {
+            let n = node_state.name();
+            opts.terminal
+                .stdout()
+                .plain(fmt_err!(
+                    "The node '{n}' is already running. If you want to restart it you can call `ockam node stop {n}` and then `ockam node start {n}`"
+                ))
+                .write_line()?;
+            return Ok(());
+        }
+
+        let mut node = run_node(&node_state, &ctx, &opts).await?;
+        let is_default = check_default(&opts, &node_name);
+        print_query_status(&opts, &ctx, &node_name, &mut node, true, is_default).await?;
+        return Ok(());
+    }
+
+    //Terminal is not interactive or the quiet input or --no-input flag
+    if !(opts.terminal.can_ask_for_user_input()) {
+        let default_node = opts.state.nodes.default()?;
+        run_node(&default_node, &ctx, &opts).await?;
         opts.terminal
             .stdout()
-            .plain(fmt_err!(
-                "The node '{n}' is already running. If you want to restart it you can call `ockam node stop {n}` and then `ockam node start {n}`"
+            .plain(fmt_ok!("{}", default_node.name()))
+            .write_line()?;
+        return Ok(());
+    }
+
+    //Get the inactive nodes list
+    let node_list = opts.state.nodes.list()?;
+    let inactive_nodes: Vec<String> = node_list
+        .iter()
+        .filter(|node_state| !(node_state.is_running()))
+        .map(|node| node.name().to_owned())
+        .collect();
+
+    if inactive_nodes.is_empty() {
+        opts.terminal
+            .stdout()
+            .plain(fmt_info!(
+                "All the nodes are already started, nothing to do. Exiting gratefully"
             ))
             .write_line()?;
         return Ok(());
     }
+
+    //Get the user nodes selection
+    let user_selection = opts
+        .terminal
+        .select_multiple("Select the nodes".to_string(), inactive_nodes);
+
+    //Exiting gratefully if no nodes are selected informing the user
+    if user_selection.is_empty() {
+        opts.terminal
+            .stdout()
+            .plain(fmt_info!("No node selected, exiting gratefully!"))
+            .write_line()?;
+        return Ok(());
+    }
+
+    //Ask for confirmation
+    if !opts.terminal.confirm_interactively(format!(
+        "You are about to start the given nodes: {}. Confirm?",
+        &user_selection.join(", ")
+    )) {
+        opts.terminal
+            .stdout()
+            .plain(fmt_info!("No node selected, exiting gratefully!"))
+            .write_line()?;
+        return Ok(());
+    }
+
+    let user_selection: Vec<NodeState> = node_list
+        .into_iter()
+        .filter(|node| !user_selection.iter().all(|name| name != node.name()))
+        .collect();
+
+    let mut node_error_flag: bool = false;
+    let mut node_starts_output: Vec<String> = vec![];
+    for node_state in &user_selection {
+        match run_node(node_state, &ctx, &opts).await {
+            Ok(_) => node_starts_output.push(fmt_ok!("{}", &node_state.name().to_owned())),
+            Err(_) => {
+                node_error_flag = true;
+                node_starts_output.push(format!(
+                    "     ⚠️ {} wont start",
+                    &node_state.name().to_owned()
+                ))
+            }
+        }
+    }
+
+    if node_error_flag {
+        node_starts_output.push(
+            "\n\n".to_string()
+                + &fmt_err!("You can check the status of failed nodes using the command\n")
+                + &fmt_log!(
+                    "{}",
+                    "ockam node show\n".color(OckamColor::PrimaryResource.color())
+                )
+                + &fmt_log!("or check the logs with the command\n")
+                + &fmt_log!(
+                    "{}",
+                    "ockam node logs".color(OckamColor::PrimaryResource.color())
+                ),
+        );
+    }
+
+    opts.terminal
+        .stdout()
+        .plain(node_starts_output.join("\n"))
+        .write_line()?;
+
+    Ok(())
+}
+
+/// Run a single node. Return the BackgroundNode istance of the created node or error.
+async fn run_node(
+    node_state: &NodeState,
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+) -> miette::Result<BackgroundNode> {
     node_state.kill_process(false)?;
     let node_setup = node_state.config().setup();
-    opts.global_args.verbose = node_setup.verbose;
-
+    let node_name = node_state.name();
     // Restart node
     spawn_node(
-        &opts,
-        &node_name,                                    // The selected node name
+        opts,
+        node_name,                                     // The selected node name
         &node_setup.api_transport()?.addr.to_string(), // The selected node api address
         None,                                          // No project information available
         None,                                          // No trusted identities
@@ -77,10 +190,6 @@ async fn run_impl(
         true,                                          // Restarted nodes will log to files
     )?;
 
-    // Print node status
-    let mut node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
-    let is_default = check_default(&opts, &node_name);
-    print_query_status(&opts, &ctx, &node_name, &mut node, true, is_default).await?;
-
-    Ok(())
+    let node = BackgroundNode::create(ctx, &opts.state, node_name).await?;
+    Ok(node)
 }


### PR DESCRIPTION
interactive selection in case no argument is given to the ockam node start. In case of single selection the behavior stays identical.


## Current behavior

The `ockam start` command with no given arguments simply print the usage help.

## Proposed changes

Now when these conditions are met:
- terminal in interactive mode
- No `--quiet` flag
- No `no-input` flag
- No node are given 
a selection prompt ask the user about what node (between the UP) should be start.
If there are no node to be started the prompt doesn't appear and the user is simply notified that all nodes are actually running.
If there are eligible node to start they appear in the selection list.
If no node are selected the user is simply informed about that and exit with no error.
If there are node selected the user is prompted with a confirmation message.
If no is chosen, then the user is informed and the sub-command returns with no errors.
Then all selected node are started. The starting result are displayed to user with a tick:
```sh
    ⚠️ {node-name} wont start
     ✔︎ {node-name} 
```
This would be an example with the user that selected only one node in the selection.
Listing the nodes
![node_list](https://github.com/build-trust/ockam/assets/90763809/9f0383bd-4cd2-4193-ae92-ff1492add5d9)
User prompt selection
![selection](https://github.com/build-trust/ockam/assets/90763809/c7e4a3a2-6d85-4919-8e49-4dcf8a4083f0)
Confirmation
![confirm](https://github.com/build-trust/ockam/assets/90763809/eca2985c-bb04-440c-8896-b38c2e1a53f9)
Output
![output](https://github.com/build-trust/ockam/assets/90763809/4d0e2a92-064a-4385-a97c-1f89c915731f)
No node selected
![no_selected](https://github.com/build-trust/ockam/assets/90763809/3d3325a5-a8eb-4052-b12a-3c2096e2f279)
No available nodes to start
![no_node_to_start](https://github.com/build-trust/ockam/assets/90763809/cd6eab38-7d76-4e19-9841-37013b5e049f)


 
## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->

