### PR TITLE
feat(rust): Add the possibility to ignore an accepted service

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -54,6 +54,14 @@ impl AppState {
                     }
                 }
             }
+
+            // the service resources are already cleaned up at this stage, since when it's
+            // removed is always also disabled.
+            if service.removed() {
+                let mut guard = services_arc.write().await;
+                guard.remove_by_id(service.id());
+            }
+
             self.publish_state().await;
         }
 

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
@@ -41,9 +41,9 @@ impl AppState {
 
         self.mark_as_loaded(StateKind::Invitations);
         if changes.changed {
-            self.publish_state().await;
             self.load_services_from_invitations(accepted_invitations.unwrap())
                 .await;
+            self.publish_state().await;
             self.schedule_inlets_refresh_now();
             if changes.new_received_invitation {
                 self.notify(Notification {
@@ -160,10 +160,6 @@ impl AppState {
                     }
                     ReceivedInvitationStatus::Ignored => {
                         debug!(?i, "Invitation was already ignored");
-                        return Ok(());
-                    }
-                    ReceivedInvitationStatus::Accepting => {
-                        debug!(?i, "Invitation is being accepted");
                         return Ok(());
                     }
                     s => {

--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		783B62722AC432B700880261 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783B62712AC432B700880261 /* Bridge.swift */; };
 		785C8DC12B0BAD5E00926DCD /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785C8DC02B0BAD5E00926DCD /* About.swift */; };
 		789FA6462AE142280009FF7F /* ExportOptions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 789FA6452AE142280009FF7F /* ExportOptions.plist */; };
+		78B7EF702B0F649D0062B2B3 /* IgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B7EF6F2B0F649D0062B2B3 /* IgnoreService.swift */; };
 		78BD349D2AFA621500F09058 /* BrokenStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BD349C2AFA621500F09058 /* BrokenStateView.swift */; };
 		78BD34A12AFCFDF100F09058 /* RemoteServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BD34A02AFCFDF100F09058 /* RemoteServiceView.swift */; };
 		78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D520822ADD5CAE00F36B64 /* Helpers.swift */; };
@@ -48,6 +49,7 @@
 		785C8DC02B0BAD5E00926DCD /* About.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = About.swift; sourceTree = "<group>"; };
 		785D8D372AD5369100DF5004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		789FA6452AE142280009FF7F /* ExportOptions.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ExportOptions.plist; sourceTree = "<group>"; };
+		78B7EF6F2B0F649D0062B2B3 /* IgnoreService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IgnoreService.swift; sourceTree = "<group>"; };
 		78BD349C2AFA621500F09058 /* BrokenStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrokenStateView.swift; sourceTree = "<group>"; };
 		78BD34A02AFCFDF100F09058 /* RemoteServiceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteServiceView.swift; sourceTree = "<group>"; };
 		78D520822ADD5CAE00F36B64 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 		782D5B472AC1D3D700D1B27F /* Ockam */ = {
 			isa = PBXGroup;
 			children = (
+				78B7EF6F2B0F649D0062B2B3 /* IgnoreService.swift */,
 				78BD34A02AFCFDF100F09058 /* RemoteServiceView.swift */,
 				789FA6452AE142280009FF7F /* ExportOptions.plist */,
 				785D8D372AD5369100DF5004 /* Info.plist */,
@@ -209,6 +212,7 @@
 				7827D5092AD93F1700F7A20F /* ClickableMenuEntry.swift in Sources */,
 				78BD34A12AFCFDF100F09058 /* RemoteServiceView.swift in Sources */,
 				782D5B4B2AC1D3D700D1B27F /* MainView.swift in Sources */,
+				78B7EF702B0F649D0062B2B3 /* IgnoreService.swift in Sources */,
 				78ED0DA12AD4354400574AE9 /* CreateService.swift in Sources */,
 				78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */,
 				78F5F3042AD4127C00B8D18E /* EmailInput.swift in Sources */,

--- a/implementations/swift/ockam/ockam_app/Ockam/IgnoreService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/IgnoreService.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct IgnoreServiceView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @State var service: Service
+
+    var body: some View {
+        VStack {
+            Text(
+                "Once you click Ignore, the service '\(service.sourceName)' will no longer show up here.\n" +
+                "Are you sure you want to do this?\n" +
+                "Once ignored, the only way to get this back is to have the person who sent you the invite, to send another one."
+            )
+            .padding()
+            Spacer()
+            HStack {
+                Spacer()
+                Button(
+                    action: {
+                        print("ignoring: \(service.id)")
+                        ignore_invitation(service.id)
+                        self.closeWindow()
+                    },
+                    label: {
+                        Text("Ignore")
+                    }
+                )
+                Button(
+                    action: {
+                        self.closeWindow()
+                    },
+                    label: {
+                        Text("Cancel")
+                    }
+                )
+                .keyboardShortcut(.defaultAction)
+                .padding(10)
+            }
+            .background(.black.opacity(0.1))
+        }
+        .frame(width: 300, height: 180)
+    }
+
+    func closeWindow() {
+        presentationMode.wrappedValue.dismiss()
+    }
+}
+
+
+struct IgnoreServiceView_Previews: PreviewProvider {
+    @State static var state = swift_demo_application_state()
+
+    static var previews: some View {
+        IgnoreServiceView(service: state.groups[1].incomingServices[0])
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
@@ -129,6 +129,15 @@ struct OckamApp: App {
         }
         .windowResizability(.contentSize)
 
+        WindowGroup("Confirmation", id: "ignore-service-confirmation", for: Service.ID.self) { $serviceId in
+            IgnoreServiceView(
+                service: StateContainer.shared.state.lookupIncomingServiceById(
+                    serviceId.unsafelyUnwrapped
+                ).unsafelyUnwrapped.1
+            )
+        }
+        .windowResizability(.contentSize)
+
         Window("About", id:"about") {
             About(runtimeInformation: swift_runtime_information())
         }

--- a/implementations/swift/ockam/ockam_app/Ockam/RemoteServiceView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/RemoteServiceView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 struct RemoteServiceView: View {
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @Environment(\.openWindow) var openWindow
+
     @State private var isHovered = false
     @State private var isOpen = false
     @ObservedObject var service: Service
 
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     func closeWindow() {
         self.presentationMode.wrappedValue.dismiss()
     }
@@ -99,6 +101,11 @@ struct RemoteServiceView: View {
                                 enable_accepted_service(service.id)
                             })
                     }
+                    ClickableMenuEntry(
+                        text: "Ignore",
+                        action: {
+                            openWindow(id: "ignore-service-confirmation", value: service.id)
+                        })
                 }
             }
         }


### PR DESCRIPTION
The idea is to allow removal of incoming services by ignoring the originating invite, it's far from ideal, but it's working with current invitations implementation.
When clicking `ignore`, there is a popup confirmation.

<img width="308" alt="image" src="https://github.com/build-trust/ockam/assets/408088/57711461-2bf9-4d85-9584-9c4ee20f55f1">
<img width="306" alt="image" src="https://github.com/build-trust/ockam/assets/408088/76100827-689f-420e-baba-842c2616d11d">
