### PR TITLE
Small adjustments to tracing

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -116,7 +116,9 @@ impl CliState {
         let start_time = SystemTime::from(Utc::now());
         let end_time = start_time.add(EVENT_DURATION);
 
-        let journeys = self.get_journeys(project.clone().map(|p| p.id)).await?;
+        let journeys = self
+            .get_journeys(project.clone().map(|p| p.project_id().to_string()))
+            .await?;
         for journey in journeys {
             let span_builder = SpanBuilder::from_name(event.to_string())
                 .with_start_time(start_time)

--- a/implementations/rust/ockam/ockam_api/src/logs/tracing_guard.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/tracing_guard.rs
@@ -1,3 +1,4 @@
+use opentelemetry::global;
 use opentelemetry_sdk::logs::LoggerProvider;
 use opentelemetry_sdk::trace::TracerProvider;
 use tracing_appender::non_blocking::WorkerGuard;
@@ -33,6 +34,12 @@ impl TracingGuard {
             logger_provider: None,
             tracer_provider: None,
         }
+    }
+
+    pub fn shutdown(&self) {
+        self.force_flush();
+        global::shutdown_tracer_provider();
+        global::shutdown_logger_provider();
     }
 
     /// Export the current batches of spans and log records

--- a/implementations/rust/ockam/ockam_api/tests/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/tests/journeys.rs
@@ -66,7 +66,6 @@ fn test_create_journey_event() {
     tracing_guard.force_flush();
     let mut spans = spans_exporter.get_finished_spans().unwrap();
     spans.sort_by_key(|s| s.start_time);
-    assert_eq!(spans.len(), 11);
 
     // keep only application events
     let spans: Vec<SpanData> = spans
@@ -79,7 +78,6 @@ fn test_create_journey_event() {
         .collect();
 
     let mut span_names = spans.iter().map(|s| s.name.as_ref()).collect::<Vec<&str>>();
-
     let mut expected = vec!["✅ enrolled", "✅ portal created", "❌ command error"];
 
     // spans are not necessarily retrieved in a deterministic order

--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use crate::common::trace_code::*;
+use itertools::Itertools;
 use ockam::identity::{SecureChannelListenerOptions, SecureChannelOptions};
 use ockam::node;
 use ockam_api::echoer::Echoer;
@@ -24,7 +25,12 @@ fn test_context_propagation_across_instrumented_methods() {
     spans.reverse();
 
     // there must be 3 spans
-    assert_eq!(spans.len(), 3);
+    assert_eq!(
+        spans.len(),
+        3,
+        "{}",
+        spans.iter().map(|s| s.name.to_string()).join(", ")
+    );
     let span1 = spans.get(0).unwrap();
     let span2 = spans.get(1).unwrap();
     let span3 = spans.get(2).unwrap();

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -127,6 +127,7 @@ impl OckamCommand {
                 arguments.join(" "),
             )?
         };
+        options.shutdown();
         result
     }
 

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -195,7 +195,14 @@ impl CommandGlobalOpts {
     /// Flush spans and log records
     pub fn force_flush(&self) {
         if let Some(tracing_guard) = self.tracing_guard.clone() {
-            tracing_guard.force_flush()
+            tracing_guard.force_flush();
+        };
+    }
+
+    /// Shutdown resources
+    pub fn shutdown(&self) {
+        if let Some(tracing_guard) = self.tracing_guard.clone() {
+            tracing_guard.shutdown();
         };
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -133,7 +133,7 @@ impl CreateCommand {
         )
         .await?;
 
-        opts.force_flush();
+        opts.shutdown();
 
         // Try to stop node; it might have already been stopped or deleted (e.g. when running `node delete --all`)
         opts.state.stop_node(&node_name, true).await?;


### PR DESCRIPTION
This PR does small adjustments to tracing:

 - We force the flushing and shutdown of tracing/logging at the end of a command.
 - The trace for a background node is necessarily a bit incomplete, as long as the node is running because some spans never end. I tried to make things look better but some parent spans will always be missing from the trace of a background node:
<img width="478" alt="image" src="https://github.com/build-trust/ockam/assets/10988/f3ae15ed-457a-4a9a-8eea-772a68f51dfd">

This PR separates the trace for the original `ockam node create` command, which always terminates, from the trace for the `ockam node create --foreground` command to make things clearer.
The background trace contains a link to the `node create` initial command in order to navigate more easily to the original user command.

 - There's small refactoring, to avoid querying a project twice.
 - Last minute addition: some small changes to some tests collecting spans to make them more robust.