### PR TITLE
tests(rust): add bats coverage for `node create ./config.yaml` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -7,7 +7,6 @@ use miette::{miette, IntoDiagnostic};
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::KeyValue;
 use tracing::instrument;
-use url::Url;
 
 use ockam_api::cli_state::random_name;
 use ockam_api::EnrollmentTicket;
@@ -19,7 +18,7 @@ use crate::service::config::Config;
 use crate::util::api::TrustOpts;
 use crate::util::embedded_node_that_is_not_stopped;
 use crate::util::{async_cmd, local_cmd};
-use crate::value_parsers::{parse_enrollment_ticket, parse_key_val};
+use crate::value_parsers::{is_url, parse_enrollment_ticket, parse_key_val};
 use crate::{docs, Command, CommandGlobalOpts, Result};
 
 pub mod background;
@@ -175,7 +174,7 @@ impl CreateCommand {
 
     // Return true if the `name` argument is a node name, false if it's a config file path or URL
     fn has_name_arg(&self) -> bool {
-        Url::parse(&self.name).is_err() && std::fs::metadata(&self.name).is_err()
+        is_url(&self.name).is_none() && std::fs::metadata(&self.name).is_err()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -40,14 +40,13 @@ impl ParsedCommands {
         for cmd in self.commands.into_iter() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
-                opts.terminal.write_line("")?;
             }
         }
         Ok(())
     }
 }
 
-impl<C: Command> From<Vec<C>> for ParsedCommands {
+impl<C: ParsedCommand> From<Vec<C>> for ParsedCommands {
     fn from(cmds: Vec<C>) -> ParsedCommands {
         ParsedCommands::new(cmds)
     }

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority.bats
@@ -81,7 +81,7 @@ teardown() {
   # Make the admin present its project admin credential to the authority
   run_success "$OCKAM" secure-channel create --from admin --to "/node/authority/service/api" --identity admin
 
-  cat <<EOF >>"$OCKAM_HOME/project.json"
+  cat <<EOF >"$OCKAM_HOME/project.json"
 {
   "id": "1",
   "name": "default",
@@ -154,7 +154,7 @@ EOF
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   sleep 1 # wait for authority to start TCP listener
 
-  cat <<EOF >>"$OCKAM_HOME/project.json"
+  cat <<EOF >"$OCKAM_HOME/project.json"
 {
   "id": "1",
   "name": "default",
@@ -213,7 +213,7 @@ EOF
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full
   sleep 2 # wait for authority to start TCP listener
 
-  cat <<EOF >>"$OCKAM_HOME/project.json"
+  cat <<EOF >"$OCKAM_HOME/project.json"
 {
   "id": "1",
   "name": "default",
@@ -263,7 +263,7 @@ EOF
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   sleep 1 # wait for authority to start TCP listener
 
-  cat <<EOF >>"$OCKAM_HOME/project.json"
+  cat <<EOF >"$OCKAM_HOME/project.json"
 {
   "id": "1",
   "name": "default",

--- a/implementations/rust/ockam/ockam_command/tests/bats/authority_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/authority_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.1.unnamed-portal.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.1.unnamed-portal.config.yaml
@@ -1,0 +1,13 @@
+variables:
+  NODE_NAME: n1
+
+name: $NODE_NAME
+tcp-listener-address: 127.0.0.1:$NODE_PORT
+
+relay: default
+
+tcp-outlet:
+  to: $SERVICE_PORT
+
+tcp-inlet:
+  from: $CLIENT_PORT

--- a/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.2.named-portal.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.2.named-portal.config.yaml
@@ -1,0 +1,16 @@
+variables:
+  NODE_NAME: n1
+
+name: $NODE_NAME
+tcp-listener-address: 127.0.0.1:$NODE_PORT
+
+relay: default
+
+tcp-outlet:
+  db-outlet:
+    to: $SERVICE_PORT
+
+tcp-inlet:
+  web-inlet:
+    from: $CLIENT_PORT
+    to: db-outlet

--- a/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.3.customer.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.3.customer.config.yaml
@@ -1,0 +1,11 @@
+relays: to-$CUSTOMER
+
+tcp-outlets:
+  from: $CUSTOMER_SERVICE_NAME
+  to: "127.0.0.1:$CUSTOMER_OUTLET_PORT"
+  allow: '(= subject.from-saas "inlet")'
+
+tcp-inlets:
+  from: "127.0.0.1:$CUSTOMER_INLET_PORT"
+  via: to-$SAAS_RELAY_NAME
+  allow: '(= subject.to-saas "outlet")'

--- a/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.3.saas.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.3.saas.config.yaml
@@ -1,0 +1,11 @@
+relays: to-$SAAS_RELAY_NAME
+
+tcp-outlets:
+  to: "127.0.0.1:$SAAS_OUTLET_PORT"
+  allow: '(= subject.to-saas "inlet")'
+
+tcp-inlets:
+  from: "127.0.0.1:$SAAS_INLET_PORT"
+  to: $CUSTOMER_SERVICE_NAME
+  via: to-$CUSTOMER
+  allow: '(= subject.from-saas "outlet")'

--- a/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.basic.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/fixtures/node-create.basic.config.yaml
@@ -1,0 +1,7 @@
+relay: default
+
+tcp-outlet:
+  to: $SERVICE_PORT
+
+tcp-inlet:
+  from: $CLIENT_PORT

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -46,7 +46,7 @@ setup_python_server() {
     touch "$p"
 
     # Log server data to OCKAM_HOME_BASE
-    python3 -m http.server --bind 127.0.0.1 $PYTHON_SERVER_PORT &>python_server.log &
+    python3 -m http.server --bind 127.0.0.1 $PYTHON_SERVER_PORT &>./.tmp/python_server.log &
     pid="$!"
     echo "$pid" >"$p"
     popd || {
@@ -66,7 +66,7 @@ teardown_python_server() {
 }
 
 python_pid_file_path() {
-  echo "$OCKAM_HOME_BASE/http_server.pid"
+  echo "$OCKAM_HOME_BASE/.tmp/http_server.pid"
 }
 
 # Sets the CLI directory to a random directory under /tmp
@@ -92,7 +92,7 @@ teardown_home_dir() {
       # Copy the CLI directory to $HOME/.bats-tests so it can be inspected.
       # For some reason, if the directory is moved, the teardown function gets stuck.
       echo "Failed test dir: $OCKAM_HOME" >&3
-      cp -r "$OCKAM_HOME/." "$HOME/.bats-tests"
+      cp -r "$OCKAM_HOME" "$HOME/.bats-tests"
     fi
     run $OCKAM node delete --all --force --yes
   done

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -17,7 +17,7 @@ function skip_if_orchestrator_tests_not_enabled() {
 function copy_local_orchestrator_data() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     export PROJECT_NAME="default"
-    export PROJECT_PATH="$OCKAM_HOME_BASE/project.json"
+    export PROJECT_PATH="$OCKAM_HOME_BASE/.tmp/project.json"
 
     # export the project data to a file
     OCKAM_HOME=$OCKAM_HOME_BASE "$OCKAM" project show -q --output json >$PROJECT_PATH

--- a/implementations/rust/ockam/ockam_command/tests/bats/message_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/message_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/nodes_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/nodes_orchestrator.bats
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# ===== SETUP
+
+setup() {
+  load load/base.bash
+  load load/orchestrator.bash
+  load_bats_ext
+  setup_home_dir
+  skip_if_orchestrator_tests_not_enabled
+  copy_local_orchestrator_data
+}
+
+teardown() {
+  teardown_home_dir
+}
+
+# ===== TESTS
+
+@test "nodes - create with config, admin enrolling twice with the project doesn't return error" {
+  # Create enrollment ticket that can be reused a few times
+  $OCKAM project ticket >"$OCKAM_HOME/enrollment.ticket"
+
+  cat <<EOF >"$OCKAM_HOME/config.yaml"
+name: n1
+EOF
+
+  ## The default identity is already enrolled, so the enrollment step should be skipped
+  run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml" \
+    --enrollment-ticket "$OCKAM_HOME/enrollment.ticket"
+  run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+}
+
+@test "nodes - create with config, non-admin enrolling twice with the project doesn't return error" {
+  # Admin: create enrollment ticket that can be reused a few times
+  ticket_path="$OCKAM_HOME/enrollment.ticket"
+  $OCKAM project ticket --relay "*" --usage-count 5 >"$ticket_path"
+
+  # User: try to enroll the same identity twice
+  setup_home_dir
+  port=$(random_port)
+
+  ## First time it works
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.basic.config.yaml" \
+    --enrollment-ticket "$ticket_path" \
+    --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
+    --variable CLIENT_PORT="$port"
+  run_success curl --head --retry-connrefused --retry 4 --max-time 11 "127.0.0.1:$port"
+
+  ## Second time it will skip the enrollment step and the node will be set up as expected
+  run_success "$OCKAM" node delete --all -y
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.basic.config.yaml" \
+    --enrollment-ticket "$ticket_path" \
+    --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
+    --variable CLIENT_PORT="$port"
+  run_success curl --head --retry-connrefused --retry 4 --max-time 11 "127.0.0.1:$port"
+}
+
+@test "nodes - create with config, single machine, unnamed portal" {
+  port1=$(random_port)
+  port2=$(random_port)
+
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.1.unnamed-portal.config.yaml" \
+    --variable NODE_PORT="$port1" \
+    --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
+    --variable CLIENT_PORT="$port2"
+
+  # node created with expected name
+  run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+  # tcp-listener-address set to expected port
+  run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$port1/secure/api/service/echo"
+  # portal is working: inlet -> relay -> outlet -> python server
+  run_success curl --head --retry-connrefused --retry 4 --max-time 11 "127.0.0.1:$port2"
+}
+
+@test "nodes - create with config, single machine, named portal" {
+  port1=$(random_port)
+  port2=$(random_port)
+  export NODE_PORT="$port1"
+
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.2.named-portal.config.yaml" \
+    --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
+    --variable CLIENT_PORT="$port2"
+
+  # node created with expected name
+  run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+  # tcp-listener-address set to expected port
+  run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$port1/secure/api/service/echo"
+  # portal is working: inlet -> relay -> outlet -> python server
+  run_success curl --head --retry-connrefused --retry 4 --max-time 11 "127.0.0.1:$port2"
+}
+
+@test "nodes - create with config, multiple machines" {
+  skip "Temporary disabled due to some upcoming changes in the dev env of the Orchestrator"
+  ADMIN_HOME_DIR="$OCKAM_HOME"
+  export SAAS_RELAY_NAME=$(random_str)
+  # Admin: create enrollment ticket for SaaS
+  $OCKAM project ticket \
+    --attribute "ockam-role=enroller" --attribute "to-saas=outlet" --attribute "from-saas=inlet" \
+    --relay "to-$SAAS_RELAY_NAME" >"$ADMIN_HOME_DIR/saas.ticket"
+
+  # SaaS: create portal + enrollment ticket for Customer
+  setup_home_dir
+  SAAS_HOME_DIR="$OCKAM_HOME"
+
+  ## The portal ports are constants in the SaaS machine, so we can export them
+  export SAAS_INLET_PORT=$(random_port)
+  export SAAS_OUTLET_PORT=$PYTHON_SERVER_PORT
+
+  ## The customer details are variables that will change everytime the SaaS wants to add a new customer
+  customer_name=$(random_str)
+  customer_service="myapp"
+
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.3.saas.config.yaml" \
+    --enrollment-ticket "$ADMIN_HOME_DIR/saas.ticket" \
+    --variable CUSTOMER="$customer_name" \
+    --variable CUSTOMER_SERVICE_NAME="$customer_service"
+
+  $OCKAM project ticket \
+    --attribute "to-saas=inlet" --attribute "from-saas=outlet" \
+    --relay "to-$customer_name" >"$SAAS_HOME_DIR/$customer_name.ticket"
+
+  # Customer: create portal
+  setup_home_dir
+
+  ## Similarly, we export the constant variables for the Customer
+  export CUSTOMER="$customer_name"
+  export CUSTOMER_INLET_PORT=$(random_port)
+  export CUSTOMER_OUTLET_PORT=$(random_port)
+  export CUSTOMER_SERVICE_NAME="$customer_service"
+
+  run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.3.customer.config.yaml" \
+    --enrollment-ticket "$SAAS_HOME_DIR/$customer_name.ticket"
+
+  # Test: SaaS service can be reached from Customer's inlet
+  $OCKAM message send hi --to "/project/default/service/forward_to_to-$SAAS_RELAY_NAME/secure/api/service/echo"
+  curl --fail --retry-connrefused --max-time 11 --retry 6 --head "127.0.0.1:$CUSTOMER_INLET_PORT"
+
+  # Test: Customer node can be reached from SaaS's side
+  export OCKAM_HOME="$SAAS_HOME_DIR"
+  $OCKAM message send hi --to "/project/default/service/forward_to_to-$CUSTOMER/secure/api/service/echo"
+}
+
+@test "nodes - create with config, download config and enrollment-ticket from URL" {
+  $OCKAM project ticket >"$OCKAM_HOME_BASE/.tmp/enrollment.ticket"
+
+  # Create a config file in the python server's root directory
+  cat <<EOF >"$OCKAM_HOME_BASE/.tmp/config.yaml"
+name: n1
+EOF
+
+  # Using a proper url (with scheme)
+  run_success "$OCKAM" node create "http://127.0.0.1:$PYTHON_SERVER_PORT/.tmp/config.yaml" \
+    --enrollment-ticket "http://127.0.0.1:$PYTHON_SERVER_PORT/.tmp/enrollment.ticket"
+  run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+
+  # Without a scheme
+  run_success "$OCKAM" node delete --all -y
+  run_success "$OCKAM" node create "127.0.0.1:$PYTHON_SERVER_PORT/.tmp/config.yaml" \
+    --enrollment-ticket "127.0.0.1:$PYTHON_SERVER_PORT/.tmp/enrollment.ticket"
+  run_success "$OCKAM" message send --timeout 5 hello --to "/node/n1/secure/api/service/echo"
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/policies_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/policies_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/portals_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash
@@ -232,13 +228,13 @@ teardown() {
     --to "/project/default/service/forward_to_${relay_name}/secure/api/service/outlet"
 
   # generate 10MB of random data
-  run_success openssl rand -out "${OCKAM_HOME_BASE}/payload" $((1024 * 1024 * 10))
+  run_success openssl rand -out "${OCKAM_HOME_BASE}/.tmp/payload" $((1024 * 1024 * 10))
 
   # write payload to file `payload.copy`
-  run_success curl --fail --max-time 60 "127.0.0.1:${port}/payload" -o "${OCKAM_HOME}/payload.copy"
+  run_success curl --fail --max-time 60 "127.0.0.1:${port}/.tmp/payload" -o "${OCKAM_HOME}/payload.copy"
 
   # compare `payload` and `payload.copy`
-  run_success cmp "${OCKAM_HOME_BASE}/payload" "${OCKAM_HOME}/payload.copy"
+  run_success cmp "${OCKAM_HOME_BASE}/.tmp/payload" "${OCKAM_HOME}/payload.copy"
 }
 
 @test "portals - create an inlet/outlet pair, connection goes down, connection restored" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "projects - a project can be imported from a JSON file" {
-  cat <<EOF >>"$OCKAM_HOME/project.json"
+  cat <<EOF >"$OCKAM_HOME/project.json"
 {
   "id": "66529571-169f-44c6-8a6f-5282c1eda44c",
   "name": "awesome",

--- a/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/projects_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/setup_suite.bash
@@ -2,6 +2,7 @@
 
 setup_suite() {
   load load/base.bash
+  mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
   OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force --yes
   export BATS_TEST_TIMEOUT=300
@@ -10,4 +11,5 @@ setup_suite() {
 teardown_suite() {
   load load/base.bash
   teardown_python_server
+  rm -rf $OCKAM_HOME_BASE/.tmp
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/spaces_orchestrator.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/spaces_orchestrator.bats
@@ -2,10 +2,6 @@
 
 # ===== SETUP
 
-setup_file() {
-  load load/base.bash
-}
-
 setup() {
   load load/base.bash
   load load/orchestrator.bash

--- a/implementations/rust/ockam/ockam_command/tests/bats/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/use_cases.bats
@@ -3,9 +3,6 @@
 # https://docs.ockam.io/use-cases
 
 # ===== SETUP
-setup_file() {
-  load load/base.bash
-}
 
 setup() {
   load load/base.bash


### PR DESCRIPTION
- Add bats coverage for `node create ./config.yaml` command. All bats passing locally ✅ 
- Fixes passing URLs for `enrollment ticket` and `config file` without scheme (defaults to `http://`), i.e. `--enrollment ticket 127.0.0.1:1234/my.ticket` will be processed as `--enrollment ticket http://127.0.0.1:1234/my.ticket`
- Using an enrollment ticket twice doesn't return an error now. This is useful so that the user doesn't have to modify the config file or command after enrolling once.