### PR TITLE
feat(rust): sample cmd to retrieve account and project admin credentials

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/account.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/account.rs
@@ -1,0 +1,79 @@
+use miette::IntoDiagnostic;
+use ockam::identity::models::CredentialAndPurposeKey;
+
+use ockam_core::api::Request;
+use ockam_core::async_trait;
+use ockam_node::Context;
+
+use crate::cloud::ControllerClient;
+use crate::nodes::InMemoryNode;
+
+const TARGET: &str = "ockam_api::cloud::account";
+
+#[async_trait]
+pub trait Accounts {
+    async fn get_account_credential(
+        &self,
+        ctx: &Context,
+    ) -> miette::Result<CredentialAndPurposeKey>;
+
+    async fn get_project_admin_credential(
+        &self,
+        ctx: &Context,
+        project_id: &str,
+    ) -> miette::Result<CredentialAndPurposeKey>;
+}
+
+#[async_trait]
+impl Accounts for InMemoryNode {
+    async fn get_account_credential(
+        &self,
+        ctx: &Context,
+    ) -> miette::Result<CredentialAndPurposeKey> {
+        let controller = self.create_controller().await?;
+        controller.get_account_credential(ctx).await
+    }
+    async fn get_project_admin_credential(
+        &self,
+        ctx: &Context,
+        project_id: &str,
+    ) -> miette::Result<CredentialAndPurposeKey> {
+        let controller = self.create_controller().await?;
+        controller
+            .get_project_admin_credential(ctx, project_id)
+            .await
+    }
+}
+
+impl ControllerClient {
+    pub async fn get_account_credential(
+        &self,
+        ctx: &Context,
+    ) -> miette::Result<CredentialAndPurposeKey> {
+        trace!(target: TARGET, "getting account credential");
+        self.secure_client
+            .ask(ctx, "accounts", Request::get("/v0/account"))
+            .await
+            .into_diagnostic()?
+            .success()
+            .into_diagnostic()
+    }
+
+    async fn get_project_admin_credential(
+        &self,
+        ctx: &Context,
+        project_id: &str,
+    ) -> miette::Result<CredentialAndPurposeKey> {
+        trace!(target: TARGET, "getting project admin credential");
+        self.secure_client
+            .ask(
+                ctx,
+                "accounts",
+                Request::get(format!("/v0/project/{}", project_id)),
+            )
+            .await
+            .into_diagnostic()?
+            .success()
+            .into_diagnostic()
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/mod.rs
@@ -1,5 +1,6 @@
 pub use secure_clients::*;
 
+pub mod account;
 pub mod addon;
 pub mod email_address;
 pub mod enroll;

--- a/implementations/rust/ockam/ockam_command/src/account/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/account/mod.rs
@@ -1,0 +1,73 @@
+use clap::{command, Args, Subcommand};
+use ockam_api::cloud::account::Accounts;
+use ockam_api::cloud::project::Projects;
+use ockam_api::nodes::InMemoryNode;
+use ockam_node::Context;
+
+use crate::{
+    output::CredentialAndPurposeKeyDisplay,
+    util::{api::CloudOpts, node_rpc},
+    CommandGlobalOpts,
+};
+
+#[derive(Clone, Debug, Args)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
+pub struct AccountCommand {
+    #[command(subcommand)]
+    subcommand: AccountSubcommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum AccountSubcommand {
+    Credential(GetAccountCredentialCommand),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct GetAccountCredentialCommand {
+    #[command(flatten)]
+    pub cloud_opts: CloudOpts,
+
+    #[arg(long, value_name = "PROJECT_NAME")]
+    pub project: Option<String>,
+}
+
+impl GetAccountCredentialCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        node_rpc(rpc, (options, self));
+    }
+}
+
+async fn rpc(
+    ctx: Context,
+    (opts, cmd): (CommandGlobalOpts, GetAccountCredentialCommand),
+) -> miette::Result<()> {
+    run_impl(&ctx, opts, cmd).await
+}
+
+async fn run_impl(
+    ctx: &Context,
+    opts: CommandGlobalOpts,
+    cmd: GetAccountCredentialCommand,
+) -> miette::Result<()> {
+    let node = InMemoryNode::start(ctx, &opts.state).await?;
+    let credential = if let Some(project_name) = cmd.project {
+        let project = node.get_project_by_name(ctx, &project_name).await?;
+        node.get_project_admin_credential(ctx, &project.id).await?
+    } else {
+        node.get_account_credential(ctx).await?
+    };
+    opts.terminal
+        .clone()
+        .stdout()
+        .plain(CredentialAndPurposeKeyDisplay(credential))
+        .write_line()?;
+    Ok(())
+}
+
+impl AccountCommand {
+    pub fn run(self, options: CommandGlobalOpts) {
+        match self.subcommand {
+            AccountSubcommand::Credential(c) => c.run(options),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -26,6 +26,7 @@ use console::Term;
 use miette::GraphicalReportHandler;
 use once_cell::sync::Lazy;
 
+use account::AccountCommand;
 use authenticated::AuthenticatedCommand;
 use completion::CompletionCommand;
 use configuration::ConfigurationCommand;
@@ -77,6 +78,7 @@ use crate::sidecar::SidecarCommand;
 use crate::subscription::SubscriptionCommand;
 pub use crate::terminal::{OckamColor, Terminal, TerminalStream};
 
+mod account;
 mod admin;
 mod authenticated;
 mod authority;
@@ -333,6 +335,7 @@ pub enum OckamSubcommand {
     Status(StatusCommand),
     Reset(ResetCommand),
     Authenticated(AuthenticatedCommand),
+    Account(AccountCommand),
     Configuration(ConfigurationCommand),
 
     Completion(CompletionCommand),
@@ -454,6 +457,7 @@ impl OckamCommand {
             OckamSubcommand::Status(c) => c.run(options),
             OckamSubcommand::Reset(c) => c.run(options),
             OckamSubcommand::Authenticated(c) => c.run(options),
+            OckamSubcommand::Account(c) => c.run(options),
             OckamSubcommand::Configuration(c) => c.run(options),
 
             OckamSubcommand::Completion(c) => c.run(),


### PR DESCRIPTION
intended as a working demonstration on how to call the orchestrator endpoint for retrieving these kind of controller-issued credentials.
