### PR TITLE
feat(rust): `run` support defining resources without names so they are assigned a random name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,6 +4382,7 @@ dependencies = [
  "serde_bare",
  "serde_json",
  "serde_yaml",
+ "shellexpand",
  "strip-ansi-escapes",
  "syntect",
  "tempfile",
@@ -6242,6 +6243,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
 
 [[package]]
 name = "shellwords"

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -99,6 +99,7 @@ serde = { version = "1", features = ["derive"] }
 serde_bare = { version = "0.5.0", default-features = false, features = ["alloc"] }
 serde_json = "1"
 serde_yaml = "0.9"
+shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 strip-ansi-escapes = "0.2.0"
 syntect = "5"
 thiserror = "1"

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -15,11 +15,11 @@ use std::path::PathBuf;
 #[command(hide = docs::hide())]
 pub struct RunCommand {
     /// Path to the recipe file
-    #[arg(long, conflicts_with = "inline")]
+    #[arg(conflicts_with = "inline", value_name = "PATH")]
     pub recipe: Option<PathBuf>,
 
     /// Inlined recipe contents
-    #[arg(long, conflicts_with = "recipe")]
+    #[arg(long, conflicts_with = "recipe", value_name = "CONTENTS")]
     pub inline: Option<String>,
 
     /// If true, block until all the created node exits it also
@@ -41,8 +41,8 @@ impl RunCommand {
     }
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let config = match &self.inline {
-            Some(config) => config.to_string(),
+        let contents = match &self.inline {
+            Some(contents) => contents.to_string(),
             None => {
                 let path = match &self.recipe {
                     Some(path) => path.clone(),
@@ -72,6 +72,6 @@ impl RunCommand {
                 std::fs::read_to_string(path).into_diagnostic()?
             }
         };
-        ConfigRunner::run_config(ctx, opts, &config).await
+        ConfigRunner::run_config(ctx, opts, &contents).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
@@ -112,7 +112,7 @@ mod tests {
             identities: Identities {
                 identities: Some(ResourcesContainer::List(vec![
                     ResourceNameOrMap::Name("i1".to_string()),
-                    ResourceNameOrMap::Map(NamedResources {
+                    ResourceNameOrMap::NamedMap(NamedResources {
                         items: vec![(
                             "i2".to_string(),
                             Args {
@@ -162,7 +162,7 @@ mod tests {
                 ])),
             },
             tcp_outlets: TcpOutlets {
-                tcp_outlets: Some(ResourceNameOrMap::Map(NamedResources {
+                tcp_outlets: Some(ResourceNameOrMap::NamedMap(NamedResources {
                     items: vec![
                         (
                             "to1".to_string(),
@@ -189,7 +189,7 @@ mod tests {
                 })),
             },
             tcp_inlets: TcpInlets {
-                tcp_inlets: Some(ResourceNameOrMap::Map(NamedResources {
+                tcp_inlets: Some(ResourceNameOrMap::NamedMap(NamedResources {
                     items: vec![
                         (
                             "ti1".to_string(),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/tcp_inlets.rs
@@ -35,15 +35,15 @@ mod tests {
 
     #[test]
     fn tcp_inlet_config() {
-        let config = r#"
+        let named = r#"
             tcp_inlets:
               ti1:
-                from: '6060'
+                from: 6060
                 at: n
               ti2:
                 from: '6061'
         "#;
-        let parsed: TcpInlets = serde_yaml::from_str(config).unwrap();
+        let parsed: TcpInlets = serde_yaml::from_str(named).unwrap();
         let cmds = parsed.into_commands().unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].alias.as_ref().unwrap(), "ti1");
@@ -53,6 +53,26 @@ mod tests {
         );
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
         assert_eq!(cmds[1].alias.as_ref().unwrap(), "ti2");
+        assert_eq!(
+            cmds[1].from,
+            SocketAddr::from_str("127.0.0.1:6061").unwrap()
+        );
+        assert!(cmds[1].at.is_none());
+
+        let unnamed = r#"
+            tcp_inlets:
+              - from: 6060
+                at: n
+              - from: '6061'
+        "#;
+        let parsed: TcpInlets = serde_yaml::from_str(unnamed).unwrap();
+        let cmds = parsed.into_commands().unwrap();
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(
+            cmds[0].from,
+            SocketAddr::from_str("127.0.0.1:6060").unwrap()
+        );
+        assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
         assert_eq!(
             cmds[1].from,
             SocketAddr::from_str("127.0.0.1:6061").unwrap()


### PR DESCRIPTION
- Resources like tcp inlets can now be also defined without names, and a random name will be assigned. Check out [this test](https://github.com/build-trust/ockam/blob/c995923c78f95d0f945ea7e6febc7737653b220a/implementations/rust/ockam/ockam_command/src/run/parser/tcp_inlets.rs#L37) for an example
- Env vars are now resolved as part of a string, e.g. `'(= subject.from-$VAR1 "$VAR2")'` is now supported