### PR TITLE
fix(rust): make a case-insensitive comparison of email addresses for a project administrator

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
@@ -99,7 +99,7 @@ impl Projects for InMemoryNode {
                     // If the project has no admin role, the name is set to the project id
                     // to avoid collisions with other projects with the same name that
                     // belong to other spaces.
-                    if !project.has_admin_role(&user.email) {
+                    if !project.is_admin(&user) {
                         project.name = project.id.clone();
                     }
                     self.cli_state.store_project(project).await?
@@ -114,7 +114,7 @@ impl Projects for InMemoryNode {
             .get_projects()
             .await?
             .into_iter()
-            .filter(|p| p.has_admin_role(&user.email))
+            .filter(|p| p.is_admin(&user))
             .collect::<Vec<_>>())
     }
 

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -203,14 +203,14 @@ impl AppState {
 
         let state = self.state().await;
 
-        let user_email = state.get_default_user().await?.email;
+        let user = state.get_default_user().await?;
         if let Some(my_project) = state
             .get_projects()
             .await?
             .iter()
             .filter(|p|
                 // filter out projects that are not owned by the user
-                p.has_admin_role(&user_email))
+                p.is_admin(&user))
             .find(|p| p.id == ticket_project.id)
         {
             debug!(


### PR DESCRIPTION
This is at least a stop-gap fix to make sure we return the user projects when their email address contains a capital letter.

Fixes #7171 