### PR TITLE
   feat(swift): Implement option to open Portals app on startup

### DIFF
--- a/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
+++ b/implementations/swift/ockam/ockam_app/Ockam.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D520822ADD5CAE00F36B64 /* Helpers.swift */; };
 		78ED0DA12AD4354400574AE9 /* OpenPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA02AD4354400574AE9 /* OpenPortal.swift */; };
 		78ED0DA32AD4501200574AE9 /* InviteToPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED0DA22AD4501200574AE9 /* InviteToPortal.swift */; };
+		ECEC32A12B4969B50074DC64 /* LaunchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC32A02B4969B50074DC64 /* LaunchService.swift */; };
+		ECEC32A32B496A4D0074DC64 /* MainAppLaunchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC32A22B496A4D0074DC64 /* MainAppLaunchService.swift */; };
+		ECEC32A52B496C130074DC64 /* LaunchServiceObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC32A42B496C130074DC64 /* LaunchServiceObservable.swift */; };
+		ECEC97962B497C300046B483 /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC97952B497C300046B483 /* PreferencesView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -100,6 +104,10 @@
 		78D520822ADD5CAE00F36B64 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		78ED0DA02AD4354400574AE9 /* OpenPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPortal.swift; sourceTree = "<group>"; };
 		78ED0DA22AD4501200574AE9 /* InviteToPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteToPortal.swift; sourceTree = "<group>"; };
+		ECEC32A02B4969B50074DC64 /* LaunchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchService.swift; sourceTree = "<group>"; };
+		ECEC32A22B496A4D0074DC64 /* MainAppLaunchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainAppLaunchService.swift; sourceTree = "<group>"; };
+		ECEC32A42B496C130074DC64 /* LaunchServiceObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchServiceObservable.swift; sourceTree = "<group>"; };
+		ECEC97952B497C300046B483 /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +146,7 @@
 		782D5B472AC1D3D700D1B27F /* Ockam */ = {
 			isa = PBXGroup;
 			children = (
+				ECEC329F2B49690D0074DC64 /* Launch Service */,
 				78A77C2E2B2B275A00DEC3AC /* AnimatedEllipsis.swift */,
 				7893D4082B1F54F800454933 /* EnrollmentBlock.swift */,
 				7859A47F2B1DD4960085C7F7 /* FluidMenuBarExtra */,
@@ -157,6 +166,7 @@
 				7827D5082AD93F1700F7A20F /* ClickableMenuEntry.swift */,
 				78D520822ADD5CAE00F36B64 /* Helpers.swift */,
 				78BD349C2AFA621500F09058 /* BrokenStateView.swift */,
+				ECEC97952B497C300046B483 /* PreferencesView.swift */,
 				785C8DC02B0BAD5E00926DCD /* About.swift */,
 				785A072F2B14A60E002FF30C /* Constants.swift */,
 				785A07312B14C810002FF30C /* SentInvitations.swift */,
@@ -192,6 +202,16 @@
 				7859A4852B1DD4960085C7F7 /* RootViewModifier.swift */,
 			);
 			path = FluidMenuBarExtra;
+			sourceTree = "<group>";
+		};
+		ECEC329F2B49690D0074DC64 /* Launch Service */ = {
+			isa = PBXGroup;
+			children = (
+				ECEC32A02B4969B50074DC64 /* LaunchService.swift */,
+				ECEC32A22B496A4D0074DC64 /* MainAppLaunchService.swift */,
+				ECEC32A42B496C130074DC64 /* LaunchServiceObservable.swift */,
+			);
+			path = "Launch Service";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -283,16 +303,20 @@
 			files = (
 				785A07342B14CF29002FF30C /* LocalPortalView.swift in Sources */,
 				7827D5092AD93F1700F7A20F /* ClickableMenuEntry.swift in Sources */,
+				ECEC32A12B4969B50074DC64 /* LaunchService.swift in Sources */,
 				78BD34A12AFCFDF100F09058 /* RemotePortalView.swift in Sources */,
 				785A07322B14C810002FF30C /* SentInvitations.swift in Sources */,
 				782D5B4B2AC1D3D700D1B27F /* MainView.swift in Sources */,
 				785A07302B14A60E002FF30C /* Constants.swift in Sources */,
 				78A77C2F2B2B275A00DEC3AC /* AnimatedEllipsis.swift in Sources */,
 				785A073C2B15EAC8002FF30C /* EnrollmentStatus.swift in Sources */,
+				ECEC32A52B496C130074DC64 /* LaunchServiceObservable.swift in Sources */,
+				ECEC97962B497C300046B483 /* PreferencesView.swift in Sources */,
 				78B7EF702B0F649D0062B2B3 /* DeleteIncomingService.swift in Sources */,
 				78ED0DA12AD4354400574AE9 /* OpenPortal.swift in Sources */,
 				78D520832ADD5CAE00F36B64 /* Helpers.swift in Sources */,
 				7859A4892B1DD4960085C7F7 /* FluidMenuBarExtraWindow.swift in Sources */,
+				ECEC32A32B496A4D0074DC64 /* MainAppLaunchService.swift in Sources */,
 				7859A48A2B1DD4960085C7F7 /* EventMonitor.swift in Sources */,
 				78695A302B2332F600432B83 /* Hint.swift in Sources */,
 				7859A4862B1DD4960085C7F7 /* UpdateSizeAction.swift in Sources */,

--- a/implementations/swift/ockam/ockam_app/Ockam/Launch Service/LaunchService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Launch Service/LaunchService.swift
@@ -1,0 +1,13 @@
+//
+//  LaunchService.swift
+//  Portals, by Ockam
+//
+//  Created by Adin Ćebić on 6. 1. 2024..
+//
+
+import Foundation
+
+protocol LaunchService {
+    var startsOnLogin: Bool { get }
+    func registerForStartOnLogin(_ startsOnLogin: Bool)
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/Launch Service/LaunchServiceObservable.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Launch Service/LaunchServiceObservable.swift
@@ -1,0 +1,25 @@
+//
+//  LaunchServiceObservable.swift
+//  Portals, by Ockam
+//
+//  Created by Adin Ćebić on 6. 1. 2024..
+//
+
+import Foundation
+import Combine
+
+final class LaunchServiceObservable: ObservableObject {
+    private let launchService: any LaunchService
+    private var cancelBag = Set<AnyCancellable>()
+    var isEnabled: Bool {
+        get { launchService.startsOnLogin }
+        set {
+            launchService.registerForStartOnLogin(newValue)
+            objectWillChange.send()
+        }
+    }
+
+    init(launchService: any LaunchService = MainAppLaunchService()) {
+        self.launchService = launchService
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/Launch Service/MainAppLaunchService.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/Launch Service/MainAppLaunchService.swift
@@ -1,0 +1,44 @@
+//
+//  MainAppLaunchService.swift
+//  Portals, by Ockam
+//
+//  Created by Adin Ćebić on 6. 1. 2024..
+//
+
+import Foundation
+import ServiceManagement
+
+final class MainAppLaunchService: LaunchService {
+    private let service: SMAppService
+    var startsOnLogin: Bool {
+        service.status == .enabled
+    }
+
+    init() {
+        self.service = .mainApp
+    }
+
+    func registerForStartOnLogin(_ startsOnLogin: Bool) {
+        if startsOnLogin {
+            registerForStartOnLogin()
+        } else {
+            unregisterForStartOnLogin()
+        }
+    }
+
+    private func registerForStartOnLogin() {
+        do {
+            try service.register()
+        } catch {
+            print(error)
+        }
+    }
+
+    private func unregisterForStartOnLogin() {
+        do {
+            try service.unregister()
+        } catch {
+            print(error)
+        }
+    }
+}

--- a/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/MainView.swift
@@ -216,6 +216,12 @@ struct MainView: View {
                                 .padding(.horizontal, HorizontalSpacingUnit)
                         }
                         ClickableMenuEntry(
+                            text: "Preferences",
+                            icon: "gear"
+                            ) {
+                                OpenWindowWorkaround.shared.openWindow(windowName: "preferences")
+                            }
+                        ClickableMenuEntry(
                             text: "Reset", icon: "arrow.counterclockwise",
                             action: {
                                 restartCurrentProcess()

--- a/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/OckamApp.swift
@@ -289,6 +289,12 @@ struct OckamApp: App {
         }
         .windowResizability(.contentSize)
 
+        // Declare a preferences window
+        Window("Preferences", id: "preferences") {
+            PreferencesView()
+        }
+        .windowResizability(.automatic)
+
         // Declare a state-independent window, not open by default
         Window("Open a Portal Outlet to a TCP service", id: "open-portal") {
             OpenPortal(localServices: $state.localServices)

--- a/implementations/swift/ockam/ockam_app/Ockam/PreferencesView.swift
+++ b/implementations/swift/ockam/ockam_app/Ockam/PreferencesView.swift
@@ -1,0 +1,29 @@
+//
+//  PreferencesView.swift
+//  Portals, by Ockam
+//
+//  Created by Adin Ćebić on 6. 1. 2024..
+//
+
+import Foundation
+import SwiftUI
+
+struct PreferencesView: View {
+    @StateObject private var launchServiceObservable = LaunchServiceObservable()
+
+    var body: some View {
+        VStack {
+            Form {
+                Section("Launch options") {
+                    Toggle("Automatically start Ockam after login", isOn: $launchServiceObservable.isEnabled)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PreferencesView()
+}


### PR DESCRIPTION
## Current behavior

Currently there is no option to make Portals app launch itself on startup except for manually doing it via login items in system settings.

## Proposed changes

* Added new menu entry to open app preferences
* Built simple preferences window
* Added option to register Portals app to launch at startup


Closes issue #7350 

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.