### PR TITLE
feat: use a dynamic relay name on the app based on the default identifier

### DIFF
--- a/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app/src/enroll/enroll_user.rs
@@ -164,7 +164,7 @@ async fn retrieve_project<R: Runtime>(
             app.notification()
                 .builder()
                 .title("Creating a new project...")
-                .body("This might take a few seconds")
+                .body("This might take a few minutes")
                 .show()
                 .unwrap_or_else(|e| error!(?e, "Failed to create push notification"));
             let ctx = &app_state.context();

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -170,7 +170,7 @@ impl AppState {
                 self.notify(Notification {
                     kind: Kind::Information,
                     title: "Creating a new project...".to_string(),
-                    message: "This might take a few seconds".to_string(),
+                    message: "This might take a few minutes".to_string(),
                 });
                 let ctx = &self.context();
                 let project = controller

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
@@ -1,18 +1,15 @@
 use crate::api::state::OrchestratorStatus;
-use crate::state::{AppState, NODE_NAME};
+use crate::state::AppState;
 use crate::Result;
 use miette::IntoDiagnostic;
 use ockam::Context;
-use ockam_api::cli_state::{CliState, StateDirTrait};
+use ockam_api::cli_state::{CliState, ProjectState, StateDirTrait, StateItemTrait};
 use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
-use once_cell::sync::Lazy;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, info, trace, warn};
-
-pub static RELAY_NAME: Lazy<String> = Lazy::new(|| format!("forward_to_{NODE_NAME}"));
 
 impl AppState {
     /// Try to create a relay until it succeeds.
@@ -54,7 +51,7 @@ impl AppState {
         }
         match cli_state.projects.default() {
             Ok(project) => {
-                if let Some(relay) = Self::get_relay(node_manager.clone()).await {
+                if let Some(relay) = self.get_relay(node_manager.clone(), &project).await {
                     debug!(project = %project.name(), "Relay already exists");
                     self.update_orchestrator_status(OrchestratorStatus::Connected);
                     self.publish_state().await;
@@ -67,7 +64,7 @@ impl AppState {
                         .create_relay(
                             context,
                             &project_address,
-                            Some(NODE_NAME.to_string()),
+                            Some(self.relay_alias(&project).await),
                             false,
                             None,
                         )
@@ -86,11 +83,30 @@ impl AppState {
         }
     }
 
-    pub(crate) async fn get_relay(node_manager: Arc<InMemoryNode>) -> Option<RelayInfo> {
+    async fn get_relay(
+        &self,
+        node_manager: Arc<InMemoryNode>,
+        project: &ProjectState,
+    ) -> Option<RelayInfo> {
+        let relay_name = self.relay_name(project).await;
         node_manager
             .get_relays()
             .await
             .into_iter()
-            .find(|r| r.remote_address() == *RELAY_NAME)
+            .find(|r| r.remote_address() == relay_name)
+    }
+
+    pub(crate) async fn relay_name(&self, project: &ProjectState) -> String {
+        let alias = self.relay_alias(project).await;
+        format!("forward_to_{alias}")
+    }
+
+    async fn relay_alias(&self, project: &ProjectState) -> String {
+        project
+            .config()
+            .identity
+            .as_ref()
+            .expect("Project should have identifier set")
+            .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/mod.rs
@@ -1,4 +1,2 @@
 mod create;
 mod state;
-
-pub(crate) use create::*;

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -28,7 +28,7 @@ struct MainView: View {
                         Text("Retrieving space").font(.subheadline)
                     case .RetrievingProject:
                         Text("Retrieving project").font(.subheadline)
-                        Text("This might take a few seconds...").font(.caption)
+                        Text("This might take a few minutes...").font(.caption)
                     }
                 }
             }.padding(5)

--- a/implementations/swift/ockam/ockam_app/Ockam/Services.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Services.swift
@@ -12,12 +12,6 @@ struct ServiceGroupView: View {
     var body: some View {
         VStack {
             HStack {
-                Image(systemName: "chevron.backward")
-                    .frame(width: 32, height: 32)
-                    //use opacity to account for space
-                    .opacity(isPictureHovered ? 1 : 0)
-
-                Spacer()
                 ProfilePicture(url: group.imageUrl, size: 32)
                 VStack(alignment: .leading) {
                     if let name = group.name {
@@ -26,11 +20,10 @@ struct ServiceGroupView: View {
                     Text(verbatim: group.email)
                 }
                 Spacer()
-                // to match the 32px icon on the left and keep the content centered
-                Spacer().frame(width: 32, height: 32)
+                Image(systemName: "chevron.down")
+                    .frame(width: 32, height: 32)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(3)
             .background(isPictureHovered ? Color.gray.opacity(0.25) : Color.clear)
             .buttonStyle(PlainButtonStyle())
             .cornerRadius(4)


### PR DESCRIPTION
Based on https://github.com/build-trust/ockam/pull/6760

- fix: relay name is now based on the default identifier
- fix: message shown when a new project is created
- feat: improve ui of services dropdown