### PR TITLE
Improve portals reliability and integration tests

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -116,7 +116,7 @@ mod test {
     async fn producer__flow_with_mock_kafka__content_encryption_and_decryption(
         context: &mut Context,
     ) -> ockam::Result<()> {
-        let handle = crate::util::test_utils::start_manager_for_tests(context).await?;
+        let handle = crate::util::test_utils::start_manager_for_tests(context, None, None).await?;
 
         let consumer_bootstrap_port = create_kafka_service(
             context,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -9,8 +9,7 @@ use ockam::Result;
 use ockam_core::api::{Error, Request, RequestHeader, Response};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Address, AsyncTryClone};
-use ockam_multiaddr::proto::Project;
-use ockam_multiaddr::{MultiAddr, Protocol};
+use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
 use crate::nodes::connection::Connection;
@@ -342,6 +341,7 @@ pub trait Relays {
         alias: String,
         authorized: Option<Identifier>,
         relay_address: Option<String>,
+        at_rust_node: bool,
     ) -> miette::Result<RelayInfo>;
 }
 
@@ -354,8 +354,8 @@ impl Relays for BackgroundNodeClient {
         alias: String,
         authorized: Option<Identifier>,
         relay_address: Option<String>,
+        at_rust_node: bool,
     ) -> miette::Result<RelayInfo> {
-        let at_rust_node = !address.starts_with(Project::CODE);
         let body = CreateRelay::new(
             address.clone(),
             alias,

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -1,0 +1,631 @@
+use crate::utils::{start_passthrough_server, start_tcp_echo_server, Disruption};
+use ockam_api::config::lookup::InternetAddress;
+use ockam_api::nodes::models::portal::OutletAccessControl;
+use ockam_api::nodes::service::{NodeManagerCredentialRetrieverOptions, NodeManagerTrustOptions};
+use ockam_api::test_utils::{start_manager_for_tests, NodeManagerHandle};
+use ockam_api::ConnectionStatus;
+use ockam_core::compat::rand::RngCore;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{route, Address, AllowAll, Error};
+use ockam_multiaddr::MultiAddr;
+use ockam_node::{Context, NodeBuilder};
+use std::ops::Deref;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio::spawn;
+use tokio::time::timeout;
+use tracing::info;
+
+mod utils;
+
+#[ockam_macros::test]
+async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<()> {
+    let echo_server_handle = start_tcp_echo_server().await;
+    let node_manager_handle = start_manager_for_tests(context, None, None).await?;
+
+    let outlet_status = node_manager_handle
+        .node_manager
+        .create_outlet(
+            context,
+            echo_server_handle.chosen_addr,
+            Some(Address::from_string("outlet")),
+            true,
+            OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+        )
+        .await?;
+
+    assert_eq!(outlet_status.socket_addr, echo_server_handle.chosen_addr);
+    assert_eq!(outlet_status.worker_addr.address(), "outlet");
+
+    let inlet_status = node_manager_handle
+        .node_manager
+        .create_inlet(
+            context,
+            "127.0.0.1:0".to_string(),
+            route![],
+            route![],
+            MultiAddr::from_str("/secure/api/service/outlet")?,
+            "alias".to_string(),
+            None,
+            None,
+            None,
+            true,
+        )
+        .await?;
+
+    assert_eq!(inlet_status.alias, "alias");
+    assert_eq!(inlet_status.status, ConnectionStatus::Up);
+    assert_eq!(inlet_status.outlet_addr, "/secure/api/service/outlet");
+    assert_ne!(inlet_status.bind_addr, "127.0.0.1:0");
+    assert!(inlet_status.outlet_route.is_some());
+
+    // connect to inlet_status.bind_addr and send dummy payload
+    let mut socket = TcpStream::connect(inlet_status.bind_addr).await.unwrap();
+    socket.write_all(b"hello").await.unwrap();
+
+    let mut buf = [0u8; 5];
+    socket.read_exact(&mut buf).await.unwrap();
+    assert_eq!(&buf, b"hello");
+
+    Ok(())
+}
+
+struct TestNode {
+    pub context: Context,
+    pub node_manager_handle: NodeManagerHandle,
+}
+
+impl TestNode {
+    pub async fn create(runtime: Arc<Runtime>, listen_addr: Option<&str>) -> Self {
+        let (mut context, mut executor) = NodeBuilder::new().with_runtime(runtime.clone()).build();
+        runtime.spawn(async move {
+            executor.start_router().await.expect("cannot start router");
+        });
+        let node_manager_handle = start_manager_for_tests(
+            &mut context,
+            listen_addr,
+            Some(NodeManagerTrustOptions::new(
+                NodeManagerCredentialRetrieverOptions::None,
+                None,
+            )),
+        )
+        .await
+        .expect("cannot start node manager");
+
+        Self {
+            context,
+            node_manager_handle,
+        }
+    }
+
+    pub async fn listen_address(&self) -> InternetAddress {
+        self.cli_state
+            .get_node(&self.node_manager.node_name())
+            .await
+            .unwrap()
+            .tcp_listener_address()
+            .unwrap()
+    }
+}
+
+impl Deref for TestNode {
+    type Target = NodeManagerHandle;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node_manager_handle
+    }
+}
+
+#[test]
+fn portal_node_goes_down_reconnect() {
+    // in this test we manually create three nodes with a shared runtime, then:
+    //  - create a portal using the first two nodes
+    //  - bring down the second node
+    //  - verify that's detected as offline
+    //  - create a third node using the same address as the second one
+    //  - verify the portal is restored
+
+    let runtime = Arc::new(Runtime::new().unwrap());
+    let runtime_cloned = runtime.clone();
+    std::env::set_var("OCKAM_LOG", "none");
+
+    let result: ockam::Result<()> = runtime_cloned.block_on(async move {
+        let test_body = async move {
+            let echo_server_handle = start_tcp_echo_server().await;
+
+            let first_node = TestNode::create(runtime.clone(), None).await;
+            let second_node = TestNode::create(runtime.clone(), None).await;
+
+            let _outlet_status = second_node
+                .node_manager
+                .create_outlet(
+                    &second_node.context,
+                    echo_server_handle.chosen_addr,
+                    Some(Address::from_string("outlet")),
+                    true,
+                    OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+                )
+                .await?;
+
+            let second_node_listen_address = second_node.listen_address().await;
+
+            // create inlet in the first node pointing to the second one
+            let inlet_status = first_node
+                .node_manager
+                .create_inlet(
+                    &first_node.context,
+                    "127.0.0.1:0".to_string(),
+                    route![],
+                    route![],
+                    second_node_listen_address
+                        .multi_addr()?
+                        .concat(&MultiAddr::from_str("/secure/api/service/outlet")?)?,
+                    "inlet_alias".to_string(),
+                    None,
+                    None,
+                    None,
+                    true,
+                )
+                .await?;
+
+            // connect to inlet_status.bind_addr and send dummy payload
+            let mut socket = TcpStream::connect(inlet_status.bind_addr.clone())
+                .await
+                .unwrap();
+            socket.write_all(b"hello").await.unwrap();
+
+            let mut buf = [0u8; 5];
+            socket.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"hello");
+
+            second_node.context.stop().await?;
+
+            // now let's verify the inlet has been detected as down
+            loop {
+                let inlet_status = first_node
+                    .node_manager
+                    .show_inlet("inlet_alias")
+                    .await
+                    .unwrap();
+                if inlet_status.status == ConnectionStatus::Down {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5000)).await;
+            }
+
+            // create third node using the same address as the second one
+            let third_node =
+                TestNode::create(runtime, Some(&second_node_listen_address.to_string())).await;
+
+            let _outlet_status = third_node
+                .node_manager
+                .create_outlet(
+                    &third_node.context,
+                    echo_server_handle.chosen_addr,
+                    Some(Address::from_string("outlet")),
+                    true,
+                    OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+                )
+                .await?;
+
+            // now let's verify the inlet has been restored
+            loop {
+                let inlet_status = first_node
+                    .node_manager
+                    .show_inlet("inlet_alias")
+                    .await
+                    .unwrap();
+                if inlet_status.status == ConnectionStatus::Up {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5000)).await;
+            }
+
+            let mut socket = TcpStream::connect(inlet_status.bind_addr).await.unwrap();
+            socket.write_all(b"hello").await.unwrap();
+
+            let mut buf = [0u8; 5];
+            socket.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"hello");
+
+            third_node.context.stop().await?;
+            first_node.context.stop().await?;
+
+            Ok(())
+        };
+
+        timeout(Duration::from_secs(90), test_body)
+            .await
+            .unwrap_or_else(|_| Err(Error::new(Origin::Node, Kind::Timeout, "Test timed out")))
+    });
+
+    result.unwrap();
+
+    // to avoid tokio panic when dropping the runtime
+    // shouldn't be necessary since this should be the default rust behavior
+    drop(runtime_cloned);
+}
+
+#[test]
+fn portal_low_bandwidth_connection_keep_working_for_60s() {
+    // in this test we use two nodes, connected through a passthrough server
+    // which limits the bandwidth to 64kb per second
+    //
+    // ┌────────┐     ┌───────────┐        ┌────────┐
+    // │  Node  └─────►    TCP    └────────►  Node  │
+    // │   1    ◄─────┐Passthrough◄────────┐   2    │
+    // └────┬───┘     │  64KB/s   │        └────▲───┘
+    //      │         └───────────┘             │
+    //      │         ┌───────────┐             │
+    //      │ Portal  │   TCP     │      Outlet │
+    //      └─────────┤   Echo    ◄─────────────┘
+    //                └───────────┘
+
+    let runtime = Arc::new(Runtime::new().unwrap());
+    let runtime_cloned = runtime.clone();
+    std::env::set_var("OCKAM_LOG", "none");
+
+    let result: ockam::Result<()> = runtime_cloned.block_on(async move {
+        let test_body = async move {
+            let echo_server_handle = start_tcp_echo_server().await;
+
+            let first_node = TestNode::create(runtime.clone(), None).await;
+            let second_node = TestNode::create(runtime, None).await;
+
+            let _outlet_status = second_node
+                .node_manager
+                .create_outlet(
+                    &second_node.context,
+                    echo_server_handle.chosen_addr,
+                    Some(Address::from_string("outlet")),
+                    true,
+                    OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+                )
+                .await?;
+
+            let second_node_listen_address = second_node
+                .cli_state
+                .get_node(&second_node.node_manager.node_name())
+                .await?
+                .tcp_listener_address()
+                .unwrap();
+
+            let passthrough_server_handle = start_passthrough_server(
+                &second_node_listen_address.to_string(),
+                Disruption::LimitBandwidth(64 * 1024),
+                Disruption::LimitBandwidth(64 * 1024),
+            )
+            .await;
+
+            // create inlet in the first node pointing to the second one
+            let inlet_status = first_node
+                .node_manager
+                .create_inlet(
+                    &first_node.context,
+                    "127.0.0.1:0".to_string(),
+                    route![],
+                    route![],
+                    InternetAddress::from(passthrough_server_handle.chosen_addr)
+                        .multi_addr()?
+                        .concat(&MultiAddr::from_str("/secure/api/service/outlet")?)?,
+                    "inlet_alias".to_string(),
+                    None,
+                    None,
+                    None,
+                    true,
+                )
+                .await?;
+
+            info!("inlet_status: {inlet_status:?}");
+
+            // connect to inlet_status.bind_addr and send dummy payload
+            let mut buf = [0u8; 48 * 1024];
+            let mut stream = TcpStream::connect(inlet_status.bind_addr.clone())
+                .await
+                .unwrap();
+
+            // check that the route is up
+            stream.write_all(b"hello").await.unwrap();
+            stream.read_exact(&mut buf[0..5]).await.unwrap();
+            assert_eq!(&buf[0..5], b"hello");
+
+            // saturate the bandwidth with empty packets
+            // and verify the connection stays up for 30 seconds
+            let end = std::time::Instant::now() + Duration::from_secs(60);
+            let (mut rx, mut tx) = stream.into_split();
+
+            spawn(async move {
+                while std::time::Instant::now() < end {
+                    let _ = tx.write_all(&buf).await;
+                }
+            });
+
+            spawn(async move {
+                while std::time::Instant::now() < end {
+                    let _ = rx.read(&mut buf).await.unwrap();
+                }
+            });
+
+            // keep checking the status of the inlet
+            while std::time::Instant::now() < end {
+                let inlet_status = first_node
+                    .node_manager
+                    .show_inlet("inlet_alias")
+                    .await
+                    .unwrap();
+                assert_eq!(inlet_status.status, ConnectionStatus::Up);
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+
+            second_node.context.stop().await?;
+            first_node.context.stop().await?;
+
+            Ok(())
+        };
+
+        timeout(Duration::from_secs(90), test_body)
+            .await
+            .unwrap_or_else(|_| Err(Error::new(Origin::Node, Kind::Timeout, "Test timed out")))
+    });
+
+    result.unwrap();
+
+    // to avoid tokio panic when dropping the runtime
+    // shouldn't be necessary since this should be the default rust behavior
+    drop(runtime_cloned);
+}
+
+#[test]
+fn portal_heavy_load_exchanged() {
+    let runtime = Arc::new(Runtime::new().unwrap());
+    let runtime_cloned = runtime.clone();
+    std::env::set_var("OCKAM_LOG", "none");
+
+    let result: ockam::Result<()> = runtime_cloned.block_on(async move {
+        let test_body = async move {
+            let echo_server_handle = start_tcp_echo_server().await;
+
+            let first_node = TestNode::create(runtime.clone(), None).await;
+            let second_node = TestNode::create(runtime, None).await;
+
+            let _outlet_status = second_node
+                .node_manager
+                .create_outlet(
+                    &second_node.context,
+                    echo_server_handle.chosen_addr,
+                    Some(Address::from_string("outlet")),
+                    true,
+                    OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+                )
+                .await?;
+
+            let second_node_listen_address = second_node
+                .cli_state
+                .get_node(&second_node.node_manager.node_name())
+                .await?
+                .tcp_listener_address()
+                .unwrap();
+
+            // create inlet in the first node pointing to the second one
+            let inlet_status = first_node
+                .node_manager
+                .create_inlet(
+                    &first_node.context,
+                    "127.0.0.1:0".to_string(),
+                    route![],
+                    route![],
+                    second_node_listen_address
+                        .multi_addr()?
+                        .concat(&MultiAddr::from_str("/secure/api/service/outlet")?)?,
+                    "inlet_alias".to_string(),
+                    None,
+                    None,
+                    None,
+                    true,
+                )
+                .await?;
+
+            info!("inlet_status: {inlet_status:?}");
+
+            // connect to inlet_status.bind_addr and send dummy payload
+            const PAYLOAD_SIZE: usize = 50 * 1024 * 1024;
+            info!("generating random payload");
+            let payload = {
+                let mut payload = vec![0u8; PAYLOAD_SIZE];
+                rand::thread_rng().fill_bytes(&mut payload);
+                payload
+            };
+
+            let stream = TcpStream::connect(inlet_status.bind_addr.clone())
+                .await
+                .unwrap();
+
+            // saturate the bandwidth with empty packets
+            // and verify the connection stays up for 30 seconds
+            let (mut rx, mut tx) = stream.into_split();
+
+            let payload_cloned = payload.clone();
+            // keeps a reference to the connection to avoid it being dropped
+            let join_tx = spawn(async move {
+                info!("writing payload");
+                tx.write_all(&payload_cloned).await.unwrap();
+                info!("payload fully written");
+                tx
+            });
+
+            let mut incoming_buffer = vec![0; PAYLOAD_SIZE];
+            let size = rx.read_exact(incoming_buffer.as_mut_slice()).await.unwrap();
+
+            // check that data is correct up to the size
+            assert_eq!(payload.len(), size);
+
+            // using assert!() to avoid MB of data being shown in the logs
+            assert!(payload == incoming_buffer);
+
+            let _ = join_tx.await.unwrap();
+            second_node.context.stop().await?;
+            first_node.context.stop().await?;
+
+            Ok(())
+        };
+
+        timeout(Duration::from_secs(90), test_body)
+            .await
+            .unwrap_or_else(|_| Err(Error::new(Origin::Node, Kind::Timeout, "Test timed out")))
+    });
+
+    result.unwrap();
+
+    // to avoid tokio panic when dropping the runtime
+    // shouldn't be necessary since this should be the default rust behavior
+    drop(runtime_cloned);
+}
+
+#[test]
+fn portal_connection_drop_packets() {
+    // Drop even packets after 32 packets (to allow for the initial
+    // handshake to complete).
+    // This test checks that:
+    //   - connection is interrupted when a failure is detected
+    //   - the portion of the received data matches with the sent data.
+    //
+
+    test_portal_payload_transfer(Disruption::DropPacketsAfter(32), Disruption::None);
+}
+
+#[test]
+fn portal_connection_change_packet_order() {
+    // Change packet order after 32 packets (to allow for the initial
+    // handshake to complete).
+    // This test checks that:
+    //   - connection is interrupted when a failure is detected
+    //   - the portion of the received data matches with the sent data.
+
+    test_portal_payload_transfer(Disruption::PacketsOutOfOrderAfter(32), Disruption::None);
+}
+
+fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disruption: Disruption) {
+    // we use two nodes, connected through a passthrough server
+    // ┌────────┐     ┌───────────┐        ┌────────┐
+    // │  Node  └─────►    TCP    └────────►  Node  │
+    // │   1    ◄─────┐Passthrough◄────────┐   2    │
+    // └────┬───┘     │ Disruption│        └────▲───┘
+    //      │         └───────────┘             │
+    //      │         ┌───────────┐             │
+    //      │ Portal  │   TCP     │      Outlet │
+    //      └─────────┤   Echo    ◄─────────────┘
+    //                └───────────┘
+
+    let runtime = Arc::new(Runtime::new().unwrap());
+    let runtime_cloned = runtime.clone();
+    std::env::set_var("OCKAM_LOG", "none");
+
+    let result: ockam::Result<_> = runtime_cloned.block_on(async move {
+        let test_body = async move {
+            let echo_server_handle = start_tcp_echo_server().await;
+
+            let first_node = TestNode::create(runtime.clone(), None).await;
+            let second_node = TestNode::create(runtime, None).await;
+
+            let _outlet_status = second_node
+                .node_manager
+                .create_outlet(
+                    &second_node.context,
+                    echo_server_handle.chosen_addr,
+                    Some(Address::from_string("outlet")),
+                    true,
+                    OutletAccessControl::IncomingAccessControl(Arc::new(AllowAll)),
+                )
+                .await?;
+
+            let second_node_listen_address = second_node
+                .cli_state
+                .get_node(&second_node.node_manager.node_name())
+                .await?
+                .tcp_listener_address()
+                .unwrap();
+
+            let passthrough_server_handle = start_passthrough_server(
+                &second_node_listen_address.to_string(),
+                outgoing_disruption,
+                incoming_disruption,
+            )
+            .await;
+
+            // create inlet in the first node pointing to the second one
+            let inlet_status = first_node
+                .node_manager
+                .create_inlet(
+                    &first_node.context,
+                    "127.0.0.1:0".to_string(),
+                    route![],
+                    route![],
+                    InternetAddress::from(passthrough_server_handle.chosen_addr)
+                        .multi_addr()?
+                        .concat(&MultiAddr::from_str("/secure/api/service/outlet")?)?,
+                    "inlet_alias".to_string(),
+                    None,
+                    None,
+                    None,
+                    true,
+                )
+                .await?;
+
+            info!("inlet_status: {inlet_status:?}");
+
+            // send 10MB of random data and verify it's correct on the other side
+            let payload_size = 10 * 1024 * 1024;
+            let mut random_buffer: Vec<u8> = vec![0; payload_size];
+            rand::thread_rng().fill_bytes(&mut random_buffer);
+
+            // connect to inlet_status.bind_addr and send dummy payload
+            let stream = TcpStream::connect(inlet_status.bind_addr.clone())
+                .await
+                .unwrap();
+
+            // we can't send and read the data from a sigle async context
+            let (mut rx, mut tx) = stream.into_split();
+
+            let copied_buffer = random_buffer.clone();
+            let _join = spawn(async move {
+                let _ = tx.write_all(&copied_buffer).await;
+                tx
+            });
+
+            let mut incoming_buffer = Vec::new();
+
+            // this call keep reading the buffer until the connection is closed
+            // we are validating that the connection actually gets closed.
+            // since the connection can be asbruptly closed, we ignore errors
+            let _ = rx.read_to_end(&mut incoming_buffer).await;
+            let size = incoming_buffer.len();
+
+            info!("size: {}", size);
+            assert_ne!(size, 0);
+            assert!(size < payload_size);
+
+            // check that data is correct up to the size,
+            // using assert to avoid MB of data being shown in the logs
+            assert!(random_buffer[0..size] == incoming_buffer[0..size]);
+
+            second_node.context.stop().await?;
+            first_node.context.stop().await?;
+
+            Ok(())
+        };
+
+        timeout(Duration::from_secs(60), test_body)
+            .await
+            .unwrap_or_else(|_| Err(Error::new(Origin::Node, Kind::Timeout, "Test timed out")))
+    });
+
+    result.unwrap();
+
+    // to avoid tokio panic when dropping the runtime
+    // shouldn't be necessary since this should be the default rust behavior
+    drop(runtime_cloned);
+}

--- a/implementations/rust/ockam/ockam_api/tests/utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/tests/utils/mod.rs
@@ -1,0 +1,335 @@
+use sqlx::__rt::timeout;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpListener, TcpSocket, TcpStream};
+use tracing::{error, info};
+
+pub struct EchoServerHandle {
+    pub chosen_addr: SocketAddr,
+    close: Arc<AtomicBool>,
+}
+
+impl Drop for EchoServerHandle {
+    fn drop(&mut self) {
+        self.close.store(true, Ordering::Relaxed);
+    }
+}
+
+#[must_use = "listener closed when dropped"]
+pub async fn start_tcp_echo_server() -> EchoServerHandle {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let listener = TcpListener::bind(&addr)
+        .await
+        .expect("Failed to bind server to address");
+
+    let chosen_addr = listener.local_addr().unwrap();
+    let close = Arc::new(AtomicBool::new(false));
+
+    {
+        let close = close.clone();
+        tokio::spawn(async move {
+            loop {
+                let result = match timeout(Duration::from_millis(200), listener.accept()).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        if close.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        continue;
+                    }
+                };
+
+                let (mut socket, _) = result.expect("Failed to accept connection");
+                tokio::spawn(async move {
+                    let mut buf = vec![0; 1024];
+                    loop {
+                        let n = match socket.read(&mut buf).await {
+                            // socket closed
+                            Ok(0) => return,
+                            Ok(n) => n,
+                            Err(e) => {
+                                println!("Failed to read from socket; err = {:?}", e);
+                                return;
+                            }
+                        };
+
+                        // Write the data back
+                        if let Err(e) = socket.write_all(&buf[0..n]).await {
+                            println!("Failed to write to socket; err = {:?}", e);
+                            return;
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    EchoServerHandle { chosen_addr, close }
+}
+
+pub struct PassthroughServerHandle {
+    pub chosen_addr: SocketAddr,
+    pub destination: SocketAddr,
+    close: Arc<AtomicBool>,
+}
+
+impl Drop for PassthroughServerHandle {
+    fn drop(&mut self) {
+        self.close.store(true, Ordering::Relaxed);
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub enum Disruption {
+    None,
+    LimitBandwidth(usize),
+    DropPacketsAfter(usize),
+    PacketsOutOfOrderAfter(usize),
+}
+
+#[must_use = "listener closed when dropped"]
+pub async fn start_passthrough_server(
+    destination: &str,
+    outgoing_disruption: Disruption,
+    incoming_disruption: Disruption,
+) -> PassthroughServerHandle {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+    let socket = TcpSocket::new_v4().unwrap();
+
+    // to reduce the impact of this passthrough server on the benchmarks and tests
+    // we set the receive buffer size to 1KB
+    socket.set_recv_buffer_size(1024).unwrap();
+    socket.bind(addr).expect("Failed to bind server to address");
+
+    let listener = socket.listen(32).unwrap();
+
+    let destination = destination
+        .parse()
+        .expect("Failed to parse destination address");
+
+    let chosen_addr = listener.local_addr().unwrap();
+    let close = Arc::new(AtomicBool::new(false));
+
+    {
+        let close = close.clone();
+        tokio::spawn(async move {
+            loop {
+                let result = match timeout(Duration::from_millis(200), listener.accept()).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        if close.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        continue;
+                    }
+                };
+
+                let (incoming_socket, _) = result.expect("Failed to accept connection");
+                tokio::spawn(async move {
+                    let outgoing_socket = match TcpStream::connect(destination).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("Failed to connect to destination; err = {:?}", e);
+                            return;
+                        }
+                    };
+                    let (incoming_read, incoming_write) = incoming_socket.into_split();
+                    let (outgoing_read, outgoing_write) = outgoing_socket.into_split();
+
+                    start_relay_for(outgoing_disruption, incoming_read, outgoing_write);
+                    start_relay_for(incoming_disruption, outgoing_read, incoming_write);
+                });
+            }
+        });
+    }
+
+    PassthroughServerHandle {
+        chosen_addr,
+        destination,
+        close,
+    }
+}
+
+fn start_relay_for(disruption: Disruption, read: OwnedReadHalf, write: OwnedWriteHalf) {
+    match disruption {
+        Disruption::None => {
+            tokio::spawn(async move { relay_stream_limit_bandwidth(read, write, None).await });
+        }
+        Disruption::LimitBandwidth(bytes_per_second) => {
+            tokio::spawn(async move {
+                relay_stream_limit_bandwidth(read, write, Some(bytes_per_second)).await
+            });
+        }
+        Disruption::DropPacketsAfter(drop_packets_after) => {
+            tokio::spawn(async move {
+                relay_stream_drop_packets(read, write, drop_packets_after).await
+            });
+        }
+        Disruption::PacketsOutOfOrderAfter(packet_out_of_order_after) => {
+            tokio::spawn(async move {
+                relay_stream_packets_out_of_order(read, write, packet_out_of_order_after).await
+            });
+        }
+    }
+}
+
+async fn relay_stream_limit_bandwidth(
+    mut read_half: OwnedReadHalf,
+    mut write_half: OwnedWriteHalf,
+    max_bytes_per_second: Option<usize>,
+) {
+    let mut bytes_counter = 0;
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        let read = match read_half.read(&mut buffer).await {
+            // socket closed
+            Ok(0) => return,
+            Ok(n) => n,
+            Err(e) => {
+                error!("Failed to read from socket; err = {:?}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = write_half.write_all(&buffer[0..read]).await {
+            error!("Failed to write to socket; err = {:?}", e);
+            return;
+        }
+
+        bytes_counter += read;
+        if let Some(max_bytes_per_second) = max_bytes_per_second {
+            let nanoseconds =
+                (1_000_000_000f32 * (bytes_counter as f32 / max_bytes_per_second as f32)) as u64;
+            tokio::time::sleep(Duration::from_nanos(nanoseconds)).await;
+            bytes_counter = 0;
+        }
+    }
+}
+
+async fn relay_stream_drop_packets(
+    mut read_half: OwnedReadHalf,
+    mut write_half: OwnedWriteHalf,
+    drop_packets_after: usize,
+) {
+    let mut packet_counter: usize = 0;
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        // read the first 2 bytes with the packet size
+        match read_half.read_exact(&mut buffer[0..2]).await {
+            // socket closed
+            Ok(0) => return,
+            Ok(n) => {
+                if n != 2 {
+                    error!(
+                        "Failed to read from socket; err = {:?}",
+                        "incomplete packet size"
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                error!("Failed to read from socket; err = {:?}", e);
+                return;
+            }
+        };
+
+        let packet_size = (&buffer[0..2]).read_u16().await.unwrap() + 2;
+        match read_half
+            .read_exact(&mut buffer[2..packet_size as usize])
+            .await
+        {
+            // socket closed
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(e) => {
+                error!("Failed to read from socket; err = {:?}", e);
+                return;
+            }
+        }
+
+        if packet_counter <= drop_packets_after || packet_counter % 2 == 0 {
+            if let Err(e) = write_half.write_all(&buffer[0..packet_size as usize]).await {
+                error!("Failed to write to socket; err = {:?}", e);
+                return;
+            }
+        } else {
+            info!("Dropping packet {packet_counter} of size {packet_size}");
+        }
+
+        packet_counter += 1;
+    }
+}
+
+async fn relay_stream_packets_out_of_order(
+    mut read_half: OwnedReadHalf,
+    mut write_half: OwnedWriteHalf,
+    packet_out_of_order_after: usize,
+) {
+    let mut packet_counter: usize = 0;
+    let mut previus_buffer: Option<Vec<u8>> = None;
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        // read the first 2 bytes with the packet size
+        match read_half.read_exact(&mut buffer[0..2]).await {
+            // socket closed
+            Ok(0) => return,
+            Ok(n) => {
+                if n != 2 {
+                    error!(
+                        "Failed to read from socket; err = {:?}",
+                        "incomplete packet size"
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                error!("Failed to read from socket; err = {:?}", e);
+                return;
+            }
+        };
+
+        let packet_size = (&buffer[0..2]).read_u16().await.unwrap() + 2;
+        match read_half
+            .read_exact(&mut buffer[2..packet_size as usize])
+            .await
+        {
+            // socket closed
+            Ok(0) => return,
+            Ok(_) => {}
+            Err(e) => {
+                error!("Failed to read from socket; err = {:?}", e);
+                return;
+            }
+        };
+
+        if packet_counter > packet_out_of_order_after {
+            // write the packet and then the previous one
+            if packet_counter % 2 == 0 {
+                if let Err(e) = write_half.write_all(&buffer[0..packet_size as usize]).await {
+                    error!("Failed to write to socket; err = {:?}", e);
+                    return;
+                }
+
+                if let Some(previous_buffer) = previus_buffer.take() {
+                    if let Err(e) = write_half.write_all(&previous_buffer).await {
+                        error!("Failed to write to socket; err = {:?}", e);
+                        return;
+                    }
+                }
+            } else {
+                info!("Reversing order of packet {packet_counter} of size {packet_size}");
+                previus_buffer = Some(buffer[0..packet_size as usize].to_vec());
+            }
+        } else if let Err(e) = write_half.write_all(&buffer[0..packet_size as usize]).await {
+            error!("Failed to write to socket; err = {:?}", e);
+            return;
+        }
+
+        packet_counter += 1;
+    }
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -229,6 +229,8 @@ teardown() {
 
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
+
+  sleep 20
   run_success curl --head --retry-connrefused --retry 2 --max-time 10 "127.0.0.1:$port"
 }
 
@@ -242,9 +244,9 @@ teardown() {
   run_success "$OCKAM" node create n2 --tcp-listener-address "127.0.0.1:${node_port}"
   run_success "$OCKAM" tcp-outlet create --at /node/n2 --to 127.0.0.1:5000
 
-  sleep 30
+  sleep 15
 
-  run_success curl --fail --head --retry 2 --max-time 10 "127.0.0.1:${inlet_port}"
+  run_success curl --fail --head --retry 4 --max-time 30 "127.0.0.1:${inlet_port}"
 }
 
 @test "portals - local portal, inlet credential expires" {

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/decryptor.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use crate::secure_channel::encryptor_worker::SecureChannelSharedState;
 use ockam_vault::{AeadSecretKeyHandle, VaultForSecureChannels};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 use tracing_attributes::instrument;
 
 pub(crate) struct DecryptorHandler {
@@ -63,9 +63,10 @@ impl DecryptorHandler {
         ctx: &mut Context,
         msg: Routed<Any>,
     ) -> Result<()> {
-        debug!(
+        trace!(
             "SecureChannel {} received Decrypt API {}",
-            self.role, &self.addresses.decryptor_remote
+            self.role,
+            &self.addresses.decryptor_remote
         );
 
         let return_route = msg.return_route();
@@ -168,9 +169,10 @@ impl DecryptorHandler {
         ctx: &mut Context,
         msg: Routed<Any>,
     ) -> Result<()> {
-        debug!(
+        trace!(
             "SecureChannel {} received Decrypt {}",
-            self.role, &self.addresses.decryptor_remote
+            self.role,
+            &self.addresses.decryptor_remote
         );
 
         // Decode raw payload binary

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/key_tracker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/key_tracker.rs
@@ -1,7 +1,6 @@
 use ockam_core::Result;
 use ockam_vault::AeadSecretKeyHandle;
-use tracing::debug;
-use tracing::warn;
+use tracing::{trace, warn};
 
 use crate::IdentityError;
 
@@ -40,9 +39,10 @@ impl KeyTracker {
     ///      - if it the previous nonce but is not set
     ///      - we reached the maximum number of rekeyings
     pub(crate) fn get_key(&self, nonce: u64) -> Result<Option<AeadSecretKeyHandle>> {
-        debug!(
+        trace!(
             "The current number of rekeys is {}, the rekey interval is {}",
-            self.number_of_rekeys, self.renewal_interval
+            self.number_of_rekeys,
+            self.renewal_interval
         );
 
         // for example 2 rekeys happened, renewal every 10 keys

--- a/implementations/rust/ockam/ockam_macros/src/lib.rs
+++ b/implementations/rust/ockam/ockam_macros/src/lib.rs
@@ -125,7 +125,7 @@ pub fn node(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[ockam::test]
-/// async fn main(mut ctx: ockam::Context) -> ockam::Result<()> {
+/// async fn main(ctx: &mut ockam::Context) -> ockam::Result<()> {
 ///     ctx.stop().await
 /// }
 /// ```

--- a/implementations/rust/ockam/ockam_node/src/channel_types.rs
+++ b/implementations/rust/ockam/ockam_node/src/channel_types.rs
@@ -5,7 +5,7 @@ pub type MessageReceiver<T> = crate::tokio::sync::mpsc::Receiver<T>;
 
 /// Create message channel
 pub fn message_channel<T>() -> (MessageSender<T>, MessageReceiver<T>) {
-    crate::tokio::sync::mpsc::channel(16)
+    crate::tokio::sync::mpsc::channel(8)
 }
 
 /// Router sender

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -9,8 +9,7 @@ use crate::{
     NodeMessage,
 };
 use core::future::Future;
-use ockam_core::compat::sync::Arc;
-use ockam_core::{Address, Result};
+use ockam_core::{compat::sync::Arc, Address, Result};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::Metrics;

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -98,9 +98,9 @@ impl NodeBuilder {
         // Shared instance of FlowControls
         let flow_controls = FlowControls::new();
 
-        let rt = self.rt.unwrap_or(Arc::new(
-            Runtime::new().expect("cannot initialize the tokio runtime"),
-        ));
+        let rt = self.rt.unwrap_or_else(|| {
+            Arc::new(Runtime::new().expect("cannot initialize the tokio runtime"))
+        });
         let mut exe = Executor::new(rt.clone(), &flow_controls);
         let addr: Address = "app".into();
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_message.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_message.rs
@@ -1,8 +1,9 @@
 use ockam_core::Message;
-use serde::{Deserialize, Serialize};
+use serde::de::{EnumAccess, VariantAccess};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// A command message type for a Portal
-#[derive(Serialize, Deserialize, Message, Debug)]
+#[derive(Serialize, Message, Debug)]
 pub enum PortalMessage {
     /// First message that Inlet sends to the Outlet
     Ping,
@@ -11,8 +12,87 @@ pub enum PortalMessage {
     /// Message to indicate that connection from Outlet to the target,
     /// or from the target to the Inlet was dropped
     Disconnect,
-    /// Message with binary payload
-    Payload(Vec<u8>),
+    /// Message with binary payload and packet counter
+    Payload(Vec<u8>, #[serde(default)] Option<u16>),
+}
+
+// Manually implement deserialization for PortalMessage
+// to support deserializing older message types
+impl<'de> Deserialize<'de> for PortalMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PayloadVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PayloadVisitor {
+            type Value = (Vec<u8>, Option<u16>);
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a valid Payload")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let payload = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+
+                // If the message is using V1 it won't contain the u8 to mark for counter presence
+                // hence we return None and ignore reading errors.
+                // However, if the field is present we can be confident that the rest of the message
+                // must be present.
+                let counter = if let Some(counter_set) = seq.next_element::<u8>().ok().flatten() {
+                    if counter_set != 0 {
+                        seq.next_element()?
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                Ok((payload, counter))
+            }
+        }
+
+        struct PortalMessageVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PortalMessageVisitor {
+            type Value = PortalMessage;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a valid PortalMessage")
+            }
+
+            fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+            where
+                A: EnumAccess<'de>,
+            {
+                let (variant_index, variant): (u8, _) = data.variant()?;
+                match variant_index {
+                    0 => Ok(PortalMessage::Ping),
+                    1 => Ok(PortalMessage::Pong),
+                    2 => Ok(PortalMessage::Disconnect),
+                    3 => {
+                        // we expect 3 elements: the first is the payload, the second is the u8
+                        // to mark for counter presence, and the third is the counter itself
+                        let (payload, counter): (Vec<u8>, Option<u16>) =
+                            variant.tuple_variant(3, PayloadVisitor)?;
+                        Ok(PortalMessage::Payload(payload, counter))
+                    }
+                    _ => Err(serde::de::Error::invalid_value(
+                        serde::de::Unexpected::Unsigned(variant_index as u64),
+                        &self,
+                    )),
+                }
+            }
+        }
+
+        const VARIANTS: &[&str] = &["Ping", "Pong", "Disconnect", "Payload"];
+        deserializer.deserialize_enum("PortalMessage", VARIANTS, PortalMessageVisitor)
+    }
 }
 
 /// An internal message type for a Portal
@@ -22,5 +102,109 @@ pub enum PortalInternalMessage {
     Disconnect,
 }
 
-///Maximum allowed size for a payload
+/// Maximum allowed size for a payload
 pub const MAX_PAYLOAD_SIZE: usize = 48 * 1024;
+
+#[cfg(test)]
+mod test {
+    use crate::PortalMessage;
+    use ockam_core::Message;
+    use ockam_core::{Decodable, Encodable};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Message, Debug)]
+    pub enum PortalMessageV1 {
+        Ping,
+        Pong,
+        Disconnect,
+        Payload(Vec<u8>),
+    }
+
+    #[test]
+    fn older_message_can_be_decoded() {
+        let payload = "hello".as_bytes().to_vec();
+
+        let encoded = PortalMessageV1::encode(&PortalMessageV1::Ping).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Ping));
+
+        let encoded = PortalMessageV1::encode(&PortalMessageV1::Pong).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Pong));
+
+        let encoded = PortalMessageV1::encode(&PortalMessageV1::Disconnect).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Disconnect));
+
+        let encoded = PortalMessageV1::encode(&PortalMessageV1::Payload(payload.clone())).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        if let PortalMessage::Payload(decoded_payload, _) = decoded {
+            assert_eq!(decoded_payload, payload);
+        } else {
+            panic!("Decoded message is not a Payload");
+        }
+    }
+
+    #[test]
+    fn newer_message_can_be_decoded() {
+        let payload = "hello".as_bytes().to_vec();
+
+        let encoded = PortalMessage::encode(&PortalMessage::Ping).unwrap();
+        let decoded = PortalMessageV1::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessageV1::Ping));
+
+        let encoded = PortalMessage::encode(&PortalMessage::Pong).unwrap();
+        let decoded = PortalMessageV1::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessageV1::Pong));
+
+        let encoded = PortalMessage::encode(&PortalMessage::Disconnect).unwrap();
+        let decoded = PortalMessageV1::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessageV1::Disconnect));
+
+        let encoded =
+            PortalMessage::encode(&PortalMessage::Payload(payload.clone(), Some(123))).unwrap();
+        let decoded = PortalMessageV1::decode(&encoded).unwrap();
+        if let PortalMessageV1::Payload(decoded_payload) = decoded {
+            assert_eq!(decoded_payload, payload);
+        } else {
+            panic!("Decoded message is not a Payload");
+        }
+    }
+
+    #[test]
+    fn newer_message_can_be_encoded() {
+        let payload = "hello".as_bytes().to_vec();
+
+        let encoded = PortalMessage::encode(&PortalMessage::Ping).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Ping));
+
+        let encoded = PortalMessage::encode(&PortalMessage::Pong).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Pong));
+
+        let encoded = PortalMessage::encode(&PortalMessage::Disconnect).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        assert!(matches!(decoded, PortalMessage::Disconnect));
+
+        let encoded =
+            PortalMessage::encode(&PortalMessage::Payload(payload.clone(), None)).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        if let PortalMessage::Payload(decoded_payload, packet_counter) = decoded {
+            assert_eq!(decoded_payload, payload);
+            assert_eq!(packet_counter, None);
+        } else {
+            panic!("Decoded message is not a Payload");
+        }
+
+        let encoded =
+            PortalMessage::encode(&PortalMessage::Payload(payload.clone(), Some(123))).unwrap();
+        let decoded = PortalMessage::decode(&encoded).unwrap();
+        if let PortalMessage::Payload(decoded_payload, packet_counter) = decoded {
+            assert_eq!(decoded_payload, payload);
+            assert_eq!(packet_counter, Some(123));
+        } else {
+            panic!("Decoded message is not a Payload");
+        }
+    }
+}

--- a/tools/nix/parts/tooling.nix
+++ b/tools/nix/parts/tooling.nix
@@ -17,6 +17,7 @@ _: {
         jq
         parallel
         which
+        socat
       ];
 
       BATS_LIB = "${config.packages.bats}/share/bats";


### PR DESCRIPTION
5 integration tests were added:
- Single node inlet->outlet validation test
- Portal goes down, can be re-spawned
- Portal works with low bandwidth (64kb/s)  when saturated
- Portals shutdown when packets are lost
- Portals shutdown when packets are out of order
- Portals can exchange heavy payload (50mb)

2 bats tests were added:
 - Relay can recover from connection loss
 - A portal over a relay can exchange heavy payload (10mb)

An echo server as well as "disruptive pass-through server" (reduce bandwidth, drop packets, changes order) was implemented.

The last 3 tests were not passing and an optional portal packet counter was added to detect when a packet was lost or out of order, current implementation is to shut the portal down.
Sessions timeout was increased from (3\*3=9 seconds) to (3\*10=30 seconds) and the worker channel size was halved from 16 to 8 messages.
