### PR TITLE
fix(rust): create .bats-tests directory before running any suite

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 rm -rf "$HOME/.bats-tests"
+mkdir -p "$HOME/.bats-tests"
 
 export BATS_TEST_RETRIES=2
 export BATS_TEST_TIMEOUT=240


### PR DESCRIPTION
Prevents an [error](https://github.com/build-trust/ockam-artifacts/actions/runs/8554896889/job/23441205614#step:9:5692) in CI where it tries to delete the directory when it doesn't exist. This error only occurs when no test is run, which is currently happening until we update the CI check.