### PR TITLE
feat(elixir): add new option to require credentials on secure channels

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/secure_channel/channel.ex
@@ -501,7 +501,7 @@ defmodule Ockam.SecureChannel.Channel do
   defp process_credentials([], _peer_identity_id, _authorities, true),
     do: {:error, :expected_peer_credential}
 
-  defp process_credentials([cred], peer_identity_id, authorities, _) do
+  defp process_credentials([cred], peer_identity_id, authorities, _require_peer_credential) do
     case Identity.verify_credential(peer_identity_id, authorities, cred) do
       {:ok, attribute_set} ->
         AttributeStorage.put_attribute_set(peer_identity_id, attribute_set)
@@ -511,7 +511,7 @@ defmodule Ockam.SecureChannel.Channel do
     end
   end
 
-  defp process_credentials(_creds, _peer_identity_id, _authorities, _),
+  defp process_credentials(_creds, _peer_identity_id, _authorities, _require_peer_credential),
     do: {:error, :multiple_credentials}
 
   defp split(k1, k2, :initiator),

--- a/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/secure_channel_test.exs
@@ -600,6 +600,59 @@ defmodule Ockam.SecureChannel.Tests do
     assert bob_new_attributes == AttributeStorage.get_attributes(bob_id)
   end
 
+  test "credential are required", %{
+    alice: alice,
+    bob: bob
+  } do
+    {:ok, authority} = Identity.create()
+
+    alice_attributes = %{"role" => "server"}
+    alice_id = Identity.get_identifier(alice)
+    bob_id = Identity.get_identifier(bob)
+    {:ok, keypair} = Crypto.generate_dh_keypair()
+    {:ok, attestation} = Identity.attest_purpose_key(alice, keypair)
+
+    {:ok, alice_credential} =
+      Identity.issue_credential(authority, alice_id, alice_attributes, 100)
+
+    {:ok, listener} =
+      SecureChannel.create_listener(
+        identity: alice,
+        encryption_options: [static_keypair: keypair, static_key_attestation: attestation],
+        authorities: [authority],
+        credentials: [alice_credential],
+        require_peer_credential: true
+      )
+
+    bob_attributes = %{"role" => "member"}
+    {:ok, keypair} = Crypto.generate_dh_keypair()
+    {:ok, attestation} = Identity.attest_purpose_key(bob, keypair)
+
+    {:ok, channel} =
+      SecureChannel.create_channel(
+        [
+          identity: bob,
+          encryption_options: [static_keypair: keypair, static_key_attestation: attestation],
+          route: [listener],
+          authorities: [authority],
+          credentials: []
+        ],
+        3000
+      )
+
+    {:ok, me} = Ockam.Node.register_random_address()
+
+    Router.route("PING!", [channel, me], [me])
+
+    # The secure channel is not established, because the listener side require credentials
+    refute_receive %Ockam.Message{
+      onward_route: [^me],
+      payload: "PING!",
+      return_route: [_channel, ^me],
+      local_metadata: %{identity_id: ^bob_id, channel: :secure_channel}
+    }
+  end
+
   defp create_secure_channel_listener() do
     {:ok, identity} = Identity.create()
     create_secure_channel_listener(identity)


### PR DESCRIPTION
require_peer_credential: true|false (default to false).  If set to true, the secure channel won't be established if the peer doesn't present a valid credential.
