### PR TITLE
fix(rust): only display the error once when an identity is not found for the enroll command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -124,8 +124,15 @@ impl EnrollCommand {
             identity_task
         )?;
 
-        // If a named or default identity can't be found, then we can't proceed, so, return error.
-        let identity = identity?;
+        // If a named or default identity can't be found, then we can't proceed, so, print an error.
+        let identity = match identity {
+            Ok(identity) => identity,
+            Err(e) => {
+                opts.terminal
+                    .write_line(&fmt_warn!("{}", color_primary(e.to_string())))?;
+                return Ok(());
+            }
+        };
         progress_display.finalize();
 
         let identity_name = identity.name();


### PR DESCRIPTION
@nazmulidris here is a quick fix but you might want to make the output nicer.
I think that the main idea we need to enforce is:

 1. Each command is responsible for displaying the user errors or down the stream errors, so `command.run()` should most of the time return `Ok(())`
  
 2. The only time it would return `Err` is if one of its direct implementation functions, like `try_join(...)?` returns an error.

Then for the errors of type 2. there is a catch all handler at the top of the command execution. That handler will also display all the errors that could happen before the command is even invoked with `command.run()`, for example if logging can not be instantiated.