### PR TITLE
feat(rust): support progress_bar in command notifications

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -80,13 +80,24 @@ impl CliState {
         self.database.set_node_name(node_name.as_ref());
     }
 
-    pub fn subscribe(&self) -> Receiver<Notification> {
+    pub fn subscribe_to_notifications(&self) -> Receiver<Notification> {
         self.notifications.subscribe()
     }
 
-    // 00: make the notification arg a ref
-    pub fn notify(&self, notification: Notification) {
-        info!(notification);
+    pub fn notify_message(&self, message: impl Into<String>) {
+        self.notify(Notification::message(message));
+    }
+
+    pub fn notify_progress_set(&self, message: impl Into<String>) {
+        self.notify(Notification::progress_set(message));
+    }
+
+    pub fn notify_progress_finish(&self, message: impl Into<Option<String>>) {
+        self.notify(Notification::progress_finish(message));
+    }
+
+    fn notify(&self, notification: Notification) {
+        debug!("{:?}", notification.contents());
         let _ = self.notifications.send(notification);
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities.rs
@@ -7,6 +7,7 @@ use ockam_vault::{HandleToSecret, SigningSecretKeyHandle};
 
 use crate::cli_state::{random_name, CliState, Result};
 use crate::colors::color_primary;
+use crate::{fmt_log, fmt_ok};
 
 /// The methods below allow the creation named identities.
 /// A NamedIdentity is an identity that is associated to a name in order to be more easily
@@ -246,22 +247,22 @@ impl CliState {
             Some(named_identity) => Ok(named_identity),
             // Create a new default identity.
             None => {
-                let message =
-                    "There is no default Identity on this machine, generating one...\n".to_string();
-                self.notify(message.clone());
+                self.notify_message(fmt_log!(
+                    "There is no default Identity on this machine, generating one...\n"
+                ));
 
                 let named_identity = self.create_identity_with_name(&random_name()).await?;
 
-                self.notify(format!(
+                self.notify_message(fmt_ok!(
                     "Generated a new Identity named {}.",
                     color_primary(named_identity.name())
                 ));
-                self.notify(format!(
+                self.notify_message(fmt_log!(
                     "{} has Identifier {}",
                     color_primary(named_identity.name()),
                     color_primary(named_identity.identifier().to_string())
                 ));
-                self.notify(format!(
+                self.notify_message(fmt_ok!(
                     "Marked {} as your default Identity, {}.\n",
                     color_primary(named_identity.name()),
                     "on this machine".dim()

--- a/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/vaults.rs
@@ -12,6 +12,7 @@ use ockam_vault_aws::AwsSigningVault;
 
 use crate::cli_state::{random_name, CliState, CliStateError, Result};
 use crate::output::Output;
+use crate::{fmt_log, fmt_ok};
 
 static DEFAULT_VAULT_NAME: &str = "default";
 
@@ -148,18 +149,21 @@ impl CliState {
             return Ok(existing_vault);
         }
 
-        self.notify("We need a Vault to store Identity secrets.".to_string());
-        self.notify("There is no default Vault on this machine, creating one...".to_string());
+        self.notify_message(fmt_log!("We need a Vault to store Identity secrets."));
+        self.notify_message(fmt_log!(
+            "There is no default Vault on this machine, creating one..."
+        ));
         let named_vault = self
             .create_a_vault(&Some(vault_name.to_string()), &None, false)
             .await?;
-        self.notify("Created a new Vault on your disk.".to_string());
+        self.notify_message(fmt_ok!("Created a new Vault on your disk."));
         if is_default {
-            self.notify(format!(
+            self.notify_message(fmt_ok!(
                 "Marked this new vault as your default Vault, {}.\n",
                 "on this machine".dim()
             ));
         }
+
         Ok(named_vault)
     }
 

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
@@ -356,8 +356,12 @@ impl<W: TerminalWriter + Debug> Terminal<W, ToStdOut> {
 
 // Extensions
 impl<W: TerminalWriter + Debug> Terminal<W> {
+    pub fn can_use_progress_spinner(&self) -> bool {
+        !self.quiet && self.stderr.is_tty()
+    }
+
     pub fn progress_spinner(&self) -> Option<ProgressBar> {
-        if self.quiet || !self.stderr.is_tty() {
+        if !self.can_use_progress_spinner() {
             return None;
         }
         let ticker = [

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
@@ -9,12 +9,36 @@ use tokio::select;
 use tokio::sync::broadcast::Receiver;
 use tokio::time::sleep;
 
-use tracing::info;
-
 const REPORTING_CHANNEL_POLL_DELAY: Duration = Duration::from_millis(100);
-const REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY: Duration = Duration::from_millis(1_000);
 
-pub type Notification = String;
+#[derive(Debug, Clone, PartialEq)]
+pub enum Notification {
+    Message(String),
+    ProgressSet(String),
+    ProgressFinish(Option<String>),
+}
+
+impl Notification {
+    pub fn contents(&self) -> Option<&str> {
+        match self {
+            Notification::Message(contents) => Some(contents),
+            Notification::ProgressSet(contents) => Some(contents),
+            Notification::ProgressFinish(contents) => contents.as_deref(),
+        }
+    }
+
+    pub fn message(contents: impl Into<String>) -> Self {
+        Self::Message(contents.into())
+    }
+
+    pub fn progress_set(contents: impl Into<String>) -> Self {
+        Self::ProgressSet(contents.into())
+    }
+
+    pub fn progress_finish(contents: impl Into<Option<String>>) -> Self {
+        Self::ProgressFinish(contents.into())
+    }
+}
 
 pub struct NotificationHandle {
     stop: Arc<Mutex<bool>>,
@@ -32,8 +56,6 @@ impl Drop for NotificationHandle {
 pub struct NotificationHandler<T: TerminalWriter + Debug + Send + 'static> {
     /// Channel to receive notifications
     rx: Receiver<Notification>,
-    /// List of all received notifications
-    notifications: Vec<Notification>,
     /// If there is a progress bar, it is used to display messages as they arrive with a spinner
     /// and all the notifications are also displayed at the end with the terminal
     progress_bar: Option<ProgressBar>,
@@ -49,8 +71,7 @@ impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
     pub fn start(cli_state: &CliState, terminal: Terminal<T>) -> NotificationHandle {
         let stop = Arc::new(Mutex::new(false));
         let _self = NotificationHandler {
-            rx: cli_state.subscribe(),
-            notifications: vec![],
+            rx: cli_state.subscribe_to_notifications(),
             terminal: terminal.clone(),
             progress_bar: None,
             stop: stop.clone(),
@@ -58,41 +79,23 @@ impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
         _self.run();
         NotificationHandle { stop }
     }
-}
 
-impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
     pub fn run(mut self) {
         tokio::spawn(async move {
             loop {
                 select! {
                     _ = sleep(REPORTING_CHANNEL_POLL_DELAY) => {
                         if *self.stop.lock().unwrap() {
-                            self.finalize();
                             break;
                         }
                     }
                     notification = self.rx.recv() => {
-                        match notification {
-                            Ok(notification) => {
-                                // If the progress bar is available, display the message and save it
-                                // for later display
-                                match self.progress_bar.as_ref() {
-                                    Some(progress_bar) => {
-                                        self.notifications.push(notification.clone());
-                                        // Fabricate a delay for a better UX, so the user has a chance to read the message.
-                                        progress_bar.set_message(notification);
-                                        let _ = sleep(REPORTING_CHANNEL_MESSAGE_DISPLAY_DELAY).await;
-                                    },
-                                    None => {
-                                        let _ = self.terminal.write_line(fmt_log!("{}", notification));
-                                    }
-                                };
-                            }
-                            // Unknown problem with the channel.
-                            _ => {
-                                self.finalize();
-                                break;
-                            }
+                        if let Ok(notification) = notification {
+                            self.handle_notification(notification).await;
+                        }
+                        // The channel was closed
+                        else {
+                            break;
                         }
                     }
                 }
@@ -100,21 +103,35 @@ impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
         });
     }
 
-    /// Finalize the notifications by displaying/logging them
-    fn finalize(&self) {
-        // If a progress bar was, then display the received notifications to user as a summary of
-        // what was done. If there was no progress bar, then all the notifications have already been
-        // printed out on the terminal
-        if let Some(progress_bar) = &self.progress_bar {
-            self.notifications.iter().for_each(|msg| {
-                let _ = self.terminal.write_line(fmt_log!("{}", msg));
-            });
-            progress_bar.finish_and_clear();
+    async fn handle_notification(&mut self, notification: Notification) {
+        match notification {
+            Notification::Message(contents) => {
+                let _ = self.terminal.write_line(contents);
+            }
+            Notification::ProgressSet(contents) => {
+                if self.terminal.can_use_progress_spinner() {
+                    if self.progress_bar.is_none() {
+                        self.progress_bar = self.terminal.progress_spinner();
+                    }
+                    if let Some(pb) = self.progress_bar.as_ref() {
+                        pb.set_message(contents);
+                    }
+                }
+                // If the progress bar can't be used (non-tty), handle as a regular message
+                else {
+                    // Since progress bar messages are not formatted, apply the log formatting here
+                    let _ = self.terminal.write_line(fmt_log!("{}", contents));
+                }
+            }
+            Notification::ProgressFinish(contents) => {
+                if let Some(pb) = self.progress_bar.take() {
+                    if let Some(contents) = contents {
+                        pb.finish_with_message(contents);
+                    } else {
+                        pb.finish_and_clear();
+                    }
+                }
+            }
         }
-
-        // Additionally log all the notifications for later debugging if necessary
-        self.notifications.iter().for_each(|msg| {
-            info!(msg);
-        });
     }
 }


### PR DESCRIPTION
It also fixes the messages formatting generated when creating the default identity and vault.