### PR TITLE
feat(rust): show ockam home on initialization issue

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -83,12 +83,13 @@ impl CommandGlobalOpts {
                         "Consider upgrading to the latest version of Ockam Command"
                     ))
                     .unwrap();
+                let ockam_home = std::env::var("OCKAM_HOME").unwrap_or("~/.ockam".to_string());
                 terminal
                     .write_line(fmt_log!(
                         "You can also try removing the local state using {} \
                         or deleting the directory at {}",
                         color_primary("ockam reset"),
-                        color_primary("~/.ockam")
+                        color_primary(ockam_home)
                     ))
                     .unwrap();
                 terminal


### PR DESCRIPTION
At the moment we show `~/.ockam` regardless of the `OCKAM_HOME` setting.