### PR TITLE
fix(rust): make sure all the handshake spans end up in the same trace with the secure channel use

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -382,9 +382,7 @@ impl CliState {
             )])
         };
         let span = tracer.build_with_context(span_builder, &Context::default());
-
         let cx = Context::current_with_span(span);
-        let _guard = cx.clone().attach();
-        OpenTelemetryContext::current()
+        OpenTelemetryContext::inject(&cx)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/uppercase.rs
+++ b/implementations/rust/ockam/ockam_api/src/uppercase.rs
@@ -7,6 +7,7 @@ impl Worker for Uppercase {
     type Message = String;
     type Context = Context;
 
+    #[instrument(skip_all, name = "Uppercase::handle_message")]
     async fn handle_message(&mut self, ctx: &mut Context, msg: Routed<String>) -> Result<()> {
         ctx.send(msg.return_route(), msg.body().to_uppercase())
             .await

--- a/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
@@ -22,7 +22,7 @@ where
     let guard = LoggingTracing::setup_with_exporters(
         spans_exporter.clone(),
         InMemoryLogsExporter::default(),
-        &LoggingConfiguration::off(),
+        &LoggingConfiguration::off().unwrap().set_all_crates(),
         &TracingConfiguration::foreground(true).unwrap(),
         "test",
     );

--- a/implementations/rust/ockam/ockam_api/tests/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/tests/journeys.rs
@@ -26,7 +26,9 @@ fn test_create_journey_event() {
     let tracing_guard = LoggingTracing::setup_with_exporters(
         spans_exporter.clone(),
         logs_exporter.clone(),
-        &LoggingConfiguration::off().set_crates(&["ockam_api"]),
+        &LoggingConfiguration::off()
+            .unwrap()
+            .set_crates(&["ockam_api"]),
         &TracingConfiguration::foreground(false).unwrap(),
         "test",
     );

--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -126,20 +126,19 @@ TcpRecvProcessor::process
 
 TcpRecvProcessor::process
 
-TcpSendWorker::handle_message
-└── TcpRecvProcessor::process
-    └── HandshakeWorker::handle_message
-        └── TcpSendWorker::handle_message
-            └── TcpRecvProcessor::process
-                └── HandshakeWorker::handle_message
-                    └── TcpSendWorker::handle_message
-                        └── TcpRecvProcessor::process
-                            └── HandshakeWorker::handle_message
-
 root
 └── send_echo_message_over_secure_channel
     ├── create tcp transport
     ├── create tcp transport
+    ├── TcpSendWorker::handle_message
+    |   └── TcpRecvProcessor::process
+    |       └── HandshakeWorker::handle_message
+    |           └── TcpSendWorker::handle_message
+    |               └── TcpRecvProcessor::process
+    |                   └── HandshakeWorker::handle_message
+    |                       └── TcpSendWorker::handle_message
+    |                           └── TcpRecvProcessor::process
+    |                               └── HandshakeWorker::handle_message
     └── MessageSender::handle_message
         └── EncryptorWorker::handle_message
             └── handle_encrypt

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -135,7 +135,7 @@ impl CommandGlobalOpts {
         is_tty: bool,
     ) -> miette::Result<LoggingConfiguration> {
         if global_args.quiet {
-            return Ok(LoggingConfiguration::off());
+            return LoggingConfiguration::off().into_diagnostic();
         };
 
         let log_path = cmd.log_path();

--- a/implementations/rust/ockam/ockam_core/src/routing/message/opentelemetry.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/opentelemetry.rs
@@ -45,7 +45,7 @@ impl OpenTelemetryContext {
     }
 
     /// Serialize the current OpenTelemetry context as OpenTelemetryContext
-    fn inject(context: &Context) -> Self {
+    pub fn inject(context: &Context) -> Self {
         global::get_text_map_propagator(|propagator| {
             let mut propagation_context = OpenTelemetryContext::empty();
             propagator.inject_context(context, &mut propagation_context);

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -119,7 +119,7 @@ impl Context {
             self.transports.clone(),
             &self.flow_controls,
             #[cfg(feature = "std")]
-            self.tracing_context(),
+            OpenTelemetryContext::current(),
         )
     }
 


### PR DESCRIPTION
This PR makes sure that:

 - The `trace_code` function sets-up the initial `Context` with the root tracing context.
 - When a `Context` is duplicated, its tracing context is updated with the most recent span.

This way, the spans corresponding to starting the secure channel end up under the same root span as the code using the secure channel
```
root
└── send_echo_message_over_secure_channel
    ├── create tcp transport
    ├── create tcp transport
    ├── TcpSendWorker::handle_message
    |   └── TcpRecvProcessor::process
    |       └── HandshakeWorker::handle_message
    |           └── TcpSendWorker::handle_message
    |               └── TcpRecvProcessor::process
    |                   └── HandshakeWorker::handle_message
    |                       └── TcpSendWorker::handle_message
    |                           └── TcpRecvProcessor::process
    |                               └── HandshakeWorker::handle_message
    └── MessageSender::handle_message
        └── EncryptorWorker::handle_message
            └── handle_encrypt
                └── TcpSendWorker::handle_message
                    └── TcpRecvProcessor::process
                        └── DecryptorWorker::handle_message
                            └── handle_decrypt
                                └── Echoer::handle_message
                                    └── EncryptorWorker::handle_message
                                        └── handle_encrypt
                                            └── TcpSendWorker::handle_message
                                                └── TcpRecvProcessor::process
                                                    └── DecryptorWorker::handle_message
                                                        └── handle_decrypt
```

**UPDATE**: I've added a fix for the creation of a user journey. I don't know but there was a regression there. 
**UPDATE**: I've added another fix the selection of crates when logging is off.