### PR TITLE
fix(rust): use the correct policies in inlets/outlets created by kafka services

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
+++ b/implementations/rust/ockam/ockam_abac/src/attribute_access_control.rs
@@ -72,7 +72,7 @@ impl AbacAccessControl {
     ) -> AbacAccessControl {
         let expression = List(vec![
             Ident("=".into()),
-            Ident(format!("subject.{attribute_name}")),
+            Ident(format!("{SUBJECT_KEY}.{attribute_name}")),
             Str(attribute_value.into()),
         ]);
         AbacAccessControl::new(

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -48,7 +48,7 @@ mod test {
     };
     use crate::test_utils::NodeManagerHandle;
 
-    //TODO: upgrade to 13 by adding a metadata request to map uuid<=>topic_name
+    // TODO: upgrade to 13 by adding a metadata request to map uuid<=>topic_name
     const TEST_KAFKA_API_VERSION: i16 = 12;
 
     struct HopRelayCreator {}
@@ -57,7 +57,7 @@ mod test {
     impl RelayCreator for HopRelayCreator {
         async fn create_relay(&self, context: &Context, alias: String) -> ockam::Result<()> {
             trace!("creating mock relay for: {alias}");
-            //replicating the same logic of the orchestrator by adding consumer__
+            // replicating the same logic of the orchestrator by adding consumer__
             context
                 .start_worker(Address::from_string(format!("consumer__{alias}")), Hop)
                 .await?;
@@ -88,6 +88,7 @@ mod test {
             route![],
             "127.0.0.1".parse().unwrap(),
             (0, 0).try_into().unwrap(),
+            None,
         );
 
         let (socket_address, _) = handler
@@ -133,7 +134,7 @@ mod test {
         )
         .await?;
 
-        //before produce a new key, the consumer has to issue a Fetch request
+        // before produce a new key, the consumer has to issue a Fetch request
         // so the sidecar can react by creating the relay for the partition 1 of 'my-topic'
         {
             let mut consumer_mock_kafka = TcpServerSimulator::start("127.0.0.1:0").await;
@@ -152,7 +153,7 @@ mod test {
             )
             .await;
             drop(consumer_mock_kafka);
-            //drop the outlet and re-create it when we need it later
+            // drop the outlet and re-create it when we need it later
             context.stop_worker("kafka_consumer_outlet").await?;
         }
 
@@ -316,8 +317,8 @@ mod test {
         send_kafka_request(stream, header, request, ApiKey::ProduceKey).await;
     }
 
-    //this is needed in order to make the consumer create the relays to the secure
-    //channel
+    // this is needed in order to make the consumer create the relays to the secure
+    // channel
     async fn simulate_first_kafka_consumer_empty_reply_and_ignore_result(
         consumer_bootstrap_port: u16,
         mock_kafka_connection: &mut TcpServerSimulator,
@@ -327,7 +328,7 @@ mod test {
                 .await
                 .unwrap();
         send_kafka_fetch_request(&mut kafka_client_connection).await;
-        //we don't want the answer, but we need to be sure the
+        // we don't want the answer, but we need to be sure the
         // message passed through and the relay had been created
         mock_kafka_connection
             .stream
@@ -336,7 +337,7 @@ mod test {
             .unwrap();
     }
 
-    //we use the encrypted producer request to generate the encrypted fetch response
+    // we use the encrypted producer request to generate the encrypted fetch response
     async fn simulate_kafka_consumer_and_read_response(
         consumer_bootstrap_port: u16,
         mock_kafka_connection: &mut TcpServerSimulator,
@@ -575,11 +576,11 @@ mod test {
         /// moving on the next test
         pub async fn destroy_and_wait(self) {
             self.is_stopping.store(true, Ordering::SeqCst);
-            //we want to close the channel _before_ joining current handles to interrupt them
+            // we want to close the channel _before_ joining current handles to interrupt them
             drop(self.stream);
             let mut guard = self.join_handles.lock().await;
             for handle in guard.iter_mut() {
-                //we don't care about failures
+                // we don't care about failures
                 let _ = handle.await;
             }
         }
@@ -602,8 +603,8 @@ mod test {
                 tokio::spawn(async move {
                     let socket;
                     loop {
-                        //tokio would block on the listener forever, we need to poll a little in
-                        //order to interrupt it
+                        // tokio would block on the listener forever, we need to poll a little in
+                        // order to interrupt it
                         let timeout_future =
                             tokio::time::timeout(Duration::from_millis(200), listener.accept());
                         if let Ok(result) = timeout_future.await {

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -12,6 +12,12 @@ mod protocol_aware;
 mod secure_channel_map;
 
 pub(crate) use inlet_controller::KafkaInletController;
+use ockam::identity::Identifier;
+use ockam_abac::attribute_access_control::{
+    ABAC_HAS_CREDENTIAL_KEY, ABAC_IDENTIFIER_KEY, SUBJECT_KEY,
+};
+use ockam_abac::expr::{eq, ident, str};
+use ockam_abac::Expr;
 use ockam_core::Address;
 pub(crate) use outlet_service::prefix_relay::PrefixRelayService;
 pub(crate) use outlet_service::OutletManagerService;
@@ -25,4 +31,14 @@ pub const KAFKA_OUTLET_BOOTSTRAP_ADDRESS: &str = "kafka_bootstrap";
 
 pub fn kafka_outlet_address(broker_id: i32) -> Address {
     format!("kafka_outlet_{}", broker_id).into()
+}
+pub fn kafka_default_policy_expression() -> Expr {
+    Expr::Ident(format!("{SUBJECT_KEY}.{ABAC_HAS_CREDENTIAL_KEY}"))
+}
+
+pub fn kafka_policy_expression(project_identifier: &Identifier) -> Expr {
+    eq([
+        ident(format!("{}.{}", SUBJECT_KEY, ABAC_IDENTIFIER_KEY)),
+        str(project_identifier.to_string()),
+    ])
 }

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_listener.rs
@@ -8,7 +8,7 @@ use crate::kafka::portal_worker::KafkaPortalWorker;
 use crate::kafka::protocol_aware::TopicUuidMap;
 use crate::kafka::secure_channel_map::KafkaSecureChannelController;
 
-///First point of ingress of kafka connections, at the first message it spawns new stateful workers
+/// First point of ingress of kafka connections, at the first message it spawns new stateful workers
 /// to take care of the connection.
 pub(crate) struct KafkaPortalListener {
     inlet_controller: KafkaInletController,

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -18,7 +18,7 @@ use crate::kafka::protocol_aware::{InletInterceptorImpl, KafkaMessageInterceptor
 use crate::kafka::secure_channel_map::KafkaSecureChannelController;
 use crate::kafka::KAFKA_OUTLET_BOOTSTRAP_ADDRESS;
 
-///by default kafka supports up to 1MB messages, 16MB is the maximum suggested
+/// By default, kafka supports up to 1MB messages. 16MB is the maximum suggested
 pub(crate) const MAX_KAFKA_MESSAGE_SIZE: u32 = 16 * 1024 * 1024;
 
 enum Receiving {
@@ -29,9 +29,9 @@ enum Receiving {
 /// Acts like a relay for messages between tcp inlet and outlet for both directions.
 /// It's meant to be created by the portal listener.
 ///
-/// This implementation manage both streams inlet and outlet in two different workers, one dedicated
+/// This implementation manages both streams inlet and outlet in two different workers, one dedicated
 /// to the requests (inlet=>outlet) the other for the responses (outlet=>inlet).
-/// Since every kafka message is length-delimited every message is read and written
+/// Since every kafka message is length-delimited, every message is read and written
 /// through a framed encoder/decoder.
 ///
 /// ```text
@@ -163,7 +163,7 @@ impl Worker for KafkaPortalWorker {
     }
 }
 
-//internal error to return both io and ockam errors
+// internal error to return both io and ockam errors
 #[derive(Debug)]
 pub(crate) enum InterceptError {
     Io(ockam_core::compat::io::Error),
@@ -251,7 +251,7 @@ impl KafkaPortalWorker {
         Ok(())
     }
 
-    ///Takes in buffer and returns a buffer made of one or more complete kafka message
+    /// Takes in buffer and returns a buffer made of one or more complete kafka message
     async fn intercept_and_transform_messages(
         &mut self,
         context: &mut Context,
@@ -280,7 +280,7 @@ impl KafkaPortalWorker {
                 }
             }?;
 
-            //avoid copying the first message
+            // avoid copying the first message
             if let Some(encoded_buffer) = encoded_buffer.as_mut() {
                 encoded_buffer.extend_from_slice(
                     length_encode(transformed_message)
@@ -298,7 +298,7 @@ impl KafkaPortalWorker {
 }
 
 impl KafkaPortalWorker {
-    /// Creates the two specular kafka workers for the outlet use case
+    /// Creates the two specular kafka workers for the outlet use case.
     /// Returns the address of the worker which handles the Requests
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn create_outlet_side_kafka_portal(
@@ -467,7 +467,7 @@ mod test {
     const TEST_MAX_KAFKA_MESSAGE_SIZE: u32 = 128 * 1024;
     const TEST_KAFKA_API_VERSION: i16 = 13;
 
-    //a simple worker that keep receiving buffer
+    // a simple worker that keep receiving buffer
     #[derive(Clone)]
     struct TcpPayloadReceiver {
         buffer: Arc<Mutex<Vec<u8>>>,
@@ -540,7 +540,7 @@ mod test {
         let first_piece_of_payload = &request_buffer[0..request_buffer.len() - 1];
         let second_piece_of_payload = &request_buffer[request_buffer.len() - 1..];
 
-        //send 2 distinct pieces and see if the kafka message is re-assembled back
+        // send 2 distinct pieces and see if the kafka message is re-assembled back
         context
             .send(
                 route![portal_inlet_address.clone(), context.address()],
@@ -609,14 +609,14 @@ mod test {
     ) -> ockam::Result<()> {
         let portal_inlet_address = setup_only_worker(context).await;
 
-        //with the message container it goes well over the max allowed message kafka size
+        // with the message container it goes well over the max allowed message kafka size
         let mut zero_buffer: Vec<u8> = Vec::new();
         for _n in 0..TEST_MAX_KAFKA_MESSAGE_SIZE + 1 {
             zero_buffer.push(0);
         }
 
-        //you don't want to create a produce request since it would trigger
-        //a lot of side effects and we just want to validate the transport
+        // you don't want to create a produce request since it would trigger
+        // a lot of side effects and we just want to validate the transport
         let mut insanely_huge_tag = BTreeMap::new();
         insanely_huge_tag.insert(0, zero_buffer);
 
@@ -661,14 +661,14 @@ mod test {
     ) -> ockam::Result<()> {
         let portal_inlet_address = setup_only_worker(context).await;
 
-        //let's build the message to 90% of max. size
+        // let's build the message to 90% of max. size
         let mut zero_buffer: Vec<u8> = Vec::new();
         for _n in 0..(TEST_MAX_KAFKA_MESSAGE_SIZE as f64 * 0.9) as usize {
             zero_buffer.push(0);
         }
 
-        //you don't want to create a produce request since it would trigger
-        //a lot of side effects and we just want to validate the transport
+        // you don't want to create a produce request since it would trigger
+        // a lot of side effects and we just want to validate the transport
         let mut insanely_huge_tag = BTreeMap::new();
         insanely_huge_tag.insert(0, zero_buffer);
 
@@ -709,7 +709,7 @@ mod test {
                 .await?;
         }
 
-        //make sure every packet was received
+        // make sure every packet was received
         loop {
             if receiver.buffer.lock().unwrap().len() >= huge_outgoing_request.len() {
                 break;
@@ -734,6 +734,7 @@ mod test {
             route![],
             [255, 255, 255, 255].into(),
             PortRange::new(0, 0).unwrap(),
+            None,
         );
 
         // Random Identifier, doesn't affect the test
@@ -812,6 +813,7 @@ mod test {
             route![],
             [127, 0, 0, 1].into(),
             PortRange::new(0, 0).unwrap(),
+            None,
         );
         let portal_inlet_address = KafkaPortalWorker::create_inlet_side_kafka_portal(
             context,
@@ -825,7 +827,7 @@ mod test {
         .await?;
 
         let mut request_buffer = BytesMut::new();
-        //let's create a real kafka request and pass it through the portal
+        // let's create a real kafka request and pass it through the portal
         encode(
             &mut request_buffer,
             create_request_header(ApiKey::MetadataKey),

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/metadata_interceptor.rs
@@ -75,7 +75,7 @@ impl KafkaMessageInterceptor for OutletInterceptorImpl {
         let header = match result {
             Ok(header) => header,
             Err(_) => {
-                //the error doesn't contain any useful information
+                // the error doesn't contain any useful information
                 warn!("cannot decode request kafka header");
                 return Err(InterceptError::Io(Error::from(ErrorKind::InvalidData)));
             }
@@ -114,7 +114,7 @@ impl KafkaMessageInterceptor for OutletInterceptorImpl {
     ) -> Result<BytesMut, InterceptError> {
         let mut buffer = original.peek_bytes(0..original.len());
 
-        //we can/need to decode only mapped requests
+        // we can/need to decode only mapped requests
         let correlation_id = buffer
             .peek_bytes(0..4)
             .try_get_i32()
@@ -138,7 +138,7 @@ impl KafkaMessageInterceptor for OutletInterceptorImpl {
             let _header = match result {
                 Ok(header) => header,
                 Err(_) => {
-                    //the error doesn't contain any useful information
+                    // the error doesn't contain any useful information
                     warn!("cannot decode response kafka header");
                     return Err(InterceptError::Io(Error::from(ErrorKind::InvalidData)));
                 }

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/mod.rs
@@ -28,7 +28,7 @@ struct RequestInfo {
 
 type CorrelationId = i32;
 
-/// map shared across all kafka workers, since the client might request it
+/// Map shared across all kafka workers, since the client might request it
 /// only from one connection
 pub(super) type TopicUuidMap = Arc<Mutex<HashMap<String, String>>>;
 
@@ -77,7 +77,7 @@ impl KafkaMessageInterceptor for InletInterceptorImpl {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-///Wraps the content within every record batch
+/// Wraps the content within every record batch
 struct MessageWrapper {
     #[n(1)] consumer_decryptor_address: Address,
     #[n(2)] content: Vec<u8>

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
@@ -27,10 +27,10 @@ impl InletInterceptorImpl {
         context: &mut Context,
         mut original: BytesMut,
     ) -> Result<BytesMut, InterceptError> {
-        //let's clone the view of the buffer without cloning the content
+        // let's clone the view of the buffer without cloning the content
         let mut buffer = original.peek_bytes(0..original.len());
 
-        //we can/need to decode only mapped requests
+        // we can/need to decode only mapped requests
         let correlation_id = buffer
             .peek_bytes(0..4)
             .try_get_i32()
@@ -53,7 +53,7 @@ impl InletInterceptorImpl {
             let header = match result {
                 Ok(header) => header,
                 Err(_) => {
-                    //the error doesn't contain any useful information
+                    // the error doesn't contain any useful information
                     warn!("cannot decode response kafka header");
                     return Err(InterceptError::Io(Error::from(ErrorKind::InvalidData)));
                 }
@@ -110,7 +110,7 @@ impl InletInterceptorImpl {
         Ok(original)
     }
 
-    //for metadata we want to replace broker address and port
+    // for metadata we want to replace broker address and port
     // to dedicated tcp inlet ports
     async fn handle_metadata_response(
         &self,
@@ -122,8 +122,8 @@ impl InletInterceptorImpl {
     ) -> Result<BytesMut, InterceptError> {
         let mut response: MetadataResponse = decode_body(buffer, request_info.request_api_version)?;
 
-        //we need to keep a map of topic uuid to topic name since fetch
-        //operations only use uuid
+        // we need to keep a map of topic uuid to topic name since fetch
+        // operations only use uuid
         if request_info.request_api_version >= 10 {
             for (topic_name, topic) in &response.topics {
                 let topic_id = topic.topic_id.to_string();
@@ -176,9 +176,9 @@ impl InletInterceptorImpl {
         let mut response: FindCoordinatorResponse =
             decode_body(buffer, request_info.request_api_version)?;
 
-        //similarly to metadata, we want to expressed the coordinator using
-        //local sidecar ip address
-        //the format changed to array since version 4
+        // similarly to metadata, we want to expressed the coordinator using
+        // local sidecar ip address
+        // the format changed to array since version 4
         if request_info.request_api_version >= 4 {
             for coordinator in response.coordinators.iter_mut() {
                 let inlet_address: SocketAddr = inlet_map
@@ -218,9 +218,9 @@ impl InletInterceptorImpl {
     ) -> Result<BytesMut, InterceptError> {
         let mut response: FetchResponse = decode_body(buffer, request_info.request_api_version)?;
 
-        //in every response we want to decrypt the message content
-        //we take every record batch content, unwrap and decode it
-        //using the relative secure channel
+        // in every response we want to decrypt the message content
+        // we take every record batch content, unwrap and decode it
+        // using the relative secure channel
         for response in response.responses.iter_mut() {
             for partition in response.partitions.iter_mut() {
                 if let Some(content) = partition.records.take() {

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -64,6 +64,7 @@ mod test {
             route![],
             [127, 0, 0, 1].into(),
             PortRange::new(0, 0).unwrap(),
+            None,
         );
 
         let interceptor = InletInterceptorImpl::new(

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
@@ -55,6 +55,6 @@ pub(crate) fn encode_response<H: Encodable, T: Encodable>(
 }
 
 pub(super) fn string_to_str_bytes(ip_address: String) -> StrBytes {
-    //TryFrom is broken, ugly but effective
+    // TryFrom is broken, ugly but effective
     unsafe { StrBytes::from_utf8_unchecked(bytes::Bytes::from(ip_address)) }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -69,13 +69,13 @@ impl StartKafkaOutletRequest {
 #[derive(Debug, Clone, Decode, Encode)]
 #[rustfmt::skip]
 #[cbor(map)]
-pub struct StartKafkaConsumerRequest {
+pub struct StartKafkaRequest {
     #[n(1)] pub bootstrap_server_addr: SocketAddr,
     #[n(2)] brokers_port_range: (u16, u16),
-    #[n(3)] project_route: String,
+    #[n(3)] project_route: MultiAddr,
 }
 
-impl StartKafkaConsumerRequest {
+impl StartKafkaRequest {
     pub fn new(
         bootstrap_server_addr: SocketAddr,
         brokers_port_range: impl Into<(u16, u16)>,
@@ -84,7 +84,7 @@ impl StartKafkaConsumerRequest {
         Self {
             bootstrap_server_addr,
             brokers_port_range: brokers_port_range.into(),
-            project_route: project_route.to_string(),
+            project_route,
         }
     }
 
@@ -94,41 +94,8 @@ impl StartKafkaConsumerRequest {
     pub fn brokers_port_range(&self) -> (u16, u16) {
         self.brokers_port_range
     }
-    pub fn project_route(&self) -> &String {
-        &self.project_route
-    }
-}
-
-#[derive(Debug, Clone, Decode, Encode)]
-#[rustfmt::skip]
-#[cbor(map)]
-pub struct StartKafkaProducerRequest {
-    #[n(1)] pub bootstrap_server_addr: SocketAddr,
-    #[n(2)] brokers_port_range: (u16, u16),
-    #[n(3)] project_route: String,
-}
-
-impl StartKafkaProducerRequest {
-    pub fn new(
-        bootstrap_server_addr: SocketAddr,
-        brokers_port_range: impl Into<(u16, u16)>,
-        project_route: MultiAddr,
-    ) -> Self {
-        Self {
-            bootstrap_server_addr,
-            brokers_port_range: brokers_port_range.into(),
-            project_route: project_route.to_string(),
-        }
-    }
-
-    pub fn bootstrap_server_addr(&self) -> SocketAddr {
-        self.bootstrap_server_addr
-    }
-    pub fn brokers_port_range(&self) -> (u16, u16) {
-        self.brokers_port_range
-    }
-    pub fn project_route(&self) -> &String {
-        &self.project_route
+    pub fn project_route(&self) -> MultiAddr {
+        self.project_route.clone()
     }
 }
 
@@ -139,7 +106,7 @@ pub struct StartKafkaDirectRequest {
     #[n(1)] bind_address: SocketAddr,
     #[n(2)] bootstrap_server_addr: SocketAddr,
     #[n(3)] brokers_port_range: (u16, u16),
-    #[n(4)] consumer_route: Option<String>,
+    #[n(4)] consumer_route: Option<MultiAddr>,
 }
 
 impl StartKafkaDirectRequest {
@@ -153,7 +120,7 @@ impl StartKafkaDirectRequest {
             bind_address,
             bootstrap_server_addr,
             brokers_port_range: brokers_port_range.into(),
-            consumer_route: consumer_route.map(|a| a.to_string()),
+            consumer_route,
         }
     }
 
@@ -166,7 +133,7 @@ impl StartKafkaDirectRequest {
     pub fn brokers_port_range(&self) -> (u16, u16) {
         self.brokers_port_range
     }
-    pub fn consumer_route(&self) -> Option<String> {
+    pub fn consumer_route(&self) -> Option<MultiAddr> {
         self.consumer_route.clone()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
@@ -28,7 +28,11 @@ pub struct ArgOpts {
     pub bootstrap_server: SocketAddr,
 }
 
-pub async fn start(ctx: &Context, opts: CommandGlobalOpts, args: ArgOpts) -> miette::Result<()> {
+pub async fn async_run(
+    ctx: &Context,
+    opts: CommandGlobalOpts,
+    args: ArgOpts,
+) -> miette::Result<()> {
     initialize_default_node(ctx, &opts).await?;
     let ArgOpts {
         endpoint,

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use crate::kafka::direct::command::{start, ArgOpts};
+use crate::kafka::direct::command::{async_run, ArgOpts};
 use crate::kafka::util::make_brokers_port_range;
 use crate::util::async_cmd;
 use crate::{
@@ -27,7 +27,7 @@ pub struct CreateCommand {
     /// In case just a port is specified, the default loopback address (127.0.0.1) will be used
     #[arg(long, default_value_t = kafka_default_consumer_server(), value_parser = socket_addr_parser)]
     bind_address: SocketAddr,
-    /// The address of the kafka bootstrap broke
+    /// The address of the kafka bootstrap broker
     #[arg(long, default_value_t = kafka_default_outlet_server())]
     bootstrap_server: SocketAddr,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
@@ -55,7 +55,7 @@ impl CreateCommand {
             bootstrap_server: self.bootstrap_server,
         };
         async_cmd(&cmd_name, opts.clone(), |ctx| async move {
-            start(&ctx, opts, args_opts).await
+            async_run(&ctx, opts, args_opts).await
         })
     }
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -21,7 +21,6 @@ use crate::{
 pub struct CreateCommand {
     #[command(flatten)]
     node_opts: NodeOpts,
-
     /// The local address of the service
     #[arg(long, default_value_t = kafka_producer_default_addr())]
     addr: String,

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -4,7 +4,7 @@ use colorful::Colorful;
 use tokio::{sync::Mutex, try_join};
 
 use ockam::Context;
-use ockam_api::nodes::models::services::{StartKafkaProducerRequest, StartServiceRequest};
+use ockam_api::nodes::models::services::{StartKafkaRequest, StartServiceRequest};
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_api::port_range::PortRange;
 use ockam_core::api::Request;
@@ -59,7 +59,7 @@ pub async fn async_run(
     let send_req = async {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &node_opts.at_node).await?;
 
-        let payload = StartKafkaProducerRequest::new(
+        let payload = StartKafkaRequest::new(
             bootstrap_server.to_owned(),
             brokers_port_range,
             project_route,


### PR DESCRIPTION
- `kafka consumer` and `kafka producer` commands expect a `project_route` argument, which implies that the services created in those commands will have a special policy to check the project id
- `kafka outlet` and `kafka direct` commands do not expect any project related data, so it uses a policy depending on the target route 

Additionally, it closes https://github.com/build-trust/ockam/issues/7544