### PR TITLE
feat(rust): compute a default port range based on the bootstrap server

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -5,11 +5,10 @@ use clap::{command, Args};
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
-use crate::kafka::util::{rpc, ArgOpts};
+use crate::kafka::util::{make_brokers_port_range, rpc, ArgOpts};
 use crate::{
     kafka::{
-        kafka_consumer_default_addr, kafka_default_consumer_port_range,
-        kafka_default_consumer_server, kafka_default_project_route,
+        kafka_consumer_default_addr, kafka_default_consumer_server, kafka_default_project_route,
     },
     node::NodeOpts,
     util::{node_rpc, parsers::socket_addr_parser},
@@ -31,8 +30,8 @@ pub struct CreateCommand {
     bootstrap_server: SocketAddr,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
-    #[arg(long, default_value_t = kafka_default_consumer_port_range())]
-    brokers_port_range: PortRange,
+    #[arg(long)]
+    brokers_port_range: Option<PortRange>,
     /// The route to the project in ockam orchestrator, expected something like /project/<name>
     #[arg(long, default_value_t = kafka_default_project_route())]
     project_route: MultiAddr,
@@ -46,7 +45,9 @@ impl CreateCommand {
             node_opts: self.node_opts,
             addr: self.addr,
             bootstrap_server: self.bootstrap_server,
-            brokers_port_range: self.brokers_port_range,
+            brokers_port_range: self
+                .brokers_port_range
+                .unwrap_or_else(|| make_brokers_port_range(&self.bootstrap_server)),
             project_route: self.project_route,
         };
         node_rpc(rpc, (opts, arg_opts));

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 
 use crate::kafka::direct::rpc::{start, ArgOpts};
+use crate::kafka::util::make_brokers_port_range;
 use crate::{
     kafka::{
-        kafka_default_consumer_port_range, kafka_default_consumer_server,
-        kafka_default_outlet_server, kafka_direct_default_addr,
+        kafka_default_consumer_server, kafka_default_outlet_server, kafka_direct_default_addr,
     },
     node::NodeOpts,
     util::{node_rpc, parsers::socket_addr_parser},
@@ -31,8 +31,8 @@ pub struct CreateCommand {
     bootstrap_server: SocketAddr,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
-    #[arg(long, default_value_t = kafka_default_consumer_port_range())]
-    brokers_port_range: PortRange,
+    #[arg(long)]
+    brokers_port_range: Option<PortRange>,
     /// The route to another kafka consumer node
     #[arg(long)]
     consumer_route: Option<MultiAddr>,
@@ -46,7 +46,9 @@ impl CreateCommand {
             node_opts: self.node_opts,
             addr: self.addr,
             bind_address: self.bind_address,
-            brokers_port_range: self.brokers_port_range,
+            brokers_port_range: self
+                .brokers_port_range
+                .unwrap_or_else(|| make_brokers_port_range(&self.bootstrap_server)),
             consumer_route: self.consumer_route,
             bootstrap_server: self.bootstrap_server,
         };

--- a/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
@@ -1,5 +1,4 @@
 use ockam_api::nodes::service::default_address::DefaultAddress;
-use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 use std::{net::SocketAddr, str::FromStr};
 
@@ -12,9 +11,7 @@ pub(crate) mod util;
 const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: &str = "127.0.0.1:9092";
 const KAFKA_DEFAULT_PROJECT_ROUTE: &str = "/project/default";
 const KAFKA_DEFAULT_CONSUMER_SERVER: &str = "127.0.0.1:4000";
-const KAFKA_DEFAULT_CONSUMER_PORT_RANGE: &str = "4001-4100";
 const KAFKA_DEFAULT_PRODUCER_SERVER: &str = "127.0.0.1:5000";
-const KAFKA_DEFAULT_PRODUCER_PORT_RANGE: &str = "5001-5100";
 
 fn kafka_default_outlet_addr() -> String {
     DefaultAddress::KAFKA_OUTLET.to_string()
@@ -46,17 +43,7 @@ fn kafka_default_consumer_server() -> SocketAddr {
         .expect("Failed to parse default consumer server")
 }
 
-fn kafka_default_consumer_port_range() -> PortRange {
-    PortRange::from_str(KAFKA_DEFAULT_CONSUMER_PORT_RANGE)
-        .expect("Failed to parse default consumer port range")
-}
-
 fn kafka_default_producer_server() -> SocketAddr {
     SocketAddr::from_str(KAFKA_DEFAULT_PRODUCER_SERVER)
         .expect("Failed to parse default producer server")
-}
-
-fn kafka_default_producer_port_range() -> PortRange {
-    PortRange::from_str(KAFKA_DEFAULT_PRODUCER_PORT_RANGE)
-        .expect("Failed to parse default producer port range")
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -5,11 +5,10 @@ use clap::{command, Args};
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
-use crate::kafka::util::{rpc, ArgOpts};
+use crate::kafka::util::{make_brokers_port_range, rpc, ArgOpts};
 use crate::{
     kafka::{
-        kafka_default_producer_port_range, kafka_default_producer_server,
-        kafka_default_project_route, kafka_producer_default_addr,
+        kafka_default_producer_server, kafka_default_project_route, kafka_producer_default_addr,
     },
     node::NodeOpts,
     util::{node_rpc, parsers::socket_addr_parser},
@@ -31,8 +30,8 @@ pub struct CreateCommand {
     bootstrap_server: SocketAddr,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
-    #[arg(long, default_value_t = kafka_default_producer_port_range())]
-    brokers_port_range: PortRange,
+    #[arg(long)]
+    brokers_port_range: Option<PortRange>,
     /// The route to the project in ockam orchestrator, expected something like /project/<name>
     #[arg(long, default_value_t = kafka_default_project_route())]
     project_route: MultiAddr,
@@ -46,7 +45,9 @@ impl CreateCommand {
             node_opts: self.node_opts,
             addr: self.addr,
             bootstrap_server: self.bootstrap_server,
-            brokers_port_range: self.brokers_port_range,
+            brokers_port_range: self
+                .brokers_port_range
+                .unwrap_or_else(|| make_brokers_port_range(&self.bootstrap_server)),
             project_route: self.project_route,
         };
         node_rpc(rpc, (opts, arg_opts));

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -27,6 +27,13 @@ pub struct ArgOpts {
     pub project_route: MultiAddr,
 }
 
+/// Return a range of 100 ports after the bootstrap server port
+pub(crate) fn make_brokers_port_range(bootstrap_server: &SocketAddr) -> PortRange {
+    let boostrap_server_port = bootstrap_server.port();
+    // we can unwrap here because we know that range start <= range end
+    PortRange::new(boostrap_server_port + 1, boostrap_server_port + 100).unwrap()
+}
+
 pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> miette::Result<()> {
     initialize_default_node(&ctx, &opts).await?;
     let ArgOpts {


### PR DESCRIPTION
This PS allows a user to only specify the `--boostrap-server` option for `ockam kafka consumer/producer/direct create` and have a port range created off the `bootstrap-server` port.