### PR TITLE
feat(rust): display initialization errors when running ockam

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
+++ b/implementations/rust/ockam/ockam_command/src/bin/ockam.rs
@@ -5,7 +5,9 @@
 use ockam_command::util::exitcode;
 
 fn main() {
-    if ockam_command::entry_point::run().is_err() {
+    if let Err(e) = ockam_command::entry_point::run() {
+        // initialization errors are displayed here
+        println!("{:?}", e);
         std::process::exit(exitcode::SOFTWARE);
     }
 }


### PR DESCRIPTION
With this PR, if the database is corrupted, a simple to `ockam` will not stay silent and will display:
<img width="629" alt="image" src="https://github.com/build-trust/ockam/assets/10988/b21738b7-fb21-47e8-bebf-389ab69070f1">

