### PR TITLE
test(rust): move a portals test to the right file

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
@@ -196,26 +196,6 @@ teardown() {
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
 }
 
-@test "portals - local inlet and outlet, removing and re-creating the outlet" {
-  port="$(random_port)"
-  node_port="$(random_port)"
-
-  setup_home_dir
-
-  run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
-  run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:5000
-  run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to /node/blue/secure/api/service/outlet
-  run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
-
-  run_success "$OCKAM" node delete blue --yes
-  run_failure curl --fail --head --max-time 2 "127.0.0.1:$port"
-
-  run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
-  run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:5000
-  run_success curl --head --retry-connrefused --retry 20 --retry-max-time 20 --max-time 1 "127.0.0.1:$port"
-}
-
 @test "portals - local inlet and outlet passing through a relay, removing and re-creating the outlet" {
   port="$(random_port)"
   node_port="$(random_port)"


### PR DESCRIPTION
This test doesn't use the Orchestrator.