### PR TITLE
fix(rust): do not enforce enrollment limit

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 pub(crate) struct EnrollerCheckResult {
     pub(crate) is_member: bool,
     pub(crate) is_enroller: bool,
+    pub(crate) is_admin: bool,
     pub(crate) is_pre_trusted: bool,
 }
 
@@ -41,14 +42,19 @@ impl EnrollerAccessControlChecks {
         identifier: &Identifier,
     ) -> Result<EnrollerCheckResult> {
         match members.get_member(identifier).await? {
-            Some(member) => Ok(EnrollerCheckResult {
-                is_member: true,
-                is_enroller: Self::check_bin_attributes_is_enroller(member.attributes()),
-                is_pre_trusted: member.is_pre_trusted(),
-            }),
+            Some(member) => {
+                let is_enroller = Self::check_bin_attributes_is_enroller(member.attributes());
+                Ok(EnrollerCheckResult {
+                    is_member: true,
+                    is_enroller,
+                    is_admin: is_enroller, //TODO: use project admin credentials
+                    is_pre_trusted: member.is_pre_trusted(),
+                })
+            }
             None => Ok(EnrollerCheckResult {
                 is_member: false,
                 is_enroller: false,
+                is_admin: false,
                 is_pre_trusted: false,
             }),
         }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
@@ -58,7 +58,7 @@ impl DirectAuthenticator {
         // Check if we're trying to create an enroller
         if EnrollerAccessControlChecks::check_bin_attributes_is_enroller(&attrs) {
             // Only pre-trusted identities will be able to add enrollers
-            if !check.is_pre_trusted {
+            if !check.is_admin {
                 warn!(
                     "Not pre trusted enroller {} is trying to create an enroller {}",
                     enroller, identifier
@@ -143,21 +143,21 @@ impl DirectAuthenticator {
 
         if check_member.is_pre_trusted {
             warn!(
-                "Enroller {} is trying to delete pre trusted enroller {}",
+                "Enroller {} is trying to delete a pre trusted identity {}",
                 enroller, identifier
             );
             return Ok(Either::Right(DirectAuthenticatorError(
-                "Enroller is trying to delete a pre trusted enroller".to_string(),
+                "Enroller is trying to delete a pre trusted identity".to_string(),
             )));
         }
 
-        if check_member.is_enroller && !check_enroller.is_pre_trusted {
+        if check_member.is_enroller && !check_enroller.is_admin {
             warn!(
-                "Not pre trusted enroller {} is trying to delete enroller {}",
+                "Not admin {} is trying to delete enroller {}",
                 enroller, identifier
             );
             return Ok(Either::Right(DirectAuthenticatorError(
-                "Not pre trusted enroller is trying to delete an enroller".to_string(),
+                "Not admin is trying to delete an enroller".to_string(),
             )));
         }
 

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -58,10 +58,13 @@ impl EnrollmentTokenIssuer {
         // Check if we're trying to create an enroller
         if EnrollerAccessControlChecks::check_str_attributes_is_enroller(&attrs) {
             // Only pre-trusted identities will be able to add enrollers
-            if !check.is_pre_trusted {
-                warn!("Not pre trusted enroller {} is trying to issue an enrollment token for an enroller", enroller);
+            if !check.is_admin {
+                warn!(
+                    "Not admin {} is trying to issue an enrollment token for an enroller",
+                    enroller
+                );
                 return Ok(Either::Right(EnrollmentTokenIssuerError(
-                    "Not pre trusted enroller is trying to issue an enrollment token for an enroller".to_string(),
+                    "Not admin is trying to issue an enrollment token for an enroller".to_string(),
                 )));
             }
         }

--- a/implementations/rust/ockam/ockam_api/tests/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/tests/direct_authenticator.rs
@@ -449,6 +449,7 @@ async fn enroller_cant_delete_admin(ctx: &mut Context) -> Result<()> {
 }
 
 #[ockam_macros::test]
+#[ignore] // TODO with admin credentials.  For now, all enrollers have rights to add/remove enrollers
 async fn enroller_cant_add_enroller(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels().await?;
 
@@ -493,6 +494,7 @@ async fn enroller_cant_add_enroller(ctx: &mut Context) -> Result<()> {
 }
 
 #[ockam_macros::test]
+#[ignore] // TODO with admin credentials.  For now, all enrollers have rights to add/remove enrollers
 async fn enroller_cant_delete_enroller(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels().await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/token_enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/tests/token_enrollment.rs
@@ -236,6 +236,7 @@ async fn enroller_can_add_member(ctx: &mut Context) -> Result<()> {
 }
 
 #[ockam_macros::test]
+#[ignore] // TODO with admin credentials.  For now, all enrollers have rights to add/remove enrollers
 async fn enroller_cant_add_enroller(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels().await?;
 


### PR DESCRIPTION
Our high level goal is to have three "roles" known by an authority:

* members:  the only thing they can do is request their own credentials.  
* enrollers: can add/remove/list existing `members`.  They can't add/remove other `enrollers`
* admins: can do what enrollers do,  but also are allowed to add/remove/list `enrollers`.

Further, we have the ability to pass a set of pre-trusted identities at the authority startup.   These identities can't be removed dynamically, they are statically there for the time the authority run.

The problem is we don't have _yet_ a way to identify admins.    The existing code checked if the enrollers was a pre-trusted one, and give the admin permission only to those.    But that doesn't cover current use cases,  so _for now_  we will make _all_ enrollers have admins rights on the authority (that is, they can add/remove other enrollers), effectively going back to the behavior prior to https://github.com/build-trust/ockam/pull/7032 .    This is a short term solution until we have project admin credential support.






