### PR TITLE
feat(rust): allow running `reset` command even if the database is in an invalid state

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -89,6 +89,12 @@ impl CliState {
         self.delete()
     }
 
+    /// Removes all the directories storing state without loading the current state
+    pub fn hard_reset() -> Result<()> {
+        let dir = Self::default_dir()?;
+        Self::delete_at(&dir)
+    }
+
     /// Delete the local database and log files
     pub fn delete(&self) -> Result<()> {
         Self::delete_at(&self.dir)

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -24,7 +24,7 @@ use std::{path::PathBuf, sync::Mutex};
 use clap::{ArgAction, Args, Parser, Subcommand};
 use colorful::Colorful;
 use console::Term;
-use miette::GraphicalReportHandler;
+use miette::{miette, GraphicalReportHandler};
 use once_cell::sync::Lazy;
 use opentelemetry::trace::{TraceContextExt, Tracer};
 use opentelemetry::{global, Context};
@@ -86,6 +86,7 @@ use crate::output::OutputFormat;
 use crate::run::RunCommand;
 use crate::sidecar::SidecarCommand;
 use crate::subscription::SubscriptionCommand;
+use crate::terminal::color_primary;
 pub use crate::terminal::{OckamColor, Terminal, TerminalStream};
 
 mod admin;
@@ -254,19 +255,40 @@ pub struct CommandGlobalOpts {
 }
 
 impl CommandGlobalOpts {
-    pub fn new(global_args: GlobalArgs) -> Self {
+    pub fn new(global_args: GlobalArgs, cmd: &OckamSubcommand) -> Self {
         let terminal = Terminal::from(&global_args);
         let state = match CliState::with_default_dir() {
             Ok(state) => state,
             Err(err) => {
+                // If the user is trying to run `ockam reset` and the local state is corrupted,
+                // we can try to hard reset the local state.
+                if let OckamSubcommand::Reset(c) = cmd {
+                    c.hard_reset();
+                    terminal
+                        .stdout()
+                        .plain(fmt_ok!("Local Ockam configuration deleted"))
+                        .write_line()
+                        .unwrap();
+                    exit(exitcode::OK);
+                }
                 terminal
-                    .write_line(fmt_err!("Failed to initialize local state, error={}", err))
+                    .write_line(fmt_err!("Failed to initialize local state"))
                     .unwrap();
                 terminal
                     .write_line(fmt_log!(
-                        "Consider upgrading to the latest version of Ockam Command, \
-                        or try removing the local state directory at ~/.ockam"
+                        "Consider upgrading to the latest version of Ockam Command"
                     ))
+                    .unwrap();
+                terminal
+                    .write_line(fmt_log!(
+                        "You can also try removing the local state using {} \
+                        or deleting the directory at {}",
+                        color_primary("ockam reset"),
+                        color_primary("~/.ockam")
+                    ))
+                    .unwrap();
+                terminal
+                    .write_line(format!("\n{:?}", miette!(err.to_string())))
                     .unwrap();
                 exit(exitcode::SOFTWARE);
             }
@@ -450,7 +472,7 @@ impl OckamCommand {
                     .with_urls(false),
             )
         }));
-        let options = CommandGlobalOpts::new(self.global_args.clone());
+        let options = CommandGlobalOpts::new(self.global_args.clone(), &self.subcommand);
 
         let tracing_guard = if !options.global_args.quiet {
             let log_path = self.log_path(&options);

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -2,6 +2,8 @@ use clap::Args;
 use colorful::Colorful;
 use miette::{miette, WrapErr};
 use ockam_api::cloud::space::Spaces;
+use ockam_api::CliState;
+use tracing::error;
 
 use ockam_api::nodes::InMemoryNode;
 use ockam_node::Context;
@@ -29,6 +31,12 @@ impl ResetCommand {
 
     pub fn name(&self) -> String {
         "reset".to_string()
+    }
+
+    pub fn hard_reset(&self) {
+        if let Err(err) = CliState::hard_reset() {
+            error!("Failed to hard reset CliState, err={err}");
+        }
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
@@ -50,12 +50,12 @@ macro_rules! color {
     };
 }
 
-pub fn color_primary(input: String) -> CString {
-    input.color(OckamColor::PrimaryResource.color())
+pub fn color_primary(input: impl Into<String>) -> CString {
+    input.into().color(OckamColor::PrimaryResource.color())
 }
 
-pub fn color_email(input: String) -> CString {
-    input.color(OckamColor::PrimaryResource.color())
+pub fn color_email(input: impl Into<String>) -> CString {
+    input.into().color(OckamColor::PrimaryResource.color())
 }
 
 pub fn color_uri(input: &str) -> String {


### PR DESCRIPTION
The database is always loaded before running a command. When we switch to a previous/older version with a different database schema (with differences in the migrations), we have to manually remove the database because we couldn't run the `reset` command.

This PR adds new logic in the command crate that allows us to remove the local state when running the `reset` command, even if it fails to load the database.

It also changes the output that we show when we detect the corrupted state:

![image](https://github.com/build-trust/ockam/assets/12375782/fbace729-0c6e-4eb9-a75b-9cf98001d769)


## How to test

```
ockam node create

# Modify one of the migrations at implementations/rust/ockam/ockam_node/src/storage/database/migrations
ockam node create # this should fail and show the above error

ockam reset # this should work and reset the state
