### PR TITLE
feat(rust): keep the same port for incoming services

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -44,14 +44,15 @@ impl AppState {
                     Ok(port) => {
                         if let Some(service) = guard.find_mut_by_id(service.id()) {
                             if let Some(port) = port {
-                                service.set_port(port)
+                                service.set_port(port);
                             }
+                            service.set_connected(true);
                         }
                     }
                     Err(err) => {
                         warn!(%err, "Failed to refresh TCP inlet for accepted invitation");
                         if let Some(service) = guard.find_mut_by_id(service.id()) {
-                            service.remove_port()
+                            service.set_connected(false);
                         }
                     }
                 }

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
@@ -172,6 +172,8 @@ pub struct IncomingService {
     // this field contains the current port number
     // it also reflects if the inlet is connected with the destination node
     port: Option<Port>,
+    // true when connected to the destination node
+    connected: bool,
     // whether the service should be enabled or not, this is the driver for the inlet
     // and may not reflect the current status
     enabled: bool,
@@ -211,6 +213,7 @@ impl IncomingService {
             shared_node_identifier,
             original_name,
             enrollment_ticket,
+            connected: false,
             removed: false,
         }
     }
@@ -228,6 +231,11 @@ impl IncomingService {
     /// The port number of the inlet, if service is connected to the destination node
     pub fn port(&self) -> Option<Port> {
         self.port
+    }
+
+    /// Returns true if the inlet is connected to the destination node
+    pub fn is_connected(&self) -> bool {
+        self.connected
     }
 
     /// The address of the inlet, if service is connected to the destination node
@@ -249,8 +257,8 @@ impl IncomingService {
         self.port = Some(port);
     }
 
-    pub fn remove_port(&mut self) {
-        self.port = None;
+    pub fn set_connected(&mut self, connected: bool) {
+        self.connected = connected;
     }
 
     pub fn enable(&mut self) {
@@ -258,7 +266,6 @@ impl IncomingService {
     }
     pub fn disable(&mut self) {
         self.enabled = false;
-        self.port = None;
     }
 
     /// True when the service is marked as removed

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -618,7 +618,7 @@ impl AppState {
                                 address: service.address().map(|addr| addr.ip().to_string()),
                                 port: service.port(),
                                 scheme: None,
-                                available: service.port().is_some(),
+                                available: service.is_connected(),
                                 enabled: service.enabled(),
                             })
                             .collect();


### PR DESCRIPTION
[ID_48] Don’t change the port number for a service shared with me (remember the first assigned port number)