### PR TITLE
add script to redo draft release

### DIFF
--- a/.github/workflows/release-bump-pull-request.yml
+++ b/.github/workflows/release-bump-pull-request.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      redo_release_from_tag:
+      redo_release_tag:
         description: 'Redo a draft release from a recent tag. Should only be used if a draft release PR has been merged'
         required: false
       git_tag:
@@ -77,19 +77,19 @@ jobs:
           gpg_email: '${{ secrets.GPG_EMAIL }}'
 
       - name: Redo Release From A Recent Draft PR
-        if: ${{ inputs.redo_release_from_tag != '' }}
+        if: ${{ inputs.redo_release_tag != '' }}
         env:
           OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION: ${{ github.event.inputs.ockam_bump_bumped_dep_crates_version }}
-          GIT_TAG_WE_WILL_BE_UPDATING: ${{ github.event.inputs.redo_release_from_tag }}
+          GIT_TAG_WE_WILL_BE_UPDATING: ${{ github.event.inputs.redo_release_tag }}
           LAST_RELEASED_TAG: ${{ github.event.inputs.git_tag }}
         run: |
           bash -ex ./tools/scripts/release/redo-draft-release.sh
 
           # Delete the old git tag, it'll be recreated when we are creating a new draft binary.
-          git push --delete origin ${{ inputs.redo_release_from_tag }}
+          git push --delete origin ${{ inputs.redo_release_tag }}
 
       - name: Bump Ockam
-        if: ${{ inputs.redo_release_from_tag == '' }}
+        if: ${{ inputs.redo_release_tag == '' }}
         env:
           OCKAM_BUMP_RELEASE_VERSION: '${{ github.event.inputs.ockam_bump_release_version }}'
           OCKAM_BUMP_MODIFIED_RELEASE: '${{ github.event.inputs.ockam_bump_modified_release }}'
@@ -98,7 +98,7 @@ jobs:
         run: bash -ex ./tools/scripts/release/crate-bump.sh
 
       - name: Generate Changelogs
-        if: ${{ inputs.redo_release_from_tag == '' }}
+        if: ${{ inputs.redo_release_tag == '' }}
         env:
           GIT_TAG: '${{ github.event.inputs.git_tag }}'
         run: bash -ex ./tools/scripts/release/changelog.sh

--- a/.github/workflows/release-bump-pull-request.yml
+++ b/.github/workflows/release-bump-pull-request.yml
@@ -6,6 +6,9 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
+      redo_release_from_tag:
+        description: 'Redo a draft release from a recent tag. Should only be used if a draft release PR has been merged'
+        required: false
       git_tag:
         description: Git Tag To Release From. Last Git Tag Is Used If Omitted
         required: false
@@ -73,7 +76,20 @@ jobs:
           gpg_name: '${{ secrets.GPG_USER_NAME }}'
           gpg_email: '${{ secrets.GPG_EMAIL }}'
 
+      - name: Redo Release From A Recent Draft PR
+        if: ${{ inputs.redo_release_from_tag != '' }}
+        env:
+          OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION: ${{ github.event.inputs.ockam_bump_bumped_dep_crates_version }}
+          GIT_TAG_WE_WILL_BE_UPDATING: ${{ github.event.inputs.redo_release_from_tag }}
+          LAST_RELEASED_TAG: ${{ github.event.inputs.git_tag }}
+        run: |
+          bash -ex ./tools/scripts/release/redo-draft-release.sh
+
+          # Delete the old git tag, it'll be recreated when we are creating a new draft binary.
+          git push --delete origin ${{ inputs.redo_release_from_tag }}
+
       - name: Bump Ockam
+        if: ${{ inputs.redo_release_from_tag == '' }}
         env:
           OCKAM_BUMP_RELEASE_VERSION: '${{ github.event.inputs.ockam_bump_release_version }}'
           OCKAM_BUMP_MODIFIED_RELEASE: '${{ github.event.inputs.ockam_bump_modified_release }}'
@@ -82,6 +98,7 @@ jobs:
         run: bash -ex ./tools/scripts/release/crate-bump.sh
 
       - name: Generate Changelogs
+        if: ${{ inputs.redo_release_from_tag == '' }}
         env:
           GIT_TAG: '${{ github.event.inputs.git_tag }}'
         run: bash -ex ./tools/scripts/release/changelog.sh

--- a/tools/scripts/release/README.md
+++ b/tools/scripts/release/README.md
@@ -1,7 +1,7 @@
 # Ockam Scripts
 
 This folder contains scripts to release Ockam Rust crates. Note, to run these scripts you need to run Bash version 4 upwards. All commands should be called from the Ockam root path.
-To perform release, release scripts automatically check for updated crates using `recently created git tags`, we can override the default setting if want to track updated crates with a more recent tag. To specify a `git tag`, we can define a variable `GIT_TAG` to any of the scripts. For example to generate changelog using a more recent `git tag` we can call the following command below
+For a release, release scripts automatically checks for updated crates using `recently created git tags`, we can override the default setting if want to track updated crates with a more recent tag. To specify a `git tag`, we can define a variable `GIT_TAG` to any of the scripts. For example to generate changelog using a more recent `git tag` we can call the following command below
 ```bash
 GIT_TAG="a_more_recent_git_tag_v0.0.0" tools/scripts/release/changelog.sh
 ```
@@ -34,15 +34,15 @@ OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION=patch RELEASE_VERSION=minor tools/scripts/r
 ```
 If `OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION` is not defined then transitive dependent crates are bumped as `minor`.
 
-## Changelog Generation (Requires zsh)
+## Changelog Generation
 
-Changelogs are generated using [git-cliff](https://github.com/orhun/git-cliff). To generate changelogs, we call the [changelog.sh script](https://github.com/build-trust/ockam/blob/develop/tools/scripts/release/changelog.sh) which will generate changelogs and append to their CHANGELOG.md file.
+We generate Changelogs using [git-cliff](https://github.com/orhun/git-cliff). To generate changelogs, we call the [changelog.sh script](https://github.com/build-trust/ockam/blob/develop/tools/scripts/release/changelog.sh) which will generate changelogs and append to their CHANGELOG.md file.
 To run changelog generator, from the Ockam root path, call
 ```bash
 tools/scripts/release/changelog.sh
 ```
 Generated changelogs should be called after `crate-bump` so we can log crates whose dependencies was only bumped.
-We can also generate changelog from a referenced `git tag`, changelog should be reviewed before commit.
+We can also generate changelog from a referenced `git tag`, you should review changelogs before commit.
 
 ## Crate Publish
 
@@ -79,12 +79,16 @@ Ockam release can also be done over CI either manually using the provided workfl
 - Homebrew Repo Bump
 - Terraform Repo Bump
 - Terraform Binary Release
+- Command Manual Update
+- Documentation Repository Update
 
 There are two steps to final release
 - Draft release
 - Production release
 
-To create a release, we first create a draft, which will later on be reviewed and pull requests merged before running the script to create a final release.
+### Creating Release
+
+To create a release, we first create a draft, which is reviewed and pull requests merged before running the script to create a final release.
 
 To start the release in draft mode we call from the ockam home
 
@@ -99,6 +103,8 @@ On a successful run will,
 - Bump Homebrew version and create a pull request for review in /homebrew-ockam repository
 - Bump Terraform version and create a pull request for review in /terraform-provider-ockam repository
 - Create Terraform draft release in /terraform-provider-ockam repository
+- Update Command manual
+- Update Ockam documentation repository
 
 After draft release is created, release is to be vetted and pull requests created in /ockam, /homebrew-ockam approved and merged before final release is started.
 
@@ -116,17 +122,21 @@ This will
 The release script also allows for modifications provided by the `bump` and `publish` scripts, for example to create a release that uses a `RELEASE_VERSION` different from the default (minor)
 
 ```bash
-RELEASE_VERSION=major GITHUB_USERNAME=metaclips release.sh
+OCKAM_BUMP_RELEASE_VERSION=major GITHUB_USERNAME=metaclips release.sh
 ```
 
+### Skipping Sets Of Release
+
 We can skip steps during a release by defining variable below as `true`
-- SKIP_OCKAM_BUMP - Skips Ockam bump
-- SKIP_OCKAM_PACKAGE_RELEASE - Skips Ockam Docker package release
-- SKIP_CRATES_IO_PUBLISH - Skips crates.io publish
-- SKIP_OCKAM_BINARY_RELEASE - Skips binary release
-- SKIP_HOMEBREW_BUMP - Skips Homebrew version bump
-- SKIP_TERRAFORM_BUMP - Skips Terraform version bump
-- SKIP_TERRAFORM_BINARY_RELEASE - Skips Terraform binary release
+- `SKIP_OCKAM_BUMP` - Skips Ockam bump
+- `SKIP_OCKAM_PACKAGE_RELEASE` - Skips Ockam Docker package release
+- `SKIP_CRATES_IO_PUBLISH` - Skips crates.io publish
+- `SKIP_OCKAM_BINARY_RELEASE` - Skips binary release
+- `SKIP_HOMEBREW_BUMP` - Skips Homebrew version bump
+- `SKIP_TERRAFORM_BUMP` - Skips Terraform version bump
+- `SKIP_TERRAFORM_BINARY_RELEASE` - Skips Terraform binary release
+- `SKIP_DOCS_UPDATE` - Skips Ockam documentation release
+- `SKIP_COMMAND_MANUAL_RELEASE` - Skips Ockam command manual release
 
 To skip Ockam bump
 ```bash
@@ -135,21 +145,18 @@ SKIP_OCKAM_BUMP=true ./tools/scripts/release/release.sh
 
 The release script can be called from any path.
 
-We also have a script to delete draft release, to delete draft
+
+### Update A Draft Release
+
+After a draft release is made, we can redo/update a draft release, updating a draft release
+- Updates the changelog
+- Updates crates versions if needed
+- Deletes the old git tag
+
+To redo a draft release...
 
 ```bash
-TAG_NAME=ockam_v0.71.0 ./delete_draft.sh
+REDO_RELEASE_TAG="ockam_v0.117.0" GIT_TAG="ockam_v0.116.0" ./tools/scripts/release/release.sh
 ```
 
-Where TAG_NAME is the tag of the draft release.
-
-## Acceptance Test
-
-After a release, we can test all generated assets to ensure they work accurately, the acceptance script checks
-
-- Test build our latest published Ockam crate from crates.io
-- Run Docker image
-- Build Homebrew
-- Build Terraform
-- Run our multi architecture binaries
-- Esure all creates are published to crates.io
+This will redo the `ockam_v0.117.0` release from `ockam_v0.116.0`, updating the changelogs, and bumping crates that were updated after the recent draft release.

--- a/tools/scripts/release/changelog.sh
+++ b/tools/scripts/release/changelog.sh
@@ -13,7 +13,7 @@ function generate_changelog() {
   # the below message.
   echo "Generating changelog for $crate with tag $last_git_tag"
   with_commit_msg="feat: updated dependencies"
-  git-cliff "$from_released_git_tag".. --config tools/cliff/cliff.toml --with-commit "$with_commit_msg" --include-path "$crate"/**/*.rs --prepend "$crate"/CHANGELOG.md
+  git-cliff "$from_released_git_tag.." --config tools/cliff/cliff.toml --with-commit "$with_commit_msg" --include-path "$crate/**/*.rs" --prepend "$crate/CHANGELOG.md"
   # Replace ## unreleased text to bumped version
   version=$(eval "tomlq package.version -f $crate/Cargo.toml")
 

--- a/tools/scripts/release/changelog.sh
+++ b/tools/scripts/release/changelog.sh
@@ -4,20 +4,29 @@ set -e
 # This script generates changelog for all Ockam crates that
 # are to be published.
 
-source tools/scripts/release/crates-to-publish.sh
-for crate in "${updated_crates[@]}"; do
+function generate_changelog() {
+  crate="$1"
+  from_released_git_tag="$2"
+
   # There are crates whose versions are only bumped due to updates
   # in their dependencies, so as not to have empty changelogs we indicate
   # the below message.
   echo "Generating changelog for $crate with tag $last_git_tag"
   with_commit_msg="feat: updated dependencies"
-  git-cliff "$last_git_tag".. --config tools/cliff/cliff.toml --with-commit "$with_commit_msg" --include-path "$crate"/**/*.rs --prepend "$crate"/CHANGELOG.md
+  git-cliff "$from_released_git_tag".. --config tools/cliff/cliff.toml --with-commit "$with_commit_msg" --include-path "$crate"/**/*.rs --prepend "$crate"/CHANGELOG.md
   # Replace ## unreleased text to bumped version
   version=$(eval "tomlq package.version -f $crate/Cargo.toml")
 
   search="## unreleased"
   replace="## $version - $(date +'%Y-%m-%d')"
   sed -i -e "s/$search/$replace/" "$crate"/CHANGELOG.md
-done
+}
 
-echo "Changelog has been generated. Please review and commit."
+if [[ -z $GIT_TAG_WE_WILL_BE_UPDATING ]]; then
+  source tools/scripts/release/crates-to-publish.sh
+  for crate in "${updated_crates[@]}"; do
+    generate_changelog "$crate" "$last_git_tag"
+  done
+
+  echo "Changelog has been generated. Please review and commit."
+fi

--- a/tools/scripts/release/delete_last_changelog.py
+++ b/tools/scripts/release/delete_last_changelog.py
@@ -14,4 +14,5 @@ def delete_first_match(filename):
         with open(filename, 'w') as file:
             file.write(pruned_content)
 
-delete_first_match("CHANGELOG.md")
+file_path = os.environ['CHANGELOG_FILE_PATH']
+delete_first_match(file_path)

--- a/tools/scripts/release/delete_last_changelog.py
+++ b/tools/scripts/release/delete_last_changelog.py
@@ -1,0 +1,17 @@
+import os
+import re
+
+def delete_first_match(filename):
+    with open(filename, 'r') as file:
+        content = file.read()
+
+    regex_pattern = r'## \d+\.\d+\.\d+.*\n+(?:### .*\n+(?:-.*\n+)+)+'
+    match = re.search(regex_pattern, content)
+
+    if match:
+        pruned_content = content.replace(match.group(), '', 1)
+
+        with open(filename, 'w') as file:
+            file.write(pruned_content)
+
+delete_first_match("CHANGELOG.md")

--- a/tools/scripts/release/redo_draft_release.sh
+++ b/tools/scripts/release/redo_draft_release.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ -z $LAST_RELEASED_TAG ]]; then
+  echo "Last production release tag must be indicated"
+  exit 1
+fi
+
+if [[ -z $GIT_TAG_WE_WILL_BE_UPDATING ]]; then
+  echo "Last production release tag must be indicated"
+  exit 1
+fi
+
+function get_crates_to_update() {
+  unset updated_crates_from_non_released_tag
+  unset updated_crates_from_released_tag
+
+  for crate in implementations/rust/ockam/*; do
+    if [[ -f $crate ]]; then
+      echo "$crate is a file, skipping."
+      continue
+    fi
+
+    # Ensure that folder contains rust crate.
+    if [[ ! -f "$crate/Cargo.toml" ]]; then
+      echo "$crate is not a crate, skipping"
+      continue
+    fi
+
+    is_publish=$(tomlq package.publish -f "$crate"/Cargo.toml)
+    if [[ $is_publish == false ]]; then
+      echo "$crate indicate as not-publish"
+      continue
+    fi
+
+    if git diff "$LAST_RELEASED_TAG..$GIT_TAG_WE_WILL_BE_UPDATING" --quiet --name-status -- "$crate"/src; then
+      git diff "$LAST_RELEASED_TAG..$GIT_TAG_WE_WILL_BE_UPDATING" --quiet --name-status -- "$crate"/Cargo.toml || updated_crates_from_released_tag="$updated_crates_from_released_tag $crate "
+    else
+      updated_crates_from_released_tag="$updated_crates_from_released_tag $crate "
+    fi
+
+    if git diff "$GIT_TAG_WE_WILL_BE_UPDATING" --quiet --name-status -- "$crate"/src; then
+      git diff "$GIT_TAG_WE_WILL_BE_UPDATING" --quiet --name-status -- "$crate"/Cargo.toml || updated_crates_from_non_released_tag="$updated_crates_from_non_released_tag $crate "
+    else
+      updated_crates_from_non_released_tag="$updated_crates_from_non_released_tag $crate "
+    fi
+  done
+}
+
+
+# - For cargo.toml bump, perform a no-version bump if a crate is updated in from the last published and unpublished release
+# - For changelog, delete the old changelog and generate a new one
+get_crates_to_update
+initial_updated_crates_from_non_released_tag=""
+
+while [[ "$initial_updated_crates_from_non_released_tag" != "$updated_crates_from_non_released_tag" ]]; do
+  initial_updated_crates_from_non_released_tag="$updated_crates_from_non_released_tag"
+  IFS=" " read -r -a updated_crates_from_non_released_tag <<<"${updated_crates_from_non_released_tag[*]}"
+
+  for crate in "${updated_crates_from_non_released_tag[@]}"; do
+    if [[ "$updated_crates_from_released_tag" == *"$crate"* ]]; then
+      # Perform a release version only bump crates that uses $crate
+      echo y | cargo release release --config tools/scripts/release/release.toml --no-push --no-publish --no-tag --no-dev-version --package "$crate" --execute
+    elif
+      # Perform a minor release
+    fi
+
+    ## Delete old changelog and create a new changelog
+
+
+  done
+  get_crates_to_update
+done

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -136,7 +136,7 @@ function ockam_bump() {
   workflow_file_name="release-bump-pull-request.yml"
   branch="develop"
 
-  gh workflow run "$workflow_file_name" --ref "$branch" -F branch_name="$release_name" -F git_tag="$GIT_TAG" -F ockam_bump_modified_release="$OCKAM_BUMP_MODIFIED_RELEASE" \
+  gh workflow run "$workflow_file_name" --ref "$branch" -F redo_release_tag="$REDO_RELEASE_TAG" -F branch_name="$release_name" -F git_tag="$GIT_TAG" -F ockam_bump_modified_release="$OCKAM_BUMP_MODIFIED_RELEASE" \
     -F ockam_bump_release_version="$OCKAM_BUMP_RELEASE_VERSION" -F ockam_bump_bumped_dep_crates_version="$OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION" \
     -R $OWNER/ockam >>$log
 
@@ -284,7 +284,7 @@ function update_docs_repo() {
   # Check if the branch was created, new branch is only created when there are new doc updates
   if gh api "repos/build-trust/ockam-documentation/branches/${release_name}" --jq .name; then
     gh pr create --title "Ockam Release $(date +'%d-%m-%Y')" --body "Ockam release" \
-      --base main -H "${release_name}" -r nazmulidris -R $OWNER/ockam-documentation
+      --base main -H "docs_${release_name}" -r nazmulidris -R $OWNER/ockam-documentation
   fi
 }
 
@@ -304,7 +304,7 @@ function update_command_manual() {
   approve_and_watch_workflow_progress "ockam-documentation" "$workflow_file_name" "$branch"
 
   gh pr create --title "Ockam command manual update to $release" --body "Ockam commnad manual update $release" \
-    --base command -H "${release_name}" -R $OWNER/ockam-documentation >>$log
+    --base command -H "manual_${release_name}" -R $OWNER/ockam-documentation >>$log
 }
 
 function delete_ockam_draft_package() {
@@ -384,7 +384,7 @@ if [[ $IS_DRAFT_RELEASE == true ]]; then
 
   echo "File and hash are $file_and_sha" >&3
 
-  if [[ -z $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE || $SKIP_OCKAM_PACKAGE_DRAFT_RELEASE == false ]]; then
+  if [[ -z $SKIP_OCKAM_PACKAGE_RELEASE || $SKIP_OCKAM_PACKAGE_RELEASE == false ]]; then
     echo "Releasing Ockam docker image"
     release_ockam_package "$latest_tag_name" "$file_and_sha" false
     success_info "Ockam docker package draft release successful...."


### PR DESCRIPTION
Allows us to redo a draft release
- Changelogs are now updated on draft release update
- Crates that needs to be updated are now updated during a draft release update