### PR TITLE
feat(elixir): use credential attribute for access control

### DIFF
--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding.ex
@@ -94,10 +94,10 @@ defmodule Ockam.Services.Relay.StaticForwarding do
 
   def check_authorization(identifier, alias_str) do
     case AttributeStorage.get_attributes(identifier) do
-      %{"allow_relay_address" => "*"} ->
+      %{"ockam-relay" => "*"} ->
         :ok
 
-      %{"allow_relay_address" => ^alias_str} ->
+      %{"ockam-relay" => ^alias_str} ->
         :ok
 
       attrs ->

--- a/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding_api.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/relay/static_forwarding_api.ex
@@ -30,7 +30,6 @@ defmodule Ockam.Services.Relay.StaticForwardingAPI do
 
   @impl true
   def authorize(:identity, %Request{} = req, _bindings) do
-    # Oposed to the legacy StaticForwarding, here we do enforce authentication of caller
     case Request.caller_identity_id(req) do
       {:ok, identifier} ->
         {true, %{identifier: identifier}}

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_api_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_api_test.exs
@@ -47,13 +47,13 @@ defmodule Test.Services.StaticForwardingApiTest do
     alias_str_2 = "test_static_forwarding_alias_2"
 
     {:ok, bob_credential} =
-      Identity.issue_credential(authority_identity, bob_id, %{"allow_relay_address" => "*"}, 100)
+      Identity.issue_credential(authority_identity, bob_id, %{"ockam-relay" => "*"}, 100)
 
     {:ok, alice_credential} =
       Identity.issue_credential(
         authority_identity,
         alice_id,
-        %{"allow_relay_address" => alias_str_1},
+        %{"ockam-relay" => alias_str_1},
         100
       )
 

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_api_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_api_test.exs
@@ -4,6 +4,8 @@ defmodule Test.Services.StaticForwardingApiTest do
   # Fail after 200ms of retrying with time between attempts 10ms
   use AssertEventually, timeout: 200, interval: 10
 
+  alias Ockam.Credential.AttributeStorageETS, as: AttributeStorage
+
   alias Ockam.API.Client
   alias Ockam.Identity
   alias Ockam.SecureChannel
@@ -13,6 +15,8 @@ defmodule Test.Services.StaticForwardingApiTest do
   alias Ockam.Services.Relay.Types.Relay
 
   test "crud" do
+    :ok = AttributeStorage.init()
+    {:ok, authority_identity} = Identity.create()
     {:ok, listener_identity} = Identity.create()
     {:ok, listener_keypair} = SecureChannel.Crypto.generate_dh_keypair()
     {:ok, attestation} = Identity.attest_purpose_key(listener_identity, listener_keypair)
@@ -23,21 +27,42 @@ defmodule Test.Services.StaticForwardingApiTest do
         encryption_options: [
           static_keypair: listener_keypair,
           static_key_attestation: attestation
-        ]
+        ],
+        authorities: [authority_identity]
       )
 
     {:ok, bob} = Identity.create()
     {:ok, alice} = Identity.create()
+    {:ok, carol} = Identity.create()
     bob_id = Identity.get_identifier(bob)
+    alice_id = Identity.get_identifier(alice)
     {:ok, bob_keypair} = SecureChannel.Crypto.generate_dh_keypair()
     {:ok, bob_attestation} = Identity.attest_purpose_key(bob, bob_keypair)
     {:ok, alice_keypair} = SecureChannel.Crypto.generate_dh_keypair()
     {:ok, alice_attestation} = Identity.attest_purpose_key(alice, alice_keypair)
+    {:ok, carol_keypair} = SecureChannel.Crypto.generate_dh_keypair()
+    {:ok, carol_attestation} = Identity.attest_purpose_key(carol, carol_keypair)
+
+    alias_str_1 = "test_static_forwarding_alias_1"
+    alias_str_2 = "test_static_forwarding_alias_2"
+
+    {:ok, bob_credential} =
+      Identity.issue_credential(authority_identity, bob_id, %{"allow_relay_address" => "*"}, 100)
+
+    {:ok, alice_credential} =
+      Identity.issue_credential(
+        authority_identity,
+        alice_id,
+        %{"allow_relay_address" => alias_str_1},
+        100
+      )
 
     {:ok, bob_channel} =
       SecureChannel.create_channel(
         identity: bob,
         encryption_options: [static_keypair: bob_keypair, static_key_attestation: bob_attestation],
+        authorities: [authority_identity],
+        credentials: [bob_credential],
         route: [listener]
       )
 
@@ -48,20 +73,33 @@ defmodule Test.Services.StaticForwardingApiTest do
           static_keypair: alice_keypair,
           static_key_attestation: alice_attestation
         ],
+        authorities: [authority_identity],
+        credentials: [alice_credential],
+        route: [listener]
+      )
+
+    {:ok, carol_channel} =
+      SecureChannel.create_channel(
+        identity: carol,
+        encryption_options: [
+          static_keypair: carol_keypair,
+          static_key_attestation: carol_attestation
+        ],
+        authorities: [authority_identity],
+        credentials: [],
         route: [listener]
       )
 
     {:ok, service_address} =
       StaticForwardingAPI.create(prefix: "forward_to", check_owner_on_delete: true)
 
-    {:ok, service_address_no_enforcement} =
-      StaticForwardingAPI.create(prefix: "forward_to", check_owner_on_delete: false)
-
-    alias_str_1 = "test_static_forwarding_alias_1"
-    alias_str_2 = "test_static_forwarding_alias_2"
-
     forwarder_address_1 = "forward_to_" <> alias_str_1
     forwarder_address_2 = "forward_to_" <> alias_str_2
+
+    on_exit(fn ->
+      Ockam.Node.stop(forwarder_address_1)
+      Ockam.Node.stop(forwarder_address_2)
+    end)
 
     {:ok, resp} = Client.sync_request(:get, "/", nil, [bob_channel, service_address])
     assert %{status: 200, body: body} = resp
@@ -97,8 +135,8 @@ defmodule Test.Services.StaticForwardingApiTest do
     assert %{status: 200, body: body} = resp
     assert {:ok, [_, _]} = Relay.decode_list_strict(body)
 
-    # Alice not allowed to overtake bob' relay
-    req = %CreateRelayRequest{alias: alias_str_2, tags: %{"name" => "test_relay2"}}
+    # Alice allowed to overtake bob' relay at alias_str_1
+    req = %CreateRelayRequest{alias: alias_str_1, tags: %{"name" => "test_relay1_alice"}}
 
     {:ok, resp} =
       Client.sync_request(:post, "/", CreateRelayRequest.encode!(req), [
@@ -106,19 +144,49 @@ defmodule Test.Services.StaticForwardingApiTest do
         service_address
       ])
 
-    assert %{status: 401} = resp
+    assert %{status: 200, body: body} = resp
 
-    assert {:ok, [%Relay{target_identifier: ^bob_id}, %Relay{target_identifier: ^bob_id}]} =
-             Relay.decode_list_strict(body)
+    assert {:ok, %Relay{target_identifier: ^alice_id, tags: %{"name" => "test_relay1_alice"}}} =
+             Relay.decode_strict(body)
 
-    # Alice not allowed to remove bob' relay
+    # Carol not allowed to take any relay
+    req = %CreateRelayRequest{alias: alias_str_1, tags: %{"name" => "carol"}}
+
     {:ok, resp} =
-      Client.sync_request(:delete, "/#{forwarder_address_1}", nil, [
-        alice_channel,
+      Client.sync_request(:post, "/", CreateRelayRequest.encode!(req), [
+        carol_channel,
         service_address
       ])
 
     assert %{status: 401} = resp
+
+    req = %CreateRelayRequest{alias: "anyalias", tags: %{"name" => "carol"}}
+
+    {:ok, resp} =
+      Client.sync_request(:post, "/", CreateRelayRequest.encode!(req), [
+        carol_channel,
+        service_address
+      ])
+
+    assert %{status: 401} = resp
+
+    # Carol not allowed to remove relay
+    {:ok, resp} =
+      Client.sync_request(:delete, "/#{forwarder_address_1}", nil, [
+        carol_channel,
+        service_address
+      ])
+
+    assert %{status: 401} = resp
+
+    # Bob can remove it
+    {:ok, resp} =
+      Client.sync_request(:delete, "/#{forwarder_address_1}", nil, [
+        bob_channel,
+        service_address
+      ])
+
+    assert %{status: 200} = resp
 
     # Bob can change its relay
     req = %CreateRelayRequest{alias: alias_str_2, tags: %{"name" => "changed!"}}
@@ -136,25 +204,16 @@ defmodule Test.Services.StaticForwardingApiTest do
 
     # Bob can remove its own relay
     {:ok, resp} =
-      Client.sync_request(:delete, "/#{forwarder_address_1}", nil, [bob_channel, service_address])
+      Client.sync_request(:delete, "/#{alias_str_1}", nil, [bob_channel, service_address])
 
     assert %{status: 200} = resp
 
-    {:ok, resp} = Client.sync_request(:get, "/", nil, [bob_channel, service_address])
-    assert %{status: 200, body: body} = resp
-    assert {:ok, [%Relay{addr: ^forwarder_address_2}]} = Relay.decode_list_strict(body)
-
-    # Alice (and anyone) allowed to remove anyone relay if so configured..
-    {:ok, resp} =
-      Client.sync_request(:delete, "/#{forwarder_address_2}", nil, [
-        alice_channel,
-        service_address_no_enforcement
-      ])
-
-    assert %{status: 200} = resp
-
-    {:ok, resp} = Client.sync_request(:get, "/", nil, [bob_channel, service_address])
-    assert %{status: 200, body: body} = resp
-    assert {:ok, []} = Relay.decode_list_strict(body)
+    assert_eventually(
+      (
+        {:ok, resp} = Client.sync_request(:get, "/", nil, [bob_channel, service_address])
+        %{status: 200, body: body} = resp
+        {:ok, [%Relay{addr: ^forwarder_address_2}]} = Relay.decode_list_strict(body)
+      )
+    )
   end
 end

--- a/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
+++ b/implementations/elixir/ockam/ockam_services/test/services/static_forwarding_test.exs
@@ -153,15 +153,15 @@ defmodule Test.Services.StaticForwardingTest do
 
     {:ok, channel_alice} =
       create_channel_with_credential(authority, alice, listener, %{
-        "allow_relay_address" => alias_str
+        "ockam-relay" => alias_str
       })
 
     {:ok, channel_bob} =
-      create_channel_with_credential(authority, bob, listener, %{"allow_relay_address" => "*"})
+      create_channel_with_credential(authority, bob, listener, %{"ockam-relay" => "*"})
 
     {:ok, channel_carol} =
       create_channel_with_credential(authority, carol, listener, %{
-        "allow_relay_address" => "other"
+        "ockam-relay" => "other"
       })
 
     {:ok, ^forwarder_address} =


### PR DESCRIPTION
instead of anchoring on the initial identity that created a relay, identities must have an 'ockam-relay' attribute attested by authority to be able to claim/delete a particular relay.
