### PR TITLE
docs: add kubernetes example to show portals to postgres

### DIFF
--- a/examples/command/portals/databases/postgres/docker/analysis_corp/app.js
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/app.js
@@ -9,8 +9,8 @@ const clientConfig = { host: "ockam", port: 15432, user: "postgres", password: "
 // Attempt to connect to the database in a loop.
 //
 // Since all the containers may take a few seconds to start up.
-// We'll attempt to connect in a loop once every five seconds by default.
-async function connect(attempts = 20, waitTimeBetweenAttempts = 5000) {
+// We'll attempt to connect in a loop once every 10 seconds by default.
+async function connect(attempts = 100, waitTimeBetweenAttempts = 10000) {
   while (attempts--) {
     const client = new Client(clientConfig);
     try {
@@ -53,7 +53,7 @@ async function run() {
 
     console.log(
       "\nThe example run was successful 🥳.\n" +
-        "\nWe connected with the database through an encrypted portal." +
+        "\nThe app connected with the database through an encrypted portal." +
         "\nCreated a table, inserted some data, and querried it back.\n",
     );
   } catch (err) {

--- a/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 # This script is used as an entrypoint to a docker container built using ../ockam.dockerfile.
 
@@ -24,10 +24,10 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # attribute postgres-outlet="true" to connect to TCP Portal Inlets on this node.
 #
 # Create a TCP Portal Inlet to postgres.
-# This makes the remote postgres available on localhost IPs at - 0.0.0.0:15432
+# This makes the remote postgres available on all localhost IPs at - 0.0.0.0:15432
 ockam node create
 ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
-ockam tcp-inlet create --from 0.0.0.0:15432 --to postgres
+until ockam tcp-inlet create --from 0.0.0.0:15432 --to postgres; do sleep 10; done
 
 # Run the container forever.
 tail -f /dev/null

--- a/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 # This script is used as an entrypoint to a docker container built using ../ockam.dockerfile.
 

--- a/examples/command/portals/databases/postgres/docker/run.sh
+++ b/examples/command/portals/databases/postgres/docker/run.sh
@@ -44,7 +44,7 @@ run() {
     # The identity that enrolls with the generated ticket will be given a project membership
     # credential in which the project membership authority will cryptographically attest to the
     # specified attributes - postgres-inlet=true.
-    anaysis_corp_ticket=$(ockam project ticket --usage-count 1 --expires-in 10m \
+    analysis_corp_ticket=$(ockam project ticket --usage-count 1 --expires-in 10m \
         --attribute "postgres-inlet=true")
 
     # Invoke `docker-compose up` in the directory that has bank_corp's configuration.
@@ -54,35 +54,31 @@ run() {
     # in bank_corp's virtual private network.
     echo; pushd bank_corp; ENROLLMENT_TICKET="$bank_corp_ticket" docker-compose up -d; popd
 
-    # Wait 30 seconds, to give the outlet and relay some time to be ready.
-    sleep 30
-
     # Invoke `docker-compose up` in the directory that has analysis_corp's configuration.
     # Pass the above enrollment ticket as an environment variable.
     #
     # Read analysis_corp/docker-compose.yml to understand the parts that are provisioned
     # in analysis_corp's virtual private network.
-    echo; pushd analysis_corp; ENROLLMENT_TICKET="$anaysis_corp_ticket" docker-compose up; popd
+    echo; pushd analysis_corp; ENROLLMENT_TICKET="$analysis_corp_ticket" docker-compose up; popd
 }
 
 # Cleanup after the example - `./run.sh cleanup`
 # Remove all containers and images pulled or created by docker compose.
 cleanup() {
-    for d in bank_corp analysis_corp; do
-        pushd "$d"; docker-compose down --rmi all --remove-orphans; popd
-    done
+    pushd bank_corp; docker-compose down --rmi all --remove-orphans; popd
+    pushd analysis_corp; docker-compose down --rmi all --remove-orphans; popd
 }
 
 # Check if Ockam Command is already installed and available in path.
 # If it's not, then install it.
-type ockam >/dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
+type ockam &>/dev/null || curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
 source "$HOME/.ockam/env"
 
 # Check that tools we we need installed.
 for c in docker docker-compose curl; do
-    command -v "$c" >/dev/null 2>&1 || { echo "ERROR: $c is not installed." && exit 1; }
+    command -v "$c" &>/dev/null || { echo "ERROR: Please install: $c" && exit 1; }
 done
 
 # Check if the first argument is "cleanup"
 # If it is, call the cleanup function. If not, call the run function.
-[[ "$1" == "cleanup" ]] && cleanup || run
+if [[ "$1" == "cleanup" ]]; then cleanup; else run; fi

--- a/examples/command/portals/databases/postgres/kubernetes/README.md
+++ b/examples/command/portals/databases/postgres/kubernetes/README.md
@@ -1,0 +1,9 @@
+# Kubernetes
+
+This hands-on example uses Ockam to create an end-to-end encrypted portal to postgres.
+
+We connect a nodejs app in one private kubernetes cluster with a postgres database in another
+private kubernetes cluster. The example uses docker and kind to create these kubernetes clusters.
+
+You can read a detailed walkthough of this example at:
+https://docs.ockam.io/portals/databases/postgres/kubernetes

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/app.dockerfile
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/app.dockerfile
@@ -1,0 +1,16 @@
+# This dockerfile builds an image that contains nodejs.
+#
+# It also copies a bash script called run_ockam.sh from its build directory
+# into the image being built and uses that script as entrypoint to containers
+# that are run using this image.
+#
+# The run_ockam.sh script is used to setup an ockam node.
+
+FROM cgr.dev/chainguard/node
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+RUN npm install pg
+COPY --chown=node:node app.js app.js
+ENTRYPOINT [ "node", "app.js" ]

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/app.js
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/app.js
@@ -1,0 +1,67 @@
+const { Client } = require("pg");
+
+// Configuration to connect to the postgres database on - localhost:15432
+//
+// localhost:15432 is the inlet address of the tcp portal to postgres.
+// This inlet is local to analysis_corp, the postgres database is remote in bank_corp.
+const clientConfig = { host: "localhost", port: 15432, user: "postgres", password: "postgres", database: "test" };
+
+// Attempt to connect to the database in a loop.
+//
+// Since all the containers may take a few seconds to start up.
+// We'll attempt to connect in a loop once every 10 seconds by default.
+async function connect(attempts = 100, waitTimeBetweenAttempts = 10000) {
+  while (attempts--) {
+    const client = new Client(clientConfig);
+    try {
+      await client.connect();
+      console.log("Connected to the database.\n");
+      return client;
+    } catch (err) {
+      console.log(`Couldn't connect to the database: ${err.message}, retrying ...`);
+      await client.end();
+      if (attempts == 0) throw err;
+      await new Promise((resolve) => setTimeout(resolve, waitTimeBetweenAttempts));
+    }
+  }
+}
+
+// This function is the core of our example app.
+//
+// We connect to the database through the inlet.
+// Create a new table called users, if it doesn't already exist.
+// We then insert some data into the users table and query it back.
+//
+// Finally we print that our app, running in analysis_corp was able
+// to successfully connect and use the postgres database in bank_corp
+// through an encrypted portal.
+async function run() {
+  const client = await connect();
+  try {
+    console.log("Creating users table ...");
+    await client.query(`CREATE TABLE IF NOT EXISTS users (name VARCHAR(255), score INTEGER)`);
+
+    console.log("Inserting some data into the users table ...");
+    const users = ["Alice", "Bob", "Charlie"].map((name) => ({ name, score: Math.floor(Math.random() * 101) }));
+    for (const user of users) {
+      await client.query(`INSERT INTO users (name, score) VALUES ($1, $2)`, [user.name, user.score]);
+    }
+
+    console.log("Querying the users table ...");
+    const res = await client.query(`SELECT * FROM users`);
+    console.log("USERS:", res.rows);
+
+    console.log(
+      "\nThe example run was successful 🥳.\n" +
+        "\nThe app connected with the database through an encrypted portal." +
+        "\nCreated a table, inserted some data, and querried it back.\n",
+    );
+  } catch (err) {
+    console.error("Error:", err.message);
+  } finally {
+    await client.end();
+    console.log("Disconnected from the database.");
+  }
+}
+
+run();

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/pod.yml
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/pod.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-ockam-pod
+  labels:
+    app: app-ockam
+spec:
+  containers:
+    # Start the app.
+    #
+    # Read app.dockerfile and app.js to understand what
+    # the app is doing.
+    - name: app
+      image: app:v1
+
+    # Start an ockam node.
+    #
+    # Read ../ockam.dockerfile and run_ockam.sh to understand
+    # how the node is set up.
+    - name: ockam
+      image: ockam_node_analysis_corp:v1
+      volumeMounts:
+        - name: ockam-node-enrollment-ticket-volume
+          mountPath: /etc/ockam/enrollment
+          readOnly: true
+
+  # Turn the enrollment ticket secret into a volume.
+  volumes:
+    - name: ockam-node-enrollment-ticket-volume
+      secret:
+        secretName: ockam-node-enrollment-ticket

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -ex
+
+# This script is used as an entrypoint to a docker container built using ../ockam.dockerfile.
+
+# Run `ockam project enroll ...`
+#
+# The `project enroll` command creates a new vault and generates a cryptographic identity with
+# private keys stored in that vault.
+#
+# The enrollment ticket includes routes and identitifiers for the project membership authority
+# and the project’s node that offers the relay service.
+#
+# The enrollment ticket also includes an enrollment token. The project enroll command
+# creates a secure channel with the project membership authority and presents this enrollment token.
+# The authority enrolls presented identity and returns a project membership credential.
+#
+# The command, stores this credential for later use and exits.
+ockam project enroll /etc/ockam/enrollment/ticket
+
+# Create an ockam node.
+#
+# Create an access control policy that only allows project members that possesses a credential with
+# attribute postgres-outlet="true" to connect to TCP Portal Inlets on this node.
+#
+# Create a TCP Portal Inlet to postgres.
+# This makes the remote postgres available on localhost:15432
+ockam node create
+ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
+until ockam tcp-inlet create --from 0.0.0.0:15432 --to postgres; do sleep 10; done
+
+# Run the container forever.
+tail -f /dev/null

--- a/examples/command/portals/databases/postgres/kubernetes/bank_corp/pod.yml
+++ b/examples/command/portals/databases/postgres/kubernetes/bank_corp/pod.yml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres-ockam-pod
+  labels:
+    app: postgres-ockam
+spec:
+  containers:
+    # Start postgres.
+    - name: postgres
+      image: cgr.dev/chainguard/postgres
+      env:
+        - name: POSTGRES_USER
+          value: "postgres"
+        - name: POSTGRES_PASSWORD
+          value: "postgres"
+        - name: POSTGRES_DB
+          value: "test"
+
+    # Start an ockam node.
+    #
+    # Read ../ockam.dockerfile and run_ockam.sh to understand
+    # how the node is set up.
+    - name: ockam
+      image: ockam_node_bank_corp:v1
+      volumeMounts:
+        - name: ockam-node-enrollment-ticket-volume
+          mountPath: /etc/ockam/enrollment
+          readOnly: true
+
+  # Turn the enrollment ticket secret into a volume.
+  volumes:
+    - name: ockam-node-enrollment-ticket-volume
+      secret:
+        secretName: ockam-node-enrollment-ticket

--- a/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ex
+
+# This script is used as an entrypoint to a docker container built using ../ockam.dockerfile.
+
+# Run `ockam project enroll ...`
+#
+# The `project enroll` command creates a new vault and generates a cryptographic identity with
+# private keys stored in that vault.
+#
+# The enrollment ticket includes routes and identitifiers for the project membership authority
+# and the project’s node that offers the relay service.
+#
+# The enrollment ticket also includes an enrollment token. The project enroll command
+# creates a secure channel with the project membership authority and presents this enrollment token.
+# The authority enrolls presented identity and returns a project membership credential.
+#
+# The command, stores this credential for later use and exits.
+ockam project enroll /etc/ockam/enrollment/ticket
+
+# Create an ockam node.
+#
+# Create an encrypted relay to this node in the project at address: postgres.
+# The relay makes this node reachable by other project members.
+#
+# Create an access control policy that only allows project members that possesses a credential with
+# attribute postgres-inlet="true" to connect to TCP Portal Outlets on this node.
+#
+# Create a TCP Portal Outlet to postgres at - localhost:5432.
+ockam node create
+ockam relay create postgres
+ockam policy create --resource tcp-output --expression '(= subject.postgres-inlet "true")'
+ockam tcp-outlet create --to 5432
+
+# Run the container forever.
+tail -f /dev/null

--- a/examples/command/portals/databases/postgres/kubernetes/ockam.dockerfile
+++ b/examples/command/portals/databases/postgres/kubernetes/ockam.dockerfile
@@ -1,0 +1,19 @@
+# This dockerfile builds an image that contains bash and ockam command.
+#
+# It also copies a bash script called run_ockam.sh from its build directory
+# into the image being built and uses that script as entrypoint to containers
+# that are run using this image.
+#
+# The run_ockam.sh script is used to set up and start an ockam node.
+#
+# Read bank_corp/run_ockam.sh and analysis_corp/run_ockam.sh to understand
+# how each node is set up.
+
+FROM ghcr.io/build-trust/ockam as builder
+
+FROM cgr.dev/chainguard/bash
+COPY --from=builder /ockam /usr/local/bin/ockam
+
+COPY run_ockam.sh /run_ockam.sh
+RUN chmod +x /run_ockam.sh
+ENTRYPOINT ["/run_ockam.sh"]

--- a/examples/command/portals/databases/postgres/kubernetes/run.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/run.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -e
+
+# This script, `./run.sh ...` is invoked on a developer’s work machine.
+#
+# This hands-on example uses Ockam to create an end-to-end encrypted portal to postgres. We
+# connect a nodejs app in one private kubernetes cluster with a postgres database in another
+# private kubernetes cluster.
+#
+# The example uses docker and kind to create these kubernetes clusters.
+#
+# You can read a detailed walkthough of this example at:
+# https://docs.ockam.io/portals/databases/postgres/kubernetes
+
+run() {
+    # Run `ockam enroll`.
+    #
+    # The enroll command creates a new vault and generates a cryptographic identity with
+    # private keys stored in that vault. It then guides you to sign in to Ockam Orchestrator.
+    #
+    # If this is your first time signing in, the Orchestrator creates a new dedicated project
+    # for you. A project offers two services: a membership authority and a relay service.
+    #
+    # The enroll command then asks this project’s membership authority to sign and issue
+    # a credential that attests that your identifier is a member of this project. Since your
+    # account in Orchestrator is the creator and hence first administrator on this new project,
+    # the membership authority issues this credential. The enroll command stores the
+    # credential for later use and exits.
+    ockam enroll
+
+    # Create an enrollment ticket to enroll the identity used by an ockam node that will run
+    # adjacent to the postgres server in bank_corp's network.
+    #
+    # The identity that enrolls with the generated ticket will be given a project membership
+    # credential in which the project membership authority will cryptographically attest to the
+    # specified attributes - postgres-outlet=true.
+    #
+    # The identity will also allowed to create a relay in the project at the address `postgres`.
+    bank_corp_ticket=$(ockam project ticket --usage-count 1 --expires-in 10m \
+        --attribute "postgres-outlet=true" --relay postgres)
+
+    # Create an enrollment ticket to enroll the identity used by an ockam node that will run
+    # adjacent to the postgres client app in analysis_corp's network.
+    #
+    # The identity that enrolls with the generated ticket will be given a project membership
+    # credential in which the project membership authority will cryptographically attest to the
+    # specified attributes - postgres-inlet=true.
+    analysis_corp_ticket=$(ockam project ticket --usage-count 1 --expires-in 10m \
+        --attribute "postgres-inlet=true")
+
+    # Create bank_corp's kubernetes cluster.
+    #
+    # Read bank_corp/pod.yml to understand the parts that are provisioned
+    # in bank_corp's kubernetes cluster.
+    pushd bank_corp
+        # Create a kubernetes cluster called bank-corp
+        kind create cluster --name bank-corp
+        sleep 30
+
+        # Build the ockam_node_bank_corp:v1 docker image and load it into the bank-corp kubernetes cluster.
+        build_and_load_docker_image ockam_node_bank_corp:v1 ../ockam.dockerfile . bank-corp
+
+        # Pass the above enrollment ticket as a kubenetes secret.
+        kubectl create secret generic ockam-node-enrollment-ticket \
+            "--from-literal=ticket=$bank_corp_ticket" --context kind-bank-corp
+
+        # Apply the kubernetes manifest at bank_corp/pod.yaml
+        kubectl apply -f pod.yml --context kind-bank-corp
+    popd
+
+    # Create analysis_corp's kubernetes cluster.
+    #
+    # Read analysis_corp/pod.yml to understand the parts that are provisioned
+    # in bank_corp's kubernetes cluster.
+    pushd analysis_corp
+        # Create a kubernetes cluster called analysis-corp
+        kind create cluster --name analysis-corp
+        sleep 30
+
+        # Build ockam_node_analysis_corp:v1 and app:v1 docker images
+        # and load them into the analysis-corp kubernetes cluster.
+        build_and_load_docker_image ockam_node_analysis_corp:v1 ../ockam.dockerfile . analysis-corp
+        build_and_load_docker_image app:v1 app.dockerfile . analysis-corp
+
+        # Pass the above enrollment ticket as a kubenetes secret.
+        kubectl create secret generic ockam-node-enrollment-ticket \
+            "--from-literal=ticket=$analysis_corp_ticket" --context kind-analysis-corp
+
+        # Apply the kubernetes manifest at analysis_corp/pod.yaml
+        kubectl apply -f pod.yml --context kind-analysis-corp
+    popd
+
+    until kubectl logs --follow app-ockam-pod -c app --context kind-analysis-corp 2> /dev/null; do sleep 2; done
+}
+
+# Build a docker image and load it into a kubernetes cluster.
+build_and_load_docker_image() {
+    tag="$1"; dockerfile="$2"; context="$3"; cluster="$4"
+
+    docker buildx ls &> /dev/null && load="--load"
+    docker build "$load" --file "$dockerfile" --tag "$tag" "$context"
+    kind load docker-image "$tag" --name "$cluster"
+}
+
+# Cleanup after the example - `./run.sh cleanup`
+# Remove all clusters, containers, and images created by this example.
+cleanup() {
+    pushd bank_corp; kind delete cluster --name bank-corp; popd
+    pushd analysis_corp; kind delete cluster --name analysis-corp; popd
+    docker rmi ockam_node_bank_corp:v1 ockam_node_analysis_corp:v1 app:v1 2> /dev/null
+}
+
+# Check if Ockam Command is already installed and available in path.
+# If it's not, then install it.
+type ockam &>/dev/null || curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
+source "$HOME/.ockam/env"
+
+# Check that tools we we need installed.
+for c in docker kind kubectl curl; do
+    command -v "$c" &>/dev/null || { echo "ERROR: Please install: $c" && exit 1; }
+done
+
+# Check if the first argument is "cleanup"
+# If it is, call the cleanup function. If not, call the run function.
+if [ "$1" = "cleanup" ]; then cleanup; else run; fi


### PR DESCRIPTION
Similar to this https://docs.ockam.io/portals/databases/postgres/docker
But with two kubernetes clusters using Kind and Docker.

With docker, kind, and kubectl installed

```
# Navigate to this example’s directory.
cd examples/command/portals/databases/postgres/docker

# Run the example, use Ctrl-C to exit at any point.
./run.sh
```

You should see a message that looks like this:

```
Connected to the database.

Creating users table ...
Inserting some data into the users table ...
Querying the users table ...
USERS: [
  { name: 'Alice', score: 27 },
  { name: 'Bob', score: 42 },
  { name: 'Charlie', score: 66 },
]

The example run was successful 🥳.

We connected with the database through an encrypted portal.
Created a table, inserted some data, and querried it back.

Disconnected from the database.
```