### PR TITLE
refactor(rust): split `node create` command code into separate files for background/foreground modes

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -12,15 +12,13 @@ impl AppState {
             .map(|s| LevelFilter::from_str(&s))
             .and_then(Result::ok)
             .unwrap_or(LevelFilter::INFO);
-        let log_path = {
+        let node_dir = {
             let this = self.clone();
             let state = self
                 .context()
                 .runtime()
                 .block_on(async move { this.state().await });
-            state
-                .stdout_logs(NODE_NAME)
-                .expect("Failed to get stdout log path for node")
+            state.node_dir(NODE_NAME)
         };
         let ockam_crates = [
             "ockam",
@@ -33,7 +31,7 @@ impl AppState {
             "ockam_command",
             "ockam_app_lib",
         ];
-        if let Some(guard) = Logging::setup(level, false, Some(log_path), &ockam_crates) {
+        if let Some(guard) = Logging::setup(level, false, Some(node_dir), &ockam_crates) {
             self.tracing_guard
                 .set(guard)
                 .expect("Failed to initialize logs");

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -192,7 +192,7 @@ async fn spawn_background_node(
     }
     args.push(cmd.node_name.to_string());
 
-    run_ockam(opts, &cmd.node_name, args, cmd.logging_to_file()).await
+    run_ockam(args).await
 }
 
 impl CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -477,10 +477,7 @@ impl OckamCommand {
                 }
                 // In the case where a node is explicitly created in foreground mode, we need
                 // to initialize the node directories before we can get the log path.
-                let path = opts.state.stdout_logs(&c.node_name).unwrap_or_else(|_| {
-                    panic!("Failed to initialize logs file for node {}", c.node_name)
-                });
-                return Some(path);
+                return Some(opts.state.node_dir(&c.node_name));
             }
         }
         None

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,44 +1,23 @@
-use std::sync::Arc;
 use std::{path::PathBuf, str::FromStr};
 
 use clap::Args;
-use colorful::Colorful;
 use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
-use minicbor::{Decoder, Encode};
-use tokio::sync::Mutex;
-use tokio::time::{sleep, Duration};
-use tokio::try_join;
-use tracing::{debug, info};
 
 use ockam::identity::Identity;
-use ockam::{Address, AsyncTryClone, TcpListenerOptions};
-use ockam::{Context, TcpTransport};
 use ockam_api::cli_state::random_name;
-use ockam_api::nodes::service::NodeManagerTrustOptions;
-use ockam_api::nodes::BackgroundNode;
-use ockam_api::nodes::InMemoryNode;
-use ockam_api::{
-    bootstrapped_identities_store::PreTrustedIdentities,
-    nodes::{
-        service::{NodeManagerGeneralOptions, NodeManagerTransportOptions},
-        NodeManagerWorker, NODEMANAGER_ADDR,
-    },
-};
-use ockam_core::api::{Request, ResponseHeader, Status};
-use ockam_core::{route, LOCAL};
 
-use crate::node::show::is_node_up;
-use crate::node::util::{spawn_node, NodeManagerDefaults};
-use crate::secure_channel::listener::create as secure_channel_listener;
+use crate::node::create::background::background_mode;
+use crate::node::create::foreground::foreground_mode;
+use crate::node::util::NodeManagerDefaults;
 use crate::service::config::Config;
-use crate::terminal::OckamColor;
 use crate::util::api::TrustContextOpts;
 use crate::util::embedded_node_that_is_not_stopped;
-use crate::util::{api, exitcode};
 use crate::util::{local_cmd, node_rpc};
-use crate::{color, docs, fmt_log, fmt_ok};
-use crate::{shutdown, CommandGlobalOpts, Result};
+use crate::{docs, CommandGlobalOpts, Result};
+
+mod background;
+mod foreground;
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
@@ -135,7 +114,10 @@ impl Default for CreateCommand {
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) {
         if self.foreground {
-            local_cmd(foreground_mode(opts, self));
+            local_cmd(embedded_node_that_is_not_stopped(
+                foreground_mode,
+                (opts, self),
+            ));
         } else {
             node_rpc(background_mode, (opts, self))
         }
@@ -177,306 +159,16 @@ pub fn parse_launch_config(config_or_path: &str) -> Result<Config> {
     }
 }
 
-// Create a new node running in the background (i.e. another, new OS process)
-pub(crate) async fn background_mode(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> miette::Result<()> {
-    guard_node_is_not_already_running(&opts, &cmd).await;
-
-    let node_name = cmd.node_name.clone();
-    debug!("create node in background mode");
-
-    opts.terminal.write_line(&fmt_log!(
-        "Creating Node {}...\n",
-        color!(&node_name, OckamColor::PrimaryResource)
-    ))?;
-
-    if cmd.child_process {
-        return Err(miette!(
-            "Cannot create a background node from background node"
-        ));
-    }
-
-    let is_finished: Mutex<bool> = Mutex::new(false);
-
-    let send_req = async {
-        spawn_background_node(&opts, cmd.clone()).await?;
-        let mut node = BackgroundNode::create_to_node(&ctx, &opts.state, &node_name).await?;
-        let is_node_up = is_node_up(&ctx, &mut node, true).await?;
-        *is_finished.lock().await = true;
-        Ok(is_node_up)
-    };
-
-    let output_messages = vec![
-        format!("Creating node..."),
-        format!("Starting services..."),
-        format!("Loading any pre-trusted identities..."),
-    ];
-
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (_response, _) = try_join!(send_req, progress_output)?;
-
-    opts.clone()
-        .terminal
-        .stdout()
-        .plain(
-            fmt_ok!(
-                "Node {} created successfully\n\n",
-                node_name.color(OckamColor::PrimaryResource.color())
-            ) + &fmt_log!("To see more details on this node, run:\n")
-                + &fmt_log!(
-                    "{}",
-                    "ockam node show".color(OckamColor::PrimaryResource.color())
-                ),
-        )
-        .write_line()?;
-
-    Ok(())
-}
-
-// Create a new node in the foreground (i.e. in this OS process)
-fn foreground_mode(opts: CommandGlobalOpts, cmd: CreateCommand) -> miette::Result<()> {
-    embedded_node_that_is_not_stopped(run_foreground_node, (opts, cmd))?;
-    Ok(())
-}
-
-async fn run_foreground_node(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> miette::Result<()> {
-    guard_node_is_not_already_running(&opts, &cmd).await;
-
-    let node_name = cmd.node_name.clone();
-    debug!("create node {node_name} in foreground mode");
-
-    if opts
-        .state
-        .get_node(&node_name)
-        .await
-        .ok()
-        .map(|n| n.is_running())
-        .unwrap_or(false)
-    {
-        eprintln!("{:?}", miette!("Node {} is already running", &node_name));
-        std::process::exit(exitcode::SOFTWARE);
-    };
-
-    let node_info = opts
-        .state
-        .create_node_with_optional_values(
-            &node_name,
-            &cmd.identity,
-            &cmd.trust_context_opts.project_name,
-        )
-        .await?;
-    debug!("created node {node_info:?}");
-
-    let named_trust_context = opts
-        .state
-        .retrieve_trust_context(
-            &cmd.trust_context_opts.trust_context,
-            &cmd.trust_context_opts.project_name,
-            &cmd.authority_identity().await?,
-            &cmd.credential,
-        )
-        .await?;
-
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-    let options = TcpListenerOptions::new();
-    let listener = tcp
-        .listen(&cmd.tcp_listener_address, options)
-        .await
-        .into_diagnostic()?;
-
-    opts.state
-        .set_tcp_listener_address(&node_name, listener.socket_address().to_string())
-        .await?;
-    debug!(
-        "set the node {node_name} listener address to {:?}",
-        listener.socket_address()
-    );
-
-    let pre_trusted_identities = load_pre_trusted_identities(&cmd)?;
-
-    let node_man = InMemoryNode::new(
-        &ctx,
-        NodeManagerGeneralOptions::new(
-            opts.state.clone(),
-            node_name.clone(),
-            pre_trusted_identities,
-            cmd.launch_config.is_none(),
-            true,
-        ),
-        NodeManagerTransportOptions::new(
-            listener.flow_control_id().clone(),
-            tcp.async_try_clone().await.into_diagnostic()?,
-        ),
-        NodeManagerTrustOptions::new(named_trust_context),
-    )
-    .await
-    .into_diagnostic()?;
-    let node_manager_worker = NodeManagerWorker::new(Arc::new(node_man));
-
-    ctx.flow_controls()
-        .add_consumer(NODEMANAGER_ADDR, listener.flow_control_id());
-    ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
-        .await
-        .into_diagnostic()?;
-
-    if let Some(config) = &cmd.launch_config {
-        if start_services(&ctx, config).await.is_err() {
-            //TODO: Process should terminate on any error during its setup phase,
-            //      not just during the start_services.
-            //TODO: This sleep here is a workaround on some orchestrated environment,
-            //      the lmdb db, that is used for policy storage, fails to be re-opened
-            //      if it's still opened from another docker container, where they share
-            //      the same pid. By sleeping for a while we let this container be promoted
-            //      and the other being terminated, so when restarted it works.  This is
-            //      FAR from ideal.
-            sleep(Duration::from_secs(10)).await;
-            ctx.stop().await.into_diagnostic()?;
-            return Err(miette!("Failed to start services"));
-        }
-    }
-
-    // Create a channel for communicating back to the main thread
-    let (tx, mut rx) = tokio::sync::mpsc::channel(2);
-    shutdown::wait(
-        opts.terminal.clone(),
-        cmd.exit_on_eof,
-        opts.global_args.quiet,
-        tx,
-        &mut rx,
-    )
-    .await?;
-
-    // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
-    opts.state.stop_node(&node_name, true).await?;
-    ctx.stop().await.into_diagnostic()?;
-    opts.terminal
-        .write_line(format!("{}Node stopped successfully", "✔︎".light_green()).as_str())
-        .unwrap();
-
-    Ok(())
-}
-
-pub fn load_pre_trusted_identities(cmd: &CreateCommand) -> Result<Option<PreTrustedIdentities>> {
-    let command = cmd.clone();
-    let pre_trusted_identities = match (
-        command.trusted_identities,
-        command.trusted_identities_file,
-        command.reload_from_trusted_identities_file,
-    ) {
-        (Some(val), _, _) => Some(PreTrustedIdentities::new_from_string(&val)?),
-        (_, Some(val), _) => Some(PreTrustedIdentities::new_from_disk(val, false)?),
-        (_, _, Some(val)) => Some(PreTrustedIdentities::new_from_disk(val, true)?),
-        _ => None,
-    };
-    Ok(pre_trusted_identities)
-}
-
-async fn start_services(ctx: &Context, cfg: &Config) -> miette::Result<()> {
-    let config = {
-        if let Some(sc) = &cfg.startup_services {
-            sc.clone()
-        } else {
-            return Ok(());
-        }
-    };
-
-    if let Some(cfg) = config.secure_channel_listener {
-        if !cfg.disabled {
-            let adr = Address::from((LOCAL, cfg.address));
-            let ids = cfg.authorized_identifiers;
-            let identity = cfg.identity;
-            println!("starting secure-channel listener ...");
-            secure_channel_listener::create_listener(ctx, adr, ids, identity, route![]).await?;
-        }
-    }
-    if let Some(cfg) = config.authenticator {
-        if !cfg.disabled {
-            println!("starting authenticator service ...");
-            let req = api::start_authenticator_service(&cfg.address, &cfg.project);
-            send_req_to_node_manager(ctx, req).await?;
-        }
-    }
-    if let Some(cfg) = config.okta_identity_provider {
-        if !cfg.disabled {
-            println!("starting okta identity provider service ...");
-            let req = api::start_okta_service(&cfg);
-            send_req_to_node_manager(ctx, req).await?;
-        }
-    }
-
-    Ok(())
-}
-
-async fn send_req_to_node_manager<T>(ctx: &Context, req: Request<T>) -> Result<()>
-where
-    T: Encode<()>,
-{
-    let buf: Vec<u8> = ctx
-        .send_and_receive(NODEMANAGER_ADDR, req.to_vec()?)
-        .await?;
-    let mut dec = Decoder::new(&buf);
-    let hdr = dec.decode::<ResponseHeader>()?;
-    if hdr.status() != Some(Status::Ok) {
-        return Err(miette!("Request failed with status: {:?}", hdr.status()).into());
-    }
-    Ok(())
-}
-
-pub async fn spawn_background_node(
+pub async fn guard_node_is_not_already_running(
     opts: &CommandGlobalOpts,
-    cmd: CreateCommand,
+    cmd: &CreateCommand,
 ) -> miette::Result<()> {
-    let trust_context = match cmd.trust_context_opts.trust_context.clone() {
-        Some(tc) => {
-            let trust_context = opts.state.get_trust_context(&tc).await?;
-            Some(trust_context)
-        }
-        None => None,
-    };
-
-    // Construct the arguments list and re-execute the ockam
-    // CLI in foreground mode to start the newly created node
-    info!("spawing a new node {}", &cmd.node_name);
-    spawn_node(
-        opts,
-        &cmd.node_name,
-        &cmd.identity,
-        &cmd.vault,
-        &cmd.tcp_listener_address,
-        cmd.trusted_identities.as_ref(),
-        cmd.trusted_identities_file.as_ref(),
-        cmd.reload_from_trusted_identities_file.as_ref(),
-        cmd.launch_config
-            .as_ref()
-            .map(|config| serde_json::to_string(config).unwrap()),
-        cmd.credential.as_ref(),
-        trust_context.as_ref(),
-        cmd.trust_context_opts.project_name.clone(),
-        cmd.logging_to_file(),
-    )
-    .await?;
-
-    Ok(())
-}
-
-async fn guard_node_is_not_already_running(opts: &CommandGlobalOpts, cmd: &CreateCommand) {
     if !cmd.child_process {
         if let Ok(node) = opts.state.get_node(&cmd.node_name).await {
             if node.is_running() {
-                eprintln!(
-                    "{:?}",
-                    miette!("Node {} is already running", &cmd.node_name)
-                );
-                std::process::exit(exitcode::SOFTWARE);
+                return Err(miette!("Node {} is already running", &cmd.node_name));
             }
         }
     }
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -1,0 +1,113 @@
+use colorful::Colorful;
+use miette::miette;
+use tokio::sync::Mutex;
+use tokio::try_join;
+use tracing::{debug, info};
+
+use ockam::Context;
+use ockam_api::nodes::BackgroundNode;
+
+use crate::node::show::is_node_up;
+use crate::node::util::spawn_node;
+use crate::node::{guard_node_is_not_already_running, CreateCommand};
+use crate::terminal::OckamColor;
+use crate::CommandGlobalOpts;
+use crate::{color, fmt_log, fmt_ok};
+
+// Create a new node running in the background (i.e. another, new OS process)
+pub(crate) async fn background_mode(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+) -> miette::Result<()> {
+    guard_node_is_not_already_running(&opts, &cmd).await?;
+
+    let node_name = cmd.node_name.clone();
+    debug!("create node in background mode");
+
+    opts.terminal.write_line(&fmt_log!(
+        "Creating Node {}...\n",
+        color!(&node_name, OckamColor::PrimaryResource)
+    ))?;
+
+    if cmd.child_process {
+        return Err(miette!(
+            "Cannot create a background node from another background node"
+        ));
+    }
+
+    let is_finished: Mutex<bool> = Mutex::new(false);
+
+    let send_req = async {
+        spawn_background_node(&opts, cmd.clone()).await?;
+        let mut node = BackgroundNode::create_to_node(&ctx, &opts.state, &node_name).await?;
+        let is_node_up = is_node_up(&ctx, &mut node, true).await?;
+        *is_finished.lock().await = true;
+        Ok(is_node_up)
+    };
+
+    let output_messages = vec![
+        format!("Creating node..."),
+        format!("Starting services..."),
+        format!("Loading any pre-trusted identities..."),
+    ];
+
+    let progress_output = opts
+        .terminal
+        .progress_output(&output_messages, &is_finished);
+
+    let (_response, _) = try_join!(send_req, progress_output)?;
+
+    opts.clone()
+        .terminal
+        .stdout()
+        .plain(
+            fmt_ok!(
+                "Node {} created successfully\n\n",
+                node_name.color(OckamColor::PrimaryResource.color())
+            ) + &fmt_log!("To see more details on this node, run:\n")
+                + &fmt_log!(
+                    "{}",
+                    "ockam node show".color(OckamColor::PrimaryResource.color())
+                ),
+        )
+        .write_line()?;
+
+    Ok(())
+}
+
+pub async fn spawn_background_node(
+    opts: &CommandGlobalOpts,
+    cmd: CreateCommand,
+) -> miette::Result<()> {
+    let trust_context = match cmd.trust_context_opts.trust_context.clone() {
+        Some(tc) => {
+            let trust_context = opts.state.get_trust_context(&tc).await?;
+            Some(trust_context)
+        }
+        None => None,
+    };
+
+    // Construct the arguments list and re-execute the ockam
+    // CLI in foreground mode to start the newly created node
+    info!("spawning a new node {}", &cmd.node_name);
+    spawn_node(
+        opts,
+        &cmd.node_name,
+        &cmd.identity,
+        &cmd.vault,
+        &cmd.tcp_listener_address,
+        cmd.trusted_identities.as_ref(),
+        cmd.trusted_identities_file.as_ref(),
+        cmd.reload_from_trusted_identities_file.as_ref(),
+        cmd.launch_config
+            .as_ref()
+            .map(|config| serde_json::to_string(config).unwrap()),
+        cmd.credential.as_ref(),
+        trust_context.as_ref(),
+        cmd.trust_context_opts.project_name.clone(),
+        cmd.logging_to_file(),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -1,0 +1,213 @@
+use std::sync::Arc;
+
+use colorful::Colorful;
+use miette::{miette, IntoDiagnostic};
+use minicbor::{Decoder, Encode};
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+use ockam::{Address, AsyncTryClone, TcpListenerOptions};
+use ockam::{Context, TcpTransport};
+use ockam_api::nodes::service::NodeManagerTrustOptions;
+use ockam_api::nodes::InMemoryNode;
+use ockam_api::{
+    bootstrapped_identities_store::PreTrustedIdentities,
+    nodes::{
+        service::{NodeManagerGeneralOptions, NodeManagerTransportOptions},
+        NodeManagerWorker, NODEMANAGER_ADDR,
+    },
+};
+use ockam_core::api::{Request, ResponseHeader, Status};
+use ockam_core::{route, LOCAL};
+
+use crate::fmt_ok;
+use crate::node::{guard_node_is_not_already_running, CreateCommand};
+use crate::secure_channel::listener::create as secure_channel_listener;
+use crate::service::config::Config;
+use crate::util::api;
+use crate::{shutdown, CommandGlobalOpts, Result};
+
+pub(super) async fn foreground_mode(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, CreateCommand),
+) -> miette::Result<()> {
+    guard_node_is_not_already_running(&opts, &cmd).await?;
+
+    let node_name = cmd.node_name.clone();
+    debug!("create node {node_name} in foreground mode");
+
+    if opts
+        .state
+        .get_node(&node_name)
+        .await
+        .ok()
+        .map(|n| n.is_running())
+        .unwrap_or(false)
+    {
+        return Err(miette!("Node {} is already running", &node_name));
+    };
+
+    let node_info = opts
+        .state
+        .create_node_with_optional_values(
+            &node_name,
+            &cmd.identity,
+            &cmd.trust_context_opts.project_name,
+        )
+        .await?;
+    debug!("created node {node_info:?}");
+
+    let named_trust_context = opts
+        .state
+        .retrieve_trust_context(
+            &cmd.trust_context_opts.trust_context,
+            &cmd.trust_context_opts.project_name,
+            &cmd.authority_identity().await?,
+            &cmd.credential,
+        )
+        .await?;
+
+    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
+    let options = TcpListenerOptions::new();
+    let listener = tcp
+        .listen(&cmd.tcp_listener_address, options)
+        .await
+        .into_diagnostic()?;
+
+    opts.state
+        .set_tcp_listener_address(&node_name, listener.socket_address().to_string())
+        .await?;
+    debug!(
+        "set the node {node_name} listener address to {:?}",
+        listener.socket_address()
+    );
+
+    let pre_trusted_identities = load_pre_trusted_identities(&cmd)?;
+
+    let node_man = InMemoryNode::new(
+        &ctx,
+        NodeManagerGeneralOptions::new(
+            opts.state.clone(),
+            node_name.clone(),
+            pre_trusted_identities,
+            cmd.launch_config.is_none(),
+            true,
+        ),
+        NodeManagerTransportOptions::new(
+            listener.flow_control_id().clone(),
+            tcp.async_try_clone().await.into_diagnostic()?,
+        ),
+        NodeManagerTrustOptions::new(named_trust_context),
+    )
+    .await
+    .into_diagnostic()?;
+    let node_manager_worker = NodeManagerWorker::new(Arc::new(node_man));
+
+    ctx.flow_controls()
+        .add_consumer(NODEMANAGER_ADDR, listener.flow_control_id());
+    ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
+        .await
+        .into_diagnostic()?;
+
+    if let Some(config) = &cmd.launch_config {
+        if start_services(&ctx, config).await.is_err() {
+            //TODO: Process should terminate on any error during its setup phase,
+            //      not just during the start_services.
+            //TODO: This sleep here is a workaround on some orchestrated environment,
+            //      the lmdb db, that is used for policy storage, fails to be re-opened
+            //      if it's still opened from another docker container, where they share
+            //      the same pid. By sleeping for a while we let this container be promoted
+            //      and the other being terminated, so when restarted it works.  This is
+            //      FAR from ideal.
+            sleep(Duration::from_secs(10)).await;
+            ctx.stop().await.into_diagnostic()?;
+            return Err(miette!("Failed to start services"));
+        }
+    }
+
+    // Create a channel for communicating back to the main thread
+    let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+    shutdown::wait(
+        opts.terminal.clone(),
+        cmd.exit_on_eof,
+        opts.global_args.quiet,
+        tx,
+        &mut rx,
+    )
+    .await?;
+
+    // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
+    opts.state.stop_node(&node_name, true).await?;
+    ctx.stop().await.into_diagnostic()?;
+    opts.terminal
+        .write_line(fmt_ok!("Node stopped successfully"))
+        .unwrap();
+
+    Ok(())
+}
+
+pub fn load_pre_trusted_identities(cmd: &CreateCommand) -> Result<Option<PreTrustedIdentities>> {
+    let command = cmd.clone();
+    let pre_trusted_identities = match (
+        command.trusted_identities,
+        command.trusted_identities_file,
+        command.reload_from_trusted_identities_file,
+    ) {
+        (Some(val), _, _) => Some(PreTrustedIdentities::new_from_string(&val)?),
+        (_, Some(val), _) => Some(PreTrustedIdentities::new_from_disk(val, false)?),
+        (_, _, Some(val)) => Some(PreTrustedIdentities::new_from_disk(val, true)?),
+        _ => None,
+    };
+    Ok(pre_trusted_identities)
+}
+
+async fn start_services(ctx: &Context, cfg: &Config) -> miette::Result<()> {
+    let config = {
+        if let Some(sc) = &cfg.startup_services {
+            sc.clone()
+        } else {
+            return Ok(());
+        }
+    };
+
+    if let Some(cfg) = config.secure_channel_listener {
+        if !cfg.disabled {
+            let adr = Address::from((LOCAL, cfg.address));
+            let ids = cfg.authorized_identifiers;
+            let identity = cfg.identity;
+            println!("starting secure-channel listener ...");
+            secure_channel_listener::create_listener(ctx, adr, ids, identity, route![]).await?;
+        }
+    }
+    if let Some(cfg) = config.authenticator {
+        if !cfg.disabled {
+            println!("starting authenticator service ...");
+            let req = api::start_authenticator_service(&cfg.address, &cfg.project);
+            send_req_to_node_manager(ctx, req).await?;
+        }
+    }
+    if let Some(cfg) = config.okta_identity_provider {
+        if !cfg.disabled {
+            println!("starting okta identity provider service ...");
+            let req = api::start_okta_service(&cfg);
+            send_req_to_node_manager(ctx, req).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn send_req_to_node_manager<T>(ctx: &Context, req: Request<T>) -> Result<()>
+where
+    T: Encode<()>,
+{
+    let buf: Vec<u8> = ctx
+        .send_and_receive(NODEMANAGER_ADDR, req.to_vec()?)
+        .await?;
+    let mut dec = Decoder::new(&buf);
+    let hdr = dec.decode::<ResponseHeader>()?;
+    if hdr.status() != Some(Status::Ok) {
+        return Err(miette!("Request failed with status: {:?}", hdr.status()).into());
+    }
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/reset.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/reset.bats
@@ -24,8 +24,10 @@ teardown() {
   run_success touch "$OCKAM_HOME"/bin/ockam
 
   # create some state in the OCKAM_HOME directory
-  run_success "$OCKAM" node create
+  refute_output --partial "nodes"
+  QUIET=0 "$OCKAM" node create -vv
   run_success ls "$OCKAM_HOME"
+  assert_output --partial "database.sqlite3"
   assert_output --partial "nodes"
 
   # reset the OCKAM_HOME directory


### PR DESCRIPTION
It also:
- Fixes the `node logs` command to return the current log file
- Remove the `stderr` log file, which is not used anymore 

Full [CI tests](https://github.com/build-trust/ockam-artifacts/actions/runs/7194879891)