### PR TITLE
feat(rust): execute an identity update in a transaction

### DIFF
--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -1,6 +1,8 @@
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
+#[cfg(feature = "storage")]
+use ockam_node::database::SqlxDatabase;
 
 #[cfg(feature = "storage")]
 use crate::identities::storage::ChangeHistorySqlxDatabase;
@@ -134,5 +136,18 @@ impl Identities {
             identity_attributes_repository: IdentityAttributesSqlxDatabase::create().await?,
             purpose_keys_repository: PurposeKeysSqlxDatabase::create().await?,
         })
+    }
+
+    /// Return a builder for identities with a specific database
+    #[cfg(feature = "storage")]
+    pub fn create(database: Arc<SqlxDatabase>) -> IdentitiesBuilder {
+        IdentitiesBuilder {
+            vault: Vault::create_with_database(database.clone()),
+            change_history_repository: Arc::new(ChangeHistorySqlxDatabase::new(database.clone())),
+            identity_attributes_repository: Arc::new(IdentityAttributesSqlxDatabase::new(
+                database.clone(),
+            )),
+            purpose_keys_repository: Arc::new(PurposeKeysSqlxDatabase::new(database.clone())),
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
@@ -1,6 +1,8 @@
 use ockam_core::compat::sync::Arc;
 #[cfg(feature = "storage")]
 use ockam_core::Result;
+#[cfg(feature = "storage")]
+use ockam_node::database::SqlxDatabase;
 use ockam_vault::storage::SecretsRepository;
 
 use crate::identities::{ChangeHistoryRepository, Identities};
@@ -20,6 +22,12 @@ pub struct IdentitiesBuilder {
 #[cfg(feature = "storage")]
 pub async fn identities() -> Result<Arc<Identities>> {
     Ok(Identities::builder().await?.build())
+}
+
+/// Return identities backed by a specific database
+#[cfg(feature = "storage")]
+pub fn create(database: Arc<SqlxDatabase>) -> Arc<Identities> {
+    Identities::create(database).build()
 }
 
 impl IdentitiesBuilder {

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_creation.rs
@@ -5,8 +5,8 @@ use ockam_vault::{SigningSecretKeyHandle, VaultForSigning, VaultForVerifyingSign
 
 use crate::identities::identity_builder::IdentityBuilder;
 use crate::models::{ChangeHistory, Identifier};
+use crate::IdentityOptions;
 use crate::{ChangeHistoryRepository, IdentitiesKeys, Identity, IdentityError};
-use crate::{IdentityHistoryComparison, IdentityOptions};
 
 /// This struct supports functions for the creation and import of identities using an IdentityVault
 pub struct IdentitiesCreation {
@@ -112,9 +112,7 @@ impl IdentitiesCreation {
             .rotate_key_with_options(identity, options)
             .await?;
 
-        self.repository
-            .store_change_history(identity.identifier(), identity.change_history().clone())
-            .await?;
+        self.update_identity(&identity).await?;
 
         Ok(())
     }
@@ -196,39 +194,12 @@ impl IdentitiesCreation {
     ///   - Do nothing if they're equal
     ///   - Throw an error if the received version has conflict or is older that previously observed
     ///   - Update stored Identity if the received version is newer
+    ///
+    /// All the code is performed in the ChangeHistoryRepository so that checking the identity
+    /// new change history and the identity old change history + insert the new change history
+    /// can be done atomically
+    ///
     pub async fn update_identity(&self, identity: &Identity) -> Result<()> {
-        if let Some(known_identity) = self
-            .repository
-            .get_change_history(identity.identifier())
-            .await?
-        {
-            let known_identity = Identity::import_from_change_history(
-                Some(identity.identifier()),
-                known_identity,
-                self.verifying_vault.clone(),
-            )
-            .await?;
-
-            match identity.compare(&known_identity) {
-                IdentityHistoryComparison::Conflict | IdentityHistoryComparison::Older => {
-                    return Err(IdentityError::ConsistencyError.into());
-                }
-                IdentityHistoryComparison::Newer => {
-                    self.repository
-                        .store_change_history(
-                            identity.identifier(),
-                            identity.change_history().clone(),
-                        )
-                        .await?;
-                }
-                IdentityHistoryComparison::Equal => {}
-            }
-        } else {
-            self.repository
-                .store_change_history(identity.identifier(), identity.change_history().clone())
-                .await?;
-        }
-
-        Ok(())
+        self.repository.update_identity(identity).await
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository.rs
@@ -1,3 +1,4 @@
+use crate::Identity;
 use ockam_core::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::vec::Vec;
@@ -8,6 +9,11 @@ use crate::models::{ChangeHistory, Identifier};
 /// This repository stores identity change histories
 #[async_trait]
 pub trait ChangeHistoryRepository: Send + Sync + 'static {
+    /// Update the change history of an identity atomically
+    ///  - verify that the new change history is compatible with the previous one
+    ///  - store the new change history
+    async fn update_identity(&self, identity: &Identity) -> Result<()>;
+
     /// Store an identifier with its change history
     async fn store_change_history(
         &self,

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
@@ -1,5 +1,7 @@
 use core::str::FromStr;
 
+use sqlx::query::Query;
+use sqlx::sqlite::SqliteArguments;
 use sqlx::*;
 use tracing::debug;
 
@@ -9,7 +11,7 @@ use ockam_core::Result;
 use ockam_node::database::{FromSqlxError, SqlxDatabase, SqlxType, ToSqlxType, ToVoid};
 
 use crate::models::{ChangeHistory, Identifier};
-use crate::ChangeHistoryRepository;
+use crate::{ChangeHistoryRepository, Identity, IdentityError, IdentityHistoryComparison, Vault};
 
 /// Implementation of `IdentitiesRepository` trait based on an underlying database
 /// using sqlx as its API, and Sqlite as its driver
@@ -35,15 +37,50 @@ impl ChangeHistorySqlxDatabase {
 
 #[async_trait]
 impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
+    async fn update_identity(&self, identity: &Identity) -> Result<()> {
+        let mut transaction = self.database.begin().await.into_core()?;
+        let query1 = query_as("SELECT * FROM identity WHERE identifier=$1")
+            .bind(identity.identifier().to_sql());
+        let row: Option<ChangeHistoryRow> =
+            query1.fetch_optional(&mut *transaction).await.into_core()?;
+
+        let do_insert = match row {
+            Some(row) => {
+                let known_identity = Identity::import_from_change_history(
+                    Some(identity.identifier()),
+                    row.change_history()?,
+                    Vault::create_verifying_vault(),
+                )
+                .await?;
+
+                match identity.compare(&known_identity) {
+                    IdentityHistoryComparison::Conflict | IdentityHistoryComparison::Older => {
+                        return Err(IdentityError::ConsistencyError.into());
+                    }
+                    IdentityHistoryComparison::Newer => true,
+                    IdentityHistoryComparison::Equal => false,
+                }
+            }
+            None => true,
+        };
+        if do_insert {
+            Self::insert_query(identity.identifier(), identity.change_history())
+                .execute(&mut *transaction)
+                .await
+                .void()?
+        };
+        transaction.commit().await.void()
+    }
+
     async fn store_change_history(
         &self,
         identifier: &Identifier,
         change_history: ChangeHistory,
     ) -> Result<()> {
-        let query = query("INSERT OR REPLACE INTO identity VALUES (?, ?)")
-            .bind(identifier.to_sql())
-            .bind(change_history.to_sql());
-        query.execute(&self.database.pool).await.void()
+        Self::insert_query(identifier, &change_history)
+            .execute(&self.database.pool)
+            .await
+            .void()
     }
 
     async fn delete_change_history(&self, identifier: &Identifier) -> Result<()> {
@@ -72,6 +109,17 @@ impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
         let query = query_as("SELECT * FROM identity");
         let row: Vec<ChangeHistoryRow> = query.fetch_all(&self.database.pool).await.into_core()?;
         row.iter().map(|r| r.change_history()).collect()
+    }
+}
+
+impl ChangeHistorySqlxDatabase {
+    fn insert_query<'a>(
+        identifier: &Identifier,
+        change_history: &ChangeHistory,
+    ) -> Query<'a, Sqlite, SqliteArguments<'a>> {
+        query("INSERT OR REPLACE INTO identity VALUES (?, ?)")
+            .bind(identifier.to_sql())
+            .bind(change_history.to_sql())
     }
 }
 
@@ -109,9 +157,8 @@ impl ChangeHistoryRow {
 
 #[cfg(test)]
 mod tests {
-    use crate::{identities, Identity};
-
     use super::*;
+    use crate::{identities, Identity};
 
     #[tokio::test]
     async fn test_identities_repository() -> Result<()> {
@@ -156,6 +203,23 @@ mod tests {
             .get_change_history(identity2.identifier())
             .await?;
         assert_eq!(result, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_update_identity() -> Result<()> {
+        let identities = identities().await?;
+        let identities_creation = identities.identities_creation();
+        let identifier = identities_creation.create_identity().await?;
+
+        // rotating the identity twice
+        identities_creation.rotate_identity(&identifier).await?;
+        let rotated = identities.get_identity(&identifier).await?;
+        identities_creation.rotate_identity(&identifier).await?;
+
+        // try to update the identity with an old rotated version
+        let result = identities_creation.update_identity(&rotated).await;
+        assert!(result.is_err());
         Ok(())
     }
 


### PR DESCRIPTION
This PR fixes a gap where it would be possible in a concurrent context to store some invalid identity updates.
