### PR TITLE
feat(swift): make the reset menu item always visible

### DIFF
--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -204,15 +204,15 @@ struct MainView: View {
                                     )
                                     bringInFront()
                                 })
-                            ClickableMenuEntry(
-                                text: "Reset", icon: "arrow.counterclockwise",
-                                action: {
-                                    restartCurrentProcess()
-                                })
                             Divider()
                                 .padding([.top,.bottom], VerticalSpacingUnit)
                                 .padding(.horizontal, HorizontalSpacingUnit)
                         }
+                        ClickableMenuEntry(
+                            text: "Reset", icon: "arrow.counterclockwise",
+                            action: {
+                                restartCurrentProcess()
+                            })
                         ClickableMenuEntry(
                             text: "Quit Ockam", icon: "power", shortcut: "⌘Q",
                             action: {


### PR DESCRIPTION
<img width="313" alt="Screenshot 2023-12-18 at 4 40 56 AM" src="https://github.com/build-trust/ockam/assets/159583/55d04af0-f10f-4b13-a1d6-7b33d305f76c">
