### PR TITLE
feat(elixir): option to terminate tcp transports due to inactivity

### DIFF
--- a/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/handler_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/transport/tcp/handler_test.exs
@@ -1,0 +1,37 @@
+defmodule Ockam.Transport.TCP.Handler.Tests do
+  use ExUnit.Case
+
+  alias Ockam.Message
+  alias Ockam.Node
+  alias Ockam.Transport.TCP
+
+  test "TCP closes idle connections" do
+    assert {:ok, _listener_address_b} =
+             TCP.start(listen: [port: 6001, handler_options: [idle_timeout: 100]])
+
+    {:ok, client_addr} = TCP.Client.create(host: "localhost", port: 6001)
+
+    {:ok, test_addr} = Node.register_random_address()
+
+    on_exit(fn ->
+      Ockam.Node.stop(client_addr)
+    end)
+
+    # Check that connection is working
+    request = %{
+      onward_route: [
+        client_addr,
+        test_addr
+      ],
+      return_route: [],
+      payload: "hello"
+    }
+
+    Ockam.Router.route(request)
+    assert_receive(%Message{payload: "hello"})
+
+    # After a period of inactivity, connection must be terminated by the receiving end
+    ref = Process.monitor(Node.whereis(client_addr))
+    assert_receive({:DOWN, ^ref, :process, _pid, :normal}, 1000)
+  end
+end


### PR DESCRIPTION
by default transport are not terminated until the underling tcp socket is closed.  This PR adds an option to close the socket and terminate the transport after a configured period of inactivity.  It's mainly a safety valve on server apps, in cases where a client leaks connections.
