### PR TITLE
Fix code snippets coloring macOS and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,6 +4365,7 @@ dependencies = [
  "opentelemetry-otlp",
  "pem-rfc7468",
  "proptest",
+ "r3bl_ansi_color",
  "r3bl_rs_utils_core",
  "r3bl_tui",
  "r3bl_tuify",
@@ -4383,6 +4384,7 @@ dependencies = [
  "strip-ansi-escapes",
  "syntect",
  "tempfile",
+ "termbg",
  "thiserror",
  "time",
  "tiny_http",
@@ -6982,6 +6984,19 @@ dependencies = [
  "fastrand 2.0.1",
  "rustix 0.38.31",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termbg"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c12e6e0bf9bc6ac887681aeddabfcc5dbdea20d3f43d6d18f237c34fe942dde"
+dependencies = [
+ "async-std",
+ "crossterm",
+ "is-terminal",
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -40,7 +40,7 @@ dockerfile = "../../../../tools/cross/Cross.Dockerfile.armv7"
 # `../ockam`) and the `ockam` binary (in `./src/bin/ockam.rs`). I won't
 # enumerate them here, but an example: `rustdoc` will try to place the docs for
 # both of these in the same path, without realizing it, which may result in one
-# overwriting the other)
+# overwriting the other
 #
 # Anyway a result, we disable them for the binary crate, which is just a single
 # file (`src/bin/ockam.rs`) which contains a single function call into
@@ -86,6 +86,7 @@ open = "5.1.0"
 opentelemetry = { version = "0.21.0", features = ["metrics", "trace"] }
 opentelemetry-otlp = { version = "0.14.0", features = ["metrics", "tls", "logs", "trace"], default-features = false }
 pem-rfc7468 = { version = "0.7.0", features = ["std"] }
+r3bl_ansi_color = "0.6.9"
 r3bl_rs_utils_core = "0.9.12"
 r3bl_tui = "0.5.2"
 r3bl_tuify = "0.1.25"
@@ -103,6 +104,7 @@ serde_yaml = "0.9"
 shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 strip-ansi-escapes = "0.2.0"
 syntect = { version = "5.2.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
+termbg = "0"
 thiserror = "1"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
 tiny_http = "0.12.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Coloring of code snippets for macOS and Linux was not working

## Proposed changes

I have added a default background of dark when the background of the terminal cannot be determined. Furthermore, a syntect to ansi function has been added for better code coloring in /ockam_command/docs.rs

## Checks

- [x] All commits in this Pull Request are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and Verified by Github.
- [x ] All commits in this Pull Request follow the Ockam [commit message convention](https://github.com/build-trust/.github/blob/main/CONTRIBUTING.md#commit-messages).
- [ x] There are no Merge commits in this Pull Request. Ockam repo maintains a linear commit history. We merge Pull Requests by rebasing them onto the develop branch. Rebasing to the latest develop branch and force pushing to your Pull Request branch is okay.
- [ x] I have read and accept the Ockam Community [Code of Conduct](https://github.com/build-trust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x ] I have read and accepted the Ockam [Contributor License Agreement](https://github.com/build-trust/.github/blob/main/CLA.md) by adding my Git/Github details in a row at the end of the [CONTRIBUTORS.csv](https://github.com/build-trust/ockam/blob/develop/.github/CONTRIBUTORS.csv) file in a separate pull request to the [build-trust/ockam](https://github.com/build-trust/ockam) repository. The easiest way to do this is to [edit the CONTRIBUTORS.csv](https://github.com/build-trust/ockam/edit/develop/.github/CONTRIBUTORS.csv) file in the github web UI and create a separate Pull Request, this will mark the commit as verified.

