### PR TITLE
feat(rust): interactive ockam node start

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -6,10 +6,12 @@ use ockam_api::nodes::BackgroundNode;
 use ockam_node::Context;
 
 use crate::node::show::print_query_status;
-use crate::node::util::{check_default, spawn_node};
-use crate::node::{get_node_name, initialize_node_if_default};
+use crate::node::util::spawn_node;
 use crate::util::node_rpc;
-use crate::{docs, fmt_err, CommandGlobalOpts};
+use crate::{docs, fmt_err, fmt_info, fmt_log, fmt_ok, fmt_warn, CommandGlobalOpts, OckamColor};
+
+use super::get_node_name;
+use super::util::check_default;
 
 const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -18,7 +20,6 @@ const AFTER_LONG_HELP: &str = include_str!("./static/start/after_long_help.txt")
 /// Start a node that was previously stopped
 #[derive(Clone, Debug, Args)]
 #[command(
-    arg_required_else_help = true,
     long_about = docs::about(LONG_ABOUT),
     before_help = docs::before_help(PREVIEW_TAG),
     after_long_help = docs::after_help(AFTER_LONG_HELP)
@@ -33,37 +34,137 @@ pub struct StartCommand {
 
 impl StartCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        initialize_node_if_default(&opts, &self.node_name);
         node_rpc(run_impl, (opts, self))
     }
 }
 
 async fn run_impl(
     ctx: Context,
-    (mut opts, cmd): (CommandGlobalOpts, StartCommand),
+    (opts, cmd): (CommandGlobalOpts, StartCommand),
 ) -> miette::Result<()> {
-    let node_name = get_node_name(&opts.state, &cmd.node_name);
+    if cmd.node_name.is_some() || !opts.terminal.can_ask_for_user_input() {
+        let node_name = &get_node_name(&opts.state, &cmd.node_name);
+        start_single_node(node_name, opts, &ctx).await?;
+        return Ok(());
+    }
 
-    let node_state = opts.state.nodes.get(&node_name)?;
+    let inactive_nodes = get_inactive_nodes(&opts)?;
+    match inactive_nodes.len() {
+        0 => {
+            opts.terminal
+                .stdout()
+                .plain(fmt_info!(
+                    "All the nodes are already started, nothing to do. Exiting gratefully"
+                ))
+                .write_line()?;
+        }
+        1 => {
+            start_single_node(&inactive_nodes[0], opts, &ctx).await?;
+        }
+        _ => {
+            let selected_nodes = opts
+                .terminal
+                .select_multiple("Select the nodes".to_string(), inactive_nodes);
+            match selected_nodes.len() {
+                0 => {
+                    opts.terminal
+                        .stdout()
+                        .plain(fmt_info!("No node selected, exiting gratefully!"))
+                        .write_line()?;
+                }
+                1 => start_single_node(&selected_nodes[0], opts, &ctx).await?,
+                _ => {
+                    if !opts.terminal.confirm_interactively(format!(
+                        "You are about to start the given nodes:[ {} ]. Confirm?",
+                        &selected_nodes.join(", ")
+                    )) {
+                        opts.terminal
+                            .stdout()
+                            .plain(fmt_info!("No node selected, exiting gratefully!"))
+                            .write_line()?;
+                        return Ok(());
+                    }
+
+                    let formatted_starts_result =
+                        start_multiple_nodes(&ctx, &opts, &selected_nodes).await?;
+
+                    opts.terminal
+                        .stdout()
+                        .plain(formatted_starts_result.join("\n"))
+                        .write_line()?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Starts a single node and display the output on the console
+async fn start_single_node(
+    node_name: &str,
+    mut opts: CommandGlobalOpts,
+    ctx: &Context,
+) -> miette::Result<()> {
+    let node_state = opts.state.nodes.get(node_name)?;
+
+    opts.global_args.verbose = node_state.config().setup().verbose;
+
     // Abort if node is already running
     if node_state.is_running() {
-        let n = node_state.name();
         opts.terminal
             .stdout()
             .plain(fmt_err!(
-                "The node '{n}' is already running. If you want to restart it you can call `ockam node stop {n}` and then `ockam node start {n}`"
+                "The node '{node_name}' is already running. If you want to restart it you can \
+                    call `ockam node stop {node_name}` and then `ockam node start {node_name}`"
             ))
             .write_line()?;
         return Ok(());
     }
+
+    let mut node: BackgroundNode = run_node(node_name, ctx, &opts).await?;
+    let is_default = check_default(&opts, node_name);
+    print_query_status(&opts, ctx, node_name, &mut node, true, is_default).await?;
+    Ok(())
+}
+
+/// Start multiples nodes and return a formatted result in the form as a list.
+/// Eventually append info on how to find error logs if there are.
+async fn start_multiple_nodes(
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+    node_selected: &[String],
+) -> miette::Result<Vec<String>> {
+    let mut node_error_flag: bool = false;
+    let mut node_starts_output: Vec<String> = vec![];
+    for node_name in node_selected {
+        match run_node(node_name, ctx, opts).await {
+            Ok(_) => node_starts_output.push(fmt_ok!("{node_name}")),
+            Err(_) => {
+                node_error_flag = true;
+                node_starts_output.push(fmt_warn!("{node_name}"))
+            }
+        }
+    }
+    if node_error_flag {
+        append_info_if_errors(&mut node_starts_output);
+    };
+    Ok(node_starts_output)
+}
+
+/// Run a single node. Return the BackgroundNode istance of the created node or error
+async fn run_node(
+    node_name: &str,
+    ctx: &Context,
+    opts: &CommandGlobalOpts,
+) -> miette::Result<BackgroundNode> {
+    let node_state = opts.state.nodes.get(node_name)?;
     node_state.kill_process(false)?;
     let node_setup = node_state.config().setup();
-    opts.global_args.verbose = node_setup.verbose;
-
+    let node_name = node_state.name();
     // Restart node
     spawn_node(
-        &opts,
-        &node_name,                                    // The selected node name
+        opts,
+        node_name,                                     // The selected node name
         &node_setup.api_transport()?.addr.to_string(), // The selected node api address
         None,                                          // No project information available
         None,                                          // No trusted identities
@@ -77,10 +178,33 @@ async fn run_impl(
         true,                                          // Restarted nodes will log to files
     )?;
 
-    // Print node status
-    let mut node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
-    let is_default = check_default(&opts, &node_name);
-    print_query_status(&opts, &ctx, &node_name, &mut node, true, is_default).await?;
+    let node = BackgroundNode::create(ctx, &opts.state, node_name).await?;
+    Ok(node)
+}
 
-    Ok(())
+/// Get a list of the inactive_nodes
+fn get_inactive_nodes(opts: &CommandGlobalOpts) -> miette::Result<Vec<String>> {
+    let node_list = opts.state.nodes.list()?;
+    Ok(node_list
+        .iter()
+        .filter(|node_state| !(node_state.is_running()))
+        .map(|node| node.name().to_owned())
+        .collect())
+}
+
+/// Append the information on how to retrieve error to the result list in case of errors
+fn append_info_if_errors(node_starts_output: &mut Vec<String>) {
+    node_starts_output.push(
+        "\n\n".to_string()
+            + &fmt_err!("You can check the status of failed nodes using the command\n")
+            + &fmt_log!(
+                "{}",
+                "ockam node show\n".color(OckamColor::PrimaryResource.color())
+            )
+            + &fmt_log!("or check the logs with the command\n")
+            + &fmt_log!(
+                "{}",
+                "ockam node logs".color(OckamColor::PrimaryResource.color())
+            ),
+    );
 }


### PR DESCRIPTION
interactive selection in case no argument is given to the ockam node start. In case of single selection the behavior stays identical.


## Current behavior

The `ockam start` command with no given arguments simply print the usage help.

## Proposed changes

Now when these conditions are met:
- terminal in interactive mode
- No `--quiet` flag
- No `no-input` flag
- No node are given 
a selection prompt ask the user about what node (between the UP) should be start.
If there are no node to be started the prompt doesn't appear and the user is simply notified that all nodes are actually running.
If there are eligible node to start they appear in the selection list.
If no node are selected the user is simply informed about that and exit with no error.
If there are node selected the user is prompted with a confirmation message.
If no is chosen, then the user is informed and the sub-command returns with no errors.
Then all selected node are started. The starting result are displayed to user with a tick:
```sh
    ⚠️ {node-name} wont start
     ✔︎ {node-name} 
```
This would be an example with the user that selected only one node in the selection.
Listing the nodes
![node_list](https://github.com/build-trust/ockam/assets/90763809/9f0383bd-4cd2-4193-ae92-ff1492add5d9)
User prompt selection
![selection](https://github.com/build-trust/ockam/assets/90763809/c7e4a3a2-6d85-4919-8e49-4dcf8a4083f0)
Confirmation
![confirm](https://github.com/build-trust/ockam/assets/90763809/eca2985c-bb04-440c-8896-b38c2e1a53f9)
Output
![output](https://github.com/build-trust/ockam/assets/90763809/4d0e2a92-064a-4385-a97c-1f89c915731f)
No node selected
![no_selected](https://github.com/build-trust/ockam/assets/90763809/3d3325a5-a8eb-4052-b12a-3c2096e2f279)
No available nodes to start
![no_node_to_start](https://github.com/build-trust/ockam/assets/90763809/cd6eab38-7d76-4e19-9841-37013b5e049f)


 
## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->

