### PR TITLE
refactor(rust): simplify the building of some components

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -2,8 +2,6 @@ use std::path::Path;
 
 use tracing::info;
 
-use ockam::identity::storage::PurposeKeysSqlxDatabase;
-use ockam::identity::{ChangeHistorySqlxDatabase, Vault};
 use ockam::identity::{
     CredentialsIssuer, Identifier, Identities, IdentityAttributesRepository,
     IdentityAttributesSqlxDatabase, SecureChannelListenerOptions, SecureChannels,
@@ -64,21 +62,19 @@ impl Authority {
         Self::create_ockam_directory_if_necessary(database_path)?;
         let database = SqlxDatabase::create_with_node_name(database_path, "authority").await?;
 
-        // create the repositories
-        let vault = Vault::create_with_database(database.clone());
-        let identity_attributes_repository =
-            Arc::new(IdentityAttributesSqlxDatabase::new(database.clone()));
-        let identity_attributes_repository =
-            Self::bootstrap_repository(identity_attributes_repository, configuration);
-        let change_history_repository = Arc::new(ChangeHistorySqlxDatabase::new(database.clone()));
-        let purpose_keys_repository = Arc::new(PurposeKeysSqlxDatabase::new(database));
+        // create the bootstrapped identity attributes repository
+        let identity_attributes_repository = Self::bootstrap_repository(
+            Arc::new(IdentityAttributesSqlxDatabase::new(database.clone())),
+            configuration,
+        );
+
+        let identities = Identities::create(database.clone())
+            .with_identity_attributes_repository(identity_attributes_repository)
+            .build();
 
         let secure_channels = SecureChannels::builder()
             .await?
-            .with_vault(vault)
-            .with_identity_attributes_repository(identity_attributes_repository)
-            .with_change_history_repository(change_history_repository)
-            .with_purpose_keys_repository(purpose_keys_repository)
+            .with_identities(identities)
             .build();
 
         let identifier = configuration.identifier();

--- a/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ockam::identity::{ChangeHistoryRepository, IdentityAttributesRepository, SecureChannels};
+use ockam::identity::{Identities, IdentityAttributesRepository, SecureChannels};
 
 use crate::bootstrapped_identities_store::{
     BootstrapedIdentityAttributesStore, PreTrustedIdentities,
@@ -14,14 +14,11 @@ impl CliState {
         node_name: &str,
         pre_trusted_identities: Option<PreTrustedIdentities>,
     ) -> Result<Arc<SecureChannels>> {
-        let change_history_repository: Arc<dyn ChangeHistoryRepository> =
-            self.change_history_repository().await?;
         let identity_attributes_repository: Arc<dyn IdentityAttributesRepository> =
             self.identity_attributes_repository().await?;
 
         //TODO: fix this.  Either don't require it to be a bootstrappedidentitystore (and use the
         //trait instead),  or pass it from the general_options always.
-        let vault = self.get_node_vault(node_name).await?.vault().await?;
         let identity_attributes_repository: Arc<dyn IdentityAttributesRepository> =
             Arc::new(match pre_trusted_identities {
                 None => BootstrapedIdentityAttributesStore::new(
@@ -35,13 +32,14 @@ impl CliState {
             });
 
         debug!("create the secure channels service");
-        let secure_channels = SecureChannels::builder()
-            .await?
+        let vault = self.get_node_vault(node_name).await?.vault().await?;
+        let identities = Identities::create(self.database())
+            .with_identity_attributes_repository(identity_attributes_repository)
             .with_vault(vault)
-            .with_change_history_repository(change_history_repository.clone())
-            .with_identity_attributes_repository(identity_attributes_repository.clone())
-            .with_purpose_keys_repository(self.purpose_keys_repository().await?)
             .build();
-        Ok(secure_channels)
+        Ok(SecureChannels::builder()
+            .await?
+            .with_identities(identities)
+            .build())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -198,12 +198,8 @@ impl CliState {
 impl CliState {
     /// Return an Identities struct using a specific Vault
     pub async fn make_identities(&self, vault: Vault) -> Result<Arc<Identities>> {
-        Ok(Identities::builder()
-            .await?
+        Ok(Identities::create(self.database())
             .with_vault(vault)
-            .with_change_history_repository(self.change_history_repository().await?)
-            .with_identity_attributes_repository(self.identity_attributes_repository().await?)
-            .with_purpose_keys_repository(self.purpose_keys_repository().await?)
             .build())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -7,7 +7,7 @@ use tokio_retry::strategy::FixedInterval;
 use tokio_retry::Retry;
 
 use ockam::identity::models::ChangeHistory;
-use ockam::identity::{identities, Identifier, Identity};
+use ockam::identity::{Identifier, Identity};
 use ockam_core::api::Request;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Error, Result};
@@ -160,16 +160,9 @@ impl Project {
     /// Return the identity of the project's authority
     pub async fn authority_identity(&self) -> Result<Identity> {
         match &self.authority_identity {
-            Some(authority_identity) => {
-                let decoded = hex::decode(authority_identity.as_bytes())
-                    .map_err(|e| Error::new(Origin::Api, Kind::Serialization, e.to_string()))?;
-                let identities = identities().await?;
-                let identifier = identities
-                    .identities_creation()
-                    .import(None, &decoded)
-                    .await?;
-                Ok(identities.get_identity(&identifier).await?)
-            }
+            Some(authority_identity) => Ok(Identity::create(authority_identity)
+                .await
+                .map_err(|e| Error::new(Origin::Api, Kind::Serialization, e.to_string()))?),
             None => Err(Error::new(
                 Origin::Api,
                 Kind::NotFound,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
 use ockam::identity::models::CredentialAndPurposeKey;
-use ockam::identity::TrustEveryonePolicy;
 use ockam::identity::Vault;
 use ockam::identity::{
     Identifier, SecureChannelListenerOptions, SecureChannelOptions, SecureChannels,
     TrustMultiIdentifiersPolicy,
 };
+use ockam::identity::{Identities, TrustEveryonePolicy};
 use ockam::identity::{SecureChannel, SecureChannelListener};
 use ockam::{Address, Result, Route};
 use ockam_core::api::{Error, Response};
@@ -468,24 +468,13 @@ impl NodeManager {
 impl NodeManager {
     /// Build a SecureChannels struct for a specific vault
     pub(crate) async fn build_secure_channels(&self, vault: Vault) -> Result<Arc<SecureChannels>> {
-        let registry = self.secure_channels.secure_channel_registry();
+        let identities = Identities::create(self.cli_state.database())
+            .with_vault(vault)
+            .build();
         Ok(SecureChannels::builder()
             .await?
-            .with_vault(vault)
-            .with_change_history_repository(
-                self.secure_channels
-                    .identities()
-                    .change_history_repository(),
-            )
-            .with_identity_attributes_repository(
-                self.secure_channels
-                    .identities()
-                    .identity_attributes_repository(),
-            )
-            .with_purpose_keys_repository(
-                self.secure_channels.identities().purpose_keys_repository(),
-            )
-            .with_secure_channels_registry(registry)
+            .with_identities(identities)
+            .with_secure_channels_registry(self.secure_channels.secure_channel_registry())
             .build())
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -113,7 +113,7 @@ impl Identities {
 
 impl Identities {
     /// Create a new identities module
-    pub(crate) fn new(
+    pub fn new(
         vault: Vault,
         change_history_repository: Arc<dyn ChangeHistoryRepository>,
         identity_attributes_repository: Arc<dyn IdentityAttributesRepository>,
@@ -130,14 +130,9 @@ impl Identities {
     /// Return a default builder for identities
     #[cfg(feature = "storage")]
     pub async fn builder() -> Result<IdentitiesBuilder> {
-        Ok(IdentitiesBuilder {
-            vault: Vault::create().await?,
-            change_history_repository: Arc::new(ChangeHistorySqlxDatabase::create().await?),
-            identity_attributes_repository: Arc::new(
-                IdentityAttributesSqlxDatabase::create().await?,
-            ),
-            purpose_keys_repository: Arc::new(PurposeKeysSqlxDatabase::create().await?),
-        })
+        Ok(Self::create(
+            SqlxDatabase::in_memory("identities-builder").await?,
+        ))
     }
 
     /// Return a builder for identities with a specific database

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
@@ -24,7 +24,7 @@ pub struct SecureChannels {
 
 impl SecureChannels {
     /// Constructor
-    pub(crate) fn new(
+    pub fn new(
         identities: Arc<Identities>,
         secure_channel_registry: SecureChannelRegistry,
     ) -> Self {


### PR DESCRIPTION
This PR simplifies a bit the building of `Identities` and `SecureChannels` when we need to override just one part.

This also fixes a bug in the wiring of components. On [this line](https://github.com/build-trust/ockam/pull/7090/files#diff-580db697c15995c6d7c1b8985056aebc78647e6e32b4c36fbed1c7de0590707fR476) we were forgetting to set the correct `identity_attributes` repository. As a result, retrieved credentials might be stored in memory and not be able to be retrieved from the database for later check.
