### PR TITLE
fix(rust): store policies isolated by node and resource

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/storage/policy_repository.rs
+++ b/implementations/rust/ockam/ockam_abac/src/storage/policy_repository.rs
@@ -12,16 +12,17 @@ use ockam_core::Result;
 #[async_trait]
 pub trait PoliciesRepository: Send + Sync + 'static {
     /// Return the policy associated to a given resource and action
-    async fn get_policy(&self, r: &Resource, a: &Action) -> Result<Option<Policy>>;
+    async fn get_policy(&self, resource: &Resource, action: &Action) -> Result<Option<Policy>>;
 
     /// Set a policy for a given resource and action
-    async fn set_policy(&self, r: &Resource, a: &Action, c: &Policy) -> Result<()>;
+    async fn set_policy(&self, resource: &Resource, action: &Action, policy: &Policy)
+        -> Result<()>;
 
     /// Delete the policy associated to a given resource and action
-    async fn delete_policy(&self, r: &Resource, a: &Action) -> Result<()>;
+    async fn delete_policy(&self, resource: &Resource, action: &Action) -> Result<()>;
 
     /// Return the list of all the policies associated to a given resource
-    async fn get_policies_by_resource(&self, r: &Resource) -> Result<Vec<(Action, Policy)>>;
+    async fn get_policies_by_resource(&self, resource: &Resource) -> Result<Vec<(Action, Policy)>>;
 }
 
 #[derive(Debug, Decode, Encode, PartialEq, Eq)]

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -69,8 +69,8 @@ impl CliState {
         Self::make_application_database_path(&self.dir)
     }
 
-    pub fn set_node_name(&mut self, node_name: String) {
-        self.database.node_name = Some(node_name)
+    pub fn set_node_name(&mut self, node_name: impl AsRef<str>) {
+        self.database.set_node_name(node_name.as_ref());
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -17,6 +17,7 @@ use crate::kafka::kafka_outlet_address;
 use crate::nodes::models::portal::{CreateInlet, InletStatus};
 use crate::nodes::NODEMANAGER_ADDR;
 use crate::port_range::PortRange;
+use crate::random_name;
 
 type BrokerId = i32;
 
@@ -121,6 +122,7 @@ impl KafkaInletController {
                     .body(CreateInlet::to_node(
                         socket_address.to_string(),
                         to,
+                        random_name(),
                         prefix,
                         suffix,
                         None,

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
@@ -1,6 +1,7 @@
 use crate::kafka::kafka_outlet_address;
 use crate::nodes::models::portal::{CreateOutlet, OutletStatus};
 use crate::nodes::NODEMANAGER_ADDR;
+use crate::random_name;
 use minicbor::Decoder;
 use ockam::compat::tokio::sync::Mutex;
 use ockam_core::api::{Request, ResponseHeader, Status};
@@ -71,7 +72,7 @@ impl KafkaOutletController {
                     .body(CreateOutlet::new(
                         socket_address,
                         worker_address,
-                        None,
+                        random_name(),
                         false,
                     ))
                     .to_vec()?,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -196,12 +196,7 @@ impl NodeManager {
 
         let resource = Resource::assert_inline(addr.address());
         let ac = self
-            .access_control(
-                &resource,
-                &actions::HANDLE_MESSAGE,
-                self.authority.clone(),
-                None,
-            )
+            .access_control(resource, actions::HANDLE_MESSAGE, self.authority(), None)
             .await?;
 
         WorkerBuilder::new(Echoer)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/resources.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/resources.rs
@@ -1,4 +1,0 @@
-use ockam_abac::Resource;
-
-pub const INLET: Resource = Resource::assert_inline("tcp-inlet");
-pub const OUTLET: Resource = Resource::assert_inline("tcp-outlet");

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -4,16 +4,13 @@ use std::time::Duration;
 
 use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
-use ockam::abac::{Policy, Resource};
 use tracing::{debug, error, info, warn};
 
 use ockam_api::address::get_free_address;
 use ockam_api::authenticator::direct::{
     OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
 };
-use ockam_api::nodes::service::actions;
 use ockam_api::nodes::service::portals::Inlets;
-use ockam_api::nodes::Policies;
 use ockam_api::ConnectionStatus;
 use ockam_core::api::Reply;
 use ockam_multiaddr::MultiAddr;
@@ -189,17 +186,10 @@ impl AppState {
         // Add a policy to check that the outlet node identity
         // is the enroller of its project and not any enrolled
         // identity.
-        inlet_node
-            .add_policy(
-                &self.context(),
-                &Resource::new(&inlet_alias),
-                &actions::HANDLE_MESSAGE,
-                &Policy::new(eq([
-                    ident(format!("subject.{}", OCKAM_ROLE_ATTRIBUTE_KEY)),
-                    str(OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE),
-                ])),
-            )
-            .await?;
+        let expr = eq([
+            ident(format!("subject.{}", OCKAM_ROLE_ATTRIBUTE_KEY)),
+            str(OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE),
+        ]);
 
         inlet_node
             .create_inlet(
@@ -207,8 +197,9 @@ impl AppState {
                 &bind_address.to_string(),
                 &MultiAddr::from_str(&service.service_route(Some(project_name.as_str())))
                     .into_diagnostic()?,
-                &Some(inlet_alias),
+                &inlet_alias,
                 &None,
+                &Some(expr),
                 Duration::from_secs(5),
             )
             .await

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
@@ -27,9 +27,10 @@ impl AppState {
                 &self.context(),
                 socket_addr,
                 worker_addr.clone().into(),
-                Some(worker_addr.clone()),
+                worker_addr.clone(),
                 true,
                 Some(self.create_invitations_access_control(worker_addr).await?),
+                None,
             )
             .await
         {

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
@@ -55,9 +55,10 @@ impl AppState {
                     &context,
                     tcp_outlet.socket_addr,
                     tcp_outlet.worker_addr.clone(),
-                    Some(tcp_outlet.alias.clone()),
+                    tcp_outlet.alias.clone(),
                     true,
                     Some(access_control),
+                    None,
                 )
                 .await
                 .map_err(|e| {

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -98,7 +98,7 @@ impl AppState {
         notification_callback: NotificationCallback,
     ) -> Result<AppState> {
         let mut cli_state = CliState::with_default_dir()?;
-        cli_state.set_node_name(NODE_NAME.to_string());
+        cli_state.set_node_name(NODE_NAME);
         let rt = Arc::new(Runtime::new().expect("cannot create a tokio runtime"));
         let (context, mut executor) = NodeBuilder::new()
             .no_logging()

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -248,7 +248,7 @@ impl CreateCommand {
         }
 
         let mut state = opts.state.clone();
-        state.set_node_name(self.node_name.to_string());
+        state.set_node_name(&self.node_name);
 
         // Create the authority identity if it has not been created before
         // If no name is specified on the command line, use "authority"

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -42,7 +42,7 @@ impl ListCommand {
             None => opts.state.get_default_node().await?.name(),
         };
         let mut opts = opts.clone();
-        opts.state.set_node_name(node_name.clone());
+        opts.state.set_node_name(&node_name);
 
         let database = opts.state.database();
         let storage = CredentialSqlxDatabase::new(database);

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -59,7 +59,7 @@ impl CreateCommand {
 
         // Set node_name so that node can isolate its data in the storage from other nodes
         let mut state = opts.state.clone();
-        state.set_node_name(node_name.clone());
+        state.set_node_name(&node_name);
 
         let node_info = state
             .start_node_with_optional_values(

--- a/implementations/rust/ockam/ockam_command/src/run/parser/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/tcp_inlets.rs
@@ -46,13 +46,13 @@ mod tests {
         let parsed: TcpInlets = serde_yaml::from_str(named).unwrap();
         let cmds = parsed.into_commands().unwrap();
         assert_eq!(cmds.len(), 2);
-        assert_eq!(cmds[0].alias.as_ref().unwrap(), "ti1");
+        assert_eq!(cmds[0].alias, "ti1");
         assert_eq!(
             cmds[0].from,
             SocketAddr::from_str("127.0.0.1:6060").unwrap()
         );
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
-        assert_eq!(cmds[1].alias.as_ref().unwrap(), "ti2");
+        assert_eq!(cmds[1].alias, "ti2");
         assert_eq!(
             cmds[1].from,
             SocketAddr::from_str("127.0.0.1:6061").unwrap()

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -11,11 +11,13 @@ use tracing::trace;
 
 use ockam::identity::Identifier;
 use ockam::Context;
+use ockam_abac::Expr;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::CliState;
 use ockam_api::nodes::models::portal::InletStatus;
 use ockam_api::nodes::service::portals::Inlets;
 use ockam_api::nodes::BackgroundNodeClient;
+use ockam_api::random_name;
 use ockam_core::api::{Reply, Status};
 use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::{MultiAddr, Protocol as _};
@@ -52,8 +54,11 @@ pub struct CreateCommand {
     pub authorized: Option<Identifier>,
 
     /// Assign a name to this inlet.
-    #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser)]
-    pub alias: Option<String>,
+    #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser, default_value_t = random_name(), hide_default_value = true)]
+    pub alias: String,
+
+    #[arg(hide = true, long = "policy", display_order = 900, id = "EXPRESSION")]
+    pub policy_expression: Option<Expr>,
 
     /// Time to wait for the outlet to be available.
     #[arg(long, display_order = 900, id = "WAIT", default_value = "5s", value_parser = duration_parser)]
@@ -119,6 +124,7 @@ impl CreateCommand {
                         &cmd.to(),
                         &cmd.alias,
                         &cmd.authorized,
+                        &cmd.policy_expression,
                         cmd.connection_wait,
                     )
                     .await?;

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/credential_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/credential_repository_sql.rs
@@ -30,7 +30,7 @@ impl CredentialSqlxDatabase {
     /// Create a new in-memory database, passing a node name to isolate data between nodes where needed
     pub async fn create_with_node_name(node_name: &str) -> Result<Self> {
         let mut db = SqlxDatabase::in_memory("credential").await?;
-        db.node_name = Some(node_name.to_string());
+        db.set_node_name(node_name);
         Ok(Self::new(db))
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/storage/identity_attributes_repository_sql.rs
@@ -34,7 +34,7 @@ impl IdentityAttributesSqlxDatabase {
     /// Create a new in-memory database, passing a node name to isolate data between nodes where needed
     pub async fn create_with_node_name(node_name: &str) -> Result<Self> {
         let mut db = SqlxDatabase::in_memory("identity attributes").await?;
-        db.node_name = Some(node_name.to_string());
+        db.set_node_name(node_name);
         Ok(Self::new(db))
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20240202100000_add_node_name_to_policies.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/20240202100000_add_node_name_to_policies.sql
@@ -1,0 +1,14 @@
+ALTER TABLE policy RENAME TO policy_old;
+
+-- Add a new column to the table "node" to isolate policies by node
+-- The rust migration will handle the data migration between the old and new table
+CREATE TABLE policy
+(
+    node       TEXT NOT NULL, -- node name
+    resource   TEXT NOT NULL, -- resource name
+    action     TEXT NOT NULL, -- action name
+    expression BLOB NOT NULL  -- expression to evaluate
+);
+
+DROP INDEX IF EXISTS policy_index;
+CREATE UNIQUE INDEX policy_index ON policy (node, resource, action);

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20240202100000_migrate_policies.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20240202100000_migrate_policies.rs
@@ -1,0 +1,165 @@
+use crate::database::{FromSqlxError, SqlxDatabase, ToSqlxType, ToVoid};
+use ockam_core::Result;
+use sqlx::*;
+
+/// This migration duplicates the existing policies for every known node
+pub struct PoliciesByNode;
+
+impl PoliciesByNode {
+    /// Duplicate all policies entry for every known node
+    pub(crate) async fn migrate_policies(pool: &SqlitePool) -> Result<bool> {
+        let migration_name = "20240202100000_add_node_name_to_policies";
+
+        if SqlxDatabase::has_migrated(pool, migration_name).await? {
+            return Ok(false);
+        }
+
+        let mut conn = pool.acquire().await.into_core()?;
+
+        let mut transaction = conn.begin().await.into_core()?;
+
+        let query_node_names = query_as("SELECT name FROM node");
+        let node_names: Vec<NodeNameRow> = query_node_names
+            .fetch_all(&mut *transaction)
+            .await
+            .into_core()?;
+        let node_names = node_names.into_iter().map(|r| r.name).collect::<Vec<_>>();
+
+        let legacy_policies: Vec<LegacyPolicyRow> =
+            query_as("SELECT resource, action, expression FROM policy_old")
+                .fetch_all(&mut *transaction)
+                .await
+                .into_core()?;
+
+        for policy in legacy_policies {
+            for node_name in node_names.iter() {
+                let insert = query(
+                    "INSERT INTO policy (node, resource, action, expression) VALUES (?, ?, ?, ?)",
+                )
+                .bind(node_name.to_sql())
+                .bind(policy.resource.to_sql())
+                .bind(policy.action.to_sql())
+                .bind(policy.expression.to_sql());
+
+                insert.execute(&mut *transaction).await.void()?;
+            }
+        }
+
+        // finally drop the old table
+        query("DROP TABLE policy_old")
+            .execute(&mut *transaction)
+            .await
+            .void()?;
+
+        transaction.commit().await.void()?;
+
+        SqlxDatabase::mark_as_migrated(pool, migration_name).await?;
+
+        Ok(true)
+    }
+}
+
+#[derive(FromRow)]
+struct NodeNameRow {
+    name: String,
+}
+
+#[derive(FromRow)]
+struct LegacyPolicyRow {
+    resource: String,
+    action: String,
+    expression: Vec<u8>,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::database::sqlx_migration::NodesMigration;
+    use sqlx::query::Query;
+    use sqlx::sqlite::SqliteArguments;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[derive(FromRow)]
+    struct PolicyRow {
+        node: String,
+        resource: String,
+        action: String,
+        expression: Vec<u8>,
+    }
+
+    #[tokio::test]
+    async fn test_migration() -> Result<()> {
+        let db_file = NamedTempFile::new().unwrap();
+        let pool = SqlxDatabase::create_connection_pool(db_file.path()).await?;
+        NodesMigration.migrate_schema(&pool).await?;
+
+        // Add data to the old table before applying the rust migration
+        let insert = insert_node("n1".to_string());
+        insert.execute(&pool).await.void()?;
+        let insert = insert_node("n2".to_string());
+        insert.execute(&pool).await.void()?;
+        let insert = insert_legacy_policy("r1", "a1", minicbor::to_vec("e1")?);
+        insert.execute(&pool).await.void()?;
+        let insert = insert_legacy_policy("r2", "a2", minicbor::to_vec("e2")?);
+        insert.execute(&pool).await.void()?;
+
+        // now create a database and apply the migrations
+        let db = SqlxDatabase::create(db_file.path()).await?;
+        for node in &["n1", "n2"] {
+            let rows: Vec<PolicyRow> =
+                query_as("SELECT node, resource, action, expression FROM policy WHERE node = ?")
+                    .bind(node.to_sql())
+                    .fetch_all(&*db.pool)
+                    .await
+                    .into_core()?;
+            assert_eq!(rows.len(), 2);
+            assert_eq!(&rows[0].node, node);
+            assert_eq!(rows[0].resource, "r1");
+            assert_eq!(rows[0].action, "a1");
+            assert!(!rows[0].expression.is_empty());
+            assert_eq!(&rows[1].node, node);
+            assert_eq!(rows[1].resource, "r2");
+            assert_eq!(rows[1].action, "a2");
+            assert!(!rows[1].expression.is_empty());
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_migration_happens_only_once() -> Result<()> {
+        let db_file = NamedTempFile::new().unwrap();
+        let db = SqlxDatabase::create_no_migration(db_file.path()).await?;
+        NodesMigration.migrate_schema(&db.pool).await?;
+
+        let migrated = PoliciesByNode::migrate_policies(&db.pool).await?;
+        assert!(migrated);
+
+        let migrated = PoliciesByNode::migrate_policies(&db.pool).await?;
+        assert!(!migrated);
+
+        Ok(())
+    }
+
+    /// HELPERS
+    fn insert_node(name: String) -> Query<'static, Sqlite, SqliteArguments<'static>> {
+        query("INSERT INTO node (name, identifier, verbosity, is_default, is_authority) VALUES (?, ?, ?, ?, ?)")
+            .bind(name.to_sql())
+            .bind("I_TEST".to_string().to_sql())
+            .bind(1.to_sql())
+            .bind(0.to_sql())
+            .bind(false.to_sql())
+    }
+
+    fn insert_legacy_policy(
+        resource: &str,
+        action: &str,
+        expression: Vec<u8>,
+    ) -> Query<'static, Sqlite, SqliteArguments<'static>> {
+        query("INSERT INTO policy_old (resource, action, expression) VALUES (?, ?, ?)")
+            .bind(resource.to_sql())
+            .bind(action.to_sql())
+            .bind(expression.to_sql())
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/mod.rs
@@ -7,3 +7,5 @@ pub(super) mod common;
 pub mod migration_20231231100000_node_name_identity_attributes;
 /// This migration moves attributes from identity_attributes to the authority_member table for authority nodes
 pub mod migration_20240111100001_add_authority_tables;
+/// This migration duplicates the existing policies for every known node
+pub mod migration_20240202100000_migrate_policies;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/sqlx_migration.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/sqlx_migration.rs
@@ -1,4 +1,5 @@
 use crate::database::migration_20240111100001_add_authority_tables::AuthorityAttributes;
+use crate::database::migration_20240202100000_migrate_policies::PoliciesByNode;
 use crate::database::migrations::migration_20231231100000_node_name_identity_attributes::NodeNameIdentityAttributes;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{async_trait, Error, Result};
@@ -35,7 +36,7 @@ impl NodesMigration {
     pub(crate) async fn migrate_data(&self, pool: &SqlitePool) -> Result<()> {
         NodeNameIdentityAttributes::migrate_attributes_node_name(pool).await?;
         AuthorityAttributes::migrate_authority_attributes_to_members(pool).await?;
-
+        PoliciesByNode::migrate_policies(pool).await?;
         Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database/sqlx_database.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database/sqlx_database.rs
@@ -159,6 +159,11 @@ impl SqlxDatabase {
         Ok(pool)
     }
 
+    /// Set the node name
+    pub fn set_node_name(&mut self, node_name: &str) {
+        self.node_name = Some(node_name.to_string());
+    }
+
     /// Return the node name
     pub fn node_name(&self) -> Result<String> {
         self.node_name.clone().ok_or_else(|| {


### PR DESCRIPTION
Main changes:
- Add a new column "node" to the `policy` table to store the node name associated to the policy/resource
- Replace global policies (`tcp-inlet` and `tcp-outlet`) with policies named after the resource (the alias, random or given, of the inlet/outlet)

Tested:
- [x] "Basic Web App" example
- [ ] ~Kafka example~
- [x] App