### PR TITLE
feat(rust): Make ockam identity delete (no args) interactive

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -27,7 +27,7 @@ pub struct DeleteCommand {
     #[arg(display_order = 901, long, short)]
     yes: bool,
 
-    #[arg(long, short, group = "identities")]
+    #[arg(long, short)]
     all: bool,
 }
 
@@ -58,7 +58,7 @@ async fn run_impl(
 
 #[ockam_core::async_trait]
 impl DeleteCommandTui for DeleteTui {
-    const ITEM_NAME: &'static str = "identities";
+    const ITEM_NAME: &'static str = "identity";
     fn cmd_arg_item_name(&self) -> Option<&str> {
         self.cmd.name.as_deref()
     }
@@ -103,16 +103,14 @@ impl DeleteCommandTui for DeleteTui {
         let plain = selected_items_names
             .iter()
             .map(|name| {
-                //Should be safe to unwrap since the identity come from the list of existing
-                //identities
-                let idt = self.opts.state.identities.get(name).unwrap();
+                let idt = self.opts.state.identities.get(name)?;
                 if self.opts.state.delete_identity(idt).is_ok() {
-                    fmt_ok!("Identity '{name}' deleted\n")
+                    Ok(fmt_ok!("Identity '{name}' deleted\n"))
                 } else {
-                    fmt_warn!("Failed to delete identity '{name}'\n")
+                    Ok(fmt_warn!("Failed to delete identity '{name}'\n"))
                 }
             })
-            .collect::<String>();
+            .collect::<miette::Result<String>>()?;
         self.terminal().stdout().plain(plain).write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,10 +1,14 @@
+use crate::terminal::tui::DeleteCommandTui;
 use crate::util::node_rpc;
-use crate::{docs, fmt_ok, CommandGlobalOpts};
+use crate::{docs, fmt_ok, fmt_warn, CommandGlobalOpts, Terminal, TerminalStream};
 use clap::Args;
 use colorful::Colorful;
 
+use console::Term;
 use ockam::Context;
 use ockam_api::cli_state::traits::StateDirTrait;
+
+use super::get_identity_name;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -12,17 +16,19 @@ const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt"
 /// Delete an identity
 #[derive(Clone, Debug, Args)]
 #[command(
-arg_required_else_help = true,
 long_about = docs::about(LONG_ABOUT),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct DeleteCommand {
     /// Name of the identity to be deleted
-    name: String,
+    name: Option<String>,
 
     /// Confirm the deletion without prompting
     #[arg(display_order = 901, long, short)]
     yes: bool,
+
+    #[arg(long, short, group = "identities")]
+    all: bool,
 }
 
 impl DeleteCommand {
@@ -31,26 +37,83 @@ impl DeleteCommand {
     }
 }
 
+pub struct DeleteTui {
+    opts: CommandGlobalOpts,
+    cmd: DeleteCommand,
+}
+
+impl DeleteTui {
+    pub async fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) -> miette::Result<()> {
+        let tui = Self { opts, cmd };
+        tui.delete().await
+    }
+}
+
 async fn run_impl(
     _ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> miette::Result<()> {
-    let state = opts.state;
-    let idt = state.identities.get(&cmd.name)?;
-    if opts
-        .terminal
-        .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this identity?")?
-    {
+    DeleteTui::run(opts, cmd).await
+}
+
+#[ockam_core::async_trait]
+impl DeleteCommandTui for DeleteTui {
+    const ITEM_NAME: &'static str = "identities";
+    fn cmd_arg_item_name(&self) -> Option<&str> {
+        self.cmd.name.as_deref()
+    }
+
+    fn cmd_arg_delete_all(&self) -> bool {
+        self.cmd.all
+    }
+
+    fn cmd_arg_confirm_deletion(&self) -> bool {
+        self.cmd.yes
+    }
+
+    fn terminal(&self) -> Terminal<TerminalStream<Term>> {
+        self.opts.terminal.clone()
+    }
+
+    async fn get_arg_item_name_or_default(&self) -> miette::Result<String> {
+        Ok(get_identity_name(&self.opts.state, &self.cmd.name))
+    }
+
+    async fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        Ok(self.opts.state.identities.list_items_names()?)
+    }
+
+    async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
+        let state = &self.opts.state;
+        let idt = state.identities.get(item_name)?;
         state.delete_identity(idt)?;
-        opts.terminal
+        self.terminal()
             .stdout()
             .plain(fmt_ok!(
                 "The identity named '{}' has been deleted",
-                &cmd.name
+                item_name
             ))
-            .machine(&cmd.name)
-            .json(serde_json::json!({ "name": &cmd.name }))
+            .machine(item_name)
+            .json(serde_json::json!({ "name": item_name }))
             .write_line()?;
+        Ok(())
     }
-    Ok(())
+
+    async fn delete_multiple(&self, selected_items_names: Vec<String>) -> miette::Result<()> {
+        let plain = selected_items_names
+            .iter()
+            .map(|name| {
+                //Should be safe to unwrap since the identity come from the list of existing
+                //identities
+                let idt = self.opts.state.identities.get(name).unwrap();
+                if self.opts.state.delete_identity(idt).is_ok() {
+                    fmt_ok!("Identity '{name}' deleted\n")
+                } else {
+                    fmt_warn!("Failed to delete identity '{name}'\n")
+                }
+            })
+            .collect::<String>();
+        self.terminal().stdout().plain(plain).write_line()?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/identity.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/identity.bats
@@ -46,6 +46,41 @@ teardown() {
   # Delete identity after deleting the node
   run_success "$OCKAM" node delete "${n}" --yes
   run_success "$OCKAM" identity delete "${i}" --yes
+
+  # Create two and list them
+
+  run_success "$OCKAM" identity create "${i}"
+  run_success "$OCKAM" identity create "${n}"
+  run_success "$OCKAM" identity list
+  assert_output --partial "${i}"
+  assert_output --partial "${n}"
+
+  # Update the list correctly after deleting one
+
+  run_success "$OCKAM" identity delete "${i}" --yes
+  run_success "$OCKAM" identity list
+  assert_output --partial "${n}"
+  refute_output --partial "${i}"
+
+  # Delete twice
+
+  run_failure "$OCKAM" identity delete {i} --yes
+
+  # Create three nodes and deletes all
+
+  i=$(random_str)
+  k=$(random_str)
+
+  run_success "$OCKAM" identity delete -a --yes
+
+  run_success "$OCKAM" identity list --output json
+  assert_output --partial "[]"
+
+  # Delete on empty list
+
+  run_success "$OCKAM" identity delete
+  ## In order to match the output that for now is identytis
+  assert_output --regexp "There are no identit.*s to delete"
 }
 
 @test "identity - set default" {


### PR DESCRIPTION
Should fix #6463
Make ockam identity delete (no args) interactive by asking the user to choose from a list of identity names to delete (tuify)

<!-- Thank you for sending a pull request :heart: -->

## Current behavior
When no arguments are given to `identity delete` sub command a usage error is shown.

<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->

## Proposed changes

Change to follow the other sub commands behavior, let the user select interactively implementing the `DeleteCommandTui` trait.

## Question
The only doubt that i have is if would be correct to unwrap the result given from the user choice as I've commented in line **106**. Maybe the program could panics if the `.ockam` folder is modified in someway during the command execution.
When such situation happen would be better to deal in the same way? (`fmt_warn!`).


## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
