### PR TITLE
feat(rust): change behavior of how the target route is handled in "tcp-inlet create"

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/policies_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/policies_orchestrator.bats
@@ -40,14 +40,14 @@ teardown() {
   setup_home_dir
   run_success $OCKAM project enroll $web_ticket
   inlet_port="$(random_port)"
-  run_success $OCKAM tcp-inlet create --from $inlet_port --to $relay_name
+  run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
   run_success curl --head --retry-connrefused --retry 2 --max-time 5 "127.0.0.1:$inlet_port"
 
   # Dashboard - Doesn't have the right attribute, so it should not be able to connect
   setup_home_dir
   run_success $OCKAM project enroll $dashboard_ticket
   inlet_port="$(random_port)"
-  run_success $OCKAM tcp-inlet create --from $inlet_port --to $relay_name
+  run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
   run_failure curl --head --retry-connrefused --max-time 5 "127.0.0.1:$inlet_port"
 }
 
@@ -70,7 +70,7 @@ teardown() {
   setup_home_dir
   run_success $OCKAM project enroll $web_ticket
   inlet_port="$(random_port)"
-  run_success $OCKAM tcp-inlet create --from $inlet_port --to $relay_name
+  run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
 
   # This will fail because the resource type policy is not satisfied
   run_failure curl --head --retry-connrefused --max-time 3 "127.0.0.1:$inlet_port"

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
@@ -27,12 +27,12 @@ teardown() {
   run_success "$OCKAM" node create blue
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  fwd="$(random_str)"
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
+  relay_name="$(random_str)"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
 
   run_success "$OCKAM" node create green
-  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$fwd/service/api \
-    | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
+  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
+    | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
 }
@@ -53,11 +53,11 @@ teardown() {
   run_success "$OCKAM" node create blue
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  fwd="$(random_str)"
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
+  relay_name="$(random_str)"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
 
   run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to "$fwd"
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
 }
@@ -76,21 +76,21 @@ teardown() {
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
 
-  fwd="$(random_str)"
+  relay_name="$(random_str)"
   run_success "$OCKAM" node create green --identity green
   run_success "$OCKAM" node create blue --identity blue
 
   # Green isn't enrolled as project member
   export OCKAM_HOME=$ENROLLED_OCKAM_HOME
-  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $fwd
+  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $relay_name
 
   export OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
-  assert_output --partial "forward_to_$fwd"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
+  assert_output --partial "forward_to_$relay_name"
 
-  run_success bash -c "$OCKAM secure-channel create --from /node/green --identity green  --to /project/default/service/forward_to_$fwd/service/api \
+  run_success bash -c "$OCKAM secure-channel create --from /node/green --identity green  --to /project/default/service/forward_to_$relay_name/service/api \
               | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
 
   # Green can't establish secure channel with blue, because it didn't exchange credential with it.
@@ -109,21 +109,21 @@ teardown() {
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
 
-  fwd="$(random_str)"
+  relay_name="$(random_str)"
   run_success "$OCKAM" node create green --identity green
   run_success "$OCKAM" node create blue --identity blue
 
   # Green isn't enrolled as project member
   export OCKAM_HOME=$ENROLLED_OCKAM_HOME
-  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $fwd
+  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $relay_name
 
   export OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
-  assert_output --partial "forward_to_$fwd"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
+  assert_output --partial "forward_to_$relay_name"
 
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --to "$fwd"
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
   # Green can't establish secure channel with blue, because it isn't a member
   run_failure curl --fail --head --max-time 10 "127.0.0.1:$port"
 }
@@ -142,23 +142,23 @@ teardown() {
   green_identifier=$($OCKAM identity show green)
   blue_identifier=$($OCKAM identity show blue)
 
-  fwd="$(random_str)"
+  relay_name="$(random_str)"
   run_success "$OCKAM" node create green --identity green
   run_success "$OCKAM" node create blue --identity blue
 
   # Add identities as members of the project
   export OCKAM_HOME=$ENROLLED_OCKAM_HOME
-  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $fwd
+  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $relay_name
   run_success "$OCKAM" project ticket --member "$green_identifier" --attribute role=member
 
   # Use project from the now enrolled identities
   export OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
-  assert_output --partial "forward_to_$fwd"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
+  assert_output --partial "forward_to_$relay_name"
 
-  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$fwd/service/api \
+  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
               | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
@@ -168,9 +168,9 @@ teardown() {
   port="$(random_port)"
   ENROLLED_OCKAM_HOME=$OCKAM_HOME
 
-  fwd="$(random_str)"
+  relay_name="$(random_str)"
   green_token=$($OCKAM project ticket --attribute app=app1)
-  blue_token=$($OCKAM project ticket --attribute app=app1 --relay $fwd)
+  blue_token=$($OCKAM project ticket --attribute app=app1 --relay $relay_name)
 
   setup_home_dir
   NON_ENROLLED_OCKAM_HOME=$OCKAM_HOME
@@ -188,11 +188,11 @@ teardown() {
   run_success "$OCKAM" tcp-outlet create --at /node/blue \
     --to 127.0.0.1:$PYTHON_SERVER_PORT --allow '(= subject.app "app1")'
 
-  run_success "$OCKAM" relay create "$fwd" --to /node/blue
-  assert_output --partial "forward_to_$fwd"
+  run_success "$OCKAM" relay create "$relay_name" --to /node/blue
+  assert_output --partial "forward_to_$relay_name"
 
   run_success "$OCKAM" tcp-inlet create --at /node/green \
-    --from "127.0.0.1:$port" --to "$fwd" --allow '(= subject.app "app1")'
+    --from "127.0.0.1:$port" --via "$relay_name" --allow '(= subject.app "app1")'
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
 }
@@ -206,8 +206,7 @@ teardown() {
   run_success "$OCKAM" relay create --to /node/blue
 
   run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green \
-    --from "127.0.0.1:$port" --to "/project/default/service/forward_to_default/secure/api/service/outlet"
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port"
   run_success curl --fail --head --retry 4 --max-time 10 "127.0.0.1:$port"
 
   $OCKAM node delete blue --yes
@@ -262,7 +261,7 @@ teardown() {
 
   run_success "$OCKAM" node create green
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:${inlet_port}" \
-    --to "${relay_name}"
+    --via "${relay_name}"
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:${inlet_port}"
   status=$("$OCKAM" relay show "${relay_name}" --output json | jq .connection_status -r)

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
@@ -95,16 +95,16 @@ teardown() {
   run_success "$OCKAM" node create green
 
   # The green identity can't create relay as it isn't a member
-  fwd=$(random_str)
-  run_failure "$OCKAM" relay create "$fwd"
+  relay_name=$(random_str)
+  run_failure "$OCKAM" relay create "$relay_name"
 
   # Add the green identity as a member
   export OCKAM_HOME=$ENROLLED_OCKAM_HOME
-  run_success "$OCKAM" project ticket --member "$green_identifier" --attribute role=member --relay $fwd
+  run_success "$OCKAM" project ticket --member "$green_identifier" --attribute role=member --relay $relay_name
 
   # Now the green node, with its green identity, can now access the project's services
   export OCKAM_HOME=$NON_ENROLLED_OCKAM_HOME
-  run_success "$OCKAM" relay create "$fwd"
+  run_success "$OCKAM" relay create "$relay_name"
 }
 
 @test "projects - send a message to a project node from an embedded node, enrolled member on different install" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/relay_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/relay_orchestrator.bats
@@ -23,11 +23,11 @@ teardown() {
   run_success "$OCKAM" node create blue
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
 
-  fwd="$(random_str)"
-  run_success "$OCKAM" relay create $fwd
+  relay_name="$(random_str)"
+  run_success "$OCKAM" relay create $relay_name
 
   run_success "$OCKAM" node create green
-  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$fwd/service/api \
+  run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
 
   run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
@@ -40,24 +40,24 @@ teardown() {
   blue_identifier=$($OCKAM identity show blue)
 
   # Green isn't enrolled as project member
-  fwd_blue="$(random_str)"
-  fwd_green="$(random_str)"
-  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $fwd_blue
-  run_success "$OCKAM" project ticket --member "$green_identifier" --attribute role=member --relay $fwd_green
+  relay_name_blue="$(random_str)"
+  relay_name_green="$(random_str)"
+  run_success "$OCKAM" project ticket --member "$blue_identifier" --attribute role=member --relay $relay_name_blue
+  run_success "$OCKAM" project ticket --member "$green_identifier" --attribute role=member --relay $relay_name_green
 
   run_success "$OCKAM" node create green --identity green
   run_success "$OCKAM" node create blue --identity blue
 
   # Blue can take its relay
-  run_success "$OCKAM" relay create $fwd_blue --to /node/blue
+  run_success "$OCKAM" relay create $relay_name_blue --to /node/blue
   # Green can't take blue's relay
-  run_failure "$OCKAM" relay create $fwd_blue --to /node/green
+  run_failure "$OCKAM" relay create $relay_name_blue --to /node/green
   # But can take its the one it was assigned to in the ticket
-  run_success "$OCKAM" relay create $fwd_green --to /node/green
+  run_success "$OCKAM" relay create $relay_name_green --to /node/green
 
   run_success "$OCKAM" node create admin_node
 
   # Admin can take any relay (has wildcard *)
-  run_success "$OCKAM" relay create $fwd_blue --to /node/admin_node
-  run_success "$OCKAM" relay create $fwd_green --to /node/admin_node
+  run_success "$OCKAM" relay create $relay_name_blue --to /node/admin_node
+  run_success "$OCKAM" relay create $relay_name_green --to /node/admin_node
 }


### PR DESCRIPTION
- The `to` argument accepts either a MultiAddr route or a short string to define the service name. Before this PR, the short string was used to define the relay name.
- Add a new optional argument `via` to define the relay name.

When `to` is passed as a service name, and `via` is also passed, the route is processed as follows:

`/project/$DEFAULT_PROJECT_NAME/service/forward_to_$RELAY_NAME/secure/api/service/$SERVICE_NAME`

which simplifies its definition to just two "words":

```
# before
ockam tcp-inlet create --to /project/myproject/service/forward_to_myrelay/secure/api/service/myservice

# now
ockam tcp-inlet create --via myrelay --to myservice
```