### PR TITLE
test: remove context stop in tests using the test macro

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -202,7 +202,6 @@ mod test {
 
             correlation_id += 1;
         }
-
-        context.stop().await
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -251,7 +251,6 @@ async fn send_echo_message_over_secure_channel(
 
     ctx.stop_worker(channel.encryptor_address().clone()).await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
-    ctx.stop().await?;
     Ok(result)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -282,7 +282,6 @@ mod tests {
             .to_string();
         assert!(res.contains("/ip4/127.0.0.1/tcp/"));
 
-        ctx.stop().await.unwrap();
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -248,7 +248,7 @@ mod tests {
     use super::*;
 
     #[ockam_macros::test(crate = "ockam")]
-    async fn test_process_multi_addr(ctx: &mut Context) -> ockam::Result<()> {
+    async fn test_process_multi_addr(_ctx: &mut Context) -> ockam::Result<()> {
         let cli_state = CliState::test().await?;
 
         cli_state.create_node("n1").await?;
@@ -284,8 +284,6 @@ mod tests {
                 assert!(process_nodes_multiaddr(&ma, &cli_state).await.is_err());
             }
         }
-
-        ctx.stop().await?;
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_identity/tests/channel.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/channel.rs
@@ -325,8 +325,7 @@ async fn test_channel_send_multiple_messages_both_directions(ctx: &mut Context) 
         let message = child_ctx.receive::<String>().await?;
         assert_eq!(&payload, message.as_body());
     }
-
-    ctx.stop().await
+    Ok(())
 }
 
 #[ockam_macros::test]
@@ -745,8 +744,7 @@ async fn test_many_times_tunneled_secure_channel_works(ctx: &mut Context) -> Res
         .send(return_route, "Hello, Alice!".to_string())
         .await?;
     assert_eq!("Hello, Alice!", child_ctx.receive::<String>().await?.body());
-
-    ctx.stop().await
+    Ok(())
 }
 
 struct Receiver {

--- a/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
+++ b/implementations/rust/ockam/ockam_macros/src/node_test_attribute.rs
@@ -81,7 +81,7 @@ fn output(mut cont: Container) -> TokenStream {
         }
     };
     let ctx_stop_stmt = quote! {
-        let _ = AssertUnwindSafe(async { #ctx_ident.stop().await.unwrap(); })
+        let _ = AssertUnwindSafe(async { let _ = #ctx_ident.stop().await; })
             .catch_unwind()
             .await;
     };

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -242,8 +242,7 @@ mod tests {
         let (_, drop_sender) = AsyncDrop::new(ctx.sender.clone());
         let (copy, _, _) = ctx.copy_with_mailboxes_detached(mailboxes, drop_sender);
         assert!(copy.is_transport_registered(transport.transport_type()));
-
-        ctx.stop().await
+        Ok(())
     }
 
     struct SomeTransport();

--- a/implementations/rust/ockam/ockam_node/src/context/transports.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/transports.rs
@@ -90,7 +90,7 @@ mod tests {
         let transport = Arc::new(SomeTransport());
         ctx.register_transport(transport.clone());
         assert!(ctx.is_transport_registered(transport.transport_type()));
-        ctx.stop().await
+        Ok(())
     }
 
     #[ockam_macros::test(crate = "crate")]
@@ -110,7 +110,7 @@ mod tests {
             .await;
 
         assert!(result.is_err());
-        ctx.stop().await
+        Ok(())
     }
 
     #[ockam_macros::test(crate = "crate")]
@@ -128,7 +128,7 @@ mod tests {
             .unwrap()
             .to_string()
             .contains("only one transport hop is allowed in a route"));
-        ctx.stop().await
+        Ok(())
     }
 
     struct SomeTransport();

--- a/implementations/rust/ockam/ockam_node/src/delayed.rs
+++ b/implementations/rust/ockam/ockam_node/src/delayed.rs
@@ -144,7 +144,7 @@ mod tests {
         sleep(Duration::from_millis(150)).await;
 
         assert_eq!(3, msgs_count.load(Ordering::Relaxed));
-        ctx.stop().await
+        Ok(())
     }
 
     #[allow(non_snake_case)]
@@ -166,7 +166,7 @@ mod tests {
         sleep(Duration::from_millis(150)).await;
 
         assert_eq!(1, msgs_count.load(Ordering::Relaxed));
-        ctx.stop().await
+        Ok(())
     }
 
     #[allow(non_snake_case)]
@@ -190,7 +190,7 @@ mod tests {
         sleep(Duration::from_millis(300)).await;
 
         assert_eq!(1, msgs_count.load(Ordering::Relaxed));
-        ctx.stop().await
+        Ok(())
     }
 
     #[allow(non_snake_case)]
@@ -214,7 +214,6 @@ mod tests {
         sleep(Duration::from_millis(300)).await;
 
         assert_eq!(1, msgs_count.load(Ordering::Relaxed));
-
-        ctx.stop().await
+        Ok(())
     }
 }


### PR DESCRIPTION
Most of the time it is not necessary to call `ctx.stop()` excepted in some very rare cases. For those cases, the `ctx.stop()` present in the test macro does not throw the error if we try to stop the context twice.