### PR TITLE
feat(rust): automatically drop tcp workers when dropping secure clients

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -127,7 +127,7 @@ impl Members for AuthorityNode {
         attributes: HashMap<&str, &str>,
     ) -> miette::Result<()> {
         let req = Request::post("/").body(AddMember::new(identifier).with_attributes(attributes));
-        self.0
+        self.secure_client
             .tell(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?
@@ -137,7 +137,7 @@ impl Members for AuthorityNode {
 
     async fn delete_member(&self, ctx: &Context, identifier: Identifier) -> miette::Result<()> {
         let req = Request::delete(format!("/{identifier}"));
-        self.0
+        self.secure_client
             .tell(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?
@@ -147,7 +147,7 @@ impl Members for AuthorityNode {
 
     async fn list_member_ids(&self, ctx: &Context) -> miette::Result<Vec<Identifier>> {
         let req = Request::get("/member_ids");
-        self.0
+        self.secure_client
             .ask(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?
@@ -160,7 +160,7 @@ impl Members for AuthorityNode {
         ctx: &Context,
     ) -> miette::Result<HashMap<Identifier, AttributesEntry>> {
         let req = Request::get("/");
-        self.0
+        self.secure_client
             .ask(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?
@@ -195,7 +195,7 @@ impl TokenIssuer for AuthorityNode {
             .with_ttl_count(ttl_count);
 
         let req = Request::post("/").body(body);
-        self.0
+        self.secure_client
             .ask(ctx, DefaultAddress::ENROLLMENT_TOKEN_ISSUER, req)
             .await
             .into_diagnostic()?
@@ -213,7 +213,7 @@ pub trait TokenAcceptor {
 impl TokenAcceptor for AuthorityNode {
     async fn present_token(&self, ctx: &Context, token: OneTimeCode) -> miette::Result<()> {
         let req = Request::post("/").body(token);
-        self.0
+        self.secure_client
             .ask(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -115,7 +115,7 @@ impl Addons for Controller {
     async fn list_addons(&self, ctx: &Context, project_id: String) -> miette::Result<Vec<Addon>> {
         trace!(target: TARGET, project_id, "listing addons");
         let req = Request::get(format!("/v0/{project_id}/addons"));
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -134,7 +134,7 @@ impl Addons for Controller {
             "/v1/projects/{project_id}/configure_addon/confluent"
         ))
         .body(config);
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -151,7 +151,7 @@ impl Addons for Controller {
         trace!(target: TARGET, project_id, "configuring okta addon");
         let req =
             Request::post(format!("/v1/projects/{project_id}/configure_addon/okta")).body(config);
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -171,7 +171,7 @@ impl Addons for Controller {
             "/v1/projects/{project_id}/configure_addon/influxdb_token_lease_manager"
         ))
         .body(config);
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -188,7 +188,7 @@ impl Addons for Controller {
         trace!(target: TARGET, project_id, "disabling addon");
         let req = Request::post(format!("/v1/projects/{project_id}/disable_addon"))
             .body(DisableAddon::new(addon_id));
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -51,7 +51,7 @@ impl Enroll for Controller {
     ) -> miette::Result<EnrollmentToken> {
         trace!(target: TARGET, "generating tokens");
         let req = Request::post("v0/").body(RequestEnrollmentToken::new(attributes));
-        self.0
+        self.secure_client
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
@@ -68,7 +68,7 @@ impl Enroll for Controller {
             token: enrollment_token.token,
         });
         trace!(target: TARGET, "authenticating token");
-        self.0
+        self.secure_client
             .tell(ctx, "enrollment_token_authenticator", req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
@@ -68,7 +68,7 @@ impl Operations for Controller {
     ) -> miette::Result<Option<Operation>> {
         trace!(target: TARGET, operation_id, "getting operation");
         let req = Request::get(format!("/v1/operations/{operation_id}"));
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -281,7 +281,7 @@ impl Projects for Controller {
         trace!(target: TARGET, %space_id, project_name = name, "creating project");
         let req = Request::post(format!("/v1/spaces/{space_id}/projects"))
             .body(CreateProject::new(name, users));
-        self.0
+        self.secure_client
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
@@ -292,7 +292,7 @@ impl Projects for Controller {
     async fn get_project(&self, ctx: &Context, project_id: String) -> miette::Result<Project> {
         trace!(target: TARGET, %project_id, "getting project");
         let req = Request::get(format!("/v0/{project_id}"));
-        self.0
+        self.secure_client
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
@@ -308,7 +308,7 @@ impl Projects for Controller {
     ) -> miette::Result<()> {
         trace!(target: TARGET, %space_id, %project_id, "deleting project");
         let req = Request::delete(format!("/v0/{space_id}/{project_id}"));
-        self.0
+        self.secure_client
             .tell(ctx, "projects", req)
             .await
             .into_diagnostic()?
@@ -318,7 +318,7 @@ impl Projects for Controller {
 
     async fn get_project_version(&self, ctx: &Context) -> miette::Result<ProjectVersion> {
         trace!(target: TARGET, "getting project version");
-        self.0
+        self.secure_client
             .ask(ctx, "version_info", Request::get(""))
             .await
             .into_diagnostic()?
@@ -328,7 +328,7 @@ impl Projects for Controller {
 
     async fn list_projects(&self, ctx: &Context) -> miette::Result<Vec<Project>> {
         let req = Request::get("/v0");
-        self.0
+        self.secure_client
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
@@ -85,7 +85,7 @@ impl Invitations for Controller {
             target_id,
         };
         let req = Request::post("/v0/invites").body(req_body);
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -121,7 +121,7 @@ impl Invitations for Controller {
             enrollment_ticket,
         };
         let req = Request::post("/v0/invites/service").body(req_body);
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -135,7 +135,7 @@ impl Invitations for Controller {
         invitation_id: String,
     ) -> miette::Result<AcceptedInvitation> {
         let req = Request::post("/v0/redeem_invite").body(AcceptInvitation { id: invitation_id });
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -150,7 +150,7 @@ impl Invitations for Controller {
     ) -> miette::Result<InvitationWithAccess> {
         trace!(?invitation_id, "showing invitation");
         let req = Request::get(format!("/v0/invites/{invitation_id}"));
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -165,7 +165,7 @@ impl Invitations for Controller {
     ) -> miette::Result<InvitationList> {
         debug!(?kind, "Sending request to list shares");
         let req = Request::get("/v0/invites").body(ListInvitations { kind });
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
@@ -176,7 +176,7 @@ impl Invitations for Controller {
     async fn ignore_invitation(&self, ctx: &Context, invitation_id: String) -> miette::Result<()> {
         debug!(?invitation_id, "sending request to ignore invitation");
         let req = Request::post(format!("/v0/invites/{invitation_id}/ignore"));
-        self.0
+        self.secure_client
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -58,7 +58,7 @@ impl Spaces for Controller {
     ) -> miette::Result<Space> {
         trace!(target: TARGET, space = %name, "creating space");
         let req = Request::post("/v0/").body(CreateSpace::new(name, users));
-        self.0
+        self.secure_client
             .ask(ctx, "spaces", req)
             .await
             .into_diagnostic()?
@@ -69,7 +69,7 @@ impl Spaces for Controller {
     async fn get_space(&self, ctx: &Context, space_id: String) -> miette::Result<Space> {
         trace!(target: TARGET, space = %space_id, "getting space");
         let req = Request::get(format!("/v0/{space_id}"));
-        self.0
+        self.secure_client
             .ask(ctx, "spaces", req)
             .await
             .into_diagnostic()?
@@ -80,7 +80,7 @@ impl Spaces for Controller {
     async fn delete_space(&self, ctx: &Context, space_id: String) -> miette::Result<()> {
         trace!(target: TARGET, space = %space_id, "deleting space");
         let req = Request::delete(format!("/v0/{space_id}"));
-        self.0
+        self.secure_client
             .tell(ctx, "spaces", req)
             .await
             .into_diagnostic()?
@@ -90,7 +90,7 @@ impl Spaces for Controller {
 
     async fn list_spaces(&self, ctx: &Context) -> miette::Result<Vec<Space>> {
         trace!(target: TARGET, "listing spaces");
-        self.0
+        self.secure_client
             .ask(ctx, "spaces", Request::get("/v0/"))
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -122,7 +122,7 @@ impl Subscriptions for Controller {
         let req_body = ActivateSubscription::existing(space_id, subscription_data);
         trace!(target: TARGET, space_id = ?req_body.space_id, space_name = ?req_body.space_name, "activating subscription");
         let req = Request::post("/v0/activate").body(req_body);
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn unsubscribe(
@@ -132,7 +132,7 @@ impl Subscriptions for Controller {
     ) -> Result<Reply<Subscription>> {
         trace!(target: TARGET, subscription = %subscription_id, "unsubscribing");
         let req = Request::put(format!("/v0/{subscription_id}/unsubscribe"));
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn update_subscription_contact_info(
@@ -143,7 +143,7 @@ impl Subscriptions for Controller {
     ) -> Result<Reply<Subscription>> {
         trace!(target: TARGET, subscription = %subscription_id, "updating subscription contact info");
         let req = Request::put(format!("/v0/{subscription_id}/contact_info")).body(contact_info);
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn update_subscription_space(
@@ -154,13 +154,13 @@ impl Subscriptions for Controller {
     ) -> Result<Reply<Subscription>> {
         trace!(target: TARGET, subscription = %subscription_id, new_space_id = %new_space_id, "updating subscription space");
         let req = Request::put(format!("/v0/{subscription_id}/space_id")).body(new_space_id);
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<Subscription>>> {
         trace!(target: TARGET, "listing subscriptions");
         let req = Request::get("/v0/");
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn get_subscription(
@@ -170,7 +170,7 @@ impl Subscriptions for Controller {
     ) -> Result<Reply<Subscription>> {
         trace!(target: TARGET, subscription = %subscription_id, "getting subscription");
         let req = Request::get(format!("/v0/{subscription_id}"));
-        self.0.ask(ctx, API_SERVICE, req).await
+        self.secure_client.ask(ctx, API_SERVICE, req).await
     }
 
     async fn get_subscription_by_space_id(

--- a/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/influxdb_token_lease.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/influxdb_token_lease.rs
@@ -19,7 +19,7 @@ pub trait InfluxDbTokenLease {
 #[async_trait]
 impl InfluxDbTokenLease for ProjectNode {
     async fn create_token(&self, ctx: &Context) -> miette::Result<Token> {
-        self.0
+        self.secure_client
             .ask(ctx, "influxdb_token_lease", Request::post("/"))
             .await
             .into_diagnostic()?
@@ -28,7 +28,7 @@ impl InfluxDbTokenLease for ProjectNode {
     }
 
     async fn get_token(&self, ctx: &Context, token_id: String) -> miette::Result<Token> {
-        self.0
+        self.secure_client
             .ask(
                 ctx,
                 "influxdb_token_lease",
@@ -41,7 +41,7 @@ impl InfluxDbTokenLease for ProjectNode {
     }
 
     async fn revoke_token(&self, ctx: &Context, token_id: String) -> miette::Result<()> {
-        self.0
+        self.secure_client
             .tell(
                 ctx,
                 "influxdb_token_lease",
@@ -54,7 +54,7 @@ impl InfluxDbTokenLease for ProjectNode {
     }
 
     async fn list_tokens(&self, ctx: &Context) -> miette::Result<Vec<Token>> {
-        self.0
+        self.secure_client
             .ask(ctx, "influxdb_token_lease", Request::get("/"))
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/credentials.rs
@@ -56,7 +56,7 @@ impl Credentials for AuthorityNode {
     ) -> miette::Result<CredentialAndPurposeKey> {
         let body = GetCredentialRequest::new(overwrite, identity_name);
         let req = Request::post("/node/credentials/actions/get").body(body);
-        self.0
+        self.secure_client
             .ask(ctx, "", req)
             .await
             .into_diagnostic()?
@@ -72,7 +72,7 @@ impl Credentials for AuthorityNode {
     ) -> miette::Result<()> {
         let body = PresentCredentialRequest::new(to, oneway);
         let req = Request::post("/node/credentials/actions/present").body(body);
-        self.0
+        self.secure_client
             .tell(ctx, "", req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -126,13 +126,14 @@ impl AppState {
     async fn retrieve_space(&self) -> Result<Space> {
         info!("retrieving the user's space");
         let controller = self.controller().await.into_diagnostic()?;
+        let context = self.context();
 
         // list the spaces that the user can access
         // and sort them by name to make sure to get the same space every time
         // if several spaces are available
         let spaces = {
             let mut spaces = controller
-                .list_spaces(&self.context())
+                .list_spaces(&context)
                 .await
                 .map_err(|e| miette!(e))?;
             spaces.sort_by(|s1, s2| s1.name.cmp(&s2.name));
@@ -146,7 +147,7 @@ impl AppState {
             None => {
                 let space_name = cli_state::random_name();
                 controller
-                    .create_space(&self.context(), space_name, vec![])
+                    .create_space(&context, space_name, vec![])
                     .await
                     .map_err(|e| miette!(e))?
             }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
@@ -4,6 +4,7 @@ use core::fmt::Formatter;
 use ockam_core::compat::net::{SocketAddr, ToSocketAddrs};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::{Address, Result};
+use ockam_node::Context;
 use ockam_transport_core::TransportError;
 
 /// Result of [`TcpTransport::connect`] call.
@@ -48,6 +49,12 @@ impl TcpConnection {
             mode,
             flow_control_id,
         }
+    }
+    /// Stops the [`TcpConnection`], this method must be called to avoid
+    /// leakage of the connection.
+    /// Simply dropping this object won't close the connection
+    pub async fn stop(&self, context: &Context) -> Result<()> {
+        context.stop_worker(self.sender_address.clone()).await
     }
     /// Corresponding [`TcpSendWorker`](super::workers::TcpSendWorker) [`Address`] that can be used
     /// in a route to send messages to the other side of the TCP connection


### PR DESCRIPTION
When resolving a `MultiAddr` to a `Route` it usually involves creating a new TCP connection. In most cases, this connection (or its relative worker) is not being tracked and properly stopped after use.

This is a partial solution for at least secure clients: controller, authority, project and an unused generic.

More should be done to address every instantiation of a `Route`, this is just a first step to avoiding socket leaks in the application which frequently create secure clients.