### PR TITLE
feat(rust): make authority issued credentials TTL configurable

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -52,6 +52,7 @@ async fn main(ctx: Context) -> Result<()> {
         node.credentials(),
         &issuer,
         "trust_context".into(),
+        None,
     );
 
     let attributes = AttributesEntry::single(b"cluster".to_vec(), b"production".to_vec(), None, None)?;

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -10,6 +10,7 @@ use ockam::identity::{
 use ockam_abac::expr::{and, eq, ident, str};
 use ockam_abac::{AbacAccessControl, Env, Policy};
 use ockam_core::compat::sync::Arc;
+use ockam_core::env::get_env;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::{Error, Result, Worker};
@@ -206,6 +207,8 @@ impl Authority {
         secure_channel_flow_control_id: &FlowControlId,
         configuration: &Configuration,
     ) -> Result<()> {
+        let ttl = get_env("CREDENTIAL_TTL_SECS")?;
+
         // create and start a credential issuer worker
         let issuer = CredentialsIssuer::new(
             self.secure_channels
@@ -214,6 +217,7 @@ impl Authority {
             self.secure_channels.identities().credentials(),
             &self.identifier,
             configuration.project_identifier(),
+            ttl,
         );
 
         let address = DefaultAddress::CREDENTIAL_ISSUER.to_string();

--- a/implementations/rust/ockam/ockam_api/src/util.rs
+++ b/implementations/rust/ockam/ockam_api/src/util.rs
@@ -375,7 +375,7 @@ pub fn local_worker(code: &Code) -> Result<bool> {
 #[cfg(test)]
 pub mod test_utils {
     use ockam::identity::utils::AttributesBuilder;
-    use ockam::identity::MAX_CREDENTIAL_VALIDITY;
+    use ockam::identity::DEFAULT_CREDENTIAL_VALIDITY;
     use ockam::identity::{SecureChannels, PROJECT_MEMBER_SCHEMA, TRUST_CONTEXT_ID};
     use ockam::Result;
     use ockam_core::compat::sync::Arc;
@@ -443,7 +443,7 @@ pub mod test_utils {
                 &identifier,
                 &identifier,
                 attributes,
-                MAX_CREDENTIAL_VALIDITY,
+                DEFAULT_CREDENTIAL_VALIDITY,
             )
             .await
             .unwrap();

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -74,6 +74,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         identities.credentials(),
         &auth_identifier,
         "project42".into(),
+        None,
     );
     ctx.start_worker(auth_worker_addr.clone(), auth).await?;
 

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -3,7 +3,7 @@ use miette::{miette, IntoDiagnostic};
 
 use ockam::identity::utils::AttributesBuilder;
 use ockam::identity::Identifier;
-use ockam::identity::{MAX_CREDENTIAL_VALIDITY, PROJECT_MEMBER_SCHEMA, TRUST_CONTEXT_ID};
+use ockam::identity::{DEFAULT_CREDENTIAL_VALIDITY, PROJECT_MEMBER_SCHEMA, TRUST_CONTEXT_ID};
 use ockam::Context;
 use ockam_core::compat::collections::HashMap;
 
@@ -83,7 +83,7 @@ async fn run_impl(
             &authority,
             &cmd.identity_identifier,
             attributes_builder.build(),
-            MAX_CREDENTIAL_VALIDITY,
+            DEFAULT_CREDENTIAL_VALIDITY,
         )
         .await
         .into_diagnostic()?;

--- a/implementations/rust/ockam/ockam_core/src/env.rs
+++ b/implementations/rust/ockam/ockam_core/src/env.rs
@@ -4,6 +4,7 @@ use crate::compat::string::String;
 use crate::compat::vec::Vec;
 use crate::errcode::{Kind, Origin};
 use crate::{Error, Result};
+use core::time::Duration;
 #[cfg(feature = "std")]
 use std::env;
 #[cfg(feature = "std")]
@@ -90,7 +91,12 @@ impl FromString for u8 {
             .map_err(|_| error("u8 parsing error".to_string()))
     }
 }
-
+impl FromString for Duration {
+    fn from_string(s: &str) -> Result<Self> {
+        let secs = u64::from_string(s)?;
+        Ok(Duration::from_secs(secs))
+    }
+}
 impl FromString for u16 {
     fn from_string(s: &str) -> Result<Self> {
         s.parse::<u16>()

--- a/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/credentials_issuer.rs
@@ -27,7 +27,7 @@ pub const TRUST_CONTEXT_ID_UTF8: &str = "trust_context_id";
 pub const PROJECT_MEMBER_SCHEMA: CredentialSchemaIdentifier = CredentialSchemaIdentifier(1);
 
 /// Maximum duration for a valid credential in seconds (30 days)
-pub const MAX_CREDENTIAL_VALIDITY: Duration = Duration::from_secs(30 * 24 * 3600);
+pub const DEFAULT_CREDENTIAL_VALIDITY: Duration = Duration::from_secs(30 * 24 * 3600);
 
 /// This struct runs as a Worker to issue credentials based on a request/response protocol
 pub struct CredentialsIssuer {
@@ -35,6 +35,7 @@ pub struct CredentialsIssuer {
     credentials: Arc<Credentials>,
     issuer: Identifier,
     subject_attributes: Attributes,
+    credential_ttl: Duration,
 }
 
 impl CredentialsIssuer {
@@ -44,6 +45,7 @@ impl CredentialsIssuer {
         credentials: Arc<Credentials>,
         issuer: &Identifier,
         trust_context: String,
+        credential_ttl: Option<Duration>,
     ) -> Self {
         let subject_attributes = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA)
             .with_attribute(TRUST_CONTEXT_ID.to_vec(), trust_context.as_bytes().to_vec())
@@ -54,6 +56,7 @@ impl CredentialsIssuer {
             credentials,
             issuer: issuer.clone(),
             subject_attributes,
+            credential_ttl: credential_ttl.unwrap_or(DEFAULT_CREDENTIAL_VALIDITY),
         }
     }
 
@@ -84,7 +87,7 @@ impl CredentialsIssuer {
                 &self.issuer,
                 subject,
                 subject_attributes,
-                MAX_CREDENTIAL_VALIDITY,
+                self.credential_ttl,
             )
             .await?;
 


### PR DESCRIPTION
CREDENTIAL_TTL_SECS env variable can be used to specify the TTL of the credential issued by the authority. If not present, a hardcoded default one is used, as has been done so far.


DO NOT MERGE AS-IS.   It changes the API for credential_issuer (instantiation),  that is part of examples/docs.      Reading the env variable from credential_issuer' directly is not possible due to no-std on the create where it's located.
