### PR TITLE
feat(rust): support TLS for outlets

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -36,7 +36,7 @@ runs:
         set -x
         use_cross_build=${{ inputs.use_cross_build }}
         if [[ $use_cross_build == true ]]; then
-          cargo install --version 0.2.4 cross
+          cargo install --version 0.2.5 cross
         else
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -1586,7 +1586,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -2565,12 +2565,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2583,6 +2592,12 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -3989,6 +4004,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4625,15 +4658,20 @@ version = "0.111.0"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.3",
+ "minicbor",
+ "native-tls",
  "ockam_core",
  "ockam_macros",
  "ockam_node",
  "ockam_transport_core",
  "opentelemetry",
  "rand",
+ "regex",
+ "rustls-native-certs 0.7.0",
  "serde",
  "socket2 0.5.6",
  "tokio",
+ "tokio-native-tls",
  "tracing",
 ]
 
@@ -4781,10 +4819,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -7199,6 +7275,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.58",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -14,6 +14,7 @@ use ockam_api::nodes::NodeManager;
 use ockam_api::{multiaddr_to_route, multiaddr_to_transport_route};
 use ockam_core::AsyncTryClone;
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_tcp::HostnamePort;
 
 /// This node supports a "control" server on which several "edge" devices can connect
 ///
@@ -106,7 +107,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 4. create a tcp outlet with the above policy
     tcp.create_outlet(
         "outlet",
-        "127.0.0.1:5000",
+        HostnamePort::new("127.0.0.1", 5000),
         TcpOutletOptions::new()
             .with_incoming_access_control_impl(incoming_access_control)
             .with_outgoing_access_control_impl(outgoing_access_control),

--- a/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
@@ -1,4 +1,6 @@
 use ockam::{node, route, Context, Result, TcpInletOptions, TcpOutletOptions, TcpTransportExtension};
+use ockam_transport_tcp::HostnamePort;
+use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -23,8 +25,12 @@ async fn main(ctx: Context) -> Result<()> {
     //    a previous message from the Inlet.
 
     let outlet_target = std::env::args().nth(2).expect("no outlet target given");
-    tcp.create_outlet("outlet", outlet_target, TcpOutletOptions::new())
-        .await?;
+    tcp.create_outlet(
+        "outlet",
+        HostnamePort::from_str(&outlet_target)?,
+        TcpOutletOptions::new(),
+    )
+    .await?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
@@ -1,4 +1,6 @@
 use ockam::{node, Context, Result, TcpListenerOptions, TcpOutletOptions, TcpTransportExtension};
+use ockam_transport_tcp::HostnamePort;
+use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -27,7 +29,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        outlet_target,
+        HostnamePort::from_str(&outlet_target)?,
         TcpOutletOptions::new().as_consumer(&tcp_listener_options.spawner_flow_control_id()),
     )
     .await?;

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
@@ -1,5 +1,7 @@
 use ockam::identity::SecureChannelListenerOptions;
 use ockam::{node, Context, Result, TcpListenerOptions, TcpOutletOptions, TcpTransportExtension};
+use ockam_transport_tcp::HostnamePort;
+use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -40,7 +42,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        outlet_target,
+        HostnamePort::from_str(&outlet_target)?,
         TcpOutletOptions::new().as_consumer(&secure_channel_flow_control_id),
     )
     .await?;

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -1,6 +1,8 @@
 use ockam::identity::SecureChannelListenerOptions;
 use ockam::remote::RemoteRelayOptions;
 use ockam::{node, Context, Result, TcpConnectionOptions, TcpOutletOptions, TcpTransportExtension};
+use ockam_transport_tcp::HostnamePort;
+use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -37,7 +39,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        outlet_target,
+        HostnamePort::from_str(&outlet_target)?,
         TcpOutletOptions::new().as_consumer(&secure_channel_flow_control_id),
     )
     .await?;

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -37,7 +37,7 @@ mod test {
     use ockam_multiaddr::proto::Service;
     use ockam_multiaddr::MultiAddr;
     use ockam_node::compat::tokio;
-    use ockam_transport_tcp::{TcpInletOptions, TcpOutletOptions};
+    use ockam_transport_tcp::{HostnamePort, TcpInletOptions, TcpOutletOptions};
 
     use crate::hop::Hop;
     use crate::kafka::protocol_aware::utils::{encode_request, encode_response};
@@ -147,7 +147,7 @@ mod test {
                 .tcp
                 .create_outlet(
                     "kafka_consumer_outlet",
-                    format!("127.0.0.1:{}", consumer_mock_kafka.port),
+                    HostnamePort::new("127.0.0.1", consumer_mock_kafka.port),
                     TcpOutletOptions::new(),
                 )
                 .await?;
@@ -167,7 +167,7 @@ mod test {
             .tcp
             .create_outlet(
                 "kafka_producer_outlet",
-                format!("127.0.0.1:{}", producer_mock_kafka.port),
+                HostnamePort::new("127.0.0.1", producer_mock_kafka.port),
                 TcpOutletOptions::new(),
             )
             .await?;
@@ -205,7 +205,7 @@ mod test {
             .tcp
             .create_outlet(
                 "kafka_consumer_outlet",
-                format!("127.0.0.1:{}", consumer_mock_kafka.port),
+                HostnamePort::new("127.0.0.1", consumer_mock_kafka.port),
                 TcpOutletOptions::new(),
             )
             .await?;

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
@@ -11,6 +11,7 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{route, Error};
 use ockam_core::{Address, Result};
 use ockam_node::Context;
+use ockam_transport_tcp::HostnamePort;
 use std::net::SocketAddr;
 
 type BrokerId = i32;
@@ -69,7 +70,8 @@ impl KafkaOutletController {
         worker_address: Address,
         policy_expression: Option<Expr>,
     ) -> Result<SocketAddr> {
-        let mut payload = CreateOutlet::new(socket_address, Some(worker_address), false);
+        let hostname_port = HostnamePort::from_socket_addr(socket_address)?;
+        let mut payload = CreateOutlet::new(hostname_port, false, Some(worker_address), false);
         if let Some(expr) = policy_expression {
             payload.set_policy_expression(expr);
         }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -12,6 +12,7 @@ use ockam::route;
 use ockam_abac::Expr;
 use ockam_core::{Address, IncomingAccessControl, OutgoingAccessControl, Route};
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_tcp::HostnamePort;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ApiError;
@@ -139,26 +140,30 @@ impl CreateInlet {
 #[cbor(map)]
 pub struct CreateOutlet {
     /// The address the portal should connect or bind to
-    #[n(1)] pub socket_addr: SocketAddr,
+    #[n(1)] pub hostname_port: HostnamePort,
+    /// If tls is true a TLS connection is established
+    #[n(2)] pub tls: bool,
     /// The address the portal should listen to
-    #[n(2)] pub worker_addr: Option<Address>,
+    #[n(3)] pub worker_addr: Option<Address>,
     /// Allow the outlet to be reachable from the default secure channel, useful when we want to
     /// tighten the flow control
-    #[n(3)] pub reachable_from_default_secure_channel: bool,
+    #[n(4)] pub reachable_from_default_secure_channel: bool,
     /// The expression for the access control policy for this outlet.
     /// If not set, the policy set for the [TCP outlet resource type](ockam_abac::ResourceType::TcpOutlet)
     /// will be used.
-    #[n(4)] pub policy_expression: Option<Expr>,
+    #[n(5)] pub policy_expression: Option<Expr>,
 }
 
 impl CreateOutlet {
     pub fn new(
-        socket_addr: SocketAddr,
+        hostname_port: HostnamePort,
+        tls: bool,
         worker_addr: Option<Address>,
         reachable_from_default_secure_channel: bool,
     ) -> Self {
         Self {
-            socket_addr,
+            hostname_port,
+            tls,
             worker_addr,
             reachable_from_default_secure_channel,
             policy_expression: None,
@@ -336,7 +341,7 @@ Outlet:
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct InletList {
-    #[n(1)] pub list: Vec<InletStatus>
+    #[n(1)] pub list: Vec<InletStatus>,
 }
 
 impl InletList {
@@ -350,7 +355,7 @@ impl InletList {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct OutletList {
-    #[n(1)] pub list: Vec<OutletStatus>
+    #[n(1)] pub list: Vec<OutletStatus>,
 }
 
 impl OutletList {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -8,6 +8,7 @@ use ockam_core::compat::rand::random_string;
 use ockam_core::route;
 use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_tcp::HostnamePort;
 
 use super::NodeManagerWorker;
 use crate::error::ApiError;
@@ -141,13 +142,13 @@ impl NodeManagerWorker {
                 Err(Response::not_found_no_request(
                     &format!("Service at address '{address}' with kind {kind} not found"),
                 ))
-            },
+            }
             Ok(DeleteKafkaServiceResult::IncorrectKind { address, actual, expected }) => {
                 Err(Response::not_found_no_request(
                     &format!("Service at address '{address}' is not a kafka {expected}. A service of kind {actual} was found instead"),
                 ))
-            },
-            Err(e) => Err(Response::internal_error_no_request( &e.to_string())),
+            }
+            Err(e) => Err(Response::internal_error_no_request(&e.to_string())),
         }
     }
 }
@@ -202,7 +203,8 @@ impl InMemoryNode {
         .await?;
         self.create_outlet(
             context,
-            bootstrap_server_addr,
+            HostnamePort::from_socket_addr(bootstrap_server_addr)?,
+            false,
             Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into()),
             false,
             OutletAccessControl::PolicyExpression(outlet_policy_expression.clone()),
@@ -405,7 +407,8 @@ impl NodeManager {
         if let Err(e) = self
             .create_outlet(
                 context,
-                bootstrap_server_addr,
+                HostnamePort::from_socket_addr(bootstrap_server_addr)?,
+                false,
                 Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into()),
                 false,
                 OutletAccessControl::PolicyExpression(outlet_policy_expression),

--- a/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+
 use crate::config::lookup::InternetAddress;
 use crate::nodes::service::{NodeManagerCredentialRetrieverOptions, NodeManagerTrustOptions};
 use ockam_node::{Context, NodeBuilder};
@@ -18,7 +19,7 @@ use ockam::identity::utils::AttributesBuilder;
 use ockam::identity::SecureChannels;
 use ockam::Result;
 use ockam_core::AsyncTryClone;
-use ockam_transport_tcp::{TcpListenerOptions, TcpTransport};
+use ockam_transport_tcp::{HostnamePort, TcpListenerOptions, TcpTransport};
 
 use crate::authenticator::credential_issuer::{DEFAULT_CREDENTIAL_VALIDITY, PROJECT_MEMBER_SCHEMA};
 use crate::cli_state::{random_name, CliState};
@@ -127,8 +128,9 @@ pub async fn start_manager_for_tests(
     Ok(handle)
 }
 
+#[derive(Debug, Clone)]
 pub struct EchoServerHandle {
-    pub chosen_addr: SocketAddr,
+    pub chosen_addr: HostnamePort,
     close: Arc<AtomicBool>,
 }
 
@@ -189,7 +191,10 @@ pub async fn start_tcp_echo_server() -> EchoServerHandle {
         });
     }
 
-    EchoServerHandle { chosen_addr, close }
+    EchoServerHandle {
+        chosen_addr: HostnamePort::from_socket_addr(chosen_addr).unwrap(),
+        close,
+    }
 }
 
 pub struct TestNode {

--- a/implementations/rust/ockam/ockam_api/tests/latency.rs
+++ b/implementations/rust/ockam/ockam_api/tests/latency.rs
@@ -17,7 +17,6 @@ use ockam_multiaddr::MultiAddr;
 /// In order for the result to be reliable, use the --profile release
 /// flag when running the tests.
 /// `cargo test --test latency --release -- --ignored --show-output`
-
 #[ignore]
 #[test]
 pub fn measure_message_latency_two_nodes() {
@@ -130,7 +129,8 @@ pub fn measure_buffer_latency_two_nodes_portal() {
                 .node_manager
                 .create_outlet(
                     &second_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -28,14 +28,18 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
         .node_manager
         .create_outlet(
             context,
-            echo_server_handle.chosen_addr,
+            echo_server_handle.chosen_addr.clone(),
+            false,
             Some(Address::from_string("outlet")),
             true,
             OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
         )
         .await?;
 
-    assert_eq!(outlet_status.socket_addr, echo_server_handle.chosen_addr);
+    assert_eq!(
+        outlet_status.socket_addr,
+        echo_server_handle.chosen_addr.to_socket_addr()?
+    );
     assert_eq!(outlet_status.worker_addr.address(), "outlet");
 
     let inlet_status = node_manager_handle
@@ -96,7 +100,8 @@ fn portal_node_goes_down_reconnect() {
                 .node_manager
                 .create_outlet(
                     &second_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
@@ -160,7 +165,8 @@ fn portal_node_goes_down_reconnect() {
                 .node_manager
                 .create_outlet(
                     &third_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
@@ -232,7 +238,8 @@ fn portal_low_bandwidth_connection_keep_working_for_60s() {
                 .node_manager
                 .create_outlet(
                     &second_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
@@ -345,7 +352,8 @@ fn portal_heavy_load_exchanged() {
                 .node_manager
                 .create_outlet(
                     &second_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),
@@ -483,7 +491,8 @@ fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disrup
                 .node_manager
                 .create_outlet(
                     &second_node.context,
-                    echo_server_handle.chosen_addr,
+                    echo_server_handle.chosen_addr.clone(),
+                    false,
                     Some(Address::from_string("outlet")),
                     true,
                     OutletAccessControl::AccessControl((Arc::new(AllowAll), Arc::new(AllowAll))),

--- a/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
+++ b/implementations/rust/ockam/ockam_api/tests/trace_context_propagation.rs
@@ -93,7 +93,7 @@ root
     ├── create tcp transport
     ├── TcpListenProcessor::start
     ├── create tcp transport
-    ├── TcpSendWorker::connect
+    ├── connect
     ├── TcpSendWorker::start
     ├── TcpRecvProcessor::start
     └── MessageSender::handle_message
@@ -190,7 +190,7 @@ root
     ├── create tcp transport
     ├── TcpListenProcessor::start
     ├── create tcp transport
-    ├── TcpSendWorker::connect
+    ├── connect
     ├── TcpSendWorker::start
     ├── TcpRecvProcessor::start
     ├── TcpSendWorker::handle_message

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
@@ -4,7 +4,7 @@ use miette::{IntoDiagnostic, WrapErr};
 use ockam_api::address::extract_address_value;
 use ockam_api::nodes::models::portal::OutletAccessControl;
 use ockam_core::Address;
-use ockam_transport_tcp::resolve_peer;
+use ockam_transport_tcp::{resolve_peer, HostnamePort};
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -36,7 +36,8 @@ impl AppState {
         match node_manager
             .create_outlet(
                 &self.context(),
-                socket_addr,
+                HostnamePort::from_socket_addr(socket_addr)?,
+                false,
                 Some(worker_addr.clone()),
                 true,
                 OutletAccessControl::AccessControl((Arc::new(incoming_ac), Arc::new(outgoing_ac))),

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
@@ -6,6 +6,7 @@ use crate::incoming_services::PersistentIncomingService;
 use crate::state::{AppState, ModelState};
 use ockam_api::nodes::models::portal::{OutletAccessControl, OutletStatus};
 use ockam_core::Address;
+use ockam_transport_tcp::HostnamePort;
 
 impl ModelState {
     pub fn add_tcp_outlet(&mut self, status: OutletStatus) {
@@ -68,7 +69,9 @@ impl AppState {
             let _ = node_manager
                 .create_outlet(
                     &context,
-                    tcp_outlet.socket_addr,
+                    HostnamePort::from_socket_addr(tcp_outlet.socket_addr)
+                        .expect("cannot parse the socket address as a hostname and port"),
+                    false,
                     Some(tcp_outlet.worker_addr.clone()),
                     true,
                     OutletAccessControl::AccessControl((

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
@@ -50,10 +50,8 @@ impl CommandsParser<CreateCommand> for TcpOutlets {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
-    use std::str::FromStr;
-
     use super::*;
+    use ockam_transport_tcp::HostnamePort;
 
     #[test]
     fn tcp_outlet_config() {
@@ -70,10 +68,10 @@ mod tests {
         let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].from.clone().unwrap(), "to1");
-        assert_eq!(cmds[0].to, SocketAddr::from_str("127.0.0.1:6060").unwrap());
+        assert_eq!(cmds[0].to, HostnamePort::new("127.0.0.1", 6060));
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
         assert_eq!(cmds[1].from.clone().unwrap(), "my_outlet");
-        assert_eq!(cmds[1].to, SocketAddr::from_str("127.0.0.1:6061").unwrap());
+        assert_eq!(cmds[1].to, HostnamePort::new("127.0.0.1", 6061));
         assert!(cmds[1].at.is_none());
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -185,6 +185,18 @@ teardown() {
   run_success curl -sS -m 20 -X POST "http://127.0.0.1:$port/upload" -F "files=@$OCKAM_HOME_BASE/.tmp/$tmp_dir_name/$file_name"
 }
 
+@test "portals - create an inlet/outlet pair and move tcp traffic through it, where the outlet points to an HTTPs endpoint" {
+  port="$(random_port)"
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2
+
+  run_success "$OCKAM" tcp-outlet create --at /node/n1 --to google.com:443
+  run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "127.0.0.1:$port" --to /node/n1/service/outlet
+
+  # This test does not pass on CI
+  # run_success curl --fail --head --max-time 10 "127.0.0.1:$port"
+}
+
 @test "portals - create an inlet/outlet pair with relay through a relay and move tcp traffic through it" {
   port="$(random_port)"
   run_success "$OCKAM" node create relay

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -31,13 +31,18 @@ alloc = []
 [dependencies]
 cfg-if = "1.0.0"
 hashbrown = { version = "0.14", default-features = false }
+minicbor = "0.21"
+native-tls = "0.2"
 ockam_core = { path = "../ockam_core", version = "^0.106.0" }
 ockam_macros = { path = "../ockam_macros", version = "^0.34.0" }
 ockam_node = { path = "../ockam_node", version = "^0.113.0" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.79.0" }
 opentelemetry = { version = "0.22.0", features = ["logs", "metrics", "trace"], optional = true }
 rand = "0.8"
+regex = "1.10.3"
+rustls-native-certs = "0.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 socket2 = { version = "0.5.6", features = ["all"] }
 tokio = { version = "1.37", features = ["rt-multi-thread", "sync", "net", "macros", "time", "io-util"] }
+tokio-native-tls = "0.3"
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -1,5 +1,5 @@
 use crate::portal::addresses::{Addresses, PortalType};
-use crate::{portal::TcpPortalWorker, TcpInletOptions, TcpRegistry};
+use crate::{portal::TcpPortalWorker, HostnamePort, TcpInletOptions, TcpRegistry};
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::{async_trait, compat::boxed::Box};
 use ockam_core::{Address, Processor, Result, Route};
@@ -94,12 +94,12 @@ impl Processor for TcpInletListenProcessor {
             outlet_listener_route.next()?,
         );
 
-        let (stream, peer) = self.inner.accept().await.map_err(TransportError::from)?;
+        let (stream, socket_addr) = self.inner.accept().await.map_err(TransportError::from)?;
         TcpPortalWorker::start_new_inlet(
             ctx,
             self.registry.clone(),
             stream,
-            peer,
+            HostnamePort::from_socket_addr(socket_addr)?,
             outlet_listener_route,
             addresses,
             self.options.incoming_access_control.clone(),

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
@@ -83,6 +83,7 @@ pub struct TcpOutletOptions {
     pub(super) consumer: Vec<FlowControlId>,
     pub(super) incoming_access_control: Arc<dyn IncomingAccessControl>,
     pub(super) outgoing_access_control: Arc<dyn OutgoingAccessControl>,
+    pub(super) tls: bool,
 }
 
 impl TcpOutletOptions {
@@ -92,6 +93,7 @@ impl TcpOutletOptions {
             consumer: vec![],
             incoming_access_control: Arc::new(AllowAll),
             outgoing_access_control: Arc::new(AllowAll),
+            tls: false,
         }
     }
 
@@ -110,6 +112,12 @@ impl TcpOutletOptions {
         access_control: Arc<dyn IncomingAccessControl>,
     ) -> Self {
         self.incoming_access_control = access_control;
+        self
+    }
+
+    /// Set TLS
+    pub fn with_tls(mut self, tls: bool) -> Self {
+        self.tls = tls;
         self
     }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/connection.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/connection.rs
@@ -1,7 +1,9 @@
 use crate::transport::common::{resolve_peer, TcpConnection};
+use crate::transport::connect;
 use crate::workers::{Addresses, TcpRecvProcessor, TcpSendWorker};
 use crate::{TcpConnectionMode, TcpConnectionOptions, TcpTransport};
 use ockam_core::{Address, Result};
+use tracing::debug;
 
 impl TcpTransport {
     /// Establish an outgoing TCP connection.
@@ -21,10 +23,10 @@ impl TcpTransport {
         peer: impl Into<String>,
         options: TcpConnectionOptions,
     ) -> Result<TcpConnection> {
-        // Resolve peer address
-        let socket = resolve_peer(peer.into())?;
-
-        let (read_half, write_half) = TcpSendWorker::connect(socket).await?;
+        let peer = peer.into();
+        let socket = resolve_peer(peer.clone())?;
+        debug!("Connecting to {}", peer.clone());
+        let (read_half, write_half) = connect(socket).await?;
 
         let mode = TcpConnectionMode::Outgoing;
         let addresses = Addresses::generate(mode);

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/hostname_port.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/hostname_port.rs
@@ -1,0 +1,134 @@
+use crate::resolve_peer;
+use core::fmt::{Display, Formatter};
+use core::str::FromStr;
+use minicbor::{Decode, Encode};
+use ockam_core::errcode::{Kind, Origin};
+use std::net::SocketAddr;
+
+/// Hostname and port
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct HostnamePort {
+    #[n(0)]
+    hostname: String,
+    #[n(1)]
+    port: u16,
+}
+
+impl HostnamePort {
+    /// Create a new HostnamePort
+    pub fn new(hostname: &str, port: u16) -> HostnamePort {
+        HostnamePort {
+            hostname: hostname.to_string(),
+            port,
+        }
+    }
+
+    /// Return a hostname and port from a socket address
+    pub fn from_socket_addr(socket_addr: SocketAddr) -> ockam_core::Result<HostnamePort> {
+        HostnamePort::from_str(&socket_addr.to_string())
+    }
+
+    /// Return a socket address from a hostname and port
+    pub fn to_socket_addr(&self) -> ockam_core::Result<SocketAddr> {
+        resolve_peer(self.to_string())
+    }
+
+    /// Return the hostname
+    pub fn hostname(&self) -> String {
+        self.hostname.clone()
+    }
+
+    /// Return the port
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl FromStr for HostnamePort {
+    type Err = ockam_core::Error;
+
+    /// Return a hostname and port when separated by a :
+    fn from_str(hostname_port: &str) -> ockam_core::Result<HostnamePort> {
+        // edge case: only the port is given
+        if let Ok(port) = hostname_port.parse::<u16>() {
+            return Ok(HostnamePort::new("127.0.0.1", port));
+        }
+
+        // otherwise check if brackets are present for an IP v6 address
+        let ip_regex = if hostname_port.contains('[') {
+            // we want to parse an IP v6 address as [hostname]:port where hostname does not contain [ or ]
+            regex::Regex::new(r"(\[[^\[\]].*\]):(\d+)").unwrap()
+        } else {
+            regex::Regex::new(r"^([^:]*):(\d+)$").unwrap()
+        };
+
+        // Attempt to match the regular expression
+        if let Some(captures) = ip_regex.captures(hostname_port) {
+            if let (Some(hostname), Some(port)) = (captures.get(1), captures.get(2)) {
+                if let Ok(port) = port.as_str().parse::<u16>() {
+                    let mut hostname = hostname.as_str().to_string();
+                    if hostname.is_empty() {
+                        hostname = "127.0.0.1".to_string()
+                    };
+                    return Ok(HostnamePort { hostname, port });
+                }
+            }
+        };
+
+        Err(ockam_core::Error::new(
+            Origin::Api,
+            Kind::Serialization,
+            format!("cannot read the value as hostname:port: {hostname_port}"),
+        ))
+    }
+}
+
+impl Display for HostnamePort {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{}:{}", self.hostname, self.port))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+
+    #[test]
+    fn test_hostname_port() -> ockam_core::Result<()> {
+        let actual = HostnamePort::from_str("localhost:80")?;
+        assert_eq!(actual, HostnamePort::new("localhost", 80));
+
+        let actual = HostnamePort::from_str("127.0.0.1:80")?;
+        assert_eq!(actual, HostnamePort::new("127.0.0.1", 80));
+
+        // this is malformed address
+        let actual = HostnamePort::from_str("127.0.0.1:80:80").ok();
+        assert_eq!(actual, None);
+
+        let actual = HostnamePort::from_str(":80")?;
+        assert_eq!(actual, HostnamePort::new("127.0.0.1", 80));
+
+        let actual = HostnamePort::from_str("80")?;
+        assert_eq!(actual, HostnamePort::new("127.0.0.1", 80));
+
+        let socket_addr = resolve_peer("76.76.21.21:8080".to_string()).unwrap();
+        let actual = HostnamePort::from_socket_addr(socket_addr).ok();
+        assert_eq!(actual, Some(HostnamePort::new("76.76.21.21", 8080)));
+
+        let actual = HostnamePort::from_str("[2001:db8:85a3::8a2e:370:7334]:8080")?;
+        assert_eq!(
+            actual,
+            HostnamePort::new("[2001:db8:85a3::8a2e:370:7334]", 8080)
+        );
+
+        let socket_addr = SocketAddr::from_str("[2001:db8:85a3::8a2e:370:7334]:8080").unwrap();
+        let actual = HostnamePort::from_socket_addr(socket_addr).ok();
+        assert_eq!(
+            actual,
+            Some(HostnamePort::new("[2001:db8:85a3::8a2e:370:7334]", 8080))
+        );
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/mod.rs
@@ -1,10 +1,12 @@
 pub(crate) mod common;
 mod connection;
+mod hostname_port;
 mod lifecycle;
 mod listener;
 mod portals;
 
 pub use common::*;
+pub use hostname_port::*;
 
 pub use crate::portal::options::*;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -7,7 +8,8 @@ use ockam_core::compat::rand::random;
 use ockam_core::{route, Result};
 use ockam_node::Context;
 use ockam_transport_tcp::{
-    TcpConnectionOptions, TcpInletOptions, TcpListenerOptions, TcpOutletOptions, TcpTransport,
+    HostnamePort, TcpConnectionOptions, TcpInletOptions, TcpListenerOptions, TcpOutletOptions,
+    TcpTransport,
 };
 
 const LENGTH: usize = 32;
@@ -18,7 +20,9 @@ async fn setup(ctx: &Context) -> Result<(String, TcpListener)> {
     let listener = {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bind_address = listener.local_addr().unwrap().to_string();
-        tcp.create_outlet("outlet", bind_address.clone(), TcpOutletOptions::new())
+        let hostname_port = HostnamePort::from_str(&bind_address)?;
+
+        tcp.create_outlet("outlet", hostname_port, TcpOutletOptions::new())
             .await?;
         listener
     };
@@ -136,7 +140,7 @@ async fn portal__tcp_connection__should_succeed(ctx: &mut Context) -> Result<()>
     let bind_address = listener.local_addr().unwrap().to_string();
     tcp.create_outlet(
         "outlet",
-        bind_address.clone(),
+        HostnamePort::from_str(&bind_address)?,
         TcpOutletOptions::new().as_consumer(&outlet_flow_control_id),
     )
     .await?;
@@ -191,7 +195,7 @@ async fn portal__tcp_connection_with_invalid_message_flow__should_not_succeed(
 
     tcp.create_outlet(
         "outlet_invalid",
-        bind_address.clone(),
+        HostnamePort::from_str(&bind_address)?,
         TcpOutletOptions::new(),
     )
     .await?;


### PR DESCRIPTION
This PR makes it possible to point tcp-outlets toward an endpoint supporting TLS.
This way, a TCP portal can be configured to send data to `https://myservice:443`.

# Implementation notes 

## Certificates

The certificates are loaded from the system certificates using the [rustls-native-certs](https://crates.io/crates/rustls-native-certs) crate.

## Configuration

The configuration parameter for the `tcp-outlet create` command `--to` option is now a `HostnamePort` which is simply a host and a port, instead of a socket address. This is necessary in order to keep the domain name (`otelcoll.orchestrator.ockam.io` for example) as long as possible before being resolved to a socket address. This domain name is then used to check certificates.

I did not propagate this configuration to every place, in particular not to the Kafka configuration yet. I provided instead a conversion function from `SocketAddr` to `HostnamePort`.

