### PR TITLE
feat(rust): add more tracing data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4469,6 +4469,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "tracing-attributes",
  "zeroize",
 ]
 

--- a/implementations/rust/ockam/ockam_abac/src/env.rs
+++ b/implementations/rust/ockam/ockam_abac/src/env.rs
@@ -1,10 +1,25 @@
 use crate::error::{EvalError, MergeError};
 use crate::expr::Expr;
+use core::fmt::{Display, Formatter};
 use ockam_core::compat::collections::BTreeMap;
+use ockam_core::compat::format;
 use ockam_core::compat::string::{String, ToString};
+use ockam_core::compat::vec::vec;
 
 #[derive(Debug, Clone, Default)]
 pub struct Env(BTreeMap<String, Expr>);
+
+impl Display for Env {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut values = vec![];
+        for (key, value) in self.0.clone() {
+            values.push(format!("{key}={value:?}"));
+        }
+        f.debug_struct("Env")
+            .field("values", &values.join(","))
+            .finish()
+    }
+}
 
 impl Env {
     pub fn new() -> Self {

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -40,6 +40,7 @@ futures = { version = "0.3.30", features = [] }
 gethostname = "0.4.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 home = "0.5"
+itertools = "0.12.1"
 kafka-protocol = "0.8.2"
 miette = "7.0.0"
 minicbor = { version = "0.20.0", features = ["alloc", "derive"] }

--- a/implementations/rust/ockam/ockam_api/build.rs
+++ b/implementations/rust/ockam/ockam_api/build.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+
+fn hash() {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}
+
+fn main() {
+    hash();
+}

--- a/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer.rs
@@ -27,6 +27,7 @@ pub struct CredentialIssuer {
 
 impl CredentialIssuer {
     /// Create a new credentials issuer
+    #[instrument(skip_all, fields(issuer = %issuer, project_identifier = project_identifier.clone(), credential_ttl = credential_ttl.map_or("n/a".to_string(), |d| d.as_secs().to_string())))]
     pub fn new(
         members: Arc<dyn AuthorityMembersRepository>,
         credentials: Arc<Credentials>,
@@ -55,6 +56,7 @@ impl CredentialIssuer {
         }
     }
 
+    #[instrument(skip_all, fields(subject = %subject))]
     pub async fn issue_credential(
         &self,
         subject: &Identifier,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -27,7 +27,7 @@ impl EnrollmentTokenAcceptor {
         Self { tokens, members }
     }
 
-    #[instrument(skip_all, fields(otc = otc.to_string(), from = %from))]
+    #[instrument(skip_all, fields(from = %from))]
     pub async fn accept_token(
         &mut self,
         otc: OneTimeCode,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -27,6 +27,7 @@ impl EnrollmentTokenAcceptor {
         Self { tokens, members }
     }
 
+    #[instrument(skip_all, fields(otc = otc.to_string(), from = %from))]
     pub async fn accept_token(
         &mut self,
         otc: OneTimeCode,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_client.rs
@@ -15,6 +15,7 @@ pub trait TokenAcceptor {
 
 #[async_trait]
 impl TokenAcceptor for AuthorityNodeClient {
+    #[instrument(skip_all, fields(token = token.to_string()))]
     async fn present_token(&self, ctx: &Context, token: OneTimeCode) -> miette::Result<()> {
         let req = Request::post("/").body(token);
         self.get_secure_client()

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_client.rs
@@ -15,7 +15,7 @@ pub trait TokenAcceptor {
 
 #[async_trait]
 impl TokenAcceptor for AuthorityNodeClient {
-    #[instrument(skip_all, fields(token = token.to_string()))]
+    #[instrument(skip_all)]
     async fn present_token(&self, ctx: &Context, token: OneTimeCode) -> miette::Result<()> {
         let req = Request::post("/").body(token);
         self.get_secure_client()

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -32,6 +32,7 @@ impl EnrollmentTokenIssuer {
         Self { tokens, members }
     }
 
+    #[instrument(skip_all, fields(enroller = %enroller, token_duration = token_duration.map_or("n/a".to_string(), |d| d.as_secs().to_string()), ttl_count = ttl_count.map_or("n/a".to_string(), |t| t.to_string())))]
     pub async fn issue_token(
         &self,
         enroller: &Identifier,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/one_time_code.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/one_time_code.rs
@@ -1,3 +1,4 @@
+use crate::cloud::enroll::auth0::OidcToken;
 use core::str::FromStr;
 use minicbor::bytes::ByteArray;
 use minicbor::{Decode, Encode};
@@ -9,6 +10,7 @@ use ockam_core::Error;
 use ockam_core::Result;
 use ockam_node::database::{SqlxType, ToSqlxType};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 /// A one-time code can be used to enroll
 /// a node with some authenticated attributes
@@ -18,6 +20,12 @@ use serde::{Deserialize, Serialize};
 #[cbor(map)]
 pub struct OneTimeCode {
     #[n(1)] code: ByteArray<32>,
+}
+
+impl Display for OidcToken {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.access_token.0)
+    }
 }
 
 impl OneTimeCode {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -25,6 +25,7 @@ use crate::cli_state::{random_name, CliState, Result};
 impl CliState {
     /// Create an identity associated with a name and a specific vault name
     /// If there is already an identity with that name, return its identifier
+    #[instrument(skip_all, fields(name = %name, vault_name = %vault_name))]
     pub async fn create_identity_with_name_and_vault(
         &self,
         name: &str,
@@ -44,6 +45,7 @@ impl CliState {
 
     /// Create an identity associated with a name, using the default vault
     /// If there is already an identity with that name, return its identifier
+    #[instrument(skip_all, fields(name = %name))]
     pub async fn create_identity_with_name(&self, name: &str) -> Result<NamedIdentity> {
         let vault = self.get_or_create_default_named_vault().await?;
         self.create_identity_with_name_and_vault(name, &vault.name())
@@ -53,6 +55,7 @@ impl CliState {
     /// Create an identity with specific key id.
     /// This method is used when the vault is a KMS vault and we just need to store a key id
     /// for the identity key existing in the KMS
+    #[instrument(skip_all, fields(name = %name, vault_name = %vault_name, key_id = %key_id))]
     pub async fn create_identity_with_key_id(
         &self,
         name: &str,
@@ -101,11 +104,13 @@ impl CliState {
 ///
 impl CliState {
     /// Return all named identities
+    #[instrument(skip_all)]
     pub async fn get_named_identities(&self) -> Result<Vec<NamedIdentity>> {
         Ok(self.identities_repository().get_named_identities().await?)
     }
 
     /// Return a named identity given its name
+    #[instrument(skip_all, fields(name = %name))]
     pub async fn get_named_identity(&self, name: &str) -> Result<NamedIdentity> {
         let repository = self.identities_repository();
         match repository.get_named_identity(name).await? {
@@ -119,6 +124,7 @@ impl CliState {
     }
 
     /// Return a named identity given its name or the default named identity
+    #[instrument(skip_all, fields(name = name.clone()))]
     pub async fn get_named_identity_or_default(
         &self,
         name: &Option<String>,
@@ -136,6 +142,7 @@ impl CliState {
 
     /// Return the identifier for identity given an optional name.
     /// If that name is None, then we return the identifier of the default identity
+    #[instrument(skip_all, fields(name = name.clone()))]
     pub async fn get_identifier_by_optional_name(
         &self,
         name: &Option<String>,
@@ -154,6 +161,7 @@ impl CliState {
 
     /// Return a full identity from its name
     /// Use the default identity if no name is given
+    #[instrument(skip_all, fields(name = name.clone()))]
     pub async fn get_identity_by_optional_name(&self, name: &Option<String>) -> Result<Identity> {
         let named_identity = match name {
             Some(name) => {
@@ -188,6 +196,7 @@ impl CliState {
     }
 
     /// Return the identity with the given identifier
+    #[instrument(skip_all, fields(identifier = %identifier))]
     pub async fn get_identity(&self, identifier: &Identifier) -> Result<Identity> {
         match self
             .change_history_repository()
@@ -207,12 +216,14 @@ impl CliState {
 
     /// Return the name of the default identity.
     /// This function creates the default identity if it does not exist!
+    #[instrument(skip_all)]
     pub async fn get_default_identity_name(&self) -> Result<String> {
         Ok(self.get_or_create_default_named_identity().await?.name())
     }
 
     /// Return the default named identity
     /// This function creates the default identity if it does not exist!
+    #[instrument(skip_all)]
     pub async fn get_or_create_default_named_identity(&self) -> Result<NamedIdentity> {
         match self
             .identities_repository()
@@ -227,6 +238,7 @@ impl CliState {
     /// Return:
     /// - the given name if defined
     /// - or the name of the default identity (which is created if it does not already exist!)
+    #[instrument(skip_all, fields(name = name.clone()))]
     pub async fn get_identity_name_or_default(&self, name: &Option<String>) -> Result<String> {
         match name {
             Some(name) => Ok(name.clone()),
@@ -235,6 +247,7 @@ impl CliState {
     }
 
     /// Return the named identity with the given identifier
+    #[instrument(skip_all, fields(identifier = %identifier))]
     pub async fn get_named_identity_by_identifier(
         &self,
         identifier: &Identifier,
@@ -254,6 +267,7 @@ impl CliState {
     }
 
     /// Return true if there is an identity with that name and it is the default one
+    #[instrument(skip_all, fields(name = %name))]
     pub async fn is_default_identity_by_name(&self, name: &str) -> Result<bool> {
         Ok(self
             .identities_repository()
@@ -268,6 +282,7 @@ impl CliState {
 impl CliState {
     /// Set a named identity as the default
     /// Return an error if that identity does not exist
+    #[instrument(skip_all, fields(name = %name))]
     pub async fn set_as_default_identity(&self, name: &str) -> Result<()> {
         Ok(self.identities_repository().set_as_default(name).await?)
     }
@@ -278,6 +293,7 @@ impl CliState {
     ///  - then remove the the name association to the identity
     ///  - and remove the identity change history
     ///
+    #[instrument(skip_all, fields(name = %name))]
     pub async fn delete_identity_by_name(&self, name: &str) -> Result<()> {
         let nodes = self.get_nodes_by_identity_name(name).await?;
         if nodes.is_empty() {
@@ -305,6 +321,7 @@ impl CliState {
 impl CliState {
     /// Once a identity has been created, store it.
     /// If there is no previous default identity we set it as the default identity
+    #[instrument(skip_all, fields(name = %name, identifier = %identifier, vault_name = %vault_name))]
     async fn store_named_identity(
         &self,
         identifier: &Identifier,
@@ -328,6 +345,7 @@ impl CliState {
     }
 
     /// Return the change history of a persisted identity
+    #[instrument(skip_all, fields(identifier = %identifier))]
     async fn get_change_history(&self, identifier: &Identifier) -> Result<ChangeHistory> {
         match self
             .change_history_repository()

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
@@ -1,0 +1,92 @@
+use crate::journeys::{
+    APPLICATION_EVENT_OCKAM_GIT_HASH, APPLICATION_EVENT_OCKAM_HOME, APPLICATION_EVENT_OCKAM_VERSION,
+};
+use crate::Version;
+use gethostname::gethostname;
+use opentelemetry::trace::TraceId;
+use opentelemetry::Key;
+use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
+use std::collections::HashMap;
+use std::process::Command;
+
+/// This function returns the default attributes to set on each user event: OCKAM_HOME, `ockam` version and git hash
+pub fn default_attributes<'a>() -> HashMap<&'a Key, String> {
+    let mut attributes = HashMap::new();
+    let ockam_home = std::env::var("OCKAM_HOME").unwrap_or("OCKAM_HOME not set".to_string());
+    attributes.insert(APPLICATION_EVENT_OCKAM_HOME, ockam_home);
+    attributes.insert(
+        APPLICATION_EVENT_OCKAM_VERSION,
+        Version::crate_version().to_string(),
+    );
+    attributes.insert(
+        APPLICATION_EVENT_OCKAM_GIT_HASH,
+        Version::git_hash().to_string(),
+    );
+    attributes
+}
+
+/// Return a host id built from the MAC address and the IP address of the machine
+/// If they can be retrieved from the command line. Otherwise return a random trace id
+pub(crate) fn make_host_trace_id() -> TraceId {
+    let machine = match (get_mac_address(), get_ip_address()) {
+        (Some(mac_address), Some(ip_address)) => format!(
+            "{}{}",
+            mac_address.replace(':', ""),
+            ip_address.replace('.', "")
+        ),
+        _ => gethostname().to_string_lossy().to_string(),
+    };
+
+    // take exactly 16 bytes from the machine name
+    let mut machine = machine.as_bytes().to_vec();
+    // make sure that there are at least 16 bytes
+    if machine.len() < 16 {
+        machine.extend(std::iter::repeat(1).take(16 - machine.len()));
+    };
+    if let Ok(truncated) = machine[0..16].try_into() {
+        TraceId::from_bytes(truncated)
+    } else {
+        let random_id_generator = RandomIdGenerator::default();
+        random_id_generator.new_trace_id()
+    }
+}
+
+/// Return the MAC address for the current machine
+pub(crate) fn get_mac_address() -> Option<String> {
+    let output = Command::new("ifconfig").output().ok()?;
+    let output_str = String::from_utf8_lossy(&output.stdout);
+
+    let mut result = None;
+    for line in output_str.lines() {
+        // Check if the line contains "ether" which is typically followed by MAC address in ifconfig output
+        if line.contains("ether") {
+            // Extract MAC address substring
+            let split = line.split(' ').collect::<Vec<_>>();
+            let mac_address = split.get(1)?;
+            result = Some(mac_address.to_string());
+            break;
+        }
+    }
+    result
+}
+
+/// Return the IP address for the current machine
+pub(crate) fn get_ip_address() -> Option<String> {
+    let output = Command::new("ifconfig").output().ok()?;
+    let output_str = String::from_utf8_lossy(&output.stdout);
+
+    let mut result = None;
+    for line in output_str.lines() {
+        // Check if the line contains "inet" which is typically followed by IP address in ifconfig output
+        //  - skip the localhost interface
+        //  - note the space after inet to catch the IPv4 address and not v6
+        if line.contains("inet ") && !line.contains("127.0.0.1") {
+            // Extract IP address substring
+            let split = line.split(' ').collect::<Vec<_>>();
+            let ip_address = split.get(1)?;
+            result = Some(ip_address.to_string());
+            break;
+        }
+    }
+    result
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
@@ -8,6 +8,13 @@ pub const TCP_OUTLET_FROM: &Key = &Key::from_static_str("app.tcp_outlet.from");
 pub const TCP_OUTLET_TO: &Key = &Key::from_static_str("app.tcp_outlet.to");
 pub const TCP_OUTLET_ALIAS: &Key = &Key::from_static_str("app.tcp_outlet.alias");
 
+pub const TCP_INLET_AT: &Key = &Key::from_static_str("app.tcp_inlet.at");
+pub const TCP_INLET_FROM: &Key = &Key::from_static_str("app.tcp_inlet.from");
+pub const TCP_INLET_TO: &Key = &Key::from_static_str("app.tcp_inlet.to");
+pub const TCP_INLET_ALIAS: &Key = &Key::from_static_str("app.tcp_inlet.alias");
+pub const TCP_INLET_CONNECTION_STATUS: &Key =
+    &Key::from_static_str("app.tcp_inlet.connection_status");
+
 /// List of all the journey events that we want to track
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum JourneyEvent {
@@ -17,23 +24,40 @@ pub enum JourneyEvent {
     TcpOutletCreated,
     RelayCreated,
     PortalCreated,
+    Ok {
+        command_name: String,
+    },
     Error {
         command_name: String,
         message: String,
     },
 }
 
+impl JourneyEvent {
+    pub fn ok(command_name: String) -> JourneyEvent {
+        JourneyEvent::Ok { command_name }
+    }
+
+    pub fn error(command_name: String, message: String) -> JourneyEvent {
+        JourneyEvent::Error {
+            command_name,
+            message,
+        }
+    }
+}
+
 impl Display for JourneyEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            JourneyEvent::Enrolled => f.write_str("enrolled"),
-            JourneyEvent::NodeCreated => f.write_str("node created"),
-            JourneyEvent::TcpInletCreated => f.write_str("tcp inlet created"),
-            JourneyEvent::TcpOutletCreated => f.write_str("tcp outlet created"),
-            JourneyEvent::RelayCreated => f.write_str("relay created"),
-            JourneyEvent::PortalCreated => f.write_str("portal created"),
+            JourneyEvent::Enrolled => f.write_str("✅ enrolled"),
+            JourneyEvent::NodeCreated => f.write_str("✅ node created"),
+            JourneyEvent::TcpInletCreated => f.write_str("✅ tcp inlet created"),
+            JourneyEvent::TcpOutletCreated => f.write_str("✅ tcp outlet created"),
+            JourneyEvent::RelayCreated => f.write_str("✅ relay created"),
+            JourneyEvent::PortalCreated => f.write_str("✅ portal created"),
+            JourneyEvent::Ok { command_name } => f.write_str(command_name),
             JourneyEvent::Error { command_name, .. } => {
-                f.write_fmt(format_args!("{} error", command_name))
+                f.write_fmt(format_args!("❌ {} error", command_name))
             }
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/mod.rs
@@ -1,6 +1,7 @@
+pub mod attributes;
 mod journey_event;
 #[allow(clippy::module_inception)]
-mod journeys;
+pub mod journeys;
 
 pub use journey_event::*;
 pub use journeys::*;

--- a/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
@@ -4,6 +4,7 @@ use ockam::identity::Identifier;
 use ockam_abac::{Action, Env, Policy, PolicyAccessControl, Resource};
 
 impl CliState {
+    #[instrument(skip_all, fields(resource = %resource, action = %action))]
     pub async fn get_policy(&self, resource: &Resource, action: &Action) -> Result<Option<Policy>> {
         Ok(self
             .policies_repository()
@@ -11,6 +12,7 @@ impl CliState {
             .await?)
     }
 
+    #[instrument(skip_all, fields(resource = %resource, action = %action, policy = %policy))]
     pub async fn set_policy(
         &self,
         resource: &Resource,
@@ -23,6 +25,7 @@ impl CliState {
             .await?)
     }
 
+    #[instrument(skip_all, fields(resource = %resource, action = %action))]
     pub async fn delete_policy(&self, resource: &Resource, action: &Action) -> Result<()> {
         Ok(self
             .policies_repository()
@@ -30,6 +33,7 @@ impl CliState {
             .await?)
     }
 
+    #[instrument(skip_all, fields(resource = %resource))]
     pub async fn get_policies_by_resource(
         &self,
         resource: &Resource,
@@ -40,6 +44,7 @@ impl CliState {
             .await?)
     }
 
+    #[instrument(skip_all, fields(resource = %resource, action = %action, env = %env, authority = %authority))]
     pub async fn make_policy_access_control(
         &self,
         resource: &Resource,

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -9,6 +9,7 @@ use crate::cloud::project::Project;
 use super::Result;
 
 impl CliState {
+    #[instrument(skip_all, fields(project_id = project.id))]
     pub async fn store_project(&self, project: Project) -> Result<()> {
         let repository = self.projects_repository();
         repository.store_project(&project).await?;
@@ -21,6 +22,7 @@ impl CliState {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     pub async fn delete_project(&self, project_id: &str) -> Result<()> {
         let repository = self.projects_repository();
         // delete the project
@@ -37,6 +39,7 @@ impl CliState {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     pub async fn set_default_project(&self, project_id: &str) -> Result<()> {
         self.projects_repository()
             .set_default_project(project_id)
@@ -44,6 +47,7 @@ impl CliState {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     pub async fn get_default_project(&self) -> Result<Project> {
         match self.projects_repository().get_default_project().await? {
             Some(project) => Ok(project),
@@ -55,6 +59,7 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all, fields(name = name))]
     pub async fn get_project_by_name(&self, name: &str) -> Result<Project> {
         match self.projects_repository().get_project_by_name(name).await? {
             Some(project) => Ok(project),
@@ -66,6 +71,7 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     pub async fn get_project(&self, project_id: &str) -> Result<Project> {
         match self.projects_repository().get_project(project_id).await? {
             Some(project) => Ok(project),
@@ -77,6 +83,7 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all, fields(project_name = project_name.clone()))]
     pub async fn get_project_by_name_or_default(
         &self,
         project_name: &Option<String>,
@@ -87,10 +94,12 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all)]
     pub async fn get_projects(&self) -> Result<Vec<Project>> {
         Ok(self.projects_repository().get_projects().await?)
     }
 
+    #[instrument(skip_all)]
     pub async fn get_projects_grouped_by_name(&self) -> Result<HashMap<String, Project>> {
         let mut projects = HashMap::new();
         for project in self.get_projects().await? {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
@@ -7,6 +7,7 @@ use crate::cloud::space::Space;
 use super::Result;
 
 impl CliState {
+    #[instrument(skip_all, fields(space_id = space_id, space_name = space_name))]
     pub async fn store_space(
         &self,
         space_id: &str,
@@ -31,6 +32,7 @@ impl CliState {
         Ok(space)
     }
 
+    #[instrument(skip_all)]
     pub async fn get_default_space(&self) -> Result<Space> {
         match self.spaces_repository().get_default_space().await? {
             Some(space) => Ok(space),
@@ -42,6 +44,7 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all, fields(name = name))]
     pub async fn get_space_by_name(&self, name: &str) -> Result<Space> {
         match self.spaces_repository().get_space_by_name(name).await? {
             Some(space) => Ok(space),
@@ -53,10 +56,12 @@ impl CliState {
         }
     }
 
+    #[instrument(skip_all)]
     pub async fn get_spaces(&self) -> Result<Vec<Space>> {
         Ok(self.spaces_repository().get_spaces().await?)
     }
 
+    #[instrument(skip_all, fields(space_id = space_id))]
     pub async fn delete_space(&self, space_id: &str) -> Result<()> {
         let repository = self.spaces_repository();
         // delete the space
@@ -75,6 +80,7 @@ impl CliState {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(space_id = space_id))]
     pub async fn set_space_as_default(&self, space_id: &str) -> Result<()> {
         Ok(self.spaces_repository().set_default_space(space_id).await?)
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/trust.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/trust.rs
@@ -11,6 +11,7 @@ impl CliState {
     ///  1. Either we explicitly know the Authority identity that we trust, and optionally route to its node to request
     ///     a new credential
     ///  2. Or we know the project name (or have default one) that contains identity and route to the Authority node
+    #[instrument(skip_all, fields(project_name = project_name.clone(), authority_identity = authority_identity.clone(), authority_route = authority_route.clone().map_or("n/a".to_string(), |r| r.to_string())))]
     pub async fn retrieve_trust_options(
         &self,
         project_name: &Option<String>,

--- a/implementations/rust/ockam/ockam_api/src/cli_state/users.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/users.rs
@@ -7,6 +7,7 @@ use crate::cloud::email_address::EmailAddress;
 use crate::cloud::enroll::auth0::UserInfo;
 
 impl CliState {
+    #[instrument(skip_all, fields(user = %user))]
     pub async fn store_user(&self, user: &UserInfo) -> Result<()> {
         let repository = self.users_repository();
         let is_first_user = repository.get_users().await?.is_empty();
@@ -19,11 +20,13 @@ impl CliState {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(email = %email))]
     pub async fn set_default_user(&self, email: &EmailAddress) -> Result<()> {
         self.users_repository().set_default_user(email).await?;
         Ok(())
     }
 
+    #[instrument(skip_all)]
     pub async fn get_default_user(&self) -> Result<UserInfo> {
         let repository = self.users_repository();
         match repository.get_default_user().await? {

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -100,6 +100,7 @@ pub trait Addons {
 
 #[async_trait]
 impl Addons for ControllerClient {
+    #[instrument(skip_all, fields(project_id = project_id))]
     async fn list_addons(&self, ctx: &Context, project_id: &str) -> miette::Result<Vec<Addon>> {
         trace!(target: TARGET, project_id, "listing addons");
         let req = Request::get(format!("/v0/{project_id}/addons"));
@@ -111,6 +112,7 @@ impl Addons for ControllerClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     async fn configure_confluent_addon(
         &self,
         ctx: &Context,
@@ -130,6 +132,7 @@ impl Addons for ControllerClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     async fn configure_okta_addon(
         &self,
         ctx: &Context,
@@ -147,6 +150,7 @@ impl Addons for ControllerClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(project_id = project_id))]
     async fn configure_influxdb_addon(
         &self,
         ctx: &Context,
@@ -167,6 +171,7 @@ impl Addons for ControllerClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(project_id = project_id, addon_id = addon_id))]
     async fn disable_addon(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -60,7 +60,7 @@ impl Enroll for ControllerClient {
             .into_diagnostic()
     }
 
-    #[instrument(skip_all, fields(enrollment_token = %enrollment_token))]
+    #[instrument(skip_all)]
     async fn authenticate_enrollment_token(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/operation.rs
@@ -69,6 +69,7 @@ const API_SERVICE: &str = "projects";
 
 #[async_trait]
 impl Operations for ControllerClient {
+    #[instrument(skip_all, fields(operation_id = operation_id))]
     async fn get_operation(
         &self,
         ctx: &Context,
@@ -84,6 +85,7 @@ impl Operations for ControllerClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(operation_id = operation_id))]
     async fn wait_until_operation_is_complete(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project.rs
@@ -1,4 +1,5 @@
 use miette::{miette, IntoDiagnostic};
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use minicbor::{Decode, Encode};
@@ -87,6 +88,17 @@ pub struct ProjectUserRole {
     #[n(2)] pub id: u64,
     #[n(3)] pub role: RoleInShare,
     #[n(4)] pub scope: ShareScope,
+}
+
+impl Display for ProjectUserRole {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProjectUserRole")
+            .field("email", &self.email)
+            .field("id", &self.id)
+            .field("role", &self.role)
+            .field("scope", &self.scope)
+            .finish()
+    }
 }
 
 impl Project {
@@ -505,6 +517,7 @@ impl ControllerClient {
 
 #[async_trait]
 impl Operations for InMemoryNode {
+    #[instrument(skip_all, fields(operation_id = operation_id))]
     async fn get_operation(
         &self,
         ctx: &Context,
@@ -516,6 +529,7 @@ impl Operations for InMemoryNode {
             .await
     }
 
+    #[instrument(skip_all, fields(operation_id = operation_id))]
     async fn wait_until_operation_is_complete(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -35,7 +36,17 @@ pub enum CredentialsEnabled {
     Off,
 }
 
+impl Display for CredentialsEnabled {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CredentialsEnabled::On => f.write_str("on"),
+            CredentialsEnabled::Off => f.write_str("off"),
+        }
+    }
+}
+
 impl NodeManager {
+    #[instrument(skip_all)]
     pub(crate) async fn create_controller_client(
         &self,
         timeout: Option<Duration>,
@@ -49,6 +60,7 @@ impl NodeManager {
         .await
     }
 
+    #[instrument(skip_all, fields(authority_identifier = %authority_identifier.clone(), authority_route = %authority_route.clone(), caller = %caller_identifier.clone()))]
     pub(crate) async fn make_authority_node_client(
         &self,
         authority_identifier: &Identifier,
@@ -65,6 +77,7 @@ impl NodeManager {
         .await
     }
 
+    #[instrument(skip_all, fields(project_identifier = %project_identifier.clone(), project_multiaddr = %project_multiaddr.clone(), caller = %caller_identifier.clone(), credentials_enabled = %credentials_enabled))]
     pub(crate) async fn make_project_node_client(
         &self,
         project_identifier: &Identifier,
@@ -88,6 +101,7 @@ impl NodeManager {
         .await
     }
 
+    #[instrument(skip_all, fields(identifier = %identifier.clone(), multiaddr = %multiaddr.clone(), caller = %caller_identifier.clone()))]
     pub async fn make_secure_client(
         &self,
         identifier: &Identifier,
@@ -104,6 +118,7 @@ impl NodeManager {
         .await
     }
 
+    #[instrument(skip_all, fields(caller = %caller_identifier.clone()))]
     pub async fn controller_node_client(
         tcp_transport: &TcpTransport,
         secure_channels: Arc<SecureChannels>,
@@ -127,6 +142,7 @@ impl NodeManager {
         })
     }
 
+    #[instrument(skip_all, fields(authority_identifier = %authority_identifier.clone(), authority_route = %authority_route.clone(), caller = %caller_identifier.clone()))]
     pub async fn authority_node_client(
         tcp_transport: &TcpTransport,
         secure_channels: Arc<SecureChannels>,
@@ -154,6 +170,7 @@ impl NodeManager {
         })
     }
 
+    #[instrument(skip_all, fields(project_identifier = %project_identifier.clone(), project_multiaddr = %project_multiaddr.clone(), caller = %caller_identifier.clone()))]
     pub async fn project_node_client(
         tcp_transport: &TcpTransport,
         secure_channels: Arc<SecureChannels>,

--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -113,6 +113,7 @@ pub trait Subscriptions {
 
 #[async_trait]
 impl Subscriptions for ControllerClient {
+    #[instrument(skip_all, fields(space_id = space_id, subscription_data = subscription_data))]
     async fn activate_subscription(
         &self,
         ctx: &Context,
@@ -125,6 +126,7 @@ impl Subscriptions for ControllerClient {
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all, fields(subscription_id = subscription_id))]
     async fn unsubscribe(
         &self,
         ctx: &Context,
@@ -135,6 +137,7 @@ impl Subscriptions for ControllerClient {
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all, fields(subscription_id = subscription_id, contact_info = contact_info))]
     async fn update_subscription_contact_info(
         &self,
         ctx: &Context,
@@ -146,6 +149,7 @@ impl Subscriptions for ControllerClient {
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all, fields(subscription_id = subscription_id, new_space_id = new_space_id))]
     async fn update_subscription_space(
         &self,
         ctx: &Context,
@@ -157,12 +161,14 @@ impl Subscriptions for ControllerClient {
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all)]
     async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<Subscription>>> {
         trace!(target: TARGET, "listing subscriptions");
         let req = Request::get("/v0/");
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all, fields(subscription_id = subscription_id))]
     async fn get_subscription(
         &self,
         ctx: &Context,
@@ -173,6 +179,7 @@ impl Subscriptions for ControllerClient {
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
+    #[instrument(skip_all, fields(space_id = space_id))]
     async fn get_subscription_by_space_id(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
@@ -71,7 +71,7 @@ impl<T: HasSecureClient + Send + Sync> Enrollment for T {
 // FiXME: this has duplicate with AuthorityNodeClient
 #[async_trait]
 impl Enrollment for SecureClient {
-    #[instrument(skip_all, fields(token = %token))]
+    #[instrument(skip_all)]
     async fn enroll_with_oidc_token(
         &self,
         ctx: &Context,
@@ -94,7 +94,7 @@ impl Enrollment for SecureClient {
         }
     }
 
-    #[instrument(skip_all, fields(token = token.clone().to_string()))]
+    #[instrument(skip_all)]
     async fn enroll_with_oidc_token_okta(
         &self,
         ctx: &Context,
@@ -109,7 +109,7 @@ impl Enrollment for SecureClient {
             .into_diagnostic()
     }
 
-    #[instrument(skip_all, fields(token = token.clone().to_string()))]
+    #[instrument(skip_all)]
     async fn present_token(&self, ctx: &Context, token: &OneTimeCode) -> miette::Result<()> {
         let req = Request::post("/").body(token);
         trace!(target: TARGET, "present a token");

--- a/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
@@ -71,6 +71,7 @@ impl<T: HasSecureClient + Send + Sync> Enrollment for T {
 // FiXME: this has duplicate with AuthorityNodeClient
 #[async_trait]
 impl Enrollment for SecureClient {
+    #[instrument(skip_all, fields(token = %token))]
     async fn enroll_with_oidc_token(
         &self,
         ctx: &Context,
@@ -93,6 +94,7 @@ impl Enrollment for SecureClient {
         }
     }
 
+    #[instrument(skip_all, fields(token = token.clone().to_string()))]
     async fn enroll_with_oidc_token_okta(
         &self,
         ctx: &Context,
@@ -107,6 +109,7 @@ impl Enrollment for SecureClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all, fields(token = token.clone().to_string()))]
     async fn present_token(&self, ctx: &Context, token: &OneTimeCode) -> miette::Result<()> {
         let req = Request::post("/").body(token);
         trace!(target: TARGET, "present a token");
@@ -117,6 +120,7 @@ impl Enrollment for SecureClient {
             .into_diagnostic()
     }
 
+    #[instrument(skip_all)]
     async fn issue_credential(&self, ctx: &Context) -> miette::Result<CredentialAndPurposeKey> {
         let req = Request::post("/");
         trace!(target: TARGET, "getting a credential");

--- a/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
@@ -50,6 +50,7 @@ impl OidcService {
 
     /// Request an authorization token with a PKCE flow
     /// See the full protocol here: https://datatracker.ietf.org/doc/html/rfc7636
+    #[instrument(skip_all)]
     pub async fn get_token_with_pkce(&self) -> Result<OidcToken> {
         let code_verifier = self.create_code_verifier();
         let authorization_code = self.authorization_code(&code_verifier).await?;

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -34,6 +34,7 @@ pub mod nodes;
 pub mod okta;
 pub mod port_range;
 pub mod uppercase;
+mod version;
 
 pub mod authority_node;
 mod influxdb_token_lease;
@@ -48,3 +49,4 @@ pub use influxdb_token_lease::*;
 pub use nodes::service::default_address::*;
 pub use session::sessions::ConnectionStatus;
 pub use util::*;
+pub use version::*;

--- a/implementations/rust/ockam/ockam_api/src/logs/setup.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/setup.rs
@@ -20,7 +20,7 @@ use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::{self as sdk};
 use opentelemetry_semantic_conventions::SCHEMA_URL;
 use std::fmt::Debug;
-use std::io::stdout;
+use std::io::{empty, stdout};
 use tonic::async_trait;
 use tonic::metadata::*;
 pub use tracing::level_filters::LevelFilter;
@@ -156,7 +156,7 @@ impl LoggingTracing {
             .with(tracing_layer);
 
         if logging_configuration.is_enabled() {
-            let (appender, guard) = match logging_configuration.log_dir() {
+            let (appender, _worker_guard) = match logging_configuration.log_dir() {
                 // If a node dir path is not provided, log to stdout.
                 None => {
                     let (n, guard) = tracing_appender::non_blocking(stdout());
@@ -187,13 +187,22 @@ impl LoggingTracing {
             res.expect("Failed to initialize tracing subscriber");
 
             TracingGuard {
-                _worker_guard: Some(guard),
+                _worker_guard,
                 logger_provider,
                 tracer_provider,
             }
         } else {
+            // even if logging is not enabled, an empty writer is
+            // necessary to make sure that all spans are emitted
+            //
+            let (n, _worker_guard) = tracing_appender::non_blocking(empty());
+            let appender = layer().with_writer(n);
+            subscriber
+                .with(appender)
+                .try_init()
+                .expect("Failed to initialize tracing subscriber");
             TracingGuard {
-                _worker_guard: None,
+                _worker_guard,
                 logger_provider,
                 tracer_provider,
             }
@@ -287,7 +296,7 @@ fn get_otlp_headers() -> MetadataMap {
 
 #[derive(Debug)]
 pub struct TracingGuard {
-    _worker_guard: Option<WorkerGuard>,
+    _worker_guard: WorkerGuard,
     logger_provider: LoggerProvider,
     tracer_provider: opentelemetry_sdk::trace::TracerProvider,
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
@@ -6,7 +6,7 @@ use crate::nodes::InMemoryNode;
 
 #[async_trait]
 impl Projects for InMemoryNode {
-    #[instrument(skip_all, fields(project_name, space_name))]
+    #[instrument(skip_all, fields(project_name = project_name, space_name = space_name))]
     async fn create_project(
         &self,
         ctx: &Context,
@@ -23,7 +23,7 @@ impl Projects for InMemoryNode {
         Ok(project)
     }
 
-    #[instrument(skip_all, fields(project_id))]
+    #[instrument(skip_all, fields(project_id = project_id))]
     async fn get_project(&self, ctx: &Context, project_id: &str) -> miette::Result<Project> {
         let controller = self.create_controller().await?;
 
@@ -35,7 +35,7 @@ impl Projects for InMemoryNode {
         Ok(self.cli_state.get_project(project_id).await?)
     }
 
-    #[instrument(skip_all, fields(project_name))]
+    #[instrument(skip_all, fields(project_name = project_name))]
     async fn get_project_by_name_or_default(
         &self,
         ctx: &Context,
@@ -49,7 +49,7 @@ impl Projects for InMemoryNode {
         self.get_project(ctx, &project_id).await
     }
 
-    #[instrument(skip_all, fields(project_name))]
+    #[instrument(skip_all, fields(project_name = project_name))]
     async fn get_project_by_name(
         &self,
         ctx: &Context,
@@ -59,7 +59,7 @@ impl Projects for InMemoryNode {
         self.get_project(ctx, &project_id).await
     }
 
-    #[instrument(skip_all, fields(project_id, space_id))]
+    #[instrument(skip_all, fields(project_id = project_id, space_id = space_id))]
     async fn delete_project(
         &self,
         ctx: &Context,
@@ -72,7 +72,7 @@ impl Projects for InMemoryNode {
         Ok(self.cli_state.delete_project(project_id).await?)
     }
 
-    #[instrument(skip_all, fields(project_name, space_name))]
+    #[instrument(skip_all, fields(project_name = project_name, space_name = space_name))]
     async fn delete_project_by_name(
         &self,
         ctx: &Context,

--- a/implementations/rust/ockam/ockam_api/src/version.rs
+++ b/implementations/rust/ockam/ockam_api/src/version.rs
@@ -1,0 +1,13 @@
+pub struct Version;
+
+impl Version {
+    /// Return the current crate version
+    pub fn crate_version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    /// Return the hash of the current git commit
+    pub fn git_hash() -> &'static str {
+        env!("GIT_HASH")
+    }
+}

--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -28,9 +28,10 @@ impl AppState {
             "ockam_command",
             "ockam_app_lib",
         ];
+
         let guard = LoggingTracing::setup(
             logging_configuration(
-                None,
+                Some(LevelFilter::DEBUG),
                 LevelFilter::DEBUG,
                 Colored::Off,
                 Some(node_dir),

--- a/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
@@ -8,7 +8,7 @@ use console::Term;
 use miette::{miette, IntoDiagnostic};
 use reqwest::StatusCode;
 use tokio::time::{sleep, Duration};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use ockam_api::cloud::enroll::auth0::*;
 use ockam_api::enroll::oidc_service::OidcService;
@@ -53,6 +53,7 @@ pub trait OidcServiceExt {
 
 #[async_trait]
 impl OidcServiceExt for OidcService {
+    #[instrument(skip_all)]
     async fn get_token_interactively(&self, opts: &CommandGlobalOpts) -> Result<OidcToken> {
         let device_code = self.device_code().await?;
 
@@ -134,6 +135,7 @@ impl OidcServiceExt for OidcService {
         self.get_token_from_browser(opts, dc, uri).await
     }
 
+    #[instrument(skip_all)]
     async fn wait_for_email_verification(
         &self,
         token: &OidcToken,

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -80,8 +80,8 @@ impl CreateCommand {
 
         let (_response, _) = try_join!(send_req, progress_output)?;
 
-        let mut attributes = HashMap::default();
-        attributes.insert(NODE_NAME, node_name.as_str());
+        let mut attributes = HashMap::new();
+        attributes.insert(NODE_NAME, node_name.clone());
         opts.state
             .add_journey_event(JourneyEvent::NodeCreated, attributes)
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -121,13 +121,12 @@ impl CreateCommand {
         let machine = outlet_status.worker_address().into_diagnostic()?;
         let json = serde_json::to_string_pretty(&outlet_status).into_diagnostic()?;
 
-        let mut attributes = HashMap::default();
-        let to = self.to.to_string();
-        attributes.insert(TCP_OUTLET_AT, node_name.as_str());
-        attributes.insert(TCP_OUTLET_FROM, self.from.as_str());
-        attributes.insert(TCP_OUTLET_TO, to.as_str());
-        attributes.insert(TCP_OUTLET_ALIAS, outlet_status.alias.as_str());
-        attributes.insert(NODE_NAME, node_name.as_str());
+        let mut attributes = HashMap::new();
+        attributes.insert(TCP_OUTLET_AT, node_name.clone());
+        attributes.insert(TCP_OUTLET_FROM, self.from.clone());
+        attributes.insert(TCP_OUTLET_TO, self.to.to_string());
+        attributes.insert(TCP_OUTLET_ALIAS, outlet_status.alias.clone());
+        attributes.insert(NODE_NAME, node_name.clone());
         opts.state
             .add_journey_event(JourneyEvent::TcpOutletCreated, attributes)
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -8,7 +8,7 @@ use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
 use opentelemetry::trace::FutureExt;
 use tokio::runtime::Runtime;
-use tracing::error;
+use tracing::{debug, error};
 
 use ockam::{Address, Context, NodeBuilder};
 use ockam_api::cli_state::CliState;
@@ -50,22 +50,9 @@ where
     F: FnOnce(Context) -> Fut + Send + Sync + 'static,
     Fut: core::future::Future<Output = miette::Result<()>> + Send + 'static,
 {
-    let command_name = command_name.to_string();
-
+    debug!("running {} asynchronously", command_name);
     let res = embedded_node(opts.clone(), |ctx| {
-        async move {
-            let res = f(ctx).await;
-            if let Err(e) = &res {
-                opts.state
-                    .add_journey_error(&command_name, e.to_string())
-                    .await
-                    .unwrap_or_else(|e1| {
-                        error!("Failed to trace an execution error: {e1:?}");
-                    });
-            };
-            res
-        }
-        .with_current_context()
+        async move { f(ctx).await }.with_current_context()
     });
     local_cmd(res)
 }

--- a/implementations/rust/ockam/ockam_identity/Cargo.toml
+++ b/implementations/rust/ockam/ockam_identity/Cargo.toml
@@ -92,6 +92,7 @@ sqlx = { version = "0.7.3", optional = true }
 subtle = { version = "2.4.1", default-features = false }
 tokio-retry = { version = "0.3.0", default-features = false, optional = true }
 tracing = { version = "0.1", default_features = false }
+tracing-attributes = { version = "0.1", default_features = false }
 
 [dev-dependencies]
 ockam_transport_tcp = { path = "../ockam_transport_tcp" }

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_attributes.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_attributes.rs
@@ -2,6 +2,7 @@ use crate::utils::now;
 use crate::{AttributesEntry, Identifier, IdentityAttributesRepository};
 use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
+use tracing_attributes::instrument;
 
 /// This struct provides access to the identities attributes stored on a node.
 ///
@@ -25,6 +26,7 @@ impl IdentitiesAttributes {
     /// Return the attributes for a given pair subject/attesting authority
     /// If there are expired attributes for any subject, they are deleted before retrieving the attributes for the
     /// current subject.
+    #[instrument(skip_all, fields(subject = %subject, attested_by = %attested_by))]
     pub async fn get_attributes(
         &self,
         subject: &Identifier,
@@ -36,6 +38,7 @@ impl IdentitiesAttributes {
 
     /// Set the attributes associated with the given identity identifier.
     /// Previous values gets overridden.
+    #[instrument(skip_all, fields(subject = %subject, entry = %entry))]
     pub async fn put_attributes(&self, subject: &Identifier, entry: AttributesEntry) -> Result<()> {
         self.repository.put_attributes(subject, entry).await
     }

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/attributes_entry.rs
@@ -1,7 +1,10 @@
+use crate::alloc::string::ToString;
 use crate::models::{Identifier, TimestampInSeconds};
 use crate::utils::now;
+use core::fmt::{Display, Formatter};
 use minicbor::{Decode, Encode};
 use ockam_core::compat::borrow::ToOwned;
+use ockam_core::compat::string::String;
 use ockam_core::compat::{collections::BTreeMap, vec::Vec};
 use ockam_core::Result;
 use serde::{Deserialize, Serialize};
@@ -15,6 +18,32 @@ pub struct AttributesEntry {
     #[n(2)] added_at: TimestampInSeconds,
     #[n(3)] expires_at: Option<TimestampInSeconds>,
     #[n(4)] attested_by: Option<Identifier>,
+}
+
+impl Display for AttributesEntry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut attributes = vec![];
+        for (key, value) in self.attrs.clone() {
+            if let (Ok(k), Ok(v)) = (String::from_utf8(key), String::from_utf8(value)) {
+                attributes.push(format!("{k}={v}"))
+            }
+        }
+        f.debug_struct("AttributesEntry")
+            .field("attrs", &attributes.join(","))
+            .field("added_att", &self.added_at)
+            .field(
+                "expires_at",
+                &self.expires_at.map_or("n/a".to_string(), |e| e.to_string()),
+            )
+            .field(
+                "attested_by",
+                &self
+                    .attested_by
+                    .clone()
+                    .map_or("n/a".to_string(), |e| e.to_string()),
+            )
+            .finish()
+    }
 }
 
 impl AttributesEntry {

--- a/implementations/rust/ockam/ockam_identity/src/models/credential.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/credential.rs
@@ -1,6 +1,8 @@
 use crate::models::{ChangeHash, Identifier, TimestampInSeconds};
+use core::fmt::{Display, Formatter};
 use minicbor::bytes::ByteVec;
 use minicbor::{Decode, Encode};
+use ockam_core::compat::string::String;
 use ockam_core::compat::{collections::BTreeMap, vec::Vec};
 use ockam_vault::{ECDSASHA256CurveP256Signature, EdDSACurve25519Signature};
 
@@ -61,4 +63,21 @@ pub struct Attributes {
     #[n(0)] pub schema: CredentialSchemaIdentifier,
     /// Set of keys&values
     #[n(1)] pub map: BTreeMap<ByteVec, ByteVec>,
+}
+
+impl Display for Attributes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        let mut attributes = vec![];
+        for (key, value) in self.map.clone() {
+            if let (Ok(k), Ok(v)) = (
+                String::from_utf8(key.to_vec()),
+                String::from_utf8(value.to_vec()),
+            ) {
+                attributes.push(format!("{k}={v}"))
+            }
+        }
+        f.debug_struct("Attributes")
+            .field("attrs", &attributes.join(","))
+            .finish_non_exhaustive()
+    }
 }


### PR DESCRIPTION
This PR adds instruments more code for tracing:

 - The `#[instrument]` attribute has been added to all the service traits at the `CliState` level (note that [we are still missing a few of those interfaces](https://github.com/build-trust/ockam/issues?q=is%3Aissue+is%3Aopen+trait+%22Command+-+refactor%22)).
 
 - More attributes have been added to user event spans: project id/name/route/authority identity etc...
 
 - The root span of the project journey now has a stable span id based on the project id (this avoids some missing span issues when the project trace is updated from several ockam homes).
 
 - Make a stable trace id for the host journey trace (based on the machine MAC + IP address). This way we can still track user events even in case of a full reset or `OCKAM_HOME` change on a given machine.
