### PR TITLE
feat(rust): add `--if-not-enrolled` flag to `enroll` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
@@ -31,6 +31,21 @@ impl CliState {
             .await?)
     }
 
+    #[instrument(skip_all)]
+    pub async fn identity_should_enroll(&self, name: &Option<String>, force: bool) -> Result<bool> {
+        if force {
+            return Ok(true);
+        }
+
+        // Force enrollment if there are no spaces or projects in the database
+        if self.get_spaces().await?.is_empty() || self.get_projects().await?.is_empty() {
+            return Ok(true);
+        }
+
+        // Force enrollment if the identity is not enrolled
+        Ok(!self.is_identity_enrolled(name).await?)
+    }
+
     #[instrument(skip_all, fields(identifier = %identifier))]
     pub async fn set_identifier_as_enrolled(&self, identifier: &Identifier) -> Result<()> {
         Ok(self
@@ -165,3 +180,6 @@ impl EnrollmentTicket {
         Ok(hex::encode(serialized))
     }
 }
+
+#[cfg(test)]
+mod tests {}

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -10,6 +10,7 @@ use ockam_api::nodes::{models, BackgroundNodeClient};
 use ockam_core::api::Request;
 use ockam_node::Context;
 
+use crate::node::util::initialize_default_node;
 use crate::output::OutputFormat;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
@@ -95,6 +96,7 @@ impl CreateCommand {
     }
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        initialize_default_node(ctx, &opts).await?;
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.from).await?;
         let payload = models::transport::CreateTcpConnection::new(self.address.clone());
         let request = Request::post("/node/tcp/connection").body(payload);

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/create.rs
@@ -9,6 +9,7 @@ use ockam_multiaddr::proto::{DnsAddr, Tcp};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
+use crate::node::util::initialize_default_node;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 use crate::{fmt_log, fmt_ok};
@@ -39,6 +40,7 @@ impl CreateCommand {
     }
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+        initialize_default_node(ctx, &opts).await?;
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.at).await?;
         let transport_status: TransportStatus = node
             .ask(

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -77,7 +77,6 @@ impl CreateCommand {
 
     pub async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         initialize_default_node(ctx, &opts).await?;
-
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.at).await?;
         let node_name = node.node_name();
         let is_finished: Mutex<bool> = Mutex::new(false);

--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -195,7 +195,10 @@ pub trait DeleteCommandTui {
             1 => {
                 if terminal.confirmed_with_flag_or_prompt(
                     self.cmd_arg_confirm_deletion(),
-                    "You are about to delete your only Outlet. Are you sure you want to proceed?",
+                    format!(
+                        "You are about to delete your only {}. Are you sure you want to proceed?",
+                        Self::ITEM_NAME.singular()
+                    ),
                 )? {
                     let item_name = items_names[0].as_str();
                     self.delete_single(item_name).await?;

--- a/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/tests/cmd_enroll.rs
@@ -3,11 +3,28 @@ use std::process::Command;
 
 #[test]
 fn valid_arguments() -> Result<(), Box<dyn std::error::Error>> {
-    let prefix_args = ["--test-argument-parser", "enroll", "--user-account-only"];
-
-    // auth0
+    let args = [
+        "--test-argument-parser",
+        "enroll",
+        "--force",
+        "--skip-resource-creation",
+    ];
     let mut cmd = Command::cargo_bin("ockam")?;
-    cmd.args(prefix_args);
+    cmd.args(args);
+    cmd.assert().failure();
+
+    let args = ["--test-argument-parser", "enroll", "--force"];
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(args);
+    cmd.assert().success();
+
+    let args = [
+        "--test-argument-parser",
+        "enroll",
+        "--skip-resource-creation",
+    ];
+    let mut cmd = Command::cargo_bin("ockam")?;
+    cmd.args(args);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
When this flag is passed, we check if the identity is enrolled and if we have the user info available. In that case, we skip the OIDC process.

I've also removed some checks to force getting the spaces/projects from the cloud instead of the local database so we always get an up-to-date state of those resources.