### PR TITLE
refactor(rust): add traits to hide the details of `show` and `delete` tui commands

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,12 +1,13 @@
 use clap::Args;
 use colorful::Colorful;
+use console::Term;
 use ockam_api::cli_state::StateDirTrait;
+use ockam_node::Context;
 
-use crate::node::get_default_node_name;
-use crate::node::util::{delete_all_nodes, delete_node};
-use crate::terminal::tui::DeleteMode;
-use crate::util::local_cmd;
-use crate::{docs, fmt_ok, fmt_warn, CommandGlobalOpts};
+use crate::node::get_node_name;
+use crate::terminal::tui::DeleteCommandTui;
+use crate::util::node_rpc;
+use crate::{docs, fmt_ok, fmt_warn, CommandGlobalOpts, Terminal, TerminalStream};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -37,104 +38,86 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
-        local_cmd(run_impl(opts, self));
+        node_rpc(run_impl, (opts, self));
     }
 }
 
-fn run_impl(opts: CommandGlobalOpts, cmd: DeleteCommand) -> miette::Result<()> {
-    let nodes_names = opts.state.nodes.list_items_names()?;
-    if nodes_names.is_empty() {
-        opts.terminal
-            .stdout()
-            .plain("There are no nodes to delete")
-            .write_line()?;
-        return Ok(());
+async fn run_impl(
+    _ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
+) -> miette::Result<()> {
+    NodeDeleteTui::run(opts, cmd).await
+}
+
+pub struct NodeDeleteTui {
+    opts: CommandGlobalOpts,
+    cmd: DeleteCommand,
+}
+
+impl NodeDeleteTui {
+    pub async fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) -> miette::Result<()> {
+        let tui = Self { opts, cmd };
+        tui.delete().await
+    }
+}
+
+#[ockam_core::async_trait]
+impl DeleteCommandTui for NodeDeleteTui {
+    const ITEM_NAME: &'static str = "nodes";
+
+    fn cmd_arg_item_name(&self) -> Option<&str> {
+        self.cmd.node_name.as_deref()
     }
 
-    let delete_mode = if cmd.all {
-        DeleteMode::All
-    } else if let Some(node_name) = cmd.node_name {
-        DeleteMode::Single(node_name)
-    } else if nodes_names.len() == 1 {
-        DeleteMode::Default
-    } else if opts.terminal.can_ask_for_user_input() {
-        DeleteMode::Selected(opts.terminal.select_multiple(
-            "Select one or more nodes that you want to delete".to_string(),
-            nodes_names,
-        ))
-    } else {
-        DeleteMode::Default
-    };
+    fn cmd_arg_delete_all(&self) -> bool {
+        self.cmd.all
+    }
 
-    match delete_mode {
-        DeleteMode::All => {
-            if opts.terminal.confirmed_with_flag_or_prompt(
-                cmd.yes,
-                "Are you sure you want to delete all nodes?",
-            )? {
-                delete_all_nodes(&opts, cmd.force)?;
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("All nodes have been deleted"))
-                    .write_line()?;
-            }
-        }
-        DeleteMode::Selected(selected_node_names) => {
-            if selected_node_names.is_empty() {
-                opts.terminal
-                    .stdout()
-                    .plain("No nodes selected for deletion")
-                    .write_line()?;
-                return Ok(());
-            }
+    fn cmd_arg_confirm_deletion(&self) -> bool {
+        self.cmd.yes
+    }
 
-            if opts.terminal.confirm_interactively(format!(
-                "Would you like to delete these items : {:?}?",
-                selected_node_names
-            )) {
-                let output = selected_node_names
-                    .iter()
-                    .map(|name| {
-                        if opts.state.nodes.delete_sigkill(name, cmd.force).is_ok() {
-                            fmt_ok!("Node '{name}' deleted\n")
-                        } else {
-                            fmt_warn!("Failed to delete Node '{name}'\n")
-                        }
-                    })
-                    .collect::<String>();
+    fn terminal(&self) -> Terminal<TerminalStream<Term>> {
+        self.opts.terminal.clone()
+    }
 
-                opts.terminal.stdout().plain(output).write_line()?;
-            }
-        }
-        DeleteMode::Single(node_name) => {
-            if opts.terminal.confirmed_with_flag_or_prompt(
-                cmd.yes,
-                format!("Are you sure you want to delete the node {node_name}?"),
-            )? {
-                delete_node(&opts, &node_name, cmd.force)?;
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("Node with name '{node_name}' has been deleted"))
-                    .machine(&node_name)
-                    .json(serde_json::json!({ "name": &node_name }))
-                    .write_line()?;
-            }
-        }
-        DeleteMode::Default => {
-            let node_name = get_default_node_name(&opts.state);
-            if opts.terminal.confirmed_with_flag_or_prompt(
-                cmd.yes,
-                format!("Are you sure you want to delete the default node '{node_name}'?"),
-            )? {
-                delete_node(&opts, &node_name, cmd.force)?;
-                opts.terminal
-                    .stdout()
-                    .plain(fmt_ok!("Node with name '{node_name}' has been deleted"))
-                    .machine(&node_name)
-                    .json(serde_json::json!({ "name": &node_name }))
-                    .write_line()?;
-            }
-        }
-    };
-    Ok(())
+    fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        Ok(self.opts.state.nodes.list_items_names()?)
+    }
+
+    async fn delete_single(&self) -> miette::Result<()> {
+        let node_name = get_node_name(&self.opts.state, &self.cmd.node_name);
+        self.opts
+            .state
+            .nodes
+            .delete_sigkill(&node_name, self.cmd.force)?;
+        self.terminal()
+            .stdout()
+            .plain(fmt_ok!("Node with name '{node_name}' has been deleted"))
+            .machine(&node_name)
+            .json(serde_json::json!({ "name": &node_name }))
+            .write_line()?;
+        Ok(())
+    }
+
+    async fn delete_multiple(&self, selected_items_names: Vec<String>) -> miette::Result<()> {
+        let plain = selected_items_names
+            .iter()
+            .map(|name| {
+                if self
+                    .opts
+                    .state
+                    .nodes
+                    .delete_sigkill(name, self.cmd.force)
+                    .is_ok()
+                {
+                    fmt_ok!("Node '{name}' deleted\n")
+                } else {
+                    fmt_warn!("Failed to delete node '{name}'\n")
+                }
+            })
+            .collect::<String>();
+        self.terminal().stdout().plain(plain).write_line()?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -52,26 +52,26 @@ async fn run_impl(
         nodes_states.iter().map(|s| s.name().to_string()).collect()
     };
 
-    let nodes = get_nodes_info(ctx, &opts, node_names).await?;
+    let nodes = get_nodes_info(&ctx, &opts, node_names).await?;
     print_nodes_info(&opts, nodes)?;
 
     Ok(())
 }
 
 pub async fn get_nodes_info(
-    ctx: Context,
+    ctx: &Context,
     opts: &CommandGlobalOpts,
     node_names: Vec<String>,
 ) -> Result<Vec<NodeListOutput>> {
     let mut nodes: Vec<NodeListOutput> = Vec::new();
     let default_node_name = get_default_node_name(&opts.state);
     for node_name in node_names {
-        let node = BackgroundNode::create(&ctx, &opts.state, &node_name).await?;
+        let node = BackgroundNode::create(ctx, &opts.state, &node_name).await?;
 
         let is_finished: Mutex<bool> = Mutex::new(false);
 
         let get_node_status = async {
-            let result: miette::Result<NodeStatus> = node.ask(&ctx, api::query_status()).await;
+            let result: miette::Result<NodeStatus> = node.ask(ctx, api::query_status()).await;
             let node_status = match result {
                 Ok(node_status) => {
                     if let Ok(node_state) = opts.state.nodes.get(&node_name) {

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -14,7 +14,7 @@ use ockam_api::nodes::models::portal::{InletList, OutletList};
 
 use crate::node::get_node_name;
 use crate::node::list;
-use crate::terminal::tui::ShowItemsTui;
+use crate::terminal::tui::ShowCommandTui;
 use crate::util::{api, node_rpc};
 use crate::{docs, CommandGlobalOpts, Result, Terminal, TerminalStream};
 
@@ -53,23 +53,32 @@ async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, ShowCommand),
 ) -> miette::Result<()> {
-    let tui = ShowNodesTui {
-        node_name: cmd.node_name,
-        opts,
-        ctx,
-    };
-    tui.run().await?;
-    Ok(())
+    NodeShowTui::run(ctx, opts, cmd.node_name).await
 }
 
-struct ShowNodesTui {
-    node_name: Option<String>,
-    opts: CommandGlobalOpts,
+pub struct NodeShowTui {
     ctx: Context,
+    opts: CommandGlobalOpts,
+    node_name: Option<String>,
+}
+
+impl NodeShowTui {
+    pub async fn run(
+        ctx: Context,
+        opts: CommandGlobalOpts,
+        node_name: Option<String>,
+    ) -> miette::Result<()> {
+        let tui = Self {
+            ctx,
+            opts,
+            node_name,
+        };
+        tui.show().await
+    }
 }
 
 #[ockam_core::async_trait]
-impl ShowItemsTui for ShowNodesTui {
+impl ShowCommandTui for NodeShowTui {
     const ITEM_NAME: &'static str = "nodes";
 
     fn cmd_arg_item_name(&self) -> Option<&str> {

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -11,7 +11,6 @@ use crate::util::node_rpc;
 use crate::{docs, fmt_err, fmt_info, fmt_log, fmt_ok, fmt_warn, CommandGlobalOpts, OckamColor};
 
 use super::get_node_name;
-use super::util::check_default;
 
 const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -122,8 +121,7 @@ async fn start_single_node(
     }
 
     let mut node: BackgroundNode = run_node(node_name, ctx, &opts).await?;
-    let is_default = check_default(&opts, node_name);
-    print_query_status(&opts, ctx, node_name, &mut node, true, is_default).await?;
+    print_query_status(&opts, ctx, node_name, &mut node, true).await?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -29,11 +29,6 @@ impl Default for NodeManagerDefaults {
     }
 }
 
-pub fn delete_node(opts: &CommandGlobalOpts, name: &str, force: bool) -> miette::Result<()> {
-    opts.state.nodes.delete_sigkill(name, force)?;
-    Ok(())
-}
-
 pub fn delete_all_nodes(opts: &CommandGlobalOpts, force: bool) -> miette::Result<()> {
     let nodes_states = opts.state.nodes.list()?;
     let mut deletion_errors = Vec::new();

--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -1,6 +1,65 @@
+use crate::{Terminal, TerminalStream};
+use console::Term;
+
 pub enum DeleteMode {
     All,
     Selected(Vec<String>),
     Single(String),
     Default,
+}
+
+#[ockam_core::async_trait]
+pub trait ShowItemsTui {
+    const ITEM_NAME: &'static str;
+
+    fn cmd_arg_item_name(&self) -> Option<&str>;
+    fn terminal(&self) -> Terminal<TerminalStream<Term>>;
+    async fn list_items_names(&self) -> miette::Result<Vec<String>>;
+    async fn show_single(&self) -> miette::Result<()>;
+    async fn show_multiple(&self, selected_items_names: Vec<String>) -> miette::Result<()>;
+
+    async fn run(&self) -> miette::Result<()> {
+        let terminal = self.terminal();
+        if self.cmd_arg_item_name().is_some() || !terminal.can_ask_for_user_input() {
+            self.show_single().await?;
+            return Ok(());
+        }
+
+        let items_names = self.list_items_names().await?;
+        match items_names.len() {
+            0 => {
+                terminal
+                    .stdout()
+                    .plain(format!("There are no {} to show", Self::ITEM_NAME))
+                    .write_line()?;
+            }
+            1 => {
+                self.show_single().await?;
+            }
+            _ => {
+                let selected_item_names = terminal.select_multiple(
+                    format!(
+                        "Select one or more {} that you want to show",
+                        Self::ITEM_NAME
+                    ),
+                    items_names,
+                );
+                match selected_item_names.len() {
+                    0 => {
+                        terminal
+                            .stdout()
+                            .plain(format!("No {} selected to show", Self::ITEM_NAME))
+                            .write_line()?;
+                    }
+                    1 => {
+                        self.show_single().await?;
+                    }
+                    _ => {
+                        self.show_multiple(selected_item_names).await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -1,37 +1,37 @@
-use crate::{Terminal, TerminalStream};
+use crate::{fmt_info, Terminal, TerminalStream};
+use colorful::Colorful;
 use console::Term;
 
-pub enum DeleteMode {
-    All,
-    Selected(Vec<String>),
-    Single(String),
-    Default,
-}
-
 #[ockam_core::async_trait]
-pub trait ShowItemsTui {
+pub trait ShowCommandTui {
     const ITEM_NAME: &'static str;
 
     fn cmd_arg_item_name(&self) -> Option<&str>;
     fn terminal(&self) -> Terminal<TerminalStream<Term>>;
+
     async fn list_items_names(&self) -> miette::Result<Vec<String>>;
     async fn show_single(&self) -> miette::Result<()>;
-    async fn show_multiple(&self, selected_items_names: Vec<String>) -> miette::Result<()>;
+    async fn show_multiple(&self, items_names: Vec<String>) -> miette::Result<()>;
 
-    async fn run(&self) -> miette::Result<()> {
+    async fn show(&self) -> miette::Result<()> {
         let terminal = self.terminal();
+        let items_names = self.list_items_names().await?;
+        if items_names.is_empty() {
+            terminal
+                .stdout()
+                .plain(fmt_info!("There are no {} to show", Self::ITEM_NAME))
+                .write_line()?;
+            return Ok(());
+        }
+
         if self.cmd_arg_item_name().is_some() || !terminal.can_ask_for_user_input() {
             self.show_single().await?;
             return Ok(());
         }
 
-        let items_names = self.list_items_names().await?;
         match items_names.len() {
             0 => {
-                terminal
-                    .stdout()
-                    .plain(format!("There are no {} to show", Self::ITEM_NAME))
-                    .write_line()?;
+                unreachable!("this case is already handled above");
             }
             1 => {
                 self.show_single().await?;
@@ -56,6 +56,95 @@ pub trait ShowItemsTui {
                     }
                     _ => {
                         self.show_multiple(selected_item_names).await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[ockam_core::async_trait]
+pub trait DeleteCommandTui {
+    const ITEM_NAME: &'static str;
+
+    fn cmd_arg_item_name(&self) -> Option<&str>;
+    fn cmd_arg_delete_all(&self) -> bool;
+    fn cmd_arg_confirm_deletion(&self) -> bool;
+    fn terminal(&self) -> Terminal<TerminalStream<Term>>;
+
+    fn list_items_names(&self) -> miette::Result<Vec<String>>;
+    async fn delete_single(&self) -> miette::Result<()>;
+    async fn delete_multiple(&self, items_names: Vec<String>) -> miette::Result<()>;
+
+    async fn delete(&self) -> miette::Result<()> {
+        let terminal = self.terminal();
+        let items_names = self.list_items_names()?;
+        if items_names.is_empty() {
+            terminal
+                .stdout()
+                .plain(fmt_info!("There are no {} to delete", Self::ITEM_NAME))
+                .write_line()?;
+            return Ok(());
+        }
+
+        if self.cmd_arg_delete_all()
+            && terminal.confirmed_with_flag_or_prompt(
+                self.cmd_arg_confirm_deletion(),
+                format!("Are you sure you want to delete all {}?", Self::ITEM_NAME),
+            )?
+        {
+            self.delete_multiple(items_names).await?;
+            return Ok(());
+        }
+
+        if self.cmd_arg_item_name().is_some() || !terminal.can_ask_for_user_input() {
+            self.delete_single().await?;
+            return Ok(());
+        }
+
+        match items_names.len() {
+            0 => {
+                unreachable!("this case is already handled above");
+            }
+            1 => {
+                if terminal.confirmed_with_flag_or_prompt(
+                    self.cmd_arg_confirm_deletion(),
+                    "Are you sure you want to proceed?",
+                )? {
+                    self.delete_single().await?;
+                }
+            }
+            _ => {
+                let selected_item_names = terminal.select_multiple(
+                    format!(
+                        "Select one or more {} that you want to delete",
+                        Self::ITEM_NAME
+                    ),
+                    items_names,
+                );
+                match selected_item_names.len() {
+                    0 => {
+                        terminal
+                            .stdout()
+                            .plain(format!("No {} selected to delete", Self::ITEM_NAME))
+                            .write_line()?;
+                    }
+                    1 => {
+                        if terminal.confirmed_with_flag_or_prompt(
+                            self.cmd_arg_confirm_deletion(),
+                            "Are you sure you want to proceed?",
+                        )? {
+                            self.delete_single().await?;
+                        }
+                    }
+                    _ => {
+                        if terminal.confirmed_with_flag_or_prompt(
+                            self.cmd_arg_confirm_deletion(),
+                            "Are you sure you want to proceed?",
+                        )? {
+                            self.delete_multiple(selected_item_names).await?;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The idea is to simplify as much as possible to logic of commands so that we don't have to repeat all the branching required to implement the TUI experience for show and delete commands.