### PR TITLE
Release fix

### DIFF
--- a/.github/workflows/release-bump-pull-request.yml
+++ b/.github/workflows/release-bump-pull-request.yml
@@ -82,11 +82,11 @@ jobs:
           OCKAM_BUMP_BUMPED_DEP_CRATES_VERSION: ${{ github.event.inputs.ockam_bump_bumped_dep_crates_version }}
           GIT_TAG_WE_WILL_BE_UPDATING: ${{ github.event.inputs.redo_release_tag }}
           LAST_RELEASED_TAG: ${{ github.event.inputs.git_tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash -ex ./tools/scripts/release/redo-draft-release.sh
-
           # Delete the old git tag, it'll be recreated when we are creating a new draft binary.
-          git push --delete origin ${{ inputs.redo_release_tag }}
+          gh release delete ${{ inputs.redo_release_tag }} --cleanup-tag
 
       - name: Bump Ockam
         if: ${{ inputs.redo_release_tag == '' }}

--- a/tools/scripts/release/release.sh
+++ b/tools/scripts/release/release.sh
@@ -255,7 +255,7 @@ function update_docs_repo() {
   approve_and_watch_workflow_progress "ockam-documentation" "$workflow_file_name" "$branch_name"
 
   # Check if the branch was created, new branch is only created when there are new doc updates
-  if gh api "repos/build-trust/ockam-documentation/branches/${release_name}" --jq .name; then
+  if gh api "repos/build-trust/ockam-documentation/branches/docs_${release_name}" --jq .name; then
     gh pr create --title "Ockam Release $(date +'%d-%m-%Y')" --body "Ockam release" \
       --base main -H "docs_${release_name}" -r nazmulidris -R $OWNER/ockam-documentation
   fi


### PR DESCRIPTION
Delete old draft release asset when we redo a draft release so that we do not clutter our release page