### PR TITLE
Slim down the node manager worker

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/expr.rs
@@ -22,6 +22,14 @@ pub enum Expr {
     #[n(7)] List  (#[n(0)] Vec<Expr>)
 }
 
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other).is_ok()
+    }
+}
+
+impl Eq for Expr {}
+
 #[derive(Debug, Clone, Encode, Decode)]
 #[rustfmt::skip]
 pub enum Val {

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+extern crate core;
 
 mod env;
 mod error;

--- a/implementations/rust/ockam/ockam_abac/src/storage/policy_repository.rs
+++ b/implementations/rust/ockam/ockam_abac/src/storage/policy_repository.rs
@@ -1,4 +1,6 @@
 use crate::{Action, Expr, Resource};
+use core::fmt::{Display, Formatter};
+use minicbor::{Decode, Encode};
 use ockam_core::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::vec::Vec;
@@ -10,14 +12,37 @@ use ockam_core::Result;
 #[async_trait]
 pub trait PoliciesRepository: Send + Sync + 'static {
     /// Return the policy associated to a given resource and action
-    async fn get_policy(&self, r: &Resource, a: &Action) -> Result<Option<Expr>>;
+    async fn get_policy(&self, r: &Resource, a: &Action) -> Result<Option<Policy>>;
 
     /// Set a policy for a given resource and action
-    async fn set_policy(&self, r: &Resource, a: &Action, c: &Expr) -> Result<()>;
+    async fn set_policy(&self, r: &Resource, a: &Action, c: &Policy) -> Result<()>;
 
     /// Delete the policy associated to a given resource and action
     async fn delete_policy(&self, r: &Resource, a: &Action) -> Result<()>;
 
     /// Return the list of all the policies associated to a given resource
-    async fn get_policies_by_resource(&self, r: &Resource) -> Result<Vec<(Action, Expr)>>;
+    async fn get_policies_by_resource(&self, r: &Resource) -> Result<Vec<(Action, Policy)>>;
+}
+
+#[derive(Debug, Decode, Encode, PartialEq, Eq)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct Policy {
+    #[n(1)] expression: Expr,
+}
+
+impl Policy {
+    pub fn new(e: Expr) -> Self {
+        Policy { expression: e }
+    }
+
+    pub fn expression(&self) -> &Expr {
+        &self.expression
+    }
+}
+
+impl Display for Policy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        self.expression.fmt(f)
+    }
 }

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -10,7 +10,7 @@ use ockam::identity::{
     TrustEveryonePolicy,
 };
 use ockam_abac::expr::{and, eq, ident, str};
-use ockam_abac::{AbacAccessControl, Env};
+use ockam_abac::{AbacAccessControl, Env, Policy};
 use ockam_core::compat::sync::Arc;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::FlowControlId;
@@ -363,7 +363,7 @@ impl Authority {
         );
         let abac = Arc::new(AbacAccessControl::new(
             self.identity_attributes_repository(),
-            rule,
+            Policy::new(rule),
             env,
         ));
         abac

--- a/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
@@ -1,53 +1,65 @@
 use crate::cli_state::CliState;
 use crate::cli_state::Result;
-use ockam_abac::{Action, Env, Expr, PolicyAccessControl, Resource};
+use ockam_abac::{Action, Env, Policy, PolicyAccessControl, Resource};
 
 impl CliState {
-    pub async fn get_policy(&self, r: &Resource, a: &Action) -> Result<Option<Expr>> {
-        Ok(self.policies_repository().await?.get_policy(r, a).await?)
-    }
-
-    pub async fn set_policy(&self, r: &Resource, a: &Action, c: &Expr) -> Result<()> {
+    pub async fn get_policy(&self, resource: &Resource, action: &Action) -> Result<Option<Policy>> {
         Ok(self
             .policies_repository()
             .await?
-            .set_policy(r, a, c)
+            .get_policy(resource, action)
             .await?)
     }
 
-    pub async fn delete_policy(&self, r: &Resource, a: &Action) -> Result<()> {
+    pub async fn set_policy(
+        &self,
+        resource: &Resource,
+        action: &Action,
+        policy: &Policy,
+    ) -> Result<()> {
         Ok(self
             .policies_repository()
             .await?
-            .delete_policy(r, a)
+            .set_policy(resource, action, policy)
             .await?)
     }
 
-    pub async fn get_policies_by_resource(&self, r: &Resource) -> Result<Vec<(Action, Expr)>> {
+    pub async fn delete_policy(&self, resource: &Resource, action: &Action) -> Result<()> {
         Ok(self
             .policies_repository()
             .await?
-            .get_policies_by_resource(r)
+            .delete_policy(resource, action)
+            .await?)
+    }
+
+    pub async fn get_policies_by_resource(
+        &self,
+        resource: &Resource,
+    ) -> Result<Vec<(Action, Policy)>> {
+        Ok(self
+            .policies_repository()
+            .await?
+            .get_policies_by_resource(resource)
             .await?)
     }
 
     pub async fn make_policy_access_control(
         &self,
-        r: &Resource,
-        a: &Action,
+        resource: &Resource,
+        action: &Action,
         env: Env,
     ) -> Result<PolicyAccessControl> {
         let policies = self.policies_repository().await?.clone();
         debug!(
             "set a policy access control for resource '{}' and action '{}'",
-            &r, &a
+            &resource, &action
         );
 
         Ok(PolicyAccessControl::new(
             policies,
             self.identity_attributes_repository().await?,
-            r.clone(),
-            a.clone(),
+            resource.clone(),
+            action.clone(),
             env,
         ))
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/credentials.rs
@@ -1,7 +1,6 @@
 //! Credential request/response types
 
 use minicbor::{Decode, Encode};
-use ockam_core::compat::borrow::Cow;
 use ockam_multiaddr::MultiAddr;
 
 #[derive(Clone, Debug, Decode, Encode)]
@@ -28,15 +27,15 @@ impl GetCredentialRequest {
 #[derive(Clone, Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct PresentCredentialRequest<'a> {
-    #[b(1)] pub route: Cow<'a, str>,
+pub struct PresentCredentialRequest {
+    #[b(1)] pub route: String,
     #[n(2)] pub oneway: bool,
 }
 
-impl<'a> PresentCredentialRequest<'a> {
+impl PresentCredentialRequest {
     pub fn new(route: &MultiAddr, oneway: bool) -> Self {
         Self {
-            route: route.to_string().into(),
+            route: route.to_string(),
             oneway,
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/policy.rs
@@ -4,23 +4,6 @@ use ockam_abac::{Action, Expr};
 #[derive(Debug, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct Policy {
-    #[n(1)] expression: Expr,
-}
-
-impl Policy {
-    pub fn new(e: Expr) -> Self {
-        Policy { expression: e }
-    }
-
-    pub fn expression(&self) -> &Expr {
-        &self.expression
-    }
-}
-
-#[derive(Debug, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
 pub struct PolicyList {
     #[n(1)] expressions: Vec<Expression>,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -118,7 +118,7 @@ pub(crate) struct VerifierServiceInfo {}
 pub(crate) struct CredentialsServiceInfo {}
 
 #[derive(Eq, PartialEq, Clone)]
-pub(crate) enum KafkaServiceKind {
+pub enum KafkaServiceKind {
     Consumer,
     Producer,
     Outlet,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -685,13 +685,15 @@ impl NodeManagerWorker {
             }
 
             // ==*== Inlets & Outlets ==*==
-            (Get, ["node", "inlet"]) => self.get_inlets(req).await.to_vec()?,
+            (Get, ["node", "inlet"]) => encode_response(self.get_inlets(req).await)?,
             (Get, ["node", "inlet", alias]) => encode_response(self.show_inlet(req, alias).await)?,
             (Get, ["node", "outlet"]) => self.get_outlets(req).await.to_vec()?,
             (Get, ["node", "outlet", alias]) => {
                 encode_response(self.show_outlet(req, alias).await)?
             }
-            (Post, ["node", "inlet"]) => encode_response(self.create_inlet(req, dec, ctx).await)?,
+            (Post, ["node", "inlet"]) => {
+                encode_response(self.create_inlet(ctx, req, dec.decode()?).await)?
+            }
             (Post, ["node", "outlet"]) => {
                 encode_response(self.create_outlet(ctx, req, dec.decode()?).await)?
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -634,7 +634,7 @@ impl NodeManagerWorker {
                 encode_response(self.start_echoer_service(ctx, req, dec).await)?
             }
             (Post, ["node", "services", DefaultAddress::HOP_SERVICE]) => {
-                encode_response(self.start_hop_service(ctx, req, dec).await)?
+                encode_response(self.start_hop_service(ctx, req, dec.decode()?).await)?
             }
             (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => encode_response(
                 self.start_credentials_service(ctx, req, dec.decode()?)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -590,12 +590,11 @@ impl NodeManagerWorker {
             }
 
             // ==*== Credential ==*==
-            (Post, ["node", "credentials", "actions", "get"]) => self
-                .get_credential(req, dec, ctx)
-                .await?
-                .either(Response::to_vec, Response::to_vec)?,
+            (Post, ["node", "credentials", "actions", "get"]) => {
+                encode_response(self.get_credential(ctx, req, dec.decode()?).await)?
+            }
             (Post, ["node", "credentials", "actions", "present"]) => {
-                encode_response(self.present_credential(req, dec, ctx).await)?
+                encode_response(self.present_credential(ctx, req, dec.decode()?).await)?
             }
 
             // ==*== Secure channels ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -439,7 +439,7 @@ impl NodeManager {
 
         // If we've been configured with a trust context, we can start Credential Exchange service
         if let Ok(tc) = self.trust_context() {
-            self.start_credentials_service_impl(
+            self.start_credentials_service(
                 ctx,
                 tc.clone(),
                 DefaultAddress::CREDENTIALS_SERVICE.into(),
@@ -636,9 +636,10 @@ impl NodeManagerWorker {
             (Post, ["node", "services", DefaultAddress::HOP_SERVICE]) => {
                 encode_response(self.start_hop_service(ctx, req, dec).await)?
             }
-            (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => {
-                encode_response(self.start_credentials_service(ctx, req, dec).await)?
-            }
+            (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => encode_response(
+                self.start_credentials_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_response(
                 self.start_kafka_outlet_service(ctx, req, dec.decode()?)
                     .await,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -724,7 +724,9 @@ impl NodeManagerWorker {
             }
 
             // ==*== Messages ==*==
-            (Post, ["v0", "message"]) => self.send_message(ctx, req, dec).await?,
+            (Post, ["v0", "message"]) => {
+                encode_response(self.send_message(ctx, req, dec.decode()?).await)?
+            }
 
             // ==*== Catch-all for Unimplemented APIs ==*==
             _ => {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -35,7 +35,6 @@ use crate::nodes::connection::{
     Connection, ConnectionBuilder, PlainTcpInstantiator, ProjectInstantiator,
     SecureChannelInstantiator,
 };
-use crate::nodes::models::base::NodeStatus;
 use crate::nodes::models::portal::{OutletList, OutletStatus};
 use crate::nodes::models::transport::{TransportMode, TransportType};
 use crate::nodes::registry::KafkaServiceKind;
@@ -556,14 +555,7 @@ impl NodeManagerWorker {
         let r = match (method, path_segments.as_slice()) {
             // ==*== Basic node information ==*==
             // TODO: create, delete, destroy remote nodes
-            (Get, ["node"]) => Response::ok(req)
-                .body(NodeStatus::new(
-                    self.node_manager.node_name.clone(),
-                    "Running",
-                    ctx.list_workers().await?.len() as u32,
-                    std::process::id() as i32,
-                ))
-                .to_vec()?,
+            (Get, ["node"]) => encode_response(self.get_node_status(ctx, req).await)?,
 
             // ==*== Tcp Connection ==*==
             (Get, ["node", "tcp", "connection"]) => self.get_tcp_connections(req).await.to_vec()?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -642,28 +642,28 @@ impl NodeManagerWorker {
                 self.start_kafka_outlet_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_response(
-                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Outlet)
+                self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Outlet)
                     .await,
             )?,
             (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
                 self.start_kafka_consumer_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => encode_response(
-                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Consumer)
+                self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Consumer)
                     .await,
             )?,
             (Post, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => {
                 self.start_kafka_producer_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => encode_response(
-                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Producer)
+                self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Producer)
                     .await,
             )?,
             (Post, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => {
                 self.start_kafka_direct_service(ctx, req, dec).await?
             }
             (Delete, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_response(
-                self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Direct)
+                self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Direct)
                     .await,
             )?,
             (Get, ["node", "services"]) => encode_response(self.list_services(req).await)?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -38,7 +38,6 @@ use crate::nodes::connection::{
 use crate::nodes::models::base::NodeStatus;
 use crate::nodes::models::portal::{OutletList, OutletStatus};
 use crate::nodes::models::transport::{TransportMode, TransportType};
-use crate::nodes::models::workers::{WorkerList, WorkerStatus};
 use crate::nodes::registry::KafkaServiceKind;
 use crate::nodes::service::default_address::DefaultAddress;
 use crate::nodes::{InMemoryNode, NODEMANAGER_ADDR};
@@ -61,6 +60,7 @@ pub mod relay;
 pub mod resources;
 mod secure_channel;
 mod transport;
+pub mod workers;
 
 const TARGET: &str = "ockam_api::nodemanager::service";
 
@@ -705,16 +705,7 @@ impl NodeManagerWorker {
             }
 
             // ==*== Workers ==*==
-            (Get, ["node", "workers"]) => {
-                let workers = ctx.list_workers().await?;
-
-                let mut list = Vec::new();
-                workers
-                    .iter()
-                    .for_each(|addr| list.push(WorkerStatus::new(addr.address())));
-
-                Response::ok(req).body(WorkerList::new(list)).to_vec()?
-            }
+            (Get, ["node", "workers"]) => encode_response(self.list_workers(ctx, req).await)?,
             (Post, ["policy", resource, action]) => encode_response(
                 self.node_manager
                     .add_policy(resource, action, req, dec)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -416,7 +416,7 @@ impl NodeManager {
         // Start services
         ctx.flow_controls()
             .add_consumer(DefaultAddress::UPPERCASE_SERVICE, api_flow_control_id);
-        self.start_uppercase_service_impl(ctx, DefaultAddress::UPPERCASE_SERVICE.into())
+        self.start_uppercase_service(ctx, DefaultAddress::UPPERCASE_SERVICE.into())
             .await?;
 
         RelayService::create(
@@ -467,7 +467,7 @@ impl NodeManager {
         // started unconditionally on every node. It's used for liveliness checks.
         ctx.flow_controls()
             .add_consumer(DefaultAddress::ECHO_SERVICE, &api_flow_control_id);
-        self.start_echoer_service_impl(ctx, DefaultAddress::ECHO_SERVICE.into())
+        self.start_echoer_service(ctx, DefaultAddress::ECHO_SERVICE.into())
             .await?;
 
         Ok(())
@@ -624,14 +624,15 @@ impl NodeManagerWorker {
             }
 
             // ==*== Services ==*==
-            (Post, ["node", "services", DefaultAddress::AUTHENTICATED_SERVICE]) => {
-                encode_response(self.start_authenticated_service(ctx, req, dec).await)?
-            }
+            (Post, ["node", "services", DefaultAddress::AUTHENTICATED_SERVICE]) => encode_response(
+                self.start_authenticated_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Post, ["node", "services", DefaultAddress::UPPERCASE_SERVICE]) => {
-                encode_response(self.start_uppercase_service(ctx, req, dec).await)?
+                encode_response(self.start_uppercase_service(ctx, req, dec.decode()?).await)?
             }
             (Post, ["node", "services", DefaultAddress::ECHO_SERVICE]) => {
-                encode_response(self.start_echoer_service(ctx, req, dec).await)?
+                encode_response(self.start_echoer_service(ctx, req, dec.decode()?).await)?
             }
             (Post, ["node", "services", DefaultAddress::HOP_SERVICE]) => {
                 encode_response(self.start_hop_service(ctx, req, dec.decode()?).await)?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -51,6 +51,7 @@ pub(crate) mod credentials;
 pub mod default_address;
 mod flow_controls;
 pub(crate) mod in_memory_node;
+pub mod kafka_services;
 pub mod message;
 mod node_services;
 mod policy;
@@ -638,30 +639,34 @@ impl NodeManagerWorker {
             (Post, ["node", "services", DefaultAddress::CREDENTIALS_SERVICE]) => {
                 encode_response(self.start_credentials_service(ctx, req, dec).await)?
             }
-            (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => {
-                self.start_kafka_outlet_service(ctx, req, dec).await?
-            }
+            (Post, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_response(
+                self.start_kafka_outlet_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Delete, ["node", "services", DefaultAddress::KAFKA_OUTLET]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Outlet)
                     .await,
             )?,
-            (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => {
-                self.start_kafka_consumer_service(ctx, req, dec).await?
-            }
+            (Post, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => encode_response(
+                self.start_kafka_consumer_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Delete, ["node", "services", DefaultAddress::KAFKA_CONSUMER]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Consumer)
                     .await,
             )?,
-            (Post, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => {
-                self.start_kafka_producer_service(ctx, req, dec).await?
-            }
+            (Post, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => encode_response(
+                self.start_kafka_producer_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Delete, ["node", "services", DefaultAddress::KAFKA_PRODUCER]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Producer)
                     .await,
             )?,
-            (Post, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => {
-                self.start_kafka_direct_service(ctx, req, dec).await?
-            }
+            (Post, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_response(
+                self.start_kafka_direct_service(ctx, req, dec.decode()?)
+                    .await,
+            )?,
             (Delete, ["node", "services", DefaultAddress::KAFKA_DIRECT]) => encode_response(
                 self.delete_kafka_service(ctx, req, dec.decode()?, KafkaServiceKind::Direct)
                     .await,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -666,9 +666,9 @@ impl NodeManagerWorker {
                 self.delete_kafka_service(ctx, req, dec, KafkaServiceKind::Direct)
                     .await,
             )?,
-            (Get, ["node", "services"]) => self.list_services(req).await?,
+            (Get, ["node", "services"]) => encode_response(self.list_services(req).await)?,
             (Get, ["node", "services", service_type]) => {
-                self.list_services_of_type(req, service_type).await?
+                encode_response(self.list_services_of_type(req, service_type).await)?
             }
 
             // ==*== Relay commands ==*==

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/flow_controls.rs
@@ -1,48 +1,72 @@
-use minicbor::Decoder;
-
 use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::flow_control::FlowControlId;
 use ockam_core::Result;
+use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
 use crate::local_multiaddr_to_route;
 use crate::nodes::models::flow_controls::AddConsumer;
+use crate::nodes::NodeManager;
 
 use super::NodeManagerWorker;
 
 impl NodeManagerWorker {
-    pub(super) fn add_consumer(
+    pub(super) async fn add_consumer(
         &self,
         ctx: &Context,
         req: &RequestHeader,
-        dec: &mut Decoder<'_>,
+        consumer: AddConsumer,
     ) -> Result<Response, Response<Error>> {
-        let request: AddConsumer = dec.decode()?;
+        match self
+            .node_manager
+            .add_consumer(ctx, consumer.address(), consumer.flow_control_id())
+            .await
+        {
+            Ok(None) => Ok(Response::ok(req)),
+            Ok(Some(failure)) => Err(Response::bad_request(req, &failure.to_string())),
+            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+        }
+    }
+}
 
-        let mut route = local_multiaddr_to_route(request.address())?;
+impl NodeManager {
+    /// Add a consumer address for a given flow control id
+    /// The given multiaddress must correspond to a route with only one Address
+    /// otherwise a  AddConsumerError is returned
+    pub async fn add_consumer(
+        &self,
+        ctx: &Context,
+        consumer: &MultiAddr,
+        flow_control_id: &FlowControlId,
+    ) -> Result<Option<AddConsumerError>> {
+        let mut route = local_multiaddr_to_route(consumer)?;
 
-        let addr = match route.step() {
-            Ok(a) => a,
-            Err(e) => {
-                return Err(Response::bad_request(
-                    req,
-                    &format!(
-                        "Unable to retrieve address from {}: {}",
-                        request.address(),
-                        e
-                    ),
-                ));
-            }
+        let address = match route.step().ok() {
+            Some(a) => a,
+            None => return Ok(Some(AddConsumerError::EmptyAddress(consumer.clone()))),
         };
         if !route.is_empty() {
-            return Err(Response::bad_request(
-                req,
-                &format!("Invalid address: {}.", request.address(),),
-            ));
+            return Ok(Some(AddConsumerError::InvalidAddress(consumer.clone())));
+        };
+
+        ctx.flow_controls().add_consumer(address, flow_control_id);
+
+        Ok(None)
+    }
+}
+
+pub enum AddConsumerError {
+    InvalidAddress(MultiAddr),
+    EmptyAddress(MultiAddr),
+}
+
+impl ToString for AddConsumerError {
+    fn to_string(&self) -> String {
+        match self {
+            AddConsumerError::EmptyAddress(address) => {
+                format!("Unable to extract an address from the route: {address:?}.")
+            }
+            AddConsumerError::InvalidAddress(address) => format!("Invalid address: {address:?}."),
         }
-
-        ctx.flow_controls()
-            .add_consumer(addr, request.flow_control_id());
-
-        Ok(Response::ok(req))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -1,0 +1,455 @@
+use std::net::IpAddr;
+
+use ockam::{Address, Context, Result};
+use ockam_abac::expr::{eq, ident, str};
+use ockam_abac::Policy;
+use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::compat::net::SocketAddr;
+use ockam_core::route;
+use ockam_multiaddr::MultiAddr;
+
+use super::{actions, resources, NodeManagerWorker};
+use crate::error::ApiError;
+use crate::kafka::{
+    ConsumerNodeAddr, KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
+    KAFKA_OUTLET_BOOTSTRAP_ADDRESS, KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
+};
+use crate::kafka::{OutletManagerService, PrefixRelayService};
+use crate::nodes::models::services::{
+    DeleteServiceRequest, StartKafkaConsumerRequest, StartKafkaDirectRequest,
+    StartKafkaOutletRequest, StartKafkaProducerRequest, StartServiceRequest,
+};
+use crate::nodes::registry::{KafkaServiceInfo, KafkaServiceKind};
+use crate::nodes::service::default_address::DefaultAddress;
+use crate::nodes::InMemoryNode;
+use crate::nodes::NodeManager;
+use crate::port_range::PortRange;
+
+impl NodeManagerWorker {
+    pub(super) async fn start_kafka_outlet_service(
+        &self,
+        context: &Context,
+        request_header: &RequestHeader,
+        body: StartServiceRequest<StartKafkaOutletRequest>,
+    ) -> Result<Response<()>, Response<Error>> {
+        match self
+            .node_manager
+            .start_kafka_outlet_service(
+                context,
+                Address::from_string(body.address()),
+                body.request().bootstrap_server_addr,
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header).body(())),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
+    }
+
+    pub(super) async fn start_kafka_direct_service(
+        &self,
+        context: &Context,
+        request_header: &RequestHeader,
+        body: StartServiceRequest<StartKafkaDirectRequest>,
+    ) -> Result<Response<()>, Response<Error>> {
+        let request = body.request();
+        let consumer_route: Option<MultiAddr> =
+            match request.consumer_route().map(|r| r.parse()).transpose() {
+                Ok(multiaddr) => multiaddr,
+                Err(e) => return Err(Response::bad_request(request_header, &e.to_string())),
+            };
+
+        match self
+            .node_manager
+            .start_kafka_direct_service(
+                context,
+                Address::from_string(body.address()),
+                request.bind_address().ip(),
+                request.bind_address().port(),
+                request.brokers_port_range(),
+                *request.bootstrap_server_addr(),
+                consumer_route,
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header).body(())),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
+    }
+
+    pub(super) async fn start_kafka_consumer_service(
+        &self,
+        context: &Context,
+        request_header: &RequestHeader,
+        body: StartServiceRequest<StartKafkaConsumerRequest>,
+    ) -> Result<Response<()>, Response<Error>> {
+        let request = body.request();
+        let outlet_node_multiaddr: MultiAddr = match request.project_route().to_string().parse() {
+            Ok(multiaddr) => multiaddr,
+            Err(e) => return Err(Response::bad_request(request_header, &e.to_string())),
+        };
+
+        match self
+            .node_manager
+            .start_kafka_service(
+                context,
+                Address::from_string(body.address()),
+                request.bootstrap_server_addr().ip(),
+                request.bootstrap_server_addr().port(),
+                request.brokers_port_range(),
+                outlet_node_multiaddr,
+                KafkaServiceKind::Consumer,
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header).body(())),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
+    }
+
+    pub(super) async fn start_kafka_producer_service(
+        &mut self,
+        context: &Context,
+        request_header: &RequestHeader,
+        body: StartServiceRequest<StartKafkaProducerRequest>,
+    ) -> Result<Response<()>, Response<Error>> {
+        let request = body.request();
+        let outlet_node_multiaddr: MultiAddr = match request.project_route().to_string().parse() {
+            Ok(multiaddr) => multiaddr,
+            Err(e) => return Err(Response::bad_request(request_header, &e.to_string())),
+        };
+
+        match self
+            .node_manager
+            .start_kafka_service(
+                context,
+                Address::from_string(body.address()),
+                request.bootstrap_server_addr().ip(),
+                request.bootstrap_server_addr().port(),
+                request.brokers_port_range(),
+                outlet_node_multiaddr,
+                KafkaServiceKind::Producer,
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header).body(())),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
+    }
+
+    pub(crate) async fn delete_kafka_service(
+        &self,
+        ctx: &Context,
+        req: &RequestHeader,
+        delete_service_request: DeleteServiceRequest,
+        kind: KafkaServiceKind,
+    ) -> Result<Response<()>, Response<Error>> {
+        match self
+            .node_manager
+            .delete_kafka_service(ctx, delete_service_request.address(), kind)
+            .await
+        {
+            Ok(DeleteKafkaServiceResult::ServiceDeleted) => Ok(Response::ok(req)),
+            Ok(DeleteKafkaServiceResult::ServiceNotFound { address, kind }) => {
+                Err(Response::not_found(
+                    req,
+                    &format!("Service at address '{address}' with kind {kind} not found"),
+                ))
+            },
+            Ok(DeleteKafkaServiceResult::IncorrectKind { address, actual, expected }) => {
+                Err(Response::not_found(
+                    req,
+                    &format!("Service at address '{address}' is not a kafka {expected}. A service of kind {actual} was found instead"),
+                ))
+            },
+            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+        }
+    }
+}
+
+impl InMemoryNode {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_kafka_direct_service(
+        &self,
+        context: &Context,
+        local_interceptor_address: Address,
+        bind_ip: IpAddr,
+        server_bootstrap_port: u16,
+        brokers_port_range: (u16, u16),
+        bootstrap_server_addr: SocketAddr,
+        consumer_route: Option<MultiAddr>,
+    ) -> Result<()> {
+        let default_secure_channel_listener_flow_control_id = context
+            .flow_controls()
+            .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
+            .ok_or_else(|| {
+                ApiError::core("Unable to get flow control for secure channel listener")
+            })?;
+
+        {
+            OutletManagerService::create(
+                context,
+                self.secure_channels.clone(),
+                self.trust_context()?.id(),
+                default_secure_channel_listener_flow_control_id,
+            )
+            .await?;
+        }
+
+        self.create_outlet(
+            context,
+            bootstrap_server_addr,
+            KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
+            Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
+            false,
+        )
+        .await?;
+
+        let trust_context_id;
+        let secure_channels;
+        {
+            trust_context_id = self.trust_context()?.id().to_string();
+            secure_channels = self.secure_channels.clone();
+        }
+
+        let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
+            secure_channels,
+            ConsumerNodeAddr::Direct(consumer_route.clone()),
+            trust_context_id,
+        );
+
+        let inlet_controller = KafkaInletController::new(
+            "/secure/api".parse().unwrap(),
+            route![local_interceptor_address.clone()],
+            route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
+            bind_ip,
+            PortRange::try_from(brokers_port_range)
+                .map_err(|_| ApiError::core("invalid port range"))?,
+        );
+
+        // since we cannot call APIs of node manager via message due to the read/write lock
+        // we need to call it directly
+        self.create_inlet(
+            context,
+            SocketAddr::new(bind_ip, server_bootstrap_port).to_string(),
+            None,
+            route![local_interceptor_address.clone()],
+            route![
+                KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
+                KAFKA_OUTLET_BOOTSTRAP_ADDRESS
+            ],
+            "/secure/api".parse().unwrap(),
+            None,
+            None,
+        )
+        .await?;
+
+        KafkaPortalListener::create(
+            context,
+            inlet_controller,
+            secure_channel_controller.into_trait(),
+            local_interceptor_address.clone(),
+        )
+        .await?;
+
+        {
+            self.registry
+                .kafka_services
+                .insert(
+                    local_interceptor_address,
+                    KafkaServiceInfo::new(KafkaServiceKind::Direct),
+                )
+                .await;
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_kafka_service(
+        &self,
+        context: &Context,
+        local_interceptor_address: Address,
+        bind_ip: IpAddr,
+        server_bootstrap_port: u16,
+        brokers_port_range: (u16, u16),
+        outlet_node_multiaddr: MultiAddr,
+        kind: KafkaServiceKind,
+    ) -> Result<()> {
+        debug!(
+            "outlet_node_multiaddr: {}",
+            outlet_node_multiaddr.to_string()
+        );
+
+        let trust_context_id;
+        let secure_channels;
+        {
+            trust_context_id = self.trust_context()?.id().to_string();
+            secure_channels = self.secure_channels.clone();
+
+            if let Some(project) = outlet_node_multiaddr.first().and_then(|value| {
+                value
+                    .cast::<ockam_multiaddr::proto::Project>()
+                    .map(|p| p.to_string())
+            }) {
+                let (_, project_identifier) = self.resolve_project(&project).await?;
+                // if we are using the project we need to allow safe communication based on the
+                // project identifier
+                self.cli_state
+                    .set_policy(
+                        &resources::INLET,
+                        &actions::HANDLE_MESSAGE,
+                        &Policy::new(eq([ident("subject.identifier"), str(project_identifier)])),
+                    )
+                    .await
+                    .map_err(ockam_core::Error::from)?
+            }
+        }
+
+        let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
+            secure_channels,
+            ConsumerNodeAddr::Relay(outlet_node_multiaddr.clone()),
+            trust_context_id,
+        );
+
+        let inlet_controller = KafkaInletController::new(
+            outlet_node_multiaddr.clone(),
+            route![local_interceptor_address.clone()],
+            route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
+            bind_ip,
+            PortRange::try_from(brokers_port_range)
+                .map_err(|_| ApiError::core("invalid port range"))?,
+        );
+
+        // since we cannot call APIs of node manager via message due to the read/write lock
+        // we need to call it directly
+        self.create_inlet(
+            context,
+            SocketAddr::new(bind_ip, server_bootstrap_port).to_string(),
+            None,
+            route![local_interceptor_address.clone()],
+            route![
+                KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
+                KAFKA_OUTLET_BOOTSTRAP_ADDRESS
+            ],
+            outlet_node_multiaddr,
+            None,
+            None,
+        )
+        .await?;
+
+        KafkaPortalListener::create(
+            context,
+            inlet_controller,
+            secure_channel_controller.into_trait(),
+            local_interceptor_address.clone(),
+        )
+        .await?;
+
+        {
+            self.registry
+                .kafka_services
+                .insert(local_interceptor_address, KafkaServiceInfo::new(kind))
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+impl NodeManager {
+    pub async fn start_kafka_outlet_service(
+        &self,
+        context: &Context,
+        service_address: Address,
+        bootstrap_server_addr: SocketAddr,
+    ) -> Result<()> {
+        let default_secure_channel_listener_flow_control_id = context
+            .flow_controls()
+            .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
+            .ok_or_else(|| {
+                ApiError::core("Unable to get flow control for secure channel listener")
+            })?;
+
+        PrefixRelayService::create(
+            context,
+            default_secure_channel_listener_flow_control_id.clone(),
+        )
+        .await?;
+
+        {
+            OutletManagerService::create(
+                context,
+                self.secure_channels.clone(),
+                self.trust_context()?.id(),
+                default_secure_channel_listener_flow_control_id,
+            )
+            .await?;
+        }
+
+        if let Err(e) = self
+            .create_outlet(
+                context,
+                bootstrap_server_addr,
+                KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
+                Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
+                false,
+            )
+            .await
+        {
+            return Err(ApiError::core(e.to_string()));
+        };
+
+        {
+            self.registry
+                .kafka_services
+                .insert(
+                    service_address,
+                    KafkaServiceInfo::new(KafkaServiceKind::Outlet),
+                )
+                .await;
+        }
+
+        Ok(())
+    }
+
+    /// Delete a Kafka service from the registry.
+    /// The expected kind must match the actual kind
+    pub async fn delete_kafka_service(
+        &self,
+        ctx: &Context,
+        address: Address,
+        kind: KafkaServiceKind,
+    ) -> Result<DeleteKafkaServiceResult> {
+        match self.registry.kafka_services.get(&address).await {
+            None => Ok(DeleteKafkaServiceResult::ServiceNotFound { address, kind }),
+            Some(e) => {
+                if kind.eq(e.kind()) {
+                    ctx.stop_worker(address.clone()).await?;
+                    self.registry.kafka_services.remove(&address).await;
+                    Ok(DeleteKafkaServiceResult::ServiceDeleted)
+                } else {
+                    error!(address = %address, "Service is not a kafka {}", kind.to_string());
+                    Ok(DeleteKafkaServiceResult::IncorrectKind {
+                        address,
+                        actual: e.kind().clone(),
+                        expected: kind,
+                    })
+                }
+            }
+        }
+    }
+}
+
+pub enum DeleteKafkaServiceResult {
+    ServiceDeleted,
+    IncorrectKind {
+        address: Address,
+        actual: KafkaServiceKind,
+        expected: KafkaServiceKind,
+    },
+    ServiceNotFound {
+        address: Address,
+        kind: KafkaServiceKind,
+    },
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -1,163 +1,28 @@
 use either::Either;
-use std::net::IpAddr;
 
 use minicbor::Decoder;
 
 use ockam::identity::{identities, AuthorityService, TrustContext};
 use ockam::{Address, Context, Result};
-use ockam_abac::expr::{eq, ident, str};
-use ockam_abac::{Policy, Resource};
+use ockam_abac::Resource;
 use ockam_core::api::{Error, RequestHeader, Response};
-use ockam_core::compat::net::SocketAddr;
-use ockam_core::route;
-use ockam_multiaddr::MultiAddr;
 use ockam_node::WorkerBuilder;
 
 use crate::auth::Server;
 use crate::echoer::Echoer;
 use crate::error::ApiError;
 use crate::hop::Hop;
-use crate::kafka::{
-    ConsumerNodeAddr, KafkaInletController, KafkaPortalListener, KafkaSecureChannelControllerImpl,
-    KAFKA_OUTLET_BOOTSTRAP_ADDRESS, KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
-};
-use crate::kafka::{OutletManagerService, PrefixRelayService};
 use crate::nodes::models::services::{
-    DeleteServiceRequest, ServiceList, ServiceStatus, StartAuthenticatedServiceRequest,
-    StartCredentialsService, StartEchoerServiceRequest, StartHopServiceRequest,
-    StartKafkaConsumerRequest, StartKafkaDirectRequest, StartKafkaOutletRequest,
-    StartKafkaProducerRequest, StartServiceRequest, StartUppercaseServiceRequest,
+    ServiceList, ServiceStatus, StartAuthenticatedServiceRequest, StartCredentialsService,
+    StartEchoerServiceRequest, StartHopServiceRequest, StartUppercaseServiceRequest,
 };
-use crate::nodes::registry::{CredentialsServiceInfo, KafkaServiceInfo, KafkaServiceKind};
+use crate::nodes::registry::CredentialsServiceInfo;
+use crate::nodes::registry::KafkaServiceKind;
 use crate::nodes::service::default_address::DefaultAddress;
 use crate::nodes::NodeManager;
-use crate::port_range::PortRange;
 use crate::uppercase::Uppercase;
 
-use super::{actions, resources, NodeManagerWorker};
-
-impl NodeManager {
-    pub(super) async fn start_credentials_service_impl(
-        &self,
-        ctx: &Context,
-        trust_context: TrustContext,
-        addr: Address,
-        oneway: bool,
-    ) -> Result<()> {
-        if self.registry.credentials_services.contains_key(&addr).await {
-            return Err(ApiError::core("Credentials service exists at this address"));
-        }
-
-        self.credentials_service()
-            .start(ctx, trust_context, self.identifier(), addr.clone(), !oneway)
-            .await?;
-
-        self.registry
-            .credentials_services
-            .insert(addr.clone(), CredentialsServiceInfo::default())
-            .await;
-
-        Ok(())
-    }
-
-    pub(super) async fn start_authenticated_service_impl(
-        &self,
-        ctx: &Context,
-        addr: Address,
-    ) -> Result<()> {
-        if self
-            .registry
-            .authenticated_services
-            .contains_key(&addr)
-            .await
-        {
-            return Err(ApiError::core(
-                "Authenticated service exists at this address",
-            ));
-        }
-
-        let server = Server::new(self.identity_attributes_repository());
-        ctx.start_worker(addr.clone(), server).await?;
-
-        self.registry
-            .authenticated_services
-            .insert(addr, Default::default())
-            .await;
-
-        Ok(())
-    }
-
-    pub(super) async fn start_uppercase_service_impl(
-        &self,
-        ctx: &Context,
-        addr: Address,
-    ) -> Result<()> {
-        if self.registry.uppercase_services.contains_key(&addr).await {
-            return Err(ApiError::core("Uppercase service exists at this address"));
-        }
-
-        ctx.start_worker(addr.clone(), Uppercase).await?;
-
-        self.registry
-            .uppercase_services
-            .insert(addr.clone(), Default::default())
-            .await;
-
-        Ok(())
-    }
-
-    pub(super) async fn start_echoer_service_impl(
-        &self,
-        ctx: &Context,
-        addr: Address,
-    ) -> Result<()> {
-        if self.registry.echoer_services.contains_key(&addr).await {
-            return Err(ApiError::core("Echoer service exists at this address"));
-        }
-
-        let maybe_trust_context_id = self.trust_context.as_ref().map(|c| c.id());
-        let resource = Resource::assert_inline(addr.address());
-        let ac = self
-            .access_control(
-                &resource,
-                &actions::HANDLE_MESSAGE,
-                maybe_trust_context_id,
-                None,
-            )
-            .await?;
-
-        WorkerBuilder::new(Echoer)
-            .with_address(addr.clone())
-            .with_incoming_access_control_arc(ac)
-            .start(ctx)
-            .await?;
-
-        self.registry
-            .echoer_services
-            .insert(addr, Default::default())
-            .await;
-
-        Ok(())
-    }
-
-    pub(super) async fn start_hop_service_impl(&self, ctx: &Context, addr: Address) -> Result<()> {
-        if self.registry.hop_services.contains_key(&addr).await {
-            return Err(ApiError::core("Hop service exists at this address"));
-        }
-
-        ctx.flow_controls()
-            .add_consumer(addr.clone(), &self.api_transport_flow_control_id);
-
-        ctx.start_worker(addr.clone(), Hop).await?;
-
-        self.registry
-            .hop_services
-            .insert(addr, Default::default())
-            .await;
-
-        Ok(())
-    }
-}
+use super::{actions, NodeManagerWorker};
 
 impl NodeManagerWorker {
     pub(super) async fn start_authenticated_service(
@@ -247,380 +112,6 @@ impl NodeManagerWorker {
             .await?;
 
         Ok(Response::ok(req))
-    }
-    pub(super) async fn start_kafka_outlet_service(
-        &self,
-        context: &Context,
-        request: &RequestHeader,
-        dec: &mut Decoder<'_>,
-    ) -> Result<Vec<u8>> {
-        let body: StartServiceRequest<StartKafkaOutletRequest> = dec.decode()?;
-
-        let default_secure_channel_listener_flow_control_id = context
-            .flow_controls()
-            .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
-            .ok_or_else(|| {
-                ApiError::core("Unable to get flow control for secure channel listener")
-            })?;
-
-        PrefixRelayService::create(
-            context,
-            default_secure_channel_listener_flow_control_id.clone(),
-        )
-        .await?;
-
-        {
-            OutletManagerService::create(
-                context,
-                self.node_manager.secure_channels.clone(),
-                self.node_manager.trust_context()?.id(),
-                default_secure_channel_listener_flow_control_id,
-            )
-            .await?;
-        }
-
-        if let Err(e) = self
-            .node_manager
-            .create_outlet(
-                context,
-                body.request().bootstrap_server_addr,
-                KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
-                Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
-                false,
-            )
-            .await
-        {
-            return Ok(e.to_string().into_bytes());
-        };
-
-        {
-            self.node_manager
-                .registry
-                .kafka_services
-                .insert(
-                    body.address().into(),
-                    KafkaServiceInfo::new(KafkaServiceKind::Outlet),
-                )
-                .await;
-        }
-
-        Ok(Response::ok(request).to_vec()?)
-    }
-
-    pub(super) async fn start_kafka_direct_service(
-        &self,
-        context: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
-    ) -> Result<Vec<u8>> {
-        let body: StartServiceRequest<StartKafkaDirectRequest> = dec.decode()?;
-        let listener_address: Address = body.address().into();
-        let body_req = body.request();
-
-        let consumer_route: Option<MultiAddr> =
-            if let Some(consumer_route) = body_req.consumer_route() {
-                Some(consumer_route.parse()?)
-            } else {
-                None
-            };
-
-        if let Err(e) = self
-            .start_direct_kafka_service_impl(
-                context,
-                listener_address,
-                body_req.bind_address().ip(),
-                body_req.bind_address().port(),
-                body_req.brokers_port_range(),
-                *body_req.bootstrap_server_addr(),
-                consumer_route,
-            )
-            .await
-        {
-            return Ok(e.to_vec()?);
-        };
-
-        Ok(Response::ok(req).to_vec()?)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(super) async fn start_direct_kafka_service_impl(
-        &self,
-        context: &Context,
-        local_interceptor_address: Address,
-        bind_ip: IpAddr,
-        server_bootstrap_port: u16,
-        brokers_port_range: (u16, u16),
-        bootstrap_server_addr: SocketAddr,
-        consumer_route: Option<MultiAddr>,
-    ) -> Result<(), Response<Error>> {
-        let default_secure_channel_listener_flow_control_id = context
-            .flow_controls()
-            .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
-            .ok_or_else(|| {
-                ApiError::core("Unable to get flow control for secure channel listener")
-            })?;
-
-        {
-            OutletManagerService::create(
-                context,
-                self.node_manager.secure_channels.clone(),
-                self.node_manager.trust_context()?.id(),
-                default_secure_channel_listener_flow_control_id,
-            )
-            .await?;
-        }
-
-        self.node_manager
-            .create_outlet(
-                context,
-                bootstrap_server_addr,
-                KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into(),
-                Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.to_string()),
-                false,
-            )
-            .await?;
-
-        let trust_context_id;
-        let secure_channels;
-        {
-            trust_context_id = self.node_manager.trust_context()?.id().to_string();
-            secure_channels = self.node_manager.secure_channels.clone();
-        }
-
-        let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
-            secure_channels,
-            ConsumerNodeAddr::Direct(consumer_route.clone()),
-            trust_context_id,
-        );
-
-        let inlet_controller = KafkaInletController::new(
-            "/secure/api".parse().unwrap(),
-            route![local_interceptor_address.clone()],
-            route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
-            bind_ip,
-            PortRange::try_from(brokers_port_range)
-                .map_err(|_| ApiError::core("invalid port range"))?,
-        );
-
-        // since we cannot call APIs of node manager via message due to the read/write lock
-        // we need to call it directly
-        self.node_manager
-            .create_inlet(
-                context,
-                SocketAddr::new(bind_ip, server_bootstrap_port).to_string(),
-                None,
-                route![local_interceptor_address.clone()],
-                route![
-                    KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
-                    KAFKA_OUTLET_BOOTSTRAP_ADDRESS
-                ],
-                "/secure/api".parse().unwrap(),
-                None,
-                None,
-            )
-            .await?;
-
-        KafkaPortalListener::create(
-            context,
-            inlet_controller,
-            secure_channel_controller.into_trait(),
-            local_interceptor_address.clone(),
-        )
-        .await?;
-
-        {
-            self.node_manager
-                .registry
-                .kafka_services
-                .insert(
-                    local_interceptor_address,
-                    KafkaServiceInfo::new(KafkaServiceKind::Direct),
-                )
-                .await;
-        }
-
-        Ok(())
-    }
-
-    pub(super) async fn start_kafka_consumer_service(
-        &self,
-        context: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
-    ) -> Result<Vec<u8>> {
-        let body: StartServiceRequest<StartKafkaConsumerRequest> = dec.decode()?;
-        let listener_address: Address = body.address().into();
-        let body_req = body.request();
-        let outlet_node_multiaddr = body_req.project_route().to_string().parse()?;
-
-        if let Err(e) = self
-            .start_kafka_service_impl(
-                context,
-                listener_address,
-                body_req.bootstrap_server_addr.ip(),
-                body_req.bootstrap_server_addr.port(),
-                body_req.brokers_port_range(),
-                outlet_node_multiaddr,
-                KafkaServiceKind::Consumer,
-            )
-            .await
-        {
-            return Ok(e.to_vec()?);
-        };
-
-        Ok(Response::ok(req).to_vec()?)
-    }
-
-    pub(super) async fn start_kafka_producer_service(
-        &mut self,
-        context: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
-    ) -> Result<Vec<u8>> {
-        let body: StartServiceRequest<StartKafkaProducerRequest> = dec.decode()?;
-        let listener_address: Address = body.address().into();
-        let body_req = body.request();
-        let outlet_node_multiaddr = body_req.project_route().to_string().parse()?;
-
-        if let Err(e) = self
-            .start_kafka_service_impl(
-                context,
-                listener_address,
-                body_req.bootstrap_server_addr.ip(),
-                body_req.bootstrap_server_addr.port(),
-                body_req.brokers_port_range(),
-                outlet_node_multiaddr,
-                KafkaServiceKind::Producer,
-            )
-            .await
-        {
-            return Ok(e.to_vec()?);
-        };
-
-        Ok(Response::ok(req).to_vec()?)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(super) async fn start_kafka_service_impl(
-        &self,
-        context: &Context,
-        local_interceptor_address: Address,
-        bind_ip: IpAddr,
-        server_bootstrap_port: u16,
-        brokers_port_range: (u16, u16),
-        outlet_node_multiaddr: MultiAddr,
-        kind: KafkaServiceKind,
-    ) -> Result<(), Response<Error>> {
-        debug!(
-            "outlet_node_multiaddr: {}",
-            outlet_node_multiaddr.to_string()
-        );
-
-        let trust_context_id;
-        let secure_channels;
-        {
-            trust_context_id = self.node_manager.trust_context()?.id().to_string();
-            secure_channels = self.node_manager.secure_channels.clone();
-
-            if let Some(project) = outlet_node_multiaddr.first().and_then(|value| {
-                value
-                    .cast::<ockam_multiaddr::proto::Project>()
-                    .map(|p| p.to_string())
-            }) {
-                let (_, project_identifier) = self.node_manager.resolve_project(&project).await?;
-                // if we are using the project we need to allow safe communication based on the
-                // project identifier
-                self.node_manager
-                    .cli_state
-                    .set_policy(
-                        &resources::INLET,
-                        &actions::HANDLE_MESSAGE,
-                        &Policy::new(eq([ident("subject.identifier"), str(project_identifier)])),
-                    )
-                    .await
-                    .map_err(ockam_core::Error::from)?
-            }
-        }
-
-        let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
-            secure_channels,
-            ConsumerNodeAddr::Relay(outlet_node_multiaddr.clone()),
-            trust_context_id,
-        );
-
-        let inlet_controller = KafkaInletController::new(
-            outlet_node_multiaddr.clone(),
-            route![local_interceptor_address.clone()],
-            route![KAFKA_OUTLET_INTERCEPTOR_ADDRESS],
-            bind_ip,
-            PortRange::try_from(brokers_port_range)
-                .map_err(|_| ApiError::core("invalid port range"))?,
-        );
-
-        // since we cannot call APIs of node manager via message due to the read/write lock
-        // we need to call it directly
-        self.node_manager
-            .create_inlet(
-                context,
-                SocketAddr::new(bind_ip, server_bootstrap_port).to_string(),
-                None,
-                route![local_interceptor_address.clone()],
-                route![
-                    KAFKA_OUTLET_INTERCEPTOR_ADDRESS,
-                    KAFKA_OUTLET_BOOTSTRAP_ADDRESS
-                ],
-                outlet_node_multiaddr,
-                None,
-                None,
-            )
-            .await?;
-
-        KafkaPortalListener::create(
-            context,
-            inlet_controller,
-            secure_channel_controller.into_trait(),
-            local_interceptor_address.clone(),
-        )
-        .await?;
-
-        {
-            self.node_manager
-                .registry
-                .kafka_services
-                .insert(local_interceptor_address, KafkaServiceInfo::new(kind))
-                .await;
-        }
-
-        Ok(())
-    }
-
-    pub(crate) async fn delete_kafka_service(
-        &self,
-        ctx: &Context,
-        req: &RequestHeader,
-        delete_service_request: DeleteServiceRequest,
-        kind: KafkaServiceKind,
-    ) -> Result<Response<()>, Response<Error>> {
-        match self
-            .node_manager
-            .delete_kafka_service(ctx, delete_service_request.address(), kind)
-            .await
-        {
-            Ok(DeleteKafkaServiceResult::ServiceDeleted) => Ok(Response::ok(req)),
-            Ok(DeleteKafkaServiceResult::ServiceNotFound { address, kind }) => {
-                Err(Response::not_found(
-                    req,
-                    &format!("Service at address '{address}' with kind {kind} not found"),
-                ))
-            },
-            Ok(DeleteKafkaServiceResult::IncorrectKind { address, actual, expected }) => {
-                Err(Response::not_found(
-                    req,
-                    &format!("Service at address '{address}' is not a kafka {expected}. A service of kind {actual} was found instead"),
-                ))
-            },
-            Err(e) => Err(Response::internal_error(req, &e.to_string())),
-        }
     }
 
     pub(super) async fn list_services_of_type(
@@ -742,43 +233,124 @@ impl NodeManager {
         Ok(list)
     }
 
-    /// Delete a Kafka service from the registry.
-    /// The expected kind must match the actual kind
-    pub async fn delete_kafka_service(
+    pub(super) async fn start_credentials_service_impl(
         &self,
         ctx: &Context,
-        address: Address,
-        kind: KafkaServiceKind,
-    ) -> Result<DeleteKafkaServiceResult> {
-        match self.registry.kafka_services.get(&address).await {
-            None => Ok(DeleteKafkaServiceResult::ServiceNotFound { address, kind }),
-            Some(e) => {
-                if kind.eq(e.kind()) {
-                    ctx.stop_worker(address.clone()).await?;
-                    self.registry.kafka_services.remove(&address).await;
-                    Ok(DeleteKafkaServiceResult::ServiceDeleted)
-                } else {
-                    error!(address = %address, "Service is not a kafka {}", kind.to_string());
-                    Ok(DeleteKafkaServiceResult::IncorrectKind {
-                        address,
-                        actual: e.kind().clone(),
-                        expected: kind,
-                    })
-                }
-            }
+        trust_context: TrustContext,
+        addr: Address,
+        oneway: bool,
+    ) -> Result<()> {
+        if self.registry.credentials_services.contains_key(&addr).await {
+            return Err(ApiError::core("Credentials service exists at this address"));
         }
-    }
-}
 
-pub enum DeleteKafkaServiceResult {
-    ServiceDeleted,
-    IncorrectKind {
-        address: Address,
-        actual: KafkaServiceKind,
-        expected: KafkaServiceKind,
-    },
-    ServiceNotFound {
-        address: Address,
-        kind: KafkaServiceKind,
-    },
+        self.credentials_service()
+            .start(ctx, trust_context, self.identifier(), addr.clone(), !oneway)
+            .await?;
+
+        self.registry
+            .credentials_services
+            .insert(addr.clone(), CredentialsServiceInfo::default())
+            .await;
+
+        Ok(())
+    }
+
+    pub(super) async fn start_authenticated_service_impl(
+        &self,
+        ctx: &Context,
+        addr: Address,
+    ) -> Result<()> {
+        if self
+            .registry
+            .authenticated_services
+            .contains_key(&addr)
+            .await
+        {
+            return Err(ApiError::core(
+                "Authenticated service exists at this address",
+            ));
+        }
+
+        let server = Server::new(self.identity_attributes_repository());
+        ctx.start_worker(addr.clone(), server).await?;
+
+        self.registry
+            .authenticated_services
+            .insert(addr, Default::default())
+            .await;
+
+        Ok(())
+    }
+
+    pub(super) async fn start_uppercase_service_impl(
+        &self,
+        ctx: &Context,
+        addr: Address,
+    ) -> Result<()> {
+        if self.registry.uppercase_services.contains_key(&addr).await {
+            return Err(ApiError::core("Uppercase service exists at this address"));
+        }
+
+        ctx.start_worker(addr.clone(), Uppercase).await?;
+
+        self.registry
+            .uppercase_services
+            .insert(addr.clone(), Default::default())
+            .await;
+
+        Ok(())
+    }
+
+    pub(super) async fn start_echoer_service_impl(
+        &self,
+        ctx: &Context,
+        addr: Address,
+    ) -> Result<()> {
+        if self.registry.echoer_services.contains_key(&addr).await {
+            return Err(ApiError::core("Echoer service exists at this address"));
+        }
+
+        let maybe_trust_context_id = self.trust_context.as_ref().map(|c| c.id());
+        let resource = Resource::assert_inline(addr.address());
+        let ac = self
+            .access_control(
+                &resource,
+                &actions::HANDLE_MESSAGE,
+                maybe_trust_context_id,
+                None,
+            )
+            .await?;
+
+        WorkerBuilder::new(Echoer)
+            .with_address(addr.clone())
+            .with_incoming_access_control_arc(ac)
+            .start(ctx)
+            .await?;
+
+        self.registry
+            .echoer_services
+            .insert(addr, Default::default())
+            .await;
+
+        Ok(())
+    }
+
+    pub(super) async fn start_hop_service_impl(&self, ctx: &Context, addr: Address) -> Result<()> {
+        if self.registry.hop_services.contains_key(&addr).await {
+            return Err(ApiError::core("Hop service exists at this address"));
+        }
+
+        ctx.flow_controls()
+            .add_consumer(addr.clone(), &self.api_transport_flow_control_id);
+
+        ctx.start_worker(addr.clone(), Hop).await?;
+
+        self.registry
+            .hop_services
+            .insert(addr, Default::default())
+            .await;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -28,43 +28,49 @@ impl NodeManagerWorker {
     pub(super) async fn start_authenticated_service(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
+        request_header: &RequestHeader,
+        request: StartAuthenticatedServiceRequest,
     ) -> Result<Response, Response<Error>> {
-        let req_body: StartAuthenticatedServiceRequest = dec.decode()?;
-        let addr = req_body.addr.to_string().into();
-        self.node_manager
-            .start_authenticated_service_impl(ctx, addr)
-            .await?;
-        Ok(Response::ok(req))
+        match self
+            .node_manager
+            .start_authenticated_service(ctx, request.addr.into())
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header)),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
     }
 
     pub(super) async fn start_uppercase_service(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
+        request_header: &RequestHeader,
+        request: StartUppercaseServiceRequest,
     ) -> Result<Response, Response<Error>> {
-        let req_body: StartUppercaseServiceRequest = dec.decode()?;
-        let addr = req_body.addr.to_string().into();
-        self.node_manager
-            .start_uppercase_service_impl(ctx, addr)
-            .await?;
-        Ok(Response::ok(req))
+        match self
+            .node_manager
+            .start_uppercase_service(ctx, request.addr.into())
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header)),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
     }
 
     pub(super) async fn start_echoer_service(
         &self,
         ctx: &Context,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
+        request_header: &RequestHeader,
+        request: StartEchoerServiceRequest,
     ) -> Result<Response, Response<Error>> {
-        let req_body: StartEchoerServiceRequest = dec.decode()?;
-        let addr = req_body.addr.to_string().into();
-        self.node_manager
-            .start_echoer_service_impl(ctx, addr)
-            .await?;
-        Ok(Response::ok(req))
+        match self
+            .node_manager
+            .start_echoer_service(ctx, request.addr.into())
+            .await
+        {
+            Ok(_) => Ok(Response::ok(request_header)),
+            Err(e) => Err(Response::internal_error(request_header, &e.to_string())),
+        }
     }
 
     pub(super) async fn start_hop_service(
@@ -268,7 +274,7 @@ impl NodeManager {
             .await
     }
 
-    pub(super) async fn start_authenticated_service_impl(
+    pub(super) async fn start_authenticated_service(
         &self,
         ctx: &Context,
         addr: Address,
@@ -295,11 +301,7 @@ impl NodeManager {
         Ok(())
     }
 
-    pub(super) async fn start_uppercase_service_impl(
-        &self,
-        ctx: &Context,
-        addr: Address,
-    ) -> Result<()> {
+    pub(super) async fn start_uppercase_service(&self, ctx: &Context, addr: Address) -> Result<()> {
         if self.registry.uppercase_services.contains_key(&addr).await {
             return Err(ApiError::core("Uppercase service exists at this address"));
         }
@@ -314,11 +316,7 @@ impl NodeManager {
         Ok(())
     }
 
-    pub(super) async fn start_echoer_service_impl(
-        &self,
-        ctx: &Context,
-        addr: Address,
-    ) -> Result<()> {
+    pub(super) async fn start_echoer_service(&self, ctx: &Context, addr: Address) -> Result<()> {
         if self.registry.echoer_services.contains_key(&addr).await {
             return Err(ApiError::core("Echoer service exists at this address"));
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -5,7 +5,7 @@ use minicbor::Decoder;
 use ockam::identity::{identities, AuthorityService, TrustContext};
 use ockam::{Address, Context, Result};
 use ockam_abac::expr::{eq, ident, str};
-use ockam_abac::Resource;
+use ockam_abac::{Policy, Resource};
 use ockam_core::api::{Error, RequestHeader, Response};
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::route;
@@ -536,7 +536,7 @@ impl NodeManagerWorker {
                     .set_policy(
                         &resources::INLET,
                         &actions::HANDLE_MESSAGE,
-                        &eq([ident("subject.identifier"), str(project_identifier)]),
+                        &Policy::new(eq([ident("subject.identifier"), str(project_identifier)])),
                     )
                     .await
                     .map_err(ockam_core::Error::from)?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -1,7 +1,5 @@
 use either::Either;
 
-use minicbor::Decoder;
-
 use ockam::identity::{AuthorityService, Identifier, Identity, TrustContext};
 use ockam::{Address, Context, Result};
 use ockam_abac::Resource;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -34,18 +34,20 @@ use super::{NodeManager, NodeManagerWorker};
 
 /// INLETS
 impl NodeManagerWorker {
-    pub(super) async fn get_inlets(&self, req: &RequestHeader) -> Response<InletList> {
+    pub(super) async fn get_inlets(
+        &self,
+        req: &RequestHeader,
+    ) -> Result<Response<InletList>, Response<Error>> {
         let inlets = self.node_manager.list_inlets().await;
-        Response::ok(req).body(inlets)
+        Ok(Response::ok(req).body(inlets))
     }
 
     pub(super) async fn create_inlet(
         &self,
-        req: &RequestHeader,
-        dec: &mut Decoder<'_>,
         ctx: &Context,
+        req: &RequestHeader,
+        create_inlet: CreateInlet,
     ) -> Result<Response<InletStatus>, Response<Error>> {
-        let create_inlet_req: CreateInlet = dec.decode()?;
         let CreateInlet {
             listen_addr,
             outlet_addr,
@@ -54,7 +56,7 @@ impl NodeManagerWorker {
             prefix_route,
             suffix_route,
             wait_for_outlet_duration,
-        } = create_inlet_req;
+        } = create_inlet;
         match self
             .node_manager
             .create_inlet(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -2,7 +2,6 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use minicbor::Decoder;
 use tokio::time::timeout;
 
 use ockam::identity::Identifier;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -340,6 +340,16 @@ impl NodeManager {
         }
     }
 
+    pub async fn get_credential_by_identity_name(
+        &self,
+        ctx: &Context,
+        name: Option<String>,
+        timeout: Option<Duration>,
+    ) -> Result<Option<CredentialAndPurposeKey>> {
+        let identifier = self.get_identifier_by_name(name).await?;
+        self.get_credential(ctx, &identifier, timeout).await
+    }
+
     pub(crate) async fn create_secure_channel_internal(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/workers.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/workers.rs
@@ -1,0 +1,26 @@
+use crate::nodes::models::workers::{WorkerList, WorkerStatus};
+use crate::nodes::NodeManagerWorker;
+use ockam_core::api::{Error, RequestHeader, Response};
+use ockam_core::Result;
+use ockam_node::Context;
+
+impl NodeManagerWorker {
+    /// Return the current list of workers
+    pub async fn list_workers(
+        &self,
+        ctx: &Context,
+        req: &RequestHeader,
+    ) -> Result<Response<WorkerList>, Response<Error>> {
+        let workers = match ctx.list_workers().await {
+            Err(e) => Err(Response::internal_error(req, &e.to_string())),
+            Ok(workers) => Ok(workers),
+        }?;
+
+        let list = workers
+            .into_iter()
+            .map(|addr| WorkerStatus::new(addr.address()))
+            .collect();
+
+        Ok(Response::ok(req).body(WorkerList::new(list)))
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -1,8 +1,7 @@
 use clap::Args;
 
 use ockam::Context;
-use ockam_abac::{Action, Expr, Resource};
-use ockam_api::nodes::models::policy::Policy;
+use ockam_abac::{Action, Expr, Policy, Resource};
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -2,8 +2,7 @@ use clap::{Args, Subcommand};
 
 use ockam::Context;
 use ockam_abac::expr::{eq, ident, str};
-use ockam_abac::{Action, Resource};
-use ockam_api::nodes::models::policy::Policy;
+use ockam_abac::{Action, Policy, Resource};
 use ockam_api::nodes::models::policy::PolicyList;
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;

--- a/implementations/rust/ockam/ockam_command/src/policy/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/show.rs
@@ -1,8 +1,7 @@
 use clap::Args;
 
 use ockam::Context;
-use ockam_abac::{Action, Resource};
-use ockam_api::nodes::models::policy::Policy;
+use ockam_abac::{Action, Policy, Resource};
 use ockam_api::nodes::BackgroundNode;
 use ockam_core::api::Request;
 


### PR DESCRIPTION
This PR refactors the `NodeManagerWorker` so that it only deals with getting parameters from requests and making `Responses` with results from the `NodeManager` for the following services:

 - workers
 - send message
 - inlets
 - kafka services
 - services start: credentials, hop, uppercase etc...
 - credentials
 - node status
