### PR TITLE
test(rust): generate project.json for orchestrator tests only once

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -89,8 +89,6 @@ teardown_home_dir() {
     fi
     run $OCKAM node delete --all --force --yes
   done
-  export OCKAM_HOME=$OCKAM_HOME_BASE
-  run $OCKAM node delete --all --force --yes
 }
 
 to_uppercase() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -16,13 +16,6 @@ function skip_if_orchestrator_tests_not_enabled() {
 
 function copy_local_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
-    export PROJECT_NAME="default"
-    export PROJECT_PATH="$OCKAM_HOME_BASE/project.json"
-
-    # export the project data to a file
-    OCKAM_HOME=$OCKAM_HOME_BASE "$OCKAM" project show -q --output json >$PROJECT_PATH
-
-    # import it to the current OCKAM_HOME directory
     cp -r $OCKAM_HOME_BASE/. $OCKAM_HOME
   fi
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
@@ -3,8 +3,18 @@
 setup_suite() {
   load load/base.bash
   setup_python_server
-  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force --yes
+
   export BATS_TEST_TIMEOUT=300
+
+  # If we're running orchestrator tests, export the project data into `BATS_SUITE_TMPDIR`
+  if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
+    export PROJECT_NAME="default"
+    export PROJECT_PATH="$BATS_SUITE_TMPDIR/project.json"
+    OCKAM_HOME=$OCKAM_HOME_BASE "$OCKAM" project show -q --output json >$PROJECT_PATH
+  fi
+
+  # Remove all nodes from the root OCKAM_HOME directory
+  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force --yes
 }
 
 teardown_suite() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/trust_context.bats
@@ -4,7 +4,6 @@
 
 setup() {
   load load/base.bash
-  load load/orchestrator.bash
   load_bats_ext
   setup_home_dir
 }
@@ -16,9 +15,6 @@ teardown() {
 # ===== TESTS
 
 @test "trust_context - CRUD" {
-  skip_if_orchestrator_tests_not_enabled
-  copy_local_orchestrator_data
-
   # Create with random name
   run_success "$OCKAM" trust-context create
 


### PR DESCRIPTION
Generate the `project.json` file only once in the `setup_suite` function instead of generating it for every orchestrator test. Now, the `copy_local_orchestrator_data` function will only copy the database to the test directory, avoiding a call to the orchestrator in every orchestrator test.