### PR TITLE
feat: transport messages v2

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/wire/binary/versions.ex
@@ -55,7 +55,7 @@ defmodule Ockam.Wire.Binary.Versions do
         context ->
           :bare.encode(
             %{
-              version: @version_1,
+              version: @latest_version,
               onward_route: normalize_route(onward_route),
               return_route: normalize_route(return_route),
               payload: payload,

--- a/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/wire/binary/versions_test.exs
@@ -129,21 +129,20 @@ defmodule Ockam.Wire.Binary.Versions.Tests do
       assert "" = payload
     end
 
-    # uncomment when the project node is able to emit v2 messages
-    #    test "encode/1 and decode/1 with tracing context" do
-    #      context = "{\"traceparent\":\"00-1234-01\",\"tracestate\":{}}"
-    #
-    #      {:ok, encoded} =
-    #        Versions.encode(%Ockam.Message{
-    #          onward_route: ["printer"],
-    #          return_route: [],
-    #          payload: "hello",
-    #          local_metadata: %{tracing_context: context}
-    #        })
-    #
-    #      {:ok, decoded} = Versions.decode(encoded)
-    #
-    #      assert decoded.local_metadata.tracing_context == context
-    #    end
+    test "encode/1 and decode/1 with tracing context" do
+      context = "{\"traceparent\":\"00-1234-01\",\"tracestate\":{}}"
+
+      {:ok, encoded} =
+        Versions.encode(%Ockam.Message{
+          onward_route: ["printer"],
+          return_route: [],
+          payload: "hello",
+          local_metadata: %{tracing_context: context}
+        })
+
+      {:ok, decoded} = Versions.decode(encoded)
+
+      assert decoded.local_metadata.tracing_context == context
+    end
   end
 end

--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -69,7 +69,6 @@ async fn nested_function() -> OpenTelemetryContext {
 
 /// This test checks that the tracing context is correctly propagated intra-nodes
 /// when several workers are involved and inter-nodes when TransportMessages are sent
-#[cfg(feature = "tracing_context")]
 #[test]
 fn test_context_propagation_across_workers_and_nodes() {
     let (received, spans) = trace_code(|ctx| send_echo_message(ctx, "hello"));
@@ -107,7 +106,6 @@ root
 /// This test checks that the tracing context is correctly propagated intra-nodes
 /// when several workers are involved and inter-nodes when TransportMessages are sent
 /// over a secure channel
-#[cfg(feature = "tracing_context")]
 #[test]
 fn test_context_propagation_across_workers_and_nodes_over_secure_channel() {
     let (received, spans) = trace_code(|ctx| send_echo_message_over_secure_channel(ctx, "hello"));
@@ -120,9 +118,6 @@ fn test_context_propagation_across_workers_and_nodes_over_secure_channel() {
     //    (if any, sometimes the received message is just a shutdown signal)
     let actual = display_traces(spans);
     let expected = r#"
-TcpSendWorker::handle_message
-└── TransportMessage::end_trace
-
 TransportMessage::start_trace
 └── TcpRecvProcessor::process
     └── DecryptorWorker::handle_message
@@ -198,6 +193,8 @@ root
     ├── TcpSendWorker::connect
     ├── TcpSendWorker::start
     ├── TcpRecvProcessor::start
+    ├── TcpSendWorker::handle_message
+    |   └── TransportMessage::end_trace
     └── MessageSender::handle_message
         └── EncryptorWorker::handle_message
             └── handle_encrypt

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -70,9 +70,6 @@ error-traces = [
 # message flows within Ockam apps.
 debugger = []
 
-# Feature: "tracing_context" adds a tracing_context field on Ockam messages to propagate the context for distributed tracing
-tracing_context = []
-
 [dependencies]
 async-trait = "0.1.78"
 backtrace = { version = "0.3", default-features = false, features = ["std", "serialize-serde"], optional = true }

--- a/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/message/local_message.rs
@@ -202,14 +202,14 @@ impl LocalMessage {
     /// Create a [`LocalMessage`] from a decoded [`TransportMessage`]
     pub fn from_transport_message(transport_message: TransportMessage) -> LocalMessage {
         cfg_if! {
-            if #[cfg(feature = "tracing_context")] {
+            if #[cfg(feature = "std")] {
                 LocalMessage::new()
                     .with_tracing_context(transport_message.tracing_context())
                     .with_onward_route(transport_message.onward_route)
                     .with_return_route(transport_message.return_route)
                     .with_payload(transport_message.payload)
                     .with_protocol_version(transport_message.version)
-            } else {
+                } else {
                 LocalMessage::new()
                     .with_onward_route(transport_message.onward_route)
                     .with_return_route(transport_message.return_route)
@@ -226,7 +226,6 @@ impl LocalMessage {
             self.onward_route,
             self.return_route,
             self.payload,
-            #[cfg(feature = "tracing_context")]
             None,
         );
 

--- a/implementations/rust/ockam/ockam_node/src/context/send_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/send_message.rs
@@ -259,24 +259,24 @@ impl Context {
 
         // Pack transport message into a LocalMessage wrapper
         cfg_if! {
-        if #[cfg(feature = "tracing_context")] {
-            let local_msg = LocalMessage::new()
-                // make sure to set the latest tracing context, to get the latest span id
-                .with_tracing_context(self.tracing_context().update())
-                .with_protocol_version(self.protocol_version())
-                .with_onward_route(route)
-                .with_return_route(route![sending_address.clone()])
-                .with_payload(payload)
-                .with_local_info(local_info);
-        } else {
-           let local_msg = LocalMessage::new()
-               .with_onward_route(route)
-               .with_return_route(route![sending_address.clone()])
-               .with_payload(payload)
-               .with_local_info(local_info)
-               .with_protocol_version(self.protocol_version());
-               }
-           }
+            if #[cfg(feature = "std")] {
+                let local_msg = LocalMessage::new()
+                    // make sure to set the latest tracing context, to get the latest span id
+                    .with_tracing_context(self.tracing_context().update())
+                    .with_protocol_version(self.protocol_version())
+                    .with_onward_route(route)
+                    .with_return_route(route![sending_address.clone()])
+                    .with_payload(payload)
+                    .with_local_info(local_info);
+            } else {
+                let local_msg = LocalMessage::new()
+                    .with_protocol_version(self.protocol_version())
+                    .with_onward_route(route)
+                    .with_return_route(route![sending_address.clone()])
+                    .with_payload(payload)
+                    .with_local_info(local_info);
+            }
+        }
 
         // Pack local message into a RelayMessage wrapper
         let relay_msg = RelayMessage::new(sending_address.clone(), addr, local_msg);


### PR DESCRIPTION
This PR enables the creation of transport messages version 2, where a `tracing_context` field is added to the message.
The PR can only be merged once #7748 has been deployed.