### PR TITLE
App - Support self-invitation without breaking project enrollment

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/background_node.rs
@@ -12,7 +12,7 @@ pub trait BackgroundNodeClient: Send + Sync + 'static {
 
 #[async_trait]
 pub trait Nodes: Send + Sync + 'static {
-    async fn create(&mut self, node_name: &str) -> Result<()>;
+    async fn create(&mut self, node_name: &str, trust_context_name: &str) -> Result<()>;
 }
 
 #[async_trait]
@@ -57,9 +57,10 @@ impl BackgroundNodeClient for Cli {
 
 #[async_trait]
 impl Nodes for Cli {
-    async fn create(&mut self, node_name: &str) -> Result<()> {
+    async fn create(&mut self, node_name: &str, trust_context_name: &str) -> Result<()> {
         let bin = self.bin.clone();
         let node_name = node_name.to_string();
+        let trust_context_name = trust_context_name.to_string();
         spawn_blocking(move || {
             let _ = duct::cmd!(
                 &bin,
@@ -68,7 +69,7 @@ impl Nodes for Cli {
                 "create",
                 &node_name,
                 "--trust-context",
-                &node_name
+                &trust_context_name
             )
             .before_spawn(log_command)
             .stderr_null()

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/state.rs
@@ -301,11 +301,12 @@ impl IncomingService {
     }
 
     /// Returns the full route to the outlet service
-    pub fn service_route(&self) -> String {
-        let project_id = &self.project_id;
+    pub fn service_route(&self, project_name: Option<&str>) -> String {
+        // when dealing with accepted invitations, the project name is the project id
+        let project_name = project_name.unwrap_or(&self.project_id);
         let relay_name = self.relay_name();
         let service_name = &self.original_name;
-        format!("/project/{project_id}/service/{relay_name}/secure/api/service/{service_name}")
+        format!("/project/{project_name}/service/{relay_name}/secure/api/service/{service_name}")
     }
 
     /// The name of the node that hosts the inlet
@@ -432,7 +433,8 @@ mod tests {
             "forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1",
             service.relay_name()
         );
-        assert_eq!("/project/project_id/service/forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1/secure/api/service/remote_service_name", service.service_route());
+        assert_eq!("/project/project_id/service/forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1/secure/api/service/remote_service_name", service.service_route(None));
+        assert_eq!("/project/custom-project-name/service/forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1/secure/api/service/remote_service_name", service.service_route(Some("custom-project-name")));
         assert_eq!(
             "ockam_app_project_id_invitation_id",
             service.local_node_name()
@@ -473,7 +475,7 @@ mod tests {
         assert_eq!("second_invitation_id", service.id());
         assert!(!service.enabled());
         assert_eq!("custom_user_name", service.name());
-        assert_eq!("/project/project_id/service/forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1/secure/api/service/remote_service_name", service.service_route());
+        assert_eq!("/project/project_id/service/forward_to_I12ab34cd56ef12ab34cd56ef12ab34cd56ef12aba1b2c3d4e5f6a6b5c4d3e2f1/secure/api/service/remote_service_name", service.service_route(None));
 
         context.stop().await
     }


### PR DESCRIPTION
Allows the user to self-invite by skipping the enrollment phase and adjusting the trust context and project name parameters accordingly [ID_4](https://docs.google.com/document/d/1tPq-OzUc1QIOUON5MoJYNV-6lNYIpCGbEbtkbFsy304/edit?pli=1#heading=h.oebcjj6jwgxd)