### PR TITLE
feat(rust): restart a project journey if project is deleted

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -111,6 +111,11 @@ impl CliState {
         Ok(result)
     }
 
+    pub async fn reset_project_journey(&self, project_id: &str) -> Result<()> {
+        let repository = self.user_journey_repository().await?;
+        Ok(repository.delete_project_journey(project_id).await?)
+    }
+
     /// Create the initial host journey, with a random trace id
     fn create_host_journey(&self) -> HostJourney {
         let (opentelemetry_context, now) = self.create_journey(

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository.rs
@@ -9,6 +9,8 @@ pub trait JourneysRepository: Send + Sync + 'static {
 
     async fn get_project_journey(&self, project_id: &str) -> Result<Option<ProjectJourney>>;
 
+    async fn delete_project_journey(&self, project_id: &str) -> Result<()>;
+
     /// Store a host journey
     async fn store_host_journey(&self, host_journey: HostJourney) -> Result<()>;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
@@ -68,6 +68,7 @@ impl Projects for InMemoryNode {
     ) -> miette::Result<()> {
         let controller = self.create_controller().await?;
         controller.delete_project(ctx, space_id, project_id).await?;
+        self.cli_state.reset_project_journey(project_id).await?;
         Ok(self.cli_state.delete_project(project_id).await?)
     }
 


### PR DESCRIPTION
This way we can properly track events even when several projects are being tried out.
