### PR TITLE
feat(rust): exporting and using `status` field in inlet structure

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -156,6 +156,7 @@ pub struct InletStatus {
     /// An optional status payload
     #[n(4)] pub payload: Option<String>,
     #[n(5)] pub outlet_route: String,
+    #[n(6)] pub status: String,
 }
 
 impl InletStatus {
@@ -166,6 +167,7 @@ impl InletStatus {
             alias: "".into(),
             payload: Some(reason.into()),
             outlet_route: "".into(),
+            status: "".into(),
         }
     }
 
@@ -175,6 +177,7 @@ impl InletStatus {
         alias: impl Into<String>,
         payload: impl Into<Option<String>>,
         outlet_route: impl Into<String>,
+        status: impl Into<String>,
     ) -> Self {
         Self {
             bind_addr: bind_addr.into(),
@@ -182,6 +185,7 @@ impl InletStatus {
             alias: alias.into(),
             payload: payload.into(),
             outlet_route: outlet_route.into(),
+            status: status.into(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -47,6 +47,7 @@ use crate::nodes::models::transport::{TransportMode, TransportType};
 use crate::nodes::models::workers::{WorkerList, WorkerStatus};
 use crate::nodes::registry::KafkaServiceKind;
 use crate::nodes::{InMemoryNode, NODEMANAGER_ADDR};
+use crate::session::MedicHandle;
 use crate::DefaultAddress;
 
 use super::registry::Registry;
@@ -101,6 +102,7 @@ pub struct NodeManager {
     trust_context: Option<TrustContext>,
     pub(crate) registry: Registry,
     policies: Arc<dyn PolicyStorage>,
+    pub(crate) medic_handle: MedicHandle,
 }
 
 impl NodeManager {
@@ -381,6 +383,7 @@ impl NodeManager {
             .build();
 
         let policies: Arc<dyn PolicyStorage> = Arc::new(node_state.policies_storage().await?);
+        let medic_handle = MedicHandle::start_medic(ctx).await?;
 
         let mut s = Self {
             cli_state,
@@ -399,6 +402,7 @@ impl NodeManager {
             trust_context: None,
             registry: Default::default(),
             policies,
+            medic_handle,
         };
 
         if let Some(tc) = trust_options.trust_context_config {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -16,7 +16,6 @@ use crate::nodes::service::{
 };
 use crate::nodes::{NodeManager, NODEMANAGER_ADDR};
 use crate::session::sessions::Session;
-use crate::session::MedicHandle;
 use crate::DefaultAddress;
 
 /// An `InMemoryNode` represents a full running node
@@ -34,7 +33,6 @@ use crate::DefaultAddress;
 ///
 pub struct InMemoryNode {
     pub(crate) node_manager: Arc<NodeManager>,
-    pub(crate) medic_handle: MedicHandle,
     persistent: bool,
 }
 
@@ -170,10 +168,8 @@ impl InMemoryNode {
         let node_manager =
             NodeManager::create(ctx, general_options, transport_options, trust_options).await?;
         debug!("start the Medic");
-        let medic_handle = MedicHandle::start_medic(ctx).await?;
         Ok(Self {
             node_manager: Arc::new(node_manager),
-            medic_handle,
             persistent,
         })
     }

--- a/implementations/rust/ockam/ockam_api/src/session/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/mod.rs
@@ -278,6 +278,11 @@ impl MedicHandle {
         let mut sessions = self.sessions.lock().unwrap();
         sessions.retain(|s| s.key() != key)
     }
+
+    pub fn status_of(&self, key: &str) -> Option<Status> {
+        let sessions = self.sessions.lock().unwrap();
+        sessions.iter().find(|s| s.key() == key).map(|s| s.status())
+    }
 }
 
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_api/src/session/sessions.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/sessions.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use core::future::Future;
 use core::pin::Pin;
+use std::fmt::Formatter;
 use std::time::Duration;
 
 use minicbor::{Decode, Encode};
@@ -30,6 +31,16 @@ pub enum Status {
     Down,
     Degraded,
     Up,
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Status::Down => write!(f, "down"),
+            Status::Degraded => write!(f, "degraded"),
+            Status::Up => write!(f, "up"),
+        }
+    }
 }
 
 impl fmt::Debug for Session {

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
@@ -402,8 +402,10 @@ impl AppState {
                     .show(&inlet_data.local_node_name, &inlet_data.service_name)
                     .await
                 {
-                    inlet_data.socket_addr = Some(inlet.bind_addr.parse()?);
-                    return Inlet::new(inlet_data).map(Some);
+                    if inlet.status == "up" {
+                        inlet_data.socket_addr = Some(inlet.bind_addr.parse()?);
+                        return Inlet::new(inlet_data).map(Some);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reading the `status` field in the app to mark the inlet as disconnected