### PR TITLE
use full path to check if crates that must be bumped is in listed

### DIFF
--- a/tools/scripts/release/crates-to-publish.sh
+++ b/tools/scripts/release/crates-to-publish.sh
@@ -48,7 +48,7 @@ done
 
 crates_that_must_be_bumped=("ockam" "ockam_app_lib" "ockam_command")
 for crate in "${crates_that_must_be_bumped[@]}"; do
-  if [[ $updated_crates == *"$crate"* ]]; then
+  if [[ $updated_crates == *"implementations/rust/ockam/$crate"* ]]; then
     continue
   fi
 


### PR DESCRIPTION
This uses the full patch of crate directory to check if a crate the must be bumped exists