### PR TITLE
feat(rust): added metadata and terminal concepts

### DIFF
--- a/implementations/rust/ockam/ockam_core/src/routing/address_meta.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/address_meta.rs
@@ -1,0 +1,22 @@
+use crate::compat::string::String;
+use crate::compat::vec::Vec;
+use crate::Address;
+
+/// Additional metadata for address
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct AddressMetadata {
+    /// Indicates that this Address will forward message to another route, therefore the next
+    /// hop after this one belongs to another node
+    pub is_terminal: bool,
+    /// Arbitrary set of attributes
+    pub attributes: Vec<(String, String)>,
+}
+
+/// A set of metadata for a particular address
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AddressAndMetadata {
+    /// Address
+    pub address: Address,
+    /// Metadata
+    pub metadata: AddressMetadata,
+}

--- a/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/mailbox.rs
@@ -197,7 +197,8 @@ impl Mailboxes {
 
     /// Return all (mail + additional) [`Address`]es represented by this [`Mailboxes`]
     pub fn addresses(&self) -> Vec<Address> {
-        let mut addresses = vec![self.main_mailbox.address.clone()];
+        let mut addresses = Vec::with_capacity(self.additional_mailboxes.len() + 1);
+        addresses.push(self.main_mailbox.address.clone());
         addresses.append(&mut self.additional_addresses());
         addresses
     }

--- a/implementations/rust/ockam/ockam_core/src/routing/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/mod.rs
@@ -17,5 +17,9 @@ mod macros;
 mod mailbox;
 pub use mailbox::*;
 
+mod address_meta;
+pub use address_meta::*;
+
 mod transport_type;
+
 pub use transport_type::*;

--- a/implementations/rust/ockam/ockam_core/src/routing/route.rs
+++ b/implementations/rust/ockam/ockam_core/src/routing/route.rs
@@ -268,6 +268,12 @@ impl Display for Route {
     }
 }
 
+impl From<Route> for Vec<Address> {
+    fn from(value: Route) -> Self {
+        value.inner.into()
+    }
+}
+
 /// Convert a `RouteBuilder` into a `Route`.
 impl From<RouteBuilder<'_>> for Route {
     fn from(RouteBuilder { ref inner, .. }: RouteBuilder) -> Self {

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -213,8 +213,13 @@ impl Context {
         let (ctx, sender, _) = self.copy_with_mailboxes_detached(mailboxes, drop_sender);
 
         // Create a "detached relay" and register it with the router
-        let (msg, mut rx) =
-            NodeMessage::start_worker(addresses, sender, true, Arc::clone(&self.mailbox_count));
+        let (msg, mut rx) = NodeMessage::start_worker(
+            addresses,
+            sender,
+            true,
+            Arc::clone(&self.mailbox_count),
+            vec![],
+        );
         self.sender
             .send(msg)
             .await

--- a/implementations/rust/ockam/ockam_node/src/processor_builder.rs
+++ b/implementations/rust/ockam/ockam_node/src/processor_builder.rs
@@ -1,11 +1,12 @@
 use crate::debugger;
 use crate::error::{NodeError, NodeReason};
 use crate::{relay::ProcessorRelay, Context, NodeMessage};
-use ockam_core::compat::sync::Arc;
+use alloc::string::String;
+use ockam_core::compat::{sync::Arc, vec::Vec};
 use ockam_core::{
     errcode::{Kind, Origin},
-    Address, DenyAll, Error, IncomingAccessControl, Mailboxes, OutgoingAccessControl, Processor,
-    Result,
+    Address, AddressAndMetadata, AddressMetadata, DenyAll, Error, IncomingAccessControl, Mailboxes,
+    OutgoingAccessControl, Processor, Result,
 };
 
 /// Start a [`Processor`]
@@ -40,6 +41,7 @@ where
             outgoing_ac: Arc::new(DenyAll),
             processor: self.processor,
             address: address.into(),
+            metadata: None,
         }
     }
 
@@ -48,6 +50,7 @@ where
         ProcessorBuilderMultipleAddresses {
             mailboxes,
             processor: self.processor,
+            metadata_list: vec![],
         }
     }
 }
@@ -58,15 +61,72 @@ where
 {
     mailboxes: Mailboxes,
     processor: P,
+    metadata_list: Vec<AddressAndMetadata>,
 }
 
 impl<P> ProcessorBuilderMultipleAddresses<P>
 where
     P: Processor<Context = Context>,
 {
+    /// Mark the provided address as terminal
+    pub fn terminal(self, address: impl Into<Address>) -> Self {
+        self.terminal_with_attributes(address.into(), vec![])
+    }
+
+    /// Mark the provided address as terminal
+    pub fn terminal_with_attributes(
+        mut self,
+        address: impl Into<Address>,
+        attributes: Vec<(String, String)>,
+    ) -> Self {
+        let address = address.into();
+        let metadata = self.metadata_list.iter_mut().find(|m| m.address == address);
+
+        if let Some(metadata) = metadata {
+            metadata.metadata.is_terminal = true;
+            metadata.metadata.attributes = attributes;
+        } else {
+            self.metadata_list.push(AddressAndMetadata {
+                address,
+                metadata: AddressMetadata {
+                    is_terminal: true,
+                    attributes,
+                },
+            });
+        }
+        self
+    }
+
+    /// Adds metadata attribute for the provided address
+    pub fn with_metadata_attribute(
+        mut self,
+        address: impl Into<Address>,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        let address = address.into();
+        let metadata = self.metadata_list.iter_mut().find(|m| m.address == address);
+
+        if let Some(metadata) = metadata {
+            metadata
+                .metadata
+                .attributes
+                .push((key.into(), value.into()));
+        } else {
+            self.metadata_list.push(AddressAndMetadata {
+                address,
+                metadata: AddressMetadata {
+                    is_terminal: false,
+                    attributes: vec![(key.into(), value.into())],
+                },
+            });
+        }
+        self
+    }
+
     /// Consume this builder and start a new Ockam [`Processor`] from the given context
     pub async fn start(self, context: &Context) -> Result<()> {
-        start(context, self.mailboxes, self.processor).await
+        start(context, self.mailboxes, self.processor, self.metadata_list).await
     }
 }
 
@@ -78,18 +138,65 @@ where
     outgoing_ac: Arc<dyn OutgoingAccessControl>,
     address: Address,
     processor: P,
+    metadata: Option<AddressAndMetadata>,
 }
 
 impl<P> ProcessorBuilderOneAddress<P>
 where
     P: Processor<Context = Context>,
 {
+    /// Mark the address as terminal
+    pub fn terminal(self) -> Self {
+        self.terminal_with_attributes(vec![])
+    }
+
+    /// Mark the address as terminal
+    pub fn terminal_with_attributes(mut self, attributes: Vec<(String, String)>) -> Self {
+        if let Some(metadata) = self.metadata.as_mut() {
+            metadata.metadata.is_terminal = true;
+            metadata.metadata.attributes = attributes;
+        } else {
+            self.metadata = Some(AddressAndMetadata {
+                address: self.address.clone(),
+                metadata: AddressMetadata {
+                    is_terminal: true,
+                    attributes,
+                },
+            });
+        }
+        self
+    }
+
+    /// Adds metadata attribute
+    pub fn with_metadata_attribute(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        if let Some(metadata) = self.metadata.as_mut() {
+            metadata
+                .metadata
+                .attributes
+                .push((key.into(), value.into()));
+        } else {
+            self.metadata = Some(AddressAndMetadata {
+                address: self.address.clone(),
+                metadata: AddressMetadata {
+                    is_terminal: false,
+                    attributes: vec![(key.into(), value.into())],
+                },
+            });
+        }
+        self
+    }
+
     /// Consume this builder and start a new Ockam [`Processor`] from the given context
     pub async fn start(self, context: &Context) -> Result<()> {
         start(
             context,
             Mailboxes::main(self.address, self.incoming_ac, self.outgoing_ac),
             self.processor,
+            self.metadata.map(|m| vec![m]).unwrap_or_default(),
         )
         .await
     }
@@ -137,7 +244,13 @@ where
 }
 
 /// Consume this builder and start a new Ockam [`Processor`] from the given context
-pub async fn start<P>(context: &Context, mailboxes: Mailboxes, processor: P) -> Result<()>
+
+pub async fn start<P>(
+    context: &Context,
+    mailboxes: Mailboxes,
+    processor: P,
+    metadata: Vec<AddressAndMetadata>,
+) -> Result<()>
 where
     P: Processor<Context = Context>,
 {
@@ -148,7 +261,7 @@ where
         mailboxes.main_mailbox().outgoing_access_control(),
     );
 
-    let main_address = mailboxes.main_address().clone();
+    let addresses = mailboxes.addresses();
 
     // Pass it to the context
     let (ctx, sender, ctrl_rx) = context.copy_with_mailboxes(mailboxes);
@@ -156,7 +269,7 @@ where
     debugger::log_inherit_context("PROCESSOR", context, &ctx);
 
     // Send start request to router
-    let (msg, mut rx) = NodeMessage::start_processor(main_address.clone(), sender);
+    let (msg, mut rx) = NodeMessage::start_processor(addresses, sender, metadata);
     context
         .sender()
         .send(msg)

--- a/implementations/rust/ockam/ockam_node/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/mod.rs
@@ -10,7 +10,7 @@ mod utils;
 #[cfg(feature = "metrics")]
 use std::sync::atomic::AtomicUsize;
 
-use record::{AddressMeta, AddressRecord, InternalMap};
+use record::{AddressRecord, InternalMap, WorkerMeta};
 use state::{NodeState, RouterState};
 
 use crate::channel_types::{router_channel, MessageSender, RouterReceiver, SmallSender};
@@ -94,7 +94,7 @@ impl Router {
                 senders.msgs,
                 senders.ctrl,
                 Arc::new(0.into()), // don't track for app worker (yet?)
-                AddressMeta {
+                WorkerMeta {
                     processor: false,
                     detached: true,
                 },
@@ -183,15 +183,30 @@ impl Router {
                 detached,
                 mailbox_count,
                 ref reply,
-            } => start_worker::exec(self, addrs, senders, detached, mailbox_count, reply).await?,
+                addresses_metadata,
+            } => {
+                start_worker::exec(
+                    self,
+                    addrs,
+                    senders,
+                    detached,
+                    addresses_metadata,
+                    mailbox_count,
+                    reply,
+                )
+                .await?
+            }
             StopWorker(ref addr, ref detached, ref reply) => {
                 stop_worker::exec(self, addr, *detached, reply).await?
             }
 
             //// ==! Basic processor control
-            StartProcessor(addr, senders, ref reply) => {
-                start_processor::exec(self, addr, senders, reply).await?
-            }
+            StartProcessor {
+                addrs,
+                senders,
+                ref reply,
+                addresses_metadata,
+            } => start_processor::exec(self, addrs, senders, addresses_metadata, reply).await?,
             StopProcessor(ref addr, ref reply) => stop_processor::exec(self, addr, reply).await?,
 
             //// ==! Core node controls
@@ -291,6 +306,20 @@ impl Router {
                     utils::resolve(self, addr, reply).await?
                 }
             },
+            FindTerminalAddress(ref addresses, ref reply) => {
+                let terminal_address = self.map.find_terminal_address(addresses);
+                reply
+                    .send(RouterReply::terminal_address(terminal_address))
+                    .await
+                    .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?;
+            }
+            GetMetadata(ref address, ref reply) => {
+                let meta = self.map.get_address_metadata(address);
+                reply
+                    .send(RouterReply::metadata(meta))
+                    .await
+                    .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?;
+            }
         }
 
         Ok(false)

--- a/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_processor.rs
@@ -1,22 +1,24 @@
-use super::{AddressMeta, AddressRecord, NodeState, Router, SenderPair};
+use super::{AddressRecord, NodeState, Router, SenderPair, WorkerMeta};
 use crate::channel_types::SmallSender;
 use crate::{
     error::{NodeError, NodeReason},
-    NodeReplyResult, RouterReply,
+    NodeReplyResult, RouterReason, RouterReply,
 };
+use ockam_core::compat::{sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use ockam_core::env::get_env;
-use ockam_core::{compat::sync::Arc, Address, Result};
+use ockam_core::{Address, AddressAndMetadata, Result};
 
 /// Execute a `StartWorker` command
 pub(super) async fn exec(
     router: &mut Router,
-    addrs: Address,
+    addrs: Vec<Address>,
     senders: SenderPair,
+    addresses_metadata: Vec<AddressAndMetadata>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
     match router.state.node_state() {
-        NodeState::Running => start(router, addrs, senders, reply).await,
+        NodeState::Running => start(router, addrs, senders, addresses_metadata, reply).await,
         NodeState::Stopping(_) => reject(reply).await,
         NodeState::Dead => unreachable!(),
     }?;
@@ -25,18 +27,23 @@ pub(super) async fn exec(
 
 async fn start(
     router: &mut Router,
-    addr: Address,
+    addrs: Vec<Address>,
     senders: SenderPair,
+    addresses_metadata: Vec<AddressAndMetadata>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
-    router.check_addr_not_exist(&addr, reply).await?;
+    let primary_addr = addrs
+        .first()
+        .ok_or_else(|| NodeError::RouterState(RouterReason::EmptyAddressSet).internal())?;
 
-    debug!("Starting new processor '{}'", &addr);
+    router.check_addr_not_exist(primary_addr, reply).await?;
+
+    debug!("Starting new processor '{}'", &primary_addr);
 
     let SenderPair { msgs, ctrl } = senders;
 
     let record = AddressRecord::new(
-        vec![addr.clone()],
+        addrs.clone(),
         msgs,
         ctrl,
         // We don't keep track of the mailbox count for processors
@@ -45,13 +52,27 @@ async fn start(
         // irrelevant.  We may want to re-visit this decision in the
         // future, if the way processors are used changes.
         Arc::new(0.into()),
-        AddressMeta {
+        WorkerMeta {
             processor: true,
             detached: false,
         },
     );
 
-    router.map.insert_address_record(addr.clone(), record);
+    router
+        .map
+        .insert_address_record(primary_addr.clone(), record);
+
+    for metadata in addresses_metadata {
+        if !addrs.contains(&metadata.address) {
+            warn!(
+                "Address {} is not in the set of addresses for this processor",
+                metadata.address
+            );
+            continue;
+        }
+
+        router.map.set_address_metadata(metadata);
+    }
 
     #[cfg(feature = "std")]
     if let Ok(Some(dump_internals)) = get_env::<bool>("OCKAM_DUMP_INTERNALS") {
@@ -62,7 +83,9 @@ async fn start(
     #[cfg(all(not(feature = "std"), feature = "dump_internals"))]
     trace!("{:#?}", router.map.address_records_map());
 
-    router.map.insert_alias(&addr, &addr);
+    addrs.iter().for_each(|addr| {
+        router.map.insert_alias(addr, primary_addr);
+    });
 
     // For now we just send an OK back -- in the future we need to
     // communicate the current executor state
@@ -74,7 +97,7 @@ async fn start(
 }
 
 async fn reject(reply: &SmallSender<NodeReplyResult>) -> Result<()> {
-    trace!("StartWorker command rejected: node shutting down");
+    trace!("StartProcessor command rejected: node shutting down");
     reply
         .send(RouterReply::node_rejected(NodeReason::Shutdown))
         .await

--- a/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/start_worker.rs
@@ -1,4 +1,4 @@
-use super::{AddressMeta, AddressRecord, NodeState, Router, SenderPair};
+use super::{AddressRecord, NodeState, Router, SenderPair, WorkerMeta};
 use crate::channel_types::SmallSender;
 use crate::{
     error::{NodeError, NodeReason},
@@ -9,7 +9,7 @@ use core::sync::atomic::AtomicUsize;
 use ockam_core::env::get_env;
 use ockam_core::{
     compat::{sync::Arc, vec::Vec},
-    Address, Result,
+    Address, AddressAndMetadata, Result,
 };
 
 /// Execute a `StartWorker` command
@@ -18,11 +18,23 @@ pub(super) async fn exec(
     addrs: Vec<Address>,
     senders: SenderPair,
     detached: bool,
+    addresses_metadata: Vec<AddressAndMetadata>,
     metrics: Arc<AtomicUsize>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
     match router.state.node_state() {
-        NodeState::Running => start(router, addrs, senders, detached, metrics, reply).await,
+        NodeState::Running => {
+            start(
+                router,
+                addrs,
+                senders,
+                detached,
+                addresses_metadata,
+                metrics,
+                reply,
+            )
+            .await
+        }
         NodeState::Stopping(_) => reject(reply).await,
         NodeState::Dead => unreachable!(),
     }?;
@@ -34,6 +46,7 @@ async fn start(
     addrs: Vec<Address>,
     senders: SenderPair,
     detached: bool,
+    addresses_metadata: Vec<AddressAndMetadata>,
     metrics: Arc<AtomicUsize>,
     reply: &SmallSender<NodeReplyResult>,
 ) -> Result<()> {
@@ -55,7 +68,7 @@ async fn start(
         msgs,
         ctrl,
         metrics,
-        AddressMeta {
+        WorkerMeta {
             processor: false,
             detached,
         },
@@ -64,6 +77,18 @@ async fn start(
     router
         .map
         .insert_address_record(primary_addr.clone(), address_record);
+
+    for metadata in addresses_metadata {
+        if !addrs.contains(&metadata.address) {
+            warn!(
+                "Address {} is not in the set of addresses for this worker",
+                metadata.address
+            );
+            continue;
+        }
+
+        router.map.set_address_metadata(metadata);
+    }
 
     #[cfg(feature = "std")]
     if let Ok(Some(_)) = get_env::<String>("OCKAM_DUMP_INTERNALS") {

--- a/implementations/rust/ockam/ockam_node/tests/router.rs
+++ b/implementations/rust/ockam/ockam_node/tests/router.rs
@@ -1,0 +1,258 @@
+use ockam_core::{
+    async_trait, route, Address, DenyAll, Mailbox, Mailboxes, Processor, Result, TransportType,
+};
+use ockam_node::{Context, NullWorker, ProcessorBuilder, WorkerBuilder};
+use std::sync::Arc;
+
+struct NullProcessor;
+
+#[async_trait]
+impl Processor for NullProcessor {
+    type Context = Context;
+
+    async fn process(&mut self, _ctx: &mut Context) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_processor(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("simple_processor")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["simple_processor", "non-existing"])
+        .await?
+        .is_none());
+
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("terminal_processor")
+        .terminal()
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context
+            .find_terminal_address(route![
+                "simple_worker",
+                "terminal_processor",
+                "non-existing"
+            ])
+            .await?
+            .unwrap()
+            .address,
+        "terminal_processor".into()
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_processor_alias(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .terminal("alias")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["main", "non-existing"])
+        .await?
+        .is_none());
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["main", "alias", "other"])
+            .await?
+            .unwrap()
+            .address,
+        "alias".into()
+    );
+
+    context.stop_processor("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(context
+        .find_terminal_address(route!["main", "alias", "other"])
+        .await?
+        .is_none());
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_processor_address_metadata(context: &mut Context) -> Result<()> {
+    ProcessorBuilder::new(NullProcessor {})
+        .with_address("processor_address")
+        .with_metadata_attribute("TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    let meta = context.read_metadata("processor_address").await?.unwrap();
+
+    assert!(!meta.is_terminal);
+
+    assert_eq!(
+        meta.attributes,
+        vec![
+            ("TEST_KEY".to_string(), "TEST_VALUE".to_string()),
+            ("TEST_KEY_2".to_string(), "TEST_VALUE_2".to_string())
+        ]
+    );
+
+    assert_eq!(context.read_metadata("non-existing-worker").await?, None);
+
+    context.stop_processor("processor_address").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(context.read_metadata("processor_address",).await?, None);
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_worker(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_address("simple_worker")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["simple_worker", "non-existing"])
+        .await?
+        .is_none());
+
+    WorkerBuilder::new(NullWorker {})
+        .with_address("terminal_worker")
+        .terminal()
+        .start(context)
+        .await?;
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["simple_worker", "terminal_worker", "non-existing"])
+            .await?
+            .unwrap()
+            .address,
+        "terminal_worker".into()
+    );
+
+    let remote = Address::new(TransportType::new(1), "127.0.0.1");
+    assert!(context
+        .find_terminal_address(route![
+            "simple_worker",
+            remote,
+            "terminal_worker",
+            "non-existing"
+        ])
+        .await
+        .is_err());
+
+    context.stop_worker("terminal_worker").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(
+        context
+            .find_terminal_address(route!["terminal_worker"])
+            .await?,
+        None
+    );
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn find_terminal_for_worker_alias(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .terminal("alias")
+        .start(context)
+        .await?;
+
+    assert!(context
+        .find_terminal_address(route!["main", "non-existing"])
+        .await?
+        .is_none());
+
+    assert_eq!(
+        context
+            .find_terminal_address(route!["main", "alias", "other"])
+            .await?
+            .unwrap()
+            .address,
+        "alias".into()
+    );
+
+    context.stop_worker("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(context
+        .find_terminal_address(route!["main", "alias", "other"])
+        .await?
+        .is_none());
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_address_metadata(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_address("worker_address")
+        .with_metadata_attribute("TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    let meta = context.read_metadata("worker_address").await?.unwrap();
+
+    assert!(!meta.is_terminal);
+
+    assert_eq!(
+        meta.attributes,
+        vec![
+            ("TEST_KEY".to_string(), "TEST_VALUE".to_string()),
+            ("TEST_KEY_2".to_string(), "TEST_VALUE_2".to_string())
+        ]
+    );
+
+    assert_eq!(context.read_metadata("non-existing-worker").await?, None);
+
+    context.stop_worker("worker_address").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(context.read_metadata("worker_address").await?, None);
+
+    context.stop().await
+}
+
+#[ockam_macros::test]
+async fn provide_and_read_address_metadata_worker_alias(context: &mut Context) -> Result<()> {
+    WorkerBuilder::new(NullWorker {})
+        .with_mailboxes(Mailboxes::new(
+            Mailbox::new("main", Arc::new(DenyAll), Arc::new(DenyAll)),
+            vec![Mailbox::new("alias", Arc::new(DenyAll), Arc::new(DenyAll))],
+        ))
+        .with_metadata_attribute("main", "TEST_KEY", "TEST_VALUE")
+        .with_metadata_attribute("alias", "TEST_KEY_2", "TEST_VALUE_2")
+        .start(context)
+        .await?;
+
+    let meta = context.read_metadata("alias").await?.unwrap();
+
+    assert!(!meta.is_terminal);
+
+    assert_eq!(
+        meta.attributes,
+        vec![("TEST_KEY_2".to_string(), "TEST_VALUE_2".to_string())]
+    );
+
+    context.stop_worker("main").await?;
+    ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(context.read_metadata("alias").await?, None);
+
+    context.stop().await
+}

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -104,7 +104,8 @@ impl TcpSendWorker {
         );
 
         WorkerBuilder::new(sender_worker)
-            .with_mailboxes(Mailboxes::new(main_mailbox, vec![internal_mailbox]))
+            .with_mailboxes(Mailboxes::new(main_mailbox.clone(), vec![internal_mailbox]))
+            .terminal(addresses.sender_address().clone())
             .start(ctx)
             .await?;
 


### PR DESCRIPTION
Add an additional registry to the Router which can store per-address metadata, which allows to add arbitrary Key Value attributes to an Address. That will be used to deduct receiver's Identifier given an onward route to further check Abac