### PR TITLE
fix(rust): fix a typo in the delete service window

### DIFF
--- a/implementations/swift/ockam/ockam_app/Ockam/DeleteIncomingService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/DeleteIncomingService.swift
@@ -8,7 +8,7 @@ struct DeleteIncomingPortalView: View {
         VStack {
             Spacer()
             Text(
-                "This will permanently delete '\(service.sourceName)'. If you need access to it in the furture, your friend would have to invite you again." +
+                "This will permanently delete '\(service.sourceName)'. If you need access to it in the future, your friend would have to invite you again." +
                 "\n\nAre you sure you want to delete: '\(service.sourceName)'?"
             )
             .padding()


### PR DESCRIPTION
`s/furture/future`
