### PR TITLE
handle project admin credentials on authority

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-client.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-client.rs
@@ -53,6 +53,7 @@ async fn main(ctx: Context) -> Result<()> {
         &issuer,
         &MultiAddr::try_from("/dnsaddr/localhost/tcp/5000/secure/api")?,
         &client,
+        None,
     )
     .await?;
     let credential = authority_node.issue_credential(node.context()).await.unwrap();

--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -54,7 +54,7 @@ async fn main(ctx: Context) -> Result<()> {
     //
     // For a different application this attested attribute set can be different and
     // distinct for each identifier, but for this example we'll keep things simple.
-    let credential_issuer = CredentialIssuerWorker::new(members.clone(), node.credentials(), &issuer, None, None);
+    let credential_issuer = CredentialIssuerWorker::new(members.clone(), node.credentials(), &issuer, None, None, None);
 
     let mut pre_trusted_identities = BTreeMap::<Identifier, PreTrustedIdentity>::new();
     let attributes = PreTrustedIdentity::new(

--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -58,6 +58,7 @@ async fn main(ctx: Context) -> Result<()> {
         &issuer,
         &MultiAddr::try_from("/dnsaddr/localhost/tcp/5000/secure/api").unwrap(),
         &server,
+        None,
     )
     .await?;
     let credential = authority_node.issue_credential(node.context()).await.unwrap();

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -67,6 +67,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         &control_plane,
         &MultiAddr::try_from("/dnsaddr/localhost/tcp/5000")?,
         &node.create_identity().await?,
+        None,
     )
     .await?;
     authority_node.present_token(node.context(), token).await.unwrap();

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -66,6 +66,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
         &edge_plane,
         &MultiAddr::try_from("/dnsaddr/localhost/tcp/5000")?,
         &node.create_identity().await?,
+        None,
     )
     .await?;
     authority_node.present_token(node.context(), token).await.unwrap();

--- a/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
@@ -5,6 +5,8 @@ use ockam_core::Result;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use super::direct::AccountAuthorityInfo;
+
 pub(crate) struct EnrollerCheckResult {
     pub(crate) is_member: bool,
     pub(crate) is_enroller: bool,
@@ -40,23 +42,40 @@ impl EnrollerAccessControlChecks {
     pub(crate) async fn check_identifier(
         members: Arc<dyn AuthorityMembersRepository>,
         identifier: &Identifier,
+        account_authority: &Option<AccountAuthorityInfo>,
     ) -> Result<EnrollerCheckResult> {
-        match members.get_member(identifier).await? {
+        let mut r = match members.get_member(identifier).await? {
             Some(member) => {
                 let is_enroller = Self::check_bin_attributes_is_enroller(member.attributes());
-                Ok(EnrollerCheckResult {
+                EnrollerCheckResult {
                     is_member: true,
                     is_enroller,
-                    is_admin: is_enroller, //TODO: use project admin credentials
+                    is_admin: false,
                     is_pre_trusted: member.is_pre_trusted(),
-                })
+                }
             }
-            None => Ok(EnrollerCheckResult {
+            None => EnrollerCheckResult {
                 is_member: false,
                 is_enroller: false,
                 is_admin: false,
                 is_pre_trusted: false,
-            }),
+            },
+        };
+        if let Some(info) = account_authority {
+            if let Some(attrs) = info
+                .identities_attributes()
+                .get_attributes(identifier, info.account_authority())
+                .await?
+            {
+                if attrs.attrs().get("project".as_bytes())
+                    == Some(&info.project_identifier().as_bytes().to_vec())
+                {
+                    r.is_admin = true;
+                    r.is_enroller = true;
+                    //TODO: review if an admin should be member
+                }
+            }
         }
+        Ok(r)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
@@ -50,7 +50,7 @@ impl EnrollerAccessControlChecks {
                 EnrollerCheckResult {
                     is_member: true,
                     is_enroller,
-                    is_admin: false,
+                    is_admin: is_enroller, // To be removed
                     is_pre_trusted: member.is_pre_trusted(),
                 }
             }
@@ -72,7 +72,7 @@ impl EnrollerAccessControlChecks {
                 {
                     r.is_admin = true;
                     r.is_enroller = true;
-                    //TODO: review if an admin should be member
+                    r.is_member = true;
                 }
             }
         }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer_worker.rs
@@ -3,6 +3,7 @@ use minicbor::Decoder;
 use tracing::trace;
 
 use crate::authenticator::credential_issuer::CredentialIssuer;
+use crate::authenticator::direct::AccountAuthorityInfo;
 use crate::authenticator::AuthorityMembersRepository;
 use ockam::identity::{Credentials, Identifier, IdentitySecureChannelLocalInfo};
 use ockam_core::api::{Method, RequestHeader, Response};
@@ -25,6 +26,7 @@ impl CredentialIssuerWorker {
         issuer: &Identifier,
         project_identifier: Option<String>, // Legacy value, should be removed when all clients are updated to the latest version
         credential_ttl: Option<Duration>,
+        account_authority: Option<AccountAuthorityInfo>,
     ) -> Self {
         Self {
             credential_issuer: CredentialIssuer::new(
@@ -33,6 +35,7 @@ impl CredentialIssuerWorker {
                 issuer,
                 project_identifier,
                 credential_ttl,
+                account_authority,
             ),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
@@ -12,14 +12,19 @@ use crate::authenticator::direct::types::AddMember;
 use crate::authenticator::direct::DirectAuthenticator;
 use crate::authenticator::AuthorityMembersRepository;
 
+use super::AccountAuthorityInfo;
+
 pub struct DirectAuthenticatorWorker {
     authenticator: DirectAuthenticator,
 }
 
 impl DirectAuthenticatorWorker {
-    pub fn new(members: Arc<dyn AuthorityMembersRepository>) -> Self {
+    pub fn new(
+        members: Arc<dyn AuthorityMembersRepository>,
+        account_authority: Option<AccountAuthorityInfo>,
+    ) -> Self {
         Self {
-            authenticator: DirectAuthenticator::new(members),
+            authenticator: DirectAuthenticator::new(members, account_authority),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -34,7 +34,8 @@ impl EnrollmentTokenAcceptor {
         from: &Identifier,
     ) -> Result<EnrollmentTokenAcceptorResult<()>> {
         let check =
-            EnrollerAccessControlChecks::check_identifier(self.members.clone(), from).await?;
+            EnrollerAccessControlChecks::check_identifier(self.members.clone(), from, &None)
+                .await?;
 
         // Not allow updating existing members
         if check.is_member {

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer_worker.rs
@@ -10,6 +10,7 @@ use ockam_core::{Result, Routed, Worker};
 use ockam_node::Context;
 
 use crate::authenticator::direct::types::CreateToken;
+use crate::authenticator::direct::AccountAuthorityInfo;
 use crate::authenticator::enrollment_tokens::EnrollmentTokenIssuer;
 use crate::authenticator::{AuthorityEnrollmentTokenRepository, AuthorityMembersRepository};
 
@@ -21,9 +22,10 @@ impl EnrollmentTokenIssuerWorker {
     pub fn new(
         tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
         members: Arc<dyn AuthorityMembersRepository>,
+        account_authority: Option<AccountAuthorityInfo>,
     ) -> Self {
         Self {
-            issuer: EnrollmentTokenIssuer::new(tokens, members),
+            issuer: EnrollmentTokenIssuer::new(tokens, members, account_authority),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -229,6 +229,7 @@ impl Authority {
             &self.identifier,
             Some(configuration.project_identifier()),
             ttl,
+            self.account_authority.clone(),
         );
 
         let address = DefaultAddress::CREDENTIAL_ISSUER.to_string();

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use ockam::identity::models::ChangeHistory;
 use serde::{Deserialize, Serialize};
 
 use ockam::identity::Identifier;
@@ -45,6 +46,9 @@ pub struct Configuration {
 
     /// optional configuration for the okta service
     pub okta: Option<OktaConfiguration>,
+
+    /// Account Authority identity
+    pub account_authority: Option<ChangeHistory>,
 }
 
 /// Local and private functions for the authority configuration

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -66,6 +66,7 @@ impl NodeManager {
         authority_identifier: &Identifier,
         authority_route: &MultiAddr,
         caller_identifier: &Identifier,
+        credential_retriever_creator: Option<Arc<dyn CredentialRetrieverCreator>>,
     ) -> Result<AuthorityNodeClient> {
         NodeManager::authority_node_client(
             &self.tcp_transport,
@@ -73,6 +74,7 @@ impl NodeManager {
             authority_identifier,
             authority_route,
             caller_identifier,
+            credential_retriever_creator,
         )
         .await
     }
@@ -149,6 +151,7 @@ impl NodeManager {
         authority_identifier: &Identifier,
         authority_route: &MultiAddr,
         caller_identifier: &Identifier,
+        credential_retriever_creator: Option<Arc<dyn CredentialRetrieverCreator>>,
     ) -> Result<AuthorityNodeClient> {
         let authority_route = multiaddr_to_transport_route(authority_route).ok_or_else(|| {
             ApiError::core(format!(
@@ -159,7 +162,7 @@ impl NodeManager {
         Ok(AuthorityNodeClient {
             secure_client: SecureClient::new(
                 secure_channels,
-                None,
+                credential_retriever_creator,
                 Arc::new(tcp_transport.clone()),
                 authority_route,
                 authority_identifier,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -155,6 +155,7 @@ impl NodeManager {
         authority_identifier: &Identifier,
         authority_route: &MultiAddr,
         caller_identity_name: Option<String>,
+        credential_retriever_creator: Option<Arc<dyn CredentialRetrieverCreator>>,
     ) -> miette::Result<AuthorityNodeClient> {
         self.make_authority_node_client(
             authority_identifier,
@@ -163,6 +164,7 @@ impl NodeManager {
                 .get_identifier_by_name(caller_identity_name)
                 .await
                 .into_diagnostic()?,
+            credential_retriever_creator,
         )
         .await
         .into_diagnostic()

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -71,8 +71,6 @@ pub async fn start_authority(
     secure_channels: Arc<SecureChannels>,
     number_of_admins: usize,
 ) -> Result<AuthorityInfo> {
-    println!("common.rs start_authority 1");
-
     let mut configuration = default_configuration().await?;
 
     let account_authority = secure_channels
@@ -109,12 +107,6 @@ pub async fn start_authority(
             )
             .await?;
 
-        println!(
-            "Admin credential for {:?}: {:?} : {:?}",
-            admin,
-            cred,
-            cred.credential.get_credential_data().unwrap().subject
-        );
         let authority_node_client = NodeManager::authority_node_client(
             &TcpTransport::create(ctx).await?,
             secure_channels.clone(),

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -72,6 +72,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         &auth_identifier,
         None,
         None,
+        None,
     );
     ctx.start_worker(auth_worker_addr.clone(), auth).await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/tests/direct_authenticator.rs
@@ -386,6 +386,7 @@ async fn enroller_can_delete_member(ctx: &mut Context) -> Result<()> {
 }
 
 #[ockam_macros::test]
+#[ignore] // TODO: for now as a stopgap, enrollers are considered as admins, so this tests is to be skipped
 async fn enroller_cant_delete_admin(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels().await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/token_enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/tests/token_enrollment.rs
@@ -236,6 +236,7 @@ async fn enroller_can_add_member(ctx: &mut Context) -> Result<()> {
 }
 
 #[ockam_macros::test]
+#[ignore] // TODO with admin credentials.  For now, all enrollers have rights to add/remove enrollers
 async fn enroller_cant_add_enroller(ctx: &mut Context) -> Result<()> {
     let secure_channels = secure_channels().await?;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -385,7 +385,12 @@ impl AppState {
     ) -> Result<AuthorityNodeClient> {
         let node_manager = self.node_manager.read().await;
         Ok(node_manager
-            .create_authority_client(authority_identifier, authority_route, caller_identity_name)
+            .create_authority_client(
+                authority_identifier,
+                authority_route,
+                caller_identity_name,
+                None,
+            )
             .await?)
     }
 

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -97,6 +97,7 @@ impl EnrollCommand {
                 &project.authority_identifier().into_diagnostic()?,
                 project.authority_multiaddr().into_diagnostic()?,
                 Some(identity.name()),
+                None,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -146,6 +146,7 @@ impl TicketCommand {
                 &p.authority_identifier().into_diagnostic()?,
                 p.authority_multiaddr().into_diagnostic()?,
                 Some(identity),
+                None,
             )
             .await?
         } else {

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -228,6 +228,7 @@ async fn check_authority_node_accessible(
             &project.authority_identifier()?,
             project.authority_multiaddr()?,
             None,
+            None,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -81,6 +81,7 @@ teardown() {
   # Make the admin present its project admin credential to the authority
   run_success "$OCKAM" secure-channel create --from admin --to "/node/authority/service/api" --identity admin
 
+
   cat <<EOF >>"$OCKAM_HOME/project.json"
 {
   "id": "1",
@@ -99,7 +100,12 @@ teardown() {
 }
 EOF
 
+
   run_success $OCKAM project import --project-file $OCKAM_HOME/project.json
+
+  run_success "$OCKAM" project enroll --identity admin
+  assert_output --partial '"ockam-relay": "*"'
+  assert_output --partial "$admin_identifier"
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
   run_success "$OCKAM" project enroll --identity m1
@@ -126,8 +132,8 @@ EOF
   # New enroller can enroll members
   run_success "$OCKAM" project ticket --identity m7
 
-  # But it can't enroll enrollers
-  run_failure "$OCKAM" project ticket --enroller --identity m7
+  # For now, it can enroll new enrollers as well.
+  run_success "$OCKAM" project ticket --enroller --identity m7
 
   run "$OCKAM" project enroll $token2 --identity m5
   assert_failure

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -70,7 +70,7 @@ teardown() {
   run_success "$OCKAM" node create admin --tcp-listener-address "127.0.0.1:$port_admin" --identity admin --authority-identity $account_authority_full --expect-cached-credential
 
   # issue and store project admin credentials for admin
-  $OCKAM credential issue --as account_authority --for "$admin_identifier" --attribute project="1"  --encoding hex >"$OCKAM_HOME/admin.cred"
+  $OCKAM credential issue --as account_authority --for "$admin_identifier" --attribute project="1" --encoding hex >"$OCKAM_HOME/admin.cred"
   run_success "$OCKAM" credential store --at admin --issuer "$account_authority_identifier" --credential-path "$OCKAM_HOME/admin.cred"
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
@@ -80,7 +80,6 @@ teardown() {
 
   # Make the admin present its project admin credential to the authority
   run_success "$OCKAM" secure-channel create --from admin --to "/node/authority/service/api" --identity admin
-
 
   cat <<EOF >>"$OCKAM_HOME/project.json"
 {
@@ -99,7 +98,6 @@ teardown() {
   "user_roles": []
 }
 EOF
-
 
   run_success $OCKAM project import --project-file $OCKAM_HOME/project.json
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -72,7 +72,7 @@ teardown() {
   # issue and store project admin credentials for admin
   $OCKAM credential issue --as account_authority --for "$admin_identifier" --attribute project="1"  --encoding hex >"$OCKAM_HOME/admin.cred"
   run_success "$OCKAM" credential store --at admin --issuer "$account_authority_identifier" --credential-path "$OCKAM_HOME/admin.cred"
-  
+
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\"} }"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -40,11 +40,15 @@ teardown() {
   run_success "$OCKAM" identity show ockam
 }
 
-@test "authority - standalone authority, enrollers, members" {
+@test "authority - standalone authority, admin, enrollers, members" {
   port="$(random_port)"
 
   run "$OCKAM" identity create authority
-  run "$OCKAM" identity create enroller
+
+  # Authority will trust project-admin credentials issued by this other identity (Account Authority)
+  run "$OCKAM" identity create account_authority
+
+  run "$OCKAM" identity create admin
   # m1 will be pre-enrolled on authority.  m2 will be added directly, m3 will be added through enrollment token
   # m4 and m5 will be added by a shared enrollment token, m6 won't be added
   run "$OCKAM" identity create m1
@@ -54,15 +58,28 @@ teardown() {
   run "$OCKAM" identity create m5
   run "$OCKAM" identity create m7
 
-  enroller_identifier=$($OCKAM identity show enroller)
+  account_authority_full=$($OCKAM identity show account_authority --full --encoding hex)
+  account_authority_identifier=$($OCKAM identity show account_authority)
+
+  admin_identifier=$($OCKAM identity show admin)
   authority_identity_full=$($OCKAM identity show --full --encoding hex authority)
   m1_identifier=$($OCKAM identity show m1)
 
+  # Create a node for the admin, used as a hack to present the project admin credential to the authority
+  port_admin="$(random_port)"
+  run_success "$OCKAM" node create admin --tcp-listener-address "127.0.0.1:$port_admin" --identity admin --authority-identity $account_authority_full --expect-cached-credential
+
+  # issue and store project admin credentials for admin
+  $OCKAM credential issue --as account_authority --for "$admin_identifier" --attribute project="1"  --encoding hex >"$OCKAM_HOME/admin.cred"
+  run_success "$OCKAM" credential store --at admin --issuer "$account_authority_identifier" --credential-path "$OCKAM_HOME/admin.cred"
+  
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
-  # For the first test we start the node with no direct authentication service nor token enrollment
-  trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\"}, \"$enroller_identifier\": {\"ockam-role\": \"enroller\"}}"
-  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication
-  sleep 1 # wait for authority to start TCP listener
+  trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\"} }"
+  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full
+  sleep 2 # wait for authority to start TCP listener
+
+  # Make the admin present its project admin credential to the authority
+  run_success "$OCKAM" secure-channel create --from admin --to "/node/authority/service/api" --identity admin
 
   cat <<EOF >>"$OCKAM_HOME/project.json"
 {
@@ -82,26 +99,35 @@ teardown() {
 }
 EOF
 
-  run_success bash -c "$OCKAM project import --project-file $OCKAM_HOME/project.json"
+  run_success $OCKAM project import --project-file $OCKAM_HOME/project.json
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
   run_success "$OCKAM" project enroll --identity m1
   assert_output --partial "sample_val"
 
-  token1=$($OCKAM project ticket --identity enroller --attribute sample_attr=m2_member)
+  # admin can enroll new members, because it has presented a project-admin credential to the authority
+  # and that is still valid (even if it doesn't present it again here)
+  token1=$($OCKAM project ticket --identity admin --attribute sample_attr=m2_member)
   run_success "$OCKAM" project enroll $token1 --identity m2
   assert_output --partial "m2_member"
 
-  token2=$($OCKAM project ticket --identity enroller --usage-count 2 --attribute sample_attr=members_group)
+  token2=$($OCKAM project ticket --identity admin --usage-count 2 --attribute sample_attr=members_group)
   run_success "$OCKAM" project enroll $token2 --identity m3
   assert_output --partial "members_group"
 
   run_success "$OCKAM" project enroll $token2 --identity m4
   assert_output --partial "members_group"
 
-  token3=$($OCKAM project ticket --identity enroller --enroller)
+  # admin can enroll new enrollers
+  token3=$($OCKAM project ticket --identity admin --enroller)
   run_success "$OCKAM" project enroll $token3 --identity m7
   assert_output --partial "enroller"
+
+  # New enroller can enroll members
+  run_success "$OCKAM" project ticket --identity m7
+
+  # But it can't enroll enrollers
+  run_failure "$OCKAM" project ticket --enroller --identity m7
 
   run "$OCKAM" project enroll $token2 --identity m5
   assert_failure


### PR DESCRIPTION
* Add a new, optional  `--account-authority` argument to `authority create`.  This is a full change history, in hex format.
* If the above argument is given,  the authority will accept credentials signed by that identity and,  if it has a `project` attribute equals to this authority' project id,   it will consider the subject as a valid administrator (as long as the credential doesn't expire, as always)
* Having such credential means:
    * It's allowed to create/remove enrollers
    * It's itself a member,  so can retrieve his own credential (allowing it to use any relay name, `relay=*`).   Implication of this is that after creating a project/enrolling with orchestrator,   that identity can start to use the project without any further action.   
    * No one can remove it

* Enrollers are not allowed to create/remove other enrollers,  altough as a stopgap we still allow it. It will be removed on a future client release.


 