### PR TITLE
refactor(rust): minor structural changes to the custom migrator

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_support/rust_migration.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/migration_support/rust_migration.rs
@@ -1,10 +1,11 @@
+use core::fmt::Debug;
 use sqlx::SqliteConnection;
 
 use ockam_core::{async_trait, Result};
 
 /// Individual rust migration
 #[async_trait]
-pub trait RustMigration: Send + Sync {
+pub trait RustMigration: Debug + Send + Sync {
     /// Name of the migration used to track which one was already applied
     fn name(&self) -> &str;
 

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20231231100000_node_name_identity_attributes.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20231231100000_node_name_identity_attributes.rs
@@ -4,6 +4,7 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::*;
 
 /// This struct adds a node name column to the identity attributes table
+#[derive(Debug)]
 pub struct NodeNameIdentityAttributes;
 
 #[async_trait]
@@ -127,7 +128,7 @@ mod test {
         let mut connection = pool.acquire().await.into_core()?;
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, NodeNameIdentityAttributes::version(), true)
+            .migrate_up_to_skip_last_rust_migration(&pool, NodeNameIdentityAttributes::version())
             .await?;
 
         // insert attribute rows in the previous table
@@ -144,7 +145,7 @@ mod test {
         // apply migrations
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, NodeNameIdentityAttributes::version() + 1, false)
+            .migrate_up_to(&pool, NodeNameIdentityAttributes::version())
             .await?;
 
         // check data

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240111100001_add_authority_tables.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240111100001_add_authority_tables.rs
@@ -4,6 +4,7 @@ use ockam_core::{async_trait, Result};
 use sqlx::*;
 
 /// This migration moves attributes from identity_attributes to the authority_member table for authority nodes
+#[derive(Debug)]
 pub struct AuthorityAttributes;
 
 #[async_trait]
@@ -123,7 +124,7 @@ mod test {
 
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, AuthorityAttributes::version(), true)
+            .migrate_up_to_skip_last_rust_migration(&pool, AuthorityAttributes::version())
             .await?;
 
         let authority_node_name = "authority".to_string();
@@ -157,7 +158,7 @@ mod test {
         // apply migrations
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, AuthorityAttributes::version() + 1, false)
+            .migrate_up_to(&pool, AuthorityAttributes::version())
             .await?;
 
         // check data

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240111100002_delete_trust_context.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240111100002_delete_trust_context.rs
@@ -8,6 +8,7 @@ use sqlx::*;
 
 /// This migration updates policies to not rely on trust_context_id,
 /// also introduces `node_name` and  replicates policy for each existing node
+#[derive(Debug)]
 pub struct PolicyTrustContextId;
 
 #[async_trait]
@@ -235,7 +236,7 @@ mod test {
 
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, PolicyTrustContextId::version(), true)
+            .migrate_up_to_skip_last_rust_migration(&pool, PolicyTrustContextId::version())
             .await?;
 
         let insert_node1 = insert_node("n1".to_string());
@@ -262,7 +263,7 @@ mod test {
         // apply migrations
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, PolicyTrustContextId::version() + 1, false)
+            .migrate_up_to(&pool, PolicyTrustContextId::version())
             .await?;
 
         for node_name in &["n1", "n2"] {

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240212100000_split_policies.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240212100000_split_policies.rs
@@ -5,6 +5,7 @@ use sqlx::*;
 
 /// This migration moves policies attached to resource types from
 /// table "resource_policy" to "resource_type_policy"
+#[derive(Debug)]
 pub struct SplitPolicies;
 
 #[async_trait]
@@ -102,7 +103,7 @@ mod test {
 
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, SplitPolicies::version(), true)
+            .migrate_up_to_skip_last_rust_migration(&pool, SplitPolicies::version())
             .await?;
 
         // insert some policies
@@ -121,7 +122,7 @@ mod test {
         // apply migrations
         NodeMigrationSet
             .create_migrator()?
-            .migrate_before(&pool, SplitPolicies::version() + 1, false)
+            .migrate_up_to(&pool, SplitPolicies::version())
             .await?;
 
         // check that the "tcp-inlet" and "tcp-outlet" policies are moved to the new table


### PR DESCRIPTION
- move the logic of how to sort and apply migrations into the `NextMigration` enum
- add struct to abstract the behavior of version intervals (from, to, incude_to)
