### PR TITLE
refactor(rust): remove re-entrant calls in repository implementations

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -1,6 +1,6 @@
 use ockam::access_control::AllowAll;
 use ockam::access_control::IdentityIdAccessControl;
-use ockam::identity::SecureChannelListenerOptions;
+use ockam::identity::{AttributesEntry, SecureChannelListenerOptions};
 use ockam::identity::{CredentialsIssuer, Vault};
 use ockam::{Context, Result, TcpListenerOptions};
 use ockam::{Node, TcpTransportExtension};
@@ -53,10 +53,12 @@ async fn main(ctx: Context) -> Result<()> {
         &issuer,
         "trust_context".into(),
     );
+
+    let attributes = AttributesEntry::single(b"cluster".to_vec(), b"production".to_vec(), None, None)?;
     for identifier in known_identifiers.iter() {
         node.identities()
             .identity_attributes_repository()
-            .put_attribute_value(identifier, b"cluster".to_vec(), b"production".to_vec())
+            .put_attributes(identifier, attributes.clone())
             .await?;
     }
 

--- a/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
+++ b/implementations/rust/ockam/ockam_api/src/bootstrapped_identities_store.rs
@@ -68,17 +68,6 @@ impl IdentityAttributesRepository for BootstrapedIdentityAttributesStore {
         }
     }
 
-    async fn put_attribute_value(
-        &self,
-        subject: &Identifier,
-        attribute_name: Vec<u8>,
-        attribute_value: Vec<u8>,
-    ) -> Result<()> {
-        self.repository
-            .put_attribute_value(subject, attribute_name, attribute_value)
-            .await
-    }
-
     async fn delete(&self, identity: &Identifier) -> Result<()> {
         self.repository.delete(identity).await
     }
@@ -161,15 +150,6 @@ impl IdentityAttributesRepository for PreTrustedIdentities {
     }
 
     async fn put_attributes(&self, _identity: &Identifier, _entry: AttributesEntry) -> Result<()> {
-        Ok(())
-    }
-
-    async fn put_attribute_value(
-        &self,
-        _subject: &Identifier,
-        _attribute_name: Vec<u8>,
-        _attribute_value: Vec<u8>,
-    ) -> Result<()> {
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/identities_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/identities_repository_sql.rs
@@ -40,18 +40,23 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
         name: &str,
         vault_name: &str,
     ) -> Result<NamedIdentity> {
-        let is_already_default = self
-            .get_default_named_identity()
-            .await?
-            .map(|n| n.name() == *name)
-            .unwrap_or(false);
+        let mut transaction = self.database.begin().await.into_core()?;
 
-        let query = query("INSERT OR REPLACE INTO named_identity VALUES (?, ?, ?, ?)")
+        let query1 = query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM named_identity WHERE is_default=$1 AND name=$2)",
+        )
+        .bind(true.to_sql())
+        .bind(name.to_sql());
+        let is_already_default: bool = query1.fetch_one(&mut *transaction).await.into_core()?;
+
+        let query2 = query("INSERT OR REPLACE INTO named_identity VALUES (?, ?, ?, ?)")
             .bind(identifier.to_sql())
             .bind(name.to_sql())
             .bind(vault_name.to_sql())
             .bind(is_already_default.to_sql());
-        query.execute(&self.database.pool).await.void()?;
+        query2.execute(&mut *transaction).await.void()?;
+
+        transaction.commit().await.void()?;
 
         Ok(NamedIdentity::new(
             identifier.clone(),
@@ -62,23 +67,43 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
     }
 
     async fn delete_identity(&self, name: &str) -> Result<Option<Identifier>> {
-        let named_identity = self.get_named_identity(name).await?;
-        let is_default = named_identity
-            .clone()
-            .map(|i| i.is_default())
-            .unwrap_or(false);
-        let query = query("DELETE FROM named_identity WHERE name=?").bind(name.to_sql());
-        query.execute(&self.database.pool).await.void()?;
+        let mut transaction = self.database.begin().await.into_core()?;
 
-        // if the deleted identity was the default one, select another identity to be the default one
-        if is_default {
-            let identities = self.get_named_identities().await?;
-            if let Some(identity) = identities.first() {
-                self.set_as_default_by_identifier(&identity.identifier())
-                    .await?;
-            };
-        }
-        Ok(named_identity.map(|i| i.identifier()))
+        // get the named identity
+        let query1 = query_as("SELECT * FROM named_identity WHERE name=$1").bind(name.to_sql());
+        let row: Option<NamedIdentityRow> =
+            query1.fetch_optional(&mut *transaction).await.into_core()?;
+        let named_identity = row.map(|r| r.named_identity()).transpose()?;
+
+        let result = match named_identity {
+            // return None if it wasn't found
+            None => None,
+
+            // otherwise delete it and set another identity as the default
+            Some(named_identity) => {
+                let query2 = query("DELETE FROM named_identity WHERE name=?").bind(name.to_sql());
+                query2.execute(&mut *transaction).await.void()?;
+
+                // if the deleted identity was the default one, select another identity to be the default one
+                if named_identity.is_default() {
+                    if let Some(other_name) =
+                        query_scalar::<_, String>("SELECT name FROM named_identity")
+                            .fetch_optional(&mut *transaction)
+                            .await
+                            .into_core()?
+                    {
+                        let query3 =
+                            query("UPDATE named_identity SET is_default = ? WHERE name = ?")
+                                .bind(true.to_sql())
+                                .bind(other_name.to_sql());
+                        query3.execute(&mut *transaction).await.void()?
+                    }
+                }
+                Some(named_identity.identifier())
+            }
+        };
+        transaction.commit().await.void()?;
+        Ok(result)
     }
 
     async fn delete_identity_by_identifier(
@@ -115,6 +140,15 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
         Ok(row.map(|r| r.name()))
     }
 
+    async fn get_named_identity(&self, name: &str) -> Result<Option<NamedIdentity>> {
+        let query = query_as("SELECT * FROM named_identity WHERE name=$1").bind(name.to_sql());
+        let row: Option<NamedIdentityRow> = query
+            .fetch_optional(&self.database.pool)
+            .await
+            .into_core()?;
+        row.map(|r| r.named_identity()).transpose()
+    }
+
     async fn get_named_identity_by_identifier(
         &self,
         identifier: &Identifier,
@@ -134,13 +168,20 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
         row.iter().map(|r| r.named_identity()).collect()
     }
 
-    async fn get_named_identity(&self, name: &str) -> Result<Option<NamedIdentity>> {
-        let query = query_as("SELECT * FROM named_identity WHERE name=$1").bind(name.to_sql());
-        let row: Option<NamedIdentityRow> = query
-            .fetch_optional(&self.database.pool)
-            .await
-            .into_core()?;
-        row.map(|r| r.named_identity()).transpose()
+    async fn set_as_default(&self, name: &str) -> Result<()> {
+        let mut transaction = self.database.begin().await.into_core()?;
+        // set the identifier as the default one
+        let query1 = query("UPDATE named_identity SET is_default = ? WHERE name = ?")
+            .bind(true.to_sql())
+            .bind(name.to_sql());
+        query1.execute(&mut *transaction).await.void()?;
+
+        // set all the others as non-default
+        let query2 = query("UPDATE named_identity SET is_default = ? WHERE name <> ?")
+            .bind(false.to_sql())
+            .bind(name.to_sql());
+        query2.execute(&mut *transaction).await.void()?;
+        transaction.commit().await.void()
     }
 
     async fn set_as_default_by_identifier(&self, identifier: &Identifier) -> Result<()> {
@@ -157,13 +198,6 @@ impl IdentitiesRepository for IdentitiesSqlxDatabase {
             .bind(identifier.to_sql());
         query2.execute(&mut *transaction).await.void()?;
         transaction.commit().await.void()
-    }
-
-    async fn set_as_default(&self, name: &str) -> Result<()> {
-        if let Some(identifier) = self.get_identifier(name).await? {
-            self.set_as_default_by_identifier(&identifier).await?
-        };
-        Ok(())
     }
 
     async fn get_default_named_identity(&self) -> Result<Option<NamedIdentity>> {

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
@@ -1,7 +1,9 @@
 use crate::models::{Identifier, TimestampInSeconds};
+use crate::utils::now;
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::ToOwned;
 use ockam_core::compat::{collections::BTreeMap, vec::Vec};
+use ockam_core::Result;
 use serde::{Deserialize, Serialize};
 
 /// An entry on the AuthenticatedIdentities table.
@@ -54,5 +56,23 @@ impl AttributesEntry {
     /// Who attested this attributes for this identity identifier
     pub fn attested_by(&self) -> Option<Identifier> {
         self.attested_by.to_owned()
+    }
+}
+
+impl AttributesEntry {
+    /// Create an AttributesEntry with just one name/value pair
+    pub fn single(
+        attribute_name: Vec<u8>,
+        attribute_value: Vec<u8>,
+        expires: Option<TimestampInSeconds>,
+        attested_by: Option<Identifier>,
+    ) -> Result<Self> {
+        let attrs = BTreeMap::from([(attribute_name, attribute_value)]);
+        Ok(Self {
+            attrs,
+            added: now()?,
+            expires,
+            attested_by,
+        })
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository.rs
@@ -17,14 +17,6 @@ pub trait IdentityAttributesRepository: Send + Sync + 'static {
     /// Previous values gets overridden.
     async fn put_attributes(&self, subject: &Identifier, entry: AttributesEntry) -> Result<()>;
 
-    /// Store an attribute name/value pair for a given identity
-    async fn put_attribute_value(
-        &self,
-        subject: &Identifier,
-        attribute_name: Vec<u8>,
-        attribute_value: Vec<u8>,
-    ) -> Result<()>;
-
     /// Remove all attributes for a given identity identifier
     async fn delete(&self, identity: &Identifier) -> Result<()>;
 }


### PR DESCRIPTION
To avoid enforcing a pattern that can lead to deadlocks

I also removed the `put_attributes` function on the `AttributesRepository` because its semantic (adding attribute name/value pairs) was questionable (that function was only introduced to make support the credentials example)