### PR TITLE
docs: simplify the ockam app readme

### DIFF
--- a/implementations/swift/Makefile
+++ b/implementations/swift/Makefile
@@ -19,7 +19,8 @@ build_ockam_release:
 # build the Portals application in Debug mode
 build: build_ockam
 	# the xcode project expects the ockam executable to be found in the release directory
-	cp $(ROOT_DIR)/target/debug/ockam $(ROOT_DIR)/target/debug/release
+	mkdir -p $(ROOT_DIR)/target/release
+	cp $(ROOT_DIR)/target/debug/ockam $(ROOT_DIR)/target/release
 	make xcode_build_Debug
 
 # build the Portals application in Release mode

--- a/implementations/swift/ockam/ockam_app/README.md
+++ b/implementations/swift/ockam/ockam_app/README.md
@@ -1,4 +1,4 @@
-# Ockam Desktop Application
+# Ockam Portals Application
 
 
 The Ockam Desktop Application is a native MacOS application that provides a GUI for users to interact with Ockam.
@@ -6,8 +6,8 @@ It's built on top of on the crate `ockam_app_lib` which exposes C APIs for inter
 
 ## How to build
 
-To build the Ockam Desktop Application:
+To build the Ockam Portals Application:
 1. Run `make swift_build` from the root of the repository.
-2. Launch it using `./implementations/swift/build/Ockam.xcarchive/Products/Applications/Ockam.app/Contents/MacOS/Ockam`
+2. Launch it with `make_swift_run` from the root of the repository.
 
 To build the package you can use `make swift_package`.


### PR DESCRIPTION
And:
  
 - rename "desktop app" to "Portals"
 - fix the `swift_build` command when starting from a clean directory

