### PR TITLE
refactor(rust):slim down the NodeManagerWorker (s_ch)

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/auth.rs
+++ b/implementations/rust/ockam/ockam_api/src/auth.rs
@@ -56,7 +56,8 @@ impl Server {
 
         let res = match req.method() {
             Some(Method::Get) => match req.path_segments::<2>().as_slice() {
-                [""] => Response::ok(&req)
+                [""] => Response::ok()
+                    .with_headers(&req)
                     .body(
                         self.identity_attributes_repository
                             .list_attributes_by_identifier()
@@ -70,7 +71,7 @@ impl Server {
                         .get_attributes(&identifier)
                         .await?
                     {
-                        Response::ok(&req).body(a).to_vec()?
+                        Response::ok().with_headers(&req).body(a).to_vec()?
                     } else {
                         Response::not_found(&req, &format!("identity {} not found", id)).to_vec()?
                     }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/authenticator.rs
@@ -88,17 +88,17 @@ impl Worker for DirectAuthenticator {
                     let add: AddMember = dec.decode()?;
                     self.add_member(&from, add.member(), add.attributes())
                         .await?;
-                    Response::ok(&req).to_vec()?
+                    Response::ok().with_headers(&req).to_vec()?
                 }
                 (Some(Method::Get), ["member_ids"]) => {
                     let entries = self.list_members().await?;
                     let ids: Vec<Identifier> = entries.into_keys().collect();
-                    Response::ok(&req).body(ids).to_vec()?
+                    Response::ok().with_headers(&req).body(ids).to_vec()?
                 }
                 (Some(Method::Get), [""]) | (Some(Method::Get), ["members"]) => {
                     let entries = self.list_members().await?;
 
-                    Response::ok(&req).body(entries).to_vec()?
+                    Response::ok().with_headers(&req).body(entries).to_vec()?
                 }
                 (Some(Method::Delete), [id]) | (Some(Method::Delete), ["members", id]) => {
                     let identifier = Identifier::try_from(id.to_string())?;
@@ -106,7 +106,7 @@ impl Worker for DirectAuthenticator {
                         .delete(&identifier)
                         .await?;
 
-                    Response::ok(&req).to_vec()?
+                    Response::ok().with_headers(&req).to_vec()?
                 }
 
                 _ => Response::unknown_path(&req).to_vec()?,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -70,7 +70,7 @@ impl EnrollmentTokenAcceptor {
             return Ok(Response::internal_error(req, "attributes storage error").to_vec()?);
         }
 
-        Ok(Response::ok(req).to_vec()?)
+        Ok(Response::ok().with_headers(req).to_vec()?)
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -86,7 +86,7 @@ impl Worker for EnrollmentTokenIssuer {
                         .issue_token(&from, att.into_owned_attributes(), duration, ttl_count)
                         .await
                     {
-                        Ok(otc) => Response::ok(&req).body(&otc).to_vec()?,
+                        Ok(otc) => Response::ok().with_headers(&req).body(&otc).to_vec()?,
                         Err(error) => {
                             Response::internal_error(&req, &error.to_string()).to_vec()?
                         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
@@ -1,4 +1,4 @@
-use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::api::{Error, Response};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::Result;
 use ockam_multiaddr::MultiAddr;
@@ -14,7 +14,6 @@ impl NodeManagerWorker {
     pub(super) async fn add_consumer(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
         consumer: AddConsumer,
     ) -> Result<Response, Response<Error>> {
         match self
@@ -22,9 +21,9 @@ impl NodeManagerWorker {
             .add_consumer(ctx, consumer.address(), consumer.flow_control_id())
             .await
         {
-            Ok(None) => Ok(Response::ok(req)),
-            Ok(Some(failure)) => Err(Response::bad_request(req, &failure.to_string())),
-            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+            Ok(None) => Ok(Response::ok()),
+            Ok(Some(failure)) => Err(Response::bad_request_no_request(&failure.to_string())),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/message.rs
@@ -5,7 +5,7 @@ use tracing::trace;
 
 use minicbor::{Decode, Encode};
 
-use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::api::{Error, Response};
 use ockam_core::{self, async_trait, AsyncTryClone, Result};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::{Context, MessageSendReceiveOptions};
@@ -42,7 +42,6 @@ impl NodeManagerWorker {
     pub(crate) async fn send_message(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
         send_message: SendMessage,
     ) -> Result<Response<Vec<u8>>, Response<Error>> {
         let multiaddr = send_message.multiaddr()?;
@@ -53,10 +52,12 @@ impl NodeManagerWorker {
             .send_message(ctx, &multiaddr, msg, None)
             .await;
         match res {
-            Ok(r) => Ok(Response::ok(req).body(r)),
+            Ok(r) => Ok(Response::ok().body(r)),
             Err(err) => {
                 error!(target: TARGET, ?err, "Failed to send message");
-                Err(Response::internal_error(req, "Failed to send message"))
+                Err(Response::internal_error_no_request(
+                    "Failed to send message",
+                ))
             }
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -3,7 +3,7 @@ use either::Either;
 use ockam::identity::{AuthorityService, Identifier, Identity, TrustContext};
 use ockam::{Address, Context, Result};
 use ockam_abac::Resource;
-use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::api::{Error, Response};
 use ockam_node::WorkerBuilder;
 
 use crate::auth::Server;
@@ -27,7 +27,6 @@ impl NodeManagerWorker {
     pub(super) async fn start_authenticated_service(
         &self,
         ctx: &Context,
-        request_header: &RequestHeader,
         request: StartAuthenticatedServiceRequest,
     ) -> Result<Response, Response<Error>> {
         match self
@@ -35,15 +34,14 @@ impl NodeManagerWorker {
             .start_authenticated_service(ctx, request.addr.into())
             .await
         {
-            Ok(_) => Ok(Response::ok(request_header)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(_) => Ok(Response::ok()),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn start_uppercase_service(
         &self,
         ctx: &Context,
-        request_header: &RequestHeader,
         request: StartUppercaseServiceRequest,
     ) -> Result<Response, Response<Error>> {
         match self
@@ -51,15 +49,14 @@ impl NodeManagerWorker {
             .start_uppercase_service(ctx, request.addr.into())
             .await
         {
-            Ok(_) => Ok(Response::ok(request_header)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(_) => Ok(Response::ok()),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn start_echoer_service(
         &self,
         ctx: &Context,
-        request_header: &RequestHeader,
         request: StartEchoerServiceRequest,
     ) -> Result<Response, Response<Error>> {
         match self
@@ -67,15 +64,14 @@ impl NodeManagerWorker {
             .start_echoer_service(ctx, request.addr.into())
             .await
         {
-            Ok(_) => Ok(Response::ok(request_header)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(_) => Ok(Response::ok()),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn start_hop_service(
         &self,
         ctx: &Context,
-        request_header: &RequestHeader,
         request: StartHopServiceRequest,
     ) -> Result<Response, Response<Error>> {
         match self
@@ -83,15 +79,14 @@ impl NodeManagerWorker {
             .start_hop_service(ctx, request.addr.into())
             .await
         {
-            Ok(_) => Ok(Response::ok(request_header)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(_) => Ok(Response::ok()),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn start_credentials_service(
         &self,
         ctx: &Context,
-        request_header: &RequestHeader,
         request: StartCredentialsService,
     ) -> Result<Response, Response<Error>> {
         let addr: Address = request.address().into();
@@ -99,48 +94,43 @@ impl NodeManagerWorker {
         let encoded_identity = request.public_identity();
         let identifier = match Identity::create(encoded_identity).await {
             Ok(identity) => identity.identifier().clone(),
-            Err(e) => return Err(Response::bad_request(request_header, &e.to_string())),
+            Err(e) => return Err(Response::bad_request_no_request(&e.to_string())),
         };
         match self
             .node_manager
             .start_credentials_service_with_trusted_identity(ctx, &identifier, addr, oneway)
             .await
         {
-            Ok(_) => Ok(Response::ok(request_header)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(_) => Ok(Response::ok()),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn list_services_of_type(
         &self,
-        req: &RequestHeader,
         service_type: &str,
     ) -> Result<Response<ServiceList>, Response<Error>> {
         match self.node_manager.list_services_of_type(service_type).await {
-            Ok(Either::Left(services)) => Ok(Response::ok(req).body(ServiceList::new(services))),
-            Ok(Either::Right(message)) => Err(Response::bad_request(req, &message)),
-            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+            Ok(Either::Left(services)) => Ok(Response::ok().body(ServiceList::new(services))),
+            Ok(Either::Right(message)) => Err(Response::bad_request_no_request(&message)),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
-    pub(super) async fn list_services(
-        &self,
-        req: &RequestHeader,
-    ) -> Result<Response<ServiceList>, Response<Error>> {
+    pub(super) async fn list_services(&self) -> Result<Response<ServiceList>, Response<Error>> {
         match self.node_manager.list_services().await {
-            Ok(services) => Ok(Response::ok(req).body(ServiceList::new(services))),
-            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+            Ok(services) => Ok(Response::ok().body(ServiceList::new(services))),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 
     pub(super) async fn get_node_status(
         &self,
         context: &Context,
-        request_header: &RequestHeader,
     ) -> Result<Response<NodeStatus>, Response<Error>> {
         match self.node_manager.get_node_status(context).await {
-            Ok(node_status) => Ok(Response::ok(request_header).body(node_status)),
-            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+            Ok(node_status) => Ok(Response::ok().body(node_status)),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -33,18 +33,14 @@ use super::{NodeManager, NodeManagerWorker};
 
 /// INLETS
 impl NodeManagerWorker {
-    pub(super) async fn get_inlets(
-        &self,
-        req: &RequestHeader,
-    ) -> Result<Response<InletList>, Response<Error>> {
+    pub(super) async fn get_inlets(&self) -> Result<Response<InletList>, Response<Error>> {
         let inlets = self.node_manager.list_inlets().await;
-        Ok(Response::ok(req).body(inlets))
+        Ok(Response::ok().body(inlets))
     }
 
     pub(super) async fn create_inlet(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
         create_inlet: CreateInlet,
     ) -> Result<Response<InletStatus>, Response<Error>> {
         let CreateInlet {
@@ -70,33 +66,30 @@ impl NodeManagerWorker {
             )
             .await
         {
-            Ok(status) => Ok(Response::ok(req).body(status)),
-            Err(e) => Err(Response::bad_request(req, &format!("{e:?}"))),
+            Ok(status) => Ok(Response::ok().body(status)),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
         }
     }
 
     pub(super) async fn delete_inlet(
         &self,
-        req: &RequestHeader,
         alias: &str,
     ) -> Result<Response<InletStatus>, Response<Error>> {
         match self.node_manager.delete_inlet(alias).await {
-            Ok(status) => Ok(Response::ok(req).body(status)),
-            Err(e) => Err(Response::bad_request(req, &format!("{e:?}"))),
+            Ok(status) => Ok(Response::ok().body(status)),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
         }
     }
 
     pub(super) async fn show_inlet(
         &self,
-        req: &RequestHeader,
         alias: &str,
     ) -> Result<Response<InletStatus>, Response<Error>> {
         match self.node_manager.show_inlet(alias).await {
-            Some(inlet) => Ok(Response::ok(req).body(inlet)),
-            None => Err(Response::not_found(
-                req,
-                &format!("Inlet with alias {alias} not found"),
-            )),
+            Some(inlet) => Ok(Response::ok().body(inlet)),
+            None => Err(Response::not_found_no_request(&format!(
+                "Inlet with alias {alias} not found"
+            ))),
         }
     }
 }
@@ -106,7 +99,6 @@ impl NodeManagerWorker {
     pub(super) async fn create_outlet(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
         create_outlet: CreateOutlet,
     ) -> Result<Response<OutletStatus>, Response<Error>> {
         let CreateOutlet {
@@ -128,49 +120,47 @@ impl NodeManagerWorker {
             )
             .await
         {
-            Ok(outlet_status) => Ok(Response::ok(req).body(outlet_status)),
-            Err(e) => Err(Response::bad_request(req, &format!("{e:?}"))),
+            Ok(outlet_status) => Ok(Response::ok().body(outlet_status)),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
         }
     }
 
     pub(super) async fn delete_outlet(
         &self,
-        req: &RequestHeader,
         alias: &str,
     ) -> Result<Response<OutletStatus>, Response<Error>> {
         match self.node_manager.delete_outlet(alias).await {
             Ok(res) => match res {
-                Some(outlet_info) => Ok(Response::ok(req).body(OutletStatus::new(
+                Some(outlet_info) => Ok(Response::ok().body(OutletStatus::new(
                     outlet_info.socket_addr,
                     outlet_info.worker_addr.clone(),
                     alias,
                     None,
                 ))),
-                None => Err(Response::bad_request(
-                    req,
-                    &format!("Outlet with alias {alias} not found"),
-                )),
+                None => Err(Response::bad_request_no_request(&format!(
+                    "Outlet with alias {alias} not found"
+                ))),
             },
-            Err(e) => Err(Response::bad_request(req, &format!("{e:?}"))),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
         }
     }
 
     pub(super) async fn show_outlet(
         &self,
-        req: &RequestHeader,
         alias: &str,
     ) -> Result<Response<OutletStatus>, Response<Error>> {
         match self.node_manager.show_outlet(alias).await {
-            Some(outlet) => Ok(Response::ok(req).body(outlet)),
-            None => Err(Response::not_found(
-                req,
-                &format!("Outlet with alias {alias} not found"),
-            )),
+            Some(outlet) => Ok(Response::ok().body(outlet)),
+            None => Err(Response::not_found_no_request(&format!(
+                "Outlet with alias {alias} not found"
+            ))),
         }
     }
 
     pub(super) async fn get_outlets(&self, req: &RequestHeader) -> Response<OutletList> {
-        Response::ok(req).body(self.node_manager.list_outlets().await)
+        Response::ok()
+            .with_headers(req)
+            .body(self.node_manager.list_outlets().await)
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -46,7 +46,7 @@ impl NodeManagerWorker {
             .create_relay(ctx, &address, alias, at_rust_node, authorized)
             .await
         {
-            Ok(body) => Ok(Response::ok(req).body(body)),
+            Ok(body) => Ok(Response::ok().with_headers(req).body(body)),
             Err(err) => Err(Response::internal_error(
                 req,
                 &format!("Failed to create relay: {}", err),
@@ -68,7 +68,7 @@ impl NodeManagerWorker {
             .delete_relay_impl(ctx, remote_address)
             .await
         {
-            Ok(body) => Ok(Response::ok(req).body(body)),
+            Ok(body) => Ok(Response::ok().with_headers(req).body(body)),
             Err(err) => match err.code().kind {
                 Kind::NotFound => Err(Response::not_found(
                     req,
@@ -95,7 +95,9 @@ impl NodeManagerWorker {
         req: &RequestHeader,
     ) -> Result<Response<Vec<RelayInfo>>, Response<Error>> {
         debug!("Handling GetRelays request");
-        Ok(Response::ok(req).body(self.node_manager.get_relays().await))
+        Ok(Response::ok()
+            .with_headers(req)
+            .body(self.node_manager.get_relays().await))
     }
 }
 
@@ -208,7 +210,9 @@ impl NodeManager {
         debug!("Handling ShowRelay request");
         if let Some(relay) = self.registry.relays.get(remote_address).await {
             debug!(%remote_address, "Relay not found in node registry");
-            Ok(Response::ok(req).body(Some(RelayInfo::from(relay.to_owned()))))
+            Ok(Response::ok()
+                .with_headers(req)
+                .body(Some(RelayInfo::from(relay.to_owned()))))
         } else {
             error!(%remote_address, "Relay not found in the node registry");
             Err(Response::not_found(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/transport.rs
@@ -106,45 +106,46 @@ impl NodeManager {
 
 impl NodeManagerWorker {
     pub(super) async fn get_tcp_connections(&self, req: &RequestHeader) -> Response<TransportList> {
-        Response::ok(req).body(self.node_manager.get_tcp_connections())
+        Response::ok()
+            .with_headers(req)
+            .body(self.node_manager.get_tcp_connections())
     }
 
     pub(super) async fn get_tcp_connection(
         &self,
-        req: &RequestHeader,
         address: String,
     ) -> Result<Response<TransportStatus>, Response<Error>> {
         self.node_manager
             .get_tcp_connection(address.to_string())
-            .map(|status| Response::ok(req).body(status))
+            .map(|status| Response::ok().body(status))
             .ok_or_else(|| {
                 let msg = format!("Connection {address} was not found in the registry.");
-                Response::not_found(req, &msg)
+                Response::not_found_no_request(&msg)
             })
     }
 
     pub(super) async fn get_tcp_listeners(&self, req: &RequestHeader) -> Response<TransportList> {
-        Response::ok(req).body(self.node_manager.get_tcp_listeners())
+        Response::ok()
+            .with_headers(req)
+            .body(self.node_manager.get_tcp_listeners())
     }
 
     pub(super) async fn get_tcp_listener(
         &self,
-        req: &RequestHeader,
         address: String,
     ) -> Result<Response<TransportStatus>, Response<Error>> {
         self.node_manager
             .get_tcp_listener(address.to_string())
-            .map(|status| Response::ok(req).body(status))
+            .map(|status| Response::ok().body(status))
             .ok_or_else(|| {
                 let msg = format!("Listener {address} was not found in the registry.");
-                Response::bad_request(req, &msg)
+                Response::bad_request_no_request(&msg)
             })
     }
 
     pub(super) async fn create_tcp_connection<'a>(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
         create: CreateTcpConnection,
     ) -> Result<Response<TransportStatus>, Response<Error>> {
         let CreateTcpConnection { addr, .. } = create;
@@ -153,15 +154,14 @@ impl NodeManagerWorker {
         self.node_manager
             .create_tcp_connection(addr.to_string(), ctx)
             .await
-            .map(|status| Response::ok(req).body(status))
+            .map(|status| Response::ok().body(status))
             .map_err(|msg| {
-                Response::bad_request(req, &format!("Unable to connect to {addr}: {msg}"))
+                Response::bad_request_no_request(&format!("Unable to connect to {addr}: {msg}"))
             })
     }
 
     pub(super) async fn create_tcp_listener<'a>(
         &self,
-        req: &RequestHeader,
         create: CreateTcpListener,
     ) -> Result<Response<TransportStatus>, Response<Error>> {
         let CreateTcpListener { addr, .. } = create;
@@ -170,15 +170,14 @@ impl NodeManagerWorker {
         self.node_manager
             .create_tcp_listener(addr.to_string())
             .await
-            .map(|status| Response::ok(req).body(status))
+            .map(|status| Response::ok().body(status))
             .map_err(|msg| {
-                Response::bad_request(req, &format!("Unable to listen on {addr}: {msg}"))
+                Response::bad_request_no_request(&format!("Unable to listen on {addr}: {msg}"))
             })
     }
 
     pub(super) async fn delete_tcp_connection(
         &self,
-        req: &RequestHeader,
         delete: DeleteTransport,
     ) -> Result<Response<()>, Response<Error>> {
         info!("Handling request to stop listener: {}", delete.address);
@@ -186,13 +185,12 @@ impl NodeManagerWorker {
         self.node_manager
             .delete_tcp_connection(delete.address)
             .await
-            .map(|status| Response::ok(req).body(status))
-            .map_err(|msg| Response::bad_request(req, &msg))
+            .map(|status| Response::ok().body(status))
+            .map_err(|msg| Response::bad_request_no_request(&msg))
     }
 
     pub(super) async fn delete_tcp_listener(
         &self,
-        req: &RequestHeader,
         delete: DeleteTransport,
     ) -> Result<Response<()>, Response<Error>> {
         info!("Handling request to stop listener: {}", delete.address);
@@ -200,7 +198,7 @@ impl NodeManagerWorker {
         self.node_manager
             .delete_tcp_listener(delete.address)
             .await
-            .map(|status| Response::ok(req).body(status))
-            .map_err(|msg| Response::bad_request(req, &msg))
+            .map(|status| Response::ok().body(status))
+            .map_err(|msg| Response::bad_request_no_request(&msg))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/workers.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/workers.rs
@@ -1,6 +1,6 @@
 use crate::nodes::models::workers::{WorkerList, WorkerStatus};
 use crate::nodes::NodeManagerWorker;
-use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::api::{Error, Response};
 use ockam_core::Result;
 use ockam_node::Context;
 
@@ -9,10 +9,9 @@ impl NodeManagerWorker {
     pub async fn list_workers(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
     ) -> Result<Response<WorkerList>, Response<Error>> {
         let workers = match ctx.list_workers().await {
-            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
             Ok(workers) => Ok(workers),
         }?;
 
@@ -21,6 +20,6 @@ impl NodeManagerWorker {
             .map(|addr| WorkerStatus::new(addr.address()))
             .collect();
 
-        Ok(Response::ok(req).body(WorkerList::new(list)))
+        Ok(Response::ok().body(WorkerList::new(list)))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/okta/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/okta/mod.rs
@@ -103,7 +103,7 @@ impl Server {
                         self.identity_attributes_repository
                             .put_attributes(from, entry)
                             .await?;
-                        Response::ok(&req).to_vec()?
+                        Response::ok().with_headers(&req).to_vec()?
                     } else {
                         Response::forbidden(&req, "Forbidden").to_vec()?
                     }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -1,12 +1,12 @@
 use clap::Args;
 use console::Term;
 use miette::IntoDiagnostic;
+use ockam_api::nodes::models::secure_channel::ListSecureChannelListenerResponse;
 use tokio_retry::strategy::FixedInterval;
 use tracing::{info, trace, warn};
 
 use ockam_api::nodes::models::base::NodeStatus;
 use ockam_api::nodes::models::portal::{InletList, OutletList};
-use ockam_api::nodes::models::secure_channel::SecureChannelListenersList;
 use ockam_api::nodes::models::services::ServiceList;
 use ockam_api::nodes::models::transport::TransportList;
 use ockam_api::nodes::BackgroundNode;
@@ -176,7 +176,7 @@ pub async fn print_query_status(
             .collect();
 
         // Get list of Secure Channel Listeners
-        let listeners: SecureChannelListenersList =
+        let listeners: ListSecureChannelListenerResponse =
             node.ask(ctx, api::list_secure_channel_listener()).await?;
         show_node.secure_channel_listeners = listeners
             .list

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -6,7 +6,7 @@ use tokio::try_join;
 
 use ockam::Context;
 use ockam_api::nodes::models::secure_channel::{
-    SecureChannelListenersList, ShowSecureChannelListenerResponse,
+    ListSecureChannelListenerResponse, ShowSecureChannelListenerResponse,
 };
 use ockam_api::nodes::BackgroundNode;
 use ockam_api::route_to_multiaddr;
@@ -52,7 +52,7 @@ async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ListCommand) -> m
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_listeners = async {
-        let listeners: SecureChannelListenersList =
+        let listeners: ListSecureChannelListenerResponse =
             node.ask(ctx, api::list_secure_channel_listener()).await?;
         *is_finished.lock().await = true;
         Ok(listeners)

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
@@ -114,7 +114,7 @@ impl Worker for CredentialsIssuer {
             let res = match (req.method(), req.path()) {
                 (Some(Method::Post), "/") | (Some(Method::Post), "/credential") => {
                     match self.issue_credential(&from).await {
-                        Ok(Some(crd)) => Response::ok(&req).body(crd).to_vec()?,
+                        Ok(Some(crd)) => Response::ok().with_headers(&req).body(crd).to_vec()?,
                         Ok(None) => {
                             // Again, this has already been checked by the access control, so if we
                             // reach this point there is an error actually.

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_server_worker.rs
@@ -86,7 +86,7 @@ impl CredentialsServerWorker {
                 match res {
                     Ok(()) => {
                         debug!("One-way credential presentation request processed successfully with {}", sender);
-                        Response::ok(req).to_vec()?
+                        Response::ok().with_headers(req).to_vec()?
                     }
                     Err(err) => {
                         debug!(
@@ -133,11 +133,11 @@ impl CredentialsServerWorker {
                     match credential.as_ref() {
                         Some(c) if self.present_back => {
                             info!("Mutual credential presentation request processed successfully with {}. Responding with own credential...", sender);
-                            Response::ok(req).body(c).to_vec()?
+                            Response::ok().with_headers(req).body(c).to_vec()?
                         }
                         _ => {
                             info!("Mutual credential presentation request processed successfully with {}. No credential to respond!", sender);
-                            Response::ok(req).to_vec()?
+                            Response::ok().with_headers(req).to_vec()?
                         }
                     }
                 }


### PR DESCRIPTION
Refactor the NodeWorkerManager for secure channel and secure channel listener

## Current behavior

The `NodeWorkerManager` is responsable for too many tasks.

## Proposed changes

1. Created typed interface for message received from node _clients_ for:
- `/node/secure_channel`.
- `/node/secure_channel_listener`.
routes.  
Those typed struct can be renamed as the request type
(e.g:`CreateSecureChannelRequest`).  
In this way there are no _untyped_
requests.
In order for this to work all the calls to the node api should be changed.  
I've grepped all the files containing the requests calls.

2. Changed the `CreateSecureChannelResponse` constructor to accept
   `SecureChannel` `struct`
3. For coherence renamed `SecureChannelListenerList` to `ListSecureChannelListenerResponse`
4. Changed the implementations of the `From<ockam_api::Error>` trait for the
   `Response<Error>` in order to discern between a not found error or an
   internal error:
```rust
impl From<crate::Error> for Response<Error> {
    fn from(e: crate::Error) -> Self {
        match e.code().kind {
            Kind::NotFound => Response::not_found_no_request(e.into()),
            _ => Response::internal_error_no_request(&e.to_string()),
        }
    }
}
```
 In this way the error from the `NodeManager` method can be used to build the
 response.
 The `not_found_no_request` associated function has been introduced for return a
 not found error without requiring the request header.

5. Changed the various signature of `NodeWorkerManager` implementations to
   receive the typed requests instead of a `Decoder` and let the
   `From<minicbor::decore::Error>` implementation for t`Response<Error>` takes
   care of the wrong parsing.
6. Changed `get_secure_channel` and `get_secure_channel_listener` methods on
   the `NodeManager` to return `Result` instead of `Option`.
   Now, if the secure channel(secure_channel_listener) with the given address is
   not found the function returns a not found error

   ```rust
   Error::new(
     Origin::Api,
     Kind::NotFound,
     format!("Secure channel with address, {}, not found", addr),
   )
   ```

   This helps the `From<Error>` implementation for the `Response<Error>` so the
   `NodeWorkerManager` could automatically convert the error.

7. Changed `delete_secure_channel` and `delete_secure_channel_listener` methods
   on `NodeManager` to return explicitly a `Kind::NotFound` if the address of
   the deleting secure channel(secure channel listener) is not found

   ```rust
   Error::new(
   Origin::Api,
   Kind::NotFound,
   format!("Secure channel with address, {}, not found", addr),
   )

   ```

   The implementation consideration is the same for the deleting functions
   above.

8. An example to how the client request should be made from the cli client is given
   for:
   - create secure channel

**This PR won't pass the tests**, it's only showing how i would implement it, if it's ok for you @etorreborre I can change the given files for making the requests typed.

## Files to changes

Here I've simply grepped all the _Untyped Request_ to be changed if this
refactoring is ok for you.

#### CreateSecureChannelRequest

implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs:236: .body(CreateSecureChannelRequest::new(
implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs:452: let body = CreateSecureChannelRequest::new(

#### CreateSecureChannelListenerRequest

implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs:65: CreateSecureChannelListenerRequest::new(
implementations/rust/ockam/ockam_command/src/util/api.rs:96: let payload = models::secure_channel::CreateSecureChannelListenerRequest::new(

#### DeleteSecureChannelRequest

implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs:4: CreateSecureChannelRequest, CreateSecureChannelResponse, DeleteSecureChannelRequest,
implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs:277: .body(DeleteSecureChannelRequest::new(encryptor_address))

#### DeleteSecureChannelListenerRequest

implementations/rust/ockam/ockam_command/src/util/api.rs:117:) -> Request<models::secure_channel::DeleteSecureChannelListenerRequest> {
implementations/rust/ockam/ockam_command/src/util/api.rs:118: let payload = models::secure_channel::DeleteSecureChannelListenerRequest::new(addr);

#### ShowSecureChannelRequest

implementations/rust/ockam/ockam_command/src/util/api.rs:85:) -> Request<models::secure_channel::ShowSecureChannelRequest> {
implementations/rust/ockam/ockam_command/src/util/api.rs:86: let payload = models::secure_channel::ShowSecureChannelRequest::new(addr);

#### ShowSecureChannelListenerRequest

implementations/rust/ockam/ockam_command/src/util/api.rs:125:) -> Request<models::secure_channel::ShowSecureChannelListenerRequest> {
implementations/rust/ockam/ockam_command/src/util/api.rs:126: let payload = models::secure_channel::ShowSecureChannelListenerRequest::new(addr);

## Question
What to do with the various macro `info!("Handling the request to ...)`.
Up until now they were called only for two function at the
`NodeWorkerManager` level. only for some methods.

## Checks


- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
