### PR TITLE
feat(rust): ensure output is plain text when piped or redirected

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -342,3 +342,4 @@ yes,haruska,Jason Haruska,<2803+haruska@users.noreply.github.com>
 yes,tropicaldog17,Tuan Tran,<tropicaldog17@gmail.com>
 yes,parkercouch,parker couch,<code@parkercouch.dev> <parkercouch@users.noreply.github.com>
 yes,rbran,Rubens Brandao,<git@rubens.io>
+yes,YuheMa702,Yuhe Ma,<mayuhe2002doubleflowers@gmail.com> <yuhem@andrew.cmu.edu>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "arboard",
  "assert_cmd",
  "async-trait",
+ "atty",
  "clap 4.4.11",
  "clap_complete",
  "clap_mangen",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -56,6 +56,7 @@ path = "src/bin/ockam.rs"
 anyhow = "1"
 arboard = "3.3.0"
 async-trait = "0.1"
+atty = "0.2"
 clap = { version = "4.4.11", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.4.4"
 clap_mangen = "0.2.15"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->
When help output is piped or redirect, it contains unnecessary ANSI escape codes.

For example, run the following command
```
ockam project ticket --help | pbcopy
```

the output copied to the clipboard would be:
```
Ockam offers several pluggable enrollment protocols. This command allows project administrators to
enroll known identities or create an one-time enrollment ticket that can be used later on the end
device to enroll themselves into the project.

�[1m�[4mUsage:�[0m �[1mockam project ticket�[0m [OPTIONS]

�[1m�[4mOptions:�[0m
      �[1m--identity�[0m <IDENTITY_NAME>
          Run the command as the given identity name
...
```

## Proposed changes
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
**Desired Behavior:** When help output is piped or redirected, we want to remove ANSI escape codes to ensure:
- Piped output remains compatible with downstream commands or files, avoiding formatting issues.
- The text maintains readability and searchability, as ANSI codes may hinder text processing.
- Log files and script outputs stay clean and human-readable, facilitating troubleshooting.

For example, now after running
```
cargo run -- project ticket -- help | pbcopy
```
the copied help output to the system clipboard should be:
```
Ockam offers several pluggable enrollment protocols. This command allows project administrators to
enroll known identities or create an one-time enrollment ticket that can be used later on the end
device to enroll themselves into the project.

Usage: ockam project ticket [OPTIONS]

Options:
      --identity <IDENTITY_NAME>
          Run the command as the given identity name
...
```

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
