### PR TITLE
Fix `RemoteCredentialRetriever`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,6 +3916,7 @@ dependencies = [
  "ockam_core",
  "ockam_macros",
  "ockam_node",
+ "ockam_transport_core",
  "ockam_transport_tcp",
  "ockam_vault",
  "ockam_vault_aws",

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -11,7 +11,7 @@ use ockam::remote::RemoteRelayOptions;
 use ockam::{node, route, Context, Result, TcpOutletOptions, TcpTransportExtension};
 use ockam_api::authenticator::enrollment_tokens::TokenAcceptor;
 use ockam_api::nodes::NodeManager;
-use ockam_api::{multiaddr_to_route, DefaultAddress};
+use ockam_api::{multiaddr_to_route, multiaddr_to_transport_route, DefaultAddress};
 use ockam_multiaddr::MultiAddr;
 
 /// This node supports a "control" server on which several "edge" devices can connect
@@ -71,14 +71,15 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     authority_node.present_token(node.context(), token).await.unwrap();
 
     let project = import_project(project_information_path, node.identities()).await?;
-    let tcp_project_session = multiaddr_to_route(&project.authority_route(), &tcp).await.unwrap(); // FIXME: Handle error
+    let project_authority_route = multiaddr_to_transport_route(&project.authority_route()).unwrap(); // FIXME: Handle error
 
     // Create a trust context that will be used to authenticate credential exchanges
     let credentials_retriever = Arc::new(RemoteCredentialsRetriever::new(
+        Arc::new(tcp.clone()),
         node.secure_channels(),
         RemoteCredentialsRetrieverInfo::new(
             project.authority_identifier(),
-            tcp_project_session.route,
+            project_authority_route,
             DefaultAddress::CREDENTIAL_ISSUER.into(),
         ),
     ));

--- a/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/trust_contexts.rs
@@ -12,7 +12,7 @@ use ockam_multiaddr::MultiAddr;
 use ockam_transport_tcp::TcpTransport;
 
 use crate::cli_state::CliState;
-use crate::multiaddr_to_route;
+use crate::multiaddr_to_transport_route;
 use crate::nodes::service::default_address::DefaultAddress;
 
 use super::Result;
@@ -278,19 +278,17 @@ impl NamedTrustContext {
             }
             (None, Some(identifier), Some(route)) => {
                 let credential_retriever = RemoteCredentialsRetriever::new(
+                    Arc::new(tcp_transport.clone()),
                     secure_channels.clone(),
                     RemoteCredentialsRetrieverInfo::new(
                         identifier.clone(),
-                        multiaddr_to_route(&route, tcp_transport)
-                            .await
-                            .ok_or_else(|| {
-                                Error::new(
-                                    Origin::Api,
-                                    Kind::Internal,
-                                    format!("cannot create a route from the address {route}"),
-                                )
-                            })?
-                            .route,
+                        multiaddr_to_transport_route(&route).ok_or_else(|| {
+                            Error::new(
+                                Origin::Api,
+                                Kind::Internal,
+                                format!("cannot create a route from the address {route}"),
+                            )
+                        })?,
                         DefaultAddress::CREDENTIAL_ISSUER.into(),
                     ),
                 );

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
@@ -5,7 +5,7 @@ use miette::{miette, IntoDiagnostic};
 use minicbor::{Decode, Encode};
 
 use ockam_core::api::{Reply, Request};
-use ockam_core::{AsyncTryClone, Route};
+use ockam_core::Route;
 use ockam_node::api::Client;
 use ockam_node::Context;
 use ockam_transport_tcp::{TcpConnection, TcpConnectionOptions, TcpTransport};
@@ -52,7 +52,7 @@ impl BackgroundNodeClient {
         node_name: &str,
     ) -> miette::Result<BackgroundNodeClient> {
         let tcp_transport = TcpTransport::create(ctx).await.into_diagnostic()?;
-        BackgroundNodeClient::new(&tcp_transport, cli_state, node_name).await
+        BackgroundNodeClient::new(&tcp_transport, cli_state, node_name)
     }
 
     pub async fn create_to_node_with_tcp(
@@ -60,11 +60,11 @@ impl BackgroundNodeClient {
         cli_state: &CliState,
         node_name: &str,
     ) -> miette::Result<BackgroundNodeClient> {
-        BackgroundNodeClient::new(tcp, cli_state, node_name).await
+        BackgroundNodeClient::new(tcp, cli_state, node_name)
     }
 
     /// Create a new client to send requests to a running background node
-    pub async fn new(
+    pub fn new(
         tcp_transport: &TcpTransport,
         cli_state: &CliState,
         node_name: &str,
@@ -74,7 +74,7 @@ impl BackgroundNodeClient {
             node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
             timeout: Some(Duration::from_secs(30)),
-            tcp_transport: Arc::new(tcp_transport.async_try_clone().await.into_diagnostic()?),
+            tcp_transport: Arc::new(tcp_transport.clone()),
         })
     }
 

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -81,6 +81,7 @@ minicbor = { version = "0.20.0", features = ["alloc", "derive"] }
 ockam_core = { path = "../ockam_core", version = "^0.100.0", default-features = false }
 ockam_macros = { path = "../ockam_macros", version = "^0.32.0", default-features = false }
 ockam_node = { path = "../ockam_node", version = "^0.107.0", default-features = false }
+ockam_transport_core = { path = "../ockam_transport_core", version = "^0.73.0", default_features = false }
 ockam_vault = { path = "../ockam_vault", version = "^0.100.0", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_retriever.rs
@@ -4,9 +4,11 @@ use tracing::debug;
 use tracing::trace;
 
 use ockam_core::compat::boxed::Box;
+
 use ockam_core::compat::sync::Arc;
 use ockam_core::{async_trait, Address, Result, Route};
 use ockam_node::{Context, DEFAULT_TIMEOUT};
+use ockam_transport_core::Transport;
 
 use crate::models::CredentialAndPurposeKey;
 use crate::{Identifier, SecureChannels, SecureClient};
@@ -50,6 +52,7 @@ impl CredentialsRetriever for CredentialsMemoryRetriever {
 
 /// Credentials retriever for credentials located on a different node
 pub struct RemoteCredentialsRetriever {
+    transport: Arc<dyn Transport>,
     secure_channels: Arc<SecureChannels>,
     issuer: RemoteCredentialsRetrieverInfo,
 }
@@ -57,35 +60,15 @@ pub struct RemoteCredentialsRetriever {
 impl RemoteCredentialsRetriever {
     /// Create a new remote credential retriever
     pub fn new(
+        transport: Arc<dyn Transport>,
         secure_channels: Arc<SecureChannels>,
         issuer: RemoteCredentialsRetrieverInfo,
     ) -> Self {
         Self {
+            transport,
             secure_channels,
             issuer,
         }
-    }
-
-    async fn make_secure_client(
-        &self,
-        ctx: &Context,
-        for_identity: &Identifier,
-    ) -> Result<SecureClient> {
-        let resolved_route = ctx
-            .resolve_transport_route(self.issuer.route.clone())
-            .await?;
-        trace!(
-            "Getting credential from resolved route: {}",
-            resolved_route.clone()
-        );
-
-        Ok(SecureClient::new(
-            self.secure_channels.clone(),
-            resolved_route,
-            &self.issuer.identifier,
-            for_identity,
-            DEFAULT_TIMEOUT,
-        ))
     }
 }
 
@@ -97,12 +80,48 @@ impl CredentialsRetriever for RemoteCredentialsRetriever {
         for_identity: &Identifier,
     ) -> Result<CredentialAndPurposeKey> {
         debug!("Getting credential from: {}", &self.issuer.route);
-        let client = self.make_secure_client(ctx, for_identity).await?;
-        let credential = client
+        let transport_type = self.transport.transport_type();
+        let (resolved_route, transport_address) = Context::resolve_transport_route_static(
+            self.issuer.route.clone(),
+            [(transport_type, self.transport.clone())].into(),
+        )
+        .await?;
+
+        trace!(
+            "Getting credential from resolved route: {}",
+            resolved_route.clone()
+        );
+
+        let client = SecureClient::new(
+            self.secure_channels.clone(),
+            resolved_route,
+            &self.issuer.identifier,
+            for_identity,
+            DEFAULT_TIMEOUT,
+        );
+
+        let credential_result = client
             .ask(ctx, "credential_issuer", Request::post("/"))
             .await?
-            .success()?;
-        Ok(credential)
+            .success();
+
+        if let Some(transport_address) = transport_address {
+            let _ = self.transport.disconnect(transport_address).await;
+        }
+
+        match credential_result {
+            Ok(credential) => {
+                debug!("Getting credential from: {} succeeded", &self.issuer.route);
+                Ok(credential)
+            }
+            Err(err) => {
+                debug!(
+                    "Getting credential from: {} failed with err: {}",
+                    &self.issuer.route, err
+                );
+                Err(err)
+            }
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -217,5 +217,9 @@ mod tests {
         async fn resolve_address(&self, address: Address) -> Result<Address> {
             Ok(address)
         }
+
+        async fn disconnect(&self, _address: Address) -> Result<()> {
+            Ok(())
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_transport_core/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/transport.rs
@@ -17,6 +17,9 @@ pub trait Transport: Send + Sync + 'static {
     /// Instantiate transport workers for in order to communicate with a remote address
     /// and return the local address of the transport worker
     async fn resolve_address(&self, address: Address) -> Result<Address>;
+
+    /// Stop all workers and free all resources associated with the connection
+    async fn disconnect(&self, address: Address) -> Result<()>;
 }
 
 /// Helper that creates a length-prefixed buffer containing the given

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
@@ -20,13 +20,13 @@ impl TcpTransport {
     /// ```
     pub async fn create(ctx: &Context) -> Result<Self> {
         let tcp = Self {
-            ctx: ctx.async_try_clone().await?,
+            ctx: Arc::new(ctx.async_try_clone().await?),
             registry: TcpRegistry::default(),
         };
         // make the TCP transport available in the list of supported transports for
         // later address resolution when socket addresses will need to be instantiated as TCP
         // worker addresses
-        ctx.register_transport(Arc::new(tcp.async_try_clone().await?));
+        ctx.register_transport(Arc::new(tcp.clone()));
         Ok(tcp)
     }
 }
@@ -128,6 +128,10 @@ impl Transport for TcpTransport {
                 ),
             ))
         }
+    }
+
+    async fn disconnect(&self, address: Address) -> Result<()> {
+        self.disconnect(address).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
@@ -9,7 +9,8 @@ pub use common::*;
 pub use crate::portal::options::*;
 
 use crate::TcpRegistry;
-use ockam_core::{async_trait, AsyncTryClone, Result};
+use ockam_core::compat::sync::Arc;
+use ockam_core::{async_trait, Result};
 use ockam_node::{Context, HasContext};
 
 /// High level management interface for TCP transports
@@ -50,10 +51,9 @@ use ockam_node::{Context, HasContext};
 /// tcp.listen("127.0.0.1:9000", TcpListenerOptions::new()).await?; // Listen on port 9000
 /// # Ok(()) }
 /// ```
-#[derive(AsyncTryClone)]
-#[async_try_clone(crate = "ockam_core")]
+#[derive(Clone)]
 pub struct TcpTransport {
-    ctx: Context,
+    ctx: Arc<Context>,
     registry: TcpRegistry,
 }
 


### PR DESCRIPTION
`RemoteCredentialsRetriever` has a route to the Authority node. Every time we ask it for a credential, it's meant to create a fresh tcp connection and a fresh secure channel. However, the tcp connection is created beforehand somewhere else, and is handed to the `RemoteCredentialsRetriever` as a resolved TCP Worker Address in the route. Therefore, when that tcp connection dies (for any reason, like connectivity problem or if it's unused for some time), it won't be recreated and we won't be able to get a credential. 