### PR TITLE
refactor(rust): use `Duration` to define orchestrator global timeouts

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -15,7 +15,7 @@ use ockam_node::{tokio, Context};
 use crate::cloud::addon::ConfluentConfigResponse;
 use crate::cloud::operation::Operations;
 use crate::cloud::share::ShareScope;
-use crate::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT_MS};
+use crate::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT};
 use crate::config::lookup::ProjectAuthority;
 use crate::error::ApiError;
 use crate::minicbor_url::Url;
@@ -350,8 +350,8 @@ impl Projects for Controller {
                 return Err(miette!("Project has no operation id"));
             }
         };
-        let retry_strategy =
-            FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
+        let retry_strategy = FixedInterval::from_millis(5000)
+            .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
         let operation = Retry::spawn(retry_strategy.clone(), || async {
             if let Some(operation) = self.get_operation(ctx, operation_id).await? {
                 if operation.is_completed() {

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -22,11 +22,11 @@ pub const DEFAULT_CONTROLLER_ADDRESS: &str = "/dnsaddr/orchestrator.ockam.io/tcp
 /// add the env variable. `OCKAM_CONTROLLER_IDENTITY_ID={identity.id-contents} ockam ...`
 pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY_ID";
 
-/// A default timeout in seconds
-pub const ORCHESTRATOR_RESTART_TIMEOUT: u64 = 180;
+/// A default timeout
+pub const ORCHESTRATOR_RESTART_TIMEOUT: Duration = Duration::from_secs(180);
 
-/// Total time in milliseconds to wait for Orchestrator long-running operations to complete
-pub const ORCHESTRATOR_AWAIT_TIMEOUT_MS: usize = 60 * 10 * 1000;
+/// Total time to wait for Orchestrator long-running operations to complete
+pub const ORCHESTRATOR_AWAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
 impl NodeManager {
     pub(crate) async fn create_controller_client(&self) -> Result<Controller> {
@@ -99,7 +99,7 @@ impl NodeManager {
             controller_route,
             &controller_identifier,
             caller_identifier,
-            Duration::from_secs(ORCHESTRATOR_RESTART_TIMEOUT),
+            ORCHESTRATOR_RESTART_TIMEOUT,
         )))
     }
 

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -4,7 +4,7 @@ use tokio_retry::strategy::FixedInterval;
 use tokio_retry::Retry;
 
 use ockam_api::cloud::operation::Operations;
-use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT_MS};
+use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT};
 use ockam_node::Context;
 
 use crate::fmt_para;
@@ -17,8 +17,8 @@ pub async fn check_for_completion(
     controller: &Controller,
     operation_id: &str,
 ) -> miette::Result<()> {
-    let retry_strategy =
-        FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
+    let retry_strategy = FixedInterval::from_millis(5000)
+        .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
 
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use ockam_api::cli_state::{StateDirTrait, StateItemTrait};
 use ockam_api::cloud::project::{Project, Projects};
-use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT_MS};
+use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT};
 use ockam_api::config::lookup::LookupMeta;
 use ockam_api::error::ApiError;
 use ockam_api::nodes::service::relay::SecureChannelsCreation;
@@ -110,8 +110,8 @@ pub async fn check_project_readiness(
     project: Project,
 ) -> Result<Project> {
     // Total of 10 Mins sleep strategy with 5 second intervals between each retry
-    let retry_strategy =
-        FixedInterval::from_millis(5000).take(ORCHESTRATOR_AWAIT_TIMEOUT_MS / 5000);
+    let retry_strategy = FixedInterval::from_millis(5000)
+        .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
 
     // Persist project config prior to checking readiness which might take a while
     opts.state


### PR DESCRIPTION
Fixes https://github.com/build-trust/ockam/issues/6376
Fixes https://github.com/build-trust/ockam/issues/6375