### PR TITLE
Node-isolated attributes

### DIFF
--- a/implementations/rust/ockam/ockam/src/node.rs
+++ b/implementations/rust/ockam/ockam/src/node.rs
@@ -41,7 +41,11 @@ pub struct Node {
 /// use ockam_vault::storage::SecretsSqlxDatabase;
 ///
 /// async fn make_node(ctx: Context) -> Result<Node> {
-///   let node = Node::builder().await?.with_secrets_repository(SecretsSqlxDatabase::create().await?).build(&ctx).await?;
+///   let node = Node::builder()
+///       .await?
+///       .with_secrets_repository(Arc::new(SecretsSqlxDatabase::create().await?))
+///       .build(&ctx)
+///       .await?;
 ///   Ok(node)
 /// }
 ///

--- a/implementations/rust/ockam/ockam_abac/src/storage/policy_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_abac/src/storage/policy_repository_sql.rs
@@ -2,7 +2,6 @@ use sqlx::*;
 use tracing::debug;
 
 use ockam_core::async_trait;
-use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_node::database::{FromSqlxError, SqlxDatabase, SqlxType, ToSqlxType, ToVoid};
@@ -11,21 +10,19 @@ use crate::{Action, Expr, PoliciesRepository, Policy, Resource};
 
 #[derive(Clone)]
 pub struct PolicySqlxDatabase {
-    database: Arc<SqlxDatabase>,
+    database: SqlxDatabase,
 }
 
 impl PolicySqlxDatabase {
     /// Create a new database for policies keys
-    pub fn new(database: Arc<SqlxDatabase>) -> Self {
+    pub fn new(database: SqlxDatabase) -> Self {
         debug!("create a repository for policies");
         Self { database }
     }
 
     /// Create a new in-memory database for policies
-    pub async fn create() -> Result<Arc<Self>> {
-        Ok(Arc::new(Self::new(
-            SqlxDatabase::in_memory("policies").await?,
-        )))
+    pub async fn create() -> Result<Self> {
+        Ok(Self::new(SqlxDatabase::in_memory("policies").await?))
     }
 }
 
@@ -38,7 +35,7 @@ impl PoliciesRepository for PolicySqlxDatabase {
         .bind(resource.to_sql())
         .bind(action.to_sql());
         let row: Option<PolicyRow> = query
-            .fetch_optional(&self.database.pool)
+            .fetch_optional(&*self.database.pool)
             .await
             .into_core()?;
         Ok(row.map(|r| r.policy()).transpose()?)
@@ -54,20 +51,20 @@ impl PoliciesRepository for PolicySqlxDatabase {
             .bind(resource.to_sql())
             .bind(action.to_sql())
             .bind(minicbor::to_vec(policy.expression())?.to_sql());
-        query.execute(&self.database.pool).await.void()
+        query.execute(&*self.database.pool).await.void()
     }
 
     async fn delete_policy(&self, resource: &Resource, action: &Action) -> Result<()> {
         let query = query("DELETE FROM policy WHERE resource = ? and action = ?")
             .bind(resource.to_sql())
             .bind(action.to_sql());
-        query.execute(&self.database.pool).await.void()
+        query.execute(&*self.database.pool).await.void()
     }
 
     async fn get_policies_by_resource(&self, resource: &Resource) -> Result<Vec<(Action, Policy)>> {
         let query = query_as("SELECT resource, action, expression FROM policy where resource = $1")
             .bind(resource.to_sql());
-        let row: Vec<PolicyRow> = query.fetch_all(&self.database.pool).await.into_core()?;
+        let row: Vec<PolicyRow> = query.fetch_all(&*self.database.pool).await.into_core()?;
         row.into_iter()
             .map(|r| r.policy().map(|e| (r.action(), e)))
             .collect::<Result<Vec<(Action, Policy)>>>()
@@ -121,6 +118,8 @@ mod test {
 
     use super::*;
 
+    use ockam_core::compat::sync::Arc;
+
     #[tokio::test]
     async fn test_repository() -> Result<()> {
         let repository = create_repository().await?;
@@ -153,6 +152,6 @@ mod test {
 
     /// HELPERS
     async fn create_repository() -> Result<Arc<dyn PoliciesRepository>> {
-        Ok(PolicySqlxDatabase::create().await?)
+        Ok(Arc::new(PolicySqlxDatabase::create().await?))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -62,7 +62,7 @@ impl Authority {
         // create the database
         let database_path = &configuration.database_path;
         Self::create_ockam_directory_if_necessary(database_path)?;
-        let database = Arc::new(SqlxDatabase::create(database_path).await?);
+        let database = SqlxDatabase::create(database_path, "authority".to_string()).await?;
 
         // create the repositories
         let vault = Vault::create_with_database(database.clone());

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -28,12 +28,12 @@ pub struct Configuration {
     /// listener address for the TCP listener, for example "127.0.0.1:4000"
     pub tcp_listener_address: InternetAddress,
 
-    /// service name for the secure channel listener, for example "secure"
+    /// service name for the secure channel listener, for example "api"
     /// The default is DefaultAddress::SECURE_CHANNEL_LISTENER
     pub secure_channel_listener_name: Option<String>,
 
-    /// Service name for the direct authenticator, for example "api"
-    /// The default is DefaultAddress::SECURE_CHANNEL_LISTENER
+    /// Service name for the direct authenticator, for example "direct_authenticator"
+    /// The default is DefaultAddress::DIRECT_AUTHENTICATOR
     pub authenticator_name: Option<String>,
 
     /// list of trusted identities (identities with the ockam-role: enroller)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/test_support.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/test_support.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 impl CliState {
     /// Return a test CliState with a random root directory
     pub async fn test() -> Result<Self> {
-        Self::create(Self::test_dir()?).await
+        Self::create(Self::test_dir()?, "test_node".to_string()).await
     }
 
     /// Return a random root directory

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -364,8 +364,10 @@ impl NamedVault {
         }
     }
 
-    async fn database(&self) -> Result<Arc<SqlxDatabase>> {
-        Ok(Arc::new(SqlxDatabase::create(self.path.as_path()).await?))
+    async fn database(&self) -> Result<SqlxDatabase> {
+        // FIXME: We should really have one instance of the SqlxDatabase per process, also the node_name is incorrect,
+        //  but we don't use it yet for the vault storage
+        Ok(SqlxDatabase::create(self.path.as_path(), "vault_node_name".to_string()).await?)
     }
 }
 
@@ -504,7 +506,7 @@ mod tests {
     async fn test_move_vault() -> Result<()> {
         let db_file = NamedTempFile::new().unwrap();
         let cli_state_directory = db_file.path().parent().unwrap().join(random_name());
-        let cli = CliState::create(cli_state_directory.clone()).await?;
+        let cli = CliState::create(cli_state_directory.clone(), "test_node".to_string()).await?;
 
         // create a vault
         let _ = cli.get_or_create_named_vault("vault1").await?;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -244,7 +244,8 @@ pub struct CommandGlobalOpts {
 impl CommandGlobalOpts {
     pub fn new(global_args: GlobalArgs) -> Self {
         let terminal = Terminal::from(&global_args);
-        let state = match CliState::with_default_dir() {
+        // This node_name is a placeholder and should be set to a proper value when creating a node
+        let state = match CliState::with_default_dir("ockam_command".to_string()) {
             Ok(state) => state,
             Err(_) => {
                 terminal

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -59,8 +59,11 @@ pub(super) async fn foreground_mode(
         listener.socket_address()
     );
 
-    let node_info = opts
-        .state
+    // Set node_name so that node can isolate its data in the storage from other nodes
+    let mut state = opts.state.clone();
+    state.set_node_name(node_name.clone());
+
+    let node_info = state
         .start_node_with_optional_values(
             &node_name,
             &cmd.identity,
@@ -70,8 +73,7 @@ pub(super) async fn foreground_mode(
         .await?;
     debug!("created node {node_info:?}");
 
-    let named_trust_context = opts
-        .state
+    let named_trust_context = state
         .retrieve_trust_context(
             &cmd.trust_context_opts.trust_context,
             &cmd.trust_context_opts.project_name,
@@ -85,7 +87,7 @@ pub(super) async fn foreground_mode(
     let node_man = InMemoryNode::new(
         &ctx,
         NodeManagerGeneralOptions::new(
-            opts.state.clone(),
+            state,
             node_name.clone(),
             pre_trusted_identities,
             cmd.launch_config.is_none(),

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -132,15 +132,17 @@ impl Identities {
     pub async fn builder() -> Result<IdentitiesBuilder> {
         Ok(IdentitiesBuilder {
             vault: Vault::create().await?,
-            change_history_repository: ChangeHistorySqlxDatabase::create().await?,
-            identity_attributes_repository: IdentityAttributesSqlxDatabase::create().await?,
-            purpose_keys_repository: PurposeKeysSqlxDatabase::create().await?,
+            change_history_repository: Arc::new(ChangeHistorySqlxDatabase::create().await?),
+            identity_attributes_repository: Arc::new(
+                IdentityAttributesSqlxDatabase::create().await?,
+            ),
+            purpose_keys_repository: Arc::new(PurposeKeysSqlxDatabase::create().await?),
         })
     }
 
     /// Return a builder for identities with a specific database
     #[cfg(feature = "storage")]
-    pub fn create(database: Arc<SqlxDatabase>) -> IdentitiesBuilder {
+    pub fn create(database: SqlxDatabase) -> IdentitiesBuilder {
         IdentitiesBuilder {
             vault: Vault::create_with_database(database.clone()),
             change_history_repository: Arc::new(ChangeHistorySqlxDatabase::new(database.clone())),

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
@@ -26,7 +26,7 @@ pub async fn identities() -> Result<Arc<Identities>> {
 
 /// Return identities backed by a specific database
 #[cfg(feature = "storage")]
-pub fn create(database: Arc<SqlxDatabase>) -> Arc<Identities> {
+pub fn create(database: SqlxDatabase) -> Arc<Identities> {
     Identities::create(database).build()
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/change_history_repository_sql.rs
@@ -6,7 +6,6 @@ use sqlx::*;
 use tracing::debug;
 
 use ockam_core::async_trait;
-use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_node::database::{FromSqlxError, SqlxDatabase, SqlxType, ToSqlxType, ToVoid};
 
@@ -17,21 +16,19 @@ use crate::{ChangeHistoryRepository, Identity, IdentityError, IdentityHistoryCom
 /// using sqlx as its API, and Sqlite as its driver
 #[derive(Clone)]
 pub struct ChangeHistorySqlxDatabase {
-    database: Arc<SqlxDatabase>,
+    database: SqlxDatabase,
 }
 
 impl ChangeHistorySqlxDatabase {
     /// Create a new database
-    pub fn new(database: Arc<SqlxDatabase>) -> Self {
+    pub fn new(database: SqlxDatabase) -> Self {
         debug!("create a repository for change history");
         Self { database }
     }
 
     /// Create a new in-memory database
-    pub async fn create() -> Result<Arc<Self>> {
-        Ok(Arc::new(Self::new(
-            SqlxDatabase::in_memory("change history").await?,
-        )))
+    pub async fn create() -> Result<Self> {
+        Ok(Self::new(SqlxDatabase::in_memory("change history").await?))
     }
 }
 
@@ -79,7 +76,7 @@ impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
         change_history: ChangeHistory,
     ) -> Result<()> {
         Self::insert_query(identifier, &change_history)
-            .execute(&self.database.pool)
+            .execute(&*self.database.pool)
             .await
             .void()
     }
@@ -100,7 +97,7 @@ impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
         let query = query_as("SELECT identifier, change_history FROM identity WHERE identifier=$1")
             .bind(identifier.to_sql());
         let row: Option<ChangeHistoryRow> = query
-            .fetch_optional(&self.database.pool)
+            .fetch_optional(&*self.database.pool)
             .await
             .into_core()?;
         row.map(|r| r.change_history()).transpose()
@@ -108,7 +105,7 @@ impl ChangeHistoryRepository for ChangeHistorySqlxDatabase {
 
     async fn get_change_histories(&self) -> Result<Vec<ChangeHistory>> {
         let query = query_as("SELECT identifier, change_history FROM identity");
-        let row: Vec<ChangeHistoryRow> = query.fetch_all(&self.database.pool).await.into_core()?;
+        let row: Vec<ChangeHistoryRow> = query.fetch_all(&*self.database.pool).await.into_core()?;
         row.iter().map(|r| r.change_history()).collect()
     }
 }
@@ -160,6 +157,8 @@ impl ChangeHistoryRow {
 mod tests {
     use super::*;
     use crate::{identities, Identity};
+
+    use ockam_core::compat::sync::Arc;
 
     #[tokio::test]
     async fn test_identities_repository() -> Result<()> {
@@ -226,7 +225,7 @@ mod tests {
 
     /// HELPERS
     async fn create_repository() -> Result<Arc<dyn ChangeHistoryRepository>> {
-        Ok(ChangeHistorySqlxDatabase::create().await?)
+        Ok(Arc::new(ChangeHistorySqlxDatabase::create().await?))
     }
 
     async fn create_identity() -> Result<Identity> {

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
@@ -4,7 +4,6 @@ use sqlx::*;
 use tracing::debug;
 
 use ockam_core::async_trait;
-use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_node::database::{FromSqlxError, SqlxDatabase, SqlxType, ToSqlxType, ToVoid};
 
@@ -15,31 +14,34 @@ use crate::{AttributesEntry, IdentityAttributesRepository, TimestampInSeconds};
 /// using sqlx as its API, and Sqlite as its driver
 #[derive(Clone)]
 pub struct IdentityAttributesSqlxDatabase {
-    database: Arc<SqlxDatabase>,
+    database: SqlxDatabase,
 }
 
 impl IdentityAttributesSqlxDatabase {
     /// Create a new database
-    pub fn new(database: Arc<SqlxDatabase>) -> Self {
+    pub fn new(database: SqlxDatabase) -> Self {
         debug!("create a repository for identity attributes");
         Self { database }
     }
 
     /// Create a new in-memory database
-    pub async fn create() -> Result<Arc<Self>> {
-        Ok(Arc::new(Self::new(
+    pub async fn create() -> Result<Self> {
+        Ok(Self::new(
             SqlxDatabase::in_memory("identity attributes").await?,
-        )))
+        ))
     }
 }
 
 #[async_trait]
 impl IdentityAttributesRepository for IdentityAttributesSqlxDatabase {
     async fn get_attributes(&self, identity: &Identifier) -> Result<Option<AttributesEntry>> {
-        let query = query_as("SELECT identifier, attributes, added, expires, attested_by FROM identity_attributes WHERE identifier=$1")
-            .bind(identity.to_sql());
+        let query = query_as(
+            "SELECT identifier, attributes, added, expires, attested_by FROM identity_attributes WHERE identifier=$1 AND node_name=$2"
+            )
+            .bind(identity.to_sql())
+            .bind(self.database.node_name.to_sql());
         let identity_attributes: Option<IdentityAttributesRow> = query
-            .fetch_optional(&self.database.pool)
+            .fetch_optional(&*self.database.pool)
             .await
             .into_core()?;
         Ok(identity_attributes.map(|r| r.attributes()).transpose()?)
@@ -47,10 +49,11 @@ impl IdentityAttributesRepository for IdentityAttributesSqlxDatabase {
 
     async fn list_attributes_by_identifier(&self) -> Result<Vec<(Identifier, AttributesEntry)>> {
         let query = query_as(
-            "SELECT identifier, attributes, added, expires, attested_by FROM identity_attributes",
-        );
+            "SELECT identifier, attributes, added, expires, attested_by FROM identity_attributes WHERE node_name=$1",
+            )
+            .bind(self.database.node_name.to_sql());
         let result: Vec<IdentityAttributesRow> =
-            query.fetch_all(&self.database.pool).await.into_core()?;
+            query.fetch_all(&*self.database.pool).await.into_core()?;
         result
             .into_iter()
             .map(|r| r.identifier().and_then(|i| r.attributes().map(|a| (i, a))))
@@ -58,19 +61,23 @@ impl IdentityAttributesRepository for IdentityAttributesSqlxDatabase {
     }
 
     async fn put_attributes(&self, subject: &Identifier, entry: AttributesEntry) -> Result<()> {
-        let query = query("INSERT OR REPLACE INTO identity_attributes VALUES (?, ?, ?, ?, ?)")
+        let query = query(
+            "INSERT OR REPLACE INTO identity_attributes (identifier, attributes, added, expires, attested_by, node_name) VALUES (?, ?, ?, ?, ?, ?)"
+            )
             .bind(subject.to_sql())
             .bind(minicbor::to_vec(entry.attrs())?.to_sql())
             .bind(entry.added().to_sql())
             .bind(entry.expires().map(|e| e.to_sql()))
-            .bind(entry.attested_by().map(|e| e.to_sql()));
-        query.execute(&self.database.pool).await.void()
+            .bind(entry.attested_by().map(|e| e.to_sql()))
+            .bind(self.database.node_name.to_sql());
+        query.execute(&*self.database.pool).await.void()
     }
 
     async fn delete(&self, identity: &Identifier) -> Result<()> {
-        let query =
-            query("DELETE FROM identity_attributes WHERE identifier = ?").bind(identity.to_sql());
-        query.execute(&self.database.pool).await.void()
+        let query = query("DELETE FROM identity_attributes WHERE identifier = ? AND node_name = ?")
+            .bind(identity.to_sql())
+            .bind(self.database.node_name.to_sql());
+        query.execute(&*self.database.pool).await.void()
     }
 }
 
@@ -120,6 +127,7 @@ impl IdentityAttributesRow {
 #[cfg(test)]
 mod tests {
     use ockam_core::compat::collections::BTreeMap;
+    use ockam_core::compat::sync::Arc;
 
     use super::*;
     use crate::identities;
@@ -180,6 +188,6 @@ mod tests {
     }
 
     async fn create_repository() -> Result<Arc<dyn IdentityAttributesRepository>> {
-        Ok(IdentityAttributesSqlxDatabase::create().await?)
+        Ok(Arc::new(IdentityAttributesSqlxDatabase::create().await?))
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
@@ -605,9 +605,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_initialization() -> Result<()> {
-        let vault = Arc::new(SoftwareVaultForSecureChannels::new(
+        let vault = Arc::new(SoftwareVaultForSecureChannels::new(Arc::new(
             SecretsSqlxDatabase::create().await?,
-        ));
+        )));
 
         let static_key = vault.generate_static_x25519_secret_key().await?;
         let mut handshake = Handshake::new_with_protocol(

--- a/implementations/rust/ockam/ockam_identity/src/vault.rs
+++ b/implementations/rust/ockam/ockam_identity/src/vault.rs
@@ -54,25 +54,25 @@ impl Vault {
     /// Create [`SoftwareVaultForSigning`] with an in-memory storage
     #[cfg(feature = "storage")]
     pub async fn create_identity_vault() -> Result<Arc<dyn VaultForSigning>> {
-        Ok(Arc::new(SoftwareVaultForSigning::new(
+        Ok(Arc::new(SoftwareVaultForSigning::new(Arc::new(
             SecretsSqlxDatabase::create().await?,
-        )))
+        ))))
     }
 
     /// Create [`SoftwareSecureChannelVault`] with an in-memory storage
     #[cfg(feature = "storage")]
     pub async fn create_secure_channel_vault() -> Result<Arc<dyn VaultForSecureChannels>> {
-        Ok(Arc::new(SoftwareVaultForSecureChannels::new(
+        Ok(Arc::new(SoftwareVaultForSecureChannels::new(Arc::new(
             SecretsSqlxDatabase::create().await?,
-        )))
+        ))))
     }
 
     /// Create [`SoftwareVaultForSigning`] with an in-memory storage
     #[cfg(feature = "storage")]
     pub async fn create_credential_vault() -> Result<Arc<dyn VaultForSigning>> {
-        Ok(Arc::new(SoftwareVaultForSigning::new(
+        Ok(Arc::new(SoftwareVaultForSigning::new(Arc::new(
             SecretsSqlxDatabase::create().await?,
-        )))
+        ))))
     }
 
     /// Create [`SoftwareVaultForVerifyingSignatures`]
@@ -84,7 +84,7 @@ impl Vault {
 impl Vault {
     /// Create Software Vaults and persist them to a sql database
     #[cfg(feature = "storage")]
-    pub fn create_with_database(database: Arc<SqlxDatabase>) -> Vault {
+    pub fn create_with_database(database: SqlxDatabase) -> Vault {
         Self::create_with_secrets_repository(Arc::new(SecretsSqlxDatabase::new(database)))
     }
 

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -141,7 +141,7 @@ pub async fn start<P>(context: &Context, mailboxes: Mailboxes, processor: P) -> 
 where
     P: Processor<Context = Context>,
 {
-    info!(
+    debug!(
         "Initializing ockam processor '{}' with access control in:{:?} out:{:?}",
         mailboxes.main_address(),
         mailboxes.main_mailbox().incoming_access_control(),

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231231100000_node_name_identity_attributes.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20231231100000_node_name_identity_attributes.sql
@@ -1,0 +1,16 @@
+ALTER TABLE identity_attributes RENAME TO identity_attributes_old;
+
+-- This table lists attributes associated to a given identity
+-- The data migration:
+--   - duplicates every attributes entry for every node that exists at the time of migration
+CREATE TABLE identity_attributes
+(
+    identifier  TEXT    NOT NULL, -- identity possessing those attributes
+    attributes  BLOB    NOT NULL, -- serialized list of attribute names and values for the identity
+    added       INTEGER NOT NULL, -- UNIX timestamp in seconds: when those attributes were inserted in the database
+    expires     INTEGER,          -- optional UNIX timestamp in seconds: when those attributes expire
+    attested_by TEXT,             -- optional identifier which attested of these attributes
+    node_name   TEXT NOT NULL     -- node name to isolate attributes that each node knows
+);
+
+CREATE UNIQUE INDEX identity_attributes_index ON identity_attributes (identifier, node_name);

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20231231100000_node_name_identity_attributes.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20231231100000_node_name_identity_attributes.rs
@@ -1,0 +1,165 @@
+use crate::database::{FromSqlxError, SqlxDatabase, ToSqlxType, ToVoid};
+use ockam_core::Result;
+use sqlx::sqlite::SqliteRow;
+use sqlx::*;
+
+impl SqlxDatabase {
+    /// Duplicate all attributes entry for every known node
+    pub(crate) async fn migrate_attributes_node_name(&self) -> Result<()> {
+        // don't run the migration twice
+        let data_migration_needed: Option<SqliteRow> =
+            query(&Self::table_exists("identity_attributes_old"))
+                .fetch_optional(&*self.pool)
+                .await
+                .into_core()?;
+        let data_migration_needed = data_migration_needed.map(|r| r.get(0)).unwrap_or(false);
+
+        if !data_migration_needed {
+            return Ok(());
+        };
+
+        let mut transaction = self.pool.begin().await.into_core()?;
+
+        let query_node_names = query_as("SELECT name FROM node");
+        let node_names: Vec<NodeNameRow> = query_node_names
+            .fetch_all(&mut *transaction)
+            .await
+            .into_core()?;
+
+        // read values from the previous table
+        let query_all = query_as("SELECT * FROM identity_attributes_old");
+        let rows: Vec<IdentityAttributesRow> =
+            query_all.fetch_all(&mut *transaction).await.into_core()?;
+
+        for row in rows {
+            for node_name in &node_names {
+                let insert = query("INSERT INTO identity_attributes (identifier, attributes, added, expires, attested_by, node_name) VALUES (?, ?, ?, ?, ?, ?)")
+                    .bind(row.identifier.to_sql())
+                    .bind(row.attributes.to_sql())
+                    .bind((row.added as u64).to_sql())
+                    .bind(row.expires.map(|e| (e as u64).to_sql()))
+                    .bind(row.attested_by.clone().map(|e| e.to_sql()))
+                    .bind(node_name.name.to_sql());
+
+                insert.execute(&mut *transaction).await.void()?;
+            }
+        }
+
+        // finally drop the old table
+        query("DROP TABLE identity_attributes_old")
+            .execute(&mut *transaction)
+            .await
+            .void()?;
+
+        transaction.commit().await.void()?;
+
+        Ok(())
+    }
+
+    fn table_exists(table_name: &str) -> String {
+        format!("SELECT EXISTS(SELECT name FROM sqlite_schema WHERE type = 'table' AND name = '{table_name}')")
+    }
+}
+
+// Low-level representation of a table row before data migration
+#[derive(FromRow)]
+struct IdentityAttributesRow {
+    identifier: String,
+    attributes: Vec<u8>,
+    added: i64,
+    expires: Option<i64>,
+    attested_by: Option<String>,
+}
+
+#[derive(FromRow)]
+struct NodeNameRow {
+    name: String,
+}
+
+#[cfg(test)]
+mod test {
+    use sqlx::query::Query;
+    use sqlx::sqlite::SqliteArguments;
+    use std::collections::BTreeMap;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_migration() -> Result<()> {
+        // create the database pool and migrate the tables
+        let db_file = NamedTempFile::new().unwrap();
+        let pool = SqlxDatabase::create_connection_pool(db_file.path()).await?;
+        SqlxDatabase::migrate_tables(&pool).await?;
+
+        // insert attribute rows in the previous table
+        let attributes = create_attributes("identifier1")?;
+        let insert = insert_query("identifier1", attributes.clone());
+        insert.execute(&pool).await.void()?;
+
+        let insert_node1 = insert_node("node1".to_string());
+        insert_node1.execute(&pool).await.void()?;
+
+        let insert_node2 = insert_node("node2".to_string());
+        insert_node2.execute(&pool).await.void()?;
+
+        // now create a database and apply the migrations
+        let db = SqlxDatabase::create(db_file.path(), "test".to_string()).await?;
+        let rows1: Vec<IdentityAttributesRow> =
+            query_as("SELECT * FROM identity_attributes WHERE node_name = ?")
+                .bind("node1".to_string().to_sql())
+                .fetch_all(&*db.pool)
+                .await
+                .into_core()?;
+        let rows2: Vec<IdentityAttributesRow> =
+            query_as("SELECT * FROM identity_attributes WHERE node_name = ?")
+                .bind("node2".to_string().to_sql())
+                .fetch_all(&*db.pool)
+                .await
+                .into_core()?;
+        assert_eq!(rows1.len(), 1);
+
+        let row1 = &rows1[0];
+        let row2 = &rows2[0];
+
+        assert_eq!(row1.identifier, row2.identifier);
+        assert_eq!(row1.attributes, row2.attributes);
+        assert_eq!(row1.added, row2.added);
+        assert_eq!(row1.expires, row2.expires);
+        assert_eq!(row1.attested_by, row2.attested_by);
+
+        assert_eq!(row1.identifier, "identifier1");
+        assert_eq!(row1.attributes, attributes);
+        assert_eq!(row1.added, 1);
+        assert_eq!(row1.expires, Some(2));
+        assert_eq!(row1.attested_by, Some("authority".to_string()));
+
+        Ok(())
+    }
+
+    /// HELPERS
+    fn create_attributes(identifier: &str) -> Result<Vec<u8>> {
+        Ok(minicbor::to_vec(BTreeMap::from([
+            ("name".as_bytes().to_vec(), identifier.as_bytes().to_vec()),
+            ("age".as_bytes().to_vec(), identifier.as_bytes().to_vec()),
+        ]))?)
+    }
+
+    fn insert_query(identifier: &str, attributes: Vec<u8>) -> Query<Sqlite, SqliteArguments> {
+        query("INSERT INTO identity_attributes_old VALUES (?, ?, ?, ?, ?)")
+            .bind(identifier.to_sql())
+            .bind(attributes.to_sql())
+            .bind(1.to_sql())
+            .bind(Some(2).map(|e| e.to_sql()))
+            .bind(Some("authority").map(|e| e.to_sql()))
+    }
+
+    fn insert_node(name: String) -> Query<'static, Sqlite, SqliteArguments<'static>> {
+        query("INSERT INTO node (name, identifier, verbosity, is_default, is_authority) VALUES (?, ?, ?, ?, ?)")
+            .bind(name.to_sql())
+            .bind("I_TEST".to_string().to_sql())
+            .bind(1.to_sql())
+            .bind(0.to_sql())
+            .bind(0.to_sql())
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod migration_20231231100000_node_name_identity_attributes;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/mod.rs
@@ -1,3 +1,4 @@
+mod migrations;
 mod sqlx_database;
 mod sqlx_types;
 

--- a/implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/vault_for_secure_channels.rs
+++ b/implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/vault_for_secure_channels.rs
@@ -43,7 +43,9 @@ impl SoftwareVaultForSecureChannels {
     /// Create Software implementation Vault with an in-memory implementation to store secrets
     #[cfg(feature = "storage")]
     pub async fn create() -> Result<Arc<Self>> {
-        Ok(Arc::new(Self::new(SecretsSqlxDatabase::create().await?)))
+        Ok(Arc::new(Self::new(Arc::new(
+            SecretsSqlxDatabase::create().await?,
+        ))))
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault/src/software/vault_for_signing/vault_for_signing.rs
+++ b/implementations/rust/ockam/ockam_vault/src/software/vault_for_signing/vault_for_signing.rs
@@ -34,7 +34,9 @@ impl SoftwareVaultForSigning {
     /// Create an in-memory Software implementation Vault
     #[cfg(feature = "storage")]
     pub async fn create() -> Result<Arc<SoftwareVaultForSigning>> {
-        Ok(Arc::new(Self::new(SecretsSqlxDatabase::create().await?)))
+        Ok(Arc::new(Self::new(Arc::new(
+            SecretsSqlxDatabase::create().await?,
+        ))))
     }
 
     /// Import a key from a binary


### PR DESCRIPTION
Introduce `node_name` field in identity_attributes sqlite table to isolate attributes between nodes. Otherwise, if we have multiple nodes with different projects talking to the same Identifier - attributes are overwritten