### PR TITLE
revert `actions/checkout` from v4.1.2 to v4.1.1

### DIFF
--- a/.github/actions/lint_workflow/action.yml
+++ b/.github/actions/lint_workflow/action.yml
@@ -8,13 +8,13 @@ runs:
   steps:
       - name: Checkout
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0 # checkout full tree
 
       - name: Checkout (Pull Request)
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0 # checkout full tree
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -47,7 +47,7 @@ jobs:
     container: # gitlab.com/greut/eclint
       image: greut/eclint:v0.3.3@sha256:95e9a3dcbd236bae6569625cd403175cbde3705303774e7baca418b6442b8d77
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - shell: sh
@@ -61,7 +61,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - name: Run Semgrep

--- a/.github/workflows/distroless.yml
+++ b/.github/workflows/distroless.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 

--- a/.github/workflows/docs_checks.yml
+++ b/.github/workflows/docs_checks.yml
@@ -57,12 +57,12 @@ jobs:
 
     steps:
       # Run ockam example code against a different version of ockam library
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.commit_sha }}
           path: ockam_examples
 
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.ockam_crate_version_to_test_with_docs_examples }}
           path: ockam_library
@@ -98,13 +98,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Ockam Repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.commit_sha }}
           path: ockam
 
       - name: Checkout Ockam Documentation Repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.ockam_docs_ref == '' && 'develop' || inputs.ockam_docs_ref }}
           repository: build-trust/ockam-documentation

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -60,7 +60,7 @@ jobs:
     name: Elixir - test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/cache_nix

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,7 +43,7 @@ jobs:
     name: Make - full_build_in_release_mode
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: ./.github/actions/cache_nix

--- a/.github/workflows/ockam-artifact.yml
+++ b/.github/workflows/ockam-artifact.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: ./tools/docker/ockam
     steps:
-    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
       with:
         registry: ghcr.io

--- a/.github/workflows/ockam-healthcheck.yml
+++ b/.github/workflows/ockam-healthcheck.yml
@@ -34,7 +34,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           path: ockam-healthcheck
 

--- a/.github/workflows/release-bump-pull-request.yml
+++ b/.github/workflows/release-bump-pull-request.yml
@@ -57,7 +57,7 @@ jobs:
       image: ghcr.io/build-trust/ockam-builder@sha256:b7790a79e5fd4265d8333bb882010e5d4326778f270bd49693fa35763865df82
     steps:
       - name: Checkout Ockam
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-bump-pull-request.yml
+++ b/.github/workflows/release-bump-pull-request.yml
@@ -85,8 +85,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bash -ex ./tools/scripts/release/redo-draft-release.sh
+
           # Delete the old git tag, it'll be recreated when we are creating a new draft binary.
-          gh release delete ${{ inputs.redo_release_tag }} --cleanup-tag
+          if gh release view ${{ inputs.redo_release_tag }}; then
+            gh release delete ${{ inputs.redo_release_tag }} --cleanup-tag
+          fi
 
       - name: Bump Ockam
         if: ${{ inputs.redo_release_tag == '' }}

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -30,7 +30,7 @@ jobs:
       tag_name: ${{ steps.release_version.outputs.tag_name }}
     steps:
       - name: Checkout Ockam
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.release_branch }}
@@ -224,7 +224,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
         ref: ${{ github.event.inputs.release_branch }}
 
@@ -366,7 +366,7 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.release_branch }}
 

--- a/.github/workflows/release-ockam-package.yml
+++ b/.github/workflows/release-ockam-package.yml
@@ -48,7 +48,7 @@ jobs:
           mkdir assets && cd assets
           gh release download ${{ github.event.inputs.tag }} -R ${ORGANIZATION}/ockam
 
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           path: ockam
 
@@ -120,7 +120,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -35,7 +35,7 @@ jobs:
           echo "sha=$develop_sha" >> $GITHUB_OUTPUT
 
       - name: Checkout To Ockam Repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-publish-crates.yml
+++ b/.github/workflows/release-publish-crates.yml
@@ -40,7 +40,7 @@ jobs:
     name: "Publish Crates To Crates IO"
     steps:
       - name: Checkout Ockam
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.release_branch }}

--- a/.github/workflows/release-test-draft-binaries.yml
+++ b/.github/workflows/release-test-draft-binaries.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - name: Checkout repository
       if: matrix.os == 'ubuntu-22.04'
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       with:
         fetch-depth: 0
         ref: ${{ github.event.inputs.git_tag }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
         shell: nix develop ./tools/nix#rust --keep CI --ignore-environment --command bash {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 
@@ -110,7 +110,7 @@ jobs:
         shell: nix develop ./tools/nix#rust${{matrix.build_projects == 'nightly' && '_nightly' || '' }} --keep CI --ignore-environment --command bash {0}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 
@@ -151,7 +151,7 @@ jobs:
           - stable
           - nightly
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 
@@ -192,7 +192,7 @@ jobs:
       run:
         shell: nix develop ./tools/nix#${{matrix.nix_toolchain }} --keep CI --ignore-environment --command bash {0}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 
@@ -229,13 +229,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout ockam cli repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.ockam_command_cli_version != '' && inputs.ockam_command_cli_version || inputs.commit_sha  }}
           path: ockam_cli
 
       - name: Checkout ockam bats repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.commit_sha }}
           path: ockam_bats
@@ -300,7 +300,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           persist-credentials: false
 

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -45,7 +45,7 @@ jobs:
     name: Shell - lint_shellcheck
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - run: shellcheck -S error $(find . -not -path "./examples/command/*" -iname "*.sh" -o -name "*.bash")
@@ -56,7 +56,7 @@ jobs:
     name: Shell - lint_shfmt
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Check spelling
         uses: crate-ci/typos@bcafd462cb07ef7ba57e34abf458fe20767e808b


### PR DESCRIPTION
Revert checkout action from v4.1.2 to v4.1.1 to [fix release](https://github.com/build-trust/ockam/actions/runs/8332874881/job/22803045681#step:6:272) https://github.com/actions/checkout/issues/1651