### PR TITLE
feat: time-limited journey traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
  "http 1.0.0",
  "once_cell",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.8",
  "time",
  "tracing",
 ]
@@ -1078,6 +1078,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1883,7 +1892,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "platforms",
  "rustc_version 0.4.0",
@@ -2141,11 +2150,20 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2227,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -2254,7 +2272,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -2276,7 +2294,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -3134,7 +3152,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3597,7 +3615,7 @@ dependencies = [
  "log",
  "multihash",
  "quick-protobuf",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -3709,7 +3727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4175,7 +4193,7 @@ dependencies = [
  "rand_xorshift",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "tracing",
  "trybuild",
 ]
@@ -4258,6 +4276,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.9.9",
  "sqlx",
  "sysinfo",
  "tempfile",
@@ -4448,7 +4467,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sqlx",
  "subtle",
  "tempfile",
@@ -4641,7 +4660,7 @@ dependencies = [
  "serde",
  "serde_bare",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sqlx",
  "static_assertions",
  "tempfile",
@@ -4665,7 +4684,7 @@ dependencies = [
  "ockam_node",
  "ockam_vault",
  "p256",
- "sha2",
+ "sha2 0.10.8",
  "thiserror",
  "tokio",
  "tracing",
@@ -4868,7 +4887,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -5728,7 +5747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6190,7 +6209,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6201,13 +6220,26 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6287,7 +6319,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core",
 ]
 
@@ -6457,7 +6489,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "smallvec",
  "sqlformat",
  "thiserror",
@@ -6496,7 +6528,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-sqlite",
@@ -6518,7 +6550,7 @@ dependencies = [
  "byteorder",
  "bytes 1.5.0",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -6539,7 +6571,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6578,7 +6610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.8",
  "smallvec",
  "sqlx-core",
  "stringprep",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -58,6 +58,7 @@ regex = "1.10.3"
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
+sha2 = "0.9.5"
 sqlx = { version = "0.7.3", features = ["runtime-tokio", "sqlite"] }
 sysinfo = "0.30"
 thiserror = "1.0"

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
@@ -2,11 +2,13 @@ use crate::journeys::{
     APPLICATION_EVENT_OCKAM_GIT_HASH, APPLICATION_EVENT_OCKAM_HOME, APPLICATION_EVENT_OCKAM_VERSION,
 };
 use crate::Version;
+use chrono::{DateTime, Datelike, Utc};
 use gethostname::gethostname;
-use opentelemetry::trace::TraceId;
+use opentelemetry::trace::{SpanId, TraceId};
 use opentelemetry::Key;
 use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
 use std::collections::HashMap;
+use std::fmt::Write;
 use std::process::Command;
 
 /// This function returns the default attributes to set on each user event: OCKAM_HOME, `ockam` version and git hash
@@ -25,10 +27,67 @@ pub fn default_attributes<'a>() -> HashMap<&'a Key, String> {
     attributes
 }
 
-/// Return a host id built from the MAC address and the IP address of the machine
-/// If they can be retrieved from the command line. Otherwise return a random trace id
-pub(crate) fn make_host_trace_id() -> TraceId {
-    let machine = match (get_mac_address(), get_ip_address()) {
+/// Return the trace id for a host journey:
+///
+///  - The first character encode the format version
+///  - The next 25 characters identify the host
+///  - The last 6 characters are the 'now' date as YYMMDD
+///
+pub(crate) fn make_host_trace_id(now: DateTime<Utc>) -> TraceId {
+    let mut machine = make_host();
+    // make sure that there exactly 25 characters
+    if machine.len() < 25 {
+        machine.extend(std::iter::repeat("1").take(25 - machine.len()));
+    };
+    machine = machine[0..25].to_string();
+
+    // date as a 6 characters string
+    let now = now_as_string(now);
+
+    // trace_id as a 32 characters hex string = 1 + 25 + 6
+    // the digit 1 is present at the beginning as a version indicator, in case we need to evolve the format
+    // We also append the date in order to roll the host traces every few days
+    trace_id_from_hex(format!("1{machine}{now}").as_str())
+}
+
+/// Return the trace id for a project journey:
+///
+///  - The first character encode the format version
+///  - The next 25 characters identify the project, based on the project id
+///  - The last 6 characters are the 'now' date as YYMMDD
+///    The date day is rounded to the nearest multiple of 5. For example 240220, then 240225, 240301, 240305, etc...
+///    This allows to bucket all the spans in the same trace, even if the spans come from  different machines which
+///    can start their own project journey trace independently.
+///
+pub(crate) fn make_project_trace_id(project_id: &str, now: DateTime<Utc>) -> TraceId {
+    // take the whole project without '-' as the base for the trace id
+    let project_id_trace_id = &project_id.replace('-', "")[0..25];
+
+    // trace_id as a 32 characters hex string = 1 + 25 + 6
+    // The digit 1 is present at the beginning as a version indicator, in case we need to evolve the format
+    // We also append the date in order to roll the project traces every few days
+    trace_id_from_hex(format!("1{}{}", project_id_trace_id, now_as_string(now)).as_str())
+}
+
+/// Create the top-level span_id for a journey, based on its trace_id
+/// We use the last 16 characters so that the span id contains the date
+/// that is incorporated in the trace id and ends-up being unique.
+pub(crate) fn make_journey_span_id(trace_id: TraceId) -> SpanId {
+    let trace_id = trace_id.to_string();
+    let length = trace_id.len();
+    match SpanId::from_hex(&trace_id[length - 16..length]) {
+        Ok(span_id) => span_id,
+        _ => {
+            let random_id_generator = RandomIdGenerator::default();
+            random_id_generator.new_span_id()
+        }
+    }
+}
+
+/// Return a string containing enough data to uniquely identify a host
+/// That string is hexadecimal string which can be part of a trace id
+pub(crate) fn make_host() -> String {
+    let host = match (get_mac_address(), get_ip_address()) {
         (Some(mac_address), Some(ip_address)) => format!(
             "{}{}",
             mac_address.replace(':', ""),
@@ -36,24 +95,50 @@ pub(crate) fn make_host_trace_id() -> TraceId {
         ),
         _ => gethostname().to_string_lossy().to_string(),
     };
+    convert_to_hex(&host)
+}
 
-    // take exactly 16 bytes from the machine name
-    // the digit 1 is added at the beginning as a version indicator, in case we need to evolve the format
-    let mut machine = format!("1{machine}").as_bytes().to_vec();
-    // make sure that there are at least 16 bytes
-    if machine.len() < 16 {
-        machine.extend(std::iter::repeat(1).take(16 - machine.len()));
-    };
-    if let Ok(truncated) = machine[0..16].try_into() {
-        TraceId::from_bytes(truncated)
+// Check if the string is already in hexadecimal format
+// If it is already hexadecimal, return it as is, otherwise convert it to hex
+fn convert_to_hex(s: &str) -> String {
+    let is_hex = s.chars().all(|c| c.is_ascii_hexdigit());
+
+    if is_hex {
+        s.to_string()
     } else {
-        let random_id_generator = RandomIdGenerator::default();
-        random_id_generator.new_trace_id()
+        s.bytes().fold(String::new(), |mut output, b| {
+            let _ = write!(output, "{b:02x}");
+            output
+        })
     }
 }
 
+/// Parse an hex string to a TraceId and generate a random one in case of a parsing error
+fn trace_id_from_hex(trace_id: &str) -> TraceId {
+    match TraceId::from_hex(trace_id) {
+        Ok(trace_id) => trace_id,
+        Err(_) => {
+            let random_id_generator = RandomIdGenerator::default();
+            random_id_generator.new_trace_id()
+        }
+    }
+}
+
+/// Return a string formatted as YYMMDD
+/// and rounded to the near multiple of 5 after DD=05
+fn now_as_string(now: DateTime<Utc>) -> String {
+    let year = now.year() - 2000;
+    let month = now.month();
+    // round the day to the closest multiple of 5
+    // so the days end-up being 1, 5, 10, 15, 20, 25, 30
+    let today = now.day();
+    let day = if today < 5 { 1 } else { (today / 5) * 5 };
+
+    format!("{:02}{:02}{:02}", year, month, day)
+}
+
 /// Return the MAC address for the current machine
-pub(crate) fn get_mac_address() -> Option<String> {
+fn get_mac_address() -> Option<String> {
     let output = Command::new("ifconfig").output().ok()?;
     let output_str = String::from_utf8_lossy(&output.stdout);
 
@@ -72,7 +157,7 @@ pub(crate) fn get_mac_address() -> Option<String> {
 }
 
 /// Return the IP address for the current machine
-pub(crate) fn get_ip_address() -> Option<String> {
+fn get_ip_address() -> Option<String> {
     let output = Command::new("ifconfig").output().ok()?;
     let output_str = String::from_utf8_lossy(&output.stdout);
 
@@ -90,4 +175,74 @@ pub(crate) fn get_ip_address() -> Option<String> {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_make_host_trace_id_ends_with_the_current_date() {
+        let trace_id = make_host_trace_id(datetime("2024-02-22T12:00:00Z")).to_string();
+        let length = trace_id.len();
+        // the day is rounded to the closest multiple of 5
+        assert_eq!(
+            &trace_id[length - 6..length],
+            "240220",
+            "the current host is {} = mac {:?} / ip {:?} / hostname {:?}",
+            make_host(),
+            get_mac_address(),
+            get_ip_address(),
+            gethostname().to_string_lossy().to_string()
+        );
+    }
+
+    #[test]
+    fn test_make_host_journey_span_id_is_end_of_trace_id() {
+        let trace_id = make_host_trace_id(datetime("2024-02-22T12:00:00Z"));
+        let span_id = make_journey_span_id(trace_id);
+        assert!(trace_id.to_string().ends_with(span_id.to_string().as_str()));
+    }
+
+    #[test]
+    fn test_make_project_trace_id_contains_part_of_the_project_id_and_current_date() {
+        let trace_id = make_project_trace_id(
+            "8a12dc0e-d48b-4da1-925d-cda822505348",
+            datetime("2024-02-22T12:00:00Z"),
+        )
+        .to_string();
+        // the day is rounded to the closest multiple of 5
+        assert_eq!(
+            trace_id, "18a12dc0ed48b4da1925dcda82240220",
+            "the trace id {trace_id} is incorrect"
+        );
+    }
+
+    #[test]
+    fn test_make_project_span_id_is_end_of_trace_id() {
+        let trace_id = make_project_trace_id(
+            "8a12dc0e-d48b-4da1-925d-cda822505348",
+            datetime("2024-02-22T12:00:00Z"),
+        );
+        let span_id = make_journey_span_id(trace_id);
+        assert!(trace_id.to_string().ends_with(span_id.to_string().as_str()));
+    }
+
+    #[test]
+    fn test_now_as_string() {
+        // days are rounded to the lower multiple of 5 after 5
+        assert_eq!(now_as_string(datetime("2024-02-01T12:00:00Z")), "240201");
+        assert_eq!(now_as_string(datetime("2024-02-04T12:00:00Z")), "240201");
+        assert_eq!(now_as_string(datetime("2024-02-05T12:00:00Z")), "240205");
+        assert_eq!(now_as_string(datetime("2024-02-07T12:00:00Z")), "240205");
+        assert_eq!(now_as_string(datetime("2024-02-09T12:00:00Z")), "240205");
+        assert_eq!(now_as_string(datetime("2024-02-10T12:00:00Z")), "240210");
+        assert_eq!(now_as_string(datetime("2024-03-31T12:00:00Z")), "240330");
+    }
+
+    /// HELPERS
+    fn datetime(s: &str) -> DateTime<Utc> {
+        Utc.from_utc_datetime(&DateTime::parse_from_rfc3339(s).unwrap().naive_utc())
+    }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/attributes.rs
@@ -7,6 +7,7 @@ use gethostname::gethostname;
 use opentelemetry::trace::{SpanId, TraceId};
 use opentelemetry::Key;
 use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::process::Command;
@@ -95,7 +96,7 @@ pub(crate) fn make_host() -> String {
         ),
         _ => gethostname().to_string_lossy().to_string(),
     };
-    convert_to_hex(&host)
+    convert_to_hex(&hash(host))
 }
 
 // Check if the string is already in hexadecimal format
@@ -111,6 +112,13 @@ fn convert_to_hex(s: &str) -> String {
             output
         })
     }
+}
+
+// Hash a string using SHA256
+fn hash(s: String) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    format!("{:x}", hasher.finalize())
 }
 
 /// Parse an hex string to a TraceId and generate a random one in case of a parsing error

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, Utc};
+use ockam_core::OpenTelemetryContext;
+use std::time::SystemTime;
+
+/// A journey is a pseudo-trace where spans represents user events.
+/// The tracing context is kept in the `opentelemetry_context` field.
+///
+/// A journey is time-limited to avoid spans accumulating for too long in a single trace.
+/// After a while a new Journey is started and its `previous_opentelemetry_context` field must
+/// point to the previous journey.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Journey {
+    opentelemetry_context: OpenTelemetryContext,
+    previous_opentelemetry_context: Option<OpenTelemetryContext>,
+    start: DateTime<Utc>,
+}
+
+impl Journey {
+    pub fn new(
+        opentelemetry_context: OpenTelemetryContext,
+        previous_opentelemetry_context: Option<OpenTelemetryContext>,
+        start: DateTime<Utc>,
+    ) -> Journey {
+        Journey {
+            opentelemetry_context,
+            previous_opentelemetry_context,
+            start,
+        }
+    }
+
+    pub fn opentelemetry_context(&self) -> OpenTelemetryContext {
+        self.opentelemetry_context.clone()
+    }
+
+    pub fn previous_opentelemetry_context(&self) -> Option<OpenTelemetryContext> {
+        self.previous_opentelemetry_context.clone()
+    }
+
+    pub fn start(&self) -> DateTime<Utc> {
+        self.start
+    }
+
+    pub fn start_system_time(&self) -> SystemTime {
+        SystemTime::from(self.start)
+    }
+
+    pub fn extract_context(&self) -> opentelemetry::Context {
+        self.opentelemetry_context.extract()
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/mod.rs
@@ -1,7 +1,11 @@
 pub mod attributes;
+mod journey;
 mod journey_event;
 #[allow(clippy::module_inception)]
 pub mod journeys;
+mod project_journey;
 
+pub use journey::*;
 pub use journey_event::*;
 pub use journeys::*;
+pub use project_journey::*;

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/project_journey.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/project_journey.rs
@@ -1,0 +1,58 @@
+use crate::journeys::Journey;
+use chrono::{DateTime, Utc};
+use ockam_core::OpenTelemetryContext;
+use std::time::SystemTime;
+
+/// A Project journey is a journey (i.e. a pseudo trace storing user events)
+/// scoped to a specific project
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectJourney {
+    project_id: String,
+    journey: Journey,
+}
+
+impl ProjectJourney {
+    pub fn new(
+        project_id: &str,
+        opentelemetry_context: OpenTelemetryContext,
+        previous_opentelemetry_context: Option<OpenTelemetryContext>,
+        start: DateTime<Utc>,
+    ) -> ProjectJourney {
+        ProjectJourney {
+            project_id: project_id.to_string(),
+            journey: Journey::new(opentelemetry_context, previous_opentelemetry_context, start),
+        }
+    }
+
+    pub fn to_journey(&self) -> Journey {
+        Journey::new(
+            self.opentelemetry_context(),
+            self.previous_opentelemetry_context(),
+            self.journey.start(),
+        )
+    }
+
+    pub fn opentelemetry_context(&self) -> OpenTelemetryContext {
+        self.journey.opentelemetry_context()
+    }
+
+    pub fn previous_opentelemetry_context(&self) -> Option<OpenTelemetryContext> {
+        self.journey.previous_opentelemetry_context()
+    }
+
+    pub fn start(&self) -> DateTime<Utc> {
+        self.journey.start()
+    }
+
+    pub fn start_system_time(&self) -> SystemTime {
+        SystemTime::from(self.start())
+    }
+
+    pub fn extract_context(&self) -> opentelemetry::Context {
+        self.opentelemetry_context().extract()
+    }
+
+    pub fn project_id(&self) -> String {
+        self.project_id.clone()
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository.rs
@@ -1,4 +1,5 @@
-use crate::{HostJourney, ProjectJourney};
+use crate::journeys::{Journey, ProjectJourney};
+use chrono::{DateTime, Utc};
 use ockam_core::async_trait;
 use ockam_core::Result;
 
@@ -7,12 +8,19 @@ pub trait JourneysRepository: Send + Sync + 'static {
     /// Store a project journey
     async fn store_project_journey(&self, project_journey: ProjectJourney) -> Result<()>;
 
-    async fn get_project_journey(&self, project_id: &str) -> Result<Option<ProjectJourney>>;
+    /// Return the most recent project journey started after now
+    async fn get_project_journey(
+        &self,
+        project_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Option<ProjectJourney>>;
 
-    async fn delete_project_journey(&self, project_id: &str) -> Result<()>;
+    /// Delete all the journeys related to a given project
+    async fn delete_project_journeys(&self, project_id: &str) -> Result<()>;
 
     /// Store a host journey
-    async fn store_host_journey(&self, host_journey: HostJourney) -> Result<()>;
+    async fn store_host_journey(&self, host_journey: Journey) -> Result<()>;
 
-    async fn get_host_journey(&self) -> Result<Option<HostJourney>>;
+    /// Return the most recent host journey started after now
+    async fn get_host_journey(&self, now: DateTime<Utc>) -> Result<Option<Journey>>;
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/journeys_repository_sql.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sqlx::*;
-use std::time::SystemTime;
 
+use crate::journeys::{Journey, ProjectJourney};
 use crate::storage::journeys_repository::JourneysRepository;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Result;
@@ -31,15 +31,33 @@ impl JourneysSqlxDatabase {
 #[async_trait]
 impl JourneysRepository for JourneysSqlxDatabase {
     async fn store_project_journey(&self, project_journey: ProjectJourney) -> Result<()> {
-        let query = query("INSERT OR REPLACE INTO project_journey VALUES (?, ?, ?)")
-            .bind(project_journey.project_id.to_sql())
-            .bind(project_journey.opentelemetry_context.to_string().to_sql())
-            .bind(project_journey.start.to_sql());
+        let query = query("INSERT OR REPLACE INTO project_journey VALUES (?, ?, ?, ?)")
+            .bind(project_journey.project_id().to_sql())
+            .bind(project_journey.opentelemetry_context().to_string().to_sql())
+            .bind(project_journey.start().to_sql())
+            .bind(
+                project_journey
+                    .previous_opentelemetry_context()
+                    .map(|c| c.to_string().to_sql()),
+            );
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn get_project_journey(&self, project_id: &str) -> Result<Option<ProjectJourney>> {
-        let query = query_as("SELECT project_id, opentelemetry_context, start_datetime FROM project_journey where project_id = ?").bind(project_id.to_sql());
+    async fn get_project_journey(
+        &self,
+        project_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Option<ProjectJourney>> {
+        let query = query_as(
+            "\
+        SELECT project_id, opentelemetry_context, start_datetime, previous_opentelemetry_context \
+        FROM project_journey \
+        WHERE  project_id = ? AND start_datetime <= ? \
+        ORDER BY start_datetime DESC \
+        LIMIT 1 OFFSET 0",
+        )
+        .bind(project_id.to_sql())
+        .bind(now.to_sql());
         let row: Option<ProjectJourneyRow> = query
             .fetch_optional(&*self.database.pool)
             .await
@@ -47,21 +65,34 @@ impl JourneysRepository for JourneysSqlxDatabase {
         Ok(row.map(|r| r.project_journey()).transpose()?)
     }
 
-    async fn delete_project_journey(&self, project_id: &str) -> Result<()> {
+    async fn delete_project_journeys(&self, project_id: &str) -> Result<()> {
         let query =
             query("DELETE FROM project_journey where project_id = ?").bind(project_id.to_sql());
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn store_host_journey(&self, host_journey: HostJourney) -> Result<()> {
-        let query = query("INSERT OR REPLACE INTO host_journey VALUES (?, ?)")
-            .bind(host_journey.opentelemetry_context.to_string().to_sql())
-            .bind(host_journey.start.to_sql());
+    async fn store_host_journey(&self, host_journey: Journey) -> Result<()> {
+        let query = query("INSERT OR REPLACE INTO host_journey VALUES (?, ?, ?)")
+            .bind(host_journey.opentelemetry_context().to_string().to_sql())
+            .bind(host_journey.start().to_sql())
+            .bind(
+                host_journey
+                    .previous_opentelemetry_context()
+                    .map(|c| c.to_string().to_sql()),
+            );
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn get_host_journey(&self) -> Result<Option<HostJourney>> {
-        let query = query_as("SELECT opentelemetry_context, start_datetime FROM host_journey");
+    async fn get_host_journey(&self, now: DateTime<Utc>) -> Result<Option<Journey>> {
+        let query = query_as(
+            "\
+        SELECT opentelemetry_context, start_datetime, previous_opentelemetry_context \
+        FROM host_journey \
+        WHERE start_datetime <= ? \
+        ORDER BY start_datetime DESC \
+        LIMIT 1 OFFSET 0",
+        )
+        .bind(now.to_sql());
         let row: Option<HostJourneyRow> = query
             .fetch_optional(&*self.database.pool)
             .await
@@ -70,106 +101,44 @@ impl JourneysRepository for JourneysSqlxDatabase {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProjectJourney {
-    project_id: String,
-    opentelemetry_context: OpenTelemetryContext,
-    start: DateTime<Utc>,
-}
-
-impl ProjectJourney {
-    pub fn new(
-        project_id: &str,
-        opentelemetry_context: OpenTelemetryContext,
-        start: DateTime<Utc>,
-    ) -> ProjectJourney {
-        ProjectJourney {
-            project_id: project_id.to_string(),
-            opentelemetry_context,
-            start,
-        }
-    }
-
-    pub fn to_host_journey(&self) -> HostJourney {
-        HostJourney {
-            opentelemetry_context: self.opentelemetry_context.clone(),
-            start: self.start,
-        }
-    }
-
-    pub fn opentelemetry_context(&self) -> OpenTelemetryContext {
-        self.opentelemetry_context.clone()
-    }
-
-    pub fn start(&self) -> DateTime<Utc> {
-        self.start
-    }
-
-    pub fn start_system_time(&self) -> SystemTime {
-        SystemTime::from(self.start)
-    }
-
-    pub fn extract_context(&self) -> opentelemetry::Context {
-        self.opentelemetry_context.extract()
-    }
-
-    pub fn project_id(&self) -> String {
-        self.project_id.clone()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct HostJourney {
-    opentelemetry_context: OpenTelemetryContext,
-    start: DateTime<Utc>,
-}
-
-impl HostJourney {
-    pub fn new(opentelemetry_context: OpenTelemetryContext, start: DateTime<Utc>) -> HostJourney {
-        HostJourney {
-            opentelemetry_context,
-            start,
-        }
-    }
-
-    pub fn opentelemetry_context(&self) -> OpenTelemetryContext {
-        self.opentelemetry_context.clone()
-    }
-
-    pub fn start(&self) -> DateTime<Utc> {
-        self.start
-    }
-
-    pub fn start_system_time(&self) -> SystemTime {
-        SystemTime::from(self.start)
-    }
-
-    pub fn extract_context(&self) -> opentelemetry::Context {
-        self.opentelemetry_context.extract()
-    }
-}
-
 //  Database serialization / deserialization
 
 /// Low-level representation of a row in the project journey table
 #[derive(sqlx::FromRow)]
 struct ProjectJourneyRow {
+    project_id: String,
     opentelemetry_context: String,
     start_datetime: String,
-    project_id: String,
+    previous_opentelemetry_context: Option<String>,
 }
 
 impl ProjectJourneyRow {
-    pub(crate) fn project_journey(&self) -> Result<ProjectJourney> {
-        Ok(ProjectJourney {
-            opentelemetry_context: self.opentelemetry_context.clone().try_into()?,
-            start: DateTime::parse_from_rfc3339(&self.start_datetime)
-                .map_err(|e| {
-                    ockam_core::Error::new(Origin::Api, Kind::Serialization, format!("{e:?}"))
-                })?
-                .into(),
-            project_id: self.project_id.clone(),
-        })
+    fn project_journey(&self) -> Result<ProjectJourney> {
+        Ok(ProjectJourney::new(
+            self.project_id.as_str(),
+            self.opentelemetry_context()?,
+            self.previous_opentelemetry_context()?,
+            self.start()?,
+        ))
+    }
+
+    fn opentelemetry_context(&self) -> Result<OpenTelemetryContext> {
+        self.opentelemetry_context.clone().try_into()
+    }
+
+    fn previous_opentelemetry_context(&self) -> Result<Option<OpenTelemetryContext>> {
+        self.previous_opentelemetry_context
+            .clone()
+            .map(|c| c.try_into())
+            .transpose()
+    }
+
+    fn start(&self) -> Result<DateTime<Utc>> {
+        Ok(DateTime::parse_from_rfc3339(&self.start_datetime)
+            .map_err(|e| {
+                ockam_core::Error::new(Origin::Api, Kind::Serialization, format!("{e:?}"))
+            })?
+            .into())
     }
 }
 
@@ -178,50 +147,204 @@ impl ProjectJourneyRow {
 struct HostJourneyRow {
     opentelemetry_context: String,
     start_datetime: String,
+    previous_opentelemetry_context: Option<String>,
 }
 
 impl HostJourneyRow {
-    pub(crate) fn host_journey(&self) -> Result<HostJourney> {
-        Ok(HostJourney {
-            opentelemetry_context: self.opentelemetry_context.clone().try_into()?,
-            start: DateTime::parse_from_rfc3339(&self.start_datetime)
-                .map_err(|e| {
-                    ockam_core::Error::new(Origin::Api, Kind::Serialization, format!("{e:?}"))
-                })?
-                .into(),
-        })
+    fn host_journey(&self) -> Result<Journey> {
+        Ok(Journey::new(
+            self.opentelemetry_context()?,
+            self.previous_opentelemetry_context()?,
+            self.start()?,
+        ))
+    }
+
+    fn opentelemetry_context(&self) -> Result<OpenTelemetryContext> {
+        self.opentelemetry_context.clone().try_into()
+    }
+
+    fn previous_opentelemetry_context(&self) -> Result<Option<OpenTelemetryContext>> {
+        self.previous_opentelemetry_context
+            .clone()
+            .map(|c| c.try_into())
+            .transpose()
+    }
+
+    fn start(&self) -> Result<DateTime<Utc>> {
+        Ok(DateTime::parse_from_rfc3339(&self.start_datetime)
+            .map_err(|e| {
+                ockam_core::Error::new(Origin::Api, Kind::Serialization, format!("{e:?}"))
+            })?
+            .into())
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::ops::{Add, Sub};
     use std::str::FromStr;
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_repository() -> Result<()> {
         let repository = create_repository().await?;
 
+        // the repository is initially empty
+        let actual = repository.get_host_journey(Utc::now()).await?;
+        assert_eq!(actual, None);
+
         // create and store a host journey
         let opentelemetry_context = OpenTelemetryContext::from_str("{\"traceparent\":\"00-b9ce70eaad5a86ef6b9fa4db00589e86-8e2d99c5e5ed66e4-01\",\"tracestate\":\"\"}").unwrap();
-        let host_journey = HostJourney::new(opentelemetry_context.clone(), Utc::now());
+        let host_journey = Journey::new(opentelemetry_context.clone(), None, Utc::now());
         repository.store_host_journey(host_journey.clone()).await?;
-        let actual = repository.get_host_journey().await?;
+        let actual = repository.get_host_journey(Utc::now()).await?;
         assert_eq!(actual, Some(host_journey));
 
         // create and store a project journey
-        let project_journey = ProjectJourney::new("project_id", opentelemetry_context, Utc::now());
+        let project_journey =
+            ProjectJourney::new("project_id", opentelemetry_context, None, Utc::now());
         repository
             .store_project_journey(project_journey.clone())
             .await?;
-        let actual = repository.get_project_journey("project_id").await?;
+        let actual = repository
+            .get_project_journey("project_id", Utc::now())
+            .await?;
         assert_eq!(actual, Some(project_journey));
 
         // delete a project journey
-        repository.delete_project_journey("project_id").await?;
-        let actual = repository.get_project_journey("project_id").await?;
+        repository.delete_project_journeys("project_id").await?;
+        let actual = repository
+            .get_project_journey("project_id", Utc::now())
+            .await?;
         assert_eq!(actual, None);
+        Ok(())
+    }
+
+    /// This test checks that we can store host journeys with a previous / next relationship
+    #[tokio::test]
+    async fn test_several_host_journeys() -> Result<()> {
+        let repository = create_repository().await?;
+
+        // create and store a the first host journey
+        let opentelemetry_context1 = OpenTelemetryContext::from_str("{\"traceparent\":\"00-b9ce70eaad5a86ef6b9fa4db00589e86-8e2d99c5e5ed66e4-01\",\"tracestate\":\"\"}").unwrap();
+        let start1 = Utc::now();
+        let host_journey1 = Journey::new(opentelemetry_context1.clone(), None, start1);
+        repository.store_host_journey(host_journey1.clone()).await?;
+
+        // retrieve the journey based on the time
+        //   before the journey 1 start -> None
+        //   equal or after the journey 1 start -> Some(journey1)
+        let actual = repository
+            .get_host_journey(start1.sub(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, None);
+
+        let actual = repository.get_host_journey(start1).await?;
+        assert_eq!(actual, Some(host_journey1.clone()));
+
+        let actual = repository
+            .get_host_journey(start1.add(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(host_journey1.clone()));
+
+        // Create the next journey
+        let opentelemetry_context2 = OpenTelemetryContext::from_str("{\"traceparent\":\"00-b9ce70eaad5a86ef6b9fa4db00589e86-8e2d99c5e5ed66e4-02\",\"tracestate\":\"\"}").unwrap();
+        let start2 = start1.add(Duration::from_secs(1000));
+        let host_journey2 = Journey::new(
+            opentelemetry_context2.clone(),
+            Some(opentelemetry_context1),
+            start2,
+        );
+        repository.store_host_journey(host_journey2.clone()).await?;
+
+        // retrieve the journey based on the time
+        //   right before the journey 2 start -> Some(journey1)
+        //   equal or after the journey 2 start -> Some(journey2)
+        let actual = repository
+            .get_host_journey(start2.sub(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(host_journey1.clone()));
+
+        let actual = repository.get_host_journey(start2).await?;
+        assert_eq!(actual, Some(host_journey2.clone()));
+        assert_eq!(
+            host_journey2.previous_opentelemetry_context(),
+            Some(host_journey1.opentelemetry_context())
+        );
+
+        let actual = repository
+            .get_host_journey(start2.add(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(host_journey2));
+
+        Ok(())
+    }
+
+    /// This test checks that we can store project journeys with a previous / next relationship
+    #[tokio::test]
+    async fn test_several_project_journeys() -> Result<()> {
+        let repository = create_repository().await?;
+
+        // create and store a the first host journey
+        let opentelemetry_context1 = OpenTelemetryContext::from_str("{\"traceparent\":\"00-b9ce70eaad5a86ef6b9fa4db00589e86-8e2d99c5e5ed66e4-01\",\"tracestate\":\"\"}").unwrap();
+        let start1 = Utc::now();
+        let project_journey1 =
+            ProjectJourney::new("project_id", opentelemetry_context1.clone(), None, start1);
+        repository
+            .store_project_journey(project_journey1.clone())
+            .await?;
+
+        // retrieve the journey based on the time
+        //   before the journey 1 start -> None
+        //   equal or after the journey 1 start -> Some(journey1)
+        let actual = repository
+            .get_project_journey("project_id", start1.sub(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, None);
+
+        let actual = repository.get_project_journey("project_id", start1).await?;
+        assert_eq!(actual, Some(project_journey1.clone()));
+
+        let actual = repository
+            .get_project_journey("project_id", start1.add(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(project_journey1.clone()));
+
+        // Create the next journey
+        let opentelemetry_context2 = OpenTelemetryContext::from_str("{\"traceparent\":\"00-b9ce70eaad5a86ef6b9fa4db00589e86-8e2d99c5e5ed66e4-02\",\"tracestate\":\"\"}").unwrap();
+        let start2 = start1.add(Duration::from_secs(1000));
+        let project_journey2 = ProjectJourney::new(
+            "project_id",
+            opentelemetry_context2.clone(),
+            Some(opentelemetry_context1),
+            start2,
+        );
+        repository
+            .store_project_journey(project_journey2.clone())
+            .await?;
+
+        // retrieve the journey based on the time
+        //   right before the journey 2 start -> Some(journey1)
+        //   equal or after the journey 2 start -> Some(journey2)
+        let actual = repository
+            .get_project_journey("project_id", start2.sub(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(project_journey1.clone()));
+
+        let actual = repository.get_project_journey("project_id", start2).await?;
+        assert_eq!(actual, Some(project_journey2.clone()));
+        assert_eq!(
+            project_journey2.previous_opentelemetry_context(),
+            Some(project_journey1.opentelemetry_context())
+        );
+
+        let actual = repository
+            .get_project_journey("project_id", start2.add(Duration::from_secs(3)))
+            .await?;
+        assert_eq!(actual, Some(project_journey2));
+
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -1,7 +1,5 @@
 use colorful::Colorful;
 use miette::miette;
-use opentelemetry::trace::TraceContextExt;
-use opentelemetry::KeyValue;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio::try_join;
@@ -9,6 +7,7 @@ use tracing::{debug, info, instrument};
 
 use ockam::Context;
 use ockam_api::journeys::{JourneyEvent, NODE_NAME};
+use ockam_api::logs::CurrentSpan;
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::OpenTelemetryContext;
 
@@ -32,9 +31,7 @@ impl CreateCommand {
         }
 
         let node_name = self.node_name.clone();
-        opentelemetry::Context::current()
-            .span()
-            .set_attribute(KeyValue::new("node_name", node_name.clone()));
+        CurrentSpan::set_attribute(NODE_NAME, node_name.as_str());
         debug!("create node in background mode");
 
         opts.terminal.write_line(&fmt_log!(

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -53,7 +53,9 @@ where
     Fut: core::future::Future<Output = miette::Result<()>> + Send + 'static,
 {
     debug!("running {} asynchronously", command_name);
-    let res = embedded_node(opts.clone(), |ctx| async move { f(ctx).await });
+    let res = embedded_node(opts.clone(), |ctx| {
+        async move { f(ctx).await }.with_context(OpenTelemetryContext::current_context())
+    });
     local_cmd(res)
 }
 

--- a/implementations/rust/ockam/ockam_node/src/storage/database/application_migrations/20242102180000_time_limited_journey.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/application_migrations/20242102180000_time_limited_journey.sql
@@ -1,0 +1,20 @@
+-- We add a column to create several journeys
+-- where each new journey has a greater start time and uses the previous_opentelemetry_context to point to the
+-- previous journey
+
+-- The migration for the project_journey table has to be done in several steps in order to remove the PRIMARY KEY
+-- constraint on project_id
+CREATE TABLE project_journey_copy AS SELECT * FROM project_journey;
+CREATE TABLE project_journey_new (
+  project_id            TEXT NOT NULL,
+  opentelemetry_context TEXT NOT NULL UNIQUE,
+  start_datetime        TEXT NOT NULL,
+  previous_opentelemetry_context TEXT
+);
+
+INSERT INTO project_journey_new SELECT project_id, opentelemetry_context, start_datetime, NULL FROM project_journey_copy;
+DROP TABLE project_journey;
+DROP TABLE project_journey_copy;
+ALTER TABLE project_journey_new RENAME TO project_journey;
+
+ALTER TABLE host_journey ADD COLUMN previous_opentelemetry_context TEXT NULL;


### PR DESCRIPTION
This PR improves the host and project journeys. Since they are represented as traces, it is desirable to limit the growth of those traces.

This PR let spans accumulate for 5 days for a given journey (not configurable for now). After that date:

 - A new project/host journey is started
 - Its top span contains a link to the previous journey so that we can navigate to the previous data
 - The journey still contains the project id / host name so that it is still possible to query for all the traces related to a given project if necessary
 - The trace id incorporates the date as `YYMMDD` so that we can quickly identify when the actions took place
 - The `YYMMDD` dates are created in 5 days buckets so that the creation of journeys is very deterministic, even 
   if user actions are executed from different nodes on different days.


