### PR TITLE
feat(rust): make the api for creating outlets more flexible

### DIFF
--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -14,7 +14,6 @@ use ockam_api::nodes::NodeManager;
 use ockam_api::{multiaddr_to_route, multiaddr_to_transport_route};
 use ockam_core::AsyncTryClone;
 use ockam_multiaddr::MultiAddr;
-use ockam_transport_tcp::HostnamePort;
 
 /// This node supports a "control" server on which several "edge" devices can connect
 ///
@@ -107,7 +106,7 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 4. create a tcp outlet with the above policy
     tcp.create_outlet(
         "outlet",
-        HostnamePort::new("127.0.0.1", 5000),
+        "127.0.0.1:5000",
         TcpOutletOptions::new()
             .with_incoming_access_control_impl(incoming_access_control)
             .with_outgoing_access_control_impl(outgoing_access_control),

--- a/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/01-inlet-outlet.rs
@@ -1,6 +1,4 @@
 use ockam::{node, route, Context, Result, TcpInletOptions, TcpOutletOptions, TcpTransportExtension};
-use ockam_transport_tcp::HostnamePort;
-use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -25,12 +23,8 @@ async fn main(ctx: Context) -> Result<()> {
     //    a previous message from the Inlet.
 
     let outlet_target = std::env::args().nth(2).expect("no outlet target given");
-    tcp.create_outlet(
-        "outlet",
-        HostnamePort::from_str(&outlet_target)?,
-        TcpOutletOptions::new(),
-    )
-    .await?;
+    tcp.create_outlet("outlet", outlet_target, TcpOutletOptions::new())
+        .await?;
 
     // Expect first command line argument to be the TCP address on which to start an Inlet
     // For example: 127.0.0.1:4001

--- a/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/02-outlet.rs
@@ -1,6 +1,4 @@
 use ockam::{node, Context, Result, TcpListenerOptions, TcpOutletOptions, TcpTransportExtension};
-use ockam_transport_tcp::HostnamePort;
-use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -29,7 +27,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        HostnamePort::from_str(&outlet_target)?,
+        outlet_target,
         TcpOutletOptions::new().as_consumer(&tcp_listener_options.spawner_flow_control_id()),
     )
     .await?;

--- a/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/03-outlet.rs
@@ -1,7 +1,5 @@
 use ockam::identity::SecureChannelListenerOptions;
 use ockam::{node, Context, Result, TcpListenerOptions, TcpOutletOptions, TcpTransportExtension};
-use ockam_transport_tcp::HostnamePort;
-use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -42,7 +40,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        HostnamePort::from_str(&outlet_target)?,
+        outlet_target,
         TcpOutletOptions::new().as_consumer(&secure_channel_flow_control_id),
     )
     .await?;

--- a/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
+++ b/examples/rust/tcp_inlet_and_outlet/examples/04-outlet.rs
@@ -1,8 +1,6 @@
 use ockam::identity::SecureChannelListenerOptions;
 use ockam::remote::RemoteRelayOptions;
 use ockam::{node, Context, Result, TcpConnectionOptions, TcpOutletOptions, TcpTransportExtension};
-use ockam_transport_tcp::HostnamePort;
-use std::str::FromStr;
 
 #[ockam::node]
 async fn main(ctx: Context) -> Result<()> {
@@ -39,7 +37,7 @@ async fn main(ctx: Context) -> Result<()> {
     let outlet_target = std::env::args().nth(1).expect("no outlet target given");
     tcp.create_outlet(
         "outlet",
-        HostnamePort::from_str(&outlet_target)?,
+        outlet_target,
         TcpOutletOptions::new().as_consumer(&secure_channel_flow_control_id),
     )
     .await?;

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -37,7 +37,7 @@ mod test {
     use ockam_multiaddr::proto::Service;
     use ockam_multiaddr::MultiAddr;
     use ockam_node::compat::tokio;
-    use ockam_transport_tcp::{HostnamePort, TcpInletOptions, TcpOutletOptions};
+    use ockam_transport_tcp::{TcpInletOptions, TcpOutletOptions};
 
     use crate::hop::Hop;
     use crate::kafka::protocol_aware::utils::{encode_request, encode_response};
@@ -147,7 +147,7 @@ mod test {
                 .tcp
                 .create_outlet(
                     "kafka_consumer_outlet",
-                    HostnamePort::new("127.0.0.1", consumer_mock_kafka.port),
+                    format!("127.0.0.1:{}", consumer_mock_kafka.port),
                     TcpOutletOptions::new(),
                 )
                 .await?;
@@ -167,7 +167,7 @@ mod test {
             .tcp
             .create_outlet(
                 "kafka_producer_outlet",
-                HostnamePort::new("127.0.0.1", producer_mock_kafka.port),
+                format!("127.0.0.1:{}", producer_mock_kafka.port),
                 TcpOutletOptions::new(),
             )
             .await?;
@@ -205,7 +205,7 @@ mod test {
             .tcp
             .create_outlet(
                 "kafka_consumer_outlet",
-                HostnamePort::new("127.0.0.1", consumer_mock_kafka.port),
+                format!("127.0.0.1:{}", consumer_mock_kafka.port),
                 TcpOutletOptions::new(),
             )
             .await?;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/hostname_port.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/hostname_port.rs
@@ -44,6 +44,22 @@ impl HostnamePort {
     }
 }
 
+impl TryFrom<String> for HostnamePort {
+    type Error = ockam_core::Error;
+
+    fn try_from(value: String) -> ockam_core::Result<Self> {
+        FromStr::from_str(value.as_str())
+    }
+}
+
+impl TryFrom<&str> for HostnamePort {
+    type Error = ockam_core::Error;
+
+    fn try_from(value: &str) -> ockam_core::Result<Self> {
+        FromStr::from_str(value)
+    }
+}
+
 impl FromStr for HostnamePort {
     type Err = ockam_core::Error;
 

--- a/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/tests/portal.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -8,8 +7,7 @@ use ockam_core::compat::rand::random;
 use ockam_core::{route, Result};
 use ockam_node::Context;
 use ockam_transport_tcp::{
-    HostnamePort, TcpConnectionOptions, TcpInletOptions, TcpListenerOptions, TcpOutletOptions,
-    TcpTransport,
+    TcpConnectionOptions, TcpInletOptions, TcpListenerOptions, TcpOutletOptions, TcpTransport,
 };
 
 const LENGTH: usize = 32;
@@ -20,9 +18,7 @@ async fn setup(ctx: &Context) -> Result<(String, TcpListener)> {
     let listener = {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let bind_address = listener.local_addr().unwrap().to_string();
-        let hostname_port = HostnamePort::from_str(&bind_address)?;
-
-        tcp.create_outlet("outlet", hostname_port, TcpOutletOptions::new())
+        tcp.create_outlet("outlet", bind_address, TcpOutletOptions::new())
             .await?;
         listener
     };
@@ -140,7 +136,7 @@ async fn portal__tcp_connection__should_succeed(ctx: &mut Context) -> Result<()>
     let bind_address = listener.local_addr().unwrap().to_string();
     tcp.create_outlet(
         "outlet",
-        HostnamePort::from_str(&bind_address)?,
+        bind_address,
         TcpOutletOptions::new().as_consumer(&outlet_flow_control_id),
     )
     .await?;
@@ -193,12 +189,8 @@ async fn portal__tcp_connection_with_invalid_message_flow__should_not_succeed(
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let bind_address = listener.local_addr().unwrap().to_string();
 
-    tcp.create_outlet(
-        "outlet_invalid",
-        HostnamePort::from_str(&bind_address)?,
-        TcpOutletOptions::new(),
-    )
-    .await?;
+    tcp.create_outlet("outlet_invalid", bind_address, TcpOutletOptions::new())
+        .await?;
 
     let (inlet_socket_addr, _) = tcp
         .create_inlet(


### PR DESCRIPTION
This PR puts back the possibility to create a TCP outlet with just a string, after the recent merge supporting TLS for outlets.