### PR TITLE
fix(rust): policies migrations

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20240212100000_split_policies.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_20240212100000_split_policies.rs
@@ -52,11 +52,11 @@ impl SplitPolicies {
 }
 
 #[derive(FromRow)]
-struct ResourcePolicyRow {
-    resource_name: String,
-    action: String,
-    expression: String,
-    node_name: String,
+pub(crate) struct ResourcePolicyRow {
+    pub(crate) resource_name: String,
+    pub(crate) action: String,
+    pub(crate) expression: String,
+    pub(crate) node_name: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
How to test:

```
git checkout ockam_v0.116.0
cargo build -p ockam_command
./target/debug/ockam reset -y
./target/debug/ockam policy create --resource tcp-inlet --expression "(= subject.component \"outlet\")"

# the `status` command should just work, and not return 
# the "Failed to initialize local state, please reset" error
git checkout adrian/fix-policies-migrations
cargo build -p ockam_command
./target/debug/ockam status
```