### PR TITLE
refactor(rust): replace `structopt` with `clap` that was used in the `file_transfer` rust example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,17 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,7 +1233,6 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
- "clap 3.2.25",
  "heck 0.4.1",
  "indexmap 1.9.3",
  "log",
@@ -1346,32 +1334,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.16.1",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
@@ -1388,7 +1350,7 @@ checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.0",
+ "clap_lex",
  "strsim 0.11.0",
  "terminal_size",
 ]
@@ -1399,7 +1361,7 @@ version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
- "clap 4.5.3",
+ "clap",
 ]
 
 [[package]]
@@ -1416,15 +1378,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
@@ -1435,7 +1388,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dd95b5ebb5c1c54581dd6346f3ed6a79a3eef95dd372fc2ac13d535535300e"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "roff",
 ]
 
@@ -2550,13 +2503,13 @@ checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
 name = "file_transfer"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "example_test_helper",
  "file_diff",
  "ockam",
  "ockam_transport_tcp",
  "rand",
  "serde",
- "structopt",
  "tokio",
 ]
 
@@ -3088,15 +3041,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -3435,7 +3379,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3470,7 +3414,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3827,7 +3771,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.16.1",
+ "textwrap",
  "thiserror",
  "unicode-width",
 ]
@@ -4178,7 +4122,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4395,7 +4339,7 @@ dependencies = [
  "arboard",
  "assert_cmd",
  "async-trait",
- "clap 4.5.3",
+ "clap",
  "clap_complete",
  "clap_mangen",
  "colorful",
@@ -4930,12 +4874,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "outref"
@@ -5567,7 +5505,7 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64406b013259923e207e2585ce39dc9e93cd6669c4eded5b9b8e0419cfef0e3e"
 dependencies = [
- "clap 4.5.3",
+ "clap",
  "crossterm",
  "is-terminal",
  "log",
@@ -6876,30 +6814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7103,15 +7017,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"

--- a/examples/rust/file_transfer/Cargo.toml
+++ b/examples/rust/file_transfer/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 rust-version = "1.56.0"
 
 [dependencies]
+clap = { version = "4.5", features = ["derive", "cargo", "wrap_help"] }
 ockam = { path = "../../../implementations/rust/ockam/ockam" }
 ockam_transport_tcp = { path = "../../../implementations/rust/ockam/ockam_transport_tcp" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-structopt = { version = "0.3.25", default-features = false }
-tokio = { version = "1.36.0", features = ["fs", "io-util"] }
+tokio = { version = "1.36", features = ["fs", "io-util"] }
 
 [dev-dependencies]
 example_test_helper = { path = "../../../tools/docs/example_test_helper" }

--- a/examples/rust/file_transfer/examples/sender.rs
+++ b/examples/rust/file_transfer/examples/sender.rs
@@ -8,29 +8,28 @@ use ockam::{Error, TcpConnectionOptions, TcpTransportExtension};
 
 use std::path::PathBuf;
 
-use structopt::StructOpt;
+use clap::Parser;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "sender", about = "An example of file transfer implemented with ockam.")]
-struct Opt {
+#[derive(Debug, Parser)]
+#[command(name = "sender", about = "An example of file transfer implemented with ockam.")]
+struct Sender {
     /// Input file
-    #[structopt(parse(from_os_str))]
     input: PathBuf,
 
     /// Forwarding address
-    #[structopt(short, long)]
+    #[arg(short, long)]
     address: String,
 
     /// Sending chunk
-    #[structopt(short, long, default_value = "8192")]
+    #[arg(short, long, default_value = "8192")]
     chunk_size: usize,
 }
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Sender::parse();
 
     let node = node(ctx).await?;
     let tcp = node.create_tcp_transport().await?;

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -51,4 +51,4 @@ tracing-core = { version = "0.1.32", default-features = false }
 tempfile = { version = "3.10.1" }
 
 [build-dependencies]
-cbindgen = "0.26"
+cbindgen = { version = "0.26", default-features = false }

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -55,7 +55,7 @@ path = "src/bin/ockam.rs"
 [dependencies]
 arboard = "3.3.2"
 async-trait = "0.1"
-clap = { version = "4.5.3", features = ["derive", "cargo", "wrap_help"] }
+clap = { version = "4.5", features = ["derive", "cargo", "wrap_help"] }
 clap_complete = "4.5.1"
 clap_mangen = "0.2.20"
 colorful = "0.2"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,8 +1,4 @@
 [[IgnoredVulns]]
-id = "RUSTSEC-2021-0145"
-reason = "atty crate pulled in from transitive dependency env_logger used by kafka-protocol and quickcheck"
-
-[[IgnoredVulns]]
 id = "RUSTSEC-2021-0127"
 reason = "Unmaintained crate pulled-in by cddl-cat used for validating CDDL schema conformance in tests"
 


### PR DESCRIPTION
Remove ignored vulnerability: `RUSTSEC-2021-0145`