### PR TITLE
feat(rust): tcp inlet creation will always optional validate unless `--no-connection-wait` is used`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -42,8 +42,8 @@ pub struct CreateInlet {
     #[n(7)] pub(crate) wait_for_outlet_duration: Option<Duration>,
     /// The expression for the access control policy
     #[n(8)] pub(crate) policy_expression: Option<Expr>,
-    /// Whether to synchronosly validate the connection with the outlet
-    #[n(9)] pub(crate) validate: bool,
+    /// Create the inlet and wait for the outlet to connect
+    #[n(9)] pub(crate) wait_connection: bool,
 }
 
 impl CreateInlet {
@@ -53,7 +53,7 @@ impl CreateInlet {
         alias: impl Into<String>,
         prefix_route: Route,
         suffix_route: Route,
-        validate: bool,
+        wait_connection: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -64,7 +64,7 @@ impl CreateInlet {
             suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
-            validate,
+            wait_connection,
         }
     }
 
@@ -75,7 +75,7 @@ impl CreateInlet {
         prefix_route: Route,
         suffix_route: Route,
         auth: Option<Identifier>,
-        validate: bool,
+        wait_connection: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -86,7 +86,7 @@ impl CreateInlet {
             suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
-            validate,
+            wait_connection,
         }
     }
 
@@ -182,6 +182,7 @@ pub struct InletStatus {
 }
 
 impl InletStatus {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bind_addr: impl Into<String>,
         worker_addr: impl Into<Option<String>>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
@@ -79,6 +79,7 @@ pub struct RelayInfo {
     #[n(6)] destination_address: MultiAddr,
     #[n(7)] alias: String,
     #[n(8)] at_rust_node: bool,
+    #[n(9)] last_failure: Option<String>,
 }
 
 impl RelayInfo {
@@ -97,6 +98,7 @@ impl RelayInfo {
             worker_address: None,
             flow_control_id: None,
             connection_status,
+            last_failure: None,
         }
     }
 
@@ -110,6 +112,21 @@ impl RelayInfo {
             destination_address: self.destination_address,
             alias: self.alias,
             at_rust_node: self.at_rust_node,
+            last_failure: self.last_failure,
+        }
+    }
+
+    pub fn with_last_failure(self, last_failure: String) -> Self {
+        Self {
+            forwarding_route: self.forwarding_route,
+            remote_address: self.remote_address,
+            worker_address: self.worker_address,
+            flow_control_id: self.flow_control_id,
+            connection_status: self.connection_status,
+            destination_address: self.destination_address,
+            alias: self.alias,
+            at_rust_node: self.at_rust_node,
+            last_failure: Some(last_failure),
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/session/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/mod.rs
@@ -192,8 +192,8 @@ impl Medic {
                 r = self.replacements.join_next(), if !self.replacements.is_empty() => match r {
                     None                  => log::debug!("no replacements"),
                     Some(Err(e))          => log::error!("task failed: {e:?}"),
-                    Some(Ok((key, Err(e)))) => {
-                        log::warn!(key = %key, err = %e, "replacing session failed");
+                    Some(Ok((key, Err(err)))) => {
+                        log::warn!(key = %key, err = %err, "replacing session failed");
                         if let Some(session) = self.session(&key).await {
                            session.down();
                         }

--- a/implementations/rust/ockam/ockam_api/src/session/sessions.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/sessions.rs
@@ -198,6 +198,7 @@ impl Session {
         inner.connection = ConnectionStatus::Up;
         inner.last_outcome = Some(replacer_outcome);
     }
+
     pub fn down(&self) {
         let mut inner = self.inner.lock().unwrap();
         inner.connection = ConnectionStatus::Down;

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals.bats
@@ -228,3 +228,18 @@ teardown() {
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:5000
   run_success curl --head --retry-connrefused --retry 2 --max-time 10 "127.0.0.1:$port"
 }
+
+@test "portals - local inlet and outlet in reverse order" {
+  inlet_port="$(random_port)"
+  node_port="$(random_port)"
+
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" tcp-inlet create --at /node/n1 --from "127.0.0.1:${inlet_port}" --to "/ip4/127.0.0.1/tcp/${node_port}/service/outlet"
+
+  run_success "$OCKAM" node create n2 --tcp-listener-address "127.0.0.1:${node_port}"
+  run_success "$OCKAM" tcp-outlet create --at /node/n2 --to 127.0.0.1:5000
+
+  sleep 30
+
+  run_success curl --fail --head --retry 2 --max-time 10 "127.0.0.1:${inlet_port}"
+}


### PR DESCRIPTION
- default create inlet behavior is to always validate but to keep trying anyway
- `--no-validation` is now `--no-connection-wait`

![Screenshot_20240215_133906](https://github.com/build-trust/ockam/assets/408088/4599da5b-0616-42fa-9a41-1d7627139e4a)


![Screenshot_20240215_133035](https://github.com/build-trust/ockam/assets/408088/f7997736-be01-4f5b-a1f9-7724418e6bc0)

