### PR TITLE
fix(rust): return error in `enroll` command if orchestrator fails to enroll identity

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -97,9 +97,8 @@ impl Error {
     }
 
     #[track_caller]
-    pub fn new_internal_error(human_err: &str, inner_err_msg: &str) -> Self {
-        let msg = format!("{}\n{}", human_err, fmt_log!("{}", inner_err_msg));
-        Self::new(exitcode::SOFTWARE, miette!(msg))
+    pub fn new_internal_error(msg: &str) -> Self {
+        Self::new(exitcode::SOFTWARE, miette!(msg.to_string()))
     }
 
     pub fn code(&self) -> ExitCode {

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -18,8 +18,7 @@ use ockam_core::errcode::Kind;
 use r3bl_rs_utils_core::*;
 use r3bl_tuify::*;
 
-use crate::{error::Error, fmt_info};
-use crate::{fmt_list, fmt_log, fmt_warn, GlobalArgs, OutputFormat, Result};
+use crate::{fmt_info, fmt_list, fmt_log, fmt_warn, GlobalArgs, OutputFormat, Result};
 
 pub mod colors;
 pub mod fmt;
@@ -349,7 +348,7 @@ impl<W: TerminalWriter + Debug> Terminal<W, ToStdErr> {
 
         self.stderr
             .write_line(msg)
-            .map_err(|e| Error::new_internal_error("Unable to write to stderr.", &e.to_string()))?;
+            .map_err(|e| miette!("Unable to write to stderr, {e}"))?;
         Ok(self)
     }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -21,7 +21,6 @@ use ockam_core::{DenyAll, OpenTelemetryContext};
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Project, Space, Tcp};
 use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
 
-use crate::error::Error;
 use crate::{CommandGlobalOpts, OckamColor, Result};
 
 pub mod api;
@@ -187,10 +186,7 @@ pub async fn clean_nodes_multiaddr(
                 let node_info = cli_state.get_node(&alias).await?;
                 let addr = node_info
                     .tcp_listener_address()
-                    .ok_or(Error::new_internal_error(
-                        "No transport API has been set on the node",
-                        "",
-                    ))?;
+                    .ok_or(miette!("No transport API has been set on the node"))?;
                 match &addr {
                     InternetAddress::Dns(dns, _) => new_ma.push_back(DnsAddr::new(dns))?,
                     InternetAddress::V4(v4) => new_ma.push_back(Ip4(*v4.ip()))?,


### PR DESCRIPTION
If the call to the `v0/enroll` returns an error, we abort the command instead of swallowing the error.

![image](https://github.com/build-trust/ockam/assets/12375782/c4209cd0-5d87-42ac-954f-26bde5f7370a)
