### PR TITLE
docs(rust): improve the aurora example

### DIFF
--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/README.md
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/README.md
@@ -5,5 +5,5 @@ This hands-on example uses Ockam to create an end-to-end encrypted portal to pos
 We connect a nodejs app in one Amazon VPC with a Amazon Aurora managed Postgres database in another Amazon VPC.
 The example uses AWS CLI to create these VPCs.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/postgres/aurora

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run.sh
@@ -30,7 +30,7 @@ run() {
     #   - TCP egress to the Internet
     #   - SSH ingress from the Internet
     sg_id=$(aws ec2 create-security-group --group-name "${name}-sg" --vpc-id "$vpc_id" --query 'GroupId' \
-        --description "Allow TCP egress and Postgres ingress")
+        --description "Allow TCP egress and SSH ingress")
     aws ec2 authorize-security-group-egress --group-id "$sg_id" --cidr 0.0.0.0/0 --protocol tcp --port 0-65535
     aws ec2 authorize-security-group-ingress --group-id "$sg_id" --cidr 0.0.0.0/0 --protocol tcp --port 22
 

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run_ockam.sh
@@ -15,7 +15,7 @@ source "$HOME/.ockam/env"
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command
@@ -32,8 +32,14 @@ ockam project enroll "$ENROLLMENT_TICKET"
 #
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:15432
-ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
-ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
+cat << EOF > inlet.yaml
+tcp-inlet:
+  from: 0.0.0.0:15432
+  via: postgres
+  allow: '(= subject.postgres-outlet "true")'
+EOF
+
+ockam node create inlet.yaml
+rm inlet.yaml
 
 EOS

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/bank_corp/run_ockam.sh
@@ -15,7 +15,7 @@ source "$HOME/.ockam/env"
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command
@@ -34,9 +34,15 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # attribute postgres-inlet="true" to connect to TCP Portal Outlets on this node.
 #
 # Create a TCP Portal Outlet to postgres at - $POSTGRES_ADDRESS:5432.
-ockam node create
-ockam relay create postgres
-ockam policy create --resource tcp-outlet --expression '(= subject.postgres-inlet "true")'
-ockam tcp-outlet create --to "$POSTGRES_ADDRESS:5432"
+cat << EOF > outlet.yaml
+tcp-outlet:
+  to: "$POSTGRES_ADDRESS:5432"
+  allow: '(= subject.postgres-inlet "true")'
+
+relay: postgres
+EOF
+
+ockam node create outlet.yaml
+rm outlet.yaml
 
 EOS

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/run.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/databases/postgres/aurora
 
 run() {
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 # Check if Ockam Command is already installed and available in path.
-# If it's not, then install it.
-if ! type ockam &>/dev/null; then
+# If it's not, then install it (only if we are not cleaning up)
+if ! [ type ockam &>/dev/null ] && ! [ "$1" = "cleanup" ]; then
     curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
     source "$HOME/.ockam/env"
 fi

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/analysis_corp/run_ockam.sh
@@ -15,7 +15,7 @@ source "$HOME/.ockam/env"
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command
@@ -32,8 +32,14 @@ ockam project enroll "$ENROLLMENT_TICKET"
 #
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:15432
-ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
-ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
+cat << EOF > inlet.yaml
+tcp-inlet:
+  from: 0.0.0.0:15432
+  via: postgres
+  allow: '(= subject.postgres-outlet "true")'
+EOF
+
+ockam node create inlet.yaml
+rm inlet.yaml
 
 EOS

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/bank_corp/run_ockam.sh
@@ -15,7 +15,7 @@ source "$HOME/.ockam/env"
 # The `project enroll` command creates a new vault and generates a cryptographic identity with
 # private keys stored in that vault.
 #
-# The enrollment ticket includes routes and identitifiers for the project membership authority
+# The enrollment ticket includes routes and identifiers for the project membership authority
 # and the project’s node that offers the relay service.
 #
 # The enrollment ticket also includes an enrollment token. The project enroll command
@@ -34,9 +34,15 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # attribute postgres-inlet="true" to connect to TCP Portal Outlets on this node.
 #
 # Create a TCP Portal Outlet to postgres at - $POSTGRES_ADDRESS:5432.
-ockam node create
-ockam relay create postgres
-ockam policy create --resource tcp-outlet --expression '(= subject.postgres-inlet "true")'
-ockam tcp-outlet create --to "$POSTGRES_ADDRESS:5432"
+cat << EOF > outlet.yaml
+tcp-outlet:
+  to: "$POSTGRES_ADDRESS:5432"
+  allow: '(= subject.postgres-inlet "true")'
+
+relay: postgres
+EOF
+
+ockam node create outlet.yaml
+rm outlet.yaml
 
 EOS

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/run.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/run.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 # Check if Ockam Command is already installed and available in path.
-# If it's not, then install it.
-if ! type ockam &>/dev/null; then
+# If it's not, then install it (only if we are not cleaning up)
+if ! [ type ockam &>/dev/null ] && ! [ "$1" = "cleanup" ]; then
     curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
     source "$HOME/.ockam/env"
 fi

--- a/examples/command/portals/databases/postgres/docker/run.sh
+++ b/examples/command/portals/databases/postgres/docker/run.sh
@@ -70,8 +70,8 @@ cleanup() {
 }
 
 # Check if Ockam Command is already installed and available in path.
-# If it's not, then install it.
-if ! type ockam &>/dev/null; then
+# If it's not, then install it (only if we are not cleaning up)
+if ! [ type ockam &>/dev/null ] && ! [ "$1" = "cleanup" ]; then
     curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
     source "$HOME/.ockam/env"
 fi


### PR DESCRIPTION
Improve the Aurora / RDS examples:

 - Fix some typos
 - Select 2 distinct availability zones with one command
 - Avoid downloading the application when cleaning-up
 - Use a configuration file to create the Ockam nodes