### PR TITLE
feat(rust): use https for the default opentelemetry collector endpoint

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
@@ -16,7 +16,7 @@ pub(crate) const DEFAULT_LOG_MAX_FILES: u64 = 60;
 
 /// Default endpoint for the OpenTelemetry collector
 pub(crate) const DEFAULT_OPENTELEMETRY_ENDPOINT: &str =
-    "http://k8s-opentele-otelcoll-aa527132c8-70cbeef1b85b559b.elb.us-west-1.amazonaws.com:4317/";
+    "https://otelcoll.orchestrator.ockam.io:443";
 
 ///
 /// TRACING

--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -182,6 +182,11 @@ fn to_socket_addr(url: Url) -> Option<SocketAddr> {
             .to_socket_addrs()
             .ok()
             .and_then(|mut addrs| addrs.next()),
+        // the port might be unspecified, in that case we use 443, a HTTPS port
+        (Some(host), None) => (host, 443)
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut addrs| addrs.next()),
         _ => None,
     }
 }


### PR DESCRIPTION
Since there is now an HTTPs endpoint deployed for the OpenTelemetry collector we use it as our default endpoint URL.
