### PR TITLE
docs(rust): improve the example for connecting to an ai model

### DIFF
--- a/examples/command/portals/ai/amazon_ec2/aws_cli/ai_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_ec2/aws_cli/ai_corp/run_ockam.sh
@@ -34,9 +34,15 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # attribute ai-inlet="true" to connect to TCP Portal Outlets on this node.
 #
 # Create a TCP Portal Outlet to ai at - localhost:3000.
-ockam node create
-ockam relay create ai
-ockam policy create --resource tcp-outlet --expression '(= subject.ai-inlet "true")'
-ockam tcp-outlet create --to localhost:3000
+cat << EOF > outlet.yaml
+tcp-outlet:
+  to: "localhost:3000"
+  allow: '(= subject.ai-inlet "true")'
+
+relay: ai
+EOF
+
+ockam node create outlet.yaml
+rm outlet.yaml
 
 EOS

--- a/examples/command/portals/ai/amazon_ec2/aws_cli/health_corp/client.js
+++ b/examples/command/portals/ai/amazon_ec2/aws_cli/health_corp/client.js
@@ -6,7 +6,7 @@ async function run() {
       return;
     }
 
-    const query = "What is Ockam's Razor?";
+    const query = "What is Ockham's Razor?";
     console.log("Connected to the model.\n\n App: ", query);
     const queryResponse = await fetch("http://localhost:3000/query", {
       method: "POST",
@@ -20,7 +20,7 @@ async function run() {
     }
 
     const answer = await queryResponse.json();
-    console.log("Model: ", answer);
+    console.log(answer['answer']);
   } catch (error) {
     console.log("Error:", error.message);
   }

--- a/examples/command/portals/ai/amazon_ec2/aws_cli/health_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_ec2/aws_cli/health_corp/run_ockam.sh
@@ -32,8 +32,14 @@ ockam project enroll "$ENROLLMENT_TICKET"
 #
 # Create a TCP Portal Inlet to AI API.
 # This makes the remote AI API available on all localhost IPs at - 0.0.0.0:3000
-ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.ai-outlet "true")'
-ockam tcp-inlet create --from 0.0.0.0:3000 --via ai
+cat << EOF > inlet.yaml
+tcp-inlet:
+  from: 0.0.0.0:3000
+  via: ai
+  allow: '(= subject.ai-outlet "true")'
+EOF
+
+ockam node create inlet.yaml
+rm inlet.yaml
 
 EOS

--- a/examples/command/portals/ai/amazon_ec2/aws_cli/run.sh
+++ b/examples/command/portals/ai/amazon_ec2/aws_cli/run.sh
@@ -8,8 +8,8 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
-# https://docs.ockam.io/portals/apis/nodejs/amazon_ec2
+# You can read a detailed walkthrough of this example at:
+# https://docs.ockam.io/portals/ai/llama
 
 run() {
     # Run `ockam enroll`.
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 # Check if Ockam Command is already installed and available in path.
-# If it's not, then install it.
-if ! type ockam &>/dev/null; then
+# If it's not, then install it (only if we are not cleaning up)
+if ! [ type ockam &>/dev/null ] && ! [ "$1" = "cleanup" ]; then
     curl --proto '=https' --tlsv1.2 -sSfL https://install.command.ockam.io | bash
     source "$HOME/.ockam/env"
 fi


### PR DESCRIPTION
This PR improves the example for connecting to an AI model using a portal:

 - Fixed some typos.
 - Don't download `ockam` on cleanup
 - Check if the instance type required to run the model is available in the current region (otherwise return the list of regions where it is supported).