### PR TITLE
[WIP] doc(rust): remove doc warnings regarding hyper-links

### DIFF
--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -58,12 +58,12 @@ pub use ockam_abac as abac;
 /// Mark an Ockam Processor implementation.
 ///
 /// This is currently implemented as a re-export of the `async_trait` macro, but
-/// may be changed in the future to a [`Processor`](crate::Processor)-specific macro.
+/// may be changed in the future to a [`Processor`]-specific macro.
 pub use ockam_core::processor;
 /// Mark an Ockam Worker implementation.
 ///
 /// This is currently implemented as a re-export of the `async_trait` macro, but
-/// may be changed in the future to a [`Worker`](crate::Worker)-specific macro.
+/// may be changed in the future to a [`Worker`]-specific macro.
 pub use ockam_core::worker;
 pub use ockam_core::{
     allow, deny, errcode, route, Address, Any, AsyncTryClone, Encoded, Error, LocalMessage,

--- a/implementations/rust/ockam/ockam_api/src/cloud/email_address.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/email_address.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 /// It is backed by a String and implements a PartialEq instance
 /// based on a lowercase comparison.
 ///
-/// Note that the SMTP RFC (https://www.rfc-editor.org/rfc/rfc5321.txt, section 2.4) specifies that
+/// Note that the SMTP RFC (<https://www.rfc-editor.org/rfc/rfc5321.txt>, section 2.4) specifies that
 /// we should not make a case insensitive comparison on the local part of the email address
 ///
 /// However we currently receive lowercase email addresses from the Controller in `ProjectUserRole`,

--- a/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/oidc_service.rs
@@ -49,7 +49,7 @@ impl OidcService {
     }
 
     /// Request an authorization token with a PKCE flow
-    /// See the full protocol here: https://datatracker.ietf.org/doc/html/rfc7636
+    /// See the full protocol here: <https://datatracker.ietf.org/doc/html/rfc7636>
     #[instrument(skip_all)]
     pub async fn get_token_with_pkce(&self) -> Result<OidcToken> {
         let code_verifier = self.create_code_verifier();

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -124,11 +124,11 @@ impl TerminalBackground {
     /// to work in some cases and fail in others. We want to degrade gracefully.
     /// So we rely on the simple tool of whether the COLORFGBG variable is set.
     ///
-    /// If it is set, it usually takes the form <foreground-color>:<background-color>
-    /// and if <background-color> is in {0,1,2,3,4,5,6,8}, then we assume the terminal
+    /// If it is set, it usually takes the form foreground-color:background-color
+    /// and if background-color is in {0,1,2,3,4,5,6,8}, then we assume the terminal
     /// has a dark background.
     ///
-    /// Reference: https://stackoverflow.com/a/54652367
+    /// Reference: <https://stackoverflow.com/a/54652367>
     pub fn detect_background_color() -> TerminalBackground {
         let terminal_colors = get_env::<TerminalColors>("COLORFGBG");
         if let Ok(Some(terminal_colors)) = terminal_colors {

--- a/implementations/rust/ockam/ockam_transport_tcp/src/registry/registry.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/registry/registry.rs
@@ -1,6 +1,7 @@
 use crate::registry::internal::InternalRegistry;
 use crate::{TcpListenerInfo, TcpReceiverInfo, TcpSenderInfo};
 use ockam_core::compat::sync::{Arc, RwLock};
+use ockam_core::Address;
 
 /// Registry of all active workers and processors in TCP Transport to ease their lifecycle management
 #[derive(Default, Clone, Debug)]

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
@@ -56,12 +56,12 @@ impl TcpConnection {
     pub async fn stop(&self, context: &Context) -> Result<()> {
         context.stop_worker(self.sender_address.clone()).await
     }
-    /// Corresponding [`TcpSendWorker`](super::workers::TcpSendWorker) [`Address`] that can be used
+    /// Corresponding [`TcpSendWorker`](crate::TcpSendWorker) [`Address`] that can be used
     /// in a route to send messages to the other side of the TCP connection
     pub fn sender_address(&self) -> &Address {
         &self.sender_address
     }
-    /// Corresponding [`TcpReceiveProcessor`](super::workers::TcpRecvProcessor) [`Address`]
+    /// Corresponding [`TcpReceiveProcessor`](crate::TcpRecvProcessor) [`Address`]
     pub fn receiver_address(&self) -> &Address {
         &self.receiver_address
     }
@@ -79,7 +79,7 @@ impl TcpConnection {
     }
 }
 
-/// Result of [`TcpTransport::listen`] call.
+/// Result of [`crate::TcpTransport::listen`] call.
 #[derive(Clone, Debug)]
 pub struct TcpListener {
     processor_address: Address,


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

This PR is an attempt to solve warnings raised by `cargo doc`. This issue: https://github.com/build-trust/ockam/issues/7145
I'm still working on this PR, as soon as it was ready to be merged, I'll squash my commits into one.

