### PR TITLE
feat(rust): clarify ockam command output to indicate that it only sup…

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -15,7 +15,7 @@ use crate::{
     CommandGlobalOpts,
 };
 
-/// Create a new Kafka Consumer
+/// Create a new Kafka Consumer. Kafka clients v3.4.x are supported. You can find the version you have with 'kafka-console-consumer.sh --version'.
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -15,7 +15,7 @@ use crate::{
     CommandGlobalOpts,
 };
 
-/// Create a new Kafka Producer
+/// Create a new Kafka Producer. Kafka clients v3.4.x are supported. You can find the version you have with 'kafka-console-producer.sh --version'.
 #[derive(Clone, Debug, Args)]
 pub struct CreateCommand {
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -104,10 +104,17 @@ pub async fn rpc(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> mi
                     .to_string()
                     .color(OckamColor::PrimaryResource.color())
             ) + &fmt_log!(
-                "Brokers port range set to {}",
+                "Brokers port range set to {}\n\n",
                 &brokers_port_range
                     .to_string()
                     .color(OckamColor::PrimaryResource.color())
+            ) + &fmt_log!(
+                "{}\n",
+                "Kafka clients v3.4.x are supported.".color(OckamColor::FmtWARNBackground.color())
+            ) + &fmt_log!(
+                "{}\n",
+                "You can find the version you have with 'kafka-console-consumer.sh --version'."
+                    .color(OckamColor::FmtWARNBackground.color())
             ),
         )
         .write_line()?;


### PR DESCRIPTION
This PR is for this [issue](https://github.com/build-trust/codebase/issues/636). It only addresses the UI strings for ...
- `ockam kafka-consumer`, `ockam kafka-consumer create`
- `ockam kafka-producer`, `ockam kafka-producer create`

... to notify the user that Kafka client v3.4.x is supported. And instructions on how to find the version they are using using Kafka CLI tools.

> This other [epic](https://github.com/orgs/build-trust/projects/45/views/5?sliceBy%5Bvalue%5D=nazmulidris&pane=issue&itemId=48916323) is meant to address broader UX review of all `ockam kafka-*` commands

## Videos
Iteration 2:

https://github.com/build-trust/ockam/assets/2966499/b2fa48e8-7ea3-4c1d-9988-a6807a271928

Iteration 1:
Here's a video of the new UI / UX in action:

https://github.com/build-trust/ockam/assets/2966499/d71b608c-7efb-48ce-b4ae-9e0f13b687e8

