### PR TITLE
feat(rust): update enroll ux with new help text, display, and log progress status messages for provisioning identity and vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,7 @@ dependencies = [
  "bytes 1.5.0",
  "cddl-cat",
  "chrono",
+ "colorful",
  "either",
  "fake",
  "fs2",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -34,6 +34,7 @@ aws-config = { version = "1.1.6", default-features = false, features = ["rustls"
 base64-url = "2.0.2"
 bytes = { version = "1.5.0", default-features = false, features = ["serde"] }
 chrono = { version = "0.4" }
+colorful = "0.2"
 either = { version = "1.10.0", default-features = false }
 fs2 = { version = "0.4.3" }
 futures = { version = "0.3.30", features = [] }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/mod.rs
@@ -3,6 +3,7 @@ pub use enrollments::*;
 pub use error::*;
 pub use identities::*;
 pub use nodes::*;
+pub use progress_bar_reporting::*;
 pub use storage::*;
 pub use vaults::*;
 
@@ -15,6 +16,7 @@ mod identities_attributes;
 pub mod journeys;
 pub mod nodes;
 pub mod policies;
+pub mod progress_bar_reporting;
 pub mod projects;
 pub mod repositories;
 mod resources;

--- a/implementations/rust/ockam/ockam_api/src/cli_state/progress_bar_reporting.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/progress_bar_reporting.rs
@@ -1,0 +1,20 @@
+use crate::CliState;
+use std::time::Duration;
+
+pub const REPORTING_CHANNEL_POLL_DELAY: Duration = Duration::from_millis(100);
+pub const REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY: Duration = Duration::from_millis(1_000);
+// 00: consider making this an enum w/ hints about which messages to log (all messages can be printed to stderr or spinner by default)
+pub type ReportingChannelMessageType = String;
+pub const REPORTING_CHANNEL_CAPACITY: usize = 16;
+
+// Broadcast channel support.
+impl CliState {
+    pub fn open_channel(&mut self) -> tokio::sync::broadcast::Sender<ReportingChannelMessageType> {
+        self.progress_bar_reporting_channel_sender.clone()
+    }
+
+    // 00: make the msg arg a ref
+    pub fn send_over_channel(&self, msg: ReportingChannelMessageType) {
+        let _ = self.progress_bar_reporting_channel_sender.send(msg);
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/oidc_service.rs
@@ -91,7 +91,7 @@ impl OidcServiceExt for OidcService {
                 );
 
             opts.terminal
-                .write_line(&fmt_log!(
+                .write_line(&fmt_heading!(
                     "Let's associate your Ockam Identity with an Orchestrator account."
                 ))?
                 .write_line(&otc_string)?

--- a/implementations/rust/ockam/ockam_command/src/enroll/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/enroll/static/long_about.txt
@@ -1,5 +1,7 @@
-When you run this command it provisions a Space for you in Ockam Orchestrator. Orchestrator is a SaaS product that allows remote relays, add-ons integration like Confluent, Okta, etc. This is where we host your Projects. A default Project is created for you within your Space in Orchestrator.
+The `enroll` command enrolls your Ockam Identity with Ockam Orchestrator.
 
-This command generates an Ockam Identity for you. Ockam Identities are unique, cryptographically verifiable digital identities. These identities authenticate by proving possession of secret keys. Ockam Vaults safely store these secret keys.
+It involves multiple steps. In the first step, if you specify an Identity using the `--identity` argument, the command uses it. If you do not specify an Identity, it checks if you have a default Identity. If you have one, the command uses this default Identity. If you do not have a default Identity, the command generates a new Identity in your default Vault. If you do not have a default Vault, the command creates a new one on your file system, makes it the default Vault, and uses it to store the private keys of your new Identity.
 
-Membership credentials are issued, for this Identity, that will be used to manage the resources in your Project. Optionally, you can pass an existing Identity.
+Ockam Identities are unique, cryptographically verifiable digital identities. These identities authenticate by proving possession of secret keys. Ockam Vaults safely store these secret keys.
+
+The command then provisions a Space for you in Ockam Orchestrator. Orchestrator is a SaaS product that allows remote relays, add-ons integration like Confluent, Okta, etc. This is where we host your Projects. A default Project is created for you within your Space in Orchestrator. Membership credentials are issued, for this Identity, that will be used to manage the resources in your Project.

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -3,7 +3,8 @@ use miette::IntoDiagnostic;
 use tracing_core::Level;
 
 use crate::{
-    add_command_error_event, has_help_flag, pager, replace_hyphen_with_stdin, OckamCommand,
+    add_command_error_event, has_help_flag, pager, replace_hyphen_with_stdin, ErrorReportHandler,
+    OckamCommand,
 };
 use ockam_api::cli_state::CliState;
 use ockam_api::logs::{
@@ -19,6 +20,8 @@ pub fn run() -> miette::Result<()> {
     let input = std::env::args()
         .map(replace_hyphen_with_stdin)
         .collect::<Vec<_>>();
+
+    let _ = miette::set_hook(Box::new(|_e| Box::new(ErrorReportHandler::new())));
 
     match OckamCommand::try_parse_from(input.clone()) {
         Err(help) => {

--- a/implementations/rust/ockam/ockam_command/src/global_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/global_args.rs
@@ -13,13 +13,13 @@ pub struct GlobalArgs {
     long,
     short,
     help("Print help information (-h compact, --help extensive)"),
-    long_help("Print help information (-h displays compact help summary, --help displays extensive help summary"),
+    long_help("Print help information (-h displays compact help summary, --help displays extensive help summary)"),
     help_heading("Global Options"),
     action = ArgAction::Help
     )]
     help: Option<bool>,
 
-    /// Do not print any log messages
+    /// Do not print any log messages and disable confirmation prompts. This is useful for scripting and automation, where you don't want the process to block on stdin
     #[arg(global = true, long, short, default_value_t = quiet_default_value())]
     pub quiet: bool,
 

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -31,12 +31,8 @@ long_about = docs::about(LONG_ABOUT),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct EnrollCommand {
-    /// Use Okta instead of an enrollment ticket. Refer to this article for more info: https://docs.ockam.io/guides/examples/okta
-    #[arg(long = "okta", group = "authentication_method")]
-    pub okta: bool,
-
     /// Path to an enrollment ticket file, or hex encoded enrollment ticket
-    #[arg(group = "authentication_method", value_name = "ENROLLMENT TICKET PATH | ENROLLMENT TICKET", value_parser = parse_enroll_ticket)]
+    #[arg(display_order = 800, group = "authentication_method", value_name = "ENROLLMENT TICKET PATH | ENROLLMENT TICKET", value_parser = parse_enroll_ticket)]
     pub enroll_ticket: Option<EnrollmentTicket>,
 
     #[command(flatten)]
@@ -45,6 +41,10 @@ pub struct EnrollCommand {
     /// Trust options, defaults to the default project
     #[command(flatten)]
     pub trust_opts: TrustOpts,
+
+    /// Use Okta instead of an enrollment ticket
+    #[arg(display_order = 900, long = "okta", group = "authentication_method")]
+    pub okta: bool,
 }
 
 pub fn parse_enroll_ticket(hex_encoded_data_or_path: &str) -> Result<EnrollmentTicket> {
@@ -72,7 +72,7 @@ impl EnrollCommand {
         "enroll".into()
     }
 
-    pub async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    pub async fn async_run(self, ctx: &Context, mut opts: CommandGlobalOpts) -> miette::Result<()> {
         if opts.global_args.output_format == OutputFormat::Json {
             return Err(miette::miette!(
                 "This command does not support JSON output. Please try running it again without '--output json'."

--- a/implementations/rust/ockam/ockam_command/src/run/runner.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/runner.rs
@@ -16,7 +16,11 @@ use ockam_node::Context;
 pub struct ConfigRunner;
 
 impl ConfigRunner {
-    pub async fn run_config(ctx: &Context, opts: CommandGlobalOpts, contents: &str) -> Result<()> {
+    pub async fn run_config(
+        ctx: &Context,
+        mut opts: CommandGlobalOpts,
+        contents: &str,
+    ) -> Result<()> {
         let config = Config::parse(contents)?;
 
         let vaults = config.vaults.into_commands()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/static/create/after_long_help.txt
@@ -1,7 +1,10 @@
 ```sh
-# To create a new TCP outlet at the given address using the default node
+# To create a new TCP Outlet to the TCP server, using the default node
 $ ockam tcp-outlet create --to 127.0.0.1:5000
 
-# To create a new TCP outlet at the given address using a specific node
+# To create a new TCP Outlet at the given address, to the TCP server, with given alias
+$ ockam tcp-outlet create --to 127.0.0.1:5000 --alias my-outlet --from payroll-db-outlet
+
+# To create a new TCP Outlet to the TCP server, using a specific node
 $ ockam tcp-outlet create --at n1 --to 127.0.0.1:5000
 ```

--- a/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
@@ -27,7 +27,7 @@ impl OckamColor {
             OckamColor::FmtOKBackground => "#A8C97D",
             OckamColor::FmtINFOBackground => "#0DCAF0",
             OckamColor::FmtWARNBackground => "#ff9a00",
-            OckamColor::FmtERRORBackground => "#ff0000",
+            OckamColor::FmtERRORBackground => "#FF0000",
             OckamColor::FmtLISTBackground => "#0DCAF0",
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/terminal/fmt.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/fmt.rs
@@ -69,7 +69,6 @@ macro_rules! fmt_heading {
         "       ",
         "─".repeat(85).dim().dark_gray(),
         "      "
-            .color($crate::terminal::OckamColor::FmtINFOBackground.color())
             .bold(),
         format!($input))
     };
@@ -78,7 +77,6 @@ macro_rules! fmt_heading {
         "       ",
         "─".repeat(85).dim().dark_gray(),
         "      "
-            .color($crate::terminal::OckamColor::FmtINFOBackground.color())
             .bold(),
         format!($input, $($args),+))
     };

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -40,9 +40,10 @@ pub async fn stop_node(ctx: Context) {
 }
 
 pub fn local_cmd(res: miette::Result<()>) -> miette::Result<()> {
-    if let Err(e) = &res {
-        error!(%e, "Failed to run command");
-        eprintln!("{:?}", e);
+    if let Err(error) = &res {
+        // Note: error! is also called in command_event.rs::add_command_error_event()
+        error!(%error, "Failed to run command");
+        eprintln!("{:?}", error);
     }
     res
 }

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -6,16 +6,13 @@ pub(crate) struct Version;
 
 impl Version {
     pub(crate) fn long() -> &'static str {
-        let crate_version = crate_version!();
-        let git_hash = env!("GIT_HASH");
-        let message = format!("{crate_version}\n\nCompiled from (git hash): {git_hash}");
-        Box::leak(message.into_boxed_str())
+        Self::short()
     }
 
     pub(crate) fn short() -> &'static str {
         let crate_version = crate_version!();
         let git_hash = env!("GIT_HASH");
-        let message = format!("Version {crate_version}, hash: {git_hash}");
+        let message = format!("Version: {crate_version}, compiled from: {git_hash}");
         Box::leak(message.into_boxed_str())
     }
 }


### PR DESCRIPTION
Issue/epic: https://github.com/build-trust/codebase/issues/737

## Screenshots
`rm -rf ~/.ockam && ockam enroll`
![Image](https://github.com/build-trust/codebase/assets/2966499/1b71c091-b08f-4ca1-940f-af28e3ed2342)

`ockam enroll` (this this again)
![Image](https://github.com/build-trust/codebase/assets/2966499/ef1dc481-cb73-46be-9f19-0ec777fd388c)

`ockam enroll --identity my_id` (my_id does not exist)
![Image](https://github.com/build-trust/codebase/assets/2966499/6e93e717-35eb-4223-a87d-c5f06a0f8d5d)

`ockam identity create my_id && ockam enroll --identity my_id`
![Image](https://github.com/build-trust/codebase/assets/2966499/e6adcd08-3a2a-43b2-aa28-e41d2abe6e4c)
![Image](https://github.com/build-trust/codebase/assets/2966499/2aa3d38e-5cbd-4a11-8d7c-7a1fa73a46bf)

UX String docs:
- [ockam enroll UX strings](https://docs.google.com/document/d/1rbJCBaZRihy4GVr_Ei1V5zCrNk3vOfQ1Z8umKVz6OU8/edit)
- [ockam project ticket|enroll UX strings](https://docs.google.com/document/d/1oLOYIAom9qFYjsAcjRd3_pgU9ukxaVrMF7c9vtfWwZc/edit#heading=h.o1swyzd1zhy1)
- [ockam tcp-outlet UX strings](https://docs.google.com/document/d/1NlJiJNDpjxZQUr_j5aV5CvQR_izuoKpnvXeBP059Kqs/edit#heading=h.o1swyzd1zhy1)