### PR TITLE
feat: small adjustments for the opentelemetry export 

### DIFF
--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = "1.19"
 open = "5.1.2"
 opentelemetry = { version = "0.22.0", features = ["logs", "metrics", "trace"] }
 opentelemetry-appender-tracing = { version = "0.3.0" }
-opentelemetry-otlp = { version = "0.15.0", features = ["logs", "metrics", "trace", "grpc-tonic", "tls-roots"], default-features = false }
+opentelemetry-otlp = { version = "0.15.0", features = ["logs", "metrics", "trace", "grpc-tonic", "tls", "tls-roots"], default-features = false }
 opentelemetry-semantic-conventions = { version = "0.14.0" }
 opentelemetry_sdk = { version = "0.22.1", features = ["logs", "metrics", "trace", "rt-tokio", "rt-tokio-current-thread", "testing", "logs_level_enabled"], default-features = false }
 petname = { version = "2.0.0-beta.4", default-features = false, features = ["default-rng", "default-words"] }

--- a/implementations/rust/ockam/ockam_api/src/logs/setup.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/setup.rs
@@ -181,12 +181,12 @@ fn create_log_exporter(
     exporting_configuration: &ExportingConfiguration,
 ) -> opentelemetry_otlp::LogExporter {
     let log_export_timeout = exporting_configuration.log_export_timeout();
-    let tracing_endpoint = exporting_configuration.opentelemetry_endpoint().to_string();
+    let endpoint = exporting_configuration.opentelemetry_endpoint().to_string();
 
     Executor::execute_future(async move {
         opentelemetry_otlp::new_exporter()
             .tonic()
-            .with_endpoint(tracing_endpoint)
+            .with_endpoint(endpoint)
             .with_timeout(log_export_timeout)
             .with_metadata(get_otlp_headers())
             .build_log_exporter()
@@ -201,12 +201,12 @@ fn create_span_exporter(
     exporting_configuration: &ExportingConfiguration,
 ) -> opentelemetry_otlp::SpanExporter {
     let trace_export_timeout = exporting_configuration.span_export_timeout();
-    let tracing_endpoint = exporting_configuration.opentelemetry_endpoint().to_string();
+    let endpoint = exporting_configuration.opentelemetry_endpoint().to_string();
 
     Executor::execute_future(async move {
         opentelemetry_otlp::new_exporter()
             .tonic()
-            .with_endpoint(tracing_endpoint.clone())
+            .with_endpoint(endpoint.clone())
             .with_timeout(trace_export_timeout)
             .with_metadata(get_otlp_headers())
             .build_span_exporter()


### PR DESCRIPTION
This PR contains: 

 - And addition of the `tls` feature for the `opentelemetry` crate. It is required to enable `tls-roots` (which allows the use of HTTPs for the OpenTelemetry collector)
 - And a small refactoring
