### PR TITLE
fix(rust): honor the `timeout` arg value on `status` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -32,11 +32,15 @@ pub const ORCHESTRATOR_RESTART_TIMEOUT: Duration = Duration::from_secs(180);
 pub const ORCHESTRATOR_AWAIT_TIMEOUT: Duration = Duration::from_secs(60 * 10);
 
 impl NodeManager {
-    pub(crate) async fn create_controller_client(&self) -> Result<Controller> {
+    pub(crate) async fn create_controller_client(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<Controller> {
         NodeManager::controller_node(
             &self.tcp_transport,
             self.secure_channels.clone(),
             &self.identifier(),
+            timeout,
         )
         .await
     }
@@ -93,6 +97,7 @@ impl NodeManager {
         tcp_transport: &TcpTransport,
         secure_channels: Arc<SecureChannels>,
         caller_identifier: &Identifier,
+        timeout: Option<Duration>,
     ) -> Result<Controller> {
         let mut controller_route = Self::controller_route(tcp_transport).await?;
         let controller_identifier = Self::load_controller_identifier()?;
@@ -109,7 +114,7 @@ impl NodeManager {
                 controller_route.route,
                 &controller_identifier,
                 caller_identifier,
-                ORCHESTRATOR_RESTART_TIMEOUT,
+                timeout.unwrap_or(ORCHESTRATOR_RESTART_TIMEOUT),
             ),
             tcp_connection,
         })

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
@@ -160,7 +160,8 @@ impl SecureClient {
     /// Create a secure channel to the node
     pub async fn create_secure_channel(&self, ctx: &Context) -> Result<SecureChannel> {
         let options = SecureChannelOptions::new()
-            .with_trust_policy(TrustIdentifierPolicy::new(self.server_identifier.clone()));
+            .with_trust_policy(TrustIdentifierPolicy::new(self.server_identifier.clone()))
+            .with_timeout(self.timeout);
         self.secure_channels
             .create_secure_channel(
                 ctx,


### PR DESCRIPTION
The `timeout` argument was not being used in the `status` command. This PR modifies the `InMemoryNode` so that in passes down its timeout value to both the `secure_channel` creation and the calls done to the node.