### PR TITLE
fix(rust): filter out non-admin projects when retrieving them from orchestrator

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -373,7 +373,7 @@ pub trait Projects {
         ctx: &Context,
     ) -> miette::Result<OrchestratorVersionInfo>;
 
-    async fn get_projects(&self, ctx: &Context) -> miette::Result<Vec<Project>>;
+    async fn get_admin_projects(&self, ctx: &Context) -> miette::Result<Vec<Project>>;
 
     async fn wait_until_project_is_ready(
         &self,

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -1,4 +1,4 @@
-use miette::{IntoDiagnostic, WrapErr};
+use miette::IntoDiagnostic;
 use tracing::{debug, error, info};
 
 use ockam_api::cli_state;
@@ -171,16 +171,11 @@ impl AppState {
 
     async fn retrieve_project(&self, space: &Space) -> Result<Project> {
         info!("retrieving the user project");
-        let email = self.user_email().await.wrap_err("User info is not valid")?;
-
         let node_manager = self.node_manager().await;
-        let projects = node_manager.get_projects(&self.context()).await?;
-        let admin_project = projects
-            .iter()
-            .filter(|p| p.has_admin_with_email(&email))
-            .find(|p| p.name == *PROJECT_NAME);
+        let projects = node_manager.get_admin_projects(&self.context()).await?;
+        let main_project = projects.iter().find(|p| p.name == *PROJECT_NAME);
 
-        let project = match admin_project {
+        let project = match main_project {
             Some(project) => project.clone(),
             None => {
                 self.notify(Notification {

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -414,10 +414,6 @@ impl AppState {
         Ok(self.state.read().await.get_default_user().await?)
     }
 
-    pub async fn user_email(&self) -> Result<String> {
-        self.user_info().await.map(|u| u.email)
-    }
-
     pub async fn model_mut(&self, f: impl FnOnce(&mut ModelState)) -> Result<()> {
         let mut model_state = self.model_state.write().await;
         trace!(?model_state, "updating model state locally");

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -280,7 +280,7 @@ async fn get_user_project(
 
     let is_finished = Mutex::new(false);
     let get_projects = async {
-        let projects = node.get_projects(ctx).await?;
+        let projects = node.get_admin_projects(ctx).await?;
         *is_finished.lock().await = true;
         Ok(projects)
     };

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -45,7 +45,7 @@ async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, _cmd: ListCommand) -> 
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_projects = async {
-        let projects = node.get_projects(ctx).await?;
+        let projects = node.get_admin_projects(ctx).await?;
         *is_finished.lock().await = true;
         Ok(projects)
     };


### PR DESCRIPTION
When using the [`Controller`'s `get_projects` function](https://github.com/build-trust/ockam/blob/0ca66af1ed508f65e127a500cf1b18819e91ae1f/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs#L88), we receive all the projects the user is part of (admin and non-admin) and they are stored in the state.

This can cause collisions when retrieving the app's projects, which are all named "default" currently.

The changes are based on the assumption that a user doesn’t get any benefit from listing non-admin projects, as they can’t do anything with them; and that the default user can only be the one created when running the `ockam enroll` command. 