### PR TITLE
refactor(rust): use `BackgroundNode` to handle tcp-inlets within the app

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -60,7 +60,7 @@ pub mod message;
 mod node_identities;
 mod node_services;
 mod policy;
-mod portals;
+pub mod portals;
 pub mod relay;
 mod secure_channel;
 mod transport;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
@@ -53,6 +53,10 @@ impl BackgroundNode {
         })
     }
 
+    pub fn delete(&self) -> miette::Result<()> {
+        Ok(self.cli_state.nodes.delete(self.node_name())?)
+    }
+
     // Set a different node name
     pub fn set_node_name(&mut self, node_name: &str) -> &Self {
         self.node_name = node_name.to_string();

--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -17,7 +17,6 @@ pub trait BackgroundNodeClient: Send + Sync + 'static {
 #[async_trait]
 pub trait Nodes: Send + Sync + 'static {
     async fn create(&mut self, node_name: &str) -> Result<()>;
-    async fn delete(&mut self, node_name: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -83,22 +82,6 @@ impl Nodes for Cli {
             .stdout_capture()
             .run()
             .map(|_| debug!(node = %node_name, "Node created"));
-        })
-        .await?;
-
-        Ok(())
-    }
-
-    async fn delete(&mut self, node_name: &str) -> Result<()> {
-        debug!(node = %node_name, "Deleting node");
-        let bin = self.bin.clone();
-        let node_name = node_name.to_string();
-        spawn_blocking(move || {
-            let _ = duct::cmd!(&bin, "--no-input", "node", "delete", "--yes", &node_name)
-                .before_spawn(log_command)
-                .stderr_null()
-                .stdout_capture()
-                .run();
         })
         .await?;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -2,18 +2,15 @@ use crate::cli::cli_bin;
 use crate::error::Error;
 use crate::Result;
 use ockam::compat::tokio::task::spawn_blocking;
-use ockam_api::nodes::models::portal::InletStatus;
 use ockam_core::async_trait;
-use std::net::SocketAddr;
 use std::process::Command;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info};
 
 // Matches backend default of 14 days
 const DEFAULT_ENROLLMENT_TICKET_EXPIRY: &str = "14d";
 
 pub trait BackgroundNodeClient: Send + Sync + 'static {
     fn nodes(&self) -> Box<dyn Nodes>;
-    fn inlets(&self) -> Box<dyn Inlets>;
     fn projects(&self) -> Box<dyn Projects>;
 }
 
@@ -21,19 +18,6 @@ pub trait BackgroundNodeClient: Send + Sync + 'static {
 pub trait Nodes: Send + Sync + 'static {
     async fn create(&mut self, node_name: &str) -> Result<()>;
     async fn delete(&mut self, node_name: &str) -> Result<()>;
-}
-
-#[async_trait]
-pub trait Inlets: Send + Sync + 'static {
-    async fn create(
-        &mut self,
-        node_name: &str,
-        from: &SocketAddr,
-        service_route: &str,
-        service_name: &str,
-    ) -> Result<()>;
-    async fn show(&self, node_name: &str, inlet_name: &str) -> Result<InletStatus>;
-    async fn delete(&mut self, node_name: &str, alias: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -71,10 +55,6 @@ fn log_command(cmd: &mut Command) -> std::io::Result<()> {
 
 impl BackgroundNodeClient for Cli {
     fn nodes(&self) -> Box<dyn Nodes> {
-        Box::new(self.clone())
-    }
-
-    fn inlets(&self) -> Box<dyn Inlets> {
         Box::new(self.clone())
     }
 
@@ -123,132 +103,6 @@ impl Nodes for Cli {
         .await?;
 
         Ok(())
-    }
-}
-
-#[async_trait]
-impl Inlets for Cli {
-    async fn create(
-        &mut self,
-        node_name: &str,
-        from: &SocketAddr,
-        service_route: &str,
-        service_name: &str,
-    ) -> Result<()> {
-        let from_str = from.to_string();
-        let bin = self.bin.clone();
-        let node_name = node_name.to_string();
-        let service_route = service_route.to_string();
-        let service_name = service_name.to_string();
-        spawn_blocking(move || {
-            duct::cmd!(
-                &bin,
-                "--no-input",
-                "tcp-inlet",
-                "create",
-                "--at",
-                &node_name,
-                "--from",
-                &from_str,
-                "--to",
-                &service_route,
-                "--alias",
-                &service_name,
-                "--retry-wait",
-                "0",
-                "--timeout",
-                "5",
-            )
-            .before_spawn(log_command)
-            .stderr_null()
-            .stdout_capture()
-            .run()
-            .map(|_| {
-                info!(
-                    from = from_str,
-                    to = service_route,
-                    "Created TCP inlet for accepted invitation"
-                );
-            })
-        })
-        .await?
-        .map_err(|err| err.into())
-    }
-
-    async fn show(&self, node_name: &str, inlet_name: &str) -> Result<InletStatus> {
-        debug!(node = %node_name, "Checking TCP inlet status");
-        let inlet_name = inlet_name.to_string();
-        let node_name = node_name.to_string();
-        let bin = self.bin.clone();
-        spawn_blocking(move || {
-            match duct::cmd!(
-                &bin,
-                "--no-input",
-                "tcp-inlet",
-                "show",
-                &inlet_name,
-                "--at",
-                &node_name,
-                "--output",
-                "json"
-            )
-            .before_spawn(log_command)
-            .env("OCKAM_LOG", "off")
-            .stderr_null()
-            .stdout_capture()
-            .run()
-            {
-                Ok(cmd) => {
-                    trace!(output = ?String::from_utf8_lossy(&cmd.stdout), "TCP inlet status");
-                    let inlet: InletStatus = serde_json::from_slice(&cmd.stdout)?;
-                    debug!(
-                        at = ?inlet.bind_addr,
-                        alias = inlet.alias,
-                        "TCP inlet running"
-                    );
-                    Ok(inlet)
-                }
-                Err(_) => Err(Error::App(format!(
-                    "TCP inlet {} is not running",
-                    inlet_name
-                ))),
-            }
-        })
-        .await?
-    }
-
-    async fn delete(&mut self, node_name: &str, alias: &str) -> Result<()> {
-        debug!(node = %node_name, %alias, "Deleting TCP inlet");
-        let bin = self.bin.clone();
-        let node_name = node_name.to_string();
-        let alias = alias.to_string();
-        spawn_blocking(move || {
-            let _ = duct::cmd!(
-                &bin,
-                "--no-input",
-                "tcp-inlet",
-                "delete",
-                &alias,
-                "--at",
-                &node_name,
-                "--yes"
-            )
-            .before_spawn(log_command)
-            .stderr_null()
-            .stdout_capture()
-            .run()
-            .map(|_| {
-                info!(
-                    node = %node_name, alias = %alias,
-                    "Disconnected TCP inlet for accepted invitation"
-                );
-            })
-            .map_err(
-                |e| warn!(%e, node = %node_name, alias = %alias, "Failed to delete TCP inlet"),
-            );
-        })
-        .await
-        .map_err(|err| err.into())
     }
 }
 

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -32,7 +32,7 @@ use ockam_api::nodes::models::transport::{CreateTransportJson, TransportMode, Tr
 use ockam_api::nodes::service::{
     NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
 };
-use ockam_api::nodes::{InMemoryNode, NodeManagerWorker, NODEMANAGER_ADDR};
+use ockam_api::nodes::{BackgroundNode, InMemoryNode, NodeManagerWorker, NODEMANAGER_ADDR};
 use ockam_api::trust_context::TrustContextConfigBuilder;
 
 use crate::api::state::OrchestratorStatus;
@@ -340,6 +340,10 @@ impl AppState {
     pub async fn controller(&self) -> Result<Controller> {
         let node_manager = self.node_manager.read().await;
         Ok(node_manager.create_controller().await?)
+    }
+
+    pub async fn background_node(&self, node_name: &str) -> Result<BackgroundNode> {
+        Ok(BackgroundNode::create(&self.context(), &self.state().await, node_name).await?)
     }
 
     pub async fn is_enrolled(&self) -> Result<bool> {

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -204,13 +204,7 @@ impl AppState {
             };
 
             for node_name in inlets {
-                let _ = this
-                    .background_node_client
-                    .read()
-                    .await
-                    .nodes()
-                    .delete(&node_name)
-                    .await;
+                let _ = this.delete_background_node(&node_name).await;
             }
 
             std::process::exit(0);
@@ -344,6 +338,10 @@ impl AppState {
 
     pub async fn background_node(&self, node_name: &str) -> Result<BackgroundNode> {
         Ok(BackgroundNode::create(&self.context(), &self.state().await, node_name).await?)
+    }
+
+    pub async fn delete_background_node(&self, node_name: &str) -> Result<()> {
+        Ok(self.state().await.nodes.delete(node_name)?)
     }
 
     pub async fn is_enrolled(&self) -> Result<bool> {


### PR DESCRIPTION
- Add an `Inlets` trait that is implemented by the `BackgroundNode` struct
- Refactor crud `tcp-inlet` commands to use the `BackgroundNode`
- Refactor crud `tcp-inlet` CLI usages from the app to use the `BackgroundNode`
- Refactor `node delete` CLI usages from the app