### PR TITLE
Send command errors as trace events

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
@@ -17,6 +17,10 @@ pub enum JourneyEvent {
     TcpOutletCreated,
     RelayCreated,
     PortalCreated,
+    Error {
+        command_name: String,
+        message: String,
+    },
 }
 
 impl Display for JourneyEvent {
@@ -28,6 +32,9 @@ impl Display for JourneyEvent {
             JourneyEvent::TcpOutletCreated => f.write_str("tcp outlet created"),
             JourneyEvent::RelayCreated => f.write_str("relay created"),
             JourneyEvent::PortalCreated => f.write_str("portal created"),
+            JourneyEvent::Error { command_name, .. } => {
+                f.write_fmt(format_args!("{} error", command_name))
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/logs/setup.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/setup.rs
@@ -342,7 +342,6 @@ struct DecoratedLogExporter<L: LogExporter> {
 #[async_trait]
 impl<L: LogExporter> LogExporter for DecoratedLogExporter<L> {
     async fn export(&mut self, batch: Vec<LogData>) -> LogResult<()> {
-        // debug!("exporting {} logs", batch.len());
         self.exporter.export(batch).await
     }
 
@@ -406,7 +405,7 @@ impl CurrentSpan {
 
     pub fn set_attribute_time(name: &Key) {
         let current_utc: DateTime<Utc> = Utc::now();
-        let formatted_time: String = current_utc.format("%Y-%m-%dT%H:%M:%S").to_string();
+        let formatted_time: String = current_utc.format("%Y-%m-%dT%H:%M:%S.%3f").to_string();
         CurrentSpan::set_attribute(name, &formatted_time)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/mod.rs
@@ -24,16 +24,15 @@ pub enum AdminSubCommand {
 }
 
 impl AdminCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            AdminSubCommand::Subscription(c) => c.run(options),
+            AdminSubCommand::Subscription(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            AdminSubCommand::Subscription(_) => "admin subscription",
+            AdminSubCommand::Subscription(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/authority/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/mod.rs
@@ -19,17 +19,16 @@ pub struct AuthorityCommand {
 }
 
 impl AuthorityCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            AuthoritySubcommand::Create(c) => c.run(options),
+            AuthoritySubcommand::Create(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            AuthoritySubcommand::Create(_) => "create authority",
+            AuthoritySubcommand::Create(c) => c.name(),
         }
-        .to_string()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
+++ b/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
@@ -2,6 +2,10 @@
 // binary names. The issue is that we need to avoid the `ockam` binary colliding
 // with the `ockam` crate.
 
+use ockam_command::util::exitcode;
+
 fn main() {
-    ockam_command::run()
+    if ockam_command::run().is_err() {
+        std::process::exit(exitcode::SOFTWARE);
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/completion/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/completion/mod.rs
@@ -22,13 +22,14 @@ pub struct CompletionCommand {
 }
 
 impl CompletionCommand {
-    pub fn run(self) {
+    pub fn run(self) -> miette::Result<()> {
         generate(
             self.shell,
             &mut OckamCommand::command(),
             "ockam",
             &mut io::stdout(),
-        )
+        );
+        Ok(())
     }
 
     pub fn name(&self) -> String {

--- a/implementations/rust/ockam/ockam_command/src/configuration/get.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/get.rs
@@ -1,8 +1,6 @@
 use clap::Args;
 
-use ockam_node::Context;
-
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
@@ -12,20 +10,23 @@ pub struct GetCommand {
 }
 
 impl GetCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), run_impl, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
     }
-}
 
-async fn run_impl(
-    _ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, GetCommand),
-) -> miette::Result<()> {
-    let node_info = opts.state.get_node(&cmd.alias).await?;
-    let addr = &node_info
-        .tcp_listener_address()
-        .map(|a| a.to_string())
-        .unwrap_or("N/A".to_string());
-    println!("Address: {addr}");
-    Ok(())
+    pub fn name(&self) -> String {
+        "get configuration".into()
+    }
+
+    async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node_info = opts.state.get_node(&self.alias).await?;
+        let addr = &node_info
+            .tcp_listener_address()
+            .map(|a| a.to_string())
+            .unwrap_or("N/A".to_string());
+        println!("Address: {addr}");
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/configuration/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/list.rs
@@ -1,22 +1,26 @@
 use clap::Args;
 
-use ockam_node::Context;
-
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::CommandGlobalOpts;
 
 #[derive(Clone, Debug, Args)]
 pub struct ListCommand {}
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), run_impl, options);
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
     }
-}
 
-async fn run_impl(_ctx: Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-    for node in opts.state.get_nodes().await? {
-        opts.terminal.write(format!("Node: {}\n", node.name()))?;
+    pub fn name(&self) -> String {
+        "list configurations".into()
     }
-    Ok(())
+
+    async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        for node in opts.state.get_nodes().await? {
+            opts.terminal.write(format!("Node: {}\n", node.name()))?;
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/configuration/mod.rs
@@ -24,18 +24,17 @@ pub enum ConfigurationSubcommand {
 }
 
 impl ConfigurationCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            ConfigurationSubcommand::Get(c) => c.run(options),
-            ConfigurationSubcommand::List(c) => c.run(options),
+            ConfigurationSubcommand::Get(c) => c.run(opts),
+            ConfigurationSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            ConfigurationSubcommand::Get(_) => "get configuration",
-            ConfigurationSubcommand::List(_) => "list configurations",
+            ConfigurationSubcommand::Get(c) => c.name(),
+            ConfigurationSubcommand::List(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -3,17 +3,14 @@ use miette::{miette, IntoDiagnostic};
 
 use ockam::identity::utils::AttributesBuilder;
 use ockam::identity::Identifier;
-use ockam::Context;
 use ockam_api::authenticator::credential_issuer::{
     DEFAULT_CREDENTIAL_VALIDITY, PROJECT_MEMBER_SCHEMA,
 };
 use ockam_core::compat::collections::HashMap;
 
 use crate::output::{CredentialAndPurposeKeyDisplay, EncodeFormat};
-use crate::{
-    util::{node_rpc, parsers::identity_identifier_parser},
-    CommandGlobalOpts, Result,
-};
+use crate::util::async_cmd;
+use crate::{util::parsers::identity_identifier_parser, CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
 pub struct IssueCommand {
@@ -38,8 +35,14 @@ pub struct IssueCommand {
 }
 
 impl IssueCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "issue credential".into()
     }
 
     fn attributes(&self) -> Result<HashMap<String, String>> {
@@ -52,45 +55,42 @@ impl IssueCommand {
         }
         Ok(attributes)
     }
-}
 
-async fn run_impl(
-    _ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, IssueCommand),
-) -> miette::Result<()> {
-    let authority = opts
-        .state
-        .get_identifier_by_optional_name(&cmd.as_identity)
-        .await?;
+    async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let authority = opts
+            .state
+            .get_identifier_by_optional_name(&self.as_identity)
+            .await?;
 
-    let vault = opts
-        .state
-        .get_named_vault_or_default(&cmd.vault)
-        .await?
-        .vault()
-        .await?;
-    let identities = opts.state.make_identities(vault).await?;
+        let vault = opts
+            .state
+            .get_named_vault_or_default(&self.vault)
+            .await?
+            .vault()
+            .await?;
+        let identities = opts.state.make_identities(vault).await?;
 
-    let mut attributes_builder = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA);
-    for (key, value) in cmd.attributes()? {
-        attributes_builder =
-            attributes_builder.with_attribute(key.as_bytes().to_vec(), value.as_bytes().to_vec());
+        let mut attributes_builder = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA);
+        for (key, value) in self.attributes()? {
+            attributes_builder = attributes_builder
+                .with_attribute(key.as_bytes().to_vec(), value.as_bytes().to_vec());
+        }
+
+        let credential = identities
+            .credentials()
+            .credentials_creation()
+            .issue_credential(
+                &authority,
+                &self.identity_identifier,
+                attributes_builder.build(),
+                DEFAULT_CREDENTIAL_VALIDITY,
+            )
+            .await
+            .into_diagnostic()?;
+
+        self.encode_format
+            .println_value(&CredentialAndPurposeKeyDisplay(credential))?;
+
+        Ok(())
     }
-
-    let credential = identities
-        .credentials()
-        .credentials_creation()
-        .issue_credential(
-            &authority,
-            &cmd.identity_identifier,
-            attributes_builder.build(),
-            DEFAULT_CREDENTIAL_VALIDITY,
-        )
-        .await
-        .into_diagnostic()?;
-
-    cmd.encode_format
-        .println_value(&CredentialAndPurposeKeyDisplay(credential))?;
-
-    Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -37,24 +37,29 @@ pub enum CredentialSubcommand {
     Verify(VerifyCommand),
 }
 
+impl CredentialSubcommand {
+    pub fn name(&self) -> String {
+        match &self {
+            CredentialSubcommand::List(c) => c.name(),
+            CredentialSubcommand::Issue(c) => c.name(),
+            CredentialSubcommand::Store(c) => c.name(),
+            CredentialSubcommand::Verify(c) => c.name(),
+        }
+    }
+}
+
 impl CredentialCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            CredentialSubcommand::List(c) => c.run(options),
-            CredentialSubcommand::Issue(c) => c.run(options),
-            CredentialSubcommand::Store(c) => c.run(options),
-            CredentialSubcommand::Verify(c) => c.run(options),
+            CredentialSubcommand::List(c) => c.run(opts),
+            CredentialSubcommand::Issue(c) => c.run(opts),
+            CredentialSubcommand::Store(c) => c.run(opts),
+            CredentialSubcommand::Verify(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
-        match &self.subcommand {
-            CredentialSubcommand::Issue(_) => "issue credential",
-            CredentialSubcommand::List(_) => "list credentials",
-            CredentialSubcommand::Store(_) => "store credential",
-            CredentialSubcommand::Verify(_) => "verify credential",
-        }
-        .to_string()
+        self.subcommand.name()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/environment/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/mod.rs
@@ -7,11 +7,12 @@ const ENV_INFO: &str = include_str!("./static/env_info.txt");
 pub struct EnvironmentCommand {}
 
 impl EnvironmentCommand {
-    pub fn run(self) {
+    pub fn run(self) -> miette::Result<()> {
         println!("{}", ENV_INFO);
+        Ok(())
     }
 
     pub fn name(&self) -> String {
-        "get environment".to_string()
+        "show environment variables".to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/flow_control/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/flow_control/mod.rs
@@ -19,15 +19,15 @@ pub enum FlowControlSubcommand {
 }
 
 impl FlowControlCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            FlowControlSubcommand::AddConsumer(c) => c.run(options),
+            FlowControlSubcommand::AddConsumer(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            FlowControlSubcommand::AddConsumer(_) => "add flowcontrol consumer",
+            FlowControlSubcommand::AddConsumer(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -3,11 +3,10 @@ use colorful::Colorful;
 use tokio::sync::Mutex;
 use tokio::try_join;
 
-use ockam::Context;
 use ockam_api::cli_state::random_name;
 
 use crate::terminal::OckamColor;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_log, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
@@ -41,18 +40,17 @@ impl CreateCommand {
         }
     }
 
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), Self::run_impl, (options, self))
+    pub fn name(&self) -> String {
+        "create identity".into()
     }
 
-    async fn run_impl(
-        ctx: Context,
-        (options, cmd): (CommandGlobalOpts, CreateCommand),
-    ) -> miette::Result<()> {
-        cmd.async_run(&ctx, options).await
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
     }
 
-    pub async fn async_run(&self, _ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    pub(crate) async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
         opts.terminal.write_line(&fmt_log!(
             "Creating identity {}...\n",
             &self

--- a/implementations/rust/ockam/ockam_command/src/identity/default.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/default.rs
@@ -2,9 +2,7 @@ use clap::Args;
 use colorful::Colorful;
 use miette::miette;
 
-use ockam_node::Context;
-
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/default/long_about.txt");
@@ -22,42 +20,45 @@ pub struct DefaultCommand {
 }
 
 impl DefaultCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), run_impl, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
     }
-}
 
-async fn run_impl(
-    _ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DefaultCommand),
-) -> miette::Result<()> {
-    match cmd.name {
-        Some(name) => {
-            if opts.state.is_default_identity_by_name(&name).await? {
-                Err(miette!(
-                    "The identity named '{}' is already the default",
-                    &name
-                ))?
-            } else {
-                opts.state.set_as_default_identity(&name).await?;
+    pub fn name(&self) -> String {
+        "get default identity".into()
+    }
+
+    async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        match &self.name {
+            Some(name) => {
+                if opts.state.is_default_identity_by_name(name).await? {
+                    Err(miette!(
+                        "The identity named '{}' is already the default",
+                        &name
+                    ))?
+                } else {
+                    opts.state.set_as_default_identity(name).await?;
+                    opts.terminal
+                        .stdout()
+                        .plain(fmt_ok!("The identity named '{}' is now the default", &name))
+                        .machine(name)
+                        .write_line()?;
+                }
+            }
+            None => {
+                let identity = opts.state.get_or_create_default_named_identity().await?;
                 opts.terminal
                     .stdout()
-                    .plain(fmt_ok!("The identity named '{}' is now the default", &name))
-                    .machine(&name)
+                    .plain(fmt_ok!(
+                        "The name of the default identity is '{}'",
+                        identity.name()
+                    ))
                     .write_line()?;
             }
-        }
-        None => {
-            let identity = opts.state.get_or_create_default_named_identity().await?;
-            opts.terminal
-                .stdout()
-                .plain(fmt_ok!(
-                    "The name of the default identity is '{}'",
-                    identity.name()
-                ))
-                .write_line()?;
-        }
-    };
+        };
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/mod.rs
@@ -38,23 +38,23 @@ pub enum IdentitySubcommand {
 }
 
 impl IdentityCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            IdentitySubcommand::Create(c) => c.run(options),
-            IdentitySubcommand::Show(c) => c.run(options),
-            IdentitySubcommand::List(c) => c.run(options),
-            IdentitySubcommand::Delete(c) => c.run(options),
-            IdentitySubcommand::Default(c) => c.run(options),
+            IdentitySubcommand::Create(c) => c.run(opts),
+            IdentitySubcommand::Show(c) => c.run(opts),
+            IdentitySubcommand::List(c) => c.run(opts),
+            IdentitySubcommand::Delete(c) => c.run(opts),
+            IdentitySubcommand::Default(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            IdentitySubcommand::Create(_) => "create identity",
-            IdentitySubcommand::Show(_) => "show identity",
-            IdentitySubcommand::List(_) => "list identities",
-            IdentitySubcommand::Default(_) => "default identity",
-            IdentitySubcommand::Delete(_) => "delete identity",
+            IdentitySubcommand::Create(c) => c.name(),
+            IdentitySubcommand::Show(c) => c.name(),
+            IdentitySubcommand::List(c) => c.name(),
+            IdentitySubcommand::Delete(c) => c.name(),
+            IdentitySubcommand::Default(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
@@ -5,7 +5,7 @@ use ockam_api::nodes::{models, BackgroundNodeClient};
 use ockam_core::api::Request;
 use ockam_node::Context;
 
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -22,28 +22,31 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let req = Request::delete("/node/services/kafka_consumer").body(
-        models::services::DeleteServiceRequest::new(cmd.address.clone()),
-    );
-    node.tell(&ctx, req).await?;
+    pub fn name(&self) -> String {
+        "delete kafka consumer".into()
+    }
 
-    opts.terminal
-        .stdout()
-        .plain(fmt_ok!(
-            "Kafka consumer with address `{}` successfully deleted",
-            cmd.address
-        ))
-        .write_line()?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let req = Request::delete("/node/services/kafka_consumer").body(
+            models::services::DeleteServiceRequest::new(self.address.clone()),
+        );
+        node.tell(ctx, req).await?;
 
-    Ok(())
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!(
+                "Kafka consumer with address `{}` successfully deleted",
+                self.address
+            ))
+            .write_line()?;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_node::Context;
 
 use crate::node::NodeOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -26,34 +26,37 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let services: ServiceList = node
-        .ask(
-            &ctx,
-            Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_CONSUMER)),
-        )
-        .await?;
-    if services.list.is_empty() {
-        opts.terminal
-            .stdout()
-            .plain(fmt_err!("No Kafka Consumers found on this node"))
-            .write_line()?;
-    } else {
-        let mut buf = String::new();
-        buf.push_str("Kafka Consumers:\n");
-        for service in services.list {
-            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
-        }
-        opts.terminal.stdout().plain(buf).write_line()?;
+    pub fn name(&self) -> String {
+        "list kafka consumers".into()
     }
-    Ok(())
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let services: ServiceList = node
+            .ask(
+                ctx,
+                Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_CONSUMER)),
+            )
+            .await?;
+        if services.list.is_empty() {
+            opts.terminal
+                .stdout()
+                .plain(fmt_err!("No Kafka Consumers found on this node"))
+                .write_line()?;
+        } else {
+            let mut buf = String::new();
+            buf.push_str("Kafka Consumers:\n");
+            for service in services.list {
+                buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+            }
+            opts.terminal.stdout().plain(buf).write_line()?;
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/mod.rs
@@ -25,20 +25,19 @@ pub enum KafkaConsumerSubcommand {
 }
 
 impl KafkaConsumerCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            KafkaConsumerSubcommand::Create(c) => c.run(options),
-            KafkaConsumerSubcommand::Delete(c) => c.run(options),
-            KafkaConsumerSubcommand::List(c) => c.run(options),
+            KafkaConsumerSubcommand::Create(c) => c.run(opts),
+            KafkaConsumerSubcommand::Delete(c) => c.run(opts),
+            KafkaConsumerSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            KafkaConsumerSubcommand::Create(_) => "create kafka consumer",
-            KafkaConsumerSubcommand::Delete(_) => "delete kafka consumer",
-            KafkaConsumerSubcommand::List(_) => "list kafka consumers",
+            KafkaConsumerSubcommand::Create(c) => c.name(),
+            KafkaConsumerSubcommand::Delete(c) => c.name(),
+            KafkaConsumerSubcommand::List(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
@@ -28,8 +28,8 @@ pub struct ArgOpts {
     pub bootstrap_server: SocketAddr,
 }
 
-pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> miette::Result<()> {
-    initialize_default_node(&ctx, &opts).await?;
+pub async fn start(ctx: &Context, opts: CommandGlobalOpts, args: ArgOpts) -> miette::Result<()> {
+    initialize_default_node(ctx, &opts).await?;
     let ArgOpts {
         endpoint,
         kafka_entity,
@@ -54,7 +54,7 @@ pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> 
 
     let is_finished = Mutex::new(false);
     let send_req = async {
-        let node = BackgroundNodeClient::create(&ctx, &opts.state, &node_opts.at_node).await?;
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &node_opts.at_node).await?;
 
         let payload = StartKafkaDirectRequest::new(
             bind_address.to_owned(),
@@ -64,7 +64,7 @@ pub async fn start(ctx: Context, (opts, args): (CommandGlobalOpts, ArgOpts)) -> 
         );
         let payload = StartServiceRequest::new(payload, &addr);
         let req = Request::post(endpoint).body(payload);
-        start_service_impl(&ctx, &node, &kafka_entity, req).await?;
+        start_service_impl(ctx, &node, &kafka_entity, req).await?;
 
         *is_finished.lock().await = true;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/delete.rs
@@ -5,7 +5,7 @@ use ockam_api::nodes::{models, BackgroundNodeClient};
 use ockam_core::api::Request;
 use ockam_node::Context;
 
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -22,28 +22,31 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let req = Request::delete("/node/services/kafka_direct").body(
-        models::services::DeleteServiceRequest::new(cmd.address.clone()),
-    );
-    node.tell(&ctx, req).await?;
+    pub fn name(&self) -> String {
+        "delete kafka direct".into()
+    }
 
-    opts.terminal
-        .stdout()
-        .plain(fmt_ok!(
-            "Kafka consumer with address `{}` successfully deleted",
-            cmd.address
-        ))
-        .write_line()?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let req = Request::delete("/node/services/kafka_direct").body(
+            models::services::DeleteServiceRequest::new(self.address.clone()),
+        );
+        node.tell(ctx, req).await?;
 
-    Ok(())
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!(
+                "Kafka consumer with address `{}` successfully deleted",
+                self.address
+            ))
+            .write_line()?;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/list.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_node::Context;
 
 use crate::node::NodeOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -26,34 +26,37 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let services: ServiceList = node
-        .ask(
-            &ctx,
-            Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_DIRECT)),
-        )
-        .await?;
-    if services.list.is_empty() {
-        opts.terminal
-            .stdout()
-            .plain(fmt_err!("No Kafka Direct Client found on this node"))
-            .write_line()?;
-    } else {
-        let mut buf = String::new();
-        buf.push_str("Kafka Direct Clients:\n");
-        for service in services.list {
-            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
-        }
-        opts.terminal.stdout().plain(buf).write_line()?;
+    pub fn name(&self) -> String {
+        "list kafka direct".into()
     }
-    Ok(())
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let services: ServiceList = node
+            .ask(
+                ctx,
+                Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_DIRECT)),
+            )
+            .await?;
+        if services.list.is_empty() {
+            opts.terminal
+                .stdout()
+                .plain(fmt_err!("No Kafka Direct Client found on this node"))
+                .write_line()?;
+        } else {
+            let mut buf = String::new();
+            buf.push_str("Kafka Direct Clients:\n");
+            for service in services.list {
+                buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+            }
+            opts.terminal.stdout().plain(buf).write_line()?;
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/mod.rs
@@ -5,10 +5,10 @@ use crate::kafka::direct::delete::DeleteCommand;
 use crate::kafka::direct::list::ListCommand;
 use crate::CommandGlobalOpts;
 
+pub(crate) mod command;
 mod create;
 mod delete;
 mod list;
-mod rpc;
 
 /// Manage Kafka Consumers
 #[derive(Clone, Debug, Args)]
@@ -26,20 +26,19 @@ pub enum KafkaDirectSubcommand {
 }
 
 impl KafkaDirectCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            KafkaDirectSubcommand::Create(c) => c.run(options),
-            KafkaDirectSubcommand::Delete(c) => c.run(options),
-            KafkaDirectSubcommand::List(c) => c.run(options),
+            KafkaDirectSubcommand::Create(c) => c.run(opts),
+            KafkaDirectSubcommand::Delete(c) => c.run(opts),
+            KafkaDirectSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            KafkaDirectSubcommand::Create(_) => "create kafka direct",
-            KafkaDirectSubcommand::Delete(_) => "delete kafka direct",
-
-            KafkaDirectSubcommand::List(_) => "list kafka direct",
+            KafkaDirectSubcommand::Create(c) => c.name(),
+            KafkaDirectSubcommand::Delete(c) => c.name(),
+            KafkaDirectSubcommand::List(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/mod.rs
@@ -18,15 +18,15 @@ pub enum KafkaOutletSubcommand {
 }
 
 impl KafkaOutletCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            KafkaOutletSubcommand::Create(c) => c.run(options),
+            KafkaOutletSubcommand::Create(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            KafkaOutletSubcommand::Create(_) => "create kafka outlet",
+            KafkaOutletSubcommand::Create(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -5,13 +5,14 @@ use clap::{command, Args};
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
-use crate::kafka::util::{make_brokers_port_range, rpc, ArgOpts};
+use crate::kafka::util::{async_run, make_brokers_port_range, ArgOpts};
+use crate::util::async_cmd;
 use crate::{
     kafka::{
         kafka_default_producer_server, kafka_default_project_route, kafka_producer_default_addr,
     },
     node::NodeOpts,
-    util::{node_rpc, parsers::socket_addr_parser},
+    util::parsers::socket_addr_parser,
     CommandGlobalOpts,
 };
 
@@ -38,7 +39,8 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let cmd_name = self.name();
         let arg_opts = ArgOpts {
             endpoint: "/node/services/kafka_producer".to_string(),
             kafka_entity: "KafkaProducer".to_string(),
@@ -50,6 +52,12 @@ impl CreateCommand {
                 .unwrap_or_else(|| make_brokers_port_range(&self.bootstrap_server)),
             project_route: self.project_route,
         };
-        node_rpc(opts.rt.clone(), rpc, (opts, arg_opts));
+        async_cmd(&cmd_name, opts.clone(), |ctx| async move {
+            async_run(&ctx, opts, arg_opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "create kafka producer".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
@@ -5,7 +5,7 @@ use ockam_api::nodes::{models, BackgroundNodeClient};
 use ockam_core::api::Request;
 use ockam_node::Context;
 
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -22,28 +22,31 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let req = Request::delete("/node/services/kafka_producer").body(
-        models::services::DeleteServiceRequest::new(cmd.address.clone()),
-    );
-    node.tell(&ctx, req).await?;
+    pub fn name(&self) -> String {
+        "delete kafka producer".into()
+    }
 
-    opts.terminal
-        .stdout()
-        .plain(fmt_ok!(
-            "Kafka producer with address `{}` successfully deleted",
-            cmd.address
-        ))
-        .write_line()?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let req = Request::delete("/node/services/kafka_producer").body(
+            models::services::DeleteServiceRequest::new(self.address.clone()),
+        );
+        node.tell(ctx, req).await?;
 
-    Ok(())
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!(
+                "Kafka producer with address `{}` successfully deleted",
+                self.address
+            ))
+            .write_line()?;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -8,7 +8,7 @@ use ockam_core::api::Request;
 use ockam_node::Context;
 
 use crate::node::NodeOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_err, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -26,34 +26,37 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let services: ServiceList = node
-        .ask(
-            &ctx,
-            Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_PRODUCER)),
-        )
-        .await?;
-    if services.list.is_empty() {
-        opts.terminal
-            .stdout()
-            .plain(fmt_err!("No Kafka Producers found on this node"))
-            .write_line()?;
-    } else {
-        let mut buf = String::new();
-        buf.push_str("Kafka Producers:\n");
-        for service in services.list {
-            buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
-        }
-        opts.terminal.stdout().plain(buf).write_line()?;
+    pub fn name(&self) -> String {
+        "list kafka producers".into()
     }
-    Ok(())
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let services: ServiceList = node
+            .ask(
+                ctx,
+                Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_PRODUCER)),
+            )
+            .await?;
+        if services.list.is_empty() {
+            opts.terminal
+                .stdout()
+                .plain(fmt_err!("No Kafka Producers found on this node"))
+                .write_line()?;
+        } else {
+            let mut buf = String::new();
+            buf.push_str("Kafka Producers:\n");
+            for service in services.list {
+                buf.push_str(&format!("{:2}Address: {}\n", "", service.addr));
+            }
+            opts.terminal.stdout().plain(buf).write_line()?;
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/mod.rs
@@ -25,19 +25,19 @@ pub enum KafkaProducerSubcommand {
 }
 
 impl KafkaProducerCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            KafkaProducerSubcommand::Create(c) => c.run(options),
-            KafkaProducerSubcommand::Delete(c) => c.run(options),
-            KafkaProducerSubcommand::List(c) => c.run(options),
+            KafkaProducerSubcommand::Create(c) => c.run(opts),
+            KafkaProducerSubcommand::Delete(c) => c.run(opts),
+            KafkaProducerSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            KafkaProducerSubcommand::Create(_) => "create kafka producer",
-            KafkaProducerSubcommand::Delete(_) => "delete kafka producer",
-            KafkaProducerSubcommand::List(_) => "list kafka producers",
+            KafkaProducerSubcommand::Create(c) => c.name(),
+            KafkaProducerSubcommand::Delete(c) => c.name(),
+            KafkaProducerSubcommand::List(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/lease/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/mod.rs
@@ -39,23 +39,22 @@ pub enum LeaseSubcommand {
 }
 
 impl LeaseCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            LeaseSubcommand::Create(c) => c.run(options, self.cloud_opts, self.trust_opts),
-            LeaseSubcommand::List(c) => c.run(options, self.cloud_opts, self.trust_opts),
-            LeaseSubcommand::Show(c) => c.run(options, self.cloud_opts, self.trust_opts),
-            LeaseSubcommand::Revoke(c) => c.run(options, self.cloud_opts, self.trust_opts),
+            LeaseSubcommand::Create(c) => c.run(opts, self.cloud_opts, self.trust_opts),
+            LeaseSubcommand::List(c) => c.run(opts, self.cloud_opts, self.trust_opts),
+            LeaseSubcommand::Show(c) => c.run(opts, self.cloud_opts, self.trust_opts),
+            LeaseSubcommand::Revoke(c) => c.run(opts, self.cloud_opts, self.trust_opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            LeaseSubcommand::Create(_) => "create lease",
-            LeaseSubcommand::List(_) => "list leases",
-            LeaseSubcommand::Show(_) => "show lease",
-            LeaseSubcommand::Revoke(_) => "revoke lease",
+            LeaseSubcommand::Create(c) => c.name(),
+            LeaseSubcommand::List(c) => c.name(),
+            LeaseSubcommand::Show(c) => c.name(),
+            LeaseSubcommand::Revoke(c) => c.name(),
         }
-        .to_string()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -4,7 +4,7 @@ use ockam_api::InfluxDbTokenLease;
 
 use crate::lease::create_project_client;
 use crate::util::api::{CloudOpts, TrustOpts};
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const HELP_DETAIL: &str = "";
@@ -19,23 +19,33 @@ pub struct RevokeCommand {
 }
 
 impl RevokeCommand {
-    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustOpts) {
-        node_rpc(
-            opts.rt.clone(),
-            run_impl,
-            (opts, cloud_opts, self, trust_opts),
-        );
+    pub fn run(
+        self,
+        opts: CommandGlobalOpts,
+        cloud_opts: CloudOpts,
+        trust_opts: TrustOpts,
+    ) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts, cloud_opts, trust_opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cloud_opts, cmd, trust_opts): (CommandGlobalOpts, CloudOpts, RevokeCommand, TrustOpts),
-) -> miette::Result<()> {
-    let project_node_client = create_project_client(&ctx, &opts, &cloud_opts, &trust_opts).await?;
-    project_node_client
-        .revoke_token(&ctx, cmd.token_id.clone())
-        .await?;
-    println!("Revoked influxdb token {}.", cmd.token_id);
-    Ok(())
+    pub fn name(&self) -> String {
+        "revoke token".into()
+    }
+
+    async fn async_run(
+        &self,
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+        cloud_opts: CloudOpts,
+        trust_opts: TrustOpts,
+    ) -> miette::Result<()> {
+        let project_node = create_project_client(ctx, &opts, &cloud_opts, &trust_opts).await?;
+        project_node
+            .revoke_token(ctx, self.token_id.clone())
+            .await?;
+        println!("Revoked influxdb token {}.", self.token_id);
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -6,7 +6,7 @@ use ockam_api::InfluxDbTokenLease;
 use crate::lease::create_project_client;
 use crate::output::Output;
 use crate::util::api::{CloudOpts, TrustOpts};
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const HELP_DETAIL: &str = "";
@@ -21,27 +21,37 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, opts: CommandGlobalOpts, cloud_opts: CloudOpts, trust_opts: TrustOpts) {
-        node_rpc(
-            opts.rt.clone(),
-            run_impl,
-            (opts, cloud_opts, self, trust_opts),
-        );
+    pub fn run(
+        self,
+        opts: CommandGlobalOpts,
+        cloud_opts: CloudOpts,
+        trust_opts: TrustOpts,
+    ) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts, cloud_opts, trust_opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cloud_opts, cmd, trust_opts): (CommandGlobalOpts, CloudOpts, ShowCommand, TrustOpts),
-) -> miette::Result<()> {
-    let project_node_client = create_project_client(&ctx, &opts, &cloud_opts, &trust_opts).await?;
-    let token = project_node_client.get_token(&ctx, cmd.token_id).await?;
+    pub fn name(&self) -> String {
+        "show ticket".into()
+    }
 
-    opts.terminal
-        .stdout()
-        .plain(token.output()?)
-        .json(serde_json::json!(&token))
-        .write_line()?;
+    async fn async_run(
+        &self,
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+        cloud_opts: CloudOpts,
+        trust_opts: TrustOpts,
+    ) -> miette::Result<()> {
+        let project_node = create_project_client(ctx, &opts, &cloud_opts, &trust_opts).await?;
+        let token = project_node.get_token(ctx, self.token_id.clone()).await?;
 
-    Ok(())
+        opts.terminal
+            .stdout()
+            .plain(token.output()?)
+            .json(serde_json::json!(&token))
+            .write_line()?;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -29,7 +29,7 @@ use once_cell::sync::Lazy;
 use opentelemetry::trace::{TraceContextExt, Tracer};
 use opentelemetry::{global, Context};
 use tokio::runtime::Runtime;
-use tracing::instrument;
+use tracing::{error, instrument};
 
 use completion::CompletionCommand;
 use configuration::ConfigurationCommand;
@@ -47,7 +47,7 @@ use node::NodeCommand;
 use ockam_api::cli_state::CliState;
 use ockam_api::logs::{TracingGuard, OCKAM_TRACER_NAME};
 use ockam_core::env::get_env_with_default;
-use ockam_node::OpenTelemetryContext;
+use ockam_node::{Executor, OpenTelemetryContext};
 use policy::PolicyCommand;
 use project::ProjectCommand;
 use r3bl_rs_utils_core::UnicodeString;
@@ -438,26 +438,60 @@ impl OckamSubcommand {
     }
 }
 
-pub fn run() {
+pub fn run() -> miette::Result<()> {
     let input = std::env::args()
         .map(replace_hyphen_with_stdin)
         .collect::<Vec<_>>();
 
-    match OckamCommand::try_parse_from(input) {
-        Ok(command) => {
-            command.run();
+    match OckamCommand::try_parse_from(input.clone()) {
+        Err(help) => {
+            let command = input
+                .iter()
+                .take_while(|a| !a.starts_with('-'))
+                .collect::<Vec<_>>()
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>()
+                .join(" ");
+            let message = format!(
+                "could not parse the command: {}\n{}",
+                command,
+                input.join(" ")
+            );
+            send_error_message(&command, &message);
+            pager::render_help(help)
         }
-        Err(help) => pager::render_help(help),
+        Ok(command) => command.run()?,
     };
+    Ok(())
+}
+
+fn send_error_message(command: &str, message: &str) {
+    let message = message.to_string();
+    let command = command.to_string();
+
+    let guard = setup_logging_tracing(false, 1, true, false, None);
+    let tracer = global::tracer(OCKAM_TRACER_NAME);
+    tracer.in_span(format!("'{}' error", command), |_| {
+        let state = CliState::with_default_dir();
+        Context::current()
+            .span()
+            .set_status(opentelemetry::trace::Status::error(message.clone()));
+        error!("{}", &message);
+        let _ = Executor::execute_future(async move {
+            state.unwrap().add_journey_error(&command, message).await
+        });
+    });
+    guard.shutdown()
 }
 
 impl OckamCommand {
-    pub fn run(self) {
+    pub fn run(self) -> miette::Result<()> {
         // If test_argument_parser is true, command arguments are checked
         // but the command is not executed. This is useful to test arguments
         // without having to execute their logic.
         if self.global_args.test_argument_parser {
-            return;
+            return Ok(());
         }
 
         // Sets a hook using our own Error Report Handler
@@ -487,7 +521,7 @@ impl OckamCommand {
             };
             tracing::debug!("{}", Version::short());
             tracing::debug!("Parsed {:#?}", &self);
-            Some(guard)
+            Some(Arc::new(guard))
         } else {
             None
         };
@@ -527,71 +561,79 @@ impl OckamCommand {
         }
 
         let tracer = global::tracer(OCKAM_TRACER_NAME);
-        if let Some(opentelemetry_context) = self.subcommand.get_opentelemetry_context() {
-            let span =
-                tracer.start_with_context(self.subcommand.name(), &opentelemetry_context.extract());
-            let cx = Context::current_with_span(span);
-            let _guard = cx.clone().attach();
-            self.run_command(options, tracing_guard);
-        } else {
-            tracer.in_span(self.subcommand.name(), |_| {
-                self.run_command(options, tracing_guard);
-            });
-        }
+        let tracing_guard_clone = tracing_guard.clone();
+        let result =
+            if let Some(opentelemetry_context) = self.subcommand.get_opentelemetry_context() {
+                let span = tracer
+                    .start_with_context(self.subcommand.name(), &opentelemetry_context.extract());
+                let cx = Context::current_with_span(span);
+                let _guard = cx.clone().attach();
+                self.run_command(options, tracing_guard_clone)
+            } else {
+                tracer.in_span(self.subcommand.name(), |_| {
+                    self.run_command(options, tracing_guard_clone)
+                })
+            };
 
-        global::shutdown_tracer_provider();
-        global::shutdown_logger_provider();
+        if let Some(tracing_guard) = tracing_guard {
+            tracing_guard.shutdown()
+        };
+        result
     }
 
     #[instrument(skip_all, fields(command = self.subcommand.name()))]
-    fn run_command(self, options: CommandGlobalOpts, tracing_guard: Option<TracingGuard>) {
+    fn run_command(
+        self,
+        opts: CommandGlobalOpts,
+        tracing_guard: Option<Arc<TracingGuard>>,
+    ) -> miette::Result<()> {
         match self.subcommand {
-            OckamSubcommand::Enroll(c) => c.run(options),
-            OckamSubcommand::Space(c) => c.run(options),
-            OckamSubcommand::Project(c) => c.run(options),
-            OckamSubcommand::Admin(c) => c.run(options),
+            OckamSubcommand::Enroll(c) => c.run(opts),
+            OckamSubcommand::Space(c) => c.run(opts),
+            OckamSubcommand::Project(c) => c.run(opts),
+            OckamSubcommand::Admin(c) => c.run(opts),
             #[cfg(feature = "orchestrator")]
-            OckamSubcommand::Share(c) => c.run(options),
-            OckamSubcommand::Subscription(c) => c.run(options),
+            OckamSubcommand::Share(c) => c.run(opts),
+            OckamSubcommand::Subscription(c) => c.run(opts),
 
-            OckamSubcommand::Node(c) => c.run(options, tracing_guard),
-            OckamSubcommand::Worker(c) => c.run(options),
-            OckamSubcommand::Service(c) => c.run(options),
-            OckamSubcommand::Message(c) => c.run(options),
-            OckamSubcommand::Relay(c) => c.run(options),
+            OckamSubcommand::Node(c) => c.run(opts, tracing_guard.clone()),
+            OckamSubcommand::Worker(c) => c.run(opts),
+            OckamSubcommand::Service(c) => c.run(opts),
+            OckamSubcommand::Message(c) => c.run(opts),
+            OckamSubcommand::Relay(c) => c.run(opts),
 
-            OckamSubcommand::KafkaOutlet(c) => c.run(options),
-            OckamSubcommand::TcpListener(c) => c.run(options),
-            OckamSubcommand::TcpConnection(c) => c.run(options),
-            OckamSubcommand::TcpOutlet(c) => c.run(options),
-            OckamSubcommand::TcpInlet(c) => c.run(options),
+            OckamSubcommand::KafkaOutlet(c) => c.run(opts),
+            OckamSubcommand::TcpListener(c) => c.run(opts),
+            OckamSubcommand::TcpConnection(c) => c.run(opts),
+            OckamSubcommand::TcpOutlet(c) => c.run(opts),
+            OckamSubcommand::TcpInlet(c) => c.run(opts),
 
-            OckamSubcommand::KafkaConsumer(c) => c.run(options),
-            OckamSubcommand::KafkaProducer(c) => c.run(options),
-            OckamSubcommand::KafkaDirect(c) => c.run(options),
+            OckamSubcommand::KafkaConsumer(c) => c.run(opts),
+            OckamSubcommand::KafkaProducer(c) => c.run(opts),
+            OckamSubcommand::KafkaDirect(c) => c.run(opts),
 
-            OckamSubcommand::SecureChannelListener(c) => c.run(options),
-            OckamSubcommand::SecureChannel(c) => c.run(options),
+            OckamSubcommand::SecureChannelListener(c) => c.run(opts),
+            OckamSubcommand::SecureChannel(c) => c.run(opts),
 
-            OckamSubcommand::Vault(c) => c.run(options),
-            OckamSubcommand::Identity(c) => c.run(options),
-            OckamSubcommand::Credential(c) => c.run(options),
-            OckamSubcommand::Authority(c) => c.run(options),
-            OckamSubcommand::Policy(c) => c.run(options),
-            OckamSubcommand::Lease(c) => c.run(options),
+            OckamSubcommand::Vault(c) => c.run(opts),
+            OckamSubcommand::Identity(c) => c.run(opts),
+            OckamSubcommand::Credential(c) => c.run(opts),
+            OckamSubcommand::Authority(c) => c.run(opts),
+            OckamSubcommand::Policy(c) => c.run(opts),
+            OckamSubcommand::Lease(c) => c.run(opts),
 
-            OckamSubcommand::Run(c) => c.run(options),
-            OckamSubcommand::Status(c) => c.run(options),
-            OckamSubcommand::Reset(c) => c.run(options),
-            OckamSubcommand::Configuration(c) => c.run(options),
+            OckamSubcommand::Run(c) => c.run(opts),
+            OckamSubcommand::Status(c) => c.run(opts),
+            OckamSubcommand::Reset(c) => c.run(opts),
+            OckamSubcommand::Configuration(c) => c.run(opts),
 
             OckamSubcommand::Completion(c) => c.run(),
             OckamSubcommand::Markdown(c) => c.run(),
             OckamSubcommand::Manpages(c) => c.run(),
             OckamSubcommand::Environment(c) => c.run(),
 
-            OckamSubcommand::FlowControl(c) => c.run(options),
-            OckamSubcommand::Sidecar(c) => c.run(options),
+            OckamSubcommand::FlowControl(c) => c.run(opts),
+            OckamSubcommand::Sidecar(c) => c.run(opts),
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/manpages.rs
+++ b/implementations/rust/ockam/ockam_command/src/manpages.rs
@@ -32,13 +32,14 @@ pub struct ManpagesCommand {
 }
 
 impl ManpagesCommand {
-    pub fn run(self) {
+    pub fn run(self) -> miette::Result<()> {
         let man_dir = match get_man_page_directory(&self.dir) {
             Ok(path) => path,
             Err(error) => panic!("Error getting man page directory: {error:?}"),
         };
         let clap_command = <OckamCommand as CommandFactory>::command();
         generate_man_pages(man_dir.as_path(), &clap_command, None, self.no_compression);
+        Ok(())
     }
 
     pub fn name(&self) -> String {

--- a/implementations/rust/ockam/ockam_command/src/markdown/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/markdown/mod.rs
@@ -21,7 +21,7 @@ pub struct MarkdownCommand {
 }
 
 impl MarkdownCommand {
-    pub fn run(self) {
+    pub fn run(self) -> miette::Result<()> {
         let mark_dir = match get_markdown_page_directory(&self.dir) {
             Ok(path) => path,
             Err(error) => panic!("Error getting markdown page directory: {error:?}"),
@@ -39,6 +39,7 @@ impl MarkdownCommand {
         );
 
         std::fs::write(mark_dir.join("SUMMARY.md"), summary).expect("Error creating SUMMARY.md.");
+        Ok(())
     }
 
     pub fn name(&self) -> String {

--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -19,16 +19,15 @@ pub enum MessageSubcommand {
 }
 
 impl MessageCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            MessageSubcommand::Send(c) => c.run(options),
+            MessageSubcommand::Send(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            MessageSubcommand::Send(_) => "send message",
+            MessageSubcommand::Send(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/message/send.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/send.rs
@@ -17,7 +17,7 @@ use crate::project::util::{
 };
 use crate::util::api::{CloudOpts, TrustOpts};
 use crate::util::duration::duration_parser;
-use crate::util::{clean_nodes_multiaddr, node_rpc};
+use crate::util::{async_cmd, clean_nodes_multiaddr};
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/send/long_about.txt");
@@ -57,38 +57,42 @@ pub struct SendCommand {
 }
 
 impl SendCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> miette::Result<()> {
-    async fn go(ctx: &Context, opts: CommandGlobalOpts, cmd: SendCommand) -> miette::Result<()> {
+    pub fn name(&self) -> String {
+        "send message".into()
+    }
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         // Process `--to` Multiaddr
-        let (to, meta) = clean_nodes_multiaddr(&cmd.to, &opts.state)
+        let (to, meta) = clean_nodes_multiaddr(&self.to, &opts.state)
             .await
             .context("Argument '--to' is invalid")?;
 
-        let msg_bytes = if cmd.hex {
-            hex::decode(cmd.message)
+        let msg_bytes = if self.hex {
+            hex::decode(self.message.clone())
                 .into_diagnostic()
                 .context("The message is not a valid hex string")?
         } else {
-            cmd.message.as_bytes().to_vec()
+            self.message.as_bytes().to_vec()
         };
 
         // Setup environment depending on whether we are sending the message from a background node
         // or an in-memory node
-        let response: Vec<u8> = if let Some(node) = &cmd.from {
+        let response: Vec<u8> = if let Some(node) = &self.from {
             BackgroundNodeClient::create_to_node(ctx, &opts.state, node.as_str())
                 .await?
-                .set_timeout(cmd.timeout)
+                .set_timeout(self.timeout)
                 .ask(ctx, req(&to, msg_bytes))
                 .await?
         } else {
             let identity_name = opts
                 .state
-                .get_identity_name_or_default(&cmd.cloud_opts.identity)
+                .get_identity_name_or_default(&self.cloud_opts.identity)
                 .await?;
 
             info!("starting an in memory node to send a message");
@@ -97,9 +101,9 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> mie
                 ctx,
                 &opts.state,
                 &identity_name,
-                cmd.trust_opts.project_name,
-                cmd.trust_opts.authority_identity,
-                cmd.trust_opts.authority_route,
+                self.trust_opts.project_name.clone(),
+                self.trust_opts.authority_identity.clone(),
+                self.trust_opts.authority_route.clone(),
             )
             .await?;
             info!("started an in memory node to send a message");
@@ -111,18 +115,18 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> mie
                 &node_manager,
                 &meta,
                 Some(identity_name),
-                Some(cmd.timeout),
+                Some(self.timeout),
             )
             .await?;
             let to = clean_projects_multiaddr(to, projects_sc)?;
             info!("sending to {to}");
             node_manager
-                .send_message(ctx, &to, msg_bytes, Some(cmd.timeout))
+                .send_message(ctx, &to, msg_bytes, Some(self.timeout))
                 .await
                 .into_diagnostic()?
         };
 
-        let result = if cmd.hex {
+        let result = if self.hex {
             hex::encode(response)
         } else {
             String::from_utf8(response)
@@ -133,7 +137,6 @@ async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, SendCommand)) -> mie
         opts.terminal.stdout().plain(result).write_line()?;
         Ok(())
     }
-    go(&ctx, opts, cmd).await
 }
 
 pub(crate) fn req(to: &MultiAddr, message: Vec<u8>) -> Request<SendMessage> {

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -14,113 +14,124 @@ use ockam_node::OpenTelemetryContext;
 
 use crate::node::show::is_node_up;
 use crate::node::util::spawn_node;
-use crate::node::{guard_node_is_not_already_running, CreateCommand};
+use crate::node::CreateCommand;
 use crate::terminal::OckamColor;
 use crate::CommandGlobalOpts;
 use crate::{color, fmt_log, fmt_ok};
 
-// Create a new node running in the background (i.e. another, new OS process)
-#[instrument(skip_all)]
-pub(crate) async fn background_mode(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> miette::Result<()> {
-    if !cmd.skip_is_running_check {
-        guard_node_is_not_already_running(&opts, &cmd.node_name, cmd.child_process).await?;
+impl CreateCommand {
+    // Create a new node running in the background (i.e. another, new OS process)
+    #[instrument(skip_all)]
+    pub(crate) async fn background_mode(
+        &self,
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+    ) -> miette::Result<()> {
+        if !self.skip_is_running_check {
+            self.guard_node_is_not_already_running(&opts).await?;
+        }
+
+        let node_name = self.node_name.clone();
+        opentelemetry::Context::current()
+            .span()
+            .set_attribute(KeyValue::new("node_name", node_name.clone()));
+        debug!("create node in background mode");
+
+        opts.terminal.write_line(&fmt_log!(
+            "Creating Node {}...\n",
+            color!(&node_name, OckamColor::PrimaryResource)
+        ))?;
+
+        if self.child_process {
+            return Err(miette!(
+                "Cannot create a background node from another background node"
+            ));
+        }
+
+        let is_finished: Mutex<bool> = Mutex::new(false);
+
+        let opentelemetry_context = OpenTelemetryContext::current();
+        let cmd_with_trace_context = CreateCommand {
+            opentelemetry_context: self
+                .opentelemetry_context
+                .clone()
+                .or(Some(opentelemetry_context)),
+            ..self.clone()
+        };
+
+        let send_req = async {
+            cmd_with_trace_context.spawn_background_node(&opts).await?;
+            let mut node =
+                BackgroundNodeClient::create_to_node(ctx, &opts.state, &node_name).await?;
+            let is_node_up = is_node_up(ctx, &mut node, true).await?;
+            *is_finished.lock().await = true;
+            Ok(is_node_up)
+        };
+
+        let output_messages = vec![
+            format!("Creating node..."),
+            format!("Starting services..."),
+            format!("Loading any pre-trusted identities..."),
+        ];
+
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
+
+        let (_response, _) = try_join!(send_req, progress_output)?;
+
+        let mut attributes = HashMap::default();
+        attributes.insert(NODE_NAME, node_name.as_str());
+        opts.state
+            .add_journey_event(JourneyEvent::NodeCreated, attributes)
+            .await?;
+
+        opts.clone()
+            .terminal
+            .stdout()
+            .plain(
+                fmt_ok!(
+                    "Node {} created successfully\n\n",
+                    node_name.color(OckamColor::PrimaryResource.color())
+                ) + &fmt_log!("To see more details on this node, run:\n")
+                    + &fmt_log!(
+                        "{}",
+                        "ockam node show".color(OckamColor::PrimaryResource.color())
+                    ),
+            )
+            .write_line()?;
+
+        Ok(())
     }
 
-    let node_name = cmd.node_name.clone();
-    opentelemetry::Context::current()
-        .span()
-        .set_attribute(KeyValue::new("node_name", node_name.clone()));
-    debug!("create node in background mode");
+    pub(crate) async fn spawn_background_node(
+        &self,
+        opts: &CommandGlobalOpts,
+    ) -> miette::Result<()> {
+        if !self.skip_is_running_check {
+            self.guard_node_is_not_already_running(opts).await?;
+        }
 
-    opts.terminal.write_line(&fmt_log!(
-        "Creating Node {}...\n",
-        color!(&node_name, OckamColor::PrimaryResource)
-    ))?;
-
-    if cmd.child_process {
-        return Err(miette!(
-            "Cannot create a background node from another background node"
-        ));
-    }
-
-    let is_finished: Mutex<bool> = Mutex::new(false);
-
-    let opentelemetry_context = OpenTelemetryContext::current();
-    let cmd_with_trace_context = CreateCommand {
-        opentelemetry_context: cmd.opentelemetry_context.or(Some(opentelemetry_context)),
-        ..cmd
-    };
-
-    let send_req = async {
-        spawn_background_node(&opts, cmd_with_trace_context.clone()).await?;
-        let mut node = BackgroundNodeClient::create_to_node(&ctx, &opts.state, &node_name).await?;
-        let is_node_up = is_node_up(&ctx, &mut node, true).await?;
-        *is_finished.lock().await = true;
-        Ok(is_node_up)
-    };
-
-    let output_messages = vec![
-        format!("Creating node..."),
-        format!("Starting services..."),
-        format!("Loading any pre-trusted identities..."),
-    ];
-
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (_response, _) = try_join!(send_req, progress_output)?;
-
-    let mut attributes = HashMap::default();
-    attributes.insert(NODE_NAME, node_name.as_str());
-    opts.state
-        .add_journey_event(JourneyEvent::NodeCreated, attributes)
+        // Construct the arguments list and re-execute the ockam
+        // CLI in foreground mode to start the newly created node
+        info!("spawning a new node {}", &self.node_name);
+        spawn_node(
+            opts,
+            self.skip_is_running_check,
+            &self.node_name,
+            &self.identity,
+            &self.tcp_listener_address,
+            self.launch_config
+                .as_ref()
+                .map(|config| serde_json::to_string(config).unwrap()),
+            self.trust_opts.project_name.clone(),
+            self.trust_opts.authority_identity.clone(),
+            self.trust_opts.authority_route.clone(),
+            self.logging_to_file(),
+            self.opentelemetry_context.clone(),
+        )
         .await?;
 
-    opts.clone()
-        .terminal
-        .stdout()
-        .plain(
-            fmt_ok!(
-                "Node {} created successfully\n\n",
-                node_name.color(OckamColor::PrimaryResource.color())
-            ) + &fmt_log!("To see more details on this node, run:\n")
-                + &fmt_log!(
-                    "{}",
-                    "ockam node show".color(OckamColor::PrimaryResource.color())
-                ),
-        )
-        .write_line()?;
-
-    Ok(())
-}
-
-pub(crate) async fn spawn_background_node(
-    opts: &CommandGlobalOpts,
-    cmd: CreateCommand,
-) -> miette::Result<()> {
-    // Construct the arguments list and re-execute the ockam
-    // CLI in foreground mode to start the newly created node
-    info!("spawning a new node {}", &cmd.node_name);
-    spawn_node(
-        opts,
-        cmd.skip_is_running_check,
-        &cmd.node_name,
-        &cmd.identity,
-        &cmd.tcp_listener_address,
-        cmd.launch_config
-            .as_ref()
-            .map(|config| serde_json::to_string(config).unwrap()),
-        cmd.trust_opts.project_name.clone(),
-        cmd.trust_opts.authority_identity.clone(),
-        cmd.trust_opts.authority_route.clone(),
-        cmd.logging_to_file(),
-        cmd.opentelemetry_context,
-    )
-    .await?;
-
-    Ok(())
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -16,128 +16,135 @@ use ockam_api::nodes::{
 use ockam_core::{route, LOCAL};
 
 use crate::fmt_ok;
-use crate::node::{guard_node_is_not_already_running, CreateCommand};
+use crate::node::CreateCommand;
 use crate::secure_channel::listener::create as secure_channel_listener;
 use crate::service::config::Config;
 use crate::{shutdown, CommandGlobalOpts};
 
-#[instrument(skip_all, fields(node_name = cmd.node_name))]
-pub(super) async fn foreground_mode(
-    ctx: Context,
-    (opts, cmd, tracing_guard): (CommandGlobalOpts, CreateCommand, Option<TracingGuard>),
-) -> miette::Result<()> {
-    if !cmd.skip_is_running_check {
-        guard_node_is_not_already_running(&opts, &cmd.node_name, cmd.child_process).await?;
-    }
+impl CreateCommand {
+    #[instrument(skip_all, fields(node_name = self.node_name))]
+    pub(super) async fn foreground_mode(
+        &self,
+        ctx: &Context,
+        opts: CommandGlobalOpts,
+        tracing_guard: Option<Arc<TracingGuard>>,
+    ) -> miette::Result<()> {
+        self.guard_node_is_not_already_running(&opts).await?;
 
-    let node_name = cmd.node_name.clone();
-    debug!("create node {node_name} in foreground mode");
+        let node_name = self.node_name.clone();
+        debug!("create node {node_name} in foreground mode");
 
-    if opts
-        .state
-        .get_node(&node_name)
-        .await
-        .ok()
-        .map(|n| n.is_running())
-        .unwrap_or(false)
-    {
-        return Err(miette!("Node {} is already running", &node_name));
-    };
+        if opts
+            .state
+            .get_node(&node_name)
+            .await
+            .ok()
+            .map(|n| n.is_running())
+            .unwrap_or(false)
+        {
+            return Err(miette!("Node {} is already running", &node_name));
+        };
 
-    let tcp = TcpTransport::create(&ctx).await.into_diagnostic()?;
-    let options = TcpListenerOptions::new();
-    let listener = tcp
-        .listen(&cmd.tcp_listener_address, options)
+        let tcp = TcpTransport::create(ctx).await.into_diagnostic()?;
+        let options = TcpListenerOptions::new();
+        let listener = tcp
+            .listen(&self.tcp_listener_address, options)
+            .await
+            .into_diagnostic()?;
+
+        debug!(
+            "set the node {node_name} listener address to {:?}",
+            listener.socket_address()
+        );
+
+        // Set node_name so that node can isolate its data in the storage from other nodes
+        let mut state = opts.state.clone();
+        state.set_node_name(node_name.clone());
+
+        let node_info = state
+            .start_node_with_optional_values(
+                &node_name,
+                &self.identity,
+                &self.trust_opts.project_name,
+                Some(&listener),
+            )
+            .await?;
+        debug!("created node {node_info:?}");
+
+        let trust_options = opts
+            .state
+            .retrieve_trust_options(
+                &self.trust_opts.project_name,
+                &self.trust_opts.authority_identity,
+                &self.trust_opts.authority_route,
+            )
+            .await
+            .into_diagnostic()?;
+
+        let node_man = InMemoryNode::new(
+            ctx,
+            NodeManagerGeneralOptions::new(
+                state,
+                node_name.clone(),
+                self.launch_config.is_none(),
+                true,
+            ),
+            NodeManagerTransportOptions::new(
+                listener.flow_control_id().clone(),
+                tcp.async_try_clone().await.into_diagnostic()?,
+            ),
+            trust_options,
+        )
         .await
         .into_diagnostic()?;
+        let node_manager_worker = NodeManagerWorker::new(Arc::new(node_man));
 
-    debug!(
-        "set the node {node_name} listener address to {:?}",
-        listener.socket_address()
-    );
+        ctx.flow_controls()
+            .add_consumer(NODEMANAGER_ADDR, listener.flow_control_id());
+        ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
+            .await
+            .into_diagnostic()?;
 
-    // Set node_name so that node can isolate its data in the storage from other nodes
-    let mut state = opts.state.clone();
-    state.set_node_name(node_name.clone());
+        if let Some(config) = &self.launch_config {
+            if start_services(ctx, config).await.is_err() {
+                //TODO: Process should terminate on any error during its setup phase,
+                //      not just during the start_services.
+                //TODO: This sleep here is a workaround on some orchestrated environment,
+                //      the lmdb db, that is used for policy storage, fails to be re-opened
+                //      if it's still opened from another docker container, where they share
+                //      the same pid. By sleeping for a while we let this container be promoted
+                //      and the other being terminated, so when restarted it works.  This is
+                //      FAR from ideal.
+                sleep(Duration::from_secs(10)).await;
+                ctx.stop().await.into_diagnostic()?;
+                return Err(miette!("Failed to start services"));
+            }
+        }
 
-    let node_info = state
-        .start_node_with_optional_values(
-            &node_name,
-            &cmd.identity,
-            &cmd.trust_opts.project_name,
-            Some(&listener),
+        if let Some(tracing_guard) = tracing_guard {
+            tracing_guard.force_flush();
+        };
+
+        // Create a channel for communicating back to the main thread
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+        shutdown::wait(
+            opts.terminal.clone(),
+            self.exit_on_eof,
+            opts.global_args.quiet,
+            tx,
+            &mut rx,
         )
         .await?;
-    debug!("created node {node_info:?}");
 
-    let trust_options = opts
-        .state
-        .retrieve_trust_options(
-            &cmd.trust_opts.project_name,
-            &cmd.trust_opts.authority_identity,
-            &cmd.trust_opts.authority_route,
-        )
-        .await
-        .into_diagnostic()?;
+        // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
+        opts.state.stop_node(&node_name, true).await?;
+        ctx.stop().await.into_diagnostic()?;
+        opts.terminal
+            .write_line(fmt_ok!("Node stopped successfully"))
+            .unwrap();
 
-    let node_man = InMemoryNode::new(
-        &ctx,
-        NodeManagerGeneralOptions::new(state, node_name.clone(), cmd.launch_config.is_none(), true),
-        NodeManagerTransportOptions::new(
-            listener.flow_control_id().clone(),
-            tcp.async_try_clone().await.into_diagnostic()?,
-        ),
-        trust_options,
-    )
-    .await
-    .into_diagnostic()?;
-    let node_manager_worker = NodeManagerWorker::new(Arc::new(node_man));
-
-    ctx.flow_controls()
-        .add_consumer(NODEMANAGER_ADDR, listener.flow_control_id());
-    ctx.start_worker(NODEMANAGER_ADDR, node_manager_worker)
-        .await
-        .into_diagnostic()?;
-
-    if let Some(config) = &cmd.launch_config {
-        if start_services(&ctx, config).await.is_err() {
-            //TODO: Process should terminate on any error during its setup phase,
-            //      not just during the start_services.
-            //TODO: This sleep here is a workaround on some orchestrated environment,
-            //      the lmdb db, that is used for policy storage, fails to be re-opened
-            //      if it's still opened from another docker container, where they share
-            //      the same pid. By sleeping for a while we let this container be promoted
-            //      and the other being terminated, so when restarted it works.  This is
-            //      FAR from ideal.
-            sleep(Duration::from_secs(10)).await;
-            ctx.stop().await.into_diagnostic()?;
-            return Err(miette!("Failed to start services"));
-        }
+        Ok(())
     }
-
-    if let Some(tracing_guard) = tracing_guard {
-        tracing_guard.force_flush()
-    }
-
-    // Create a channel for communicating back to the main thread
-    let (tx, mut rx) = tokio::sync::mpsc::channel(2);
-    shutdown::wait(
-        opts.terminal.clone(),
-        cmd.exit_on_eof,
-        opts.global_args.quiet,
-        tx,
-        &mut rx,
-    )
-    .await?;
-
-    // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
-    opts.state.stop_node(&node_name, true).await?;
-    ctx.stop().await.into_diagnostic()?;
-    opts.terminal
-        .write_line(fmt_ok!("Node stopped successfully"))
-        .unwrap();
-
-    Ok(())
 }
 
 async fn start_services(ctx: &Context, cfg: &Config) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 use ockam_api::address::extract_address_value;
+use std::sync::Arc;
 
 pub use create::CreateCommand;
 pub use create::*;
@@ -70,36 +71,33 @@ pub enum NodeSubcommand {
 impl NodeSubcommand {
     pub fn name(&self) -> String {
         match self {
-            NodeSubcommand::Create(cmd) => {
-                if cmd.child_process {
-                    "create background node"
-                } else {
-                    "create node"
-                }
-            }
-            NodeSubcommand::Delete(_) => "delete node",
-            NodeSubcommand::List(_) => "list nodes",
-            NodeSubcommand::Logs(_) => "logs node",
-            NodeSubcommand::Show(_) => "show node",
-            NodeSubcommand::Start(_) => "start node",
-            NodeSubcommand::Stop(_) => "stop node",
-            NodeSubcommand::Default(_) => "default node",
+            NodeSubcommand::Create(c) => c.name(),
+            NodeSubcommand::Delete(c) => c.name(),
+            NodeSubcommand::List(c) => c.name(),
+            NodeSubcommand::Logs(c) => c.name(),
+            NodeSubcommand::Show(c) => c.name(),
+            NodeSubcommand::Start(c) => c.name(),
+            NodeSubcommand::Stop(c) => c.name(),
+            NodeSubcommand::Default(c) => c.name(),
         }
-        .to_string()
     }
 }
 
 impl NodeCommand {
-    pub fn run(self, options: CommandGlobalOpts, tracing_guard: Option<TracingGuard>) {
+    pub fn run(
+        self,
+        opts: CommandGlobalOpts,
+        tracing_guard: Option<Arc<TracingGuard>>,
+    ) -> miette::Result<()> {
         match self.subcommand {
-            NodeSubcommand::Create(c) => c.run(options, tracing_guard),
-            NodeSubcommand::Delete(c) => c.run(options),
-            NodeSubcommand::List(c) => c.run(options),
-            NodeSubcommand::Show(c) => c.run(options),
-            NodeSubcommand::Start(c) => c.run(options),
-            NodeSubcommand::Stop(c) => c.run(options),
-            NodeSubcommand::Logs(c) => c.run(options),
-            NodeSubcommand::Default(c) => c.run(options),
+            NodeSubcommand::Create(c) => c.run(opts, tracing_guard),
+            NodeSubcommand::Delete(c) => c.run(opts),
+            NodeSubcommand::List(c) => c.run(opts),
+            NodeSubcommand::Show(c) => c.run(opts),
+            NodeSubcommand::Start(c) => c.run(opts),
+            NodeSubcommand::Stop(c) => c.run(opts),
+            NodeSubcommand::Logs(c) => c.run(opts),
+            NodeSubcommand::Default(c) => c.run(opts),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -6,7 +6,7 @@ use ockam_node::Context;
 
 use crate::node::show::print_query_status;
 use crate::node::util::spawn_node;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_err, fmt_info, fmt_log, fmt_ok, fmt_warn, CommandGlobalOpts, OckamColor};
 
 const LONG_ABOUT: &str = include_str!("./static/start/long_about.txt");
@@ -26,70 +26,77 @@ pub struct StartCommand {
 }
 
 impl StartCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
-    }
-}
-
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, StartCommand),
-) -> miette::Result<()> {
-    if cmd.node_name.is_some() || !opts.terminal.can_ask_for_user_input() {
-        let node_name = opts.state.get_node_or_default(&cmd.node_name).await?.name();
-        start_single_node(&node_name, opts, &ctx).await?;
-        return Ok(());
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
 
-    let inactive_nodes = get_inactive_nodes(&opts).await?;
-    match inactive_nodes.len() {
-        0 => {
-            opts.terminal
-                .stdout()
-                .plain(fmt_info!(
-                    "All the nodes are already started, nothing to do. Exiting gratefully"
-                ))
-                .write_line()?;
+    pub fn name(&self) -> String {
+        "start node".into()
+    }
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        if self.node_name.is_some() || !opts.terminal.can_ask_for_user_input() {
+            let node_name = opts
+                .state
+                .get_node_or_default(&self.node_name)
+                .await?
+                .name();
+            start_single_node(&node_name, opts, ctx).await?;
+            return Ok(());
         }
-        1 => {
-            start_single_node(&inactive_nodes[0], opts, &ctx).await?;
-        }
-        _ => {
-            let selected_nodes = opts
-                .terminal
-                .select_multiple("Select the nodes".to_string(), inactive_nodes);
-            match selected_nodes.len() {
-                0 => {
-                    opts.terminal
-                        .stdout()
-                        .plain(fmt_info!("No node selected, exiting gratefully!"))
-                        .write_line()?;
-                }
-                1 => start_single_node(&selected_nodes[0], opts, &ctx).await?,
-                _ => {
-                    if !opts.terminal.confirm_interactively(format!(
-                        "You are about to start the given nodes:[ {} ]. Confirm?",
-                        &selected_nodes.join(", ")
-                    )) {
+
+        let inactive_nodes = get_inactive_nodes(&opts).await?;
+        match inactive_nodes.len() {
+            0 => {
+                opts.terminal
+                    .stdout()
+                    .plain(fmt_info!(
+                        "All the nodes are already started, nothing to do. Exiting gratefully"
+                    ))
+                    .write_line()?;
+            }
+            1 => {
+                start_single_node(&inactive_nodes[0], opts, ctx).await?;
+            }
+            _ => {
+                let selected_nodes = opts
+                    .terminal
+                    .select_multiple("Select the nodes".to_string(), inactive_nodes);
+                match selected_nodes.len() {
+                    0 => {
                         opts.terminal
                             .stdout()
                             .plain(fmt_info!("No node selected, exiting gratefully!"))
                             .write_line()?;
-                        return Ok(());
                     }
+                    1 => start_single_node(&selected_nodes[0], opts, ctx).await?,
+                    _ => {
+                        if !opts.terminal.confirm_interactively(format!(
+                            "You are about to start the given nodes:[ {} ]. Confirm?",
+                            &selected_nodes.join(", ")
+                        )) {
+                            opts.terminal
+                                .stdout()
+                                .plain(fmt_info!("No node selected, exiting gratefully!"))
+                                .write_line()?;
+                            return Ok(());
+                        }
 
-                    let formatted_starts_result =
-                        start_multiple_nodes(&ctx, &opts, &selected_nodes).await?;
+                        let formatted_starts_result =
+                            start_multiple_nodes(ctx, &opts, &selected_nodes).await?;
 
-                    opts.terminal
-                        .stdout()
-                        .plain(formatted_starts_result.join("\n"))
-                        .write_line()?;
+                        opts.terminal
+                            .stdout()
+                            .plain(formatted_starts_result.join("\n"))
+                            .write_line()?;
+                    }
                 }
             }
         }
+        Ok(())
     }
-    Ok(())
 }
 
 /// Starts a single node and display the output on the console

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -11,7 +11,6 @@ use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 use ockam_node::OpenTelemetryContext;
 
-use crate::node::background::spawn_background_node;
 use crate::node::show::is_node_up;
 use crate::node::CreateCommand;
 use crate::util::api::TrustOpts;
@@ -57,7 +56,7 @@ pub async fn initialize_default_node(
     if opts.state.get_default_node().await.is_err() {
         let cmd = CreateCommand::default();
         let node_name = cmd.node_name.clone();
-        spawn_background_node(opts, cmd).await?;
+        cmd.spawn_background_node(opts).await?;
         let mut node = BackgroundNodeClient::create_to_node(ctx, &opts.state, &node_name).await?;
         is_node_up(ctx, &mut node, true).await?;
     }

--- a/implementations/rust/ockam/ockam_command/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/mod.rs
@@ -32,8 +32,19 @@ pub enum PolicySubcommand {
     List(ListCommand),
 }
 
+impl PolicySubcommand {
+    pub fn name(&self) -> String {
+        match &self {
+            PolicySubcommand::Create(c) => c.name(),
+            PolicySubcommand::Show(c) => c.name(),
+            PolicySubcommand::Delete(c) => c.name(),
+            PolicySubcommand::List(c) => c.name(),
+        }
+    }
+}
+
 impl PolicyCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
             PolicySubcommand::Create(c) => c.run(opts),
             PolicySubcommand::Show(c) => c.run(opts),
@@ -43,13 +54,7 @@ impl PolicyCommand {
     }
 
     pub fn name(&self) -> String {
-        match &self.subcommand {
-            PolicySubcommand::Create(_) => "create policy",
-            PolicySubcommand::Show(_) => "show policy",
-            PolicySubcommand::Delete(_) => "delete policy",
-            PolicySubcommand::List(_) => "list policies",
-        }
-        .to_string()
+        self.subcommand.name()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/aiven.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/aiven.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
-use crate::util::node_rpc;
+use crate::project::addon::configure_kafka::{AddonConfigureKafkaSubcommand, KafkaCommandConfig};
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("../static/configure_aiven/long_about.txt");
@@ -19,11 +19,17 @@ pub struct AddonConfigureAivenSubcommand {
 }
 
 impl AddonConfigureAivenSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(
-            opts.rt.clone(),
-            run_impl,
-            (opts, "Aiven (Kafka)", self.config),
-        );
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            AddonConfigureKafkaSubcommand {
+                config: self.config,
+            }
+            .async_run(&ctx, opts, "Aiven (Kafka)")
+            .await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "configure aiven kafka addon".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/confluent.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/confluent.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
-use crate::util::node_rpc;
+use crate::project::addon::configure_kafka::{AddonConfigureKafkaSubcommand, KafkaCommandConfig};
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("../static/configure_confluent/long_about.txt");
@@ -19,7 +19,17 @@ pub struct AddonConfigureConfluentSubcommand {
 }
 
 impl AddonConfigureConfluentSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, "Confluent", self.config));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            AddonConfigureKafkaSubcommand {
+                config: self.config,
+            }
+            .async_run(&ctx, opts, "Confluent")
+            .await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "configure confluent kafka addon".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/instaclustr.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/instaclustr.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
-use crate::util::node_rpc;
+use crate::project::addon::configure_kafka::{AddonConfigureKafkaSubcommand, KafkaCommandConfig};
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("../static/configure_instaclustr/long_about.txt");
@@ -19,11 +19,17 @@ pub struct AddonConfigureInstaclustrSubcommand {
 }
 
 impl AddonConfigureInstaclustrSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(
-            opts.rt.clone(),
-            run_impl,
-            (opts, "Instaclustr (Kafka)", self.config),
-        );
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            AddonConfigureKafkaSubcommand {
+                config: self.config,
+            }
+            .async_run(&ctx, opts, "Instaclustr (Kafka)")
+            .await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "configure instaclustr kafka addon".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/redpanda.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/redpanda.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
-use crate::util::node_rpc;
+use crate::project::addon::configure_kafka::{AddonConfigureKafkaSubcommand, KafkaCommandConfig};
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("../static/configure_redpanda/long_about.txt");
@@ -19,7 +19,17 @@ pub struct AddonConfigureRedpandaSubcommand {
 }
 
 impl AddonConfigureRedpandaSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, "Redpanda", self.config));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            AddonConfigureKafkaSubcommand {
+                config: self.config,
+            }
+            .async_run(&ctx, opts, "Redpanda")
+            .await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "configure redpanda kafka addon".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/warpstream.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_kafka/warpstream.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
-use crate::project::addon::configure_kafka::{run_impl, KafkaCommandConfig};
-use crate::util::node_rpc;
+use crate::project::addon::configure_kafka::{AddonConfigureKafkaSubcommand, KafkaCommandConfig};
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("../static/configure_warpstream/long_about.txt");
@@ -19,7 +19,17 @@ pub struct AddonConfigureWarpstreamSubcommand {
 }
 
 impl AddonConfigureWarpstreamSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, "WarpStream", self.config));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            AddonConfigureKafkaSubcommand {
+                config: self.config,
+            }
+            .async_run(&ctx, opts, "Warpstream")
+            .await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "configure warpstream kafka addon".into()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/disable.rs
@@ -7,7 +7,7 @@ use ockam_api::cloud::addon::Addons;
 use ockam_api::nodes::InMemoryNode;
 
 use crate::operation::util::check_for_operation_completion;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{fmt_ok, CommandGlobalOpts};
 
 /// Disable an addon for a project
@@ -33,31 +33,34 @@ pub struct AddonDisableSubcommand {
 }
 
 impl AddonDisableSubcommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, AddonDisableSubcommand),
-) -> miette::Result<()> {
-    let AddonDisableSubcommand {
-        project_name,
-        addon_id,
-    } = cmd;
-    let project_id = &opts.state.get_project_by_name(&project_name).await?.id();
-    let node = InMemoryNode::start(&ctx, &opts.state).await?;
-    let controller = node.create_controller().await?;
+    pub fn name(&self) -> String {
+        "disable addon".into()
+    }
 
-    let response = controller
-        .disable_addon(&ctx, project_id, &addon_id)
-        .await?;
-    let operation_id = response.operation_id;
-    check_for_operation_completion(&opts, &ctx, &node, &operation_id, "the addon disabling")
-        .await?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let project_id = &opts
+            .state
+            .get_project_by_name(&self.project_name)
+            .await?
+            .id();
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
+        let controller = node.create_controller().await?;
 
-    opts.terminal
-        .write_line(&fmt_ok!("Addon disabled successfully"))?;
-    Ok(())
+        let response = controller
+            .disable_addon(ctx, project_id, &self.addon_id)
+            .await?;
+        let operation_id = response.operation_id;
+        check_for_operation_completion(&opts, ctx, &node, &operation_id, "the addon disabling")
+            .await?;
+
+        opts.terminal
+            .write_line(&fmt_ok!("Addon disabled successfully"))?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -47,11 +47,19 @@ pub enum AddonSubcommand {
 }
 
 impl AddonCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
             AddonSubcommand::List(cmd) => cmd.run(opts),
             AddonSubcommand::Disable(cmd) => cmd.run(opts),
             AddonSubcommand::Configure(cmd) => cmd.run(opts),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match &self.subcommand {
+            AddonSubcommand::List(c) => c.name(),
+            AddonSubcommand::Disable(c) => c.name(),
+            AddonSubcommand::Configure(c) => c.name(),
         }
     }
 }
@@ -70,7 +78,7 @@ pub enum ConfigureAddonCommand {
 }
 
 impl ConfigureAddonCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self {
             ConfigureAddonCommand::Okta(cmd) => cmd.run(opts),
             ConfigureAddonCommand::Influxdb(cmd) => cmd.run(opts),
@@ -80,6 +88,19 @@ impl ConfigureAddonCommand {
             ConfigureAddonCommand::Redpanda(cmd) => cmd.run(opts),
             ConfigureAddonCommand::Warpstream(cmd) => cmd.run(opts),
             ConfigureAddonCommand::Kafka(cmd) => cmd.run(opts),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match &self {
+            ConfigureAddonCommand::Okta(c) => c.name(),
+            ConfigureAddonCommand::Influxdb(c) => c.name(),
+            ConfigureAddonCommand::Confluent(c) => c.name(),
+            ConfigureAddonCommand::InstaclustrKafka(c) => c.name(),
+            ConfigureAddonCommand::AivenKafka(c) => c.name(),
+            ConfigureAddonCommand::Redpanda(c) => c.name(),
+            ConfigureAddonCommand::Warpstream(c) => c.name(),
+            ConfigureAddonCommand::Kafka(c) => c.name(),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -7,7 +7,7 @@ use ockam_api::cloud::project::Projects;
 use ockam_api::nodes::InMemoryNode;
 
 use crate::util::api::CloudOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
@@ -37,36 +37,34 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
-
-async fn run_impl(
-    ctx: &Context,
-    opts: CommandGlobalOpts,
-    cmd: DeleteCommand,
-) -> miette::Result<()> {
-    if opts
-        .terminal
-        .confirmed_with_flag_or_prompt(cmd.yes, "Are you sure you want to delete this project?")?
-    {
-        let node = InMemoryNode::start(ctx, &opts.state).await?;
-        node.delete_project_by_name(ctx, &cmd.space_name, &cmd.project_name)
-            .await?;
-        opts.terminal
-            .stdout()
-            .plain(fmt_ok!(
-                "Project with name '{}' has been deleted.",
-                &cmd.project_name
-            ))
-            .machine(&cmd.project_name)
-            .json(serde_json::json!({ "name": &cmd.project_name }))
-            .write_line()?;
+    pub fn name(&self) -> String {
+        "delete project".into()
     }
-    Ok(())
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        if opts.terminal.confirmed_with_flag_or_prompt(
+            self.yes,
+            "Are you sure you want to delete this project?",
+        )? {
+            let node = InMemoryNode::start(ctx, &opts.state).await?;
+            node.delete_project_by_name(ctx, &self.space_name, &self.project_name)
+                .await?;
+            opts.terminal
+                .stdout()
+                .plain(fmt_ok!(
+                    "Project with name '{}' has been deleted.",
+                    &self.project_name
+                ))
+                .machine(&self.project_name)
+                .json(serde_json::json!({ "name": &self.project_name }))
+                .write_line()?;
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -55,34 +55,33 @@ pub enum ProjectSubcommand {
 }
 
 impl ProjectCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            ProjectSubcommand::Create(c) => c.run(options),
-            ProjectSubcommand::Import(c) => c.run(options),
-            ProjectSubcommand::Delete(c) => c.run(options),
-            ProjectSubcommand::List(c) => c.run(options),
-            ProjectSubcommand::Show(c) => c.run(options),
-            ProjectSubcommand::Version(c) => c.run(options),
-            ProjectSubcommand::Ticket(c) => c.run(options),
-            ProjectSubcommand::Information(c) => c.run(options),
-            ProjectSubcommand::Addon(c) => c.run(options),
-            ProjectSubcommand::Enroll(c) => c.run(options),
+            ProjectSubcommand::Create(c) => c.run(opts),
+            ProjectSubcommand::Import(c) => c.run(opts),
+            ProjectSubcommand::Delete(c) => c.run(opts),
+            ProjectSubcommand::List(c) => c.run(opts),
+            ProjectSubcommand::Show(c) => c.run(opts),
+            ProjectSubcommand::Version(c) => c.run(opts),
+            ProjectSubcommand::Ticket(c) => c.run(opts),
+            ProjectSubcommand::Information(c) => c.run(opts),
+            ProjectSubcommand::Addon(c) => c.run(opts),
+            ProjectSubcommand::Enroll(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            ProjectSubcommand::Create(_) => "create project",
-            ProjectSubcommand::Delete(_) => "delete project",
-            ProjectSubcommand::List(_) => "list projects",
-            ProjectSubcommand::Show(_) => "show project",
-            ProjectSubcommand::Import(_) => "import project",
-            ProjectSubcommand::Version(_) => "show project version",
-            ProjectSubcommand::Information(_) => "show project information",
-            ProjectSubcommand::Ticket(_) => "create project ticket",
-            ProjectSubcommand::Addon(_) => "configure project addon",
-            ProjectSubcommand::Enroll(_) => "enroll project",
+            ProjectSubcommand::Create(c) => c.name(),
+            ProjectSubcommand::Delete(c) => c.name(),
+            ProjectSubcommand::List(c) => c.name(),
+            ProjectSubcommand::Show(c) => c.name(),
+            ProjectSubcommand::Import(c) => c.name(),
+            ProjectSubcommand::Version(c) => c.name(),
+            ProjectSubcommand::Information(c) => c.name(),
+            ProjectSubcommand::Ticket(c) => c.name(),
+            ProjectSubcommand::Addon(c) => c.name(),
+            ProjectSubcommand::Enroll(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -15,8 +15,9 @@ use ockam_api::cloud::project::Project;
 use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
 
+use crate::fmt_ok;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts, Result};
-use crate::{fmt_ok, util::node_rpc};
 use crate::{
     output::OutputFormat,
     util::api::{CloudOpts, TrustOpts},
@@ -80,8 +81,14 @@ pub struct TicketCommand {
 }
 
 impl TicketCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "create project ticket".into()
     }
 
     fn attributes(&self) -> Result<BTreeMap<String, String>> {
@@ -97,75 +104,71 @@ impl TicketCommand {
         }
         Ok(attributes)
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, TicketCommand),
-) -> miette::Result<()> {
-    if opts.global_args.output_format == OutputFormat::Json {
-        return Err(miette::miette!(
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        if opts.global_args.output_format == OutputFormat::Json {
+            return Err(miette::miette!(
             "This command only outputs a hex encoded string for 'ockam project enroll' to use. \
             Please try running it again without '--output json'."
         ));
-    }
+        }
 
-    let node = InMemoryNode::start_with_project_name(
-        &ctx,
-        &opts.state,
-        cmd.trust_opts.project_name.clone(),
-    )
-    .await?;
-
-    let project: Option<Project>;
-
-    let authority_node_client = if let Some(p) = get_project(&opts.state, &cmd.to).await? {
-        let identity = opts
-            .state
-            .get_identity_name_or_default(&cmd.cloud_opts.identity)
-            .await?;
-        project = Some(p.clone());
-        node.create_authority_client(
-            &p.authority_identifier().await.into_diagnostic()?,
-            &p.authority_access_route().into_diagnostic()?,
-            Some(identity),
+        let node = InMemoryNode::start_with_project_name(
+            ctx,
+            &opts.state,
+            self.trust_opts.project_name.clone(),
         )
-        .await?
-    } else {
-        return Err(miette!("Cannot create a ticket. Please specify a route to your project or to an authority node"));
-    };
+        .await?;
 
-    // If an identity identifier is given add it as a member, otherwise
-    // request an enrollment token that a future member can use to get a
-    // credential.
-    if let Some(id) = &cmd.member {
-        authority_node_client
-            .add_member(&ctx, id.clone(), cmd.attributes()?)
+        let project: Option<Project>;
+
+        let authority_node_client = if let Some(p) = get_project(&opts.state, &self.to).await? {
+            let identity = opts
+                .state
+                .get_identity_name_or_default(&self.cloud_opts.identity)
+                .await?;
+            project = Some(p.clone());
+            node.create_authority_client(
+                &p.authority_identifier().await.into_diagnostic()?,
+                &p.authority_access_route().into_diagnostic()?,
+                Some(identity),
+            )
             .await?
-    } else {
-        let token = authority_node_client
-            .create_token(&ctx, cmd.attributes()?, cmd.expires_in, cmd.usage_count)
-            .await?;
+        } else {
+            return Err(miette!("Cannot create a ticket. Please specify a route to your project or to an authority node"));
+        };
 
-        let ticket = EnrollmentTicket::new(token, project);
-        let ticket_serialized = ticket.hex_encoded().into_diagnostic()?;
+        // If an identity identifier is given add it as a member, otherwise
+        // request an enrollment token that a future member can use to get a
+        // credential.
+        if let Some(id) = &self.member {
+            authority_node_client
+                .add_member(ctx, id.clone(), self.attributes()?)
+                .await?
+        } else {
+            let token = authority_node_client
+                .create_token(ctx, self.attributes()?, self.expires_in, self.usage_count)
+                .await?;
 
-        opts.terminal.write_line(&fmt_ok!(
-            "{}: {}",
-            "Created enrollment ticket. You can use it to enroll another machine using",
-            color_primary("ockam project enroll".to_string())
-        ))?;
+            let ticket = EnrollmentTicket::new(token, project);
+            let ticket_serialized = ticket.hex_encoded().into_diagnostic()?;
 
-        opts.terminal
-            .clone()
-            .stdout()
-            .machine(ticket_serialized)
-            .write_line()?;
+            opts.terminal.write_line(&fmt_ok!(
+                "{}: {}",
+                "Created enrollment ticket. You can use it to enroll another machine using",
+                color_primary("ockam project enroll".to_string())
+            ))?;
+
+            opts.terminal
+                .clone()
+                .stdout()
+                .machine(ticket_serialized)
+                .write_line()?;
+        }
+
+        Ok(())
     }
-
-    Ok(())
 }
-
 /// Get the project authority from the first address protocol.
 ///
 /// If the first protocol is a `/project`, look up the project's config.

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -20,7 +20,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 use crate::node::util::initialize_default_node;
 use crate::output::Output;
 use crate::terminal::OckamColor;
-use crate::util::{node_rpc, process_nodes_multiaddr};
+use crate::util::{async_cmd, process_nodes_multiaddr};
 use crate::{display_parse_logs, fmt_ok, CommandGlobalOpts};
 use crate::{docs, fmt_log, Error, Result};
 
@@ -57,8 +57,14 @@ pub fn default_at_addr() -> String {
 }
 
 impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "create relay".into()
     }
 
     pub async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
@@ -180,10 +186,6 @@ impl CreateCommand {
             Ok(relay_name)
         }
     }
-}
-
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> miette::Result<()> {
-    cmd.async_run(&ctx, opts).await
 }
 
 impl Output for RelayInfo {

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -1,18 +1,19 @@
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
-use miette::miette;
+use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::api::Request;
+use ockam_core::AsyncTryClone;
 
 use crate::relay::util::relay_name_parser;
 use crate::terminal::tui::DeleteCommandTui;
 use crate::terminal::PluralTerm;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{color, docs, fmt_ok, CommandGlobalOpts, OckamColor, Terminal, TerminalStream};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -35,16 +36,24 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), run_impl, (options, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-pub async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    DeleteTui::run(ctx, opts, cmd).await
+    pub fn name(&self) -> String {
+        "delete relay".into()
+    }
+
+    pub async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        DeleteTui::run(
+            ctx.async_try_clone().await.into_diagnostic()?,
+            opts,
+            self.clone(),
+        )
+        .await
+    }
 }
 
 struct DeleteTui {

--- a/implementations/rust/ockam/ockam_command/src/relay/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/mod.rs
@@ -38,7 +38,7 @@ pub enum RelaySubCommand {
 }
 
 impl RelayCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
             RelaySubCommand::Create(c) => c.run(opts),
             RelaySubCommand::List(c) => c.run(opts),
@@ -49,11 +49,10 @@ impl RelayCommand {
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            RelaySubCommand::Create(_) => "create relay",
-            RelaySubCommand::List(_) => "list relays",
-            RelaySubCommand::Show(_) => "show relay",
-            RelaySubCommand::Delete(_) => "delete relay",
+            RelaySubCommand::Create(c) => c.name(),
+            RelaySubCommand::List(c) => c.name(),
+            RelaySubCommand::Show(c) => c.name(),
+            RelaySubCommand::Delete(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -9,7 +9,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_node::Context;
 
 use crate::terminal::ConfirmResult;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{color, fmt_ok, CommandGlobalOpts, OckamColor};
 
 /// Removes the local Ockam configuration including all Identities and Nodes
@@ -25,12 +25,14 @@ pub struct ResetCommand {
 }
 
 impl ResetCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
 
     pub fn name(&self) -> String {
-        "reset".to_string()
+        "reset".into()
     }
 
     pub fn hard_reset(&self) {
@@ -38,49 +40,45 @@ impl ResetCommand {
             error!("Failed to hard reset CliState, err={err}");
         }
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ResetCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
-
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ResetCommand) -> miette::Result<()> {
-    let delete_orchestrator_resources =
-        cmd.all && opts.state.is_enrolled().await.unwrap_or_default();
-    if !cmd.yes {
-        let msg = if delete_orchestrator_resources {
-            "This will delete the local Ockam configuration and remove your spaces from the Orchestrator. Are you sure?"
-        } else {
-            "This will delete the local Ockam configuration. Are you sure?"
-        };
-        match opts.terminal.confirm(msg)? {
-            ConfirmResult::Yes => {}
-            ConfirmResult::No => {
-                return Ok(());
-            }
-            ConfirmResult::NonTTY => {
-                return Err(miette!("Use --yes to confirm"));
-            }
-        }
-    }
-    if delete_orchestrator_resources {
-        if let Err(e) = delete_orchestrator_resources_impl(ctx, opts.clone()).await {
-            match opts.terminal.confirm(
-                "We couldn't delete the resources from the Orchestrator. Do you want to continue?",
-            )? {
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let delete_orchestrator_resources =
+            self.all && opts.state.is_enrolled().await.unwrap_or_default();
+        if !self.yes {
+            let msg = if delete_orchestrator_resources {
+                "This will delete the local Ockam configuration and remove your spaces from the Orchestrator. Are you sure?"
+            } else {
+                "This will delete the local Ockam configuration. Are you sure?"
+            };
+            match opts.terminal.confirm(msg)? {
                 ConfirmResult::Yes => {}
-                _ => {
-                    return Err(e);
+                ConfirmResult::No => {
+                    return Ok(());
+                }
+                ConfirmResult::NonTTY => {
+                    return Err(miette!("Use --yes to confirm"));
                 }
             }
         }
+        if delete_orchestrator_resources {
+            if let Err(e) = delete_orchestrator_resources_impl(ctx, opts.clone()).await {
+                match opts.terminal.confirm(
+                    "We couldn't delete the resources from the Orchestrator. Do you want to continue?",
+                )? {
+                    ConfirmResult::Yes => {}
+                    _ => {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        opts.state.reset().await?;
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!("Local Ockam configuration deleted"))
+            .write_line()?;
+        Ok(())
     }
-    opts.state.reset().await?;
-    opts.terminal
-        .stdout()
-        .plain(fmt_ok!("Local Ockam configuration deleted"))
-        .write_line()?;
-    Ok(())
 }
 
 async fn delete_orchestrator_resources_impl(

--- a/implementations/rust/ockam/ockam_command/src/run/runner.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/runner.rs
@@ -21,12 +21,12 @@ impl ConfigRunner {
 
         let vaults = config.vaults.into_commands()?;
         for vault in vaults {
-            vault.async_run(ctx, opts.clone()).await?;
+            vault.async_run(opts.clone()).await?;
         }
 
         let identities = config.identities.into_commands()?;
         for identity in identities {
-            identity.async_run(ctx, opts.clone()).await?;
+            identity.async_run(opts.clone()).await?;
         }
 
         let projects = config.projects.into_commands()?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/delete.rs
@@ -7,7 +7,7 @@ use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::Address;
 
 use crate::node::NodeOpts;
-use crate::util::{api, node_rpc};
+use crate::util::{api, async_cmd};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
@@ -29,30 +29,29 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> miette::Result<()> {
-    run_impl(&ctx, (opts, cmd)).await
-}
+    pub fn name(&self) -> String {
+        "delete secure channel listener".into()
+    }
 
-async fn run_impl(
-    ctx: &Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let req = api::delete_secure_channel_listener(&cmd.address);
-    let response: DeleteSecureChannelListenerResponse = node.ask(ctx, req).await?;
-    let addr = response.addr;
-    opts.terminal
-        .stdout()
-        .plain(fmt_ok!(
-            "Deleted secure-channel listener with address '{addr}' on node '{}'",
-            node.node_name()
-        ))
-        .machine(addr)
-        .write_line()?;
-    Ok(())
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let req = api::delete_secure_channel_listener(&self.address);
+        let response: DeleteSecureChannelListenerResponse = node.ask(ctx, req).await?;
+        let addr = response.addr;
+        opts.terminal
+            .stdout()
+            .plain(fmt_ok!(
+                "Deleted secure-channel listener with address '{addr}' on node '{}'",
+                node.node_name()
+            ))
+            .machine(addr)
+            .write_line()?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/mod.rs
@@ -32,22 +32,21 @@ pub enum SecureChannelListenerSubcommand {
 }
 
 impl SecureChannelListenerCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            SecureChannelListenerSubcommand::Create(c) => c.run(options),
-            SecureChannelListenerSubcommand::Delete(c) => c.run(options),
-            SecureChannelListenerSubcommand::List(c) => c.run(options),
-            SecureChannelListenerSubcommand::Show(c) => c.run(options),
+            SecureChannelListenerSubcommand::Create(c) => c.run(opts),
+            SecureChannelListenerSubcommand::Delete(c) => c.run(opts),
+            SecureChannelListenerSubcommand::List(c) => c.run(opts),
+            SecureChannelListenerSubcommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            SecureChannelListenerSubcommand::Create(_) => "create secure channel listener",
-            SecureChannelListenerSubcommand::Delete(_) => "delete secure channel listener",
-            SecureChannelListenerSubcommand::List(_) => "list secure channel listeners",
-            SecureChannelListenerSubcommand::Show(_) => "show secure channel listener",
+            SecureChannelListenerSubcommand::Create(c) => c.name(),
+            SecureChannelListenerSubcommand::Delete(c) => c.name(),
+            SecureChannelListenerSubcommand::List(c) => c.name(),
+            SecureChannelListenerSubcommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/mod.rs
@@ -42,22 +42,21 @@ enum SecureChannelSubcommand {
 }
 
 impl SecureChannelCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            SecureChannelSubcommand::Create(c) => c.run(options),
-            SecureChannelSubcommand::Delete(c) => c.run(options),
-            SecureChannelSubcommand::List(c) => c.run(options),
-            SecureChannelSubcommand::Show(c) => c.run(options),
+            SecureChannelSubcommand::Create(c) => c.run(opts),
+            SecureChannelSubcommand::Delete(c) => c.run(opts),
+            SecureChannelSubcommand::List(c) => c.run(opts),
+            SecureChannelSubcommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            SecureChannelSubcommand::Create(_) => "create secure channel",
-            SecureChannelSubcommand::Delete(_) => "delete secure channel",
-            SecureChannelSubcommand::List(_) => "list secure channels",
-            SecureChannelSubcommand::Show(_) => "show secure channel",
+            SecureChannelSubcommand::Create(c) => c.name(),
+            SecureChannelSubcommand::Delete(c) => c.name(),
+            SecureChannelSubcommand::List(c) => c.name(),
+            SecureChannelSubcommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -13,7 +13,7 @@ use ockam_api::nodes::BackgroundNodeClient;
 use crate::node::NodeOpts;
 use crate::output::Output;
 use crate::terminal::OckamColor;
-use crate::util::{api, node_rpc};
+use crate::util::{api, async_cmd};
 use crate::CommandGlobalOpts;
 
 /// List service(s) of a given node
@@ -24,49 +24,51 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
+    pub fn name(&self) -> String {
+        "list services".into()
+    }
 
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ListCommand) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let is_finished: Mutex<bool> = Mutex::new(false);
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let is_finished: Mutex<bool> = Mutex::new(false);
 
-    let get_services = async {
-        let services: ServiceList = node.ask(ctx, api::list_services()).await?;
-        *is_finished.lock().await = true;
-        Ok(services)
-    };
+        let get_services = async {
+            let services: ServiceList = node.ask(ctx, api::list_services()).await?;
+            *is_finished.lock().await = true;
+            Ok(services)
+        };
 
-    let output_messages = vec![format!(
-        "Listing Services on {}...\n",
-        node.node_name().color(OckamColor::PrimaryResource.color())
-    )];
+        let output_messages = vec![format!(
+            "Listing Services on {}...\n",
+            node.node_name().color(OckamColor::PrimaryResource.color())
+        )];
 
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
 
-    let (services, _) = try_join!(get_services, progress_output)?;
+        let (services, _) = try_join!(get_services, progress_output)?;
 
-    let plain = opts.terminal.build_list(
-        &services.list,
-        &format!("Services on {}", node.node_name()),
-        &format!("No services found on {}", node.node_name()),
-    )?;
-    let json = serde_json::to_string_pretty(&services.list).into_diagnostic()?;
-    opts.terminal
-        .stdout()
-        .plain(plain)
-        .json(json)
-        .write_line()?;
+        let plain = opts.terminal.build_list(
+            &services.list,
+            &format!("Services on {}", node.node_name()),
+            &format!("No services found on {}", node.node_name()),
+        )?;
+        let json = serde_json::to_string_pretty(&services.list).into_diagnostic()?;
+        opts.terminal
+            .stdout()
+            .plain(plain)
+            .json(json)
+            .write_line()?;
 
-    Ok(())
+        Ok(())
+    }
 }
 
 impl Output for ServiceStatus {

--- a/implementations/rust/ockam/ockam_command/src/service/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/mod.rs
@@ -27,18 +27,17 @@ pub enum ServiceSubcommand {
 }
 
 impl ServiceCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            ServiceSubcommand::Start(c) => c.run(options),
-            ServiceSubcommand::List(c) => c.run(options),
+            ServiceSubcommand::Start(c) => c.run(opts),
+            ServiceSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            ServiceSubcommand::Start(_) => "start service",
-            ServiceSubcommand::List(_) => "list services",
+            ServiceSubcommand::Start(c) => c.name(),
+            ServiceSubcommand::List(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/list.rs
@@ -9,7 +9,7 @@ use ockam_api::cloud::share::{InvitationListKind, Invitations};
 use ockam_api::nodes::InMemoryNode;
 
 use crate::util::api::CloudOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -26,61 +26,65 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
+    pub fn name(&self) -> String {
+        "list invitations".into()
+    }
 
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, _cmd: ListCommand) -> miette::Result<()> {
-    let is_finished: Mutex<bool> = Mutex::new(false);
-    let node = InMemoryNode::start(ctx, &opts.state).await?;
-    let controller = node.create_controller().await?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let is_finished: Mutex<bool> = Mutex::new(false);
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
+        let controller = node.create_controller().await?;
 
-    let get_invitations = async {
-        let invitations = controller
-            .list_invitations(ctx, InvitationListKind::All)
-            .await?;
-        *is_finished.lock().await = true;
-        Ok(invitations)
-    };
+        let get_invitations = async {
+            let invitations = controller
+                .list_invitations(ctx, InvitationListKind::All)
+                .await?;
+            *is_finished.lock().await = true;
+            Ok(invitations)
+        };
 
-    let output_messages = vec![format!("Listing shares...\n",)];
+        let output_messages = vec![format!("Listing shares...\n",)];
 
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (shares, _) = try_join!(get_invitations, progress_output)?;
-
-    if let Some(sent) = shares.sent.as_ref() {
-        let opts = opts.clone();
-        let plain = opts
+        let progress_output = opts
             .terminal
-            .build_list(sent, "Sent Shares", "No sent shares found.")?;
-        let json = serde_json::to_string_pretty(sent).into_diagnostic()?;
-        opts.terminal
-            .stdout()
-            .plain(plain)
-            .json(json)
-            .write_line()?;
-    }
+            .progress_output(&output_messages, &is_finished);
 
-    if let Some(received) = shares.received.as_ref() {
-        let opts = opts.clone();
-        let plain =
+        let (shares, _) = try_join!(get_invitations, progress_output)?;
+
+        if let Some(sent) = shares.sent.as_ref() {
+            let opts = opts.clone();
+            let plain = opts
+                .terminal
+                .build_list(sent, "Sent Shares", "No sent shares found.")?;
+            let json = serde_json::to_string_pretty(sent).into_diagnostic()?;
             opts.terminal
-                .build_list(received, "Received Shares", "No received shares found.")?;
-        let json = serde_json::to_string_pretty(received).into_diagnostic()?;
-        opts.terminal
-            .stdout()
-            .plain(plain)
-            .json(json)
-            .write_line()?;
-    }
+                .stdout()
+                .plain(plain)
+                .json(json)
+                .write_line()?;
+        }
 
-    Ok(())
+        if let Some(received) = shares.received.as_ref() {
+            let opts = opts.clone();
+            let plain = opts.terminal.build_list(
+                received,
+                "Received Shares",
+                "No received shares found.",
+            )?;
+            let json = serde_json::to_string_pretty(received).into_diagnostic()?;
+            opts.terminal
+                .stdout()
+                .plain(plain)
+                .json(json)
+                .write_line()?;
+        }
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/mod.rs
@@ -40,27 +40,26 @@ pub enum ShareSubcommand {
 }
 
 impl ShareCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         use ShareSubcommand::*;
         match self.subcommand {
-            Accept(c) => c.run(options),
-            Create(c) => c.run(options),
-            List(c) => c.run(options),
+            Accept(c) => c.run(opts),
+            Create(c) => c.run(opts),
+            List(c) => c.run(opts),
             Revoke => todo!(),
-            Service(c) => c.run(options),
-            Show(c) => c.run(options),
+            Service(c) => c.run(opts),
+            Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            ShareSubcommand::Accept(_) => "accept invitation",
-            ShareSubcommand::Create(_) => "create invitation",
-            ShareSubcommand::List(_) => "list invitations",
-            ShareSubcommand::Revoke => "revoke invitation",
-            ShareSubcommand::Service(_) => "create shared service",
-            ShareSubcommand::Show(_) => "show invitation",
+            ShareSubcommand::Accept(c) => c.name(),
+            ShareSubcommand::Create(c) => c.name(),
+            ShareSubcommand::List(c) => c.name(),
+            ShareSubcommand::Show(c) => c.name(),
+            ShareSubcommand::Service(c) => c.name(),
+            ShareSubcommand::Revoke => "revoke invitation".to_string(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/share/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/show.rs
@@ -10,7 +10,7 @@ use ockam_api::cloud::share::Invitations;
 use ockam_api::nodes::InMemoryNode;
 
 use crate::util::api::CloudOpts;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
@@ -26,42 +26,46 @@ pub struct ShowCommand {
 }
 
 impl ShowCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
-        node_rpc(options.rt.clone(), rpc, (options, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ShowCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
+    pub fn name(&self) -> String {
+        "show invitation".into()
+    }
 
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ShowCommand) -> miette::Result<()> {
-    let is_finished: Mutex<bool> = Mutex::new(false);
-    let node = InMemoryNode::start(ctx, &opts.state).await?;
-    let controller = node.create_controller().await?;
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let is_finished: Mutex<bool> = Mutex::new(false);
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
+        let controller = node.create_controller().await?;
 
-    let get_invitation_with_access = async {
-        let invitation_with_access = controller.show_invitation(ctx, cmd.invitation_id).await?;
-        *is_finished.lock().await = true;
-        Ok(invitation_with_access)
-    };
+        let get_invitation_with_access = async {
+            let invitation_with_access = controller
+                .show_invitation(ctx, self.invitation_id.clone())
+                .await?;
+            *is_finished.lock().await = true;
+            Ok(invitation_with_access)
+        };
 
-    let output_messages = vec![format!("Showing invitation...\n",)];
+        let output_messages = vec![format!("Showing invitation...\n",)];
 
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
 
-    let (response, _) = try_join!(get_invitation_with_access, progress_output)?;
+        let (response, _) = try_join!(get_invitation_with_access, progress_output)?;
 
-    // TODO: Emit connection details
-    let plain = fmt_ok!("Invite {}", response.invitation.id);
-    let json = serde_json::to_string_pretty(&response).into_diagnostic()?;
-    opts.terminal
-        .stdout()
-        .plain(plain)
-        .json(json)
-        .write_line()?;
+        // TODO: Emit connection details
+        let plain = fmt_ok!("Invite {}", response.invitation.id);
+        let json = serde_json::to_string_pretty(&response).into_diagnostic()?;
+        opts.terminal
+            .stdout()
+            .plain(plain)
+            .json(json)
+            .write_line()?;
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/mod.rs
@@ -29,18 +29,17 @@ pub enum SidecarSubcommand {
 }
 
 impl SidecarCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            SidecarSubcommand::SecureRelayOutlet(c) => c.run(options),
-            SidecarSubcommand::SecureRelayInlet(c) => c.run(options),
+            SidecarSubcommand::SecureRelayOutlet(c) => c.run(opts),
+            SidecarSubcommand::SecureRelayInlet(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            SidecarSubcommand::SecureRelayInlet(_) => "sidecar relay inlet",
-            SidecarSubcommand::SecureRelayOutlet(_) => "sidecar relay outlet",
+            SidecarSubcommand::SecureRelayInlet(c) => c.name(),
+            SidecarSubcommand::SecureRelayOutlet(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -5,7 +5,7 @@ use ockam_node::Context;
 use std::net::SocketAddr;
 
 use crate::run::ConfigRunner;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::util::parsers::socket_addr_parser;
 use crate::{docs, fmt_info, CommandGlobalOpts};
 
@@ -52,22 +52,23 @@ struct Enroll {
 }
 
 impl SecureRelayOutlet {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, SecureRelayOutlet),
-) -> miette::Result<()> {
-    cmd.create_config_and_start(ctx, opts).await
-}
+    pub fn name(&self) -> String {
+        "show relay outlet".into()
+    }
 
-impl SecureRelayOutlet {
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        self.create_config_and_start(ctx, opts).await
+    }
+
     pub async fn create_config_and_start(
-        self,
-        ctx: Context,
+        &self,
+        ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
         let recipe: String = self.create_config_recipe();
@@ -86,7 +87,7 @@ impl SecureRelayOutlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        ConfigRunner::run_config(&ctx, opts, &recipe).await
+        ConfigRunner::run_config(ctx, opts, &recipe).await
     }
 
     fn create_config_recipe(&self) -> String {

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -39,22 +39,21 @@ pub enum SpaceSubcommand {
 }
 
 impl SpaceCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            SpaceSubcommand::Create(c) => c.run(options),
-            SpaceSubcommand::Delete(c) => c.run(options),
-            SpaceSubcommand::List(c) => c.run(options),
-            SpaceSubcommand::Show(c) => c.run(options),
+            SpaceSubcommand::Create(c) => c.run(opts),
+            SpaceSubcommand::Delete(c) => c.run(opts),
+            SpaceSubcommand::List(c) => c.run(opts),
+            SpaceSubcommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            SpaceSubcommand::Create(_) => "create space",
-            SpaceSubcommand::Delete(_) => "delete space",
-            SpaceSubcommand::List(_) => "list spaces",
-            SpaceSubcommand::Show(_) => "show space",
+            SpaceSubcommand::Create(c) => c.name(),
+            SpaceSubcommand::Delete(c) => c.name(),
+            SpaceSubcommand::List(c) => c.name(),
+            SpaceSubcommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -13,7 +13,7 @@ use ockam_node::Context;
 use crate::node::NodeOpts;
 use crate::output::Output;
 use crate::terminal::OckamColor;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -30,48 +30,51 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let is_finished: Mutex<bool> = Mutex::new(false);
+    pub fn name(&self) -> String {
+        "list tcp connections".into()
+    }
 
-    let get_transports = async {
-        let transports: TransportList =
-            node.ask(&ctx, Request::get("/node/tcp/connection")).await?;
-        *is_finished.lock().await = true;
-        Ok(transports)
-    };
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let is_finished: Mutex<bool> = Mutex::new(false);
 
-    let output_messages = vec![format!(
-        "Listing TCP Connections on {}...\n",
-        node.node_name().color(OckamColor::PrimaryResource.color())
-    )];
+        let get_transports = async {
+            let transports: TransportList =
+                node.ask(ctx, Request::get("/node/tcp/connection")).await?;
+            *is_finished.lock().await = true;
+            Ok(transports)
+        };
 
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (transports, _) = try_join!(get_transports, progress_output)?;
-
-    let list = opts.terminal.build_list(
-        &transports.list,
-        &format!("TCP Connections on {}", node.node_name()),
-        &format!(
-            "No TCP Connections found on {}",
+        let output_messages = vec![format!(
+            "Listing TCP Connections on {}...\n",
             node.node_name().color(OckamColor::PrimaryResource.color())
-        ),
-    )?;
+        )];
 
-    opts.terminal.stdout().plain(list).write_line()?;
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
 
-    Ok(())
+        let (transports, _) = try_join!(get_transports, progress_output)?;
+
+        let list = opts.terminal.build_list(
+            &transports.list,
+            &format!("TCP Connections on {}", node.node_name()),
+            &format!(
+                "No TCP Connections found on {}",
+                node.node_name().color(OckamColor::PrimaryResource.color())
+            ),
+        )?;
+
+        opts.terminal.stdout().plain(list).write_line()?;
+
+        Ok(())
+    }
 }
 
 impl Output for TransportStatus {

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
@@ -28,22 +28,21 @@ pub enum TcpConnectionSubCommand {
 }
 
 impl TcpConnectionCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            TcpConnectionSubCommand::Create(c) => c.run(options),
-            TcpConnectionSubCommand::Delete(c) => c.run(options),
-            TcpConnectionSubCommand::List(c) => c.run(options),
-            TcpConnectionSubCommand::Show(c) => c.run(options),
+            TcpConnectionSubCommand::Create(c) => c.run(opts),
+            TcpConnectionSubCommand::Delete(c) => c.run(opts),
+            TcpConnectionSubCommand::List(c) => c.run(opts),
+            TcpConnectionSubCommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            TcpConnectionSubCommand::Create(_) => "create tcp connection",
-            TcpConnectionSubCommand::Delete(_) => "delete tcp connection",
-
-            TcpConnectionSubCommand::List(_) => "list tcp connections",
-            TcpConnectionSubCommand::Show(_) => "show tcp connection",
+            TcpConnectionSubCommand::Create(c) => c.name(),
+            TcpConnectionSubCommand::Delete(c) => c.name(),
+            TcpConnectionSubCommand::List(c) => c.name(),
+            TcpConnectionSubCommand::Show(c) => c.name(),
         }
         .to_string()
     }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -25,7 +25,7 @@ use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
 use crate::util::duration::duration_parser;
 use crate::util::parsers::socket_addr_parser;
-use crate::util::{find_available_port, node_rpc, port_is_free_guard, process_nodes_multiaddr};
+use crate::util::{async_cmd, find_available_port, port_is_free_guard, process_nodes_multiaddr};
 use crate::Error;
 use crate::{display_parse_logs, docs, fmt_log, fmt_ok, CommandGlobalOpts};
 
@@ -78,8 +78,14 @@ fn default_to_addr() -> String {
 }
 
 impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "create tcp inlet".into()
     }
 
     pub async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
@@ -247,10 +253,6 @@ impl CreateCommand {
         };
         Ok(process_nodes_multiaddr(&ma, state).await?.to_string())
     }
-}
-
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, CreateCommand)) -> miette::Result<()> {
-    cmd.async_run(&ctx, opts).await
 }
 
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/mod.rs
@@ -35,22 +35,21 @@ pub enum TcpInletSubCommand {
 }
 
 impl TcpInletCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            TcpInletSubCommand::Create(c) => c.run(options),
-            TcpInletSubCommand::Delete(c) => c.run(options),
-            TcpInletSubCommand::List(c) => c.run(options),
-            TcpInletSubCommand::Show(c) => c.run(options),
+            TcpInletSubCommand::Create(c) => c.run(opts),
+            TcpInletSubCommand::Delete(c) => c.run(opts),
+            TcpInletSubCommand::List(c) => c.run(opts),
+            TcpInletSubCommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            TcpInletSubCommand::Create(_) => "create tcp inlet",
-            TcpInletSubCommand::Delete(_) => "delete tcp inlet",
-            TcpInletSubCommand::List(_) => "list tcp inlets",
-            TcpInletSubCommand::Show(_) => "show tcp inlet",
+            TcpInletSubCommand::Create(c) => c.name(),
+            TcpInletSubCommand::Delete(c) => c.name(),
+            TcpInletSubCommand::List(c) => c.name(),
+            TcpInletSubCommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/delete.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_api::nodes::{models, BackgroundNodeClient};
 use ockam_core::api::Request;
 
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, fmt_ok, node::NodeOpts, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -29,49 +29,52 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-
-    // Check if there an TCP listener with the provided address exists
-    let address = cmd.address;
-    node.ask_and_get_reply::<_, TransportStatus>(
-        &ctx,
-        Request::get(format!("/node/tcp/listener/{address}")),
-    )
-    .await?
-    .found()
-    .into_diagnostic()?
-    .ok_or(miette!(
-        "TCP listener with address {address} was not found on Node {}",
-        node.node_name()
-    ))?;
-
-    // Proceed with the deletion
-    if opts.terminal.confirmed_with_flag_or_prompt(
-        cmd.yes,
-        "Are you sure you want to delete this TCP listener?",
-    )? {
-        let req = Request::delete("/node/tcp/listener")
-            .body(models::transport::DeleteTransport::new(address.clone()));
-        node.tell(&ctx, req).await?;
-
-        opts.terminal
-            .stdout()
-            .plain(fmt_ok!(
-                "TCP listener with address {address} on Node {} has been deleted",
-                node.node_name()
-            ))
-            .json(serde_json::json!({"node": node.node_name() }))
-            .write_line()
-            .unwrap();
+    pub fn name(&self) -> String {
+        "delete tcp listener".into()
     }
-    Ok(())
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+
+        // Check if there an TCP listener with the provided address exists
+        let address = self.address.clone();
+        node.ask_and_get_reply::<_, TransportStatus>(
+            ctx,
+            Request::get(format!("/node/tcp/listener/{address}")),
+        )
+        .await?
+        .found()
+        .into_diagnostic()?
+        .ok_or(miette!(
+            "TCP listener with address {address} was not found on Node {}",
+            node.node_name()
+        ))?;
+
+        // Proceed with the deletion
+        if opts.terminal.confirmed_with_flag_or_prompt(
+            self.yes,
+            "Are you sure you want to delete this TCP listener?",
+        )? {
+            let req = Request::delete("/node/tcp/listener")
+                .body(models::transport::DeleteTransport::new(address.clone()));
+            node.tell(ctx, req).await?;
+
+            opts.terminal
+                .stdout()
+                .plain(fmt_ok!(
+                    "TCP listener with address {address} on Node {} has been deleted",
+                    node.node_name()
+                ))
+                .json(serde_json::json!({"node": node.node_name() }))
+                .write_line()
+                .unwrap();
+        }
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -9,7 +9,7 @@ use ockam_api::nodes::BackgroundNodeClient;
 
 use crate::node::NodeOpts;
 use crate::terminal::OckamColor;
-use crate::util::{api, node_rpc};
+use crate::util::{api, async_cmd};
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -26,44 +26,46 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, ListCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
+    pub fn name(&self) -> String {
+        "list tcp listeners".into()
+    }
 
-async fn run_impl(ctx: &Context, opts: CommandGlobalOpts, cmd: ListCommand) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.node_opts.at_node).await?;
-    let is_finished: Mutex<bool> = Mutex::new(false);
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+        let is_finished: Mutex<bool> = Mutex::new(false);
 
-    let get_transports = async {
-        let transports: TransportList = node.ask(ctx, api::list_tcp_listeners()).await?;
-        *is_finished.lock().await = true;
-        Ok(transports)
-    };
+        let get_transports = async {
+            let transports: TransportList = node.ask(ctx, api::list_tcp_listeners()).await?;
+            *is_finished.lock().await = true;
+            Ok(transports)
+        };
 
-    let output_messages = vec![format!(
-        "Listing TCP Listeners on {}...\n",
-        node.node_name().color(OckamColor::PrimaryResource.color())
-    )];
-
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (transports, _) = try_join!(get_transports, progress_output)?;
-
-    let list = opts.terminal.build_list(
-        &transports.list,
-        &format!("TCP Listeners on {}", node.node_name()),
-        &format!(
-            "No TCP Listeners found on {}",
+        let output_messages = vec![format!(
+            "Listing TCP Listeners on {}...\n",
             node.node_name().color(OckamColor::PrimaryResource.color())
-        ),
-    )?;
-    opts.terminal.stdout().plain(list).write_line()?;
-    Ok(())
+        )];
+
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
+
+        let (transports, _) = try_join!(get_transports, progress_output)?;
+
+        let list = opts.terminal.build_list(
+            &transports.list,
+            &format!("TCP Listeners on {}", node.node_name()),
+            &format!(
+                "No TCP Listeners found on {}",
+                node.node_name().color(OckamColor::PrimaryResource.color())
+            ),
+        )?;
+        opts.terminal.stdout().plain(list).write_line()?;
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/mod.rs
@@ -34,22 +34,21 @@ pub enum TcpListenerSubCommand {
 }
 
 impl TcpListenerCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            TcpListenerSubCommand::Create(c) => c.run(options),
-            TcpListenerSubCommand::Delete(c) => c.run(options),
-            TcpListenerSubCommand::List(c) => c.run(options),
-            TcpListenerSubCommand::Show(c) => c.run(options),
+            TcpListenerSubCommand::Create(c) => c.run(opts),
+            TcpListenerSubCommand::Delete(c) => c.run(opts),
+            TcpListenerSubCommand::List(c) => c.run(opts),
+            TcpListenerSubCommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            TcpListenerSubCommand::Create(_) => "create tcp listener",
-            TcpListenerSubCommand::Delete(_) => "delete tcp listener",
-            TcpListenerSubCommand::List(_) => "list tcp listeners",
-            TcpListenerSubCommand::Show(_) => "show tcp listener",
+            TcpListenerSubCommand::Create(c) => c.name(),
+            TcpListenerSubCommand::Delete(c) => c.name(),
+            TcpListenerSubCommand::List(c) => c.name(),
+            TcpListenerSubCommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -22,7 +22,7 @@ use crate::node::util::initialize_default_node;
 use crate::policy::{add_default_project_policy, has_policy};
 use crate::tcp::util::alias_parser;
 use crate::terminal::OckamColor;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::util::parsers::socket_addr_parser;
 use crate::{display_parse_logs, fmt_log};
 use crate::{docs, fmt_ok, CommandGlobalOpts};
@@ -51,8 +51,14 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "create tcp outlet".into()
     }
 
     pub async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
@@ -140,13 +146,6 @@ impl CreateCommand {
 
 pub fn default_from_addr() -> String {
     "/service/outlet".to_string()
-}
-
-pub async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, CreateCommand),
-) -> miette::Result<()> {
-    cmd.async_run(&ctx, opts).await
 }
 
 pub async fn send_request(

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/delete.rs
@@ -1,18 +1,19 @@
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
-use miette::miette;
+use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
 use ockam_api::nodes::models::portal::OutletList;
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::api::Request;
+use ockam_core::AsyncTryClone;
 
 use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
 use crate::terminal::tui::DeleteCommandTui;
 use crate::terminal::PluralTerm;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{color, docs, fmt_ok, CommandGlobalOpts, OckamColor, Terminal, TerminalStream};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -62,16 +63,24 @@ impl DeleteTui {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
+        })
     }
-}
 
-pub async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, DeleteCommand),
-) -> miette::Result<()> {
-    DeleteTui::run(ctx, opts, cmd).await
+    pub fn name(&self) -> String {
+        "delete tcp outlet".into()
+    }
+
+    pub async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        DeleteTui::run(
+            ctx.async_try_clone().await.into_diagnostic()?,
+            opts,
+            self.clone(),
+        )
+        .await
+    }
 }
 
 #[ockam_core::async_trait]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -10,7 +10,7 @@ use ockam_node::Context;
 
 use crate::node::NodeOpts;
 use crate::terminal::OckamColor;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -27,58 +27,61 @@ pub struct ListCommand {
 }
 
 impl ListCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), run_impl, (opts, self))
-    }
-}
-
-async fn run_impl(
-    ctx: Context,
-    (opts, cmd): (CommandGlobalOpts, ListCommand),
-) -> miette::Result<()> {
-    let node = BackgroundNodeClient::create(&ctx, &opts.state, &cmd.node_opts.at_node).await?;
-
-    let is_finished: Mutex<bool> = Mutex::new(false);
-
-    let send_req = async {
-        let res: OutletList = node.ask(&ctx, Request::get("/node/outlet")).await?;
-        *is_finished.lock().await = true;
-        Ok(res)
-    };
-
-    let output_messages = vec![format!(
-        "Listing TCP Outlets on node {}...\n",
-        node.node_name().color(OckamColor::PrimaryResource.color())
-    )];
-
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
-
-    let (outlets, _) = try_join!(send_req, progress_output)?;
-
-    let list = opts.terminal.build_list(
-        &outlets.list,
-        &format!("Outlets on Node {}", node.node_name()),
-        &format!("No TCP Outlets found on node {}.", node.node_name()),
-    )?;
-    let json: Vec<_> = outlets
-        .list
-        .iter()
-        .map(|outlet| {
-            Ok(serde_json::json!({
-                "alias": outlet.alias,
-                "from": outlet.worker_address()?,
-                "to": outlet.socket_addr,
-            }))
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |ctx| async move {
+            self.async_run(&ctx, opts).await
         })
-        .flat_map(|res: Result<_, ockam_core::Error>| res.ok())
-        .collect();
-    opts.terminal
-        .stdout()
-        .plain(list)
-        .json(serde_json::json!(json))
-        .write_line()?;
+    }
 
-    Ok(())
+    pub fn name(&self) -> String {
+        "list tcp outlets".into()
+    }
+
+    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
+
+        let is_finished: Mutex<bool> = Mutex::new(false);
+
+        let send_req = async {
+            let res: OutletList = node.ask(ctx, Request::get("/node/outlet")).await?;
+            *is_finished.lock().await = true;
+            Ok(res)
+        };
+
+        let output_messages = vec![format!(
+            "Listing TCP Outlets on node {}...\n",
+            node.node_name().color(OckamColor::PrimaryResource.color())
+        )];
+
+        let progress_output = opts
+            .terminal
+            .progress_output(&output_messages, &is_finished);
+
+        let (outlets, _) = try_join!(send_req, progress_output)?;
+
+        let list = opts.terminal.build_list(
+            &outlets.list,
+            &format!("Outlets on Node {}", node.node_name()),
+            &format!("No TCP Outlets found on node {}.", node.node_name()),
+        )?;
+        let json: Vec<_> = outlets
+            .list
+            .iter()
+            .map(|outlet| {
+                Ok(serde_json::json!({
+                    "alias": outlet.alias,
+                    "from": outlet.worker_address()?,
+                    "to": outlet.socket_addr,
+                }))
+            })
+            .flat_map(|res: Result<_, ockam_core::Error>| res.ok())
+            .collect();
+        opts.terminal
+            .stdout()
+            .plain(list)
+            .json(serde_json::json!(json))
+            .write_line()?;
+
+        Ok(())
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/mod.rs
@@ -35,22 +35,21 @@ pub enum TcpOutletSubCommand {
 }
 
 impl TcpOutletCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            TcpOutletSubCommand::Create(c) => c.run(options),
-            TcpOutletSubCommand::Delete(c) => c.run(options),
-            TcpOutletSubCommand::List(c) => c.run(options),
-            TcpOutletSubCommand::Show(c) => c.run(options),
+            TcpOutletSubCommand::Create(c) => c.run(opts),
+            TcpOutletSubCommand::Delete(c) => c.run(opts),
+            TcpOutletSubCommand::List(c) => c.run(opts),
+            TcpOutletSubCommand::Show(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            TcpOutletSubCommand::Create(_) => "create tcp outlet",
-            TcpOutletSubCommand::Delete(_) => "delete tcp outlet",
-            TcpOutletSubCommand::List(_) => "list tcp outlets",
-            TcpOutletSubCommand::Show(_) => "show tcp outlet",
+            TcpOutletSubCommand::Create(c) => c.name(),
+            TcpOutletSubCommand::Delete(c) => c.name(),
+            TcpOutletSubCommand::List(c) => c.name(),
+            TcpOutletSubCommand::Show(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -30,15 +30,6 @@ pub(crate) fn list_tcp_listeners() -> Request<()> {
     Request::get("/node/tcp/listener")
 }
 
-/// Construct a request to create node tcp connection
-pub(crate) fn create_tcp_connection(
-    cmd: &crate::tcp::connection::CreateCommand,
-) -> Request<models::transport::CreateTcpConnection> {
-    let payload = models::transport::CreateTcpConnection::new(cmd.address.clone());
-
-    Request::post("/node/tcp/connection").body(payload)
-}
-
 /// Construct a request to print a list of services for the given node
 pub(crate) fn list_services() -> Request<()> {
     Request::get("/node/services")

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -2,11 +2,10 @@ use clap::Args;
 use colorful::Colorful;
 
 use console::Term;
-use ockam::Context;
 
 use crate::terminal::tui::DeleteCommandTui;
 use crate::terminal::PluralTerm;
-use crate::util::node_rpc;
+use crate::util::async_cmd;
 use crate::{color, docs, fmt_ok, CommandGlobalOpts, OckamColor, Terminal, TerminalStream};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
@@ -31,8 +30,18 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
-        node_rpc(opts.rt.clone(), rpc, (opts, self));
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        async_cmd(&self.name(), opts.clone(), |_ctx| async move {
+            self.async_run(opts).await
+        })
+    }
+
+    pub fn name(&self) -> String {
+        "delete vault".into()
+    }
+
+    async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        DeleteTui::run(opts, self.clone()).await
     }
 }
 
@@ -46,18 +55,6 @@ impl DeleteTui {
         let tui = Self { opts, cmd };
         tui.delete().await
     }
-}
-
-async fn rpc(ctx: Context, (opts, cmd): (CommandGlobalOpts, DeleteCommand)) -> miette::Result<()> {
-    run_impl(&ctx, opts, cmd).await
-}
-
-async fn run_impl(
-    _ctx: &Context,
-    opts: CommandGlobalOpts,
-    cmd: DeleteCommand,
-) -> miette::Result<()> {
-    DeleteTui::run(opts, cmd).await
 }
 
 #[ockam_core::async_trait]

--- a/implementations/rust/ockam/ockam_command/src/vault/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/mod.rs
@@ -38,7 +38,7 @@ pub enum VaultSubcommand {
 }
 
 impl VaultCommand {
-    pub fn run(self, opts: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
             VaultSubcommand::Create(cmd) => cmd.run(opts),
             VaultSubcommand::Move(cmd) => cmd.run(opts),
@@ -50,12 +50,11 @@ impl VaultCommand {
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            VaultSubcommand::Create(_) => "create vault",
-            VaultSubcommand::Move(_) => "move vault",
-            VaultSubcommand::Show(_) => "show vault",
-            VaultSubcommand::Delete(_) => "delete vault",
-            VaultSubcommand::List(_) => "list vaults",
+            VaultSubcommand::Create(c) => c.name(),
+            VaultSubcommand::Move(c) => c.name(),
+            VaultSubcommand::Show(c) => c.name(),
+            VaultSubcommand::Delete(c) => c.name(),
+            VaultSubcommand::List(c) => c.name(),
         }
-        .to_string()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/worker/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/mod.rs
@@ -26,16 +26,15 @@ pub enum WorkerSubcommand {
 }
 
 impl WorkerCommand {
-    pub fn run(self, options: CommandGlobalOpts) {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self.subcommand {
-            WorkerSubcommand::List(c) => c.run(options),
+            WorkerSubcommand::List(c) => c.run(opts),
         }
     }
 
     pub fn name(&self) -> String {
         match &self.subcommand {
-            WorkerSubcommand::List(_) => "list workers",
+            WorkerSubcommand::List(c) => c.name(),
         }
-        .to_string()
     }
 }


### PR DESCRIPTION
This PR makes sure that we create a span, and export it, each time a command returns an error.

The main changes are in `journey.rs` and in the (ex) `node_rpc` execution which does not exit in case of an error anymore.
Instead, results are propagated up to the `main` function which then exits with an error code.

Since this PR required a change throughout all the commands to change the signature of the `node_rpc` function, I took the opportunity to make all that code more consistent. All the calls now look like:
```rust
pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
    async_cmd(&self.name(), opts.clone(), |ctx| async move {
        self.async_run(&ctx, opts).await
    })
}
```

Where `async_run` is a function of the command we are implementing.