### PR TITLE
feat(rust): update display, log output in frequently used commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -122,10 +122,11 @@ impl CliState {
             // Unable to get named identity.
             None => {
                 let error_message = format!(
-                    "{} {}\n{} {}\n",
-                    "Could not find an Identity with name",
+                    "{} {} {}.\n{} {}\n",
+                    "There is no Identity with name",
                     color_primary(name),
-                    "To get a list of Identities on your machine, please run",
+                    "on this machine",
+                    "To see a list of Identities on this machine, please run",
                     color_primary("ockam identity list")
                 );
                 Err(Error::new(Origin::Api, Kind::NotFound, error_message))?

--- a/implementations/rust/ockam/ockam_command/src/arguments.rs
+++ b/implementations/rust/ockam/ockam_command/src/arguments.rs
@@ -3,6 +3,11 @@ pub fn has_help_flag(input: &[String]) -> bool {
     input.contains(&"-h".to_string()) || input.contains(&"--help".to_string())
 }
 
+/// Return true if the list of arguments contains a version flag
+pub fn has_version_flag(input: &[String]) -> bool {
+    input.contains(&"-V".to_string()) || input.contains(&"--version".to_string())
+}
+
 /// Replaces the '-' placeholder character with a string value coming from stdin
 /// This is useful to be able to pipe the output of a command to another command.
 ///

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -1,11 +1,11 @@
 use crate::command_events::{add_command_error_event, add_command_event};
 use crate::command_global_opts::CommandGlobalOpts;
 use crate::docs;
+use crate::fmt_warn;
 use crate::global_args::GlobalArgs;
 use crate::subcommand::OckamSubcommand;
 use crate::upgrade::check_if_an_upgrade_is_available;
 use crate::version::Version;
-use crate::{fmt_warn, OckamColor};
 
 use clap::Parser;
 use colorful::Colorful;
@@ -13,10 +13,6 @@ use miette::GraphicalReportHandler;
 use ockam_core::OCKAM_TRACER_NAME;
 use opentelemetry::trace::{Link, SpanBuilder, TraceContextExt, Tracer};
 use opentelemetry::{global, Context};
-use r3bl_rs_utils_core::UnicodeString;
-use r3bl_tui::{
-    ColorWheel, ColorWheelConfig, ColorWheelSpeed, GradientGenerationPolicy, TextColorizationPolicy,
-};
 use tracing::{instrument, warn};
 
 const ABOUT: &str = include_str!("./static/about.txt");
@@ -77,32 +73,6 @@ impl OckamCommand {
                 .terminal
                 .write_line(&fmt_warn!("Failed to check for upgrade"))
                 .unwrap();
-        }
-
-        // Display Header if needed
-        if self.subcommand.should_display_header() {
-            let ockam_header = include_str!("../static/ockam_ascii.txt").trim();
-            let gradient_steps = Vec::from(
-                [
-                    OckamColor::OckamBlue.value(),
-                    OckamColor::HeaderGradient.value(),
-                ]
-                .map(String::from),
-            );
-            let colored_header = ColorWheel::new(vec![ColorWheelConfig::Rgb(
-                gradient_steps,
-                ColorWheelSpeed::Medium,
-                50,
-            )])
-            .colorize_into_string(
-                &UnicodeString::from(ockam_header),
-                GradientGenerationPolicy::ReuseExistingGradientAndResetIndex,
-                TextColorizationPolicy::ColorEachCharacter(None),
-            );
-
-            let _ = options
-                .terminal
-                .write_line(&format!("{}\n", colored_header));
         }
 
         let tracer = global::tracer(OCKAM_TRACER_NAME);

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -1,10 +1,13 @@
+use std::process::exit;
+
 use clap::Parser;
+
 use miette::IntoDiagnostic;
 use tracing_core::Level;
 
 use crate::{
-    add_command_error_event, has_help_flag, pager, replace_hyphen_with_stdin, ErrorReportHandler,
-    OckamCommand,
+    add_command_error_event, fmt_log, has_help_flag, has_version_flag, pager,
+    replace_hyphen_with_stdin, util::exitcode, version::Version, ErrorReportHandler, OckamCommand,
 };
 use ockam_api::cli_state::CliState;
 use ockam_api::logs::{
@@ -22,6 +25,10 @@ pub fn run() -> miette::Result<()> {
         .collect::<Vec<_>>();
 
     let _ = miette::set_hook(Box::new(|_e| Box::new(ErrorReportHandler::new())));
+
+    if has_version_flag(&input) {
+        print_version_and_exit();
+    }
 
     match OckamCommand::try_parse_from(input.clone()) {
         Err(help) => {
@@ -47,6 +54,7 @@ pub fn run() -> miette::Result<()> {
                     &ExportingConfiguration::foreground(true).into_diagnostic()?,
                     "local node",
                 );
+
                 let cli_state = CliState::with_default_dir()?;
                 let message = format!("could not parse the command: {}", command);
                 add_command_error_event(cli_state, &command, &message, input.join(" "))?;
@@ -54,6 +62,16 @@ pub fn run() -> miette::Result<()> {
             pager::render_help(help);
         }
         Ok(command) => command.run(input)?,
-    };
+    }
     Ok(())
+}
+
+fn print_version_and_exit() {
+    let version_msg = Version::long();
+    let version_msg_vec = version_msg.split('\n').collect::<Vec<_>>();
+    println!("{}", fmt_log!("ockam {}", version_msg_vec[0]));
+    for item in version_msg_vec.iter().skip(1) {
+        println!("{}", fmt_log!("{}", item));
+    }
+    exit(exitcode::OK);
 }

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -150,11 +150,6 @@ impl OckamSubcommand {
         }
     }
 
-    /// Currently only enroll command displays the header
-    pub fn should_display_header(&self) -> bool {
-        matches!(self, OckamSubcommand::Enroll(_))
-    }
-
     /// Return the opentelemetry context if the command can be executed as the continuation
     /// of an existing trace
     pub fn get_opentelemetry_context(&self) -> Option<OpenTelemetryContext> {

--- a/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/colors.rs
@@ -1,6 +1,9 @@
 use colorful::{core::color_string::CString, Colorful, RGB};
 use colors_transform::{Color, Rgb};
-use r3bl_tui::ColorWheel;
+use r3bl_rs_utils_core::UnicodeString;
+use r3bl_tui::{
+    ColorWheel, ColorWheelConfig, ColorWheelSpeed, GradientGenerationPolicy, TextColorizationPolicy,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum OckamColor {
@@ -54,9 +57,25 @@ pub fn color_primary(input: impl AsRef<str>) -> CString {
     input.as_ref().color(OckamColor::PrimaryResource.color())
 }
 
-#[allow(dead_code)]
 pub fn color_primary_alt(input: impl AsRef<str>) -> String {
-    ColorWheel::lolcat_into_string(input.as_ref())
+    let gradient_steps = Vec::from(
+        [
+            OckamColor::OckamBlue.value(),
+            OckamColor::HeaderGradient.value(),
+        ]
+        .map(String::from),
+    );
+    let colored_output = ColorWheel::new(vec![ColorWheelConfig::Rgb(
+        gradient_steps,
+        ColorWheelSpeed::Fast,
+        15,
+    )])
+    .colorize_into_string(
+        &UnicodeString::from(input.as_ref()),
+        GradientGenerationPolicy::ReuseExistingGradientAndResetIndex,
+        TextColorizationPolicy::ColorEachCharacter(None),
+    );
+    colored_output
 }
 
 pub fn color_email(input: impl AsRef<str>) -> CString {
@@ -64,5 +83,5 @@ pub fn color_email(input: impl AsRef<str>) -> CString {
 }
 
 pub fn color_uri(input: impl AsRef<str>) -> String {
-    ColorWheel::lolcat_into_string(input.as_ref())
+    color_primary_alt(input)
 }

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -12,7 +12,7 @@ impl Version {
     pub(crate) fn short() -> &'static str {
         let crate_version = crate_version!();
         let git_hash = env!("GIT_HASH");
-        let message = format!("Version: {crate_version}, compiled from: {git_hash}");
+        let message = format!("{crate_version}\ncompiled from: {git_hash}");
         Box::leak(message.into_boxed_str())
     }
 }


### PR DESCRIPTION
- Make the changes described in the doc below to `ockam enroll`. 
- Fix error reporting (don't display duplicate error output).
- Fix --version / -V to display indented output.

Issue / Epic: https://github.com/build-trust/codebase/issues/726
Docs: https://docs.google.com/document/d/16Cq2RQU95hcQ1ddNu2ETtd9qkpCEToQW7ikv12LxEVo/edit
Video (WIP): https://drive.google.com/file/d/19mGya91w0qNS8PBveiharMgqWdP_8zQw/view?usp=drive_link