### PR TITLE
feat(rust): tcp outlet delete interactive

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,17 +1,19 @@
 use clap::Args;
 use colorful::Colorful;
-use miette::{miette, IntoDiagnostic};
+use console::Term;
+use miette::miette;
 
 use ockam::Context;
-use ockam_api::nodes::models::portal::OutletStatus;
+use ockam_api::nodes::models::portal::OutletList;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 
-use crate::fmt_ok;
 use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
+use crate::terminal::tui::DeleteCommandTui;
 use crate::util::node_rpc;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, fmt_warn, CommandGlobalOpts};
+use crate::{fmt_ok, Terminal, TerminalStream};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
 
@@ -20,8 +22,8 @@ const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt"
 #[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct DeleteCommand {
     /// Delete the outlet with this alias
-    #[arg(display_order = 900, required = true, id = "ALIAS", value_parser = alias_parser)]
-    alias: String,
+    #[arg(display_order = 900,  id = "ALIAS", value_parser = alias_parser)]
+    alias: Option<String>,
 
     /// Node on which to stop the tcp outlet. If none are provided, the default node will be used
     #[command(flatten)]
@@ -30,6 +32,33 @@ pub struct DeleteCommand {
     /// Confirm the deletion without prompting
     #[arg(display_order = 901, long, short)]
     yes: bool,
+
+    #[arg(long, short, group = "tcp-outlets")]
+    all: bool,
+}
+
+pub struct DeleteTui {
+    ctx: Context,
+    opts: CommandGlobalOpts,
+    cmd: DeleteCommand,
+    node: BackgroundNode,
+}
+
+impl DeleteTui {
+    pub async fn run(
+        ctx: Context,
+        opts: CommandGlobalOpts,
+        cmd: DeleteCommand,
+    ) -> miette::Result<()> {
+        let node = BackgroundNode::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
+        let tui = Self {
+            ctx,
+            opts,
+            cmd,
+            node,
+        };
+        tui.delete().await
+    }
 }
 
 impl DeleteCommand {
@@ -42,37 +71,85 @@ pub async fn run_impl(
     ctx: Context,
     (opts, cmd): (CommandGlobalOpts, DeleteCommand),
 ) -> miette::Result<()> {
-    let node = BackgroundNode::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
+    DeleteTui::run(ctx, opts, cmd).await
+}
 
-    // Check if there an outlet with the provided alias/name exists
-    let alias = cmd.alias;
-    node.ask_and_get_reply::<_, OutletStatus>(&ctx, Request::get(format!("/node/outlet/{alias}")))
-        .await?
-        .found()
-        .into_diagnostic()?
-        .ok_or(miette!(
-            "TCP outlet with alias {alias} was not found on Node {}",
-            node.node_name()
-        ))?;
+#[ockam_core::async_trait]
+impl DeleteCommandTui for DeleteTui {
+    const ITEM_NAME: &'static str = "tcp-outlet";
 
-    // Proceed with the deletion
-    if opts.terminal.confirmed_with_flag_or_prompt(
-        cmd.yes,
-        "Are you sure you want to delete this TCP outlet?",
-    )? {
-        node.tell(&ctx, Request::delete(format!("/node/outlet/{alias}")))
+    fn cmd_arg_item_name(&self) -> Option<&str> {
+        self.cmd.alias.as_deref()
+    }
+
+    fn cmd_arg_delete_all(&self) -> bool {
+        self.cmd.all
+    }
+
+    fn cmd_arg_confirm_deletion(&self) -> bool {
+        self.cmd.yes
+    }
+
+    fn terminal(&self) -> Terminal<TerminalStream<Term>> {
+        self.opts.terminal.clone()
+    }
+
+    async fn get_arg_item_name_or_default(&self) -> miette::Result<String> {
+        self.cmd.alias.clone().ok_or(miette!("No alias provided"))
+    }
+
+    async fn list_items_names(&self) -> miette::Result<Vec<String>> {
+        let res: OutletList = self
+            .node
+            .ask(&self.ctx, Request::get("/node/outlet"))
             .await?;
+        let items_names: Vec<String> = res.list.iter().map(|outlet| outlet.alias.clone()).collect();
+        Ok(items_names)
+    }
 
-        opts.terminal
+    async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
+        let node_name = self.node.node_name();
+        self.node
+            .tell(
+                &self.ctx,
+                Request::delete(format!("/node/outlet/{item_name}")),
+            )
+            .await?;
+        self.terminal()
             .stdout()
             .plain(fmt_ok!(
-                "TCP outlet with alias {alias} on Node {} has been deleted",
-                node.node_name()
+                "TCP outlet with alias {item_name} on Node {node_name} has been deleted"
             ))
-            .machine(&alias)
-            .json(serde_json::json!({ "alias": alias, "node": node.node_name() }))
+            .machine(item_name)
+            .json(serde_json::json!({ "alias": item_name, "node": node_name }))
             .write_line()
             .unwrap();
+        Ok(())
     }
-    Ok(())
+
+    async fn delete_multiple(&self, items_names: Vec<String>) -> miette::Result<()> {
+        let mut plain_delete_result: Vec<String> = Vec::with_capacity(items_names.len());
+        for alias in items_names {
+            let outlet_path = format!("/node/outlet/{}", alias);
+            match self
+                .node
+                .tell(&self.ctx, Request::delete(outlet_path))
+                .await
+            {
+                Ok(_) => plain_delete_result.push(fmt_ok!(
+                    "TCP outlet with alias {} deleted\n",
+                    alias.light_magenta()
+                )),
+                Err(_) => plain_delete_result.push(fmt_warn!(
+                    "Failed to delete TCP outlet with alias {} \n",
+                    alias.light_magenta()
+                )),
+            }
+        }
+        self.terminal()
+            .stdout()
+            .plain(plain_delete_result.concat())
+            .write_line()?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -63,8 +63,8 @@ teardown() {
   run_success $OCKAM tcp-outlet delete "test-outlet" --yes
 
   # Test deletion of a previously deleted TCP outlet
-  run_failure $OCKAM tcp-outlet delete "test-outlet" --yes
-  assert_output --partial "not found"
+  run_success $OCKAM tcp-outlet delete "test-outlet" --yes
+  assert_output --partial "There are no tcp-outlets to delete"
 }
 
 @test "portals - list inlets on a node" {


### PR DESCRIPTION
## Current behavior
When terminal is interactive and no argument is provided `ockam tcp-outlet delete` return a clap missing argument error, because of the tcp-outlet required alias.

## Proposed changes
If the terminal is interactive and no arguments are given, the user is prompted about what tcp-outlet should be deleted based on the list of items present at the given node. 
If the argument `--at` specifying the node is absent, the list of tcp-outlets on the default node is given.
If the terminal isn't interactive an `<ALIAS>` argument should be provided, since there is no such *default tcp-outlet*.
## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
