### PR TITLE
docs: fix typos in database examples

### DIFF
--- a/examples/command/portals/databases/postgres/docker/README.md
+++ b/examples/command/portals/databases/postgres/docker/README.md
@@ -2,7 +2,8 @@
 
 This hands-on example uses Ockam to create an end-to-end encrypted portal to postgres.
 
-We connect a nodejs app in one virtual private network with a postgres database in another virtual private network. The example uses docker and docker compose to create these virtual networks.
+We connect a nodejs app in one virtual private network with a postgres database in another virtual private network. The
+example uses docker and docker compose to create these virtual networks.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/postgres/docker

--- a/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
@@ -8,7 +8,7 @@ set -ex
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command

--- a/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
@@ -8,7 +8,7 @@ set -ex
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command

--- a/examples/command/portals/databases/postgres/docker/run.sh
+++ b/examples/command/portals/databases/postgres/docker/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses docker and docker compose to create these virtual networks.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/databases/postgres/docker
 
 run() {

--- a/examples/command/portals/databases/postgres/kubernetes/README.md
+++ b/examples/command/portals/databases/postgres/kubernetes/README.md
@@ -5,5 +5,5 @@ This hands-on example uses Ockam to create an end-to-end encrypted portal to pos
 We connect a nodejs app in one private kubernetes cluster with a postgres database in another
 private kubernetes cluster. The example uses docker and kind to create these kubernetes clusters.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/postgres/kubernetes

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
@@ -8,7 +8,7 @@ set -ex
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command

--- a/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
@@ -8,7 +8,7 @@ set -ex
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command

--- a/examples/command/portals/databases/postgres/kubernetes/run.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/run.sh
@@ -9,7 +9,7 @@ set -e
 #
 # The example uses docker and kind to create these kubernetes clusters.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/databases/postgres/kubernetes
 
 run() {


### PR DESCRIPTION
This PR fixes typos in the database examples.