### PR TITLE
feat(rust): add lock file to cli state items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,6 +4809,7 @@ dependencies = [
  "cddl-cat",
  "either",
  "fake",
+ "fs2",
  "hex",
  "home",
  "indexmap 2.0.2",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -33,6 +33,7 @@ aws-config = { version = "0.56.1", default-features = false, features = ["rustls
 base64-url = "2.0.0"
 bytes = { version = "1.5.0", default-features = false, features = ["serde"] }
 either = { version = "1.9.0", default-features = false }
+fs2 = { version = "0.4.3" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 home = "0.5"
 kafka-protocol = "0.7.0"

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -69,6 +69,7 @@ impl NodeState {
     fn _delete(&self, sikgill: bool) -> Result<()> {
         self.kill_process(sikgill)?;
         std::fs::remove_dir_all(&self.path)?;
+        let _ = std::fs::remove_file(self.path.with_extension("lock"));
         let _ = std::fs::remove_dir(&self.path); // Make sure the dir is gone
         info!(name=%self.name, "node deleted");
         Ok(())


### PR DESCRIPTION
This PR uses the `fs2` crate to use a lock file on every CliState item to mitigate the side effects of having concurrent writes through the `overwrite` or `persist` methods of the CliState traits.