### PR TITLE
test(rust): export postgres port variable before running the test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -270,7 +270,7 @@ jobs:
           ockam --version
           echo $(which ockam)
           echo $BATS_TEST_RETRIES
-          pushd implementations/rust/ockam/ockam_command/tests/bats; bash run.sh; popd
+          bash implementations/rust/ockam/ockam_command/tests/bats/run.sh
         env:
           OCKAM_DISABLE_UPGRADE_CHECK: 1
           BATS_TEST_RETRIES: 2

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -30,13 +30,13 @@ if [[ -z $BATS_LIB ]]; then
   # export BATS_LIB=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
 fi
 
+export PYTHON_SERVER_PORT=5000
+
 # Load bats extensions
 load_bats_ext() {
   load "$BATS_LIB/bats-support/load.bash"
   load "$BATS_LIB/bats-assert/load.bash"
 }
-
-export PYTHON_SERVER_PORT=5000
 
 setup_python_server() {
   p=$(python_pid_file_path)

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/docs.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/docs.bash
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+export PG_PORT=5432
+
 function skip_if_docs_tests_not_enabled() {
   # shellcheck disable=SC2031
   if [ -z "${DOCS_TESTS}" ]; then
@@ -10,8 +13,6 @@ start_python_server() {
   if [[ "$BATS_TEST_DESCRIPTION" != *"basic-web-app"* ]]; then
     return
   fi
-
-  export PG_PORT=5432
 
   pushd $OCKAM_HOME_BASE
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-function exit_if_orchestrator_tests_not_enabled() {
-  # shellcheck disable=SC2031
-  if [ -z "${ORCHESTRATOR_TESTS}" ]; then
-    exit 0
-  fi
-}
-
 function skip_if_orchestrator_tests_not_enabled() {
   # shellcheck disable=SC2031
   if [ -z "${ORCHESTRATOR_TESTS}" ]; then

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -104,7 +104,7 @@ teardown() {
   run_success "$OCKAM" tcp-outlet create --at "$n3" --to "127.0.0.1:$PYTHON_SERVER_PORT"
   run_success "$OCKAM" tcp-inlet create --at "$n1" --from "127.0.0.1:$inlet_port" --to "/worker/${n1_id}/service/forward_to_$n3/service/hop/service/outlet"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/routing

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
@@ -32,5 +32,5 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/client_sidecar --to /node/relay/service/forward_to_server_sidecar/service/api \
               | $OCKAM tcp-inlet create --at /node/client_sidecar --from 127.0.0.1:$port --to -/service/outlet"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/nodes.bats
@@ -33,7 +33,8 @@ EOF
 
 @test "nodes - create with config, non-admin enrolling twice with the project doesn't return error" {
   # Admin: create enrollment ticket that can be reused a few times
-  ticket_path="$OCKAM_HOME/enrollment.ticket"
+  ADMIN_HOME_DIR="$OCKAM_HOME"
+  ticket_path="$ADMIN_HOME_DIR/enrollment.ticket"
   export RELAY_NAME=$(random_str)
   $OCKAM project ticket --usage-count 10 --relay $RELAY_NAME >"$ticket_path"
 
@@ -46,7 +47,7 @@ EOF
     --enrollment-ticket "$ticket_path" \
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
     --variable CLIENT_PORT="$port"
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 
   ## Second time it will skip the enrollment step and the node will be set up as expected
   run_success "$OCKAM" node delete --all -y
@@ -54,7 +55,7 @@ EOF
     --enrollment-ticket "$ticket_path" \
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT" \
     --variable CLIENT_PORT="$port"
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "nodes - create with config, single machine, unnamed portal" {
@@ -72,7 +73,7 @@ EOF
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$port1/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port2"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port2"
 }
 
 @test "nodes - create with config, single machine, named portal" {
@@ -90,7 +91,7 @@ EOF
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$port1/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port2"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port2"
 }
 
 @test "nodes - create with config, multiple machines" {
@@ -137,7 +138,7 @@ EOF
 
   # Test: SaaS service can be reached from Customer's inlet
   $OCKAM message send hi --to "/project/default/service/forward_to_to-$SAAS_RELAY_NAME/secure/api/service/echo"
-  run_success curl --fail --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 --head "127.0.0.1:$CUSTOMER_INLET_PORT"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CUSTOMER_INLET_PORT"
 
   # Test: Customer node can be reached from SaaS's side
   export OCKAM_HOME="$SAAS_HOME_DIR"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
@@ -36,14 +36,14 @@ teardown() {
   run_success $OCKAM project enroll $web_ticket
   inlet_port="$(random_port)"
   run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Dashboard - Doesn't have the right attribute, so it should not be able to connect
   setup_home_dir
   run_success $OCKAM project enroll $dashboard_ticket
   inlet_port="$(random_port)"
   run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$inlet_port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 }
 
 @test "policies - inlet/outlet with resource type policies override" {
@@ -68,14 +68,14 @@ teardown() {
   run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
 
   # This will fail because the resource type policy is not satisfied
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$inlet_port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 
   # Update resource type policy and try again. Now the policy is satisfied
   export OCKAM_HOME=$DB_OCKAM_HOME
   run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "web")'
-  run_success curl --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Update the policy for the outlet and try again. It will fail because the local policy is not satisfied
   run_success $OCKAM policy create --resource outlet --expression '(= subject.component "NOT_web")'
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$inlet_port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -30,7 +30,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - create an inlet using only default arguments, an outlet, a relay in an orchestrator project and move tcp traffic through it" {
@@ -41,7 +41,7 @@ teardown() {
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
 
   addr=$($OCKAM tcp-inlet create --via $relay_name)
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 $addr
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 $addr
 }
 
 @test "portals - create an inlet (with implicit secure channel creation), an outlet, a relay in an orchestrator project and move tcp traffic through it" {
@@ -56,7 +56,7 @@ teardown() {
   run_success "$OCKAM" node create green
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - inlet/outlet example with credential, not provided" {
@@ -91,7 +91,7 @@ teardown() {
   run_success $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --via $relay_name
 
   # Green can't establish secure channel with blue, because it didn't exchange credential with it.
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$port"
 }
 
 @test "portals - inlet (with implicit secure channel creation) / outlet example with credential, not provided" {
@@ -123,7 +123,7 @@ teardown() {
 
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
   # Green can't establish secure channel with blue, because it isn't a member
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$port"
 }
 
 @test "portals - inlet/outlet example with credential" {
@@ -160,7 +160,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
               | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - inlet (with implicit secure channel creation) / outlet example with enrollment token" {
@@ -193,7 +193,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green \
     --from "127.0.0.1:$port" --via "$relay_name" --allow '(= subject.app "app1")'
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - local inlet and outlet passing through a relay, removing and re-creating the outlet" {
@@ -207,15 +207,15 @@ teardown() {
 
   run_success "$OCKAM" node create green
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port" --via "$relay_name"
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 
   $OCKAM node delete blue --yes
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:$port"
+  run_failure curl -sfI -m 3 "127.0.0.1:$port"
 
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - create an inlet/outlet pair, copy heavy payload" {
@@ -235,7 +235,7 @@ teardown() {
   run_success openssl rand -out "${OCKAM_HOME_BASE}/.tmp/payload" $((1024 * 1024 * 10))
 
   # write payload to file `payload.copy`
-  run_success curl --fail --max-time 60 "127.0.0.1:${port}/.tmp/payload" -o "${OCKAM_HOME}/payload.copy"
+  run_success curl -sf -m 60 "127.0.0.1:${port}/.tmp/payload" -o "${OCKAM_HOME}/payload.copy"
 
   # compare `payload` and `payload.copy`
   run_success cmp "${OCKAM_HOME_BASE}/.tmp/payload" "${OCKAM_HOME}/payload.copy"
@@ -263,13 +263,13 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:${inlet_port}" \
     --via "${relay_name}"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:${inlet_port}"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"
   status=$("$OCKAM" relay show "${relay_name}" --output json | jq .connection_status -r)
   assert_equal "$status" "Up"
 
   kill -QUIT $socat_pid
   sleep 1
-  run_failure curl --fail --head --max-time 3 "127.0.0.1:${inlet_port}"
+  run_failure curl -sfI -m 3 "127.0.0.1:${inlet_port}"
   sleep 40
   status=$("$OCKAM" relay show "${relay_name}" --output json | jq .connection_status -r)
   assert [ "$status" != "Up" ]
@@ -279,7 +279,7 @@ teardown() {
   socat_pid=$!
   sleep 2
 
-  run_success curl --fail --head --retry-all-errors --retry-delay 2 --retry 10 --max-time 30 "127.0.0.1:${inlet_port}"
+  run_success curl -sfI --retry-all-errors --retry-delay 2 --retry 10 -m 30 "127.0.0.1:${inlet_port}"
   status=$("$OCKAM" relay show "${relay_name}" --output json | jq .connection_status -r)
   assert_equal "$status" "Up"
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
@@ -30,7 +30,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
 
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "relay - control who can create/claim a relay" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/setup_suite.bash
@@ -6,7 +6,6 @@ setup_suite() {
 
   load ../load/base.bash
   load ../load/orchestrator.bash
-  exit_if_orchestrator_tests_not_enabled
 
   mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
@@ -22,7 +21,6 @@ setup_suite() {
 teardown_suite() {
   load ../load/base.bash
   load ../load/orchestrator.bash
-  exit_if_orchestrator_tests_not_enabled
 
   teardown_python_server
   rm -rf $OCKAM_HOME_BASE/.tmp

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
@@ -34,7 +34,7 @@ teardown() {
 
   # Client
   run_success $OCKAM tcp-inlet create --from "$inlet_port" --via "$relay_name"
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac
@@ -70,7 +70,7 @@ teardown() {
   $OCKAM node create edge_plane1 --identity edge_identity
   $OCKAM tcp-inlet create --at /node/edge_plane1 --from "127.0.0.1:$port_1" \
     --via "$relay_name" --allow '(= subject.component "control")'
-  run_success curl --fail --head --retry-connrefused --retry-delay 5 --retry 10 --max-time 5 "127.0.0.1:$port_1"
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port_1"
 
   ## The following is denied
   $OCKAM identity create x_identity
@@ -78,7 +78,7 @@ teardown() {
   $OCKAM node create x --identity x_identity
   $OCKAM tcp-inlet create --at /node/x --from "127.0.0.1:$port_2" \
     --via "$relay_name" --allow '(= subject.component "control")'
-  run curl --fail --head --max-time 5 "127.0.0.1:$port_2"
+  run curl -sfI -m 5 "127.0.0.1:$port_2"
   assert_failure 28 # timeout error
 }
 
@@ -90,10 +90,10 @@ teardown() {
   relay_name=$(random_str)
 
   # Ensure that telegraf works without using Ockam route
-  run_success curl \
-    --header "Authorization: Token $INFLUX_TOKEN" \
-    --header "Accept: application/csv" \
-    --header 'Content-type: application/vnd.flux' \
+  run_success curl -s \
+    -Ier "Authorization: Token $INFLUX_TOKEN" \
+    -Ier "Accept: application/csv" \
+    -Ier 'Content-type: application/vnd.flux' \
     --data "from(bucket:\"$INFLUX_BUCKET\") |> range(start:-1m)" \
     "http://localhost:$INFLUX_PORT/api/v2/query?org=$INFLUX_ORG"
 
@@ -123,10 +123,10 @@ teardown() {
   run_success start_telegraf_instance
 
   # Ensure that telegraf works with using Ockam route
-  run_success curl \
-    --header "Authorization: Token $INFLUX_TOKEN" \
-    --header "Accept: application/csv" \
-    --header 'Content-type: application/vnd.flux' \
+  run_success curl -s \
+    -Ier "Authorization: Token $INFLUX_TOKEN" \
+    -Ier "Accept: application/csv" \
+    -Ier 'Content-type: application/vnd.flux' \
     --data "from(bucket:\"$INFLUX_BUCKET\") |> range(start:-1m)" \
     "http://localhost:$INFLUX_PORT/api/v2/query?org=$INFLUX_ORG"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
+set -e
 
 rm -rf "$HOME/.bats-tests"
 mkdir -p "$HOME/.bats-tests"
 
 export BATS_TEST_RETRIES=2
 export BATS_TEST_TIMEOUT=240
+
 current_directory=$(dirname "$0")
 
 echo "Running local suite..."
 bats "$current_directory/local" --timing -j 8
+
+if [ -z "${ORCHESTRATOR_TESTS}" ]; then
+  exit 0
+fi
 
 echo "Running orchestrator suite..."
 bats "$current_directory/orchestrator" --timing

--- a/implementations/rust/ockam/ockam_command/tests/bats/serial/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/serial/setup_suite.bash
@@ -6,7 +6,6 @@ setup_suite() {
 
   load ../load/base.bash
   load ../load/orchestrator.bash
-  exit_if_orchestrator_tests_not_enabled
 
   mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
@@ -22,7 +21,6 @@ setup_suite() {
 teardown_suite() {
   load ../load/base.bash
   load ../load/orchestrator.bash
-  exit_if_orchestrator_tests_not_enabled
 
   teardown_python_server
   rm -rf $OCKAM_HOME_BASE/.tmp


### PR DESCRIPTION
It also uses the short version of some curl arguments:

- `-s`: silent, to omit output for errors and progress
- `-f`: same as `--fail`
- `-I`: same as `--head`