### PR TITLE
fix(rust): store initial created project on desktop app

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -187,12 +187,13 @@ impl AppState {
                 let project = node_manager
                     .create_project(ctx, &space.name, PROJECT_NAME, vec![])
                     .await?;
-                node_manager
+                let project = node_manager
                     .wait_until_project_is_ready(ctx, project)
-                    .await?
+                    .await?;
+                self.state().await.store_project(project.clone()).await?;
+                project
             }
         };
-
         self.state()
             .await
             .set_node_project(&node_manager.node_name(), &Some(project.name()))


### PR DESCRIPTION
if there is no project, one is created as part of the desktop app initialization. This project need to be stored on the state
