### PR TITLE
During enrollment, set the selected project as default

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -82,6 +82,14 @@ impl CliState {
         Ok(())
     }
 
+    pub async fn set_default_project(&self, project_id: &str) -> Result<()> {
+        self.projects_repository()
+            .await?
+            .set_default_project(project_id)
+            .await?;
+        Ok(())
+    }
+
     pub async fn get_default_project(&self) -> Result<Project> {
         match self
             .projects_repository()

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -195,6 +195,12 @@ impl AppState {
                     .await?
             }
         };
+        // set the selected project as the default one
+        self.state()
+            .await
+            .set_default_trust_context(&project.name)
+            .await?;
+        self.state().await.set_default_project(&project.id).await?;
         self.state()
             .await
             .set_node_project(&node_manager.node_name(), &Some(project.name()))

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -349,6 +349,9 @@ async fn get_user_project(
     let project = check_project_readiness(opts, ctx, node, project).await?;
     // store the updated project
     opts.state.store_project(project.clone()).await?;
+    // set the project as the default one
+    opts.state.set_default_trust_context(&project.name).await?;
+    opts.state.set_default_project(&project.id).await?;
 
     opts.terminal.write_line(&fmt_ok!(
         "Marked this project as your default project, on this machine.\n"


### PR DESCRIPTION
When the controller is returning multiple projects, the first received would be the default one, even if wasn't the selected default.
This PR changes the behavior by explicitly marking the selected project as the default trust context and project.