### PR TITLE
Add Command Option to Enroll Without Creating Space nor Project

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--test-argument-parser", "enroll"];
+    let prefix_args = ["--test-argument-parser", "enroll", "--user-account-only"];
 
     // auth0
     let mut cmd = Command::cargo_bin("ockam")?;


### PR DESCRIPTION
The purpose of this feature is add an option to the `ockam enroll` command so that only the first step is executed using the `--user-account-only` flag. If a current Space and/or Project already exist, they will continue to be retrieved and set as the user defaults. If they do not exist, they will not be created as part of the enroll command.

resolves https://github.com/build-trust/ockam/issues/5452

## Current behavior

The current `ockam enroll` command 3 things at once:

1. it executes an authentication flow to enroll a user (you can think about that as "create an account on the Orchestrator")
2. it creates a default Space for the user (a Space is a collection of Projects at the level of an organization)
3. it creates a default Project in that Space for the user

## Proposed changes

The purpose of this feature is to add an option to `ockam enroll` so that only the first step is executed:

`ockam enroll --user-account-only`

Note that a user re-enrolling could have a Space and/or Project defined. With this flag enabled, enroll will still check for the presence of a Space and setting the default if one exists. Likewise, if a Project is found in the Space it will continue to be set as the default.

see GH Issue: https://github.com/build-trust/ockam/issues/5452

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
