### PR TITLE
refactor(rust): rename reset option with-orchestrator to all

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -19,7 +19,7 @@ pub struct ResetCommand {
 
     /// Remove your spaces from the Orchestrator
     #[arg(long)]
-    with_orchestrator: bool,
+    all: bool,
 }
 
 impl ResetCommand {
@@ -33,7 +33,7 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ResetCommand)) -> mi
 }
 
 async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ResetCommand) -> miette::Result<()> {
-    let delete_orchestrator_resources = cmd.with_orchestrator && opts.state.is_enrolled().await?;
+    let delete_orchestrator_resources = cmd.all && opts.state.is_enrolled().await?;
     if !cmd.yes {
         let msg = if delete_orchestrator_resources {
             "This will delete the local Ockam configuration and remove your spaces from the Orchestrator. Are you sure?"


### PR DESCRIPTION
Rename the option `with-orchestrator` from the command `ockam reset --with-orchestrator` to `ockam reset --all`  as requested at #7013