### PR TITLE
refactor binary release workflow

### DIFF
--- a/.github/workflows/release-publish-crates.yml
+++ b/.github/workflows/release-publish-crates.yml
@@ -11,7 +11,7 @@ on:
         required: false
       release_branch:
         description: Release Branch Where Recent Bump Occurred
-        required: true
+        required: false
       ockam_publish_recent_failure:
         description: Indicate A Recent Failure
         type: choice
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.release_branch }}
 
       - name: Publish Ockam Crates
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "ockam_app_lib"
-version = "0.15.0"
+version = "0.111.0"
 dependencies = [
  "cbindgen",
  "duct",

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ockam_app_lib"
-version = "0.15.0"
+version = "0.111.0"
 authors = ["Ockam Developers"]
 categories = [
   "cryptography",

--- a/implementations/rust/ockam/ockam_app_lib/README.md
+++ b/implementations/rust/ockam/ockam_app_lib/README.md
@@ -21,7 +21,7 @@ Add this to your `Cargo.toml`:
 
 ```
 [dependencies]
-ockam_app_lib = "0.15.0"
+ockam_app_lib = "0.111.0"
 ```
 
 ## License

--- a/tools/scripts/release/crates-to-publish.sh
+++ b/tools/scripts/release/crates-to-publish.sh
@@ -38,11 +38,21 @@ for crate in implementations/rust/ockam/*; do
     continue
   fi
 
+  # Check if the src file is updated, if it isn't check if the Cargo.toml file is updated.
   if git diff "$last_git_tag" --quiet --name-status -- "$crate"/src; then
     git diff "$last_git_tag" --quiet --name-status -- "$crate"/Cargo.toml || updated_crates="$updated_crates $crate"
   else
     updated_crates="$updated_crates $crate"
   fi
+done
+
+crates_that_must_be_bumped="ockam ockam_app_lib ockam_command"
+for crate in ${crates_that_must_be_bumped[@]}; do
+  if [[ $updated_crates == *"$crate"* ]]; then
+    continue
+  fi
+
+  updated_crates="$updated_crates $crate"
 done
 
 IFS=" " read -r -a updated_crates <<<"${updated_crates[*]}"

--- a/tools/scripts/release/crates-to-publish.sh
+++ b/tools/scripts/release/crates-to-publish.sh
@@ -46,12 +46,13 @@ for crate in implementations/rust/ockam/*; do
   fi
 done
 
-crates_that_must_be_bumped="ockam ockam_app_lib ockam_command"
-for crate in ${crates_that_must_be_bumped[@]}; do
+crates_that_must_be_bumped=("ockam" "ockam_app_lib" "ockam_command")
+for crate in "${crates_that_must_be_bumped[@]}"; do
   if [[ $updated_crates == *"$crate"* ]]; then
     continue
   fi
 
+  echo "$crate wasn't updated but is intended to be released"
   updated_crates="$updated_crates $crate"
 done
 

--- a/tools/scripts/release/crates-to-publish.sh
+++ b/tools/scripts/release/crates-to-publish.sh
@@ -53,7 +53,7 @@ for crate in "${crates_that_must_be_bumped[@]}"; do
   fi
 
   echo "$crate wasn't updated but is intended to be released"
-  updated_crates="$updated_crates $crate"
+  updated_crates="$updated_crates implementations/rust/ockam/$crate"
 done
 
 IFS=" " read -r -a updated_crates <<<"${updated_crates[*]}"

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -105,11 +105,11 @@ function watch_workflow_progress() {
   set -e
   repository="$1"
   workflow_file_name="$2"
-  branch="$3"
+  repo_branch="$3"
 
   echo "Waiting for workflow to be in progress before kickstarting gh run watch"
   while true; do
-    run_status=$(gh run list --workflow="$workflow_file_name" -b "$branch" -u "$GITHUB_USERNAME" -L 1 -R ${OWNER}/${repository} --json databaseId,status)
+    run_status=$(gh run list --workflow="$workflow_file_name" -b "$repo_branch" -u "$GITHUB_USERNAME" -L 1 -R ${OWNER}/${repository} --json databaseId,status)
     status=$(jq -r '.[0].status' <<<$run_status)
     run_id=$(jq -r '.[0].databaseId' <<<$run_status)
 
@@ -124,11 +124,11 @@ function approve_and_watch_workflow_progress() {
   set -e
   repository="$1"
   workflow_file_name="$2"
-  branch="$3"
+  repo_branch="$3"
 
-  run_id=$(gh run list --workflow="$workflow_file_name" -b "$branch" -u "$GITHUB_USERNAME" -L 1 -R ${OWNER}/${repository} --json databaseId | jq -r '.[0].databaseId')
+  run_id=$(gh run list --workflow="$workflow_file_name" -b "$repo_branch" -u "$GITHUB_USERNAME" -L 1 -R ${OWNER}/${repository} --json databaseId | jq -r '.[0].databaseId')
   approve_deployment "$repository" "$run_id" &
-  watch_workflow_progress "$repository" "$workflow_file_name"
+  watch_workflow_progress "$repository" "$workflow_file_name" "$repo_branch"
 }
 
 function ockam_bump() {
@@ -147,7 +147,7 @@ function ockam_bump() {
 
   # Merge PR to a new branch
   pr_link=$(gh pr create --title "Ockam Release $(date +'%d-%m-%Y')" --body "Ockam release" \
-    --base "$branch" -H "${release_name}" -R $OWNER/ockam >>$log)
+    --base "$branch" -H "${release_name}" -R $OWNER/ockam)
 
   # Wait for PR to be created
   success_info "Pull request that bumps ockam crates created ${pr_link}, please review and merge pull request to kickstart draft release..."
@@ -346,7 +346,7 @@ if [[ $IS_DRAFT_RELEASE == true ]]; then
   if [[ -z $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE || $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE == false ]]; then
     echo "Releasing Ockam docker image"
     release_ockam_package "$latest_tag_name" "$file_and_sha" false
-    success_info "Ockam package draft release successful...."
+    success_info "Ockam docker package draft release successful...."
   fi
 
   # Homebrew Release

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -374,7 +374,7 @@ fi
 
 # If we are to release to production, we check if all draft release was successful.
 if [[ $IS_DRAFT_RELEASE == false ]]; then
-  success_info "Check if recent draft release was successful...."
+  success_info "Checking if recent draft release was successful...."
 
   # Check if the SHAsum file exists for the released binaries. We generate shasum file
   # after all binaries are released.
@@ -387,15 +387,6 @@ if [[ $IS_DRAFT_RELEASE == false ]]; then
     gh release download "$latest_tag_name" -p "**SHA256SUMS" -R $OWNER/terraform-provider-ockam -O "$(mktemp -d)/sha256sums.txt"
   fi
 
-  # To release crates to crates.io, we need to ensure that there's a bump PR that's open.
-  if [[ -z $SKIP_OCKAM_PACKAGE_RELEASE || $SKIP_OCKAM_PACKAGE_RELEASE == false ]]; then
-    ockam_prs=$(gh api -H "Accept: application/vnd.github+json" /repos/${OWNER}/ockam/pulls)
-    if [[ $ockam_prs != *"Ockam Release"* ]]; then
-      echo "Could not find ockam release PR"
-      exit 1
-    fi
-  fi
-
   # Check if there's an homebrew PR
   if [[ -z $SKIP_OCKAM_HOMEBREW_RELEASE || $SKIP_OCKAM_HOMEBREW_RELEASE == false ]]; then
     ockam_prs=$(gh api -H "Accept: application/vnd.github+json" /repos/${OWNER}/homebrew-ockam/pulls)
@@ -405,8 +396,8 @@ if [[ $IS_DRAFT_RELEASE == false ]]; then
     fi
   fi
 
-  success_info "All draft release asset have been created. /ockam and /homebrew-ockam PRs can be merged now for release."
-  dialog_info "Press enter to start production release"
+  success_info "Recent draft release was successful"
+  dialog_info "Press enter to start final release"
 fi
 
 # Release to production


### PR DESCRIPTION
- Ensure that we can release without needing a -ff merge to retain git commit SHA
- We can now release crates even where there are no changes to the ockam, ockam_command, and ockam_app_lib crate
- We now use same version of ockam, ockam_app_lib and ockam_command

How release workflow runs
- Create a PR that bumps the version of our crates, after PR is created, script waits for PR to be merged
- PR merged and script automatically detects and start release from the develop branch