### PR TITLE
feat(rust): fixes many papercuts and better avoid and handle state resets

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
@@ -177,7 +177,7 @@ impl Invitations for Controller {
         debug!(?invitation_id, "sending request to ignore invitation");
         let req = Request::post(format!("/v0/invites/{invitation_id}/ignore"));
         self.secure_client
-            .ask(ctx, API_SERVICE, req)
+            .tell(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
             .success()

--- a/implementations/rust/ockam/ockam_app_lib/src/cli/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/cli/mod.rs
@@ -43,6 +43,13 @@ pub(crate) fn add_homebrew_to_path() {
     }
 }
 
+/// Set the OCKAM_NO_AUTOMATIC_RESET environment variable to avoid
+/// automatically resetting the node when the application find an incoherent state
+/// this may happen if a command is launched during a write operation
+pub(crate) fn set_no_automatic_reset() {
+    std::env::set_var("OCKAM_NO_AUTOMATIC_RESET", "true");
+}
+
 /// Check that the OCKAM environment variable defines an absolute path
 /// Otherwise we might fail to run the ockam command when starting the desktop application from an unexpected path
 /// Check that the ockam command can at least be called with the `--version` option and log

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -79,13 +79,12 @@ pub struct AppState {
 }
 
 impl AppState {
-    /// Create a new AppState
+    /// Create a new AppState, if it fails you can assume it's because the state cannot be loaded
     pub fn new(
         application_state_callback: Option<ApplicationStateCallback>,
         notification_callback: Option<NotificationCallback>,
-    ) -> AppState {
-        let cli_state =
-            CliState::initialize().expect("Failed to load the local Ockam configuration");
+    ) -> Result<AppState> {
+        let cli_state = CliState::initialize()?;
         let (context, mut executor) = NodeBuilder::new().no_logging().build();
         let context = Arc::new(context);
         let runtime = context.runtime().clone();
@@ -133,7 +132,7 @@ impl AppState {
             }
         };
 
-        runtime.block_on(future)
+        Ok(runtime.block_on(future))
     }
 
     /// Load a previously persisted ModelState and start refreshing schedule

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -244,6 +244,9 @@ impl CommandGlobalOpts {
             Ok(state) => state,
             Err(err) => {
                 eprintln!("Failed to initialize state: {}", err);
+                if std::env::var("OCKAM_NO_AUTOMATIC_RESET").is_ok() {
+                    std::process::exit(exitcode::CONFIG);
+                }
                 let state = CliState::backup_and_reset().expect(
                     "Failed to initialize CliState. Try to manually remove the '~/.ockam' directory",
                 );

--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		782D5BAF2AC33F9400D1B27F /* libockam_app_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 782D5B792AC1E36700D1B27F /* libockam_app_lib.a */; };
 		783B62722AC432B700880261 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783B62712AC432B700880261 /* Bridge.swift */; };
 		789FA6462AE142280009FF7F /* ExportOptions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 789FA6452AE142280009FF7F /* ExportOptions.plist */; };
+		78BD349D2AFA621500F09058 /* BrokenStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BD349C2AFA621500F09058 /* BrokenStateView.swift */; };
 		78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D520822ADD5CAE00F36B64 /* Helpers.swift */; };
 		78ED0DA12AD4354400574AE9 /* CreateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA02AD4354400574AE9 /* CreateService.swift */; };
 		78ED0DA32AD4501200574AE9 /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA22AD4501200574AE9 /* ShareService.swift */; };
@@ -44,6 +45,7 @@
 		783B62712AC432B700880261 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
 		785D8D372AD5369100DF5004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		789FA6452AE142280009FF7F /* ExportOptions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ExportOptions.plist; sourceTree = "<group>"; };
+		78BD349C2AFA621500F09058 /* BrokenStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokenStateView.swift; sourceTree = "<group>"; };
 		78D520822ADD5CAE00F36B64 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		78ED0DA02AD4354400574AE9 /* CreateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateService.swift; sourceTree = "<group>"; };
 		78ED0DA22AD4501200574AE9 /* ShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				7827D5062AD93EE700F7A20F /* ProfilePicture.swift */,
 				7827D5082AD93F1700F7A20F /* ClickableMenuEntry.swift */,
 				78D520822ADD5CAE00F36B64 /* Helpers.swift */,
+				78BD349C2AFA621500F09058 /* BrokenStateView.swift */,
 			);
 			path = Ockam;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				7827D5072AD93EE700F7A20F /* ProfilePicture.swift in Sources */,
 				782D5B492AC1D3D700D1B27F /* OckamApp.swift in Sources */,
 				78ED0DA32AD4501200574AE9 /* ShareService.swift in Sources */,
+				78BD349D2AFA621500F09058 /* BrokenStateView.swift in Sources */,
 				4CB45C522AEB06C700D27F22 /* OpenUrlView.swift in Sources */,
 				783B62722AC432B700880261 /* Bridge.swift in Sources */,
 			);

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
@@ -121,7 +121,7 @@ typedef struct C_Notification {
 /**
  * This functions initializes the application state.
  */
-void initialize_application(void (*application_state_callback)(struct C_ApplicationState state),
+bool initialize_application(void (*application_state_callback)(struct C_ApplicationState state),
                             void (*notification_callback)(struct C_Notification notification));
 
 /**

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
@@ -252,7 +252,7 @@ func swift_application_snapshot() -> ApplicationState {
     return convertApplicationState(cState: application_state_snapshot())
 }
 
-func swift_initialize_application() {
+func swift_initialize_application() -> Bool {
     let applicationStateClosure: @convention(c) (C_ApplicationState) -> Void = { state in
         StateContainer.shared.update(state: convertApplicationState(cState: state))
     }
@@ -277,7 +277,7 @@ func swift_initialize_application() {
         }
     }
 
-    initialize_application(applicationStateClosure, notificationClosure)
+    let result = initialize_application(applicationStateClosure, notificationClosure)
 
     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
         granted, error in
@@ -287,6 +287,8 @@ func swift_initialize_application() {
             print("Notifications not allowed")
         }
     }
+
+    return result
 }
 
 func optional_string(str: UnsafePointer<Int8>?) -> String? {

--- a/implementations/swift/ockam/ockam_app/Ockam/BrokenStateView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/BrokenStateView.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+import SwiftUI
+
+struct BrokenStateView: View {
+    var body: some View {
+        VStack {
+            Text("The Ockam state is either corrupted or incompatible with the current version.\n\nYou can reset the state or quit the application and try another version.")
+                .multilineTextAlignment(.center)
+                .padding()
+            Spacer()
+            HStack {
+                Spacer()
+                Button(
+                    action: {
+                        restartCurrentProcess()
+                    },
+                    label: {
+                        Text("Reset State")
+                    }
+                    )
+                Button(
+                    action: {
+                        exit(1)
+                    },
+                    label: {
+                        Text("Quit")
+                    }
+                )
+                .keyboardShortcut(.defaultAction)
+                .padding(10)
+            }
+            .background(.black.opacity(0.1))
+        }
+        .frame(width: 300, height: 160)
+    }
+
+}
+
+struct BrokenState_Previews: PreviewProvider {
+    static var previews: some View {
+        BrokenStateView()
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -154,6 +154,14 @@ struct MainView: View {
         .onReceive(timer) { time in
             optionPressed = NSEvent.modifierFlags.contains(.option)
         }
+        .onReceive(state.$groups) { _ in
+            // the selected group could have been deleted, if so, reset the selection
+            if selectedGroup != "" {
+                if !state.groups.contains(where: { $0.id == selectedGroup }) {
+                    selectedGroup = ""
+                }
+            }
+        }
     }
 
     func closeWindow() {

--- a/implementations/swift/ockam/ockam_app/Ockam/Services.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Services.swift
@@ -63,7 +63,7 @@ struct ServiceGroupButton: View {
             Spacer()
             Circle()
                 .fill(Color.orange)
-                .frame(width: 8)
+                .frame(width: 8, height: 8)
                 .opacity(group.invitations.isEmpty ? 0 : 1)
             Image(systemName: "chevron.right")
                 .frame(width: 32, height: 32)


### PR DESCRIPTION
Fixes many paper cuts:

- invitation ignore taking a lot of time to refresh
- allow for application initialization to fail: in this case, the app shows a dialogue asking for the action to take (see screenshot)
- added `OCKAM_NO_AUTOMATIC_RESET` for both command and app, when set the application won't perfom any automatic reset
- fixed a bug when ignoring an invitation, the services view would get blank
- fixed a bug not showing correctly the "pending invitation" circle
- fixed a bug of not allowing CMD+V in fields (didn't allow pasting emails)

<img width="448" alt="Screenshot 2023-11-07 at 14 07 27" src="https://github.com/build-trust/ockam/assets/408088/060f18d5-6464-4a95-93a7-d6ad0cc75483">
