### PR TITLE
fix(rust): decode a transport message even without a tracing_context field

### DIFF
--- a/examples/rust/mitm_node/src/bin/tcp_mitm.rs
+++ b/examples/rust/mitm_node/src/bin/tcp_mitm.rs
@@ -21,7 +21,7 @@ impl MitmMonitor {
 
             let should_be_not_reachable_address: Address = address.trim().into();
 
-            let msg = TransportMessage::v1(route![should_be_not_reachable_address.clone()], route![], vec![]);
+            let msg = TransportMessage::latest(route![should_be_not_reachable_address.clone()], route![], vec![]);
 
             let msg = encode_transport_message(msg)?;
             {

--- a/implementations/elixir/ockam/ockam/lib/ockam/wire.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/wire.ex
@@ -12,7 +12,7 @@ defmodule Ockam.Wire do
   require DecodeError
   require EncodeError
 
-  @default_implementation Ockam.Wire.Binary.V1
+  @default_implementation Ockam.Wire.Binary.Versions
 
   @doc """
   Encodes a message into a binary.

--- a/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
@@ -55,7 +55,7 @@ defmodule Ockam.Wire.Binary.Versions do
         context ->
           :bare.encode(
             %{
-              version: @latest_version,
+              version: @version_1,
               onward_route: normalize_route(onward_route),
               return_route: normalize_route(return_route),
               payload: payload,

--- a/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
@@ -1,4 +1,4 @@
-defmodule Ockam.Wire.Binary.V1 do
+defmodule Ockam.Wire.Binary.Versions do
   @moduledoc false
 
   @behaviour Ockam.Wire
@@ -6,7 +6,8 @@ defmodule Ockam.Wire.Binary.V1 do
   alias Ockam.Address
   alias Ockam.Message
 
-  @version 1
+  @latest_version 2
+  @version_1 1
 
   @address_spec {:struct, [type: :uint, value: :data]}
   @route_spec {:array, @address_spec}
@@ -43,7 +44,7 @@ defmodule Ockam.Wire.Binary.V1 do
         nil ->
           :bare.encode(
             %{
-              version: @version,
+              version: @version_1,
               onward_route: normalize_route(onward_route),
               return_route: normalize_route(return_route),
               payload: payload
@@ -54,7 +55,7 @@ defmodule Ockam.Wire.Binary.V1 do
         context ->
           :bare.encode(
             %{
-              version: @version,
+              version: @latest_version,
               onward_route: normalize_route(onward_route),
               return_route: normalize_route(return_route),
               payload: payload,
@@ -78,7 +79,7 @@ defmodule Ockam.Wire.Binary.V1 do
   def decode(encoded) do
     ## Expect first byte to be the version
     case encoded do
-      <<@version, _rest::binary>> ->
+      <<@version_1, _rest::binary>> ->
         case :bare.decode(encoded, @message_spec) do
           {:ok, %{onward_route: onward_route, return_route: return_route} = decoded, ""} ->
             {:ok,
@@ -90,6 +91,12 @@ defmodule Ockam.Wire.Binary.V1 do
                })
              )}
 
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      <<@latest_version, _rest::binary>> ->
+        case :bare.decode(encoded, @message_spec) do
           {:ok, _decoded, _rest} ->
             decode_with_tracing_context(encoded)
 

--- a/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
@@ -1,15 +1,15 @@
-defmodule Ockam.Wire.Binary.V1.Tests do
+defmodule Ockam.Wire.Binary.Versions.Tests do
   use ExUnit.Case, async: true
 
   alias Ockam.Transport.TCPAddress
   alias Ockam.Transport.UDPAddress
-  alias Ockam.Wire.Binary.V1
+  alias Ockam.Wire.Binary.Versions
 
   @localhost <<14, 49, 50, 55, 46, 48, 46, 48, 46, 49>>
   @port_4000 <<58, 52, 48, 48, 48>>
   @port_3000 <<58, 51, 48, 48, 48>>
 
-  describe "Ockam.Wire.V1" do
+  describe "Ockam.Wire.Versions" do
     test "encode/1 for TCP" do
       {a, b, c, d} = {127, 0, 0, 1}
 
@@ -34,7 +34,7 @@ defmodule Ockam.Wire.Binary.V1.Tests do
       assert {:ok,
               <<^version, ^onward_route_size, 1, @localhost::binary, @port_4000::binary, 0, 7,
                 112, 114, 105, 110, 116, 101, 114, 1, 1, @localhost::binary, @port_3000::binary,
-                5, 104, 101, 108, 108, 111>>} = V1.encode(message)
+                5, 104, 101, 108, 108, 111>>} = Versions.encode(message)
     end
 
     test "encode/1 for UDP" do
@@ -54,7 +54,7 @@ defmodule Ockam.Wire.Binary.V1.Tests do
       assert {:ok,
               <<1, 2, 2, @localhost::binary, @port_4000::binary, 0, 7, 112, 114, 105, 110, 116,
                 101, 114, 1, 2, @localhost::binary, @port_3000::binary, 5, 104, 101, 108, 108,
-                111>>} = V1.encode(message)
+                111>>} = Versions.encode(message)
     end
 
     test "encode/1 for TCP (minimal)" do
@@ -73,7 +73,7 @@ defmodule Ockam.Wire.Binary.V1.Tests do
 
       assert {:ok,
               <<^version, ^onward_route_size, 1, @localhost::binary, @port_4000::binary, 0, 0>>} =
-               V1.encode(message)
+               Versions.encode(message)
     end
 
     test "encode/1 for UDP (minimal)" do
@@ -87,7 +87,8 @@ defmodule Ockam.Wire.Binary.V1.Tests do
         payload: ""
       }
 
-      assert {:ok, <<1, 1, 2, @localhost::binary, @port_4000::binary, 0, 0>>} = V1.encode(message)
+      assert {:ok, <<1, 1, 2, @localhost::binary, @port_4000::binary, 0, 0>>} =
+               Versions.encode(message)
     end
 
     test "decode/1 for UDP" do
@@ -101,7 +102,7 @@ defmodule Ockam.Wire.Binary.V1.Tests do
                 onward_route: onward_route,
                 return_route: return_route,
                 payload: payload
-              }} = V1.decode(encoded)
+              }} = Versions.decode(encoded)
 
       assert [UDPAddress.new({127, 0, 0, 1}, 4000), "printer"] ==
                onward_route
@@ -121,7 +122,7 @@ defmodule Ockam.Wire.Binary.V1.Tests do
                 onward_route: onward_route,
                 return_route: return_route,
                 payload: payload
-              }} = V1.decode(encoded)
+              }} = Versions.decode(encoded)
 
       assert [TCPAddress.new({a, b, c, d}, 4000)] == onward_route
       assert [] = return_route
@@ -132,14 +133,14 @@ defmodule Ockam.Wire.Binary.V1.Tests do
       context = "{\"traceparent\":\"00-1234-01\",\"tracestate\":{}}"
 
       {:ok, encoded} =
-        V1.encode(%Ockam.Message{
+        Versions.encode(%Ockam.Message{
           onward_route: ["printer"],
           return_route: [],
           payload: "hello",
           local_metadata: %{tracing_context: context}
         })
 
-      {:ok, decoded} = V1.decode(encoded)
+      {:ok, decoded} = Versions.decode(encoded)
 
       assert decoded.local_metadata.tracing_context == context
     end

--- a/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
@@ -129,20 +129,21 @@ defmodule Ockam.Wire.Binary.Versions.Tests do
       assert "" = payload
     end
 
-    test "encode/1 and decode/1 with tracing context" do
-      context = "{\"traceparent\":\"00-1234-01\",\"tracestate\":{}}"
-
-      {:ok, encoded} =
-        Versions.encode(%Ockam.Message{
-          onward_route: ["printer"],
-          return_route: [],
-          payload: "hello",
-          local_metadata: %{tracing_context: context}
-        })
-
-      {:ok, decoded} = Versions.decode(encoded)
-
-      assert decoded.local_metadata.tracing_context == context
-    end
+    # uncomment when the project node is able to emit v2 messages
+    #    test "encode/1 and decode/1 with tracing context" do
+    #      context = "{\"traceparent\":\"00-1234-01\",\"tracestate\":{}}"
+    #
+    #      {:ok, encoded} =
+    #        Versions.encode(%Ockam.Message{
+    #          onward_route: ["printer"],
+    #          return_route: [],
+    #          payload: "hello",
+    #          local_metadata: %{tracing_context: context}
+    #        })
+    #
+    #      {:ok, decoded} = Versions.decode(encoded)
+    #
+    #      assert decoded.local_metadata.tracing_context == context
+    #    end
   end
 end

--- a/implementations/rust/ockam/ockam_api/tests/common/test_spans.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/test_spans.rs
@@ -26,6 +26,11 @@ impl TestSpan {
         self.id.clone()
     }
 
+    /// Return the span name
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
     /// Return the id of the parent span
     pub fn parent_id(&self) -> TestSpanId {
         TestSpanId {
@@ -73,7 +78,7 @@ impl Display for TestSpanId {
 /// Tree of TestSpans forming a trace where the
 /// parent / child relationship uses the span.parent_span_id attribute
 #[derive(Debug)]
-pub struct Trace(Tree<TestSpan>);
+pub struct Trace(pub Tree<TestSpan>);
 
 impl Display for Trace {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
@@ -54,6 +54,14 @@ where
 pub fn display_traces(spans: Vec<SpanData>) -> String {
     let mut traces = Trace::from_span_data(spans);
     traces.sort_by_key(|t| t.to_string());
+
+    // remove some uninteresting traces based on their root name
+    traces.retain(|t| {
+        !["start", "shutdown", "initialize", "process"]
+            .iter()
+            .any(|v| t.0.to_string().split('\n').collect::<Vec<_>>()[0].ends_with(v))
+    });
+
     traces
         .iter()
         .map(|t| t.to_string())

--- a/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
@@ -210,7 +210,7 @@ impl LocalMessage {
     /// Create a [`TransportMessage`] from a [`LocalMessage`]
     pub fn into_transport_message(self) -> TransportMessage {
         let transport_message =
-            TransportMessage::v1(self.onward_route, self.return_route, self.payload);
+            TransportMessage::latest(self.onward_route, self.return_route, self.payload);
 
         cfg_if! {
             if #[cfg(feature = "std")] {

--- a/implementations/rust/ockam/ockam_core/src/routing/message/relay_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/relay_message.rs
@@ -1,4 +1,4 @@
-use crate::{Address, LocalMessage, Route};
+use crate::{Address, LocalMessage, ProtocolVersion, Route};
 
 /// A message addressed to the relay responsible for delivery of the
 /// wrapped [`LocalMessage`]
@@ -49,6 +49,11 @@ impl RelayMessage {
     /// Payload
     pub fn payload(&self) -> &[u8] {
         self.local_msg.payload_ref()
+    }
+
+    /// Protocol version
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.local_msg.protocol_version()
     }
 
     /// Local message

--- a/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/transport_message.rs
@@ -1,8 +1,12 @@
+use crate::alloc::string::ToString;
+use crate::errcode::{Kind, Origin};
 use crate::errcode::{Kind, Origin};
 #[cfg(feature = "std")]
 use crate::OpenTelemetryContext;
 #[cfg(feature = "tracing_context")]
 use crate::OCKAM_TRACER_NAME;
+use crate::{Error, Result};
+#[cfg(feature = "std")]
 use crate::{compat::vec::Vec, Decodable, Encodable, Encoded, Message, Route};
 use cfg_if::cfg_if;
 use core::fmt::{self, Display, Formatter};
@@ -45,19 +49,54 @@ pub struct TransportMessage {
 }
 
 impl TransportMessage {
-    /// Create a new v1 transport message with empty return route.
-    pub fn v1(
+    /// Create the latest version of a transport message with an empty return route.
+    pub fn latest(
         onward_route: impl Into<Route>,
         return_route: impl Into<Route>,
         payload: Vec<u8>,
     ) -> Self {
         Self {
-            version: 1,
+            version: 2,
             onward_route: onward_route.into(),
             return_route: return_route.into(),
             payload,
             #[cfg(feature = "tracing_context")]
             tracing_context: None,
+        }
+    }
+
+    /// Decode the transport message according to the first byte, which is the version number
+    pub fn decode_message(buf: Vec<u8>) -> Result<TransportMessage> {
+        if buf.is_empty() {
+            return Err(Error::new(
+                Origin::Transport,
+                Kind::Serialization,
+                "empty buffer, no transport message received".to_string(),
+            ));
+        };
+        let version = buf[0];
+        match version {
+            1 => TransportMessageV1::decode(&buf)
+                .map(|t| t.to_latest())
+                .map_err(|e| {
+                    Error::new(
+                        Origin::Transport,
+                        Kind::Serialization,
+                        format!("Error decoding message: {:?}", e),
+                    )
+                }),
+            2 => TransportMessage::decode(&buf).map_err(|e| {
+                Error::new(
+                    Origin::Transport,
+                    Kind::Serialization,
+                    format!("Error decoding message: {:?}", e),
+                )
+            }),
+            v => Err(Error::new(
+                Origin::Transport,
+                Kind::Serialization,
+                format!("Unsupported version: {v}"),
+            )),
         }
     }
 
@@ -122,6 +161,91 @@ impl Display for TransportMessage {
             "Message (onward route: {}, return route: {})",
             self.onward_route, self.return_route
         )
+    }
+}
+
+/// This is
+#[derive(Debug, Clone, Eq, PartialEq, Message)]
+pub struct TransportMessageV1 {
+    /// The transport protocol version.
+    pub version: u8,
+    /// Onward message route.
+    pub onward_route: Route,
+    /// Return message route.
+    ///
+    /// This field must be populated by routers handling this message
+    /// along the way.
+    pub return_route: Route,
+    /// The message payload.
+    pub payload: Vec<u8>,
+}
+
+impl TransportMessageV1 {
+    /// Convert a transport message v1 to the latest version of the protocol
+    pub fn to_latest(self) -> TransportMessage {
+        TransportMessage {
+            version: 2,
+            onward_route: self.onward_route,
+            return_route: self.return_route,
+            payload: self.payload,
+            #[cfg(feature = "tracing_context")]
+            tracing_context: None,
+        }
+    }
+
+    /// Create a new transport message with version v1
+    pub fn new(
+        onward_route: impl Into<Route>,
+        return_route: impl Into<Route>,
+        payload: Vec<u8>,
+    ) -> Self {
+        Self {
+            version: 1,
+            onward_route: onward_route.into(),
+            return_route: return_route.into(),
+            payload,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "tracing_context")]
+mod tests {
+    use super::*;
+    use crate::{route, Encodable, TransportMessageV1};
+
+    #[test]
+    fn test_encode_decode() {
+        let transport_message_v1 =
+            TransportMessageV1::new(route!["onward"], route!["return"], vec![]);
+        let transport_message_v2 =
+            TransportMessage::latest(route!["onward"], route!["return"], vec![]);
+
+        // a v1 message should be decodable as the latest version
+        let encoded_v1 = transport_message_v1.encode().unwrap();
+        assert_eq!(
+            TransportMessage::decode_message(encoded_v1).unwrap(),
+            transport_message_v2
+        );
+
+        // a v2 message should be decodable as the latest version
+        let encoded_v2 = transport_message_v2.encode().unwrap();
+        assert_eq!(
+            TransportMessage::decode_message(encoded_v2).unwrap(),
+            transport_message_v2
+        );
+
+        // any other version must fail to be decoded
+        let encoded_v3 = TransportMessage {
+            version: 3,
+            onward_route: route![],
+            return_route: route![],
+            payload: vec![],
+            tracing_context: None,
+        }
+        .encode()
+        .unwrap();
+        assert!(TransportMessage::decode_message(encoded_v3).is_err());
     }
 }
 
@@ -213,6 +337,55 @@ impl TransportMessage {
                 })
             }
         }
+    }
+}
+
+impl Encodable for TransportMessageV1 {
+    fn encode(self) -> crate::Result<Encoded> {
+        let tracing = 0;
+        let mut encoded = Vec::with_capacity(
+            1 + self.onward_route.encoded_size()
+                + self.return_route.encoded_size()
+                + crate::bare::size_of_slice(&self.payload)
+                + tracing,
+        );
+        encoded.push(self.version);
+        self.onward_route.manual_encode(&mut encoded);
+        self.return_route.manual_encode(&mut encoded);
+        crate::bare::write_slice(&mut encoded, &self.payload);
+        encoded.push(0);
+        Ok(encoded)
+    }
+}
+
+impl Decodable for TransportMessageV1 {
+    fn decode(slice: &[u8]) -> crate::Result<Self> {
+        Self::internal_decode(slice).ok_or_else(|| {
+            crate::Error::new(
+                Origin::Transport,
+                Kind::Protocol,
+                "Failed to decode TransportMessage",
+            )
+        })
+    }
+}
+
+impl TransportMessageV1 {
+    fn internal_decode(slice: &[u8]) -> Option<Self> {
+        let mut index = 0;
+        let version = slice.get(index)?;
+        index += 1;
+
+        let onward_route = Route::manual_decode(slice, &mut index)?;
+        let return_route = Route::manual_decode(slice, &mut index)?;
+        let payload = crate::bare::read_slice(slice, &mut index)?;
+
+        Some(Self {
+            version: *version,
+            onward_route,
+            return_route,
+            payload: payload.to_vec(),
+        })
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/context/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context.rs
@@ -9,7 +9,9 @@ use ockam_core::compat::{string::String, vec::Vec};
 use ockam_core::flow_control::FlowControls;
 #[cfg(feature = "std")]
 use ockam_core::OpenTelemetryContext;
-use ockam_core::{async_trait, Address, Mailboxes, RelayMessage, Result, TransportType};
+use ockam_core::{
+    async_trait, Address, Mailboxes, ProtocolVersion, RelayMessage, Result, TransportType,
+};
 
 #[cfg(feature = "std")]
 use core::fmt::{Debug, Formatter};
@@ -31,6 +33,8 @@ pub struct Context {
     pub(super) flow_controls: FlowControls,
     #[cfg(feature = "std")]
     pub(super) tracing_context: OpenTelemetryContext,
+    /// Protocol version of the message currently being processed by a worker
+    pub(super) protocol_version: ProtocolVersion,
 }
 
 /// This trait can be used to integrate transports into a node
@@ -93,10 +97,20 @@ impl Context {
         self.tracing_context.clone()
     }
 
+    /// Return the protocol version of the message being processed
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
+
     /// Set the current tracing context
     #[cfg(feature = "std")]
     pub fn set_tracing_context(&mut self, tracing_context: OpenTelemetryContext) {
         self.tracing_context = tracing_context
+    }
+
+    /// Set the current protocol version
+    pub fn set_protocol_version(&mut self, protocol_version: ProtocolVersion) {
+        self.protocol_version = protocol_version
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -9,7 +9,7 @@ use ockam_core::OpenTelemetryContext;
 use ockam_core::{
     errcode::{Kind, Origin},
     Address, AsyncTryClone, DenyAll, Error, IncomingAccessControl, Mailboxes,
-    OutgoingAccessControl, Result, TransportType,
+    OutgoingAccessControl, ProtocolVersion, Result, TransportType,
 };
 use ockam_transport_core::Transport;
 
@@ -58,7 +58,9 @@ impl Context {
     ///
     /// `async_drop_sender` must be provided when creating a detached
     /// Context type (i.e. not backed by a worker relay).
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        protocol_version: ProtocolVersion,
         rt: Handle,
         sender: SmallSender<NodeMessage>,
         mailboxes: Mailboxes,
@@ -71,6 +73,7 @@ impl Context {
         let (ctrl_tx, ctrl_rx) = small_channel();
         (
             Self {
+                protocol_version,
                 rt,
                 sender,
                 mailboxes,
@@ -95,6 +98,7 @@ impl Context {
         mailboxes: Mailboxes,
     ) -> (Context, SenderPair, SmallReceiver<CtrlSignal>) {
         Context::new(
+            self.protocol_version(),
             self.runtime().clone(),
             self.sender().clone(),
             mailboxes,
@@ -112,6 +116,7 @@ impl Context {
         drop_sender: AsyncDropSender,
     ) -> (Context, SenderPair, SmallReceiver<CtrlSignal>) {
         Context::new(
+            self.protocol_version(),
             self.runtime().clone(),
             self.sender().clone(),
             mailboxes,

--- a/implementations/rust/ockam/ockam_node/src/context/send_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/send_message.rs
@@ -108,6 +108,7 @@ impl Context {
 
         #[cfg(feature = "std")]
         child_ctx.set_tracing_context(self.tracing_context());
+        child_ctx.set_protocol_version(self.protocol_version());
 
         child_ctx.send(route, msg).await?;
         child_ctx
@@ -262,6 +263,7 @@ impl Context {
             let local_msg = LocalMessage::new()
                 // make sure to set the latest tracing context, to get the latest span id
                 .with_tracing_context(self.tracing_context().update())
+                .with_protocol_version(self.protocol_version())
                 .with_onward_route(route)
                 .with_return_route(route![sending_address.clone()])
                 .with_payload(payload)
@@ -271,7 +273,8 @@ impl Context {
                .with_onward_route(route)
                .with_return_route(route![sending_address.clone()])
                .with_payload(payload)
-               .with_local_info(local_info);
+               .with_local_info(local_info)
+               .with_protocol_version(self.protocol_version());
                }
            }
 
@@ -361,6 +364,9 @@ impl Context {
             .take_sender()?;
 
         // Pack the transport message into a RelayMessage wrapper
+        let mut local_msg = local_msg;
+        local_msg = local_msg.with_protocol_version(self.protocol_version());
+
         let relay_msg = RelayMessage::new(sending_address, addr, local_msg);
 
         debugger::log_outgoing_message(self, &relay_msg);

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -4,7 +4,7 @@ use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::FlowControls;
 #[cfg(feature = "std")]
 use ockam_core::OpenTelemetryContext;
-use ockam_core::{Address, AllowAll, Mailbox, Mailboxes};
+use ockam_core::{Address, AllowAll, Mailbox, Mailboxes, LATEST_PROTOCOL_VERSION};
 
 /// A minimal worker implementation that does nothing
 pub struct NullWorker;
@@ -107,6 +107,7 @@ impl NodeBuilder {
         // The root application worker needs a mailbox and relay to accept
         // messages from workers, and to buffer incoming transcoded data.
         let (ctx, sender, _) = Context::new(
+            LATEST_PROTOCOL_VERSION,
             rt.handle().clone(),
             exe.sender(),
             Mailboxes::new(

--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -74,6 +74,7 @@ where
                 // that same tracing context will be passed along when a LocalMessage will be created
                 // (see send_from_address_impl)
                 self.ctx.set_tracing_context(tracing_context.clone());
+                self.ctx.set_protocol_version(relay_msg.protocol_version());
 
                 self.worker
                     .handle_message(&mut self.ctx, Self::wrap_direct_message(relay_msg))
@@ -82,6 +83,7 @@ where
                     .with_context(tracing_context.update().extract())
                     .await?;
             } else {
+                self.ctx.set_protocol_version(relay_msg.protocol_version());
                 let routed = Self::wrap_direct_message(relay_msg);
                 self.worker
                     .handle_message(&mut self.ctx, routed)

--- a/implementations/rust/ockam/ockam_transport_core/src/transport.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/transport.rs
@@ -57,7 +57,7 @@ mod test {
 
     #[test]
     fn prepare_message_should_discard_large_messages() {
-        let msg = TransportMessage::v1(route![], route![], vec![0; u16::MAX as usize + 1]);
+        let msg = TransportMessage::latest(route![], route![], vec![0; u16::MAX as usize + 1]);
         let result = encode_transport_message(msg);
         assert!(result.is_err());
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
@@ -6,7 +6,7 @@ use ockam_core::flow_control::FlowControlId;
 use ockam_core::{
     async_trait, AllowOnwardAddress, DenyAll, Mailbox, Mailboxes, OutgoingAccessControl,
 };
-use ockam_core::{Decodable, LocalMessage, Processor, Result, TransportMessage};
+use ockam_core::{LocalMessage, Processor, Result, TransportMessage};
 use ockam_node::{Context, ProcessorBuilder};
 use ockam_transport_core::TransportError;
 use tokio::{io::AsyncReadExt, net::tcp::OwnedReadHalf};
@@ -166,8 +166,8 @@ impl Processor for TcpRecvProcessor {
         }
 
         // Deserialize the message now
-        let transport_message = TransportMessage::decode(&buf).map_err(|e| {
-            error!("Error decoding message: {:?}", e);
+        let transport_message = TransportMessage::decode_message(buf).map_err(|e| {
+            error!("{e:?}");
             TransportError::RecvBadMessage
         })?;
         let local_message = LocalMessage::from_transport_message(transport_message);

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/sender.rs
@@ -191,7 +191,7 @@ where
 
         let recipient = msg.msg_addr();
         if recipient == self.internal_addr {
-            let msg = TransportMessage::v1(route![], route![], vec![]);
+            let msg = TransportMessage::latest(route![], route![], vec![]);
             // Sending empty heartbeat
             if ws_sink
                 .send(WebSocketMessage::from(msg.encode()?))


### PR DESCRIPTION
This PR makes it possible to decode transport messages produced by nodes which are not yet emitting a `tracing_context` field.

*NOTE*: This PR does not enable the `tracing_context` field yet. For now:

  - It produces transport messages with protocol `v1` and no `tracing_context` field
  - Yet it can consume protocol `v2` messages (with a `tracing_context`) field

So once this PR is deployed in a new Orchestrator version, we will be able to switch to `v2` as the default protocol version. 

# New protocol version

In this PR we introduce a new protocol version, `v2`, where transport messages in `v2` have an additional `tracing_context` field.

That change was tested by deploying locally the code from this PR (using the [orchestrator docker-compose setup](https://github.com/build-trust/ockam-orchestrator/blob/main/compose/README.md)) and by sending a message using a secure channel to the project node, with:

 - A version of `ockam` based on `develop`, which only knows about transport messages in version `v1`.
 - This version of `ockam` which can read both `v1` and `v2`

Indeed, clients which understand only protocol v1 can communicate with:

 - The controller and the project node which, with orchestrator#555, just discard the `tracing_context` field and emit v1 messages
 - The authority node (based on this PR) which 
    - Accepts v1 messages and reply with v1 messages
    - Accepts v2 messages and reply with v2 messages 

## Implementation notes

In order to know which protocol version needs to be used to reply to a v1 or v2 messages, we add a new field to `LocalMessage` and make sure that each new `LocalMessage` that is propagated inside a node keep this information.
This is very similar to what we do for the `tracing_context` and that explains why we also need to add a `protocol_version` field to the `Context` that is setup for a worker.
