### PR TITLE
fix(rust): command's verbose argument now has preference over env vars

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -30,6 +30,7 @@ impl AppState {
         ];
         let guard = LoggingTracing::setup(
             logging_configuration(
+                None,
                 LevelFilter::TRACE,
                 Colored::Off,
                 Some(node_dir),

--- a/implementations/rust/ockam/ockam_command/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/logs/mod.rs
@@ -19,8 +19,6 @@ pub fn setup_logging_tracing(
     } else {
         Colored::Off
     };
-    let default_log_level = verbose_log_level(verbose);
-
     if background_node {
         LoggingTracing::setup(
             LoggingConfiguration::background(log_path, LoggingConfiguration::default_crates()),
@@ -28,9 +26,14 @@ pub fn setup_logging_tracing(
             "local node",
         )
     } else {
+        let preferred_log_level = match verbose_log_level(verbose) {
+            LevelFilter::OFF => None,
+            level => Some(level),
+        };
         LoggingTracing::setup(
             logging_configuration(
-                default_log_level,
+                preferred_log_level,
+                LevelFilter::OFF,
                 colored,
                 log_path,
                 LoggingConfiguration::default_crates(),


### PR DESCRIPTION
The verbose argument (`-v`) should have preference over logging related env vars. This preference was inverted accidentally recently. This PR restores the expected preference.

```
# This should print INFO logs
OCKAM_LOG=info ockam message send --to /project/default/service/echo hi

# This should print TRACE logs
ock message send --to /project/default/service/echo hi -vvv

# This one too, as the verbose argument has preference over the env var
OCKAM_LOG=info ock message send --to /project/default/service/echo hi -vvv
``` 