### PR TITLE
Revert "refactor(rust): use `AuthorityNode` directly in the app to enroll to a project"

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/identity/enrollment_ticket.rs
+++ b/implementations/rust/ockam/ockam_api/src/identity/enrollment_ticket.rs
@@ -26,21 +26,8 @@ impl EnrollmentTicket {
     }
 
     pub fn hex_encoded(&self) -> Result<String> {
-        let serialized = serde_json::to_vec(&self).map_err(|_err| {
-            ApiError::core("Failed to serialize enrollment ticket to json format")
-        })?;
+        let serialized = serde_json::to_vec(&self)
+            .map_err(|_err| ApiError::core("Failed to authenticate with Okta"))?;
         Ok(hex::encode(serialized))
-    }
-}
-
-impl TryFrom<&str> for EnrollmentTicket {
-    type Error = ockam_core::Error;
-
-    fn try_from(hex_encoded_ticket: &str) -> Result<Self> {
-        let bytes = hex::decode(hex_encoded_ticket)
-            .map_err(|_err| ApiError::core("Failed to hex decode enrollment ticket"))?;
-        let enrollment_ticket = serde_json::from_slice(&bytes)
-            .map_err(|_err| ApiError::core("Failed to decode enrollment ticket from json"))?;
-        Ok(enrollment_ticket)
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -7,11 +7,17 @@ use tracing::{debug, info};
 
 pub trait BackgroundNodeClient: Send + Sync + 'static {
     fn nodes(&self) -> Box<dyn Nodes>;
+    fn projects(&self) -> Box<dyn Projects>;
 }
 
 #[async_trait]
 pub trait Nodes: Send + Sync + 'static {
     async fn create(&mut self, node_name: &str) -> Result<()>;
+}
+
+#[async_trait]
+pub trait Projects: Send + Sync + 'static {
+    async fn enroll(&self, node_name: &str, hex_encoded_ticket: &str) -> Result<()>;
 }
 
 #[derive(Clone)]
@@ -43,6 +49,10 @@ impl BackgroundNodeClient for Cli {
     fn nodes(&self) -> Box<dyn Nodes> {
         Box::new(self.clone())
     }
+
+    fn projects(&self) -> Box<dyn Projects> {
+        Box::new(self.clone())
+    }
 }
 
 #[async_trait]
@@ -69,5 +79,34 @@ impl Nodes for Cli {
         .await?;
 
         Ok(())
+    }
+}
+
+#[async_trait]
+impl Projects for Cli {
+    async fn enroll(&self, node_name: &str, hex_encoded_ticket: &str) -> Result<()> {
+        let node_name = node_name.to_string();
+        let hex_encoded_ticket = hex_encoded_ticket.to_string();
+        let bin = self.bin.clone();
+        spawn_blocking(move || {
+            let _ = duct::cmd!(
+                &bin,
+                "--no-input",
+                "project",
+                "enroll",
+                "--new-trust-context-name",
+                &node_name,
+                &hex_encoded_ticket,
+            )
+            .before_spawn(log_command)
+            .stderr_null()
+            .stdout_capture()
+            .run()
+            .map(|_| {
+                debug!(node = %node_name, "Node enrolled using enrollment ticket");
+            });
+        })
+        .await
+        .map_err(|err| err.into())
     }
 }


### PR DESCRIPTION
It also fixes a problem about how we were handling the node that hosts the tcp-inlet.