### PR TITLE
Simplify the ockam test macro and make arguments tests more robust

### DIFF
--- a/implementations/rust/ockam/ockam/tests/node_test.rs
+++ b/implementations/rust/ockam/ockam/tests/node_test.rs
@@ -4,8 +4,8 @@ use ockam_node::Context;
 use std::time::Duration;
 
 #[ockam_macros::test]
-async fn ok_if_return_ok(ctx: &mut Context) -> Result<()> {
-    ctx.stop().await
+async fn ok_if_return_ok(_ctx: &mut Context) -> Result<()> {
+    Ok(())
 }
 
 #[ockam_macros::test]

--- a/implementations/rust/ockam/ockam/tests/relay.rs
+++ b/implementations/rust/ockam/ockam/tests/relay.rs
@@ -24,8 +24,7 @@ async fn test1(ctx: &mut Context) -> Result<()> {
         .await?;
 
     assert_eq!(resp, "Hello");
-
-    ctx.stop().await
+    Ok(())
 }
 
 // Cloud: Hosts a Relay service and listens on a tcp port. No flow control
@@ -71,8 +70,7 @@ async fn test2(ctx: &mut Context) -> Result<()> {
         .await?;
 
     assert_eq!(resp, "Hello");
-
-    ctx.stop().await
+    Ok(())
 }
 
 // Server: Connects to a Cloud using tcp and creates a dynamic Relay. Using flow control
@@ -131,8 +129,7 @@ async fn test3(ctx: &mut Context) -> Result<()> {
         .await?;
 
     assert_eq!(res.body(), "Hello");
-
-    ctx.stop().await
+    Ok(())
 }
 
 // Cloud:
@@ -251,5 +248,5 @@ async fn test4(ctx: &mut Context) -> Result<()> {
 
     assert_eq!(resp, "Hello");
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
+++ b/implementations/rust/ockam/ockam_api/tests/auth_smoke.rs
@@ -56,5 +56,5 @@ async fn auth_smoke(ctx: &mut Context) -> Result<()> {
 
     assert_eq!(2, client.list_identifiers(ctx).await.unwrap().len());
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_api/tests/authority.rs
+++ b/implementations/rust/ockam/ockam_api/tests/authority.rs
@@ -30,8 +30,6 @@ async fn authority_starts_with_default_configuration(ctx: &mut Context) -> Resul
 
     assert!(!workers.contains(&Address::from(DefaultAddress::DIRECT_AUTHENTICATOR)));
 
-    ctx.stop().await?;
-
     Ok(())
 }
 
@@ -81,8 +79,6 @@ async fn controlling_authority_by_member_times_out(ctx: &mut Context) -> Result<
 
     assert!(timeout.load(Ordering::Relaxed));
 
-    ctx.stop().await?;
-
     Ok(())
 }
 
@@ -118,8 +114,6 @@ async fn one_admin_test_api(ctx: &mut Context) -> Result<()> {
     let members = admin.client.list_member_ids(ctx).await.unwrap();
     assert_eq!(members.len(), 1);
     assert_eq!(members[0], admin.identifier);
-
-    ctx.stop().await?;
 
     Ok(())
 }
@@ -190,8 +184,6 @@ async fn test_one_admin_one_member(ctx: &mut Context) -> Result<()> {
     let members = admin.client.list_members(ctx).await.unwrap();
     assert_eq!(members.len(), 1);
     assert!(members.get(&admin.identifier).is_some());
-
-    ctx.stop().await?;
 
     Ok(())
 }
@@ -311,8 +303,6 @@ async fn two_admins_two_members_exist_in_one_global_scope(ctx: &mut Context) -> 
     assert_eq!(members1.len(), 2);
     assert!(members1.get(&admin1.identifier).is_some());
     assert!(members1.get(&admin2.identifier).is_some());
-
-    ctx.stop().await?;
 
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -118,5 +118,5 @@ async fn credential(ctx: &mut Context) -> Result<()> {
             .map
             .get::<ByteSlice>(b"attr".as_slice().into())
     );
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -439,6 +439,13 @@ pub fn run() {
 
 impl OckamCommand {
     pub fn run(self) {
+        // If test_argument_parser is true, command arguments are checked
+        // but the command is not executed. This is useful to test arguments
+        // without having to execute their logic.
+        if self.global_args.test_argument_parser {
+            return;
+        }
+
         // Sets a hook using our own Error Report Handler
         // This allows us to customize how we
         // format the error messages and their content.
@@ -470,13 +477,6 @@ impl OckamCommand {
         } else {
             None
         };
-
-        // If test_argument_parser is true, command arguments are checked
-        // but the command is not executed. This is useful to test arguments
-        // without having to execute their logic.
-        if options.global_args.test_argument_parser {
-            return;
-        }
 
         if let Err(err) = check_if_an_upgrade_is_available(&options) {
             warn!("Failed to check for upgrade, error={err}");

--- a/implementations/rust/ockam/ockam_identity/src/identities/identity_keys.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identity_keys.rs
@@ -156,15 +156,14 @@ mod test {
     use core::str::FromStr;
     use ockam_core::errcode::{Kind, Origin};
     use ockam_core::Error;
-    use ockam_node::Context;
     use ockam_vault::SigningKeyType;
 
     fn test_error<S: Into<String>>(error: S) -> Result<()> {
         Err(Error::new_without_cause(Origin::Identity, Kind::Unknown).context("msg", error.into()))
     }
 
-    #[ockam_macros::test]
-    async fn test_basic_identity_key_ops(ctx: &mut Context) -> Result<()> {
+    #[tokio::test]
+    async fn test_basic_identity_key_ops() -> Result<()> {
         let identities = identities().await?;
         let identities_keys = identities.identities_keys();
 
@@ -266,7 +265,6 @@ mod test {
             .get_verifying_public_key(&secret2)
             .await
             .is_ok());
-
-        ctx.stop().await
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -78,7 +78,7 @@ async fn test_channel(ctx: &mut Context) -> Result<()> {
 
     assert_eq!("Hello, Alice!", msg.body());
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -219,7 +219,7 @@ async fn test_channel_send_credentials(context: &mut Context) -> Result<()> {
         bob_attributes.attrs().get("bob_2".as_bytes()).unwrap()
     );
 
-    context.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -276,7 +276,7 @@ async fn test_channel_rejected_trust_policy(ctx: &mut Context) -> Result<()> {
 
     assert!(result.is_err());
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -408,7 +408,7 @@ async fn test_channel_registry(ctx: &mut Context) -> Result<()> {
     assert_eq!(bob_channel_data.my_id(), &bob);
     assert_eq!(bob_channel_data.their_id(), &alice);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -518,7 +518,7 @@ async fn test_channel_api(ctx: &mut Context) -> Result<()> {
     assert_eq!(decrypted_alice, b"Pong");
     assert_eq!(decrypted_bob, b"Ping");
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -593,7 +593,7 @@ async fn test_tunneled_secure_channel_works(ctx: &mut Context) -> Result<()> {
         .await?;
     assert_eq!("Hello, Alice!", child_ctx.receive::<String>().await?.body());
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -684,7 +684,7 @@ async fn test_double_tunneled_secure_channel_works(ctx: &mut Context) -> Result<
         .await?;
     assert_eq!("Hello, Alice!", child_ctx.receive::<String>().await?.body());
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -825,7 +825,7 @@ async fn access_control__known_participant__should_pass_messages(ctx: &mut Conte
 
     assert_eq!(received_count.load(Ordering::Relaxed), 1);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[allow(non_snake_case)]
@@ -875,7 +875,7 @@ async fn access_control__unknown_participant__should_not_pass_messages(
 
     assert_eq!(received_count.load(Ordering::Relaxed), 0);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[allow(non_snake_case)]
@@ -905,7 +905,7 @@ async fn access_control__no_secure_channel__should_not_pass_messages(
 
     assert_eq!(received_count.load(Ordering::Relaxed), 0);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -1091,5 +1091,5 @@ async fn should_stop_encryptor__and__decryptor__in__secure_channel(
     assert!(!workers.contains(channel2.decryptor_messaging_address()));
     assert!(!workers.contains(channel2.encryptor_messaging_address()));
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_identity/tests/ciphertext_message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/ciphertext_message_flow_auth.rs
@@ -59,7 +59,7 @@ async fn test1(ctx: &mut Context) -> Result<()> {
         "We can create multiple secure channels with that connection"
     );
 
-    ctx.stop().await
+    Ok(())
 }
 
 // Alice: TCP connection + Secure Channel listener
@@ -98,5 +98,5 @@ async fn test2(ctx: &mut Context) -> Result<()> {
     message_should_not_pass(ctx, &channel_to_alice.address).await?;
     message_should_not_pass(ctx, &channel_to_bob).await?;
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_identity/tests/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials.rs
@@ -91,7 +91,7 @@ async fn full_flow_oneway(ctx: &mut Context) -> Result<()> {
 
     assert_eq!(val.as_slice(), b"true");
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -202,7 +202,7 @@ async fn full_flow_twoway(ctx: &mut Context) -> Result<()> {
         b"true"
     );
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -307,7 +307,7 @@ async fn access_control(ctx: &mut Context) -> Result<()> {
     ctx.sleep(Duration::from_millis(100)).await;
     assert_eq!(counter.load(Ordering::Relaxed), 1);
 
-    ctx.stop().await
+    Ok(())
 }
 
 struct CountingWorker {

--- a/implementations/rust/ockam/ockam_identity/tests/credentials_refresh.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/credentials_refresh.rs
@@ -91,7 +91,7 @@ async fn autorefresh(ctx: &mut Context) -> Result<()> {
     // Server asks for a credential on second 0; 4 and 8
     assert_eq!(call_counter_server.load(Ordering::Relaxed), 3);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -183,7 +183,7 @@ async fn autorefresh_attributes_update(ctx: &mut Context) -> Result<()> {
     assert_eq!(added3, added2);
     assert!(added3 < added4);
 
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -255,7 +255,7 @@ async fn autorefresh_retry(ctx: &mut Context) -> Result<()> {
     assert_eq!(call_counter.load(Ordering::Relaxed), 3);
     assert_eq!(failed_call_counter.load(Ordering::Relaxed), 1);
 
-    ctx.stop().await
+    Ok(())
 }
 struct LocalCredentialsRetriever {
     credentials: Arc<Credentials>,

--- a/implementations/rust/ockam/ockam_identity/tests/plaintext_message_flow_auth.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/plaintext_message_flow_auth.rs
@@ -57,7 +57,7 @@ async fn test1(ctx: &mut Context) -> Result<()> {
         .add_consumer("alice_ctx", channel_to_bob.flow_control_id());
     message_should_pass_with_ctx(ctx, &channel_to_alice, &mut alice_ctx).await?;
 
-    ctx.stop().await
+    Ok(())
 }
 
 // Alice: TCP connection + Secure Channel
@@ -137,5 +137,5 @@ async fn test2(ctx: &mut Context) -> Result<()> {
         .add_consumer("alice_ctx", channel_to_bob.flow_control_id());
     message_should_pass_with_ctx(ctx, &channel_to_alice, &mut alice_ctx).await?;
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_node/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_node/tests/tests.rs
@@ -33,7 +33,7 @@ async fn receive_timeout__1_sec__should_return_from_call(ctx: &mut Context) -> R
         diff < Duration::from_secs(2),
         "1 sec timeout definitely should not take longer than 2 secs"
     );
-    ctx.stop().await
+    Ok(())
 }
 
 #[allow(non_snake_case)]
@@ -152,7 +152,7 @@ async fn starting_processor_with_dup_address_should_fail(ctx: &mut Context) -> R
         .start_processor("dummy_processor", DummyProcessor)
         .await
         .is_err());
-    ctx.stop().await
+    Ok(())
 }
 
 struct CountingProcessor {
@@ -213,7 +213,7 @@ async fn counting_processor__run_node_lifecycle__processor_lifecycle_should_be_f
     assert!(shutdown_was_called.load(Ordering::Relaxed));
     assert_eq!(5, run_called_count.load(Ordering::Relaxed));
 
-    ctx.stop().await
+    Ok(())
 }
 
 struct WaitingProcessor {
@@ -270,7 +270,7 @@ async fn waiting_processor__shutdown__should_be_interrupted(ctx: &mut Context) -
 
     assert!(initialize_was_called.load(Ordering::Relaxed));
     assert!(shutdown_was_called.load(Ordering::Relaxed));
-    ctx.stop().await
+    Ok(())
 }
 
 struct MessagingProcessor {
@@ -350,7 +350,7 @@ async fn waiting_processor__messaging__should_work(ctx: &mut Context) -> Result<
     assert!(initialize_was_called.load(Ordering::Relaxed));
     assert!(shutdown_was_called.load(Ordering::Relaxed));
 
-    ctx.stop().await
+    Ok(())
 }
 
 struct BadWorker;
@@ -476,7 +476,7 @@ async fn worker_calls_stopworker_from_handlemessage(ctx: &mut Context) -> Result
         counter_a.load(Ordering::Relaxed),
         counter_b.load(Ordering::Relaxed)
     );
-    ctx.stop().await
+    Ok(())
 }
 
 struct SendReceiveWorker;
@@ -524,7 +524,7 @@ async fn use_context_send_and_receive(ctx: &mut Context) -> Result<()> {
     if let SendReceiveResponse::Connect(Err(e)) = msg_rx {
         panic!("test failure: {}", e)
     }
-    ctx.stop().await
+    Ok(())
 }
 
 struct DummyWorker;
@@ -559,7 +559,7 @@ async fn starting_worker_with_dup_address_should_fail(ctx: &mut Context) -> Resu
         .start_worker_with_access_control("dummy_worker", DummyWorker, DenyAll, DenyAll)
         .await
         .is_err());
-    ctx.stop().await
+    Ok(())
 }
 
 struct CountingErrorWorker {
@@ -608,5 +608,5 @@ async fn message_handle__error_during_handling__keep_worker_running(
     ctx.sleep(Duration::from_millis(100)).await;
     assert_eq!(3, counter.load(Ordering::Relaxed));
 
-    ctx.stop().await
+    Ok(())
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/lifecycle.rs
@@ -177,8 +177,7 @@ mod tests {
         let _route = tcp
             .resolve_address(Address::new(TCP, local_address))
             .await?;
-
-        ctx.stop().await
+        Ok(())
     }
 
     #[ockam_macros::test]
@@ -204,6 +203,6 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
-        ctx.stop().await
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/lifecycle.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/lifecycle.rs
@@ -55,10 +55,6 @@ async fn tcp_lifecycle__two_connections__should_both_work(ctx: &mut Context) -> 
         .await?;
     assert_eq!(reply2, msg2, "Should receive the same message");
 
-    if let Err(e) = ctx.stop().await {
-        println!("Unclean stop: {}", e)
-    }
-
     Ok(())
 }
 
@@ -122,11 +118,6 @@ async fn tcp_lifecycle__disconnect__should_stop_worker(ctx: &mut Context) -> Res
         .send(route![connection2.clone(), "echoer"], msg3.clone())
         .await;
     assert!(res.is_err(), "Should not send messages after disconnection");
-
-    if let Err(e) = ctx.stop().await {
-        println!("Unclean stop: {}", e)
-    }
-
     Ok(())
 }
 
@@ -180,10 +171,5 @@ async fn tcp_lifecycle__stop_listener__should_stop_accepting_connections(
         .send_and_receive(route![tx_address.clone(), "echoer"], msg2.clone())
         .await?;
     assert_eq!(reply2, msg2, "Should receive the same message");
-
-    if let Err(e) = ctx.stop().await {
-        println!("Unclean stop: {}", e)
-    }
-
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/send_receive.rs
@@ -45,10 +45,5 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
 
         assert_eq!(reply, msg, "Should receive the same message");
     };
-
-    if let Err(e) = ctx.stop().await {
-        println!("Unclean stop: {}", e)
-    }
-
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/rendezvous.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/rendezvous_service/rendezvous.rs
@@ -208,9 +208,6 @@ mod tests {
         // Query service for non-existent node, should error
         let res = query_operation("DoesNotExist", ctx, &rendezvous_route).await;
         assert!(res.is_err(), "Query operation should have failed");
-
-        // Shutdown
-        ctx.stop().await?;
         Ok(())
     }
 
@@ -222,9 +219,6 @@ mod tests {
             .send_and_receive(rendezvous_route, RendezvousRequest::Ping)
             .await?;
         assert!(matches!(res, RendezvousResponse::Pong));
-
-        // Shutdown
-        ctx.stop().await?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_transport_udp/tests/tests.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/tests/tests.rs
@@ -54,7 +54,6 @@ async fn reply_from_correct_server_port(ctx: &mut Context) -> Result<()> {
         );
     };
 
-    ctx.stop().await?;
     Ok(())
 }
 
@@ -104,7 +103,6 @@ async fn recover_from_sender_error(ctx: &mut Context) -> Result<()> {
         .await;
     assert!(res.is_ok(), "Should have been able to send message");
 
-    ctx.stop().await?;
     Ok(())
 }
 
@@ -143,7 +141,6 @@ async fn send_from_same_client_port(ctx: &mut Context) -> Result<()> {
         assert_eq!(reply, msg, "Should receive the same message");
     }
 
-    ctx.stop().await?;
     Ok(())
 }
 
@@ -187,8 +184,6 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
             assert_eq!(reply, msg, "Should receive the same message");
         }
     };
-
-    ctx.stop().await?;
     Ok(())
 }
 

--- a/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/tests/send_receive.rs
@@ -22,11 +22,6 @@ async fn send_receive(ctx: &mut Context) -> Result<()> {
 
         assert_eq!(reply, msg, "Should receive the same message");
     };
-
-    if let Err(e) = ctx.stop().await {
-        println!("Unclean stop: {}", e)
-    }
-
     Ok(())
 }
 


### PR DESCRIPTION
This PR:

 - Makes sure that the test `Context` provided by the `ockam::test` macro is always closed, without the user having to do it.
 
 - Returns successfully when a command is just testing the parsing of arguments. This avoids some potential later issues related to the initialization of `CommandGlobalOpts`

