### PR TITLE
 Fix the stopping of the router + a node start refactoring

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
@@ -42,7 +42,11 @@ pub trait NodesRepository: Send + Sync + 'static {
     async fn delete_node(&self, node_name: &str) -> Result<()>;
 
     /// Set the TCP listener of a node
-    async fn set_tcp_listener_address(&self, node_name: &str, address: &str) -> Result<()>;
+    async fn set_tcp_listener_address(
+        &self,
+        node_name: &str,
+        address: &InternetAddress,
+    ) -> Result<()>;
 
     /// Set that node as an authority node
     async fn set_as_authority_node(&self, node_name: &str) -> Result<()>;

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
@@ -109,9 +109,13 @@ impl NodesRepository for NodesSqlxDatabase {
         query.execute(&self.database.pool).await.void()
     }
 
-    async fn set_tcp_listener_address(&self, node_name: &str, address: &str) -> Result<()> {
+    async fn set_tcp_listener_address(
+        &self,
+        node_name: &str,
+        address: &InternetAddress,
+    ) -> Result<()> {
         let query = query("UPDATE node SET tcp_listener_address = ? WHERE name = ?")
-            .bind(address.to_sql())
+            .bind(address.to_string().to_sql())
             .bind(node_name.to_sql());
         query.execute(&self.database.pool).await.void()
     }

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -684,7 +684,7 @@ pub(crate) async fn make_node_manager(
         .into_diagnostic()?;
 
     let _ = cli_state
-        .create_node_with_optional_values(NODE_NAME, &None, &None)
+        .start_node_with_optional_values(NODE_NAME, &None, &None, Some(&listener))
         .await?;
 
     let node_manager = Arc::new(

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
-use std::process;
 
 use clap::ArgGroup;
 use clap::Args;
@@ -273,13 +272,9 @@ async fn start_authority_node(
 
     let node = opts
         .state
-        .create_node_with_optional_values(&cmd.node_name, &Some(identity_name), &None)
-        .await?;
-    opts.state
-        .set_tcp_listener_address(&node.name(), cmd.tcp_listener_address.to_string())
+        .start_node_with_optional_values(&cmd.node_name, &Some(identity_name), &None, None)
         .await?;
     opts.state.set_as_authority_node(&node.name()).await?;
-    opts.state.set_node_pid(&node.name(), process::id()).await?;
 
     let okta_configuration = match (&cmd.tenant_base_url, &cmd.certificate, &cmd.attributes) {
         (Some(tenant_base_url), Some(certificate), Some(attributes)) => Some(OktaConfiguration {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -249,7 +249,10 @@ mod tests {
         cli_state.create_node("n1").await?;
 
         cli_state
-            .set_tcp_listener_address("n1", "127.0.0.0:4000".to_string())
+            .set_tcp_listener_address(
+                "n1",
+                &SocketAddr::from_str("127.0.0.0:4000").unwrap().into(),
+            )
             .await?;
 
         let test_cases = vec![

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -162,21 +162,27 @@ impl InternalMap {
     }
 
     /// Retrieve the next cluster in reverse-initialisation order
+    /// Return None if there is no next cluster or if the cluster
+    /// contained no more active addresses
     pub(super) fn next_cluster(&mut self) -> Option<Vec<&mut AddressRecord>> {
         let name = self.cluster_order.pop()?;
         let addrs = self.clusters.remove(&name)?;
-        Some(
-            self.address_records_map
-                .iter_mut()
-                .filter_map(|(primary, rec)| {
-                    if addrs.contains(primary) {
-                        Some(rec)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        )
+        let active_addresses: Vec<&mut AddressRecord> = self
+            .address_records_map
+            .iter_mut()
+            .filter_map(|(primary, rec)| {
+                if addrs.contains(primary) {
+                    Some(rec)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if active_addresses.is_empty() {
+            None
+        } else {
+            Some(active_addresses)
+        }
     }
 
     /// Mark this address as "having started to stop"


### PR DESCRIPTION
This PR fixes 2 issues:

 1. an `ockam node create` command might stay stuck
 2. the setting of a node pid and tcp listener should be done on node start, not when the node info is retrieved

### `ockam node create`

During testing it has been observed that `ockam node create` could stay stuck if:

 - the corresponding background node is not responding
 - the TCP workers of the foreground node detect the connection drop and clean themselves up
 - the `node create` task starts to close its `Context`
 - then a Router `cluster`, containing the list of all the TCP workers end up returning no address and the `Context` never gets closed

The issue is fixed by considering that there is no cluster to return on shutdown if it contains no active address.

### Setting the node pid and TCP listener

The setting of the node current pid was done in several places and when retrieving the node from the database. 
Same thing for setting the current TCP listener address. 

This PR refactors that code to make sure we only do it in one place.