### PR TITLE
fix(rust): use the transaction api properly with sqlx

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
@@ -89,18 +89,18 @@ impl NodesRepository for NodesSqlxDatabase {
     }
 
     async fn set_default_node(&self, node_name: &str) -> Result<()> {
-        let transaction = self.database.begin().await.into_core()?;
+        let mut transaction = self.database.begin().await.into_core()?;
         // set the node as the default one
         let query1 = query("UPDATE node SET is_default = ? WHERE name = ?")
             .bind(true.to_sql())
             .bind(node_name.to_sql());
-        query1.execute(&self.database.pool).await.void()?;
+        query1.execute(&mut *transaction).await.void()?;
 
         // set all the others as non-default
         let query2 = query("UPDATE node SET is_default = ? WHERE name <> ?")
             .bind(false.to_sql())
             .bind(node_name.to_sql());
-        query2.execute(&self.database.pool).await.void()?;
+        query2.execute(&mut *transaction).await.void()?;
         transaction.commit().await.void()
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/trust_contexts_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/trust_contexts_repository_sql.rs
@@ -80,18 +80,18 @@ impl TrustContextsRepository for TrustContextsSqlxDatabase {
     }
 
     async fn set_default_trust_context(&self, name: &str) -> Result<()> {
-        let transaction = self.database.begin().await.into_core()?;
+        let mut transaction = self.database.begin().await.into_core()?;
         // set the trust context as the default one
         let query1 = query("UPDATE trust_context SET is_default = ? WHERE name = ?")
             .bind(true.to_sql())
             .bind(name.to_sql());
-        query1.execute(&self.database.pool).await.void()?;
+        query1.execute(&mut *transaction).await.void()?;
 
         // set all the others as non-default
         let query2 = query("UPDATE trust_context SET is_default = ? WHERE name <> ?")
             .bind(false.to_sql())
             .bind(name.to_sql());
-        query2.execute(&self.database.pool).await.void()?;
+        query2.execute(&mut *transaction).await.void()?;
         transaction.commit().await.void()
     }
 

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
@@ -47,13 +47,13 @@ impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
     }
 
     async fn delete_change_history(&self, identifier: &Identifier) -> Result<()> {
-        let transaction = self.database.begin().await.into_core()?;
+        let mut transaction = self.database.begin().await.into_core()?;
         let query1 = query("DELETE FROM identity where identifier=?").bind(identifier.to_sql());
-        query1.execute(&self.database.pool).await.void()?;
+        query1.execute(&mut *transaction).await.void()?;
 
         let query2 =
             query("DELETE FROM identity_attributes where identifier=?").bind(identifier.to_sql());
-        query2.execute(&self.database.pool).await.void()?;
+        query2.execute(&mut *transaction).await.void()?;
         transaction.commit().await.void()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
@@ -74,17 +74,13 @@ impl IdentityAttributesRepository for IdentityAttributesSqlxDatabase {
         attribute_name: Vec<u8>,
         attribute_value: Vec<u8>,
     ) -> Result<()> {
-        let transaction = self.database.begin().await.into_core()?;
-
         let mut attributes = match self.get_attributes(subject).await? {
             Some(entry) => (*entry.attrs()).clone(),
             None => BTreeMap::new(),
         };
         attributes.insert(attribute_name, attribute_value);
         let entry = AttributesEntry::new(attributes, now()?, None, Some(subject.clone()));
-        self.put_attributes(subject, entry).await?;
-
-        transaction.commit().await.void()
+        self.put_attributes(subject, entry).await
     }
 
     async fn delete(&self, identity: &Identifier) -> Result<()> {


### PR DESCRIPTION
This PR fixes the use of transactions with `sqlx`
