### PR TITLE
fix(rust): use the same in-memory database for the vault used in nif

### DIFF
--- a/implementations/elixir/ockam/ockly/native/ockly/Cargo.toml
+++ b/implementations/elixir/ockam/ockly/native/ockly/Cargo.toml
@@ -16,6 +16,7 @@ hex = { version = "0.4", default-features = false }
 lazy_static = "1.4.0"
 minicbor = { version = "0.20.0", features = ["alloc", "derive"] }
 ockam_identity = { path = "../../../../../rust/ockam/ockam_identity" }
+ockam_node = { path = "../../../../../rust/ockam/ockam_node" }
 ockam_vault = { path = "../../../../../rust/ockam/ockam_vault" }
 ockam_vault_aws = { path = "../../../../../rust/ockam/ockam_vault_aws" }
 # Enable credentials-sso feature in ockam_vault_aws for use on sso environments (like dev machines)


### PR DESCRIPTION
This PR:

 - fixes the creation of the software vault in NIF code by making sure that the in-memory database is shared by all special purpose vaults (signing, secure channels, etc...)
 
 - uses a random URL for the in-memory database and specify that the shared mode should be used to avoid the issue described [here](https://github.com/launchbadge/sqlx/issues/2510)
