### PR TITLE
feat(rust): setup app's logs with the same features we use in the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4971,6 +4971,8 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "tracing-appender",
+ "tracing-error",
  "tracing-subscriber",
 ]
 

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0.108"
 sysinfo = "0.29"
 tempfile = "3.8.0"
 thiserror = "1.0"
-time = { version = "0.3.29", default-features = false }
+time = { version = "0.3.29", default-features = false, features = ["std", "local-offset"] }
 tiny_http = "0.12.0"
 tinyvec = { version = "1.6.0", features = ["rustc_1_57"] }
 tokio = { version = "1.33.0", features = ["full"] }

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -146,6 +146,7 @@ pub mod uppercase;
 pub mod authority_node;
 mod influxdb_token_lease;
 
+pub mod logs;
 mod schema;
 mod session;
 mod util;

--- a/implementations/rust/ockam/ockam_api/src/logs/env.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env.rs
@@ -1,0 +1,21 @@
+use super::LogFormat;
+use ockam_core::env::{get_env, get_env_with_default};
+
+pub fn log_level() -> Option<String> {
+    get_env("OCKAM_LOG").unwrap_or_default()
+}
+
+pub fn log_max_size_bytes() -> u64 {
+    let default = 100;
+    get_env_with_default("OCKAM_LOG_MAX_SIZE_MB", default).unwrap_or(default) * 1024 * 1024
+}
+
+pub fn log_max_files() -> usize {
+    let default: u64 = 60;
+    get_env_with_default("OCKAM_LOG_MAX_FILES", default).unwrap_or(default) as usize
+}
+
+pub fn log_format() -> LogFormat {
+    let default = LogFormat::Default;
+    get_env_with_default("OCKAM_LOG_FORMAT", default.clone()).unwrap_or(default)
+}

--- a/implementations/rust/ockam/ockam_api/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/mod.rs
@@ -1,0 +1,32 @@
+use ockam_core::env::FromString;
+
+pub mod env;
+#[allow(unused, clippy::enum_variant_names)]
+pub mod rolling;
+
+#[derive(Clone)]
+pub enum LogFormat {
+    Default,
+    Pretty,
+    Json,
+}
+
+impl FromString for LogFormat {
+    fn from_string(s: &str) -> ockam_core::Result<Self> {
+        match s {
+            "pretty" => Ok(LogFormat::Pretty),
+            "json" => Ok(LogFormat::Json),
+            _ => Ok(LogFormat::Default),
+        }
+    }
+}
+
+impl std::fmt::Display for LogFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            LogFormat::Default => write!(f, "default"),
+            LogFormat::Pretty => write!(f, "pretty"),
+            LogFormat::Json => write!(f, "json"),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/logs/rolling.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/rolling.rs
@@ -8,7 +8,6 @@ use std::{
     io::{BufWriter, Write},
     path::Path,
 };
-
 use time::{OffsetDateTime, Time};
 
 /// Determines when a file should be "rolled over".
@@ -295,7 +294,6 @@ where
 /// A rolling file appender with a rolling condition based on date/time or size.
 pub type BasicRollingFileAppender = RollingFileAppender<RollingConditionBasic>;
 
-// LCOV_EXCL_START
 #[cfg(test)]
 mod t {
     use std::convert::TryInto;
@@ -635,4 +633,3 @@ mod t {
         .assume_offset(offset!(UTC)))
     }
 }
-// LCOV_EXCL_STOP

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -44,6 +44,8 @@ thiserror = "1.0"
 tokio = { version = "1.31.0", features = ["full"] }
 tokio-retry = "0.3"
 tracing = { version = "0.1", features = ["attributes"] }
+tracing-appender = "0.2.2"
+tracing-error = "0.2"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
 
 [build-dependencies]

--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -1,36 +1,74 @@
 use crate::state::{AppState, NODE_NAME};
-use ockam_core::env::get_env;
-use std::fs::OpenOptions;
+use ockam_api::logs::env::{log_format, log_level, log_max_files, log_max_size_bytes};
+use ockam_api::logs::rolling::{RollingConditionBasic, RollingFileAppender};
+use ockam_api::logs::LogFormat;
 use std::str::FromStr;
 use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt::layer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 impl AppState {
     pub fn setup_logging(&self) {
-        let level = if let Some(raw) = get_env::<String>("OCKAM_LOG").unwrap_or_default() {
-            LevelFilter::from_str(&raw).unwrap_or(LevelFilter::INFO)
-        } else {
-            LevelFilter::INFO
-        };
-        let file = {
+        if self.tracing_guard.get().is_some() {
+            return;
+        }
+
+        let log_path = {
             let this = self.clone();
             let state = self
                 .context()
                 .runtime()
                 .block_on(async move { this.state().await });
-            let log_path = state
+            state
                 .nodes
                 .stdout_logs(NODE_NAME)
-                .expect("Failed to get stdout log path for node");
-            OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(log_path)
-                .expect("Failed to open stdout log file")
+                .expect("Failed to get stdout log path for node")
         };
-        tracing_subscriber::fmt()
-            .with_max_level(level)
-            .with_ansi(false)
-            .with_writer(file)
-            .init();
+        let level = log_level()
+            .map(|s| LevelFilter::from_str(&s))
+            .and_then(Result::ok)
+            .unwrap_or(LevelFilter::INFO);
+        let filter = {
+            let ockam_crates = [
+                "ockam",
+                "ockam_node",
+                "ockam_core",
+                "ockam_vault",
+                "ockam_identity",
+                "ockam_transport_tcp",
+                "ockam_api",
+                "ockam_command",
+            ];
+            let builder = EnvFilter::builder();
+            builder
+                .with_default_directive(level.into())
+                .parse_lossy(ockam_crates.map(|c| format!("{c}={level}")).join(","))
+        };
+        let subscriber = tracing_subscriber::registry()
+            .with(filter)
+            .with(tracing_error::ErrorLayer::default());
+        let (appender, guard) = {
+            let r = RollingFileAppender::new(
+                log_path,
+                RollingConditionBasic::new()
+                    .daily()
+                    .max_size(log_max_size_bytes()),
+                log_max_files(),
+            )
+            .expect("Failed to create rolling file appender");
+            let (n, guard) = tracing_appender::non_blocking(r);
+            let appender = layer().with_ansi(false).with_writer(n);
+            (Box::new(appender), guard)
+        };
+        let res = match log_format() {
+            LogFormat::Pretty => subscriber.with(appender.pretty()).try_init(),
+            LogFormat::Json => subscriber.with(appender.json()).try_init(),
+            LogFormat::Default => subscriber.with(appender).try_init(),
+        };
+        res.expect("Failed to initialize tracing subscriber");
+
+        self.tracing_guard
+            .set(guard)
+            .expect("Failed to initialize logs");
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use miette::{IntoDiagnostic, WrapErr};
 use tokio::sync::RwLock;
 use tracing::{error, info, trace, warn};
+use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::api::notification::rust::{Notification, NotificationCallback};
 use crate::api::state::rust::{
@@ -71,6 +72,7 @@ pub struct AppState {
     refresh_inlets_scheduler: Arc<OnceLock<Scheduler>>,
     refresh_relay_scheduler: Arc<OnceLock<Scheduler>>,
     last_published_snapshot: Arc<Mutex<Option<ApplicationState>>>,
+    pub(crate) tracing_guard: Arc<OnceLock<WorkerGuard>>,
 }
 
 impl AppState {
@@ -123,6 +125,7 @@ impl AppState {
                     refresh_inlets_scheduler: Arc::new(Default::default()),
                     refresh_relay_scheduler: Arc::new(Default::default()),
                     last_published_snapshot: Arc::new(Mutex::new(None)),
+                    tracing_guard: Arc::new(Default::default()),
                 }
             }
         };


### PR DESCRIPTION
The app now supports file rotation and can be customized with the log env variables we use in the CLI:

https://github.com/build-trust/ockam/blob/1ca0e18cf019d0f6e6702cd800901ea7652fef30/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt#L14-L17