### PR TITLE
refactor(rust): optimize Debug implementation for PolicyAccessControl

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/policy.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy.rs
@@ -4,7 +4,6 @@ use crate::{AbacAccessControl, PoliciesRepository};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use ockam_core::compat::boxed::Box;
-use ockam_core::compat::format;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{async_trait, RelayMessage};
 use ockam_core::{IncomingAccessControl, Result};
@@ -27,12 +26,11 @@ pub struct PolicyAccessControl {
 /// Debug implementation writing out the resource, action and initial environment
 impl Debug for PolicyAccessControl {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let resource = &self.resource;
-        let action = &self.action;
-        let environment = &self.environment;
-        f.write_str(format!("resource {resource:?}").as_str())?;
-        f.write_str(format!("action {action:?}").as_str())?;
-        f.write_str(format!("environment {environment:?}").as_str())
+        f.debug_struct("PolicyAccessControl")
+            .field("resource", &self.resource)
+            .field("action", &self.action)
+            .field("environment", &self.environment)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Current behavior
- The `Debug` implementation for `PolicyAccessControl` uses `format!` to create strings for logging resource, action, and environment
- This results in unnecessary allocation of intermediate `String` objects

## Proposed changes
- Refactor the `Debug` implementation to use `f.debug_struct()` for formatting
- This change avoids the creation of intermediate `String` objects and directly writes to the formatter
- The proposed implementation is more efficient and aligns with Rust's idiomatic practices for `Debug` trait implementations as in [Rust docs](https://doc.rust-lang.org/std/fmt/struct.Formatter.html#method.debug_struct)

## Checks

<!--
To help us review and merge this pull request quickly, please confirm the following
by replacing the [ ] in front of each bullet point below with [x]
-->

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

<!-- We're looking forward to merging your contribution!! -->
