### PR TITLE
feat(rust): always using enum when representing the inlet connection status

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -152,6 +152,7 @@ mod session;
 mod util;
 
 pub use influxdb_token_lease::*;
+pub use session::sessions::ConnectionStatus;
 pub use util::*;
 
 #[macro_use]

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ApiError;
 use crate::route_to_multiaddr;
+use crate::session::sessions::ConnectionStatus;
 
 /// Request body to create an inlet
 #[derive(Clone, Debug, Decode, Encode)]
@@ -156,7 +157,7 @@ pub struct InletStatus {
     /// An optional status payload
     #[n(4)] pub payload: Option<String>,
     #[n(5)] pub outlet_route: String,
-    #[n(6)] pub status: String,
+    #[n(6)] pub status: ConnectionStatus,
 }
 
 impl InletStatus {
@@ -167,7 +168,7 @@ impl InletStatus {
             alias: "".into(),
             payload: Some(reason.into()),
             outlet_route: "".into(),
-            status: "".into(),
+            status: ConnectionStatus::Down,
         }
     }
 
@@ -177,7 +178,7 @@ impl InletStatus {
         alias: impl Into<String>,
         payload: impl Into<Option<String>>,
         outlet_route: impl Into<String>,
-        status: impl Into<String>,
+        status: ConnectionStatus,
     ) -> Self {
         Self {
             bind_addr: bind_addr.into(),
@@ -185,7 +186,7 @@ impl InletStatus {
             alias: alias.into(),
             payload: payload.into(),
             outlet_route: outlet_route.into(),
-            status: status.into(),
+            status,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -26,7 +26,9 @@ use crate::nodes::registry::{InletInfo, OutletInfo};
 use crate::nodes::service::policy::Policies;
 use crate::nodes::service::random_alias;
 use crate::nodes::{BackgroundNode, InMemoryNode};
-use crate::session::sessions::{Replacer, Session, Status, MAX_CONNECT_TIME, MAX_RECOVERY_TIME};
+use crate::session::sessions::{
+    ConnectionStatus, Replacer, Session, MAX_CONNECT_TIME, MAX_RECOVERY_TIME,
+};
 use crate::{actions, resources, DefaultAddress};
 
 use super::{NodeManager, NodeManagerWorker};
@@ -416,7 +418,7 @@ impl NodeManager {
                         alias,
                         None,
                         outlet_route.to_string(),
-                        Status::Up.to_string(),
+                        ConnectionStatus::Up,
                     ),
                     access_control,
                 )
@@ -450,7 +452,7 @@ impl NodeManager {
                         alias,
                         None,
                         inlet_to_delete.outlet_route.to_string(),
-                        Status::Down.to_string(),
+                        ConnectionStatus::Down,
                     ))
                 }
                 Err(e) => {
@@ -480,8 +482,7 @@ impl NodeManager {
             let status = self
                 .medic_handle
                 .status_of(&format!("inlet-{alias}"))
-                .unwrap_or(Status::Down)
-                .to_string();
+                .unwrap_or(ConnectionStatus::Down);
 
             debug!(%alias, "Inlet not found in node registry");
             Some(InletStatus::new(
@@ -509,8 +510,7 @@ impl NodeManager {
                     let status = self
                         .medic_handle
                         .status_of(&format!("inlet-{alias}"))
-                        .unwrap_or(Status::Down)
-                        .to_string();
+                        .unwrap_or(ConnectionStatus::Down);
 
                     InletStatus::new(
                         &info.bind_addr,

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
@@ -15,6 +15,7 @@ use ockam_api::cloud::share::InvitationListKind;
 use ockam_api::cloud::share::{CreateServiceInvitation, InvitationWithAccess, Invitations};
 use ockam_api::nodes::service::portals::Inlets;
 use ockam_api::nodes::BackgroundNode;
+use ockam_api::ConnectionStatus;
 use ockam_multiaddr::MultiAddr;
 
 use crate::background_node::BackgroundNodeClient;
@@ -393,7 +394,7 @@ impl AppState {
                     .await?
                     .success()
                 {
-                    if inlet.status == "up" {
+                    if inlet.status == ConnectionStatus::Up {
                         inlet_data.socket_addr = Some(inlet.bind_addr.parse()?);
                         return Inlet::new(inlet_data).map(Some);
                     }


### PR DESCRIPTION
Using the `ConnectionStatus` enum for the `InletStatus` for better readability and API clarity