### PR TITLE
feat(rust): catch execution panics and exit the process

### DIFF
--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
@@ -103,7 +103,8 @@ fn output(mut cont: Container) -> TokenStream {
                Some(_) => (),
             };
 
-            let (mut #ctx_ident, mut executor) = NodeBuilder::new().build();
+            // we don't exit on a panic because we want to catch the panic and report it from within the test.
+            let (mut #ctx_ident, mut executor) = NodeBuilder::new().no_exit_on_panic().build();
             executor
                 .execute(async move {
                     // Wraps the test function call in a `catch_unwind` to catch possible panics.

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -19,6 +19,7 @@ impl ockam_core::Worker for NullWorker {
 /// builder API to customise the underlying node that is created.
 pub struct NodeBuilder {
     logging: bool,
+    exit_on_panic: bool,
 }
 
 impl Default for NodeBuilder {
@@ -30,12 +31,26 @@ impl Default for NodeBuilder {
 impl NodeBuilder {
     /// Create a node
     pub fn new() -> Self {
-        Self { logging: true }
+        Self {
+            logging: true,
+            exit_on_panic: true,
+        }
     }
 
     /// Disable logging on this node
     pub fn no_logging(self) -> Self {
-        Self { logging: false }
+        Self {
+            logging: false,
+            exit_on_panic: self.exit_on_panic,
+        }
+    }
+
+    /// Disable exit on panic on this node
+    pub fn no_exit_on_panic(self) -> Self {
+        Self {
+            logging: self.logging,
+            exit_on_panic: false,
+        }
     }
 
     /// Consume this builder and yield a new Ockam Node
@@ -43,6 +58,20 @@ impl NodeBuilder {
     pub fn build(self) -> (Context, Executor) {
         if self.logging {
             setup_tracing();
+        }
+
+        // building a node should happen only once per process
+        // to create the Context and the Executor (containing the Router)
+        // Since the Executor is used to run async functions we need to catch
+        // any panic raised by those functions and exit the current process in case this happens.
+        // Otherwise the Executor might stay blocked on the Router execution.
+        #[cfg(feature = "std")]
+        if self.exit_on_panic {
+            std::panic::set_hook(Box::new(|panic_info| {
+                println!("A fatal error occurred: {panic_info}.");
+                println!("Please report this issue, with a copy of your logs, to https://github.com/build-trust/ockam/issues.");
+                std::process::exit(1);
+            }));
         }
 
         info!("Initializing ockam node");


### PR DESCRIPTION
When we execute async functions using the `Executor` we might be left hanging if a panic is raised.
This PR:
 
 - catches the panic information
 - displays it
 - and exits the process

It is implemented as a panic hook, at the level of the `NodeBuilder` which is the point where we create the application `Context` and `Executor`, which are used throughout a whole command invocation or portal application use.

I tested this change by:

 - adding a `panic` in various places in the code (like the `InMemoryNode` creation), 
 - calling a command, like `ockam status`
 - checking that we would exit the process