### PR TITLE
feat(rust): use subset of features for `syntect` to not use `safemem`

### DIFF
--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -102,7 +102,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 strip-ansi-escapes = "0.2.0"
-syntect = "5"
+syntect = { version = "5.2.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 thiserror = "1"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
 tiny_http = "0.12.0"


### PR DESCRIPTION
This removes the dependency to `safemem` from `ockam_command`. But we still have that transitive dep through `r3bl`. We need to wait until those packages are updated to get rid of `safemem` completely.