### PR TITLE
docs(rust): update `vault` argument name of `secure-channel-listener create` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -34,7 +34,8 @@ pub struct CreateCommand {
     #[arg(short, long, value_name = "IDENTIFIERS")]
     authorized: Option<Vec<Identifier>>,
 
-    #[arg(value_name = "VAULT", long, requires = "identity")]
+    /// Name of the Vault that the secure-channel listener will use
+    #[arg(value_name = "VAULT_NAME", long, requires = "identity")]
     vault: Option<String>,
 
     /// Name of the Identity that the secure-channel listener will use


### PR DESCRIPTION
Lands https://github.com/build-trust/ockam/pull/6641 / https://github.com/build-trust/ockam/pull/6795

Fixes https://github.com/build-trust/ockam/issues/6385