### PR TITLE
feat: user journey improvements

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
@@ -19,6 +19,8 @@ pub const TCP_INLET_CONNECTION_STATUS: &Key =
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum JourneyEvent {
     Enrolled,
+    IdentityCreated,
+    IdentityImported,
     NodeCreated,
     TcpInletCreated,
     TcpOutletCreated,
@@ -50,6 +52,8 @@ impl Display for JourneyEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             JourneyEvent::Enrolled => f.write_str("✅ enrolled"),
+            JourneyEvent::IdentityCreated => f.write_str("✅ identity created"),
+            JourneyEvent::IdentityImported => f.write_str("✅ identity imported"),
             JourneyEvent::NodeCreated => f.write_str("✅ node created"),
             JourneyEvent::TcpInletCreated => f.write_str("✅ tcp inlet created"),
             JourneyEvent::TcpOutletCreated => f.write_str("✅ tcp outlet created"),

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -43,6 +43,8 @@ pub const APPLICATION_EVENT_SPAN_ID: &Key = &Key::from_static_str("app.event.spa
 pub const APPLICATION_EVENT_TIMESTAMP: &Key = &Key::from_static_str("app.event.timestamp");
 pub const APPLICATION_EVENT_ERROR_MESSAGE: &Key = &Key::from_static_str("app.event.error_message");
 pub const APPLICATION_EVENT_COMMAND: &Key = &Key::from_static_str("app.event.command");
+pub const APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE: &Key =
+    &Key::from_static_str("app.event.command.configuration_file");
 pub const APPLICATION_EVENT_OCKAM_HOME: &Key = &Key::from_static_str("app.event.ockam_home");
 pub const APPLICATION_EVENT_OCKAM_VERSION: &Key = &Key::from_static_str("app.event.ockam_version");
 pub const APPLICATION_EVENT_OCKAM_GIT_HASH: &Key =

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -18,6 +18,8 @@ pub const USER_NAME: &Key = &Key::from_static_str("app.user_name");
 pub const USER_EMAIL: &Key = &Key::from_static_str("app.user_email");
 pub const APP_NAME: &Key = &Key::from_static_str("app.name");
 pub const NODE_NAME: &Key = &Key::from_static_str("app.node_name");
+pub const IDENTIFIER: &Key = &Key::from_static_str("app.identifier");
+pub const IDENTITY_NAME: &Key = &Key::from_static_str("app.identity_name");
 
 pub const APPLICATION_EVENT_HOST: &Key = &Key::from_static_str("app.event.host");
 pub const APPLICATION_EVENT_SPACE_ID: &Key = &Key::from_static_str("app.event.space.id");


### PR DESCRIPTION
This PR:

 - Adds a field with the contents of a configuration file to one of the spans when creating one or several nodes.
 - Adds an event showing when an identity has been successfully created or imported.

###  Implementation notes 

In terms of user experience for navigating a user journey it would be better to have an additional method for a given command returning "resolved options" (meaning command options where we potentially do a bit of work to get the content of a file). Then we could attach this info to the journey event corresponding to the command execution (around [here](https://github.com/build-trust/ockam/blob/develop/implementations/rust/ockam/ockam_command/src/command.rs#L120)).

@adrianbenavides since you are still working on this kind of code I preferred to avoid touching this area