### PR TITLE
fix(rust): fix worker and processor relay start order

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -26,22 +26,27 @@ pub enum NodeError {
 
 impl NodeError {
     /// Turn a NodeError into a Kind::NotFound ockam_core::Error
+    #[track_caller]
     pub fn not_found(self) -> Error {
         Error::new(Origin::Node, Kind::NotFound, self)
     }
     /// Turn a NodeError into a Kind::AlreadyExists ockam_core::Error
+    #[track_caller]
     pub fn already_exists(self) -> Error {
         Error::new(Origin::Node, Kind::AlreadyExists, self)
     }
     /// Turn a NodeError into a Kind::Conflict ockam_core::Error
+    #[track_caller]
     pub fn conflict(self) -> Error {
         Error::new(Origin::Node, Kind::Conflict, self)
     }
     /// Turn a NodeError into a Kind::Internal ockam_core::Error
+    #[track_caller]
     pub fn internal(self) -> Error {
         Error::new(Origin::Node, Kind::Internal, self)
     }
     /// Create an ockam_core::Error based on a tokio::SendError
+    #[track_caller]
     pub(crate) fn from_send_err<T: fmt::Debug>(err: SendError<T>) -> Error {
         Error::new(
             Origin::Node,
@@ -52,6 +57,7 @@ impl NodeError {
     }
 
     /// Create an ockam_core::Error from a tokio::Elapsed
+    #[track_caller]
     pub(crate) fn with_elapsed(self, err: Elapsed) -> Error {
         Error::new(Origin::Node, Kind::Timeout, err).context("Type", self)
     }

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -155,9 +155,6 @@ where
 
     debugger::log_inherit_context("PROCESSOR", context, &ctx);
 
-    // Then initialise the processor message relay
-    ProcessorRelay::<P>::init(context.runtime(), processor, ctx, ctrl_rx);
-
     // Send start request to router
     let (msg, mut rx) = NodeMessage::start_processor(main_address.clone(), sender);
     context
@@ -170,6 +167,9 @@ where
     rx.recv()
         .await
         .ok_or_else(|| NodeError::NodeState(NodeReason::Unknown).internal())??;
+
+    // Then initialise the processor message relay
+    ProcessorRelay::<P>::init(context.runtime(), processor, ctx, ctrl_rx);
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_node/src/worker_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/worker_builder.rs
@@ -155,9 +155,6 @@ where
 
     debugger::log_inherit_context("WORKER", context, &ctx);
 
-    // Then initialise the worker message relay
-    WorkerRelay::init(context.runtime(), worker, ctx, ctrl_rx);
-
     // Send start request to router
     let (msg, mut rx) =
         NodeMessage::start_worker(addresses, sender, false, context.mailbox_count());
@@ -171,6 +168,9 @@ where
     rx.recv()
         .await
         .ok_or_else(|| NodeError::NodeState(NodeReason::Unknown).internal())??;
+
+    // Then initialise the worker message relay
+    WorkerRelay::init(context.runtime(), worker, ctx, ctrl_rx);
 
     Ok(())
 }


### PR DESCRIPTION
In current implementation Worker/Processor relay is spawned before corresponding addresses are added to the Router map, which creates a race condition if Worker/Processor init function requires Router to know about those addresses. For example, we have TCP workers trying to call `ctx.set_cluster(super::CLUSTER_NAME).await` first thing in their `initialize` function, which will fail if it gets executed by the environment before Router added this worker to its map.