### PR TITLE
feat(rust): export opentelemetry traces by default

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -132,12 +132,8 @@ impl Display for ExportingConfiguration {
 }
 
 /// Return true if tracing is enabled, as decided by the OCKAM_TRACING environment variable.
-///
-/// FOR NOW THE DEFAULT IS FALSE.
-/// TODO: set it to true after enough testing!
-///
 pub fn is_exporting_set() -> ockam_core::Result<bool> {
-    get_env_with_default(OCKAM_OPENTELEMETRY_EXPORT, false)
+    get_env_with_default(OCKAM_OPENTELEMETRY_EXPORT, true)
 }
 
 /// Return ExportingEnabled::On if:

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
@@ -40,7 +40,7 @@ impl LoggingConfiguration {
     pub fn new(
         enabled: LoggingEnabled,
         level: Level,
-        global_error_handler_enabled: GlobalErrorHandler,
+        global_error_handler: GlobalErrorHandler,
         max_size_bytes: u64,
         max_files: u64,
         format: LogFormat,
@@ -57,7 +57,7 @@ impl LoggingConfiguration {
         LoggingConfiguration {
             enabled,
             level,
-            global_error_handler: global_error_handler_enabled,
+            global_error_handler,
             max_size_bytes,
             max_files,
             format,
@@ -177,7 +177,7 @@ impl LoggingConfiguration {
         Ok(LoggingConfiguration::new(
             LoggingEnabled::Off,
             log_level(None)?,
-            global_error_handler_enabled()?,
+            global_error_handler()?,
             0,
             0,
             LogFormat::Default,
@@ -195,7 +195,7 @@ impl LoggingConfiguration {
         Ok(LoggingConfiguration::new(
             LoggingEnabled::On,
             log_level(None)?,
-            GlobalErrorHandler::LogFile,
+            global_error_handler()?,
             log_max_size_bytes()?,
             log_max_files()?,
             log_format()?,
@@ -258,7 +258,7 @@ pub fn logging_configuration(
     Ok(LoggingConfiguration::new(
         enabled,
         level,
-        GlobalErrorHandler::LogFile,
+        global_error_handler()?,
         log_max_size_bytes()?,
         log_max_files()?,
         log_format()?,
@@ -327,7 +327,7 @@ fn get_log_level(
 }
 
 /// Return the strategy to use for reporting logging/tracing errors
-pub fn global_error_handler_enabled() -> ockam_core::Result<GlobalErrorHandler> {
+pub fn global_error_handler() -> ockam_core::Result<GlobalErrorHandler> {
     match get_env::<GlobalErrorHandler>(OCKAM_TRACING_GLOBAL_ERROR_HANDLER)? {
         Some(v) => Ok(v),
         None => Ok(GlobalErrorHandler::LogFile),

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -1,5 +1,5 @@
 use ockam_api::logs::{
-    global_error_handler_enabled, Colored, CratesFilter, ExportingConfiguration, LogFormat,
+    global_error_handler, Colored, CratesFilter, ExportingConfiguration, LogFormat,
     LoggingConfiguration, LoggingEnabled, LoggingTracing,
 };
 use ockam_api::random_name;
@@ -94,7 +94,7 @@ fn make_configuration() -> ockam_core::Result<LoggingConfiguration> {
     Ok(LoggingConfiguration::new(
         LoggingEnabled::On,
         Level::TRACE,
-        global_error_handler_enabled()?,
+        global_error_handler()?,
         100,
         60,
         LogFormat::Default,

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -207,6 +207,7 @@ impl CommandGlobalOpts {
     /// Shutdown resources
     pub fn shutdown(&self) {
         if let Some(tracing_guard) = self.tracing_guard.clone() {
+            tracing_guard.force_flush();
             tracing_guard.shutdown();
         };
     }


### PR DESCRIPTION
This PR enables the export of OpenTelemetry traces by default. This can be deactivated by setting `export OCKAM_OPENTELEMETRY_EXPORT=false`