### PR TITLE
feat(rust): simplifies `projects` section from the `run` config file

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
@@ -129,7 +129,7 @@ impl IdentityEnrollment {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EnrollmentTicket {
     pub one_time_code: OneTimeCode,
     pub project: Option<Project>,

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/1.basic-web-app.single-machine.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/1.basic-web-app.single-machine.yaml
@@ -1,6 +1,4 @@
 # https://docs.ockam.io/guides/examples/basic-web-app
-version: 1
-
 relays: default
 
 tcp-outlets:

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.basic-web-app.inlet.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.basic-web-app.inlet.yaml
@@ -1,9 +1,5 @@
 # https://docs.ockam.io/guides/examples/basic-web-app
-version: 1
-
-projects:
-  enroll:
-    ticket: webapp.ticket
+ticket: webapp.ticket
 
 nodes: web
 

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.basic-web-app.outlet.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.basic-web-app.outlet.yaml
@@ -1,9 +1,5 @@
 # https://docs.ockam.io/guides/examples/basic-web-app
-version: 1
-
-projects:
-  enroll:
-    ticket: db.ticket
+ticket: db.ticket
 
 nodes: db
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
@@ -56,8 +56,6 @@ mod tests {
     #[test]
     fn can_parse_base_config() {
         let config = r#"
-            version: 1
-
             vaults:
               - v1
               - v2
@@ -66,6 +64,8 @@ mod tests {
               - i1
               - i2:
                   vault: v2
+
+            ticket: ./path/to/ticket
 
             nodes:
               - n1
@@ -126,7 +126,9 @@ mod tests {
                     }),
                 ])),
             },
-            projects: Projects { projects: None },
+            projects: Projects {
+                ticket: Some("./path/to/ticket".to_string()),
+            },
             nodes: Nodes {
                 nodes: Some(ResourcesContainer::List(vec![
                     ResourceNameOrMap::Name("n1".to_string()),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/projects.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/projects.rs
@@ -1,27 +1,19 @@
-use crate::project::{CreateCommand, EnrollCommand};
-use std::collections::BTreeMap;
+use crate::project::EnrollCommand;
 
-use crate::run::parser::resources::{
-    as_command_arg, as_keyword_arg, parse_cmd_from_args, ResourceName, UnnamedResources,
-};
+use crate::run::parser::resources::{parse_cmd_from_args, resolve, ArgValue};
+use crate::run::parser::ArgsToCommands;
 use crate::OckamSubcommand;
 use miette::{miette, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Projects {
-    pub projects: Option<BTreeMap<ResourceName, UnnamedResources>>,
+    pub ticket: Option<String>,
 }
 
-#[derive(Debug, Default)]
-pub struct ProjectCmds {
-    pub create: Vec<CreateCommand>,
-    pub enroll: Vec<EnrollCommand>,
-}
-
-impl Projects {
-    pub fn into_commands(self) -> Result<ProjectCmds> {
-        let get_enroll_subcommand = |args: &[String]| -> Result<EnrollCommand> {
+impl ArgsToCommands<EnrollCommand> for Projects {
+    fn into_commands(self) -> Result<Vec<EnrollCommand>> {
+        let get_subcommand = |args: &[String]| -> Result<EnrollCommand> {
             if let OckamSubcommand::Project(cmd) = parse_cmd_from_args("project enroll", args)? {
                 if let crate::project::ProjectSubcommand::Enroll(c) = cmd.subcommand {
                     return Ok(*c);
@@ -29,56 +21,12 @@ impl Projects {
             }
             Err(miette!("Failed to parse command"))
         };
-        let get_create_subcommand = |args: &[String]| -> Result<CreateCommand> {
-            if let OckamSubcommand::Project(cmd) = parse_cmd_from_args("project create", args)? {
-                if let crate::project::ProjectSubcommand::Create(c) = cmd.subcommand {
-                    return Ok(c);
-                }
+        match self.ticket {
+            Some(path_or_contents) => {
+                get_subcommand(&[resolve(&ArgValue::String(path_or_contents))]).map(|c| vec![c])
             }
-            Err(miette!("Failed to parse command"))
-        };
-        let mut cmds = ProjectCmds::default();
-        if let Some(c) = self.projects {
-            for (name, args) in c.into_iter() {
-                let mut list_of_args = match args {
-                    UnnamedResources::Single(args) => vec![args],
-                    UnnamedResources::List(args) => args,
-                };
-                match name.as_str() {
-                    "enroll" => {
-                        for cmd_args in list_of_args {
-                            let args = cmd_args
-                                .args
-                                .into_iter()
-                                .flat_map(|(k, v)| as_command_arg(k, v))
-                                // Remove "ticket" arg name from args, as it's expected to be a positional argument
-                                .filter(|a| a != &as_keyword_arg(&"ticket".to_string()))
-                                .collect::<Vec<_>>();
-                            let cmd = get_enroll_subcommand(&args)?;
-                            cmds.enroll.push(cmd);
-                        }
-                    }
-                    "ticket" => {
-                        unimplemented!()
-                    }
-                    project_name => {
-                        let args = list_of_args.pop().expect("There should be one element");
-                        let mut args = args
-                            .args
-                            .into_iter()
-                            .flat_map(|(k, v)| as_command_arg(k, v))
-                            // Remove "space" arg name from args, as it's expected to be a positional argument
-                            .filter(|a| a != &as_keyword_arg(&"space".to_string()))
-                            .collect::<Vec<_>>();
-                        // Add the project name at the end, as the first positional argument must be the space name
-                        args.push(project_name.to_string());
-                        let cmd = get_create_subcommand(&args)?;
-                        cmds.create.push(cmd);
-                    }
-                }
-            }
+            None => Ok(vec![]),
         }
-        Ok(cmds)
     }
 }
 
@@ -87,71 +35,32 @@ mod tests {
     use super::*;
     use ockam_api::authenticator::one_time_code::OneTimeCode;
     use ockam_api::EnrollmentTicket;
+    use std::fs::File;
+    use std::io::Write;
+    use tempfile::tempdir;
 
     #[test]
     fn project_enroll_config() {
         let enrollment_ticket = EnrollmentTicket::new(OneTimeCode::new(), None);
         let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
-        std::env::set_var("ENROLLMENT_TICKET", enrollment_ticket_hex);
 
-        // Single
-        let config = r#"
-            projects:
-              enroll:
-                ticket: $ENROLLMENT_TICKET
-        "#;
+        // As contents
+        std::env::set_var("ENROLLMENT_TICKET", &enrollment_ticket_hex);
+        let config = "ticket: $ENROLLMENT_TICKET";
         let parsed: Projects = serde_yaml::from_str(config).unwrap();
         let cmds = parsed.into_commands().unwrap();
-        assert_eq!(cmds.enroll.len(), 1);
-        assert!(cmds.enroll[0].enroll_ticket.is_some());
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].enroll_ticket.as_ref().unwrap(), &enrollment_ticket);
 
-        // List
-        let config = r#"
-            projects:
-              enroll:
-                - ticket: $ENROLLMENT_TICKET
-                  identity: i1
-                - ticket: $ENROLLMENT_TICKET
-        "#;
-        let parsed: Projects = serde_yaml::from_str(config).unwrap();
+        // As path
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("my.ticket");
+        let mut file = File::create(&file_path).unwrap();
+        file.write_all(enrollment_ticket_hex.as_bytes()).unwrap();
+        let config = format!("ticket: {}", file_path.to_str().unwrap());
+        let parsed: Projects = serde_yaml::from_str(&config).unwrap();
         let cmds = parsed.into_commands().unwrap();
-        assert_eq!(cmds.enroll.len(), 2);
-        assert!(cmds.enroll[0].enroll_ticket.is_some());
-        assert_eq!(cmds.enroll[0].cloud_opts.identity.as_ref().unwrap(), "i1");
-        assert!(cmds.enroll[1].enroll_ticket.is_some());
-    }
-
-    #[test]
-    fn projects_full_config() {
-        let enrollment_ticket = EnrollmentTicket::new(OneTimeCode::new(), None);
-        let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
-        std::env::set_var("ENROLLMENT_TICKET", enrollment_ticket_hex);
-        let config = r#"
-            projects:
-              p1:
-                space: s1
-                identity: i1
-              p2:
-                space: s2
-              enroll:
-                - ticket: $ENROLLMENT_TICKET
-                  identity: i1
-                - ticket: $ENROLLMENT_TICKET
-        "#;
-        let parsed: Projects = serde_yaml::from_str(config).unwrap();
-        let cmds = parsed.into_commands().unwrap();
-
-        assert_eq!(cmds.create.len(), 2);
-        assert_eq!(&cmds.create[0].project_name, "p1");
-        assert_eq!(&cmds.create[0].space_name, "s1");
-        assert_eq!(cmds.create[0].cloud_opts.identity.as_ref().unwrap(), "i1");
-        assert_eq!(&cmds.create[1].project_name, "p2");
-        assert_eq!(&cmds.create[1].space_name, "s2");
-        assert!(cmds.create[1].cloud_opts.identity.is_none());
-
-        assert_eq!(cmds.enroll.len(), 2);
-        assert!(cmds.enroll[0].enroll_ticket.is_some());
-        assert_eq!(cmds.enroll[0].cloud_opts.identity.as_ref().unwrap(), "i1");
-        assert!(cmds.enroll[1].enroll_ticket.is_some());
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].enroll_ticket.as_ref().unwrap(), &enrollment_ticket);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/runner.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/runner.rs
@@ -29,24 +29,9 @@ impl ConfigRunner {
             identity.async_run(opts.clone()).await?;
         }
 
-        let projects = config.projects.into_commands()?;
-        for project_create in projects.create {
-            if opts
-                .state
-                .get_project_by_name(&project_create.project_name)
-                .await
-                .is_ok()
-            {
-                opts.terminal.write_line(&fmt_info!(
-                    "Project {} is already created",
-                    color!(project_create.project_name, OckamColor::PrimaryResource)
-                ))?;
-                continue;
-            }
-            project_create.async_run(ctx, opts.clone()).await?;
-        }
-        for project_enrollment in projects.enroll {
-            let identity_name = &project_enrollment.cloud_opts.identity;
+        let projects_enrollment_tickets = config.projects.into_commands()?;
+        for enrollment_ticket in projects_enrollment_tickets {
+            let identity_name = &enrollment_ticket.cloud_opts.identity;
             let identity = opts
                 .state
                 .get_named_identity_or_default(identity_name)
@@ -60,7 +45,7 @@ impl ConfigRunner {
                     continue;
                 }
             }
-            project_enrollment.async_run(ctx, opts.clone()).await?;
+            enrollment_ticket.async_run(ctx, opts.clone()).await?;
         }
 
         let nodes = config.nodes.into_commands()?;


### PR DESCRIPTION
The `projects` section now only supports running the `project enroll` command to use enrollment tickets. It goes from:

```yaml
projects:
  enroll:
    ticket: db.ticket
```

to:

```yaml
ticket: [path|contents]
```

It also adds some improvements in the `version` section, to handle values out of the expected version values.