### PR TITLE
feat(rust): fixed app crashes during refresh and during reset/shutdown

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -156,6 +156,8 @@ impl Inlets for Cli {
                 &service_name,
                 "--retry-wait",
                 "0",
+                "--timeout",
+                "5",
             )
             .before_spawn(log_command)
             .stderr_null()

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -43,6 +43,13 @@ impl AppState {
         // trigger the relay connection right away
         self.schedule_relay_refresh_now();
 
+        // avoid time gap between the enrollment and the invitations appearing in the UI
+        self.schedule_invitations_refresh_now();
+
+        // if we don't have project list and the user creates a service right away
+        // it would break service sharing
+        self.schedule_projects_refresh_now();
+
         info!("User enrolled successfully");
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -240,17 +240,21 @@ pub struct CommandGlobalOpts {
 
 impl CommandGlobalOpts {
     pub fn new(global_args: GlobalArgs) -> Self {
-        let state = CliState::initialize().unwrap_or_else(|_| {
-            let state = CliState::backup_and_reset().expect(
-                "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
-            );
-            let dir = &state.dir;
-            let backup_dir = CliState::backup_default_dir().unwrap();
-            eprintln!(
-                "The {dir:?} directory has been reset and has been backed up to {backup_dir:?}"
-            );
-            state
-        });
+        let state = match CliState::initialize() {
+            Ok(state) => state,
+            Err(err) => {
+                eprintln!("Failed to initialize state: {}", err);
+                let state = CliState::backup_and_reset().expect(
+                    "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
+                );
+                let dir = &state.dir;
+                let backup_dir = CliState::backup_default_dir().unwrap();
+                eprintln!(
+                    "The {dir:?} directory has been reset and has been backed up to {backup_dir:?}"
+                );
+                state
+            }
+        };
         let terminal = Terminal::new(
             global_args.quiet,
             global_args.no_color,


### PR DESCRIPTION
- Fixed crash during inlet refresh by starting one `command` at the time (and --timeout 5 to the inlet creation)
- Fixed crash during reset and shutdown since by pinning the memory of the App status
- Fixed "no default project found" when creating a share right after enrollment
- Removed time gap of invitations appearing in the UI after enrollment
- Quality of life: more verbose error when app state is not initialized and made callback optionals