### PR TITLE
feat(rust): flag to enable/disable enrollers-as-admins on authority

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
@@ -50,7 +50,7 @@ impl EnrollerAccessControlChecks {
                 EnrollerCheckResult {
                     is_member: true,
                     is_enroller,
-                    is_admin: is_enroller, // To be removed
+                    is_admin: false,
                     is_pre_trusted: member.is_pre_trusted(),
                 }
             }
@@ -75,6 +75,11 @@ impl EnrollerAccessControlChecks {
                     r.is_member = true;
                 }
             }
+            r.is_admin = r.is_admin || (!info.enforce_admin_checks() && r.is_enroller);
+        } else {
+            // If there is no account authority configured, treat enrollers as admins.
+            // To be removed when we stop supporting legacy clients.
+            r.is_admin = r.is_enroller;
         }
         Ok(r)
     }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
@@ -31,6 +31,7 @@ pub struct AccountAuthorityInfo {
     identities_attributes: Arc<IdentitiesAttributes>,
     account_authority: Identifier,
     project_identifier: String,
+    enforce_admin_checks: bool,
 }
 
 impl AccountAuthorityInfo {
@@ -38,11 +39,13 @@ impl AccountAuthorityInfo {
         identities_attributes: Arc<IdentitiesAttributes>,
         account_authority: Identifier,
         project_identifier: String,
+        enforce_admin_checks: bool,
     ) -> Self {
         Self {
             identities_attributes,
             account_authority,
             project_identifier,
+            enforce_admin_checks,
         }
     }
 
@@ -54,6 +57,9 @@ impl AccountAuthorityInfo {
     }
     pub fn project_identifier(&self) -> String {
         self.project_identifier.clone()
+    }
+    pub fn enforce_admin_checks(&self) -> bool {
+        self.enforce_admin_checks
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -90,6 +90,7 @@ impl Authority {
                     identity_attrs,
                     acc_authority_identifier,
                     configuration.project_identifier(),
+                    configuration.enforce_admin_checks,
                 ))
             } else {
                 None

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -49,6 +49,9 @@ pub struct Configuration {
 
     /// Account Authority identity
     pub account_authority: Option<ChangeHistory>,
+
+    /// Differentiate between admins and enrollers
+    pub enforce_admin_checks: bool,
 }
 
 /// Local and private functions for the authority configuration

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -38,6 +38,7 @@ pub async fn default_configuration() -> Result<Configuration> {
         no_token_enrollment: true,
         okta: None,
         account_authority: None,
+        enforce_admin_checks: false,
     };
 
     // Hack to create Authority Identity using the same vault and storage

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -100,6 +100,10 @@ pub struct CreateCommand {
     /// for account and project administrator credentials.
     #[arg(long, value_name = "ACCOUNT_AUTHORITY_CHANGE_HISTORY", default_value = None)]
     account_authority: Option<String>,
+
+    /// Enforce distintion between admins and enrollers
+    #[arg(long, value_name = "ENFORCE_ADMIN_CHECKS", default_value_t = false)]
+    enforce_admin_checks: bool,
 }
 
 impl CreateCommand {
@@ -184,6 +188,9 @@ impl CreateCommand {
         if let Some(acc_auth_identity) = &self.account_authority {
             args.push("--account-authority".to_string());
             args.push(acc_auth_identity.clone());
+        }
+        if self.enforce_admin_checks {
+            args.push("--enforce-admin-checks".to_string());
         }
         args.push(self.node_name.to_string());
 
@@ -310,6 +317,7 @@ impl CreateCommand {
             no_token_enrollment: self.no_token_enrollment,
             okta: okta_configuration,
             account_authority,
+            enforce_admin_checks: self.enforce_admin_checks,
         };
 
         authority_node::start_node(ctx, &configuration)

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -75,7 +75,7 @@ teardown() {
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\"} }"
-  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1  --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full --enforce-admin-checks
+  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full --enforce-admin-checks
   sleep 2 # wait for authority to start TCP listener
 
   # Make the admin present its project admin credential to the authority
@@ -137,7 +137,6 @@ EOF
   run "$OCKAM" project enroll $token2 --identity m5
   assert_failure
 }
-
 
 @test "authority - enrollment ticket ttl" {
   port="$(random_port)"
@@ -207,12 +206,11 @@ EOF
   authority_identity_full=$($OCKAM identity show --full --encoding hex authority)
   m1_identifier=$($OCKAM identity show m1)
 
-
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   trusted="{\"$m1_identifier\": {\"ockam-role\": \"enroller\", \"sample_attr\": \"sample_val\"} }"
 
   # Authority in legacy mode, with enrollers as admins
-  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1  --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full
+  run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full
   sleep 2 # wait for authority to start TCP listener
 
   cat <<EOF >>"$OCKAM_HOME/project.json"
@@ -240,12 +238,11 @@ EOF
   assert_output --partial "sample_val"
 
   # m1 can enroll new enrollers
-  token1=$($OCKAM project ticket --identity m1 --enroller  --attribute sample_attr=m2_member)
+  token1=$($OCKAM project ticket --identity m1 --enroller --attribute sample_attr=m2_member)
   run_success "$OCKAM" project enroll $token1 --identity m2
   assert_output --partial "m2_member"
   assert_output --partial "enroller"
 }
-
 
 @test "local authority - test api commands" {
   port="$(random_port)"


### PR DESCRIPTION
we plan to phase out the legacy behaviour of enrollers able to enroll/remove other enrollers. For some time that behaviour will still be available, for now add a flag to _disable_ that behaviour if desired.

`--enforce-admin-checks`  if passed at authority creation time,   the authority enforces that only admins (as attested by account authority) can add/remove enrollers.     The argument is expected to be removed in future version.  

It was chosen to require explicit enablement rather than an explicit disable (like `--enrollers-as-admins` or something similar,  so that authority behaviour doesn't change if updating the code but maintaining the same startup args.