### PR TITLE
refactor(rust): make sure that the project is always updated with its latest state

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
@@ -101,15 +101,35 @@ impl Projects for InMemoryNode {
             .collect::<Vec<_>>())
     }
 
+    /// Wait until the operation associated with the project creation is complete
+    /// At this stage the project node must be up and running
+    async fn wait_until_project_creation_operation_is_complete(
+        &self,
+        ctx: &Context,
+        project: Project,
+    ) -> miette::Result<Project> {
+        let project = self
+            .create_controller()
+            .await?
+            .wait_until_project_creation_operation_is_complete(ctx, project)
+            .await?;
+        self.cli_state.store_project(project.clone()).await?;
+        Ok(project)
+    }
+
+    /// Wait until the project is ready to be used
+    /// At this stage the project authority node must be up and running
     async fn wait_until_project_is_ready(
         &self,
         ctx: &Context,
         project: Project,
     ) -> miette::Result<Project> {
-        Ok(self
+        let project = self
             .create_controller()
             .await?
             .wait_until_project_is_ready(ctx, project)
-            .await?)
+            .await?;
+        self.cli_state.store_project(project.clone()).await?;
+        Ok(project)
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -188,10 +188,11 @@ impl AppState {
                     .create_project(ctx, &space.name, PROJECT_NAME, vec![])
                     .await?;
                 let project = node_manager
-                    .wait_until_project_is_ready(ctx, project)
+                    .wait_until_project_creation_operation_is_complete(ctx, project)
                     .await?;
-                self.state().await.store_project(project.clone()).await?;
-                project
+                node_manager
+                    .wait_until_project_is_ready(ctx, project)
+                    .await?
             }
         };
         self.state()

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -20,7 +20,7 @@ use ockam_api::enroll::oidc_service::OidcService;
 use ockam_api::nodes::InMemoryNode;
 
 use crate::enroll::OidcServiceExt;
-use crate::operation::util::check_for_completion;
+use crate::operation::util::check_for_project_completion;
 use crate::output::OutputFormat;
 use crate::project::util::check_project_readiness;
 use crate::terminal::OckamColor;
@@ -329,11 +329,7 @@ async fn get_user_project(
                     .color(OckamColor::PrimaryResource.color())
             ))?;
 
-            let operation_id = project.operation_id.clone().unwrap();
-            check_for_completion(opts, ctx, &node.create_controller().await?, &operation_id)
-                .await?;
-
-            project.to_owned()
+            check_for_project_completion(opts, ctx, node, project).await?
         }
         Some(project) => {
             opts.terminal.write_line(&fmt_log!(
@@ -346,7 +342,7 @@ async fn get_user_project(
         }
     };
 
-    let project = check_project_readiness(opts, ctx, node, project.clone()).await?;
+    let project = check_project_readiness(opts, ctx, node, project).await?;
     // store the updated project
     opts.state.store_project(project.clone()).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -1,25 +1,20 @@
 use colorful::Colorful;
 use miette::miette;
-use tokio_retry::strategy::FixedInterval;
-use tokio_retry::Retry;
-
 use ockam_api::cloud::operation::Operations;
-use ockam_api::cloud::{Controller, ORCHESTRATOR_AWAIT_TIMEOUT};
+use ockam_api::cloud::project::{Project, Projects};
+use ockam_api::nodes::InMemoryNode;
 use ockam_node::Context;
 
 use crate::fmt_para;
 use crate::terminal::OckamColor;
 use crate::CommandGlobalOpts;
 
-pub async fn check_for_completion(
+pub async fn check_for_project_completion(
     opts: &CommandGlobalOpts,
     ctx: &Context,
-    controller: &Controller,
-    operation_id: &str,
-) -> miette::Result<()> {
-    let retry_strategy = FixedInterval::from_millis(5000)
-        .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
-
+    node: &InMemoryNode,
+    project: Project,
+) -> miette::Result<Project> {
     let spinner_option = opts.terminal.progress_spinner();
     if let Some(spinner) = spinner_option.as_ref() {
         let message = format!(
@@ -34,25 +29,51 @@ pub async fn check_for_completion(
         );
         spinner.set_message(message);
     }
-    let operation = Retry::spawn(retry_strategy.clone(), || async {
-        // Handle the operation show request result
-        // so we can provide better errors in the case orchestrator does not respond timely
-        let result = controller.get_operation(ctx, operation_id).await?;
+    let project = node
+        .wait_until_project_creation_operation_is_complete(ctx, project)
+        .await?;
 
-        match result {
-            Some(o) if o.is_completed() => Ok(o),
-            _ => Err(miette!("Operation timed out. Please try again.")),
-        }
-    })
-    .await?;
+    if let Some(spinner) = spinner_option.as_ref() {
+        spinner.finish_and_clear();
+    }
+    Ok(project)
+}
+
+pub async fn check_for_operation_completion(
+    opts: &CommandGlobalOpts,
+    ctx: &Context,
+    node: &InMemoryNode,
+    operation_id: &str,
+    operation_name: &str,
+) -> miette::Result<()> {
+    let spinner_option = opts.terminal.progress_spinner();
+    if let Some(spinner) = spinner_option.as_ref() {
+        let message = format!(
+            "Waiting for {operation_name} to finish ...\n{}",
+            fmt_para!(
+                "{}",
+                "Please do not press Ctrl+C or exit the terminal process until this is complete."
+                    .to_string()
+                    .color(OckamColor::FmtWARNBackground.color())
+            ),
+        );
+        spinner.set_message(message);
+    }
+    let result = node
+        .wait_until_operation_is_complete(ctx, operation_id)
+        .await;
 
     if let Some(spinner) = spinner_option.as_ref() {
         spinner.finish_and_clear();
     }
 
-    if operation.is_successful() {
-        Ok(())
-    } else {
-        Err(miette!("Operation failed. Please try again."))
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => Err(miette!(
+            "The operation {} ({}) was not successful: {}. Please try again.",
+            operation_name,
+            operation_id,
+            e
+        )),
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -6,7 +6,7 @@ use ockam::Context;
 use ockam_api::cloud::addon::Addons;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::operation::util::check_for_completion;
+use crate::operation::util::check_for_operation_completion;
 use crate::util::node_rpc;
 use crate::{fmt_ok, CommandGlobalOpts};
 
@@ -54,7 +54,8 @@ async fn run_impl(
         .disable_addon(&ctx, project_id, &addon_id)
         .await?;
     let operation_id = response.operation_id;
-    check_for_completion(&opts, &ctx, &controller, &operation_id).await?;
+    check_for_operation_completion(&opts, &ctx, &node, &operation_id, "the addon disabling")
+        .await?;
 
     opts.terminal
         .write_line(&fmt_ok!("Addon disabled successfully"))?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -3,10 +3,11 @@ use core::fmt::Write;
 use clap::{Args, Subcommand};
 
 use ockam_api::cloud::addon::Addon;
+use ockam_api::cloud::project::Projects;
 use ockam_api::nodes::InMemoryNode;
 use ockam_node::Context;
 
-use crate::operation::util::check_for_completion;
+use crate::operation::util::check_for_operation_completion;
 use crate::output::Output;
 use crate::project::addon::configure_confluent::AddonConfigureConfluentSubcommand;
 use crate::project::addon::configure_influxdb::AddonConfigureInfluxdbSubcommand;
@@ -87,9 +88,9 @@ async fn check_configuration_completion(
     project_id: &str,
     operation_id: &str,
 ) -> Result<()> {
-    let controller = node.create_controller().await?;
-    check_for_completion(opts, ctx, &controller, operation_id).await?;
-    let project = controller.get_project(ctx, project_id).await?;
+    check_for_operation_completion(opts, ctx, node, operation_id, "the addon configuration")
+        .await?;
+    let project = node.get_project(ctx, project_id).await?;
     let _ = check_project_readiness(opts, ctx, node, project).await?;
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -5,7 +5,7 @@ use ockam_api::cli_state::random_name;
 use ockam_api::cloud::project::Projects;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::operation::util::check_for_completion;
+use crate::operation::util::check_for_project_completion;
 use crate::project::util::check_project_readiness;
 use crate::util::api::CloudOpts;
 use crate::util::node_rpc;
@@ -54,12 +54,8 @@ async fn run_impl(
     let project = node
         .create_project(ctx, &cmd.space_name, &cmd.project_name, vec![])
         .await?;
-    let operation_id = project.operation_id.clone().unwrap();
-    let controller = node.create_controller().await?;
-    check_for_completion(&opts, ctx, &controller, &operation_id).await?;
+    let project = check_for_project_completion(&opts, ctx, &node, project).await?;
     let project = check_project_readiness(&opts, ctx, &node, project).await?;
-    // update the project state when it's ready
-    opts.state.store_project(project.clone()).await?;
     opts.println(&project)?;
     Ok(())
 }


### PR DESCRIPTION
This PR refactors the functions for waiting on project creation + project readiness to make sure that the latest project state is always persisted locally.
