### PR TITLE
Release improvement

### DIFF
--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -31,23 +31,12 @@ runs:
         override: true
         target: ${{ inputs.target }}
     - shell: bash
-      if: inputs.platform_operating_system == 'ubuntu-20.04'
-      run: |
-        set -x
-        use_cross_build=${{ inputs.use_cross_build }}
-        if [[ $use_cross_build == true ]]; then
-          cargo install --version 0.1.16 cross
-        else
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-        fi
-    - shell: bash
       if: inputs.platform_operating_system == 'ubuntu-22.04'
       run: |
         set -x
         use_cross_build=${{ inputs.use_cross_build }}
         if [[ $use_cross_build == true ]]; then
-          cargo install --version 0.1.16 cross
+          cargo install --version 0.2.4 cross
         else
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf

--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -24,10 +24,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: dtolnay/rust-toolchain@78c6b5541adb5849f5d72d15da722aedb26327ca # Stable branch
-      with:
-        toolchain: ${{ inputs.toolchain }}
-        target: ${{ inputs.target }}
+    - shell: bash
+      run: |
+        # This will allow us update to rust version indicated in our rust-toolchain.toml file
+        rustup show
+        rustup target add ${{ inputs.target }}
 
     - shell: bash
       if: inputs.platform_operating_system == 'ubuntu-22.04'

--- a/.github/actions/build_binaries/action.yml
+++ b/.github/actions/build_binaries/action.yml
@@ -24,12 +24,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions-rs/toolchain@b3ea035039aa8cb07d1f4a5168b0f8065c4a2eeb
+    - uses: dtolnay/rust-toolchain@78c6b5541adb5849f5d72d15da722aedb26327ca # Stable branch
       with:
         toolchain: ${{ inputs.toolchain }}
-        profile: minimal
-        override: true
         target: ${{ inputs.target }}
+
     - shell: bash
       if: inputs.platform_operating_system == 'ubuntu-22.04'
       run: |

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -185,19 +185,19 @@ jobs:
         build: [linux_arm64, linux_86, linux_armv7, macos_silicon, macos_86]
         include:
         - build: linux_arm64
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           toolchain: stable
           target: aarch64-unknown-linux-musl
           build_app: false
           use-cross-build: true
         - build: linux_armv7
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           toolchain: stable
           target: armv7-unknown-linux-musleabihf
           use-cross-build: true
           build_app: false
         - build: linux_86
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           toolchain: stable
           target: x86_64-unknown-linux-musl
           use-cross-build: true
@@ -210,13 +210,13 @@ jobs:
           build_app: true
           build_command: false
         - build: macos_silicon
-          os: macos-13
+          os: macos-14
           toolchain: stable
           target: aarch64-apple-darwin
           use-cross-build: false
           build_app: true
         - build: macos_86
-          os: macos-13
+          os: macos-14
           toolchain: stable
           target: x86_64-apple-darwin
           use-cross-build: false
@@ -232,7 +232,7 @@ jobs:
       run: echo "${{ needs.create_release.outputs.upload_url }}"
 
     - name: Apple Signing Initialization
-      if: ${{ matrix.os == 'macos-13' }}
+      if: ${{ matrix.os == 'macos-14' }}
       shell: bash
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.inputs.release_branch }}
 
       - name: Import GPG key
-        uses: build-trust/.github/actions/import_gpg@a6377d3c2dac878b92a0da26cdf3da2856c64840
+        uses: build-trust/.github/actions/import_gpg@ae127cb92387ed76f24d4d1c6d6bfc2d382f7946
         with:
           gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
           gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
@@ -160,7 +160,7 @@ jobs:
           release_name: 'Ockam v${{ steps.release_version.outputs.version }}'
           tag_name: '${{ steps.release_version.outputs.tag_name }}'
           body_path: 'release_note.md'
-          draft: true
+          prerelease: true
 
       - name: Echo Link
         run: echo "${{ steps.release_upload_url.outputs.html_url }}"

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -371,10 +371,10 @@ jobs:
           ref: ${{ github.event.inputs.release_branch }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@78c6b5541adb5849f5d72d15da722aedb26327ca # Stable branch
-        with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
+        run: |
+          # This will allow us update to rust version indicated in our rust-toolchain.toml file
+          rustup show
+          rustup target add ${{ matrix.job.target }}
 
       - name: Install Cross
         if: matrix.job.use-cross == true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -288,12 +288,12 @@ jobs:
         build: [linux_armv7, macos_silicon]
         include:
         - build: linux_armv7
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           toolchain: stable
           target: armv7-unknown-linux-musleabihf
           use-cross-build: true
         - build: macos_silicon
-          os: macos-13
+          os: macos-14
           toolchain: stable
           target: aarch64-apple-darwin
           use-cross-build: false


### PR DESCRIPTION
Reduces time required to build our binaries by using macos m1 runners and latest version of Cross. Build time got reduced from >30min to <16min