### PR TITLE
Implemented Desired Behaviour

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -8,6 +8,7 @@ use ockam_core::{Result, Route};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 use ockam_transport_tcp::TcpTransport;
+use std::time::Duration;
 
 use crate::error::ApiError;
 use crate::multiaddr_to_route;
@@ -19,14 +20,14 @@ pub const DEFAULT_CONTROLLER_ADDRESS: &str = "/dnsaddr/orchestrator.ockam.io/tcp
 /// If it's present, its contents will be used and will have priority over the contents
 /// from ./static/controller.id.
 /// How to use: when running a command that spawns a background node or use an embedded node
-/// add the env variable. `OCKAM_CONTROLLER_IDENTITY_ID={identity.id-contents} ockam ...`
+/// add the env variable. `OCKAM_CONTROLLER_IDENTITY_ID={identity.id-contents} occargo clippykam ...`
 pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY_ID";
 
 /// A default timeout in seconds
 pub const ORCHESTRATOR_RESTART_TIMEOUT: u64 = 180;
 
 /// Total time in milliseconds to wait for Orchestrator long-running operations to complete
-pub const ORCHESTRATOR_AWAIT_TIMEOUT_MS: usize = 60 * 10 * 1000;
+pub const ORCHESTRATOR_LONG_OPERATIONS_TIMEOUT: Duration = Duration::from_secs(180);
 
 impl NodeManager {
     pub(crate) async fn create_controller_client(&self) -> Result<Controller> {

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -26,7 +26,7 @@ pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY
 /// A default timeout in seconds
 pub const ORCHESTRATOR_RESTART_TIMEOUT: u64 = 180;
 
-/// Total time in milliseconds to wait for Orchestrator long-running operations to complete
+/// Timeout for Orchestrator's long-running operations
 pub const ORCHESTRATOR_LONG_OPERATIONS_TIMEOUT: Duration = Duration::from_secs(180);
 
 impl NodeManager {


### PR DESCRIPTION
## Current behavior

The ORCHESTRATOR_AWAIT_TIMEOUT_MS constant is of type u64.

## Proposed changes

The ORCHESTRATOR_AWAIT_TIMEOUT_MS constant should be of type Duration and should default to 180 seconds. The doc string should read as Timeout for Orchestrator's long-running operations.

Also, rename the constant to ORCHESTRATOR_LONG_OPERATIONS_TIMEOUT.

Fixes #6376 

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
