### PR TITLE
feat(rust): set a 30 seconds timeout for background node calls by default

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node.rs
@@ -65,7 +65,7 @@ impl BackgroundNode {
             cli_state: cli_state.clone(),
             node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
-            timeout: None,
+            timeout: Some(Duration::from_secs(30)),
             tcp_transport: Arc::new(tcp_transport.async_try_clone().await.into_diagnostic()?),
         })
     }


### PR DESCRIPTION
Fixes #7123.

This PR sets a default timeout on the client used to make calls to background nodes. 
This makes sure that we don't stay blocked if a background node does not respond.  