### PR TITLE
docs: fix the make swift_build command

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -102,14 +102,14 @@ runs:
           brew install create-dmg
 
           if [[ ${{ inputs.target }} == *x86_64* ]]; then
-            make swift_xcode_signed_build \
+            make swift_xcode_build_signed \
               DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}" \
               PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER}" \
               CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}" \
               OTHER_CODE_SIGN_FLAGS="--keychain \"${keychain_path}\"" \
               ARCH=x86_64
           else
-            make swift_xcode_signed_build \
+            make swift_xcode_build_signed \
               DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}" \
               PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER}" \
               CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}" \

--- a/implementations/swift/Makefile
+++ b/implementations/swift/Makefile
@@ -1,25 +1,53 @@
 ROOT_DIR := $(realpath $(dir $(firstword $(MAKEFILE_LIST)))/../..)
 
-build: ockam_app_lib
-    # the xcode project expect the ockam executable to be found in the release directory
-	cp $(ROOT_DIR)/target/debug/ockam $(ROOT_DIR)/target/debug/release
-	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Debug -archivePath build/Ockam.xcarchive
-	@echo "Build complete.  See build/Ockam.xcarchive for the built app."
-	@echo "To execute run: build/Ockam.xcarchive/Products/Applications/Portals,\ by\ Ockam.app/Contents/MacOS/Portals,\ by\ Ockam"
-build_release: ockam_app_lib_release xcode_build
-xcode_build:
-	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Release -archivePath build/Ockam.xcarchive
-	@echo "Build complete.  See build/Ockam.xcarchive for the built app."
-	@echo "To execute run: build/Ockam.xcarchive/Products/Applications/Portals,\ by\ Ockam.app/Contents/MacOS/Portals,\ by\ Ockam"
-xcode_signed_build:
-	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Release -archivePath build/Ockam.xcarchive -arch $(ARCH)  CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}"  PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER}" DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}"
-ockam_app_lib_release:
-	$(MAKE) -f ../rust/Makefile build_release
-ockam_command_release:
-	$(MAKE) -f ../rust/Makefile build_release_ockam_command
-ockam_app_lib:
+# delete the swift build artifacts
+clean:
+	rm -rf "build/"
+
+# delete the swift build artifacts and the ockam command + ockam_app_lib artifacts
+very_clean: clean
+	$(MAKE) -f ../rust/Makefile clean
+
+# build the ockam command line application + ockam_app_lib crate in Debug mode
+build_ockam:
 	$(MAKE) -f ../rust/Makefile build
-package: ockam_command_release build_release package_only
+
+# build the ockam command line application + ockam_app_lib crate in Release mode
+build_ockam_release:
+	$(MAKE) -f ../rust/Makefile build_release
+
+# build the Portals application in Debug mode
+build: build_ockam
+	# the xcode project expects the ockam executable to be found in the release directory
+	cp $(ROOT_DIR)/target/debug/ockam $(ROOT_DIR)/target/debug/release
+	make xcode_build_Debug
+
+# build the Portals application in Release mode
+build_release: build_ockam_release
+	make xcode_build_Release
+
+# build the Portals application in Release mode and sign it
+build_signed: build_ockam_release
+	make xcode_build_signed
+
+# build the Swift code in Debug or Release mode
+xcode_build_%:
+	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration $* -archivePath build/Ockam.xcarchive
+	@echo "Build complete.  See build/Ockam.xcarchive for the built app."
+	@echo "To execute run: build/Ockam.xcarchive/Products/Applications/Portals,\ by\ Ockam.app/Contents/MacOS/Portals,\ by\ Ockam"
+
+# build the Swift code in Release mode and sign the application
+xcode_build_signed:
+	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Release -archivePath build/Ockam.xcarchive \
+		-arch $(ARCH) \
+		CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}" \
+		PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER}" \
+		DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}"
+
+# build the Portals application and package it as a .dmg file
+package: build_release package_only
+
+# package the Portals application as a .dmg file
 package_only:
 	xcodebuild -exportArchive -archivePath build/Ockam.xcarchive/ -exportPath build/ -exportOptionsPlist ockam/ockam_app/Ockam/ExportOptions.plist
 	rm -f build/Ockam.dmg
@@ -30,21 +58,23 @@ package_only:
 			--window-size 600 400 --icon-size 128 \
 			--icon "Portals, by Ockam.app" 126 185 --app-drop-link 466 185 \
 			build/Ockam.dmg "build/Portals, by Ockam.app/"
-test:
-	@echo "No test command specified."
+
+# build the Portals application in Debug mode and start it
 run: build
 	"build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
+
+# build the Portals application in Release mode and start it
 run_release: build_release
 	"build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
+
+test:
+	@echo "No test command specified."
 lint:
 	@echo "No lint command specified."
-clean:
-	rm -rf "build/"
-very_clean: clean
-	$(MAKE) -f ../rust/Makefile clean_ockam_app_lib
 
 .PHONY: \
-	build_release build_package \
-	test lint clean very_clean \
-	ockam_app_lib_release ockam_app_lib \
-	ockam_command_release
+	clean very_clean \
+	build build_release build_signed \
+	package package_only \
+	run run_release \
+	test lint \

--- a/implementations/swift/Makefile
+++ b/implementations/swift/Makefile
@@ -1,4 +1,8 @@
+ROOT_DIR := $(realpath $(dir $(firstword $(MAKEFILE_LIST)))/../..)
+
 build: ockam_app_lib
+    # the xcode project expect the ockam executable to be found in the release directory
+	cp $(ROOT_DIR)/target/debug/ockam $(ROOT_DIR)/target/debug/release
 	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Debug -archivePath build/Ockam.xcarchive
 	@echo "Build complete.  See build/Ockam.xcarchive for the built app."
 	@echo "To execute run: build/Ockam.xcarchive/Products/Applications/Portals,\ by\ Ockam.app/Contents/MacOS/Portals,\ by\ Ockam"
@@ -10,11 +14,11 @@ xcode_build:
 xcode_signed_build:
 	xcodebuild archive -project ockam/ockam_app/Ockam.xcodeproj/ -scheme "Portals, by Ockam" -configuration Release -archivePath build/Ockam.xcarchive -arch $(ARCH)  CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY}"  PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_SPECIFIER}" DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM}"
 ockam_app_lib_release:
-	$(MAKE) -f ../rust/Makefile build_release_ockam_app_lib
+	$(MAKE) -f ../rust/Makefile build_release
 ockam_command_release:
 	$(MAKE) -f ../rust/Makefile build_release_ockam_command
 ockam_app_lib:
-	$(MAKE) -f ../rust/Makefile build_ockam_app_lib
+	$(MAKE) -f ../rust/Makefile build
 package: ockam_command_release build_release package_only
 package_only:
 	xcodebuild -exportArchive -archivePath build/Ockam.xcarchive/ -exportPath build/ -exportOptionsPlist ockam/ockam_app/Ockam/ExportOptions.plist
@@ -28,6 +32,10 @@ package_only:
 			build/Ockam.dmg "build/Portals, by Ockam.app/"
 test:
 	@echo "No test command specified."
+run: build
+	"build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
+run_release: build_release
+	"build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
 lint:
 	@echo "No lint command specified."
 clean:

--- a/implementations/swift/README.md
+++ b/implementations/swift/README.md
@@ -39,7 +39,7 @@ This produces an executable, which can be executed by typing:
 "build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
 ```
 
-## Run 
+## Run
 
 The application can be built _and_ started with:
 ```
@@ -63,7 +63,7 @@ The previous command builds the debug version of the application. To build the r
 make build_release
 ```
 
-(Use `make run_release` to build and run the release version of the application). 
+(Use `make run_release` to build and run the release version of the application).
 
 ## Test
 

--- a/implementations/swift/README.md
+++ b/implementations/swift/README.md
@@ -39,6 +39,13 @@ This produces an executable, which can be executed by typing:
 "build/Ockam.xcarchive/Products/Applications/Portals, by Ockam.app/Contents/MacOS/Portals, by Ockam"
 ```
 
+## Run 
+
+The application can be built _and_ started with:
+```
+make run
+```
+
 ### Clean
 
 The command to clean previously built artifacts is:
@@ -55,6 +62,8 @@ The previous command builds the debug version of the application. To build the r
 ```
 make build_release
 ```
+
+(Use `make run_release` to build and run the release version of the application). 
 
 ## Test
 
@@ -84,6 +93,8 @@ This table presents all the `make` commands, executed from the root directory
  `make swift_build_release`    | build the application in release mode
  `make swift_test`             | not implemented yet
  `make swift_lint`             | not implemented yet
+ `make swift_run`              | build and run the application in debug mode
+ `make swift_run_release`      | build and run the application in release mode
  `make swift_package`          | create a `.dmg` file for the application
 
 ## Get Help


### PR DESCRIPTION
The current `make swift_build` command does not work because `xcodebuild` expects an `ockam` executable in `target/release`, even though we should building the `debug` version.

This PR:

 - makes sure that all the Rust code is recompiled before building the Swift code since we eventually need the `ockam` executable
 - copies the `ockam` executable is copied to the right place in debug mode. It feels like the wrong to do it because I couldn't find a way to change the XCode project to pick either the `debug` or the `release` executable when building the Portals application
 - adds 2 convenience commands `make swift_run` and `make_swift_run_release` to build and start the application at once
