### PR TITLE
refactor(node): improve error handling and decouple dependencies

### DIFF
--- a/implementations/typescript/ockam/ockam_command/src/node.ts
+++ b/implementations/typescript/ockam/ockam_command/src/node.ts
@@ -1,31 +1,43 @@
-import { Runner, RunnerOutput } from "./runner";
+import { Runner } from "./runner";
 
 export class Node {
   name: string;
 
-  constructor(name: string) {
+  constructor(name: string, private runner: Runner = new Runner()) {
     this.name = name;
   }
 
-  async show() {
-    const { code } = await Runner.run(["node", "show", this.name]);
-    return code === 0;
+  async show(): Promise<boolean> {
+    try {
+      const { code } = await this.runner.run(["node", "show", this.name]);
+      return code === 0;
+    } catch (error) {
+      throw new Error(`Failed to get status: ${error}`);
+    }
   }
 
-  async isRunning() {
+  async isRunning(): Promise<boolean> {
     return this.show();
   }
 
-  async delete() {
-    const { code } = await Runner.run(["node", "delete", this.name]);
-    return code === 0;
+  async delete(): Promise<boolean> {
+    try {
+      const { code } = await this.runner.run(["node", "delete", this.name]);
+      return code === 0;
+    } catch (error) {
+      throw new Error(`Failed to delete node: ${error}`);
+    }
   }
 
-  static async create(name: string): Promise<Node | null> {
-    const { code } = await Runner.run(["node", "create", name]);
-
-    return new Promise<Node | null>((resolve, reject) => {
-      code === 0 ? resolve(new Node(name)) : reject();
-    });
+  static async create(name: string, runner: Runner = new Runner()): Promise<Node> {
+    try {
+      const { code } = await runner.run(["node", "create", name]);
+      if (code !== 0) {
+        throw new Error(`Node creation failed with code: ${code}`);
+      }
+      return new Node(name, runner);
+    } catch (error) {
+      throw new Error(`Failed to create node: ${error}`);
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

- Introduced `Runner` dependency injection in `Node` constructor for better testability
- `show` method now throws an error with a descriptive message upon failure
- `isRunning` method leverages `show` to determine node status
- `delete` method throws an error with a descriptive message if node deletion fails
- `create` is now a static method that handles node creation and throws descriptive errors on failure


## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
