### PR TITLE
   fix(swift): Disable autocorrect in textfields

### DIFF
--- a/implementations/swift/ockam/ockam_app/Ockam/InviteToPortal.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/InviteToPortal.swift
@@ -20,6 +20,7 @@ struct InviteToPortal: View {
                     "ex: alice@example.com",
                     text: $emailInput
                 )
+                .autocorrectionDisabled()
                 .padding(.leading, 1)
                 .onSubmit {
                     if validateEmail(email: self.emailInput) {

--- a/implementations/swift/ockam/ockam_app/Ockam/OpenPortal.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/OpenPortal.swift
@@ -32,6 +32,7 @@ struct OpenPortal: View {
                     .foregroundStyle(OckamSecondaryTextColor)
                     .padding(.leading, 4)
             }
+            .autocorrectionDisabled()
             .padding(.top, VerticalSpacingUnit*3)
             .padding(.bottom, VerticalSpacingUnit*2)
             .padding(.horizontal, VerticalSpacingUnit*4)


### PR DESCRIPTION
## Current behavior

If autocorrect is enabled system-wide, it gets annoying that it tries to correct things like addresses, names and emails. Issue: #6431 

## Proposed changes

* I applied `.autocorrectionDisabled()` modifier to the whole form on OpenPortal view.
* Also Applied same modifier on textfield in InviteToPortal view.

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.