### PR TITLE
refactor(rust): Remove is_tty utility function from ockam_command #6679

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3732,12 +3732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb4def18c48926ccac55c1223e02865ce1a821751a95920448662696e7472c"
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,8 +4924,6 @@ dependencies = [
  "home",
  "indicatif",
  "indoc",
- "io-lifetimes 2.0.2",
- "is-terminal",
  "itertools 0.11.0",
  "miette",
  "minicbor",
@@ -6430,7 +6422,7 @@ checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
- "io-lifetimes 1.0.11",
+ "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -71,20 +71,24 @@ hex = "0.4"
 home = "0.5"
 indicatif = "0.17.7"
 indoc = "2.0.4"
-io-lifetimes = "2"
-is-terminal = "0.4"
 itertools = "0.11"
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.20.0", features = ["derive", "alloc", "half"] }
 nix = "0.27"
-ockam = { path = "../ockam", version = "^0.102.0", features = ["software_vault"] }
+ockam = { path = "../ockam", version = "^0.102.0", features = [
+  "software_vault",
+] }
 ockam_abac = { path = "../ockam_abac", version = "0.36.0", features = ["std"] }
 ockam_api = { path = "../ockam_api", version = "0.45.0", features = ["std"] }
 ockam_core = { path = "../ockam_core", version = "^0.92.0" }
-ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.36.0", features = ["std"] }
+ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.36.0", features = [
+  "std",
+] }
 ockam_node = { path = "../ockam_node", version = "^0.97.0" }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.95.0" }
-ockam_vault = { path = "../ockam_vault", version = "^0.90.0", features = ["storage"] }
+ockam_vault = { path = "../ockam_vault", version = "^0.90.0", features = [
+  "storage",
+] }
 ockam_vault_aws = { path = "../ockam_vault_aws", version = "^0.15.0" }
 once_cell = "1.18"
 open = "5.0.0"
@@ -93,17 +97,25 @@ r3bl_rs_utils_core = "0.9.7"
 r3bl_tuify = "0.1.20"
 rand = "0.8"
 regex = "1.10.2"
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+reqwest = { version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls-native-roots",
+] }
 rustls = "0.21.8"
 rustls-native-certs = "0.6.3"
 serde = { version = "1", features = ["derive"] }
-serde_bare = { version = "0.5.0", default-features = false, features = ["alloc"] }
+serde_bare = { version = "0.5.0", default-features = false, features = [
+  "alloc",
+] }
 serde_json = "1"
 serde_yaml = "0.9"
 strip-ansi-escapes = "0.2.0"
 syntect = "5"
 thiserror = "1"
-time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
+time = { version = "0.3", default-features = false, features = [
+  "std",
+  "local-offset",
+] }
 tiny_http = "0.12.0"
 tokio = { version = "1.33.0", features = ["full"] }
 tokio-retry = "0.3"
@@ -119,7 +131,10 @@ assert_cmd = "2"
 ockam_macros = { path = "../ockam_macros", version = "^0.32.0" }
 proptest = "1.3.1"
 tempfile = "3.8.0"
-time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
+time = { version = "0.3", default-features = false, features = [
+  "std",
+  "local-offset",
+] }
 
 [features]
 default = ["orchestrator"]

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/delete.rs
@@ -11,7 +11,7 @@ use ockam_core::{Address, AddressParseError};
 
 use crate::docs;
 use crate::node::get_node_name;
-use crate::util::{is_tty, parse_node_name};
+use crate::util::parse_node_name;
 use crate::{
     util::{api, exitcode, node_rpc},
     CommandGlobalOpts, OutputFormat,
@@ -60,7 +60,7 @@ impl DeleteCommand {
                     Some(multiaddr) => {
                         // if stdout is not interactive/tty write the secure channel address to it
                         // in case some other program is trying to read it as piped input
-                        if !is_tty(std::io::stdout()) {
+                        if !options.terminal.clone().stdout().is_tty() {
                             println!("{multiaddr}")
                         }
 
@@ -72,7 +72,7 @@ impl DeleteCommand {
 
                         // if stderr is interactive/tty and we haven't been asked to be quiet
                         // and output format is plain then write a plain info to stderr.
-                        if is_tty(std::io::stderr())
+                        if options.terminal.is_tty()
                             && !options.global_args.quiet
                             && options.global_args.output_format == OutputFormat::Plain
                         {
@@ -96,7 +96,7 @@ impl DeleteCommand {
                     None => {
                         // if stderr is interactive/tty and we haven't been asked to be quiet
                         // and output format is plain then write a plain info to stderr.
-                        if is_tty(std::io::stderr())
+                        if options.terminal.is_tty()
                             && !options.global_args.quiet
                             && options.global_args.output_format == OutputFormat::Plain
                         {
@@ -114,7 +114,7 @@ impl DeleteCommand {
             None => {
                 // if stderr is interactive/tty and we haven't been asked to be quiet
                 // and output format is plain then write a plain info to stderr.
-                if is_tty(std::io::stderr())
+                if options.terminal.is_tty()
                     && !options.global_args.quiet
                     && options.global_args.output_format == OutputFormat::Plain
                 {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -264,11 +264,6 @@ pub fn port_is_free_guard(address: &SocketAddr) -> Result<()> {
     Ok(())
 }
 
-pub fn is_tty<S: io_lifetimes::AsFilelike>(s: S) -> bool {
-    use is_terminal::IsTerminal;
-    s.is_terminal()
-}
-
 pub fn is_enrolled_guard(cli_state: &CliState, identity_name: Option<&str>) -> miette::Result<()> {
     if !cli_state
         .identities


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Fix #6679 
## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
