### PR TITLE
feat(elixir): added packet counter support

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/node.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/node.ex
@@ -140,7 +140,7 @@ defmodule Ockam.Node do
         Process.sleep(sleep_ms)
 
         if queue_len > @queue_size_high_watermark * 2 do
-          Logger.warn(
+          Logger.warning(
             "backpressure, pausing sender for #{sleep_ms}ms,  destination #{inspect(destination_pid)} has a queue of #{queue_len}"
           )
         end

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/tunnel_protocol.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/portal/tunnel_protocol.ex
@@ -7,13 +7,25 @@ defmodule Ockam.Transport.Portal.TunnelProtocol do
   Tunneling protocol messages
   """
   alias Ockam.Bare.Extended, as: BareExt
-  @type msg :: :ping | :pong | :disconnect | {:payload, binary()}
+  @type msg :: :ping | :pong | :disconnect | {:payload, {binary(), integer()}}
 
-  @schema {:variant, [:ping, :pong, :disconnect, {:payload, :data}]}
+  @schema {:variant,
+           [:ping, :pong, :disconnect, {:payload, {:tuple, [:data, {:optional, :u16}]}}]}
 
   @spec encode(msg()) :: binary()
-  def encode(t), do: BareExt.encode(t, @schema)
+  def encode({:payload, {data, counter}}) do
+    BareExt.encode({:payload, [data, counter]}, @schema)
+  end
+
+  @spec encode(msg()) :: binary()
+  def encode(data) do
+    BareExt.encode(data, @schema)
+  end
 
   @spec decode(binary()) :: {:ok, msg()} | {:error, any()}
-  def decode(data), do: BareExt.decode(data, @schema)
+  def decode(data) do
+    with {:ok, {:payload, [data, packet_counter]}} <- BareExt.decode(data, @schema) do
+      {:ok, {:payload, {data, packet_counter}}}
+    end
+  end
 end

--- a/implementations/elixir/ockam/ockam/test/ockam/protocol/bare_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/protocol/bare_test.exs
@@ -1,0 +1,45 @@
+defmodule Ockam.Bare.Extended.Tests do
+  use ExUnit.Case, async: true
+  doctest Ockam.Bare.Extended
+  alias Ockam.Bare.Extended
+
+  def encode_decode_test(data, schema, encoded) do
+    actual_encoded = Extended.encode(data, schema)
+    assert actual_encoded == encoded
+    {:ok, actual_data, <<>>} = Extended.decode(encoded, schema)
+    assert actual_data == data
+  end
+
+  describe "Bare tuple" do
+    test "Bare tuples can be encoded and decoded" do
+      encode_decode_test(
+        [0xAA, 0xBB, 0xCC],
+        {:tuple, [:int, :int, :int]},
+        <<212, 2, 246, 2, 152, 3>>
+      )
+
+      encode_decode_test([0xAA, 0xBB], {:tuple, [:int, :int]}, <<212, 2, 246, 2>>)
+      encode_decode_test([0xAA], {:tuple, [:int]}, <<212, 2>>)
+    end
+
+    test "Bare tuple with optional elements" do
+      encode_decode_test(
+        [0xAA, 0xBB, 0xCC],
+        {:tuple, [:int, :int, {:optional, :int}]},
+        <<212, 2, 246, 2, 1, 152, 3>>
+      )
+
+      encode_decode_test(
+        [0xAA, 0xBB, :undefined],
+        {:tuple, [:int, :int, {:optional, :int}]},
+        <<212, 2, 246, 2, 0>>
+      )
+
+      encode_decode_test([0xAA, 0xBB], {:tuple, [:int, {:optional, :int}]}, <<212, 2, 1, 246, 2>>)
+      encode_decode_test([0xAA, :undefined], {:tuple, [:int, {:optional, :int}]}, <<212, 2, 0>>)
+
+      encode_decode_test([0xAA], {:tuple, [{:optional, :int}]}, <<1, 212, 2>>)
+      encode_decode_test([:undefined], {:tuple, [{:optional, :int}]}, <<0>>)
+    end
+  end
+end

--- a/implementations/elixir/ockam/ockam/test/ockam/transport/portal/tunnel_protocol_test.exs
+++ b/implementations/elixir/ockam/ockam/test/ockam/transport/portal/tunnel_protocol_test.exs
@@ -5,7 +5,13 @@ defmodule Ockam.Transport.Portal.TunnelProtocol.Tests do
 
   describe "Ockam.Transport.Portal.TunnelProtocol" do
     test "protocol msgs can be encoded/decoded" do
-      msgs = [:ping, :pong, :disconnect, {:payload, "arbitrary data"}]
+      msgs = [
+        :ping,
+        :pong,
+        :disconnect,
+        {:payload, {"arbitrary data", :undefined}},
+        {:payload, {"arbitrary data", 0xABCD}}
+      ]
 
       assert msgs ==
                msgs
@@ -14,9 +20,19 @@ defmodule Ockam.Transport.Portal.TunnelProtocol.Tests do
                |> Enum.map(fn {:ok, v} -> v end)
     end
 
-    test "format is compatible with rust bare serialization" do
-      msg = {:payload, <<5, 5>>}
-      assert <<3, 2, 5, 5>> == TunnelProtocol.encode(msg)
+    test "format is compatible with rust bare serialization, no packet counter" do
+      msg = {:payload, {<<5, 5>>, :undefined}}
+      assert <<3, 2, 5, 5, 0>> == TunnelProtocol.encode(msg)
+    end
+
+    test "format is compatible with rust bare serialization, with packet counter" do
+      msg = {:payload, {<<5, 5>>, 0xAABB}}
+      assert <<3, 2, 5, 5, 1, 0xBB, 0xAA>> == TunnelProtocol.encode(msg)
+    end
+
+    test "deserialization is compatible with old bare serialization" do
+      assert {:ok, {:payload, {<<5, 5>>, :undefined}}} ==
+               TunnelProtocol.decode(<<3, 2, 5, 5>>)
     end
   end
 end

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/interceptor_test.exs
@@ -36,7 +36,7 @@ defmodule Ockam.Kafka.Interceptor.Test.FakeOutlet do
         Worker.route(
           %Message{
             onward_route: Map.get(state, :peer_route),
-            payload: TunnelProtocol.encode({:payload, response})
+            payload: TunnelProtocol.encode({:payload, {response, :undefined}})
           },
           state
         )

--- a/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
+++ b/implementations/elixir/ockam/ockam_kafka/test/interceptor/outlet_manager_test.exs
@@ -17,7 +17,7 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test.TcpEchoer do
         transport.send(socket, data)
         loop(socket, transport)
 
-      _ ->
+      _err ->
         :ok = transport.close(socket)
     end
   end
@@ -144,9 +144,6 @@ defmodule Ockam.Kafka.Interceptor.OutletManager.Test do
 
     ## Send message to inlet
     :ok = :gen_tcp.send(socket, "HI")
-
-    ## log socket
-    IO.inspect(socket)
 
     ## Receive message from outlet
     {:ok, data} = :gen_tcp.recv(socket, 0)


### PR DESCRIPTION
Adding packet counter support to the elixir side, the idea is to have a 2-step deployment, first the elixir side and then “unlock” the rust side.

To have a more lenient parser, and to better match the rust side, I've added the  `tuple` schema in BARE parsing.

I haven't written in Erlang in years and never used Elixir before, I'm pretty sure I made silly mistakes!