### PR TITLE
fix(rust): call the right function when enrolling with okta

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
@@ -97,7 +97,7 @@ impl Enrollment for SecureClient {
         token: OidcToken,
     ) -> miette::Result<()> {
         let req = Request::post("v0/enroll").body(AuthenticateOidcToken::new(token));
-        trace!(target: TARGET, "executing auth0 flow");
+        trace!(target: TARGET, "executing okta flow");
         self.tell(ctx, DefaultAddress::OKTA_IDENTITY_PROVIDER, req)
             .await
             .into_diagnostic()?

--- a/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
@@ -170,7 +170,10 @@ impl OidcService {
             ps.extend_from_slice(query_parameters);
             ps
         };
-
+        info!(
+            "getting a code from {url} with client-id {} and parameters {query_parameters:?}",
+            self.provider().client_id()
+        );
         let req = || {
             client
                 .post(url.clone())

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -246,9 +246,9 @@ impl CommandGlobalOpts {
         let terminal = Terminal::from(&global_args);
         let state = match CliState::with_default_dir() {
             Ok(state) => state,
-            Err(_) => {
+            Err(e) => {
                 terminal
-                    .write_line(fmt_err!("Failed to initialize local state"))
+                    .write_line(fmt_err!("Failed to initialize local state: {e:?}"))
                     .unwrap();
                 terminal
                     .write_line(fmt_log!(

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -112,7 +112,9 @@ async fn run_impl(
 
         let auth0 = OidcService::new(Arc::new(OktaOidcProvider::new(okta_config)));
         let token = auth0.get_token_interactively(&opts).await?;
-        authority_node.enroll_with_oidc_token(&ctx, token).await?;
+        authority_node
+            .enroll_with_oidc_token_okta(&ctx, token)
+            .await?;
     };
 
     // Issue credential

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231222160000_okta_config_primary_key.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231222160000_okta_config_primary_key.sql
@@ -1,0 +1,8 @@
+-- add a unique constraint to the okta_config table
+-- and remove duplicate rows
+DELETE FROM okta_config WHERE
+    rowid NOT IN (
+        SELECT min(rowid) FROM okta_config
+        GROUP BY project_id, tenant_base_url, client_id
+    );
+CREATE UNIQUE INDEX IF NOT EXISTS okta_config_index ON okta_config (project_id, tenant_base_url, client_id);


### PR DESCRIPTION
This PR fixes

 - [an incorrect function call](https://github.com/build-trust/ockam/pull/7219/files#diff-5fd702823db300c905c424872daadede22639f8c2bff15f22ba4b53570f6f4f1R115) when enrolling with Okta
 - a duplication of rows in the `okta_config` table

It also adds some logging to help diagnose issues when checking a token