### PR TITLE
improve nix dev shells

### DIFF
--- a/tools/nix/parts/all.nix
+++ b/tools/nix/parts/all.nix
@@ -20,11 +20,10 @@
       inherit (config.devShells.rust) nativeBuildInputs CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER DYLD_FALLBACK_LIBRARY_PATH OCKAM_DISABLE_UPGRADE_CHECK RUSTFLAGS RUST_SRC_PATH CARGO_INCREMENTAL;
       inherit (config.devShells.tooling) BATS_LIB;
 
-      # TODO: Move HOME override to wrapper script or other localized definition
       shellHook = ''
         ${config.devShells.rust.shellHook or ""}
 
-        export HOME=$PWD/.home
+        [ -z "$HOME" ] && export HOME=~
       '';
     };
   };

--- a/tools/nix/parts/elixir.nix
+++ b/tools/nix/parts/elixir.nix
@@ -10,13 +10,13 @@ in {
   options = {
     ockam.elixir = {
       erlangVersion = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "25.3.2";
       };
       languageServer = mkEnableOption "elixir-ls" // {default = true;};
       shadowAsdf = mkEnableOption "override ASDF to use Nix-provided binaries" // {default = true;};
       version = mkOption {
-        type = types.nullOr types.string;
+        type = types.nullOr types.str;
         default = "1.14.4";
       };
     };


### PR DESCRIPTION
- build: fix deprecated nix type `types.string`
- build: remove `$HOME` override in nix shell environment
