### PR TITLE
Fix persistence issues

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -49,17 +49,40 @@ impl CliState {
         self.create_identity_with_name_and_vault(name, &vault.name())
             .await
     }
+
     /// Create an identity associated with an optional name and an optional vault name
-    /// If the vault name is not specified then the default vault is used
+    ///  - if the vault name is not specified then the default vault is used
+    ///  - if no name is specified:
+    ///     - if there is no default identity, create an identity with a random name
+    ///     - if there is a default identity with the correct vault, return it
+    ///     - otherwise create a new identity
+    ///  - if a name is given create a new identity with the proper vault (unless it has already been created)
     pub async fn create_identity_with_optional_name_and_optional_vault(
         &self,
         name: &Option<String>,
         vault_name: &Option<String>,
     ) -> Result<NamedIdentity> {
-        let name = name.clone().unwrap_or_else(random_name);
-        let vault = self.get_named_vault_or_default(vault_name).await?.name();
-        self.create_identity_with_name_and_vault(&name, &vault)
-            .await
+        let vault_name = self.get_named_vault_or_default(vault_name).await?.name();
+        match name {
+            Some(name) => {
+                self.create_identity_with_name_and_vault(name, &vault_name)
+                    .await
+            }
+            None => {
+                let default_identity = self
+                    .identities_repository()
+                    .await?
+                    .get_default_named_identity()
+                    .await?;
+                if let Some(default_identity) = default_identity {
+                    if default_identity.vault_name == vault_name {
+                        return Ok(default_identity);
+                    }
+                };
+                self.create_identity_with_name_and_vault(&random_name(), &vault_name)
+                    .await
+            }
+        }
     }
 
     /// Create an identity with specific key id.
@@ -332,7 +355,7 @@ impl CliState {
                     node_names.join(", ")
                 ),
             )
-            .into())
+                .into())
         }
     }
 }
@@ -505,6 +528,112 @@ mod tests {
         // check that the identity uses the default vault
         let default_vault = cli.get_default_named_vault().await?;
         assert_eq!(identity.vault_name, default_vault.name());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_identity_with_a_name_and_no_vault() -> Result<()> {
+        let cli = CliState::test().await?;
+
+        // create a named identity using the default vault
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(&Some("name".to_string()), &None)
+            .await?;
+
+        // the created identity becomes the default one
+        let expected = cli.get_default_named_identity().await?;
+        assert_eq!(identity, expected);
+
+        // the identity can be retrieved by name
+        let expected = cli.get_named_identity("name").await?;
+        assert_eq!(identity, expected);
+
+        // the identity will not be recreated a second time
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(&Some("name".to_string()), &None)
+            .await?;
+        assert_eq!(identity, expected);
+        let identities = cli.get_named_identities().await?;
+        assert_eq!(identities.len(), 1);
+
+        // the created identity uses the default vault
+        let default_vault = cli.get_default_named_vault().await?;
+        assert_eq!(identity.vault_name, default_vault.name());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_identity_with_no_name_and_a_vault() -> Result<()> {
+        let cli = CliState::test().await?;
+
+        // create a named identity using a given vault
+        let vault = cli.create_named_vault("vault").await?;
+
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(&None, &Some(vault.name()))
+            .await?;
+
+        // the created identity becomes the default one
+        let expected = cli.get_default_named_identity().await?;
+        assert_eq!(identity, expected);
+
+        // the identity can be retrieved by name
+        let expected = cli.get_named_identity(&identity.name()).await?;
+        assert_eq!(identity, expected);
+
+        // the identity will not be recreated a second time
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(
+                &Some(identity.name()),
+                &Some(vault.name()),
+            )
+            .await?;
+        assert_eq!(identity, expected);
+        let identities = cli.get_named_identities().await?;
+        assert_eq!(identities.len(), 1);
+
+        // the created identity uses the specified vault
+        assert_eq!(identity.vault_name, vault.name());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_identity_with_no_name_and_a_non_default_vault() -> Result<()> {
+        let cli = CliState::test().await?;
+
+        // create two vaults
+        let _ = cli.create_named_vault("vault1").await?;
+        let vault2 = cli.create_named_vault("vault2").await?;
+
+        // create an identity with vault2 which is not the default vault
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(&None, &Some(vault2.name()))
+            .await?;
+
+        // the created identity becomes the default one
+        let expected = cli.get_default_named_identity().await?;
+        assert_eq!(identity, expected);
+
+        // the identity can be retrieved by name
+        let expected = cli.get_named_identity(&identity.name()).await?;
+        assert_eq!(identity, expected);
+
+        // the identity will not be recreated a second time
+        let identity = cli
+            .create_identity_with_optional_name_and_optional_vault(
+                &Some(identity.name()),
+                &Some(vault2.name()),
+            )
+            .await?;
+        assert_eq!(identity, expected);
+        let identities = cli.get_named_identities().await?;
+        assert_eq!(identities.len(), 1);
+
+        // the created identity uses the specified vault
+        assert_eq!(identity.vault_name, vault2.name());
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -59,8 +59,8 @@ impl CliState {
             Some(project.name()),
             Some(project.id()),
             None,
-            Some(project.authority_identity().await?),
-            Some(project.authority_access_route()?),
+            project.authority_identity().await.ok(),
+            project.authority_access_route().ok(),
         )
         .await?;
         Ok(())
@@ -150,5 +150,29 @@ impl CliState {
             projects.insert(project.name.clone(), project);
         }
         Ok(projects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ockam_core::env::FromString;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_import_project() -> Result<()> {
+        let cli = CliState::test().await?;
+
+        // a project can be created without specifying its authority
+        cli.import_project(
+            "project_id",
+            "project_name",
+            &None,
+            &MultiAddr::from_string("/project/default").unwrap(),
+            &None,
+            &None,
+        )
+        .await?;
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -76,28 +76,31 @@ impl InMemoryNode {
         project_name: Option<String>,
         trust_context: Option<NamedTrustContext>,
     ) -> miette::Result<Self> {
-        Self::start_node(ctx, cli_state, None, None, project_name, trust_context).await
+        let default_identity_name = cli_state.get_default_named_identity().await?.name();
+        Self::start_node(
+            ctx,
+            cli_state,
+            &default_identity_name,
+            project_name,
+            trust_context,
+        )
+        .await
     }
 
     /// Start an in memory node
     pub async fn start_node(
         ctx: &Context,
         cli_state: &CliState,
-        identity_name: Option<String>,
-        vault_name: Option<String>,
+        identity_name: &str,
         project_name: Option<String>,
         trust_context: Option<NamedTrustContext>,
     ) -> miette::Result<InMemoryNode> {
         let defaults = NodeManagerDefaults::default();
 
-        // if no identity is specified, create one
-        let identity = cli_state
-            .create_identity_with_optional_name_and_optional_vault(&identity_name, &vault_name)
-            .await?;
         let node = cli_state
             .create_node_with_optional_values(
                 &defaults.node_name,
-                &Some(identity.name()),
+                &Some(identity_name.to_string()),
                 &project_name,
             )
             .await?;

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -190,7 +190,7 @@ impl AppState {
                 });
                 let ctx = &self.context();
                 let project = node_manager
-                    .create_project(ctx, &space.id, PROJECT_NAME, vec![])
+                    .create_project(ctx, &space.name, PROJECT_NAME, vec![])
                     .await?;
                 node_manager
                     .wait_until_project_is_ready(ctx, project)

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -4,11 +4,11 @@ use std::process;
 
 use clap::ArgGroup;
 use clap::Args;
-use miette::{IntoDiagnostic, miette};
+use miette::{miette, IntoDiagnostic};
 use serde::{Deserialize, Serialize};
 
-use ockam::Context;
 use ockam::identity::{AttributesEntry, Identifier};
+use ockam::Context;
 use ockam_api::authority_node;
 use ockam_api::authority_node::{OktaConfiguration, TrustedIdentity};
 use ockam_api::bootstrapped_identities_store::PreTrustedIdentities;
@@ -17,11 +17,11 @@ use ockam_api::nodes::service::default_address::DefaultAddress;
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::fmt;
 
-use crate::{CommandGlobalOpts, docs, Result};
 use crate::node::util::run_ockam;
+use crate::util::parsers::internet_address_parser;
 use crate::util::{embedded_node_that_is_not_stopped, exitcode};
 use crate::util::{local_cmd, node_rpc};
-use crate::util::parsers::internet_address_parser;
+use crate::{docs, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -324,7 +324,7 @@ fn parse_trusted_identities(values: &str) -> Result<TrustedIdentities> {
 
 #[cfg(test)]
 mod tests {
-    use ockam::identity::{Identifier, identities};
+    use ockam::identity::{identities, Identifier};
     use ockam_core::compat::collections::HashMap;
 
     use super::*;

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -346,7 +346,9 @@ async fn get_user_project(
         }
     };
 
-    check_project_readiness(opts, ctx, node, project.clone()).await?;
+    let project = check_project_readiness(opts, ctx, node, project.clone()).await?;
+    // store the updated project
+    opts.state.store_project(project.clone()).await?;
 
     opts.terminal.write_line(&fmt_ok!(
         "Marked this project as your default project, on this machine.\n"

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -307,7 +307,7 @@ async fn get_user_project(
             let project_name = "default".to_string();
             let get_project = async {
                 let project = node
-                    .create_project(ctx, &space.id, &project_name, vec![])
+                    .create_project(ctx, &space.name, &project_name, vec![])
                     .await?;
                 *is_finished.lock().await = true;
                 Ok(project)

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -109,8 +109,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> mie
             let node_manager = InMemoryNode::start_node(
                 ctx,
                 &opts.state,
-                Some(identity_name.clone()),
-                None,
+                &identity_name,
                 cmd.trust_context_opts.project_name,
                 named_trust_context,
             )

--- a/implementations/rust/ockam/ockam_command/src/node/models/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/models/show.rs
@@ -23,6 +23,7 @@ pub struct ShowNodeResponse {
     pub is_default: bool,
     pub name: String,
     pub is_up: bool,
+    pub node_pid: Option<u32>,
     pub route: RouteToNode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identity: Option<String>,
@@ -46,6 +47,7 @@ impl ShowNodeResponse {
         name: &str,
         is_up: bool,
         node_port: Option<u16>,
+        node_pid: Option<u32>,
     ) -> ShowNodeResponse {
         let mut m = MultiAddr::default();
         let short = m.push_back(Node::new(name)).ok().map(|_| m);
@@ -64,6 +66,7 @@ impl ShowNodeResponse {
             is_default,
             name: name.to_owned(),
             is_up,
+            node_pid,
             route: RouteToNode { short, verbose },
             identity: None,
             transports: Default::default(),
@@ -93,6 +96,10 @@ impl Display for ShowNodeResponse {
                 false => "DOWN".light_red(),
             }
         )?;
+
+        if let Some(node_pid) = self.node_pid {
+            writeln!(buffer, "  PID: {}", node_pid)?;
+        }
 
         writeln!(buffer, "  Route To Node:")?;
         if let Some(short) = &self.route.short {

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -148,6 +148,7 @@ pub async fn print_query_status(
             &node_name,
             is_authority_node,
             node_info.tcp_listener_port(),
+            node_info.pid(),
         )
     } else {
         let mut show_node = ShowNodeResponse::new(
@@ -155,6 +156,7 @@ pub async fn print_query_status(
             &node_name,
             true,
             node_info.tcp_listener_port(),
+            node_info.pid(),
         );
         // Get list of services for the node
         let services: ServiceList = node.ask(ctx, api::list_services()).await?;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -58,6 +58,8 @@ async fn run_impl(
     let controller = node.create_controller().await?;
     check_for_completion(&opts, ctx, &controller, &operation_id).await?;
     let project = check_project_readiness(&opts, ctx, &node, project).await?;
+    // update the project state when it's ready
+    opts.state.store_project(project.clone()).await?;
     opts.println(&project)?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -24,6 +24,22 @@ teardown() {
   assert_output --partial "\"is_up\": true"
 }
 
+@test "authority - an authority identity is created by default for the authority node" {
+  port="$(random_port)"
+
+  trusted="{}"
+  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
+  run_success "$OCKAM" identity show authority
+}
+
+@test "authority - an authority identity is created by default for the authority node - with a given name" {
+  port="$(random_port)"
+
+  trusted="{}"
+  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --identity ockam
+  run_success "$OCKAM" identity show ockam
+}
+
 @test "authority - standalone authority, enrollers, members" {
   port="$(random_port)"
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -87,7 +87,6 @@ teardown_home_dir() {
       cp -r "$OCKAM_HOME/." "$HOME/.bats-tests"
     fi
     run $OCKAM node delete --all --force --yes
-    run $OCKAM reset -y
   done
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes.bats
@@ -15,7 +15,19 @@ teardown() {
 # ===== UTILS
 
 force_kill_node() {
-  run killall ockam
+  max_retries=5
+    i=0
+    while [[ $i -lt $max_retries ]]; do
+      pid="$($OCKAM node show $1 --output json | jq .node_pid)"
+      run kill -9 $pid
+      # Killing a node created without `-f` leaves the
+      # process in a defunct state when running within Docker.
+      if ! ps -p $pid || ps -p $pid | grep defunct; then
+        return
+      fi
+      sleep 0.2
+      ((i = i + 1))
+    done
 }
 
 # ===== TESTS

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes.bats
@@ -16,18 +16,18 @@ teardown() {
 
 force_kill_node() {
   max_retries=5
-    i=0
-    while [[ $i -lt $max_retries ]]; do
-      pid="$($OCKAM node show $1 --output json | jq .node_pid)"
-      run kill -9 $pid
-      # Killing a node created without `-f` leaves the
-      # process in a defunct state when running within Docker.
-      if ! ps -p $pid || ps -p $pid | grep defunct; then
-        return
-      fi
-      sleep 0.2
-      ((i = i + 1))
-    done
+  i=0
+  while [[ $i -lt $max_retries ]]; do
+    pid="$($OCKAM node show $1 --output json | jq .node_pid)"
+    run kill -9 $pid
+    # Killing a node created without `-f` leaves the
+    # process in a defunct state when running within Docker.
+    if ! ps -p $pid || ps -p $pid | grep defunct; then
+      return
+    fi
+    sleep 0.2
+    ((i = i + 1))
+  done
 }
 
 # ===== TESTS

--- a/implementations/rust/ockam/ockam_identity/src/error.rs
+++ b/implementations/rust/ockam/ockam_identity/src/error.rs
@@ -4,6 +4,7 @@ use ockam_core::{
 };
 
 /// Identity crate error
+#[repr(u8)]
 #[derive(Clone, Debug)]
 pub enum IdentityError {
     /// Invalid key type
@@ -11,7 +12,7 @@ pub enum IdentityError {
     /// Invalid Key Data
     InvalidKeyData,
     /// Invalid Identifier format
-    InvalidIdentifier,
+    InvalidIdentifier(String),
     /// Identity Change History is empty
     EmptyIdentity,
     /// Identity Verification Failed

--- a/implementations/rust/ockam/ockam_identity/src/error.rs
+++ b/implementations/rust/ockam/ockam_identity/src/error.rs
@@ -1,3 +1,4 @@
+use ockam_core::compat::string::String;
 use ockam_core::{
     errcode::{Kind, Origin},
     Error,
@@ -66,6 +67,7 @@ pub enum IdentityError {
 }
 
 impl ockam_core::compat::error::Error for IdentityError {}
+
 impl core::fmt::Display for IdentityError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::Debug::fmt(self, f)

--- a/implementations/rust/ockam/ockam_identity/src/models/utils/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/utils/identifiers.rs
@@ -1,18 +1,19 @@
-use ockam_core::compat::{string::String, vec::Vec};
-use ockam_core::env::FromString;
-use ockam_core::{Error, Result};
-
-use crate::{Identifier, IdentityError};
-
-use crate::models::{ChangeHash, CHANGE_HASH_LEN, IDENTIFIER_LEN};
 use core::fmt::{Display, Formatter};
 use core::str::FromStr;
+
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+use ockam_core::{Error, Result};
+use ockam_core::compat::{string::String, vec::Vec};
+use ockam_core::env::FromString;
+
+use crate::{Identifier, IdentityError};
+use crate::models::{CHANGE_HASH_LEN, ChangeHash, IDENTIFIER_LEN};
 
 impl Serialize for Identifier {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         serializer.serialize_str(&String::from(self))
     }
@@ -20,8 +21,8 @@ impl Serialize for Identifier {
 
 impl<'de> Deserialize<'de> for Identifier {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         let str: String = Deserialize::deserialize(deserializer)?;
 
@@ -60,10 +61,10 @@ impl TryFrom<&str> for Identifier {
             if let Ok(data) = hex::decode(value) {
                 data.try_into()
             } else {
-                Err(IdentityError::InvalidIdentifier.into())
+                Err(IdentityError::InvalidIdentifier(value.into()).into())
             }
         } else {
-            Err(IdentityError::InvalidIdentifier.into())
+            Err(IdentityError::InvalidIdentifier(value.into()).into())
         }
     }
 }
@@ -75,7 +76,7 @@ impl TryFrom<&[u8]> for Identifier {
         if let Ok(value) = <[u8; IDENTIFIER_LEN]>::try_from(value) {
             Ok(Self(value))
         } else {
-            Err(IdentityError::InvalidIdentifier.into())
+            Err(IdentityError::InvalidIdentifier(hex::encode(value)).into())
         }
     }
 }
@@ -142,7 +143,7 @@ impl TryFrom<&str> for ChangeHash {
         if let Ok(data) = hex::decode(value) {
             data.try_into()
         } else {
-            Err(IdentityError::InvalidIdentifier.into())
+            Err(IdentityError::InvalidIdentifier(value.into()).into())
         }
     }
 }
@@ -154,7 +155,7 @@ impl TryFrom<&[u8]> for ChangeHash {
         if let Ok(value) = <[u8; CHANGE_HASH_LEN]>::try_from(value) {
             Ok(Self(value))
         } else {
-            Err(IdentityError::InvalidIdentifier.into())
+            Err(IdentityError::InvalidIdentifier(hex::encode(value)).into())
         }
     }
 }
@@ -197,8 +198,9 @@ impl AsRef<[u8]> for ChangeHash {
 
 #[cfg(test)]
 mod test {
+    use quickcheck::{Arbitrary, Gen, quickcheck};
+
     use super::*;
-    use quickcheck::{quickcheck, Arbitrary, Gen};
 
     impl Arbitrary for Identifier {
         fn arbitrary(g: &mut Gen) -> Self {

--- a/implementations/rust/ockam/ockam_identity/src/models/utils/identifiers.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/utils/identifiers.rs
@@ -3,17 +3,17 @@ use core::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use ockam_core::{Error, Result};
 use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::env::FromString;
+use ockam_core::{Error, Result};
 
+use crate::models::{ChangeHash, CHANGE_HASH_LEN, IDENTIFIER_LEN};
 use crate::{Identifier, IdentityError};
-use crate::models::{CHANGE_HASH_LEN, ChangeHash, IDENTIFIER_LEN};
 
 impl Serialize for Identifier {
     fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&String::from(self))
     }
@@ -21,8 +21,8 @@ impl Serialize for Identifier {
 
 impl<'de> Deserialize<'de> for Identifier {
     fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let str: String = Deserialize::deserialize(deserializer)?;
 
@@ -198,7 +198,7 @@ impl AsRef<[u8]> for ChangeHash {
 
 #[cfg(test)]
 mod test {
-    use quickcheck::{Arbitrary, Gen, quickcheck};
+    use quickcheck::{quickcheck, Arbitrary, Gen};
 
     use super::*;
 


### PR DESCRIPTION
This PR fixes a number of regressions after the merge of the [database persistence PR](https://github.com/build-trust/ockam/pull/6913):

 - incorrect use of the space id instead of the space name in a command
 - create the authority identity for the identity node if it doesn't exist
 - correctly stop nodes in the bats test suite when running concurrently
 - create a default identity only once when using the function accepting optional values
