### PR TITLE
App - Addresses recently introduced UI regressions

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
@@ -145,6 +145,7 @@ impl AppState {
 
             guard.services.push(IncomingService::new(
                 invite.invitation.id,
+                invite.invitation.owner_email,
                 name.unwrap_or_else(|| original_name.clone()),
                 None,
                 enabled,
@@ -167,6 +168,8 @@ impl AppState {
 pub struct IncomingService {
     // it's assumed the id is also the accepted invitation id
     id: String,
+    // the email of the inviter
+    email: String,
     // user-defined name, by default it's the same as the original name
     name: String,
     // this field contains the current port number
@@ -194,6 +197,7 @@ impl IncomingService {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
+        email: String,
         name: String,
         port: Option<Port>,
         enabled: bool,
@@ -204,6 +208,7 @@ impl IncomingService {
     ) -> Self {
         Self {
             id,
+            email,
             name,
             port,
             enabled,
@@ -218,6 +223,11 @@ impl IncomingService {
     /// This is the id of the service as well as of the relative invitation
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// This is the email of the inviter
+    pub fn email(&self) -> &str {
+        &self.email
     }
 
     /// This is the user-defined name of the service

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -97,8 +97,7 @@ impl AppState {
         application_state_callback: ApplicationStateCallback,
         notification_callback: NotificationCallback,
     ) -> Result<AppState> {
-        let cli_state =
-            CliState::with_default_dir().expect("Failed to load the local Ockam configuration");
+        let cli_state = CliState::with_default_dir()?;
         let (context, mut executor) = NodeBuilder::new().no_logging().build();
         let context = Arc::new(context);
 
@@ -612,6 +611,7 @@ impl AppState {
                         let mut incoming_services: Vec<Service> = incoming_services_state
                             .services
                             .iter()
+                            .filter(|service| service.email() == email)
                             .map(|service| Service {
                                 id: service.id().to_string(),
                                 source_name: service.name().to_string(),

--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -18,13 +18,18 @@
 		782D5BAC2AC33EAD00D1B27F /* Bridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 782D5BAB2AC33EAD00D1B27F /* Bridge.h */; };
 		782D5BAF2AC33F9400D1B27F /* libockam_app_lib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 782D5B792AC1E36700D1B27F /* libockam_app_lib.a */; };
 		783B62722AC432B700880261 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783B62712AC432B700880261 /* Bridge.swift */; };
+		7859A4862B1DD4960085C7F7 /* UpdateSizeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4802B1DD4960085C7F7 /* UpdateSizeAction.swift */; };
+		7859A4872B1DD4960085C7F7 /* FluidMenuBarExtra.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4812B1DD4960085C7F7 /* FluidMenuBarExtra.swift */; };
+		7859A4882B1DD4960085C7F7 /* FluidMenuBarExtraStatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4822B1DD4960085C7F7 /* FluidMenuBarExtraStatusItem.swift */; };
+		7859A4892B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4832B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift */; };
+		7859A48A2B1DD4960085C7F7 /* EventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4842B1DD4960085C7F7 /* EventMonitor.swift */; };
+		7859A48B2B1DD4960085C7F7 /* RootViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A4852B1DD4960085C7F7 /* RootViewModifier.swift */; };
 		785A07302B14A60E002FF30C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A072F2B14A60E002FF30C /* Constants.swift */; };
 		785A07322B14C810002FF30C /* SentInvitations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A07312B14C810002FF30C /* SentInvitations.swift */; };
 		785A07342B14CF29002FF30C /* LocalServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A07332B14CF29002FF30C /* LocalServiceView.swift */; };
 		785A07362B14D697002FF30C /* ServiceGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A07352B14D697002FF30C /* ServiceGroupView.swift */; };
 		785A07382B14D734002FF30C /* IncomingInvite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A07372B14D734002FF30C /* IncomingInvite.swift */; };
 		785A073C2B15EAC8002FF30C /* EnrollmentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785A073B2B15EAC8002FF30C /* EnrollmentStatus.swift */; };
-		785A07432B161617002FF30C /* FluidMenuBarExtra in Frameworks */ = {isa = PBXBuildFile; productRef = 785A07422B161617002FF30C /* FluidMenuBarExtra */; };
 		785C8DC12B0BAD5E00926DCD /* About.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785C8DC02B0BAD5E00926DCD /* About.swift */; };
 		789FA6462AE142280009FF7F /* ExportOptions.plist in Resources */ = {isa = PBXBuildFile; fileRef = 789FA6452AE142280009FF7F /* ExportOptions.plist */; };
 		78B7EF702B0F649D0062B2B3 /* DeclineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B7EF6F2B0F649D0062B2B3 /* DeclineService.swift */; };
@@ -51,6 +56,12 @@
 		782D5BAB2AC33EAD00D1B27F /* Bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bridge.h; path = Ockam/Bridge.h; sourceTree = "<group>"; };
 		782D5BAD2AC33F7B00D1B27F /* libockam_app_lib.d */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.dtrace; name = libockam_app_lib.d; path = ../../../../target/debug/libockam_app_lib.d; sourceTree = "<group>"; };
 		783B62712AC432B700880261 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
+		7859A4802B1DD4960085C7F7 /* UpdateSizeAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateSizeAction.swift; sourceTree = "<group>"; };
+		7859A4812B1DD4960085C7F7 /* FluidMenuBarExtra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluidMenuBarExtra.swift; sourceTree = "<group>"; };
+		7859A4822B1DD4960085C7F7 /* FluidMenuBarExtraStatusItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluidMenuBarExtraStatusItem.swift; sourceTree = "<group>"; };
+		7859A4832B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluidMenuBarExtraWindow.swift; sourceTree = "<group>"; };
+		7859A4842B1DD4960085C7F7 /* EventMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
+		7859A4852B1DD4960085C7F7 /* RootViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootViewModifier.swift; sourceTree = "<group>"; };
 		785A072F2B14A60E002FF30C /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		785A07312B14C810002FF30C /* SentInvitations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentInvitations.swift; sourceTree = "<group>"; };
 		785A07332B14CF29002FF30C /* LocalServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalServiceView.swift; sourceTree = "<group>"; };
@@ -77,7 +88,6 @@
 				7807276C2ACF5AB500C93A44 /* CoreFoundation.framework in Frameworks */,
 				7807276F2ACF5B3400C93A44 /* SystemConfiguration.framework in Frameworks */,
 				782D5BAF2AC33F9400D1B27F /* libockam_app_lib.a in Frameworks */,
-				785A07432B161617002FF30C /* FluidMenuBarExtra in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,6 +115,7 @@
 		782D5B472AC1D3D700D1B27F /* Ockam */ = {
 			isa = PBXGroup;
 			children = (
+				7859A47F2B1DD4960085C7F7 /* FluidMenuBarExtra */,
 				78B7EF6F2B0F649D0062B2B3 /* DeclineService.swift */,
 				78BD34A02AFCFDF100F09058 /* RemoteServiceView.swift */,
 				789FA6452AE142280009FF7F /* ExportOptions.plist */,
@@ -144,6 +155,19 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		7859A47F2B1DD4960085C7F7 /* FluidMenuBarExtra */ = {
+			isa = PBXGroup;
+			children = (
+				7859A4802B1DD4960085C7F7 /* UpdateSizeAction.swift */,
+				7859A4812B1DD4960085C7F7 /* FluidMenuBarExtra.swift */,
+				7859A4822B1DD4960085C7F7 /* FluidMenuBarExtraStatusItem.swift */,
+				7859A4832B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift */,
+				7859A4842B1DD4960085C7F7 /* EventMonitor.swift */,
+				7859A4852B1DD4960085C7F7 /* RootViewModifier.swift */,
+			);
+			path = FluidMenuBarExtra;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -173,7 +197,6 @@
 			);
 			name = Ockam;
 			packageProductDependencies = (
-				785A07422B161617002FF30C /* FluidMenuBarExtra */,
 			);
 			productName = Ockam;
 			productReference = 782D5B452AC1D3D700D1B27F /* Ockam.app */;
@@ -242,16 +265,22 @@
 				78B7EF702B0F649D0062B2B3 /* DeclineService.swift in Sources */,
 				78ED0DA12AD4354400574AE9 /* CreateService.swift in Sources */,
 				78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */,
+				7859A4892B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift in Sources */,
+				7859A48A2B1DD4960085C7F7 /* EventMonitor.swift in Sources */,
 				78F5F3042AD4127C00B8D18E /* EmailInput.swift in Sources */,
+				7859A4862B1DD4960085C7F7 /* UpdateSizeAction.swift in Sources */,
 				7827D5072AD93EE700F7A20F /* ProfilePicture.swift in Sources */,
 				782D5B492AC1D3D700D1B27F /* OckamApp.swift in Sources */,
 				785C8DC12B0BAD5E00926DCD /* About.swift in Sources */,
 				785A07382B14D734002FF30C /* IncomingInvite.swift in Sources */,
+				7859A4882B1DD4960085C7F7 /* FluidMenuBarExtraStatusItem.swift in Sources */,
+				7859A4872B1DD4960085C7F7 /* FluidMenuBarExtra.swift in Sources */,
 				785A07362B14D697002FF30C /* ServiceGroupView.swift in Sources */,
 				78ED0DA32AD4501200574AE9 /* ShareService.swift in Sources */,
 				78BD349D2AFA621500F09058 /* BrokenStateView.swift in Sources */,
 				4CB45C522AEB06C700D27F22 /* AcceptingInvitation.swift in Sources */,
 				783B62722AC432B700880261 /* Bridge.swift in Sources */,
+				7859A48B2B1DD4960085C7F7 /* RootViewModifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,14 +521,6 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		785A07422B161617002FF30C /* FluidMenuBarExtra */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 785A07412B161617002FF30C /* XCRemoteSwiftPackageReference "fluid-menu-bar-extra" */;
-			productName = FluidMenuBarExtra;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 782D5B3D2AC1D3D700D1B27F /* Project object */;
 }

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
@@ -282,22 +282,15 @@ func swift_initialize_application() -> Bool {
 
     let notificationClosure: @convention(c) (C_Notification) -> Void = { cNotification in
         let notification = convertNotification(cNotification: cNotification)
-        let center = UNUserNotificationCenter.current()
 
-        center.requestAuthorization(options: [.alert, .sound, .badge]) { (granted, error) in
-            if granted {
-                let content = UNMutableNotificationContent()
-                content.title = notification.title
-                content.body = notification.message
+        let content = UNMutableNotificationContent()
+        content.title = notification.title
+        content.body = notification.message
 
-                let request = UNNotificationRequest(
-                    identifier: UUID().uuidString, content: content, trigger: nil)
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString, content: content, trigger: nil)
 
-                UNUserNotificationCenter.current().add(request)
-            } else {
-                print("Notification permission denied.")
-            }
-        }
+        UNUserNotificationCenter.current().add(request)
     }
 
     let result = initialize_application(applicationStateClosure, notificationClosure)

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/EventMonitor.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/EventMonitor.swift
@@ -1,0 +1,63 @@
+//
+//  EventMonitor.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-17.
+//  Copyright © 2022 Lukas Romsicki.
+//
+
+import AppKit
+
+class EventMonitor {
+    fileprivate let mask: NSEvent.EventTypeMask
+    fileprivate var monitor: Any?
+
+    fileprivate init(mask: NSEvent.EventTypeMask) {
+        self.mask = mask
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() {
+        fatalError("start must be implemented by a subclass of EventMonitor")
+    }
+
+    func stop() {
+        if monitor != nil {
+            NSEvent.removeMonitor(monitor!)
+            monitor = nil
+        }
+    }
+}
+
+final class LocalEventMonitor: EventMonitor {
+    typealias Handler = (NSEvent) -> NSEvent?
+
+    private let handler: Handler
+
+    init(mask: NSEvent.EventTypeMask, handler: @escaping Handler) {
+        self.handler = handler
+        super.init(mask: mask)
+    }
+
+    override func start() {
+        monitor = NSEvent.addLocalMonitorForEvents(matching: mask, handler: handler)
+    }
+}
+
+final class GlobalEventMonitor: EventMonitor {
+    typealias Handler = (NSEvent) -> Void
+
+    private let handler: Handler
+
+    init(mask: NSEvent.EventTypeMask, handler: @escaping Handler) {
+        self.handler = handler
+        super.init(mask: mask)
+    }
+
+    override func start() {
+        monitor = NSEvent.addGlobalMonitorForEvents(matching: mask, handler: handler)
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtra.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtra.swift
@@ -1,0 +1,62 @@
+//
+//  FluidMenuBarExtra.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-17.
+//  Copyright © 2022 Lukas Romsicki.
+//  Copyright © 2023 Ockam.
+//
+
+import SwiftUI
+
+/// A class you use to create a SwiftUI menu bar extra in both SwiftUI and non-SwiftUI
+/// applications.
+///
+/// A fluid menu bar extra is configured by initializing it once during the lifecycle of your
+/// app, most commonly in your application delegate. In SwiftUI apps, use
+/// `NSApplicationDelegateAdaptor` to create an application delegate in which
+/// a ``FluidMenuBarExtra`` can be created:
+///
+/// ```swift
+/// class AppDelegate: NSObject, NSApplicationDelegate {
+///     private var menuBarExtra: FluidMenuBarExtra?
+///
+///     func applicationDidFinishLaunching(_ notification: Notification) {
+///         menuBarExtra = FluidMenuBarExtra(title: "My Menu", systemImage: "cloud.fill") {
+///             Text("My SwiftUI View")
+///         }
+///     }
+/// }
+/// ```
+///
+/// Because an application delegate is a plain object, not a `View` or `Scene`, you
+/// can't pass state properties to views in the closure of `FluidMenuBarExtra` directly.
+/// Instead, define state properties inside child views, or pass published properties from
+/// your application delegate to the child views using the `environmentObject`
+/// modifier.
+public final class FluidMenuBarExtra {
+    private let statusItem: FluidMenuBarExtraStatusItem
+
+    public init(title: String, @ViewBuilder content: @escaping () -> some View) {
+        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        statusItem = FluidMenuBarExtraStatusItem(title: title, window: window)
+    }
+
+    public init(title: String, image: String, @ViewBuilder content: @escaping () -> some View) {
+        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        statusItem = FluidMenuBarExtraStatusItem(title: title, image: image, window: window)
+    }
+
+    public init(title: String, systemImage: String, @ViewBuilder content: @escaping () -> some View) {
+        let window = FluidMenuBarExtraWindow(title: title, content: content)
+        statusItem = FluidMenuBarExtraStatusItem(title: title, systemImage: systemImage, window: window)
+    }
+
+    public func showWindow() {
+        statusItem.showWindow()
+    }
+
+    public func dismissWindow() {
+        statusItem.dismissWindow()
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtraStatusItem.swift
@@ -1,0 +1,178 @@
+//
+//  FluidMenuBarExtraStatusItem.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-17.
+//  Copyright © 2022 Lukas Romsicki.
+//  Copyright © 2023 Ockam.
+//
+
+import AppKit
+import SwiftUI
+
+/// An individual element displayed in the system menu bar that displays a window
+/// when triggered.
+final class FluidMenuBarExtraStatusItem: NSObject, NSWindowDelegate {
+    private let window: NSWindow
+    private let statusItem: NSStatusItem
+
+    private var localEventMonitor: EventMonitor?
+    private var globalEventMonitor: EventMonitor?
+
+    private init(window: NSWindow) {
+        self.window = window
+
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem.isVisible = true
+
+        super.init()
+
+        localEventMonitor = LocalEventMonitor(mask: [.leftMouseDown]) { [weak self] event in
+            if let button = self?.statusItem.button, event.window == button.window, !event.modifierFlags.contains(.command) {
+                self?.didPressStatusBarButton(button)
+
+                // Stop propagating the event so that the button remains highlighted.
+                return nil
+            }
+
+            return event
+        }
+
+        globalEventMonitor = GlobalEventMonitor(mask: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            if let window = self?.window, window.isKeyWindow {
+                // Resign key window status if a external non-activating event is triggered,
+                // such as other system status bar menus.
+                window.resignKey()
+            }
+        }
+
+        window.delegate = self
+        localEventMonitor?.start()
+    }
+
+    deinit {
+        NSStatusBar.system.removeStatusItem(statusItem)
+    }
+
+    private func didPressStatusBarButton(_ sender: NSStatusBarButton) {
+        if window.isVisible {
+            dismissWindow()
+            return
+        }
+
+        setWindowPosition()
+
+        // Tells the system to persist the menu bar in full screen mode.
+        DistributedNotificationCenter.default().post(name: .beginMenuTracking, object: nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func windowDidBecomeKey(_ notification: AppKit.Notification) {
+        globalEventMonitor?.start()
+        setButtonHighlighted(to: true)
+    }
+
+    func windowDidResignKey(_ notification: AppKit.Notification) {
+        globalEventMonitor?.stop()
+        dismissWindow()
+    }
+
+    public func showWindow() {
+        if window.isVisible {
+            return
+        }
+
+        setWindowPosition()
+        // Tells the system to persist the menu bar in full screen mode.
+        DistributedNotificationCenter.default().post(name: .beginMenuTracking, object: nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    public func dismissWindow() {
+        // Tells the system to cancel persisting the menu bar in full screen mode.
+        DistributedNotificationCenter.default().post(name: .endMenuTracking, object: nil)
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.3
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+
+            window.animator().alphaValue = 0
+        }
+
+        // Instead of using animation completion, which could be unreliable,
+        // use an async operation with the same animation duration
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.window.orderOut(nil)
+            self?.window.alphaValue = 1
+            self?.setButtonHighlighted(to: false)
+        }
+    }
+
+    private func setButtonHighlighted(to highlight: Bool) {
+        statusItem.button?.highlight(highlight)
+    }
+
+    private func setWindowPosition() {
+        guard let statusItemWindow = statusItem.button?.window else {
+            // If we don't know where the status item is, just place the window in the center.
+            window.center()
+            return
+        }
+
+        var targetRect = statusItemWindow.frame
+
+        if let screen = statusItemWindow.screen {
+            let windowWidth = window.frame.width
+
+            if statusItemWindow.frame.origin.x + windowWidth > screen.visibleFrame.width {
+                targetRect.origin.x += statusItemWindow.frame.width
+                targetRect.origin.x -= windowWidth
+
+                // Offset by window border size to align with highlighted button.
+                targetRect.origin.x += Metrics.windowBorderSize
+
+            } else {
+                // Offset by window border size to align with highlighted button.
+                targetRect.origin.x -= Metrics.windowBorderSize
+            }
+        } else {
+            // If there's no screen, assume default positioning.
+            targetRect.origin.x -= Metrics.windowBorderSize
+        }
+
+        window.setFrameTopLeftPoint(targetRect.origin)
+    }
+}
+
+extension FluidMenuBarExtraStatusItem {
+    convenience init(title: String, window: NSWindow) {
+        self.init(window: window)
+
+        statusItem.button?.title = title
+        statusItem.button?.setAccessibilityTitle(title)
+    }
+
+    convenience init(title: String, image: String, window: NSWindow) {
+        self.init(window: window)
+
+        statusItem.button?.setAccessibilityTitle(title)
+        statusItem.button?.image = NSImage(named: image)
+        statusItem.button?.image?.isTemplate = true
+    }
+
+    convenience init(title: String, systemImage: String, window: NSWindow) {
+        self.init(window: window)
+
+        statusItem.button?.setAccessibilityTitle(title)
+        statusItem.button?.image = NSImage(systemSymbolName: systemImage, accessibilityDescription: title)
+    }
+}
+
+private extension AppKit.Notification.Name {
+    static let beginMenuTracking = AppKit.Notification.Name("com.apple.HIToolbox.beginMenuTrackingNotification")
+    static let endMenuTracking = AppKit.Notification.Name("com.apple.HIToolbox.endMenuTrackingNotification")
+}
+
+private enum Metrics {
+    static let windowBorderSize: CGFloat = 2
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/FluidMenuBarExtraWindow.swift
@@ -1,0 +1,112 @@
+//
+//  FluidMenuBarExtraWindow.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-16.
+//  Copyright © 2022 Lukas Romsicki.
+//
+
+import AppKit
+import SwiftUI
+
+/// A custom window configured to behave as closely to an `NSMenu` as possible.
+///
+/// `FluidMenuBarExtraWindow` listens for changes to the size of its content and
+/// automatically adjusts its frame to match.
+final class FluidMenuBarExtraWindow<Content: View>: NSPanel {
+    private let content: () -> Content
+
+    private lazy var visualEffectView: NSVisualEffectView = {
+        let view = NSVisualEffectView()
+        view.blendingMode = .behindWindow
+        view.state = .active
+        view.material = .popover
+        view.translatesAutoresizingMaskIntoConstraints = true
+        return view
+    }()
+
+    private var rootView: some View {
+        content()
+            .modifier(RootViewModifier(windowTitle: title))
+            .onSizeUpdate { [weak self] size in
+                self?.contentSizeDidUpdate(to: size)
+            }
+    }
+
+    private lazy var hostingView: NSHostingView<some View> = {
+        let view = NSHostingView(rootView: rootView)
+        // Disable NSHostingView's default automatic sizing behavior.
+        if #available(macOS 13.0, *) {
+            view.sizingOptions = []
+        }
+        view.isVerticalContentSizeConstraintActive = false
+        view.isHorizontalContentSizeConstraintActive = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    init(title: String, content: @escaping () -> Content) {
+        self.content = content
+
+        super.init(
+            contentRect: CGRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .nonactivatingPanel, .utilityWindow, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        self.title = title
+
+        isMovable = false
+        isMovableByWindowBackground = false
+        isFloatingPanel = true
+        level = .statusBar
+        isOpaque = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+
+        animationBehavior = .none
+        if #available(macOS 13.0, *) {
+            collectionBehavior = [.auxiliary, .stationary, .moveToActiveSpace, .fullScreenAuxiliary]
+        } else {
+            collectionBehavior = [.stationary, .moveToActiveSpace, .fullScreenAuxiliary]
+        }
+        isReleasedWhenClosed = false
+        hidesOnDeactivate = false
+
+        standardWindowButton(.closeButton)?.isHidden = true
+        standardWindowButton(.miniaturizeButton)?.isHidden = true
+        standardWindowButton(.zoomButton)?.isHidden = true
+
+        contentView = visualEffectView
+        visualEffectView.addSubview(hostingView)
+        setContentSize(hostingView.intrinsicContentSize)
+
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: visualEffectView.topAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: visualEffectView.trailingAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: visualEffectView.bottomAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: visualEffectView.leadingAnchor)
+        ])
+    }
+
+    private func contentSizeDidUpdate(to size: CGSize) {
+        var nextFrame = frame
+        let previousContentSize = contentRect(forFrameRect: frame).size
+
+        let deltaX = size.width - previousContentSize.width
+        let deltaY = size.height - previousContentSize.height
+
+        nextFrame.origin.y -= deltaY
+        nextFrame.size.width += deltaX
+        nextFrame.size.height += deltaY
+
+        guard frame != nextFrame else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.setFrame(nextFrame, display: true, animate: true)
+        }
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/README.md
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/README.md
@@ -1,0 +1,1 @@
+This library was initially developed by Lukas Romsicki under MIT license, and it's available [here](https://github.com/lfroms/fluid-menu-bar-extra)

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/RootViewModifier.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/RootViewModifier.swift
@@ -1,0 +1,60 @@
+//
+//  RootViewModifier.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-16.
+//  Copyright © 2022 Lukas Romsicki.
+//
+
+import SwiftUI
+
+/// A view modifier that reads the size of its content and posts a notification when
+/// the size changes.
+///
+/// When the parent of the view affected by this modifier updates its size, `RootViewModifier`
+/// expands the view to fill the available space, aligning its content to the top. When the window
+/// the view is contained in changes scene phase, the current phase is provided through the
+/// `scenePhase` environment key.
+///
+/// When applied, the affected view ignores all safe areas so as to fill the space usually occupied
+/// by the title bar.
+struct RootViewModifier: ViewModifier {
+    @Environment(\.updateSize) private var updateSize
+
+    @State private var scenePhase: ScenePhase = .background
+
+    let windowTitle: String
+
+    func body(content: Content) -> some View {
+        content
+            .environment(\.scenePhase, scenePhase)
+            .edgesIgnoringSafeArea(.all)
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            updateSize?(size: geometry.size)
+                        }
+                        .onChange(of: geometry.size) { newValue in
+                            updateSize?(size: geometry.size)
+                        }
+                }
+            )
+            .fixedSize()
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { notification in
+                guard let window = notification.object as? NSWindow, window.title == windowTitle, scenePhase != .active else {
+                    return
+                }
+
+                scenePhase = .active
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) { notification in
+                guard let window = notification.object as? NSWindow, window.title == windowTitle, scenePhase != .background else {
+                    return
+                }
+
+                scenePhase = .background
+            }
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/UpdateSizeAction.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/FluidMenuBarExtra/UpdateSizeAction.swift
@@ -1,0 +1,44 @@
+//
+//  UpdateSizeAction.swift
+//  FluidMenuBarExtra
+//
+//  Created by Lukas Romsicki on 2022-12-17.
+//  Copyright © 2022 Lukas Romsicki.
+//
+
+import SwiftUI
+
+/// Structure representing an action that is called by a child view to notify a parent view
+/// that one of its children has resized.
+struct UpdateSizeAction {
+    typealias Action = (_ size: CGSize) -> Void
+
+    let action: Action
+
+    func callAsFunction(size: CGSize) {
+        action(size)
+    }
+}
+
+private struct UpdateSizeKey: EnvironmentKey {
+    static var defaultValue: UpdateSizeAction?
+}
+
+extension EnvironmentValues {
+    var updateSize: UpdateSizeAction? {
+        get { self[UpdateSizeKey.self] }
+        set { self[UpdateSizeKey.self] = newValue }
+    }
+}
+
+extension View {
+    /// Adds an action to perform when a child view reports that it has resized.
+    /// - Parameter action: The action to perform.
+    func onSizeUpdate(_ action: @escaping (_ size: CGSize) -> Void) -> some View {
+        let action = UpdateSizeAction { size in
+            action(size)
+        }
+
+        return environment(\.updateSize, action)
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct MainView: View {
     @Environment(\.openWindow) private var openWindow
-    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appDelegate: AppDelegate
 
     @Binding var state: ApplicationState
     @State private var selectedGroup: String = ""
@@ -45,7 +45,7 @@ struct MainView: View {
                         text: "Enroll...", icon: "arrow.right.square",
                         action: {
                             enroll_user()
-                            dismiss()
+                            appDelegate.dismissPopover()
                         })
                     .padding(.top, VerticalSpacingUnit)
                     .padding(.horizontal, HorizontalSpacingUnit)
@@ -69,7 +69,6 @@ struct MainView: View {
                             text: "Create a service...",
                             action: {
                                 openWindow(id: "create-service")
-                                dismiss()
                                 bringInFront()
                             }
                         )
@@ -118,7 +117,7 @@ struct MainView: View {
                                 if let url = URL(string: "https://github.com/build-trust/ockam") {
                                     NSWorkspace.shared.open(url)
                                 }
-                                dismiss()
+                                appDelegate.dismissPopover()
                             })
                         ClickableMenuEntry(
                             text: "Learn more from our documentation...", icon: "book",
@@ -126,7 +125,7 @@ struct MainView: View {
                                 if let url = URL(string: "https://docs.ockam.io") {
                                     NSWorkspace.shared.open(url)
                                 }
-                                dismiss()
+                                appDelegate.dismissPopover()
                             })
                     }
                 }
@@ -140,6 +139,7 @@ struct MainView: View {
                                 text: "About", icon: "questionmark.circle",
                                 action: {
                                     openWindow(id: "about")
+                                    bringInFront()
                                 })
                             ClickableMenuEntry(
                                 text: "Reset", icon: "arrow.counterclockwise",
@@ -155,7 +155,7 @@ struct MainView: View {
                                 //even if the graceful shutdown takes a few seconds
                                 //we can give a "acknowledged" feedback to the user
                                 //by closing the window first
-                                dismiss()
+                                appDelegate.dismissPopover()
                                 shutdown_application()
                             }
                         ).keyboardShortcut("Q", modifiers: .command)


### PR DESCRIPTION
After introducing the new `FluidMenuBarExtra` library, the application had several regressions, to fix them I included the small library and fixed it in-place.

- menu bar icon didn't change with the theme
- clicking notification didn't do anything before, but after the switch it opened the "accept invitation" window
- when status is not compatible the application would crash right away, without showing the "broken state" window
- the popover didn't hide after browser links were clicked  [ID_44]
- application quits right away in Ventura
- incoming services duplicated in every user [ID_51]

So now:
- The popover is opened at bootstrap, this is mainly for new users to make more evident where ockam window is [ID_60]
- Notifications click opens the popover like clicking the menu bar extra
