### PR TITLE
test(rust): fix the setup for the orchestrator bats tests

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -23,6 +23,6 @@ function copy_local_orchestrator_data() {
     OCKAM_HOME=$OCKAM_HOME_BASE "$OCKAM" project show -q --output json >$PROJECT_PATH
 
     # import it to the current OCKAM_HOME directory
-    "$OCKAM" project import --project-file $PROJECT_PATH
+    cp -r $OCKAM_HOME_BASE/. $OCKAM_HOME
   fi
 }


### PR DESCRIPTION
This PR fixes the bats tests using the Orchestrator by copying the full database of an enrolled home to the currently tested `OCKAM_HOME`. 
The previous setup was just importing the project data but this is not sufficient to run the Orchestrator bats tests.