### PR TITLE
fix(rust): kms identity can be used in regular api nodes

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -138,7 +138,7 @@ impl CliState {
     /// Return a named identity given its name or the default named identity
     #[instrument(skip_all, fields(name = name.clone()))]
     pub async fn get_named_identity_or_default(
-        &mut self,
+        &self,
         name: &Option<String>,
     ) -> Result<NamedIdentity> {
         match name {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -370,14 +370,14 @@ impl NamedVault {
     }
 
     pub async fn vault(&self) -> Result<Vault> {
+        let mut vault = Vault::create_with_database(self.database().await?);
         if self.is_kms {
-            let mut vault = Vault::create().await?;
             let aws_vault = Arc::new(AwsSigningVault::create().await?);
             vault.identity_vault = aws_vault.clone();
             vault.credential_vault = aws_vault;
             Ok(vault)
         } else {
-            Ok(Vault::create_with_database(self.database().await?))
+            Ok(vault)
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
@@ -249,7 +249,7 @@ pub fn logging_configuration(
     crates: CratesFilter,
 ) -> ockam_core::Result<LoggingConfiguration> {
     let is_legacy_variable_set = is_set::<LevelVar>(OCKAM_LOG)?;
-    let enabled = if is_legacy_variable_set {
+    let enabled = if is_legacy_variable_set || preferred_log_level.is_some() {
         LoggingEnabled::On
     } else {
         logging_enabled()?

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -105,7 +105,7 @@ impl InMemoryNode {
     }
 
     /// Start an in memory node with a specific identity
-    pub async fn start_node_with_identity(
+    pub async fn start_with_identity(
         ctx: &Context,
         cli_state: &CliState,
         identity_name: &str,

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -109,7 +109,7 @@ impl EnrollCommand {
         force = % self.force,
         skip_orchestrator_resources_creation = % self.skip_orchestrator_resources_creation,
     ))]
-    async fn run_impl(&self, ctx: &Context, mut opts: CommandGlobalOpts) -> miette::Result<()> {
+    async fn run_impl(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         ctrlc_handler(opts.clone());
 
         if self.is_already_enrolled(&opts.state, &opts).await? {
@@ -127,7 +127,7 @@ impl EnrollCommand {
 
         let identity_name = identity.name();
         let identifier = identity.identifier();
-        let node = InMemoryNode::start_node_with_identity(ctx, &opts.state, &identity_name).await?;
+        let node = InMemoryNode::start_with_identity(ctx, &opts.state, &identity_name).await?;
 
         let user_info = self.enroll_identity(ctx, &opts, &node).await?;
 
@@ -352,9 +352,6 @@ async fn retrieve_user_space_and_project(
         .await
         .wrap_err("Unable to retrieve and set a Space as default")?
         .ok_or(miette!("No Space was found"))?;
-
-    info!("Retrieved your default Space {space:#?}");
-
     let project = get_user_project(
         opts,
         ctx,
@@ -368,7 +365,6 @@ async fn retrieve_user_space_and_project(
         color_primary(&space.name)
     ))?
     .ok_or(miette!("No Project was found"))?;
-    info!("Retrieved your default Project {project:#?}");
     opts.terminal.write_line(fmt_heading!(""))?;
     Ok(project)
 }

--- a/implementations/rust/ockam/ockam_command/src/global_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/global_args.rs
@@ -2,7 +2,6 @@ use clap::ArgAction;
 use clap::Args;
 use ockam_core::env::get_env_with_default;
 
-use crate::docs;
 use crate::output::OutputFormat;
 
 /// Those arguments are common to all commands
@@ -35,21 +34,15 @@ pub struct GlobalArgs {
     pub verbose: u8,
 
     /// Output without any colors
-    #[arg(hide = docs::hide(), global = true, long, default_value_t = no_color_default_value())]
+    #[arg(global = true, long, default_value_t = no_color_default_value())]
     pub no_color: bool,
 
     /// Disable tty functionality
-    #[arg(hide = docs::hide(), global = true, long, default_value_t = no_input_default_value())]
+    #[arg(global = true, long, default_value_t = no_input_default_value())]
     pub no_input: bool,
 
     /// Output format
-    #[arg(
-    hide = docs::hide(),
-    global = true,
-    long = "output",
-    value_enum,
-    default_value = "plain"
-    )]
+    #[arg(global = true, long = "output", value_enum, default_value = "plain")]
     pub output_format: OutputFormat,
 
     // if test_argument_parser is true, command arguments are checked

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -51,7 +51,7 @@ pub struct EnrollCommand {
 impl Command for EnrollCommand {
     const NAME: &'static str = "project enroll";
 
-    async fn async_run(self, ctx: &Context, mut opts: CommandGlobalOpts) -> miette::Result<()> {
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         if opts.global_args.output_format == OutputFormat::Json {
             return Err(miette::miette!(
                 "This command does not support JSON output. Please try running it again without '--output json'."


### PR DESCRIPTION
The KMS vault was using the stateless implementation for the `VaultForSecureChannels` and it wasn't persisting necessary information (e.g. the `x25519 secrets`) in the local database.