### PR TITLE
feat(rust): propagating the errors from api clients to the command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,7 +4192,6 @@ dependencies = [
 name = "ockam_api"
 version = "0.60.0"
 dependencies = [
- "anyhow",
  "aws-config",
  "base64-url",
  "bytes 1.5.0",
@@ -4293,7 +4292,6 @@ dependencies = [
 name = "ockam_command"
 version = "0.117.0"
 dependencies = [
- "anyhow",
  "arboard",
  "assert_cmd",
  "async-trait",
@@ -4373,6 +4371,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.14.3",
  "hex",
+ "miette",
  "minicbor",
  "ockam_macros",
  "once_cell",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -29,7 +29,6 @@ std = [
 storage = ["ockam/storage"]
 
 [dependencies]
-anyhow = "1"
 aws-config = { version = "1.1.7", default-features = false, features = ["rustls"] }
 base64-url = "2.0.2"
 bytes = { version = "1.5.0", default-features = false, features = ["serde"] }
@@ -43,7 +42,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde
 home = "0.5"
 itertools = "0.12.1"
 kafka-protocol = "0.10"
-miette = "7.1.0"
+miette = "7"
 minicbor = { version = "0.21.0", features = ["alloc", "derive"] }
 nix = { version = "0.27", features = ["signal"] }
 once_cell = "1.19"

--- a/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/addon.rs
@@ -108,8 +108,7 @@ impl Addons for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("list addons")
     }
 
     #[instrument(skip_all, fields(project_id = project_id))]
@@ -128,8 +127,7 @@ impl Addons for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("configure kafka addon")
     }
 
     #[instrument(skip_all, fields(project_id = project_id))]
@@ -146,8 +144,7 @@ impl Addons for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("configure okta addon")
     }
 
     #[instrument(skip_all, fields(project_id = project_id))]
@@ -167,8 +164,7 @@ impl Addons for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("configure influxdb addon")
     }
 
     #[instrument(skip_all, fields(project_id = project_id, addon_id = addon_id))]
@@ -185,7 +181,6 @@ impl Addons for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("disable addon")
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/enroll.rs
@@ -56,8 +56,7 @@ impl Enroll for ControllerClient {
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("generate token")
     }
 
     #[instrument(skip_all)]
@@ -74,8 +73,7 @@ impl Enroll for ControllerClient {
             .tell(ctx, "enrollment_token_authenticator", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("authenticate token")
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cloud/project/controller_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project/controller_client.rs
@@ -28,8 +28,7 @@ impl ControllerClient {
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("create project")
     }
 
     pub async fn get_project(
@@ -43,8 +42,7 @@ impl ControllerClient {
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("get project")
     }
 
     pub async fn delete_project(
@@ -59,8 +57,7 @@ impl ControllerClient {
             .tell(ctx, "projects", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("delete project")
     }
 
     pub async fn get_orchestrator_version_info(
@@ -72,8 +69,7 @@ impl ControllerClient {
             .ask(ctx, "version_info", Request::get(""))
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("get orchestrator version")
     }
 
     #[instrument(skip_all)]
@@ -83,8 +79,7 @@ impl ControllerClient {
             .ask(ctx, "projects", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("list projects")
     }
 
     pub async fn wait_until_project_creation_operation_is_complete(

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/invitations.rs
@@ -90,8 +90,7 @@ impl Invitations for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("create invitation")
     }
 
     async fn create_service_invitation(
@@ -126,8 +125,7 @@ impl Invitations for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("create service invitation")
     }
 
     async fn accept_invitation(
@@ -140,8 +138,7 @@ impl Invitations for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("redeem invitation")
     }
 
     async fn show_invitation(
@@ -155,8 +152,7 @@ impl Invitations for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("get invitation")
     }
 
     async fn list_invitations(
@@ -170,8 +166,7 @@ impl Invitations for ControllerClient {
             .ask(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("list invitations")
     }
 
     async fn ignore_invitation(&self, ctx: &Context, invitation_id: String) -> miette::Result<()> {
@@ -181,7 +176,6 @@ impl Invitations for ControllerClient {
             .tell(ctx, API_SERVICE, req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("ignore invitation")
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/space.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/space.rs
@@ -183,8 +183,7 @@ impl ControllerClient {
             .ask(ctx, "spaces", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("create space")
     }
 
     pub async fn get_space(&self, ctx: &Context, space_id: &str) -> miette::Result<Space> {
@@ -194,8 +193,7 @@ impl ControllerClient {
             .ask(ctx, "spaces", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("get space")
     }
 
     pub async fn delete_space(&self, ctx: &Context, space_id: &str) -> miette::Result<()> {
@@ -205,8 +203,7 @@ impl ControllerClient {
             .tell(ctx, "spaces", req)
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("delete space")
     }
 
     pub async fn list_spaces(&self, ctx: &Context) -> miette::Result<Vec<Space>> {
@@ -215,8 +212,7 @@ impl ControllerClient {
             .ask(ctx, "spaces", Request::get("/v0/"))
             .await
             .into_diagnostic()?
-            .success()
-            .into_diagnostic()
+            .miette_success("list spaces")
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -53,7 +53,6 @@ test = false
 path = "src/bin/ockam.rs"
 
 [dependencies]
-anyhow = "1"
 arboard = "3.3.1"
 async-trait = "0.1"
 clap = { version = "4.5.1", features = ["derive", "cargo", "wrap_help"] }

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -107,9 +107,9 @@ impl StoreCommand {
                 .map_err(|_e| miette!("Invalid credential"))?;
 
             *is_finished.lock().await = true;
-            Ok(credential
+            credential
                 .encode_as_string()
-                .map_err(|_e| miette!("Invalid credential"))?)
+                .map_err(|_e| miette!("Invalid credential"))
         };
 
         let output_messages = vec![format!("Storing credential...")];

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -85,15 +85,16 @@ pub async fn verify_credential(
     let send_req = async {
         let credential_as_str = match (&credential, &credential_path) {
             (_, Some(credential_path)) => tokio::fs::read_to_string(credential_path)
-                .await?
+                .await
+                .into_diagnostic()?
                 .trim()
                 .to_string(),
             (Some(credential), _) => credential.clone(),
             _ => {
                 *is_finished.lock().await = true;
-                return Err(
-                    miette!("Credential or Credential Path argument must be provided").into(),
-                );
+                return Err(miette!(
+                    "Credential or Credential Path argument must be provided"
+                ));
             }
         };
 
@@ -108,7 +109,7 @@ pub async fn verify_credential(
         .await;
 
         *is_finished.lock().await = true;
-        Ok(result.map_err(|e| e.wrap_err("Credential is invalid"))?)
+        result.map_err(|e| e.wrap_err("Credential is invalid"))
     };
 
     let output_messages = vec!["Verifying credential...".to_string()];

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
@@ -70,7 +70,7 @@ pub async fn async_run(
 
         *is_finished.lock().await = true;
 
-        Ok::<_, crate::Error>(())
+        Ok(())
     };
 
     let msgs = vec![

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -60,7 +60,7 @@ impl CreateCommand {
             start_service_impl(ctx, &node, "KafkaOutlet", req).await?;
             *is_finished.lock().await = true;
 
-            Ok::<_, crate::Error>(())
+            Ok(())
         };
 
         let msgs = vec![

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -70,7 +70,7 @@ pub async fn async_run(
 
         *is_finished.lock().await = true;
 
-        Ok::<_, crate::Error>(())
+        Ok(())
     };
 
     let msgs = vec![

--- a/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/mod.rs
@@ -513,7 +513,7 @@ impl<W: TerminalWriter + Debug> Terminal<W> {
         &self,
         output_messages: &[String],
         is_finished: &Mutex<bool>,
-    ) -> Result<()> {
+    ) -> miette::Result<()> {
         if output_messages.is_empty() {
             return Ok(());
         }
@@ -527,7 +527,7 @@ impl<W: TerminalWriter + Debug> Terminal<W> {
         output_messages: &[String],
         is_finished: &Mutex<bool>,
         progress_bar: Option<&ProgressBar>,
-    ) -> Result<()> {
+    ) -> miette::Result<()> {
         let progress_bar = match progress_bar {
             Some(pb) => pb,
             None => return Ok(()),

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -43,7 +43,6 @@ pub fn local_cmd(res: miette::Result<()>) -> miette::Result<()> {
     if let Err(error) = &res {
         // Note: error! is also called in command_event.rs::add_command_error_event()
         error!(%error, "Failed to run command");
-        eprintln!("{:?}", error);
     }
     res
 }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -43,6 +43,7 @@ std = [
   "tracing-opentelemetry",
   "tracing-subscriber",
   "strum/std",
+  "miette",
 ]
 
 # Feature: "no_std" enables functionality required for platforms
@@ -80,6 +81,7 @@ core2 = { version = "0.4.0", default-features = false, optional = true }
 futures-util = { version = "0.3.30", default-features = false, features = ["alloc", "async-await-macro", "sink"] }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "serde"] }
 hex = { version = "0.4", default-features = false, optional = true }
+miette = { version = "7", optional = true }
 minicbor = { version = "0.21.0", features = ["derive"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.34.0", default_features = false }
 once_cell = { version = "1", optional = true, default-features = false }


### PR DESCRIPTION
In this PR I mapped the error code from the api clients to a miette Report via a new method `miette_success`. This new method performs both `success()` and `into_diagnostic()` but without loosing any information (status code).
Change every method signature involved with the error passing to `miette::Result`.

Extras:
- Completely dropped anyhow (unused)
- Changed the formatting of errors in the custom miette error handler, otherwise `wrap_error()` completly obscure the previous error. 
- Delete duplicate error printing in `local_cmd()` (The method printing the error is command main)

See screenshot for thefinal  result.

![ockam_new_error_reporting](https://github.com/build-trust/ockam/assets/408088/47216baa-5068-496d-bd9a-4e8b353cb439)
