### PR TITLE
fix(rust): put the tracing context field under a compilation flag

### DIFF
--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -63,6 +63,7 @@ async fn nested_function() -> OpenTelemetryContext {
 
 /// This test checks that the tracing context is correctly propagated intra-nodes
 /// when several workers are involved and inter-nodes when TransportMessages are sent
+#[cfg(feature = "tracing_context")]
 #[test]
 fn test_context_propagation_across_workers_and_nodes() {
     let (received, spans) = trace_code(|ctx| send_echo_message(ctx, "hello"));
@@ -94,6 +95,7 @@ root
 /// This test checks that the tracing context is correctly propagated intra-nodes
 /// when several workers are involved and inter-nodes when TransportMessages are sent
 /// over a secure channel
+#[cfg(feature = "tracing_context")]
 #[test]
 fn test_context_propagation_across_workers_and_nodes_over_secure_channel() {
     let (received, spans) = trace_code(|ctx| send_echo_message_over_secure_channel(ctx, "hello"));

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -67,6 +67,9 @@ error-traces = [
 # message flows within Ockam apps.
 debugger = []
 
+# Feature: "tracing_context" adds a tracing_context field on Ockam messages to propagate the context for distributed tracing
+tracing_context = []
+
 [dependencies]
 async-trait = "0.1.77"
 backtrace = { version = "0.3", default-features = false, features = ["std", "serialize-serde"], optional = true }


### PR DESCRIPTION
Which is not included in std for now, until we know how to decode that field on the Controller.


