### PR TITLE
refactor(rust): refactor to use typed interfaces to implement commands for relays

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -386,6 +386,17 @@ pub trait Relays {
         alias: Option<String>,
         authorized: Option<Identifier>,
     ) -> miette::Result<RelayInfo>;
+
+    async fn list_relay(
+        &self,
+        ctx: &Context,
+    ) -> miette::Result<Vec<RelayInfo>>;
+
+    async fn delete_relay(
+        &self,
+        ctx: &Context,
+        item_name: &str,
+    ) -> miette::Result<()>;
 }
 
 #[async_trait]
@@ -401,6 +412,14 @@ impl Relays for BackgroundNode {
         let body = CreateRelay::new(address.clone(), alias, at_rust_node, authorized);
         self.ask(ctx, Request::post("/node/forwarder").body(body))
             .await
+    }
+
+    async fn list_relay(&self, ctx: &Context) -> miette::Result<Vec<RelayInfo>> {
+        self.ask(ctx, Request::get("/node/forwarder")).await
+    }
+
+    async fn delete_relay(&self, ctx: &Context, item_name: &str) -> miette::Result<()> {
+        self.tell(ctx, Request::delete(format!("/node/forwarder/{item_name}"))).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -387,16 +387,9 @@ pub trait Relays {
         authorized: Option<Identifier>,
     ) -> miette::Result<RelayInfo>;
 
-    async fn list_relay(
-        &self,
-        ctx: &Context,
-    ) -> miette::Result<Vec<RelayInfo>>;
+    async fn list_relays(&self, ctx: &Context) -> miette::Result<Vec<RelayInfo>>;
 
-    async fn delete_relay(
-        &self,
-        ctx: &Context,
-        item_name: &str,
-    ) -> miette::Result<()>;
+    async fn delete_relay(&self, ctx: &Context, item_name: &str) -> miette::Result<()>;
 }
 
 #[async_trait]
@@ -414,12 +407,13 @@ impl Relays for BackgroundNode {
             .await
     }
 
-    async fn list_relay(&self, ctx: &Context) -> miette::Result<Vec<RelayInfo>> {
+    async fn list_relays(&self, ctx: &Context) -> miette::Result<Vec<RelayInfo>> {
         self.ask(ctx, Request::get("/node/forwarder")).await
     }
 
     async fn delete_relay(&self, ctx: &Context, item_name: &str) -> miette::Result<()> {
-        self.tell(ctx, Request::delete(format!("/node/forwarder/{item_name}"))).await
+        self.tell(ctx, Request::delete(format!("/node/forwarder/{item_name}")))
+            .await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -5,8 +5,8 @@ use miette::miette;
 
 use ockam::Context;
 use ockam_api::address::extract_address_value;
-use ockam_api::nodes::BackgroundNode;
 use ockam_api::nodes::service::relay::Relays;
+use ockam_api::nodes::BackgroundNode;
 
 use crate::relay::util::relay_name_parser;
 use crate::terminal::tui::DeleteCommandTui;
@@ -98,7 +98,7 @@ impl DeleteCommandTui for DeleteTui {
     }
 
     async fn list_items_names(&self) -> miette::Result<Vec<String>> {
-        let relays = self.node.list_relay(&self.ctx).await?;
+        let relays = self.node.list_relays(&self.ctx).await?;
         let names = relays
             .into_iter()
             .map(|i| i.remote_address().to_string())

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -1,15 +1,14 @@
 use clap::Args;
 use colorful::Colorful;
 use miette::IntoDiagnostic;
+use ockam_api::nodes::service::relay::Relays;
 use tokio::sync::Mutex;
 use tokio::try_join;
 use tracing::trace;
 
 use ockam::Context;
 use ockam_api::address::extract_address_value;
-use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::BackgroundNode;
-use ockam_core::api::Request;
 
 use crate::terminal::OckamColor;
 use crate::util::node_rpc;
@@ -47,7 +46,7 @@ async fn run_impl(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relays = async {
-        let relay_infos: Vec<RelayInfo> = node.ask(&ctx, Request::get("/node/forwarder")).await?;
+        let relay_infos = node.list_relay(&ctx).await?;
         *is_finished.lock().await = true;
         Ok(relay_infos)
     };

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -46,7 +46,7 @@ async fn run_impl(
     let is_finished: Mutex<bool> = Mutex::new(false);
 
     let get_relays = async {
-        let relay_infos = node.list_relay(&ctx).await?;
+        let relay_infos = node.list_relays(&ctx).await?;
         *is_finished.lock().await = true;
         Ok(relay_infos)
     };


### PR DESCRIPTION
## Current behavior

Please refer to #6704.

## Proposed changes

Implement the list/delete command for relays using typed interface.

## Test results

To verify my changes, I tested them with `ockam/implementations/rust/ockam/ockam_command/tests/bats/relay.bats`. All tests passed.
```
$ bats relay.bats
relay.bats
 ✓ relay - create relay and send message through it
 ✓ relay - create two relays and list them on a node
 ✓ relay - CRUD

3 tests, 0 failures
```

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.
