### PR TITLE
feat(rust): add `variables` section to the `run` config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// Defines the high-level structure of the configuration file.
 ///
-/// The fields of this struct represents a section of the configuration file. Each section
+/// The fields of this struct represent a section of the configuration file. Each section
 /// is a list of resources, which, in turn, can be defined in different ways, depending
 /// on the nature of the underlying commands.
 ///
@@ -43,11 +43,8 @@ pub struct Config {
 
 impl Config {
     pub fn parse(contents: &str) -> miette::Result<Self> {
-        // Resolve environment variables
-        let resolved = shellexpand::env(&contents).into_diagnostic()?.to_string();
         // Parse variables section and resolve them
-        let variables: Variables = serde_yaml::from_str(&resolved).into_diagnostic()?;
-        let resolved = variables.resolve(&resolved)?;
+        let resolved = Variables::resolve(contents)?;
         // Parse the configuration
         serde_yaml::from_str(&resolved).into_diagnostic()
     }
@@ -241,12 +238,12 @@ mod tests {
             variables:
               prefix: ockam
               ticket_path: ./path/to/ticket
-              
-            ticket: #{ticket_path}
-            
+
+            ticket: ${ticket_path}
+
             nodes:
-              - #{prefix}_n1_${SUFFIX}
-              - #{prefix}_n2_${SUFFIX}
+              - ${prefix}_n1_${SUFFIX}
+              - ${prefix}_n2_${SUFFIX}
         "#;
         let parsed = Config::parse(config).unwrap();
         let expected = Config {

--- a/implementations/rust/ockam/ockam_command/src/run/parser/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/mod.rs
@@ -7,6 +7,7 @@ mod relays;
 mod resources;
 mod tcp_inlets;
 mod tcp_outlets;
+mod variables;
 mod vaults;
 mod version;
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/projects.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/projects.rs
@@ -1,6 +1,6 @@
 use crate::project::EnrollCommand;
 
-use crate::run::parser::resources::{parse_cmd_from_args, resolve, ArgValue};
+use crate::run::parser::resources::parse_cmd_from_args;
 use crate::run::parser::ArgsToCommands;
 use crate::OckamSubcommand;
 use miette::{miette, Result};
@@ -22,9 +22,7 @@ impl ArgsToCommands<EnrollCommand> for Projects {
             Err(miette!("Failed to parse command"))
         };
         match self.ticket {
-            Some(path_or_contents) => {
-                get_subcommand(&[resolve(&ArgValue::String(path_or_contents))]).map(|c| vec![c])
-            }
+            Some(path_or_contents) => get_subcommand(&[path_or_contents]).map(|c| vec![c]),
             None => Ok(vec![]),
         }
     }
@@ -45,9 +43,8 @@ mod tests {
         let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
 
         // As contents
-        std::env::set_var("ENROLLMENT_TICKET", &enrollment_ticket_hex);
-        let config = "ticket: $ENROLLMENT_TICKET";
-        let parsed: Projects = serde_yaml::from_str(config).unwrap();
+        let config = format!("ticket: {enrollment_ticket_hex}");
+        let parsed: Projects = serde_yaml::from_str(&config).unwrap();
         let cmds = parsed.into_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].enroll_ticket.as_ref().unwrap(), &enrollment_ticket);

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resources.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resources.rs
@@ -189,7 +189,7 @@ pub fn as_command_arg(k: ArgKey, v: ArgValue) -> Vec<String> {
                 vec![]
             }
         }
-        v => vec![as_keyword_arg(&k), resolve(&v)],
+        v => vec![as_keyword_arg(&k), v.to_string()],
     }
 }
 
@@ -202,22 +202,6 @@ pub fn as_keyword_arg(k: &ArgKey) -> String {
     // Otherwise, it's the long version of the argument.
     else {
         format!("--{k}")
-    }
-}
-
-/// Resolve environment variables if applicable
-pub fn resolve(v: &ArgValue) -> String {
-    match v {
-        ArgValue::String(v) => {
-            if v.contains('$') {
-                return shellexpand::env(v)
-                    .expect("Failed to resolve environment variables")
-                    .to_string();
-            }
-            v.to_string()
-        }
-        ArgValue::Int(v) => v.to_string(),
-        ArgValue::Bool(v) => v.to_string(),
     }
 }
 
@@ -236,23 +220,4 @@ pub fn parse_cmd_from_args(cmd: &str, args: &[String]) -> Result<OckamSubcommand
 
 pub trait ArgsToCommands<T> {
     fn into_commands(self) -> Result<Vec<T>>;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_env_vars() {
-        // Set a random env var
-        std::env::set_var("MY_ENV_VAR", "my_env_var_value");
-
-        // Simple case: the arg value is the name of an environment variable
-        let v = resolve(&ArgValue::String("$MY_ENV_VAR".into()));
-        assert_eq!(&v, "my_env_var_value");
-
-        // Complex case: the arg value contains the name of an environment variable
-        let v = resolve(&ArgValue::String("foo $MY_ENV_VAR bar".into()));
-        assert_eq!(&v, "foo my_env_var_value bar");
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resources.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resources.rs
@@ -4,6 +4,7 @@ use miette::{IntoDiagnostic, Result};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt::Display;
 
 static BINARY_PATH: Lazy<String> = Lazy::new(|| {
     std::env::args()
@@ -161,6 +162,17 @@ impl From<&str> for ArgValue {
             return ArgValue::Bool(v);
         }
         ArgValue::String(s.to_string())
+    }
+}
+
+impl Display for ArgValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            ArgValue::String(v) => v.to_string(),
+            ArgValue::Int(v) => v.to_string(),
+            ArgValue::Bool(v) => v.to_string(),
+        };
+        write!(f, "{}", str)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
@@ -1,0 +1,125 @@
+use crate::run::parser::resources::{ArgKey, ArgValue};
+use miette::{miette, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Variables {
+    pub variables: Option<BTreeMap<ArgKey, ArgValue>>,
+}
+
+impl Variables {
+    const VAR_SIGN: char = '#';
+    const VAR_START: char = '{';
+    const VAR_END: char = '}';
+
+    pub fn resolve(&self, contents: &str) -> Result<String> {
+        let env = self.load()?;
+        let mut resolved = contents.to_string();
+        for (k, v) in env.iter() {
+            let from = format!(
+                "{}{}{}{}",
+                Variables::VAR_SIGN,
+                Variables::VAR_START,
+                k,
+                Variables::VAR_END
+            );
+            resolved = resolved.replace(&from, v);
+        }
+        Ok(resolved)
+    }
+
+    fn load(&self) -> Result<BTreeMap<String, String>> {
+        let mut env = BTreeMap::new();
+        if let Some(vars) = &self.variables {
+            for (k, v) in vars {
+                let v = v.to_string();
+                self.validate(k, &v)?;
+                env.insert(k.clone(), v);
+            }
+        }
+        Ok(env)
+    }
+
+    fn validate(&self, k: &ArgKey, v: &str) -> Result<()> {
+        // Check variable name
+        if k.contains([
+            Variables::VAR_SIGN,
+            Variables::VAR_START,
+            Variables::VAR_END,
+        ]) {
+            return Err(miette!("The variable name '{k}' is not valid"));
+        }
+        // Check variable value
+        if let Some(sign_pos) = v.find(Variables::VAR_SIGN) {
+            // if the next character is Variables::VAR_START and
+            // contains a Variables::VAR_END after that, then it's a variable
+            if v.chars().nth(sign_pos + 1) == Some(Variables::VAR_START) {
+                if let Some(end_pos) = v.find(Variables::VAR_END) {
+                    if end_pos > sign_pos {
+                        return Err(miette!(
+                            "The value '{v}' of the variable '{k}' can't contain another variable"
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_variables() {
+        std::env::set_var("VALUE", "my_env_value");
+        let yaml = r#"
+            variables:
+              var_s: $VALUE
+              var_b: true
+              var_i: 1
+        "#;
+        let vars = serde_yaml::from_str::<Variables>(yaml).unwrap();
+        let template = "#{var_s} is_#{var_b} num_#{var_i}";
+        let resolved = vars.resolve(template).unwrap();
+        assert_eq!(resolved, "$VALUE is_true num_1");
+    }
+
+    #[test]
+    fn leave_unknown_variables_unresolved() {
+        let yaml = r#"
+            variables:
+              var_s: value
+        "#;
+        let vars = serde_yaml::from_str::<Variables>(yaml).unwrap();
+        let template = "my_#{var_s} is_#{var_b} num_#{var_i}";
+        let resolved = vars.resolve(template).unwrap();
+        assert_eq!(resolved, "my_value is_#{var_b} num_#{var_i}");
+    }
+
+    #[test]
+    fn fail_if_invalid_variable_name() {
+        let yaml = r#"
+            variables:
+              var{}_s: value
+        "#;
+        let vars = serde_yaml::from_str::<Variables>(yaml).unwrap();
+        let template = "";
+        let result = vars.resolve(template);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn fail_if_invalid_variable_value() {
+        let yaml = r#"
+            variables:
+              var_s: '#{var_s}'
+        "#;
+        let vars = serde_yaml::from_str::<Variables>(yaml).unwrap();
+        let template = "";
+        let result = vars.resolve(template);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
This new section allows you to define local variables. It will also resolve (and give preference to) externally defined env vars. 


For example, if we externally set `MY_ENV_VAR=my_env_value` and `var_s=external`, the following yaml:

```yaml
variables:
  var_s: local
  var_b: true
  var_i: 1

nodes: 
  - ${MY_ENV_VAR}-${var_s}
  - is_${var_b}
  - num_${var_i}
```

would get resolved to:

```yaml
nodes: 
  - my_env_value-external
  - is_true
  - num_1
```