### PR TITLE
refactor(rust): remove unused dependencies from ockam_command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,29 +1175,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cli-table"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
-dependencies = [
- "cli-table-derive",
- "csv",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "cli-table-derive"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af3bfb9da627b0a6c467624fb7963921433774ed435493b5c08a3053e829ad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "clipboard-win"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,27 +1530,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3822,7 +3778,6 @@ dependencies = [
  "clap 4.4.8",
  "clap_complete",
  "clap_mangen",
- "cli-table",
  "colorful",
  "colors-transform",
  "console",
@@ -3830,12 +3785,9 @@ dependencies = [
  "dialoguer",
  "duct",
  "flate2",
- "futures 0.3.29",
  "hex",
- "home",
  "indicatif",
  "indoc",
- "itertools 0.11.0",
  "miette",
  "minicbor",
  "nix 0.27.1",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -59,7 +59,6 @@ async-trait = "0.1"
 clap = { version = "4.4.7", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.4.4"
 clap_mangen = "0.2.15"
-cli-table = "0.4"
 colorful = "0.2"
 colors-transform = "0.2.11"
 console = "0.15.7"
@@ -67,12 +66,9 @@ ctrlc = { version = "3.4.1", features = ["termination"] }
 dialoguer = "0.11.0"
 duct = "0.13"
 flate2 = "1.0.28"
-futures = "0.3.28"
 hex = "0.4"
-home = "0.5"
 indicatif = "0.17.7"
 indoc = "2.0.4"
-itertools = "0.11"
 miette = { version = "5.10.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.20.0", features = ["derive", "alloc", "half"] }
 nix = "0.27"

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -161,8 +161,16 @@ async fn run_impl(
             opts.terminal.write_line(&response.output()?)?
         }
         SubscriptionSubcommand::List => {
-            let response = controller.get_subscriptions(&ctx).await.into_diagnostic()?;
-            opts.terminal.write_line(&response.output()?)?
+            let response = controller
+                .get_subscriptions(&ctx)
+                .await
+                .into_diagnostic()?
+                .success()
+                .into_diagnostic()?;
+            let output =
+                opts.terminal
+                    .build_list(&response, "Subscriptions", "No Subscriptions found")?;
+            opts.terminal.write_line(output)?
         }
         SubscriptionSubcommand::Unsubscribe {
             subscription_id,

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -2,10 +2,9 @@ use crate::terminal::TerminalBackground;
 use colorful::Colorful;
 use ockam_core::env::get_env_with_default;
 use once_cell::sync::Lazy;
-use syntect::highlighting::Theme;
 use syntect::{
     easy::HighlightLines,
-    highlighting::{Style, ThemeSet},
+    highlighting::{Style, Theme, ThemeSet},
     parsing::Regex,
     parsing::SyntaxSet,
     util::{as_24_bit_terminal_escaped, LinesWithEndings},

--- a/implementations/rust/ockam/ockam_command/src/output/output.rs
+++ b/implementations/rust/ockam/ockam_command/src/output/output.rs
@@ -2,7 +2,6 @@ use core::fmt;
 use core::fmt::Write;
 use std::fmt::Formatter;
 
-use cli_table::{Cell, Style, Table};
 use colorful::Colorful;
 use miette::miette;
 use miette::IntoDiagnostic;
@@ -114,31 +113,6 @@ impl Output for Space {
     }
 }
 
-impl Output for Vec<Space> {
-    fn output(&self) -> Result<String> {
-        if self.is_empty() {
-            return Ok("No spaces found".to_string());
-        }
-        let mut rows = vec![];
-        for Space {
-            id, name, users, ..
-        } in self
-        {
-            rows.push([id.cell(), name.cell(), comma_separated(users).cell()]);
-        }
-        let table = rows
-            .table()
-            .title([
-                "Id".cell().bold(true),
-                "Name".cell().bold(true),
-                "Users".cell().bold(true),
-            ])
-            .display()?
-            .to_string();
-        Ok(table)
-    }
-}
-
 impl Output for Project {
     fn output(&self) -> Result<String> {
         let mut w = String::new();
@@ -205,41 +179,6 @@ impl Output for ProjectConfigCompact {
         writeln!(w, "{}: {}", "Authority address".bold(), ar)?;
         write!(w, "{}: {}", "Authority identity".bold(), ai)?;
         Ok(w)
-    }
-}
-
-impl Output for Vec<Project> {
-    fn output(&self) -> Result<String> {
-        if self.is_empty() {
-            return Ok("No projects found".to_string());
-        }
-        let mut rows = vec![];
-        for Project {
-            id,
-            name,
-            users,
-            space_name,
-            ..
-        } in self
-        {
-            rows.push([
-                id.cell(),
-                name.cell(),
-                comma_separated(users).cell(),
-                space_name.cell(),
-            ]);
-        }
-        let table = rows
-            .table()
-            .title([
-                "Id".cell().bold(true),
-                "Name".cell().bold(true),
-                "Users".cell().bold(true),
-                "Space Name".cell().bold(true),
-            ])
-            .display()?
-            .to_string();
-        Ok(table)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -38,7 +38,11 @@ async fn run_impl(
     let controller = node.create_controller().await?;
 
     let addons = controller.list_addons(&ctx, project_id).await?;
-
-    opts.println(&addons)?;
+    let output = opts.terminal.build_list(
+        &addons,
+        &format!("Addons for project {project_name}"),
+        &format!("No addons enabled for project {project_name}"),
+    )?;
+    opts.terminal.stdout().plain(output).write_line()?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -80,23 +80,6 @@ impl Output for Addon {
     }
 }
 
-impl Output for Vec<Addon> {
-    fn output(&self) -> Result<String> {
-        if self.is_empty() {
-            return Ok("No addons found".to_string());
-        }
-        let mut w = String::new();
-        for (idx, a) in self.iter().enumerate() {
-            write!(w, "\n{idx}:")?;
-            write!(w, "\n  Id: {}", a.id)?;
-            write!(w, "\n  Enabled: {}", a.enabled)?;
-            write!(w, "\n  Description: {}", a.description)?;
-            writeln!(w)?;
-        }
-        Ok(w)
-    }
-}
-
 async fn check_configuration_completion(
     opts: &CommandGlobalOpts,
     ctx: &Context,

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -127,27 +127,3 @@ impl Output for Subscription {
         Ok(w)
     }
 }
-
-impl Output for Vec<Subscription> {
-    fn output(&self) -> Result<String> {
-        if self.is_empty() {
-            return Ok("No subscriptions found".to_string());
-        }
-        let mut w = String::new();
-        for (idx, s) in self.iter().enumerate() {
-            write!(w, "\n{idx}:")?;
-            write!(w, "\n  Id: {}", s.id)?;
-            write!(w, "\n  Status: {}", s.status)?;
-            write!(
-                w,
-                "\n  Space id: {}",
-                s.space_id.as_ref().unwrap_or(&"N/A".to_string())
-            )?;
-            write!(w, "\n  Entitlements: {}", s.entitlements)?;
-            write!(w, "\n  Metadata: {}", s.metadata)?;
-            write!(w, "\n  Contact info: {}", s.contact_info)?;
-            writeln!(w)?;
-        }
-        Ok(w)
-    }
-}

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -221,10 +221,10 @@ pub async fn clean_nodes_multiaddr(
 }
 
 pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
-    use itertools::Itertools;
-
-    #[allow(unstable_name_collisions)]
-    data.iter().map(AsRef::as_ref).intersperse(", ").collect()
+    data.iter()
+        .map(AsRef::as_ref)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 pub fn port_is_free_guard(address: &SocketAddr) -> Result<()> {
@@ -306,5 +306,12 @@ mod tests {
             ctx.stop().await.into_diagnostic()?;
             Err(miette!("boom"))
         }
+    }
+
+    #[test]
+    fn test_comma_separated() {
+        let data = vec!["a", "b", "c"];
+        let result = comma_separated(&data);
+        assert_eq!(result, "a, b, c");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use miette::miette;
 
-use ockam::identity::{Identifier, Identity};
+use ockam::identity::Identifier;
 use ockam_api::config::lookup::InternetAddress;
 use ockam_multiaddr::MultiAddr;
 use ockam_transport_tcp::resolve_peer;
@@ -31,16 +31,6 @@ pub(crate) fn socket_addr_parser(input: &str) -> Result<SocketAddr> {
 /// [`ockam_identity::Identifier::from_str()`]
 pub(crate) fn identity_identifier_parser(input: &str) -> Result<Identifier> {
     Identifier::from_str(input).map_err(|_| miette!("Invalid identity identifier: {input}").into())
-}
-
-/// Helper fn for parsing an identity from user input by using
-/// [`ockam_identity::Identity::create()`]
-pub(crate) fn identity_parser(input: &str) -> Result<Identity> {
-    futures::executor::block_on(async {
-        Identity::create(input)
-            .await
-            .map_err(|_| miette!("Invalid identity: {input}").into())
-    })
 }
 
 /// Helper fn for parsing a MultiAddr from user input by using


### PR DESCRIPTION
Closes https://github.com/build-trust/ockam/issues/6680 and removes other unused/unnecessary dependencies.