### PR TITLE
feat(rust): added `invitation_email` attribute

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/commands.rs
@@ -228,7 +228,7 @@ impl AppState {
         }?;
 
         let enrollment_ticket = self
-            .create_enrollment_ticket(project_id)
+            .create_enrollment_ticket(&project_id, &recipient_email)
             .await
             .map_err(|e| e.to_string())?;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
@@ -16,7 +16,8 @@ use super::error::{Error, Result};
 impl AppState {
     pub(crate) async fn create_enrollment_ticket(
         &self,
-        project_id: String,
+        project_id: &str,
+        invitation_email: &str,
     ) -> Result<EnrollmentTicket> {
         debug!(?project_id, "Creating enrollment ticket");
         let projects = self.projects();
@@ -37,7 +38,7 @@ impl AppState {
         let otc = authority_node
             .create_token(
                 &self.context(),
-                HashMap::new(),
+                HashMap::from([("invitation_email", invitation_email)]),
                 Some(Duration::from_secs(60 * 60 * 24 * 14)),
                 None,
             )


### PR DESCRIPTION
Added `invitation_email` attribute when creating an enrollment ticket for the app invitation.
The attribute will be used in the next iteration to validate service-level incoming accesses.