### PR TITLE
fix(rust): fix routing and flow control for local kafka outlets

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -128,7 +128,7 @@ impl KafkaInletController {
             prefix,
             suffix,
             None,
-            false,
+            true,
         );
         if let Some(expr) = policy_expression {
             payload.set_policy_expression(expr);

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map.rs
@@ -154,8 +154,7 @@ impl<F: RelayCreator> Clone for KafkaSecureChannelControllerImpl<F> {
     }
 }
 
-/// Describe to reach the consumer node:
-/// either directly or through a relay
+/// Describe how to reach the consumer node: either directly or through a relay
 #[derive(Clone)]
 pub(crate) enum ConsumerNodeAddr {
     Direct(MultiAddr),
@@ -318,8 +317,8 @@ impl<F: RelayCreator> KafkaSecureChannelControllerImpl<F> {
 
         let mut inner = self.inner.lock().await;
 
-        // when we are using direct mode, there is only one consumer, and use the same secure
-        // channel for all topics
+        // when we are using direct mode, there is only one consumer, and the same
+        // secure channel is used for all topics
         let topic_partition_key = match &inner.consumer_node_multiaddr {
             ConsumerNodeAddr::Direct(_) | ConsumerNodeAddr::None => ("".to_string(), 0i32),
             ConsumerNodeAddr::Relay(_) => (topic_name.to_string(), partition),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -246,7 +246,7 @@ impl InMemoryNode {
             outlet_policy_expression,
             None,
             None,
-            false,
+            true,
         )
         .await?;
 
@@ -344,7 +344,7 @@ impl InMemoryNode {
             inlet_policy_expression,
             None,
             None,
-            false,
+            true,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/create.rs
@@ -50,7 +50,7 @@ impl CreateCommand {
             bind_address: self.bind_address,
             brokers_port_range: self
                 .brokers_port_range
-                .unwrap_or_else(|| make_brokers_port_range(&self.bootstrap_server)),
+                .unwrap_or_else(|| make_brokers_port_range(&self.bind_address)),
             consumer_route: self.consumer_route,
             bootstrap_server: self.bootstrap_server,
         };

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_message.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_message.rs
@@ -84,12 +84,13 @@ impl PortalMessage<'_> {
                 let mut vec = Vec::with_capacity(capacity);
                 vec.push(3);
                 write_slice(&mut vec, payload);
-                if let Some(counter) = counter {
-                    vec.push(1); // has counter
-                    vec.extend_from_slice(&counter.to_le_bytes())
-                } else {
-                    vec.push(0);
-                }
+                // TODO: re-enable once orchestrator accepts packet counter
+                // if let Some(counter) = counter {
+                //     vec.push(1); // has counter
+                //     vec.extend_from_slice(&counter.to_le_bytes())
+                // } else {
+                //     vec.push(0);
+                // }
                 Ok(vec)
             }
         }


### PR DESCRIPTION
This is a follow-up after we found out the Redpanda example was not working correctly.
Fixed outlet routing, which was broken after a `LocalMessage` refactor.
Now Kafka inlets will wait for connection when creating inlets for a smoother experience (avoid several “cannot connect errors” before the inlet becomes available).

Fixed flow control, when opening/closing Kafka clients, **sometime** the flow control cleanup would remove consumer flow control id for static addresses. Resolved by splitting the flow control id of spawner and producer for listener and interceptor.

Also allowing the Kafka instance to respond with hostname addresses instead of IP addresses so we can use docker names or `localhost`.