### PR TITLE
fix(rust): restore orchestrator timeout to its original time of 10 minutes

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -28,7 +28,7 @@ pub(crate) const OCKAM_CONTROLLER_IDENTITY_ID: &str = "OCKAM_CONTROLLER_IDENTITY
 pub const ORCHESTRATOR_RESTART_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Total time to wait for Orchestrator long-running operations to complete
-pub const ORCHESTRATOR_AWAIT_TIMEOUT: Duration = Duration::from_secs(240);
+pub const ORCHESTRATOR_AWAIT_TIMEOUT: Duration = Duration::from_secs(60 * 10);
 
 impl NodeManager {
     pub(crate) async fn create_controller_client(&self) -> Result<Controller> {


### PR DESCRIPTION
At [6829](https://github.com/build-trust/ockam/pull/6829/files#diff-4b323902197638e5433eccb090c0f27ed95bfe6956811f243cbe30278816b676R29) I didn't do the conversion properly from `ms` to `seconds`