### PR TITLE
refactor(rust): simplify `ProgressDisplay` to remove the external mutex used to stop the message recv end

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -141,15 +141,14 @@ impl CliState {
     #[instrument(skip_all, fields(vault_name = vault_name))]
     pub async fn get_or_create_named_vault(&self, vault_name: &str) -> Result<NamedVault> {
         let vaults_repository = self.vaults_repository();
-        self.notify("We need a Vault to store Identity secrets.".to_string());
         let is_default = vault_name == DEFAULT_VAULT_NAME;
 
         if let Ok(Some(existing_vault)) = vaults_repository.get_named_vault(vault_name).await {
             return Ok(existing_vault);
-        } else {
-            self.notify("There is no default Vault on this machine, creating one...".to_string());
         }
 
+        self.notify("We need a Vault to store Identity secrets.".to_string());
+        self.notify("There is no default Vault on this machine, creating one...".to_string());
         let named_vault = self
             .create_a_vault(&Some(vault_name.to_string()), &None, false)
             .await?;

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 impl CreateCommand {
     pub async fn run_config(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
         let contents = async_parse_path_or_url(&self.name).await?;
+        // Set environment variables from the cli command args
         for (key, value) in &self.variables {
             std::env::set_var(key, value);
         }
@@ -50,8 +51,8 @@ impl NodeConfig {
     /// Merge the arguments of the node defined in the config with the arguments from the
     /// "create" command, giving precedence to the config values.
     fn merge(&mut self, cli_args: CreateCommand) -> miette::Result<String> {
-        // Set environment variables from the cli command
-        // overriding the duplicates the config file.
+        // Set environment variables from the cli command again
+        // to override the duplicate entries from the config file.
         for (key, value) in &cli_args.variables {
             std::env::set_var(key, value);
         }

--- a/implementations/rust/ockam/ockam_command/src/progress_display.rs
+++ b/implementations/rust/ockam/ockam_command/src/progress_display.rs
@@ -2,19 +2,30 @@ use crate::{fmt_log, CommandGlobalOpts, Terminal, TerminalStream};
 use console::Term;
 use indicatif::ProgressBar;
 use ockam_api::Notification;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::select;
 use tokio::sync::broadcast::Receiver;
-use tokio::sync::Mutex;
+use tokio::time::sleep;
 use tracing::info;
 
 const REPORTING_CHANNEL_POLL_DELAY: Duration = Duration::from_millis(100);
 const REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY: Duration = Duration::from_millis(1_000);
 
+pub struct ProgressDisplayHandle {
+    stop: Arc<Mutex<bool>>,
+}
+
+impl Drop for ProgressDisplayHandle {
+    fn drop(&mut self) {
+        let mut stop = self.stop.lock().unwrap();
+        *stop = true;
+    }
+}
+
 /// This struct displays notifications coming from the CliState when commands are executed
 #[derive(Debug)]
 pub struct ProgressDisplay {
-    /// Receive notifications from the CliState
     notifications: Receiver<Notification>,
     /// List of all received notifications
     received: Vec<Notification>,
@@ -23,97 +34,84 @@ pub struct ProgressDisplay {
     progress_bar: Option<ProgressBar>,
     /// User terminal
     terminal: Terminal<TerminalStream<Term>>,
+    /// Flag to determine if the progress display should stop
+    stop: Arc<Mutex<bool>>,
 }
 
 impl ProgressDisplay {
     /// Create a new NotificationsProgress without progress bar.
     /// The notifications are printed as they arrive and stay on screen
-    pub fn new(opts: &CommandGlobalOpts) -> ProgressDisplay {
-        ProgressDisplay {
+    pub fn start(opts: &CommandGlobalOpts) -> ProgressDisplayHandle {
+        let stop = Arc::new(Mutex::new(false));
+        let _self = ProgressDisplay {
             notifications: opts.state.subscribe(),
             received: vec![],
             terminal: opts.terminal.clone(),
             progress_bar: None,
-        }
-    }
-
-    /// Create a new NotificationsProgress with a progress bar.
-    /// The notifications are displayed by the progress bar, one after the other,
-    /// and can be finally displayed all at once by using the `finalize` method
-    #[allow(unused)]
-    pub fn new_with_progress_bar(opts: &CommandGlobalOpts) -> ProgressDisplay {
-        ProgressDisplay {
-            notifications: opts.state.subscribe(),
-            received: vec![],
-            terminal: opts.terminal.clone(),
-            progress_bar: opts.terminal.progress_spinner(),
-        }
+            stop: stop.clone(),
+        };
+        _self.run();
+        ProgressDisplayHandle { stop }
     }
 }
 
 impl ProgressDisplay {
     /// Start displaying the progress of a given action.
     /// When that action changes the values of the can_stop mutex, then the display stops.
-    pub async fn start(&mut self, can_stop: Arc<Mutex<bool>>) -> miette::Result<()> {
-        loop {
-            tokio::select! {
-                _ = tokio::time::sleep(REPORTING_CHANNEL_POLL_DELAY) => {
-                    if *can_stop.lock().await {
-                        self.stop_progress_bar();
-                        break;
-                    }
-                }
-                notification = self.notifications.recv() => {
-                    match notification {
-                        Ok(notification) => {
-                            // If the progress bar is available, display the message and save it
-                            // for later display
-                            match self.progress_bar.as_ref() {
-                                Some(progress_bar) => {
-                                   self.received.push(notification.clone());
-                                   // Fabricate a delay for a better UX, so the user has a chance to read the message.
-                                   progress_bar.set_message(notification);
-                                    let _ = tokio::time::sleep(REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY)
-                                    .await;
-                                },
-                                None => {
-                                   let _ = self.terminal.write_line(fmt_log!("{}", notification));
-                               }
-                            };
-                        }
-                        // Unknown problem with channel.
-                        _ => {
-                            self.stop_progress_bar();
+    pub fn run(mut self) {
+        tokio::spawn(async move {
+            loop {
+                select! {
+                    _ = sleep(REPORTING_CHANNEL_POLL_DELAY) => {
+                        if *self.stop.lock().unwrap() {
+                            self.finalize();
                             break;
+                        }
+                    }
+                    notification = self.notifications.recv() => {
+                        match notification {
+                            Ok(notification) => {
+                                // If the progress bar is available, display the message and save it
+                                // for later display
+                                match self.progress_bar.as_ref() {
+                                    Some(progress_bar) => {
+                                        self.received.push(notification.clone());
+                                        // Fabricate a delay for a better UX, so the user has a chance to read the message.
+                                        progress_bar.set_message(notification);
+                                        let _ = sleep(REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY).await;
+                                    },
+                                    None => {
+                                        let _ = self.terminal.write_line(fmt_log!("{}", notification));
+                                    }
+                                };
+                            }
+                            // Unknown problem with the channel.
+                            _ => {
+                                self.finalize();
+                                break;
+                            }
                         }
                     }
                 }
             }
-        }
-        Ok(())
+        });
     }
 
     /// Finalize the notifications by displaying/logging them
-    pub fn finalize(&self) {
+    fn finalize(&self) {
         // If a progress bar was, then display the received notifications to user as a summary of
         // what was done. If there was no progress bar, then all the notifications have already been
         // printed out on the terminal
-        if self.progress_bar.is_some() {
+        if let Some(progress_bar) = &self.progress_bar {
             self.received.iter().for_each(|msg| {
                 let _ = self.terminal.write_line(fmt_log!("{}", msg));
             });
+            progress_bar.finish_and_clear();
         }
 
         // Additionally log all the notifications for later debugging if necessary
         self.received.iter().for_each(|msg| {
             info!(msg);
         });
-    }
-
-    /// Stop the progress bar if any
-    fn stop_progress_bar(&self) {
-        if let Some(progress_bar) = self.progress_bar.as_ref() {
-            progress_bar.finish_and_clear()
-        }
     }
 }


### PR DESCRIPTION
- Simplify `ProgressDisplay` to remove the external mutex used to stop the message recv end
- Use `ProgressDisplay` in the `identity create` command to show the vault creation messages