### PR TITLE
fix: logging must be disabled by default on parse errors

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -24,6 +24,9 @@ pub(crate) const OCKAM_LOG_MAX_FILES: &str = "OCKAM_LOG_MAX_FILES";
 /// Log format. Accepted values, see LogFormat. For example: pretty, json, default
 pub(crate) const OCKAM_LOG_FORMAT: &str = "OCKAM_LOG_FORMAT";
 
+/// Filter for log messages based on crate names. Accepted values: 'all', 'default', 'comma-separated strings'. For example: ockam_core,ockam_api
+pub(crate) const OCKAM_LOG_CRATES_FILTER: &str = "OCKAM_LOG_CRATES_FILTER";
+
 ///
 /// TRACING CONFIGURATION
 ///

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
@@ -159,21 +159,6 @@ impl LoggingConfiguration {
         )
     }
 
-    /// LoggingConfiguration for a foreground command
-    pub fn foreground() -> ockam_core::Result<Self> {
-        Ok(LoggingConfiguration::new(
-            LoggingEnabled::On,
-            Level::TRACE,
-            global_error_handler_enabled()?,
-            100,
-            60,
-            LogFormat::Default,
-            Colored::Off,
-            None,
-            None,
-        ))
-    }
-
     /// Return a LoggingConfiguration which creates logs for a background node
     pub fn background(
         log_dir: Option<PathBuf>,

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -1,6 +1,6 @@
 use ockam_api::logs::{
-    global_error_handler_enabled, Colored, LogFormat, LoggingConfiguration, LoggingEnabled,
-    LoggingTracing, TracingConfiguration,
+    global_error_handler_enabled, Colored, CratesFilter, LogFormat, LoggingConfiguration,
+    LoggingEnabled, LoggingTracing, TracingConfiguration,
 };
 use ockam_api::random_name;
 
@@ -31,7 +31,7 @@ fn test_log_and_traces() {
     let guard = LoggingTracing::setup_with_exporters(
         spans_exporter.clone(),
         logs_exporter.clone(),
-        &LoggingConfiguration::make_configuration()
+        &make_configuration()
             .unwrap()
             .set_log_directory(log_directory.into()),
         &TracingConfiguration::foreground(false).unwrap(),
@@ -99,6 +99,6 @@ fn make_configuration() -> ockam_core::Result<LoggingConfiguration> {
         LogFormat::Default,
         Colored::Off,
         None,
-        None,
+        CratesFilter::All,
     ))
 }

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -1,4 +1,7 @@
-use ockam_api::logs::{LoggingConfiguration, LoggingTracing, TracingConfiguration};
+use ockam_api::logs::{
+    global_error_handler_enabled, Colored, LogFormat, LoggingConfiguration, LoggingEnabled,
+    LoggingTracing, TracingConfiguration,
+};
 use ockam_api::random_name;
 
 use opentelemetry::global;
@@ -13,6 +16,7 @@ use std::fs;
 use tempfile::NamedTempFile;
 
 use tracing::{error, info};
+use tracing_core::Level;
 
 /// These tests need to be integration tests
 /// They need to run in isolation because
@@ -27,7 +31,7 @@ fn test_log_and_traces() {
     let guard = LoggingTracing::setup_with_exporters(
         spans_exporter.clone(),
         logs_exporter.clone(),
-        &LoggingConfiguration::foreground()
+        &LoggingConfiguration::make_configuration()
             .unwrap()
             .set_log_directory(log_directory.into()),
         &TracingConfiguration::foreground(false).unwrap(),
@@ -81,4 +85,20 @@ fn test_log_and_traces() {
         stdout_file_checked,
         "the stdout log file must have been found and checked"
     )
+}
+
+/// HELPERS
+
+fn make_configuration() -> ockam_core::Result<LoggingConfiguration> {
+    Ok(LoggingConfiguration::new(
+        LoggingEnabled::On,
+        Level::TRACE,
+        global_error_handler_enabled()?,
+        100,
+        60,
+        LogFormat::Default,
+        Colored::Off,
+        None,
+        None,
+    ))
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -1,5 +1,7 @@
 use crate::state::{AppState, NODE_NAME};
-use ockam_api::logs::{logging_configuration, Colored, LoggingTracing, TracingConfiguration};
+use ockam_api::logs::{
+    logging_configuration, Colored, CratesFilter, LoggingTracing, TracingConfiguration,
+};
 use tracing_core::Level;
 
 impl AppState {
@@ -17,24 +19,24 @@ impl AppState {
                 .block_on(async move { this.state().await });
             state.node_dir(NODE_NAME)
         };
-        let ockam_crates = [
-            "ockam",
-            "ockam_node",
-            "ockam_core",
-            "ockam_vault",
-            "ockam_identity",
-            "ockam_transport_tcp",
-            "ockam_api",
-            "ockam_command",
-            "ockam_app_lib",
-        ];
+        let ockam_crates = CratesFilter::Selected(vec![
+            "ockam".to_string(),
+            "ockam_node".to_string(),
+            "ockam_core".to_string(),
+            "ockam_vault".to_string(),
+            "ockam_identity".to_string(),
+            "ockam_transport_tcp".to_string(),
+            "ockam_api".to_string(),
+            "ockam_command".to_string(),
+            "ockam_app_lib".to_string(),
+        ]);
 
         let tracing_guard = LoggingTracing::setup(
             &logging_configuration(
                 Some(Level::DEBUG),
                 Colored::Off,
                 Some(node_dir),
-                &ockam_crates,
+                ockam_crates,
             )
             .unwrap(),
             &TracingConfiguration::foreground(true).unwrap(),

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -8,8 +8,8 @@ use tracing::{debug, info};
 use tracing_core::Level;
 
 use ockam_api::logs::{
-    logging_configuration, Colored, LoggingConfiguration, LoggingTracing, TracingConfiguration,
-    TracingGuard,
+    crates_filter, logging_configuration, Colored, LoggingConfiguration, LoggingTracing,
+    TracingConfiguration, TracingGuard,
 };
 use ockam_api::CliState;
 
@@ -138,11 +138,9 @@ impl CommandGlobalOpts {
         };
 
         let log_path = cmd.log_path();
+        let crates = crates_filter().into_diagnostic()?;
         if cmd.is_background_node() {
-            Ok(
-                LoggingConfiguration::background(log_path, LoggingConfiguration::default_crates())
-                    .into_diagnostic()?,
-            )
+            Ok(LoggingConfiguration::background(log_path, crates).into_diagnostic()?)
         } else {
             let preferred_log_level = verbose_log_level(global_args.verbose);
             let colored = if !global_args.no_color && is_tty {
@@ -150,13 +148,10 @@ impl CommandGlobalOpts {
             } else {
                 Colored::Off
             };
-            Ok(logging_configuration(
-                preferred_log_level,
-                colored,
-                log_path,
-                LoggingConfiguration::default_crates(),
+            Ok(
+                logging_configuration(preferred_log_level, colored, log_path, crates)
+                    .into_diagnostic()?,
             )
-            .into_diagnostic()?)
         }
     }
 

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use ockam_api::cli_state::CliState;
 use ockam_api::logs::{
-    logging_configuration, Colored, LoggingConfiguration, LoggingTracing, TracingConfiguration,
+    crates_filter, logging_configuration, Colored, LoggingTracing, TracingConfiguration,
 };
 
 /// Main method for running the `ockam` executable:
@@ -37,7 +37,7 @@ pub fn run() -> miette::Result<()> {
                     Some(Level::TRACE),
                     Colored::On,
                     None,
-                    LoggingConfiguration::default_crates(),
+                    crates_filter().into_diagnostic()?,
                 );
                 let _guard = LoggingTracing::setup(
                     &logging_configuration.into_diagnostic()?,

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -1,11 +1,14 @@
 use clap::Parser;
 use miette::IntoDiagnostic;
+use tracing_core::Level;
 
 use crate::{
     add_command_error_event, has_help_flag, pager, replace_hyphen_with_stdin, OckamCommand,
 };
 use ockam_api::cli_state::CliState;
-use ockam_api::logs::{LoggingConfiguration, LoggingTracing, TracingConfiguration};
+use ockam_api::logs::{
+    logging_configuration, Colored, LoggingConfiguration, LoggingTracing, TracingConfiguration,
+};
 
 /// Main method for running the `ockam` executable:
 ///
@@ -29,8 +32,15 @@ pub fn run() -> miette::Result<()> {
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>()
                     .join(" ");
+
+                let logging_configuration = logging_configuration(
+                    Some(Level::TRACE),
+                    Colored::On,
+                    None,
+                    LoggingConfiguration::default_crates(),
+                );
                 let _guard = LoggingTracing::setup(
-                    &LoggingConfiguration::foreground().into_diagnostic()?,
+                    &logging_configuration.into_diagnostic()?,
                     &TracingConfiguration::foreground(true).into_diagnostic()?,
                     "local node",
                 );

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -19,6 +19,7 @@ Logging
 - OCKAM_LOG_FORMAT: a `string` that overrides the default format of the logs: `default`, `json`, or `pretty`. Default value: `default`.
 - OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB. Default value `100`.
 - OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node. Default value `60`.
+- OCKAM_LOG_CRATES_FILTER: a filter for log messages based on crate names: `all`, `default`, comma-separated list of crate names. Default value: `default`, i.e. the list of `ockam` crates.
 
 Tracing
 - OCKAM_TRACING: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`


### PR DESCRIPTION
I have also added an environment variable to be able to select crates when filtering log messages (the next step would be a `crate=log level` format).
