### PR TITLE
fix(rust): load variables defined in `node create` before parsing the config file

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -12,6 +12,9 @@ use serde::{Deserialize, Serialize};
 impl CreateCommand {
     pub async fn run_config(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
         let contents = async_parse_path_or_url(&self.name).await?;
+        for (key, value) in &self.variables {
+            std::env::set_var(key, value);
+        }
         let mut config = NodeConfig::new(&contents)?;
         let node_name = config.merge(self)?;
         config.run(ctx, opts.clone(), &node_name).await?;

--- a/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
@@ -1,7 +1,8 @@
 use crate::fmt_warn;
 use crate::run::parser::building_blocks::{ArgKey, ArgValue};
 use colorful::Colorful;
-use miette::{IntoDiagnostic, Result};
+use miette::{miette, IntoDiagnostic, Result};
+use ockam_api::color_primary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tracing::warn;
@@ -16,8 +17,14 @@ impl Variables {
         let self_ = serde_yaml::from_str::<Variables>(contents).into_diagnostic()?;
         self_.load()?;
         shellexpand::env(&contents)
-            .into_diagnostic()
             .map(|c| c.to_string())
+            .map_err(|e| {
+                miette!(
+                    "Failed to resolve variable {}: {}",
+                    color_primary(&e.var_name),
+                    e.cause
+                )
+            })
     }
 
     /// Loads the variables into the environment, giving preference to variables set externally.


### PR DESCRIPTION
The variables set using the `--variable` argument weren't having any effect, as they weren't being loaded.

```
node create ./config.yaml --variable VAR=value
```