### PR TITLE
feat(elixir): expose schema id in credential related nif calls

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_set.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_set.ex
@@ -19,10 +19,12 @@ defmodule Ockam.Credential.AttributeSet do
     end
   end
 
+  # This is never exchanged on his own, why we define cbor encoding for it here?
   typedstruct do
     plugin(Ockam.TypedCBOR.Plugin)
     field(:attributes, Attributes.t(), minicbor: [key: 1, schema: Attributes.minicbor_schema()])
     field(:expiration, integer(), minicbor: [key: 2])
+    field(:schema, integer(), minicbor: [key: 3])
   end
 
   def expired?(%__MODULE__{expiration: expiration}) do

--- a/implementations/elixir/ockam/ockam_rust_elixir_nifs/lib/ockam_rust_elixir_nifs/native.ex
+++ b/implementations/elixir/ockam/ockam_rust_elixir_nifs/lib/ockam_rust_elixir_nifs/native.ex
@@ -23,7 +23,7 @@ defmodule OckamRustElixirNifs.Native do
 
   def setup_aws_kms(_), do: error()
 
-  def issue_credential(_, _, _, _), do: error()
+  def issue_credential(_, _, _, _, _), do: error()
 
   defp error, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/implementations/elixir/ockam/ockam_rust_elixir_nifs/test/ockam_rust_elixir_nifs_test.exs
+++ b/implementations/elixir/ockam/ockam_rust_elixir_nifs/test/ockam_rust_elixir_nifs_test.exs
@@ -35,10 +35,18 @@ defmodule OckamRustElixirNifsTest do
     {subject_id, _subject_identity} = OckamRustElixirNifs.Native.create_identity()
     attrs = %{"Some" => "works!", "other" => "yes!"}
 
-    credential =
-      OckamRustElixirNifs.Native.issue_credential(exported_identity, subject_id, attrs, 60)
+    schema = 2
 
-    {ttl, verified_attrs} =
+    credential =
+      OckamRustElixirNifs.Native.issue_credential(
+        schema,
+        exported_identity,
+        subject_id,
+        attrs,
+        60
+      )
+
+    {^schema, ttl, verified_attrs} =
       OckamRustElixirNifs.Native.verify_credential(subject_id, [exported_identity], credential)
 
     {:error, {:credential_verification_failed, _}} =


### PR DESCRIPTION
accept schema id when issuing credentials, and return schemaid when validating credentials.
