### PR TITLE
fix(rust): fixes for okta authenticator

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -12,8 +12,7 @@ use crate::authenticator::{
     AuthorityMembersRepository, AuthorityMembersSqlxDatabase,
 };
 use ockam::identity::{
-    Identifier, Identities, IdentitiesAttributes, SecureChannelListenerOptions, SecureChannels,
-    TrustEveryonePolicy,
+    Identifier, Identities, SecureChannelListenerOptions, SecureChannels, TrustEveryonePolicy,
 };
 use ockam_core::compat::sync::Arc;
 use ockam_core::env::get_env;
@@ -224,7 +223,7 @@ impl Authority {
     ) -> Result<()> {
         if let Some(okta) = &configuration.okta {
             let okta_worker = crate::okta::Server::new(
-                self.identities_attributes(),
+                self.members.clone(),
                 okta.tenant_base_url(),
                 okta.certificate(),
                 okta.attributes().as_slice(),
@@ -255,16 +254,6 @@ impl Authority {
 
 /// Private Authority functions
 impl Authority {
-    /// Return the identities storage used by the authority
-    fn identities(&self) -> Arc<Identities> {
-        self.secure_channels.identities()
-    }
-
-    /// Return the service managing identities attributes used by the Authority
-    fn identities_attributes(&self) -> Arc<IdentitiesAttributes> {
-        self.identities().identities_attributes()
-    }
-
     /// Create a directory to save storage files if they haven't been  created before
     fn create_ockam_directory_if_necessary(path: &Path) -> Result<()> {
         let parent = path.parent().unwrap();

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -111,7 +111,7 @@ impl EnrollCommand {
             let auth0 = OidcService::new(Arc::new(OktaOidcProvider::new(okta_config)));
             let token = auth0.get_token_interactively(&opts).await?;
             authority_node_client
-                .enroll_with_oidc_token(ctx, token)
+                .enroll_with_oidc_token_okta(ctx, token)
                 .await?;
         };
 


### PR DESCRIPTION
* call the correct function from the cmd cli to enroll with okta
* fix the okta worker to store the new enrolled member on the member' table

Note:  the `AuthorityMember` has an `added_by` mandatory field.    There is no enroller here, so not sure what to put there (and didn't want to go to modify the schema to allow None there).  I completed it with the same member identifier, which is probably not what we want (maybe putting the authority' identity itself?).  

