### PR TITLE
fix(rust): set the proper span id on the propagated tracing context

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
@@ -38,7 +38,8 @@ pub(crate) fn make_host_trace_id() -> TraceId {
     };
 
     // take exactly 16 bytes from the machine name
-    let mut machine = machine.as_bytes().to_vec();
+    // the digit 1 is added at the beginning as a version indicator, in case we need to evolve the format
+    let mut machine = format!("1{machine}").as_bytes().to_vec();
     // make sure that there are at least 16 bytes
     if machine.len() < 16 {
         machine.extend(std::iter::repeat(1).take(16 - machine.len()));

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use ockam_node::OpenTelemetryContext;
 use opentelemetry::trace::{Link, SpanBuilder, SpanId, TraceContextExt, TraceId, Tracer};
 use opentelemetry::{global, Context, Key};
-use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
 use std::collections::HashMap;
 use std::ops::Add;
 use std::time::{Duration, SystemTime};
@@ -230,12 +229,10 @@ impl CliState {
 
     /// Create the initial host journey, with a random trace id
     fn create_host_journey(&self) -> HostJourney {
-        let random_id_generator = RandomIdGenerator::default();
-        let (opentelemetry_context, now) = self.create_journey(
-            "start host journey",
-            make_host_trace_id(),
-            random_id_generator.new_span_id(),
-        );
+        let trace_id = make_host_trace_id();
+        let span_id = SpanId::from_hex(&trace_id.to_string()[..16]).unwrap();
+        let (opentelemetry_context, now) =
+            self.create_journey("start host journey", trace_id, span_id);
         HostJourney::new(opentelemetry_context, now)
     }
 

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -1,7 +1,8 @@
 use ockam_api::logs::{LoggingConfiguration, LoggingTracing};
 use ockam_api::random_name;
+use ockam_node::{Executor, OpenTelemetryContext};
 use opentelemetry::global;
-use opentelemetry::trace::Tracer;
+use opentelemetry::trace::{FutureExt, Tracer};
 use opentelemetry_sdk::{self as sdk};
 use sdk::testing::logs::*;
 use sdk::testing::trace::*;
@@ -9,9 +10,10 @@ use std::fs;
 use tempfile::NamedTempFile;
 use tracing::{error, info};
 
-/// This test needs to be an integration test
-/// It needs to run in isolation because
-/// it sets up some global spans / logs exporters that might interact with other tests
+/// These tests need to be integration tests
+/// They need to run in isolation because
+/// they set up some global spans / logs exporters that might interact with other tests
+
 #[test]
 fn test_log_and_traces() {
     let temp_file = NamedTempFile::new().unwrap();
@@ -74,4 +76,71 @@ fn test_log_and_traces() {
         stdout_file_checked,
         "the stdout log file must have been found and checked"
     )
+}
+
+/// This test essentially checks that the tracing context that we propagate to other systems contains
+/// a proper span id.
+#[test]
+fn test_context_propagation() {
+    let spans_exporter = InMemorySpanExporter::default();
+    let logs_exporter = InMemoryLogsExporter::default();
+    let guard = LoggingTracing::setup_with_exporters(
+        spans_exporter.clone(),
+        logs_exporter.clone(),
+        None,
+        LoggingConfiguration::off(),
+        "test",
+    );
+
+    let tracer = global::tracer("ockam-test");
+    let propagated_context = Executor::execute_future(async move {
+        tracer
+            .in_span("root", |_| {
+                async { function().await }.with_current_context()
+            })
+            .await
+    })
+    .unwrap();
+
+    // get the exported spans
+    guard.force_flush();
+    let mut spans = spans_exporter.get_finished_spans().unwrap();
+    spans.reverse();
+
+    // there must be 3 spans
+    assert_eq!(spans.len(), 3);
+    let span1 = spans.get(0).unwrap();
+    let span2 = spans.get(1).unwrap();
+    let span3 = spans.get(2).unwrap();
+
+    // the spans must have proper parent / child relationships
+    assert_eq!(span1.name, "root");
+
+    assert_eq!(span2.name, "function");
+    assert_eq!(span2.parent_span_id, span1.span_context.span_id());
+
+    assert_eq!(span3.name, "nested_function");
+    assert_eq!(span3.parent_span_id, span2.span_context.span_id());
+
+    // the propagated context must use the span id of the most nested span id
+    let context = propagated_context.as_map();
+    let traceparent = context.get("traceparent").unwrap();
+    assert_eq!(
+        traceparent.to_string(),
+        format!(
+            "00-{}-{}-01",
+            span1.span_context.trace_id(),
+            span3.span_context.span_id()
+        )
+    );
+}
+
+#[tracing::instrument]
+async fn function() -> OpenTelemetryContext {
+    nested_function().await
+}
+
+#[tracing::instrument]
+async fn nested_function() -> OpenTelemetryContext {
+    OpenTelemetryContext::current()
 }


### PR DESCRIPTION
This PR fixes the creation of the tracing context that's propagated between nodes.
The fix is a bit involved because the standard `tracing` support is not fully integrated with the `OpenTelemetry` tracing support.

Please see the comments in the code explaining how the correct span id is eventually retrieved.

I have also added a fix to make the root span of the host journey stable. Otherwise we get disjoint "start host journey" spans pointing to a missing root span.