### PR TITLE
App - handling email validation as en enrollment state

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/api/state.rs
@@ -15,6 +15,7 @@ pub enum OrchestratorStatus {
     Connected,
 
     WaitingForToken,
+    WaitingForEmailValidation,
     RetrievingSpace,
     RetrievingProject,
 }

--- a/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
@@ -153,7 +153,7 @@ impl OidcServiceExt for OidcService {
                         user_info.email
                     ))
                 }
-                sleep(Duration::from_secs(5)).await;
+                sleep(Duration::from_secs(10)).await;
             }
         }
     }

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.h
@@ -19,6 +19,7 @@ typedef enum C_OrchestratorStatus {
   Connecting,
   Connected,
   WaitingForToken,
+  WaitingForEmailValidation,
   RetrievingSpace,
   RetrievingProject,
 } C_OrchestratorStatus;

--- a/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Bridge.swift
@@ -183,6 +183,7 @@ enum OrchestratorStatus: Int {
     case Connecting
     case Connected
     case WaitingForToken
+    case WaitingForEmailValidation
     case RetrievingSpace
     case RetrievingProject
 }

--- a/implementations/swift/ockam/ockam_app/Ockam/EnrollmentBlock.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/EnrollmentBlock.swift
@@ -72,7 +72,8 @@ Your friends will have access to it on their **localhost**!
                     EnrollmentStatus(status: $appState.orchestrator_status)
                         .padding(.vertical, VerticalSpacingUnit*2)
                     
-                    if appState.orchestrator_status == OrchestratorStatus.WaitingForToken {
+                    if appState.orchestrator_status == OrchestratorStatus.WaitingForToken ||
+                        appState.orchestrator_status == OrchestratorStatus.WaitingForEmailValidation {
                         Button(action: {
                             restartCurrentProcess()
                         }) {

--- a/implementations/swift/ockam/ockam_app/Ockam/EnrollmentStatus.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/EnrollmentStatus.swift
@@ -11,6 +11,8 @@ struct EnrollmentStatus: View {
             case .WaitingForToken:
                 Text("Opened account.ockam.io")
                 Text("Please finish enrolling in your browser.").font(.caption)
+            case .WaitingForEmailValidation:
+                Text("We’ve sent you a verification email.\n\nPlease check your inbox and click the included link so we can verify your email address.").padding(.bottom, VerticalSpacingUnit*2)
             case .RetrievingSpace:
                 Text("Fetching your spaces...")
             case .RetrievingProject:
@@ -33,6 +35,7 @@ struct EnrollmentStatus_Previews: PreviewProvider {
             EnrollmentStatus(status: .constant(.Connected))
             EnrollmentStatus(status: .constant(.Connecting))
             EnrollmentStatus(status: .constant(.WaitingForToken))
+            EnrollmentStatus(status: .constant(.WaitingForEmailValidation))
             EnrollmentStatus(status: .constant(.RetrievingSpace))
             EnrollmentStatus(status: .constant(.RetrievingProject))
         }


### PR DESCRIPTION
Added `WaitForEmailValidation` as an enrollment phase, with its relative view during enrollment.
Removed email validation notification.

Waiting for 10 seconds instead of 5 to keep the API rate low enough to avoid failure, this is valid for both command and portals.