### PR TITLE
tests(rust): simplify local bats tests by removing unnecessary random variables

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/README.md
+++ b/implementations/rust/ockam/ockam_command/tests/bats/README.md
@@ -17,6 +17,12 @@ Linux:
 npm install -g bats bats-support bats-assert
 ```
 
+Additionally, you need to install the `uploadserver` python package:
+
+```bash
+pip install uploadserver
+```
+
 ### How to format the tests scripts
 
 We use the `shfmt` tool, which can be download from https://github.com/mvdan/sh.

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -24,6 +24,7 @@ if [ ! -d "$OCKAM_HOME_BASE" ]; then
   echo "Ockam CLI directory $OCKAM_HOME_BASE does not exist. Creating..." >&3
   mkdir -p "$OCKAM_HOME_BASE"
 fi
+mkdir -p "$OCKAM_HOME_BASE/.tmp"
 
 if [[ -z $BATS_LIB ]]; then
   export BATS_LIB=$(brew --prefix)/lib # macos

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -15,11 +15,10 @@ teardown() {
 # ===== TESTS
 
 @test "authority - an authority node must be shown as UP even if its tcp listener cannot be accessed" {
-  port="$(random_port)"
-
   run_success "$OCKAM" identity create authority
   authority_identity_full=$($OCKAM identity show --full --encoding hex authority)
   trusted="{}"
+  port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   run_success "$OCKAM" node show authority
   assert_output --partial "\"is_up\": true"
@@ -27,7 +26,6 @@ teardown() {
 
 @test "authority - an authority identity is created by default for the authority node" {
   port="$(random_port)"
-
   trusted="{}"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   run_success "$OCKAM" identity show authority
@@ -35,15 +33,12 @@ teardown() {
 
 @test "authority - an authority identity is created by default for the authority node - with a given name" {
   port="$(random_port)"
-
   trusted="{}"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --identity ockam
   run_success "$OCKAM" identity show ockam
 }
 
 @test "authority - standalone authority, admin, enrollers, members" {
-  port="$(random_port)"
-
   run "$OCKAM" identity create authority
 
   # Authority will trust project-admin credentials issued by this other identity (Account Authority)
@@ -75,6 +70,7 @@ teardown() {
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   trusted="{\"$m1_identifier\": {\"sample_attr\": \"sample_val\"} }"
+  port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full --enforce-admin-checks
   sleep 2 # wait for authority to start TCP listener
 
@@ -139,8 +135,6 @@ EOF
 }
 
 @test "authority - enrollment ticket ttl" {
-  port="$(random_port)"
-
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller
   #m3 will be added through enrollment token
@@ -151,6 +145,7 @@ EOF
 
   # Start the authority node.
   trusted="{\"$enroller_identifier\": {\"ockam-role\": \"enroller\"}}"
+  port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   sleep 1 # wait for authority to start TCP listener
 
@@ -187,8 +182,6 @@ EOF
 }
 
 @test "authority - legacy enrollers as admins" {
-  port="$(random_port)"
-
   run "$OCKAM" identity create authority
 
   # Authority will trust project-admin credentials issued by this other identity (Account Authority)
@@ -210,6 +203,7 @@ EOF
   trusted="{\"$m1_identifier\": {\"ockam-role\": \"enroller\", \"sample_attr\": \"sample_val\"} }"
 
   # Authority in legacy mode, with enrollers as admins
+  port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted" --no-direct-authentication --account-authority $account_authority_full
   sleep 2 # wait for authority to start TCP listener
 
@@ -245,8 +239,6 @@ EOF
 }
 
 @test "local authority - test api commands" {
-  port="$(random_port)"
-
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller
 
@@ -260,6 +252,7 @@ EOF
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
   # For the first test we start the node with no direct authentication service nor token enrollment
   trusted="{\"$enroller_identifier\": {\"ockam-role\": \"enroller\"}}"
+  port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
   sleep 1 # wait for authority to start TCP listener
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -17,229 +17,194 @@ teardown() {
 @test "nodes" {
   run_success "$OCKAM" node create
 
-  n1="$(random_str)"
-  n2="$(random_str)"
-  run_success "$OCKAM" node create "$n1"
-  run_success "$OCKAM" node create "$n2" --verbose
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2 --verbose
 
   run_success "$OCKAM" node list
-  assert_output --partial "\"node_name\": \"$n1\""
+  assert_output --partial "\"node_name\": \"n1\""
   assert_output --partial "\"status\": \"running\""
 
-  run_success "$OCKAM" node stop "$n1"
-  assert_output --partial "Node with name $n1 was stopped"
+  run_success "$OCKAM" node stop n1
+  assert_output --partial "Node with name n1 was stopped"
 
-  run_success "$OCKAM" node start "$n1"
+  run_success "$OCKAM" node start n1
 
-  run "$OCKAM" node delete "$n1" --yes
+  run "$OCKAM" node delete n1 --yes
   run "$OCKAM" node delete --all --yes
 }
 
 @test "workers and services" {
-  n1="$(random_str)"
-  run_success "$OCKAM" node create "$n1"
-  run_success "$OCKAM" worker list --at "$n1"
-  run_success "$OCKAM" message send hello --to "/node/$n1/service/uppercase"
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" worker list --at n1
+  run_success "$OCKAM" message send hello --to "/node/n1/service/uppercase"
   assert_output "HELLO"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/routing
 @test "routing" {
-  n1="$(random_str)"
+  run_success "$OCKAM" node create n1
 
-  run_success "$OCKAM" node create "$n1"
-
-  run_success "$OCKAM" message send 'Hello Ockam!' --to "/node/$n1/service/echo"
+  run_success "$OCKAM" message send 'Hello Ockam!' --to "/node/n1/service/echo"
   assert_output "Hello Ockam!"
 
   run_success "$OCKAM" service start hop --addr h1
-  run_success "$OCKAM" message send hello --to "/node/$n1/service/h1/service/echo"
+  run_success "$OCKAM" message send hello --to "/node/n1/service/h1/service/echo"
   assert_output "hello"
 
   run_success "$OCKAM" service start hop --addr h2
 
-  run_success "$OCKAM" message send hello --to "/node/$n1/service/h1/service/h2/service/echo"
+  run_success "$OCKAM" message send hello --to "/node/n1/service/h1/service/h2/service/echo"
   assert_output "hello"
 }
 
 @test "transports" {
-  n1="$(random_str)"
-  n2="$(random_str)"
   n2_port="$(random_port)"
-  n3="$(random_str)"
   n3_port="$(random_port)"
 
-  run_success "$OCKAM" node create "$n1"
-  run_success "$OCKAM" node create "$n2" --tcp-listener-address="127.0.0.1:$n2_port"
-  run_success "$OCKAM" node create "$n3" --tcp-listener-address="127.0.0.1:$n3_port"
-  run_success "$OCKAM" service start hop --at "$n2"
+  run_success "$OCKAM" node create n1
+  run_success "$OCKAM" node create n2 --tcp-listener-address="127.0.0.1:$n2_port"
+  run_success "$OCKAM" node create n3 --tcp-listener-address="127.0.0.1:$n3_port"
+  run_success "$OCKAM" service start hop --at n2
 
-  n1_id=$("$OCKAM" tcp-connection create --from "$n1" --to "127.0.0.1:$n2_port" | grep -o "[0-9a-f]\{32\}" | head -1)
-  n2_id=$("$OCKAM" tcp-connection create --from "$n2" --to "127.0.0.1:$n3_port" | grep -o "[0-9a-f]\{32\}" | head -1)
+  n1_id=$("$OCKAM" tcp-connection create --from n1 --to "127.0.0.1:$n2_port" | grep -o "[0-9a-f]\{32\}" | head -1)
+  n2_id=$("$OCKAM" tcp-connection create --from n2 --to "127.0.0.1:$n3_port" | grep -o "[0-9a-f]\{32\}" | head -1)
 
-  run_success "$OCKAM" message send hello --from "$n1" --to /worker/${n1_id}/service/hop/worker/${n2_id}/service/uppercase
+  run_success "$OCKAM" message send hello --from n1 --to /worker/${n1_id}/service/hop/worker/${n2_id}/service/uppercase
   assert_output "HELLO"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/advanced-routing
 @test "relays and portals" {
-  n1="$(random_str)"
-  n2="$(random_str)"
   n2_port="$(random_port)"
-  n3="$(random_str)"
   inlet_port="$(random_port)"
 
-  run_success "$OCKAM" node create "$n2" --tcp-listener-address="127.0.0.1:$n2_port"
-  run_success "$OCKAM" node create "$n3"
-  run_success "$OCKAM" service start hop --at "$n3"
+  run_success "$OCKAM" node create n2 --tcp-listener-address="127.0.0.1:$n2_port"
+  run_success "$OCKAM" node create n3
+  run_success "$OCKAM" service start hop --at n3
 
-  run_success "$OCKAM" relay create "$n3" --at "/node/$n2" --to "/node/$n3"
-  run_success "$OCKAM" node create "$n1"
+  run_success "$OCKAM" relay create n3 --at "/node/n2" --to "/node/n3"
+  run_success "$OCKAM" node create n1
 
-  n1_id=$("$OCKAM" tcp-connection create --from "$n1" --to "127.0.0.1:$n2_port" | grep -o "[0-9a-f]\{32\}" | head -1)
+  n1_id=$("$OCKAM" tcp-connection create --from n1 --to "127.0.0.1:$n2_port" | grep -o "[0-9a-f]\{32\}" | head -1)
 
-  run_success "$OCKAM" message send hello --from "$n1" --to "/worker/${n1_id}/service/forward_to_$n3/service/uppercase"
+  run_success "$OCKAM" message send hello --from n1 --to "/worker/${n1_id}/service/forward_to_n3/service/uppercase"
   assert_output "HELLO"
 
-  run_success "$OCKAM" tcp-outlet create --at "$n3" --to "127.0.0.1:$PYTHON_SERVER_PORT"
-  run_success "$OCKAM" tcp-inlet create --at "$n1" --from "127.0.0.1:$inlet_port" --to "/worker/${n1_id}/service/forward_to_$n3/service/hop/service/outlet"
+  run_success "$OCKAM" tcp-outlet create --at n3 --to "$PYTHON_SERVER_PORT"
+  run_success "$OCKAM" tcp-inlet create --at n1 --from "$inlet_port" --to "/worker/${n1_id}/service/forward_to_n3/service/hop/service/outlet"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/routing
 @test "vaults and identities" {
-  v1="$(random_str)"
-  i1="$(random_str)"
-  run_success "$OCKAM" vault create "$v1"
-  run_success "$OCKAM" identity create "$i1" --vault "$v1"
-  run_success "$OCKAM" identity show "$i1"
-  run_success "$OCKAM" identity show "$i1" --full
+  run_success "$OCKAM" vault create v1
+  run_success "$OCKAM" identity create i1 --vault v1
+  run_success "$OCKAM" identity show i1
+  run_success "$OCKAM" identity show i1 --full
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/secure-channels
 @test "identifiers" {
-  a="$(random_str)"
-  b="$(random_str)"
+  run_success "$OCKAM" node create a
+  run_success "$OCKAM" node create b
 
-  run_success "$OCKAM" node create "$a"
-  run_success "$OCKAM" node create "$b"
+  id=$("$OCKAM" secure-channel create --from a --to /node/b/service/api | grep -o "[0-9a-f]\{32\}" | head -1)
 
-  id=$("$OCKAM" secure-channel create --from "$a" --to "/node/$b/service/api" | grep -o "[0-9a-f]\{32\}" | head -1)
-
-  run_success "$OCKAM" message send hello --from "$a" --to /service/${id}/service/uppercase
+  run_success "$OCKAM" message send hello --from a --to "/service/${id}/service/uppercase"
   assert_output "HELLO"
 
-  "$OCKAM" secure-channel create --from "$a" --to "/node/$b/service/api" |
-    "$OCKAM" message send hello --from "$a" --to -/service/uppercase
+  "$OCKAM" secure-channel create --from a --to /node/b/service/api |
+    "$OCKAM" message send hello --from a --to -/service/uppercase
 
-  run_success bash -c "$OCKAM secure-channel create --from $a --to /node/$b/service/api |
-    $OCKAM message send hello --from $a --to -/service/uppercase"
+  run_success bash -c "$OCKAM secure-channel create --from a --to /node/b/service/api |
+    $OCKAM message send hello --from a --to -/service/uppercase"
   assert_output "HELLO"
 
 }
 
 @test "through relays" {
   relay="$(random_str)"
-  a="$(random_str)"
-  b="$(random_str)"
   port="$(random_port)"
 
   run_success "$OCKAM" node create "$relay" --tcp-listener-address="127.0.0.1:$port"
-  run_success "$OCKAM" node create "$b"
-  run_success "$OCKAM" relay create "$b" --at "/node/$relay" --to "$b"
-  run_success "$OCKAM" node create "$a"
+  run_success "$OCKAM" node create b
+  run_success "$OCKAM" relay create b --at "/node/$relay" --to b
+  run_success "$OCKAM" node create a
 
-  worker_id=$("$OCKAM" tcp-connection create --from "$a" --to "127.0.0.1:$port" | grep -o "[0-9a-f]\{32\}" | head -1)
+  worker_id=$("$OCKAM" tcp-connection create --from a --to "127.0.0.1:$port" | grep -o "[0-9a-f]\{32\}" | head -1)
 
-  run_success bash -c "$OCKAM secure-channel create --from $a --to /worker/${worker_id}/service/forward_to_$b/service/api |
-    $OCKAM message send hello --from $a --to -/service/uppercase"
+  run_success bash -c "$OCKAM secure-channel create --from a --to /worker/${worker_id}/service/forward_to_b/service/api |
+    $OCKAM message send hello --from a --to -/service/uppercase"
   assert_output "HELLO"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/credentials
 @test "issuing credentials" {
-  a="$(random_str)"
-  b="$(random_str)"
+  run_success "$OCKAM" identity create a
+  run_success "$OCKAM" identity create b
 
-  run_success "$OCKAM" identity create "$a"
-  run_success "$OCKAM" identity create "$b"
+  id=$("$OCKAM" identity show b)
 
-  id=$("$OCKAM" identity show "$b")
-
-  run_success "$OCKAM" credential issue --as "$a" --for ${id}
-  run_success "$OCKAM" credential issue --as "$a" --for ${id} --attribute location=Chicago --attribute department=Operations
+  run_success "$OCKAM" credential issue --as a --for ${id}
+  run_success "$OCKAM" credential issue --as a --for ${id} --attribute location=Chicago --attribute department=Operations
 }
 
 @test "verifying - storing credentials" {
-  a="$(random_str)"
-  b="$(random_str)"
+  run_success "$OCKAM" identity create a
+  run_success "$OCKAM" identity create b
 
-  run_success "$OCKAM" identity create "$a"
-  run_success "$OCKAM" identity create "$b"
+  id_a=$("$OCKAM" identity show a --full --encoding hex)
+  id_a_short=$("$OCKAM" identity show a)
+  id_b_short=$("$OCKAM" identity show b)
 
-  id_a=$("$OCKAM" identity show "$a" --full --encoding hex)
-  id_a_short=$("$OCKAM" identity show "$a")
-  id_b_short=$("$OCKAM" identity show "$b")
-
-  "$OCKAM" credential issue --as "$a" --for ${id_b_short} --encoding hex >/${BATS_TEST_TMPDIR}/b.credential
+  "$OCKAM" credential issue --as a --for ${id_b_short} --encoding hex >/${BATS_TEST_TMPDIR}/b.credential
 
   run_success "$OCKAM" credential verify --issuer ${id_a_short} --credential-path /${BATS_TEST_TMPDIR}/b.credential
 }
 
 @test "trust anchors" {
-  n1="$(random_str)"
-  n2="$(random_str)"
-  i1="$(random_str)"
-  i2="$(random_str)"
+  run_success "$OCKAM" identity create i1
 
-  run_success "$OCKAM" identity create "$i1"
+  "$OCKAM" identity show i1 >/${BATS_TEST_TMPDIR}/i1.identifier
 
-  "$OCKAM" identity show "$i1" >/${BATS_TEST_TMPDIR}/i1.identifier
+  run_success "$OCKAM" node create n1 --identity i1
+  run_success "$OCKAM" identity create i2
 
-  run_success "$OCKAM" node create "$n1" --identity "$i1"
-  run_success "$OCKAM" identity create "$i2"
+  "$OCKAM" identity show i2 >/${BATS_TEST_TMPDIR}/i2.identifier
 
-  "$OCKAM" identity show "$i2" >/${BATS_TEST_TMPDIR}/i2.identifier
-
-  run_success "$OCKAM" node create "$n2" --identity "$i2"
-  run_success "$OCKAM" secure-channel-listener create l --at "$n2" \
-    --identity "$i2" --authorized $(cat /${BATS_TEST_TMPDIR}/i1.identifier)
+  run_success "$OCKAM" node create n2 --identity i2
+  run_success "$OCKAM" secure-channel-listener create l --at n2 \
+    --identity i2 --authorized $(cat /${BATS_TEST_TMPDIR}/i1.identifier)
 
   run_success bash -c "$OCKAM secure-channel create \
-    --from $n1 --to /node/$n2/service/l \
-    --identity $i1 --authorized $(cat /${BATS_TEST_TMPDIR}/i2.identifier) |
-    $OCKAM message send hello --from $n1 --to -/service/uppercase"
+    --from n1 --to /node/n2/service/l \
+    --identity i1 --authorized $(cat /${BATS_TEST_TMPDIR}/i2.identifier) |
+    $OCKAM message send hello --from n1 --to -/service/uppercase"
   assert_output "HELLO"
 }
 
 @test "anchoring trust in a credential issuer" {
-  n1="$(random_str)"
-  n2="$(random_str)"
-  i1="$(random_str)"
-  i2="$(random_str)"
-  authority="$(random_str)"
+  run_success "$OCKAM" identity create authority
+  AUTHORITY_IDENTIFIER=$("$OCKAM" identity show authority)
+  AUTHORITY_IDENTITY=$("$OCKAM" identity show authority --full --encoding hex)
 
-  run_success "$OCKAM" identity create "$authority"
-  AUTHORITY_IDENTIFIER=$("$OCKAM" identity show "$authority")
-  AUTHORITY_IDENTITY=$("$OCKAM" identity show "$authority" --full --encoding hex)
-
-  run_success "$OCKAM" identity create "$i1"
-  run_success "$OCKAM" identity create "$i2"
-  I1_IDENTIFIER=$("$OCKAM" identity show "$i1")
-  I1_CREDENTIAL=$("$OCKAM" credential issue --as "$authority" \
+  run_success "$OCKAM" identity create i1
+  run_success "$OCKAM" identity create i2
+  I1_IDENTIFIER=$("$OCKAM" identity show i1)
+  I1_CREDENTIAL=$("$OCKAM" credential issue --as authority \
     --for "$I1_IDENTIFIER" --attribute city="New York" \
     --encoding hex)
 
-  run_success "$OCKAM" node create "$n1" --identity "$i1" --authority-identity "$AUTHORITY_IDENTITY" --credential-scope "test"
-  run_success "$OCKAM" node create "$n2" --identity "$i2" --authority-identity "$AUTHORITY_IDENTITY"
+  run_success "$OCKAM" node create n1 --identity i1 --authority-identity "$AUTHORITY_IDENTITY" --credential-scope "test"
+  run_success "$OCKAM" node create n2 --identity i2 --authority-identity "$AUTHORITY_IDENTITY"
 
-  run_success "$OCKAM" credential store --issuer "$AUTHORITY_IDENTIFIER" --credential "$I1_CREDENTIAL" --at "$n1" --scope "test"
+  run_success "$OCKAM" credential store --issuer "$AUTHORITY_IDENTIFIER" --credential "$I1_CREDENTIAL" --at n1 --scope "test"
 
-  run_success bash -c "$OCKAM secure-channel create --from $n1 --identity $i1 --to /node/$n2/service/api |
-    $OCKAM message send --timeout 1 hello --from $n1 --to -/service/echo"
+  run_success bash -c "$OCKAM secure-channel create --from n1 --identity i1 --to /node/n2/service/api |
+    $OCKAM message send --timeout 1 hello --from n1 --to -/service/echo"
   assert_output "hello"
 
-  run_failure bash -c "$OCKAM secure-channel create --from $n2 --identity $i2 --to /node/$n1/service/api |
-    $OCKAM message send --timeout 1 hello --from $n2 --to -/service/echo"
+  run_failure bash -c "$OCKAM secure-channel create --from n2 --identity i2 --to /node/n1/service/api |
+    $OCKAM message send --timeout 1 hello --from n2 --to -/service/echo"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/identity.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/identity.bats
@@ -15,12 +15,11 @@ teardown() {
 # ===== TESTS
 
 @test "identity - create and check show output" {
-  i=$(random_str)
-  run_success "$OCKAM" identity create "${i}"
-  run_success "$OCKAM" identity show "${i}"
+  run_success "$OCKAM" identity create i
+  run_success "$OCKAM" identity show i
   assert_output --regexp '^I'
 
-  run_success "$OCKAM" identity show "${i}" --full
+  run_success "$OCKAM" identity show i --full
   assert_output --partial "Change[0]:"
   assert_output --partial "Identifier: "
   assert_output --partial "primary_public_key: "
@@ -31,37 +30,33 @@ teardown() {
   run_success "$OCKAM" identity create
 
   # Create a named identity and delete it
-  i=$(random_str)
-  run_success "$OCKAM" identity create "${i}"
-  run_success "$OCKAM" identity delete "${i}" --yes
+  run_success "$OCKAM" identity create i
+  run_success "$OCKAM" identity delete i --yes
 
   # Fail to delete identity when it's in use by a node
-  i=$(random_str)
-  n=$(random_str)
-
-  run_success "$OCKAM" identity create "${i}"
-  run_success "$OCKAM" node create "${n}" --identity "${i}"
-  run_failure "$OCKAM" identity delete "${i}" --yes
+  run_success "$OCKAM" identity create i
+  run_success "$OCKAM" node create n --identity i
+  run_failure "$OCKAM" identity delete i --yes
 
   # Delete identity after deleting the node
-  run_success "$OCKAM" node delete "${n}" --yes
-  run_success "$OCKAM" identity delete "${i}" --yes
+  run_success "$OCKAM" node delete n --yes
+  run_success "$OCKAM" identity delete i --yes
 
   # Create two and list them
-  run_success "$OCKAM" identity create "${i}"
-  run_success "$OCKAM" identity create "${n}"
+  run_success "$OCKAM" identity create i1
+  run_success "$OCKAM" identity create i2
   run_success "$OCKAM" identity list
-  assert_output --partial "${i}"
-  assert_output --partial "${n}"
+  assert_output --partial i1
+  assert_output --partial i2
 
   # Update the list correctly after deleting one
-  run_success "$OCKAM" identity delete "${i}" --yes
+  run_success "$OCKAM" identity delete i1 --yes
   run_success "$OCKAM" identity list
-  assert_output --partial "${n}"
-  refute_output --partial "${i}"
+  assert_output --partial i2
+  refute_output --partial i1
 
   # Delete twice
-  run_failure "$OCKAM" identity delete {i} --yes
+  run_failure "$OCKAM" identity delete i1 --yes
 
   # Delete all and check that the list is empty
   run_success "$OCKAM" identity delete -a --yes
@@ -75,20 +70,17 @@ teardown() {
 }
 
 @test "identity - set default" {
-  i=$(random_str)
-
-  run_success "$OCKAM" identity create "${i}"
+  run_success "$OCKAM" identity create i1
 
   run_success "$OCKAM" identity default
-  assert_output --partial "The name of the default identity is '${i}'"
+  assert_output --partial "The name of the default identity is 'i1'"
 
-  run_failure "$OCKAM" identity default "${i}"
-  assert_output --partial "The identity named '${i}' is already the default"
+  run_failure "$OCKAM" identity default i1
+  assert_output --partial "The identity named 'i1' is already the default"
 
-  i=$(random_str)
-  run_success "$OCKAM" identity create "${i}"
-  run_success "$OCKAM" identity default "${i}"
-  assert_output "${i}"
+  run_success "$OCKAM" identity create i2
+  run_success "$OCKAM" identity default i2
+  assert_output i2
 }
 
 @test "identity - export/import" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -37,10 +37,9 @@ force_kill_node() {
 }
 
 @test "node - create with name" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create "$n"
+  run_success "$OCKAM" node create n
 
-  run_success "$OCKAM" node show "$n"
+  run_success "$OCKAM" node show n
   assert_output --partial "/dnsaddr/localhost/tcp/"
   assert_output --partial "/service/api"
   assert_output --partial "/service/uppercase"
@@ -55,100 +54,89 @@ force_kill_node() {
 }
 
 @test "node - is restarted with default services" {
-  n="$(random_str)"
   # Create node, check that it has one of the default services running
-  run_success "$OCKAM" node create "$n"
-  assert_output --partial "Node ${n} created successfully"
+  run_success "$OCKAM" node create n
+  assert_output --partial "Node n created successfully"
 
   # Stop node, restart it, and check that the service is up again
-  $OCKAM node stop "$n"
-  run_success "$OCKAM" node start "$n"
+  $OCKAM node stop n
+  run_success "$OCKAM" node start n
   assert_output --partial "/service/echo"
 }
 
 @test "node - fail to create two background nodes with the same name" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create "$n"
-  run_failure "$OCKAM" node create "$n"
+  run_success "$OCKAM" node create n
+  run_failure "$OCKAM" node create n
 }
 
 @test "node - can recreate a background node after it was gracefully stopped" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create "$n"
-  run_success "$OCKAM" node stop "$n"
+  run_success "$OCKAM" node create n
+  run_success "$OCKAM" node stop n
   # Recreate node
-  run_success "$OCKAM" node create "$n"
+  run_success "$OCKAM" node create n
 }
 
 @test "node - can recreate a background node after it was killed" {
   # This test emulates the situation where a node is killed by the OS
   # on a restart or a shutdown. The node should be able to restart without errors.
-  n="$(random_str)"
-  run_success "$OCKAM" node create "$n"
+  run_success "$OCKAM" node create n
 
-  force_kill_node "$n"
+  force_kill_node n
 
   # Recreate node
-  run_success "$OCKAM" node create "$n"
+  run_success "$OCKAM" node create n
 }
 
 @test "node - fail to create node when not existing identity is passed" {
-  i=$(random_str)
-
   # Background node
-  run_failure "$OCKAM" node create --identity "$i"
+  run_failure "$OCKAM" node create --identity i
   # Foreground node
-  run_failure "$OCKAM" node create -f --identity "$i"
+  run_failure "$OCKAM" node create -f --identity i
 }
 
 @test "node - fail to create two foreground nodes with the same name" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create $n -f &
+  run_success "$OCKAM" node create n -f &
   sleep 1
-  run_success "$OCKAM" node show "$n"
-  run_failure "$OCKAM" node create "$n" -f
+  run_success "$OCKAM" node show n
+  run_failure "$OCKAM" node create n -f
 }
 
 @test "node - can recreate a foreground node after it was killed" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create $n -f &
+  run_success "$OCKAM" node create n -f &
   sleep 1
-  run_success "$OCKAM" node show "$n"
+  run_success "$OCKAM" node show n
 
-  force_kill_node "$n"
+  force_kill_node n
 
   # Recreate node
-  run_success "$OCKAM" node create $n -f &
+  run_success "$OCKAM" node create n -f &
   sleep 1
-  run_success "$OCKAM" node show "$n"
+  run_success "$OCKAM" node show n
 }
 
 @test "node - can recreate a foreground node after it was gracefully stopped" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create $n -f &
+  run_success "$OCKAM" node create n -f &
   sleep 1
-  run_success "$OCKAM" node show "$n"
+  run_success "$OCKAM" node show n
 
-  run_success "$OCKAM" node stop "$n"
+  run_success "$OCKAM" node stop n
 
   # Recreate node
-  run_success "$OCKAM" node create $n -f &
+  run_success "$OCKAM" node create n -f &
   sleep 1
-  run_success "$OCKAM" node show "$n"
+  run_success "$OCKAM" node show n
 }
 
 @test "node - background node logs to file" {
   QUIET=0
-  n="$(random_str)"
-  run_success "$OCKAM" node create $n
-  run_success ls -l "$OCKAM_HOME/nodes/$n"
+  run_success "$OCKAM" node create n
+  run_success ls -l "$OCKAM_HOME/nodes/n"
   assert_output --partial "stdout"
 }
 
 @test "node - foreground node logs to stdout only" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create $n -vv -f &
+  run_success "$OCKAM" node create n -vv -f &
   sleep 1
   # It should even create the node directory
-  run_failure ls -l "$OCKAM_HOME/nodes/$n"
+  run_failure ls -l "$OCKAM_HOME/nodes/n"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/setup_suite.bash
@@ -2,7 +2,6 @@
 
 setup_suite() {
   load ../load/base.bash
-  mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
 
   # Remove all nodes from the root OCKAM_HOME directory

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
@@ -17,7 +17,6 @@ teardown() {
 @test "tcp connection - CRUD" {
   port="$(random_port)"
   addr="127.0.0.1:$port"
-
   run_success "$OCKAM" node create n1 --tcp-listener-address "$addr"
 
   # Create tcp-connection and check output
@@ -41,12 +40,11 @@ teardown() {
 }
 
 @test "tcp listener - CRUD" {
-  port="$(random_port)"
-  addr="127.0.0.1:$port"
-
   run_success "$OCKAM" node create n1
 
   # Create tcp-listener and check output
+  port="$(random_port)"
+  addr="127.0.0.1:$port"
   run_success "$OCKAM" tcp-listener create "$addr" --at n1
   assert_output --regexp '/dnsaddr/localhost/tcp/[[:digit:]]+'
 
@@ -69,7 +67,6 @@ teardown() {
 @test "tcp - create a tcp connection and then delete it" {
   port="$(random_port)"
   addr="127.0.0.1:$port"
-
   run_success "$OCKAM" node create n1 --tcp-listener-address "$addr"
   run_success "$OCKAM" tcp-connection create --from n1 --to "$addr" --output json
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
@@ -23,14 +23,14 @@ teardown() {
   # Service
   run_success "$OCKAM" node create server_sidecar
 
-  run_success "$OCKAM" tcp-outlet create --at /node/server_sidecar --to 127.0.0.1:$PYTHON_SERVER_PORT
+  run_success "$OCKAM" tcp-outlet create --at /node/server_sidecar --to "$PYTHON_SERVER_PORT"
   run_success "$OCKAM" relay create server_sidecar --at /node/relay --to /node/server_sidecar
   assert_output --partial "forward_to_server_sidecar"
 
   # Client
   run_success "$OCKAM" node create client_sidecar
   run_success bash -c "$OCKAM secure-channel create --from /node/client_sidecar --to /node/relay/service/forward_to_server_sidecar/service/api \
-              | $OCKAM tcp-inlet create --at /node/client_sidecar --from 127.0.0.1:$port --to -/service/outlet"
+              | $OCKAM tcp-inlet create --at /node/client_sidecar --from $port --to -/service/outlet"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/vault.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/vault.bats
@@ -15,27 +15,25 @@ teardown() {
 # ===== TESTS
 
 @test "vault - create and check show/list output" {
-  v1=$(random_str)
-  run_success "$OCKAM" vault create "${v1}"
+  run_success "$OCKAM" vault create v1
 
-  run_success "$OCKAM" vault show "${v1}" --output json
-  assert_output --partial "\"name\":\"${v1}\""
+  run_success "$OCKAM" vault show v1 --output json
+  assert_output --partial "\"name\":\"v1\""
   assert_output --partial "\"is_kms\":false"
 
   run_success "$OCKAM" vault list --output json
-  assert_output --partial "\"name\":\"${v1}\""
+  assert_output --partial "\"name\":\"v1\""
   assert_output --partial "\"is_kms\":false"
 
-  v2=$(random_str)
-  run_success "$OCKAM" vault create "${v2}"
+  run_success "$OCKAM" vault create v2
 
-  run_success "$OCKAM" vault show "${v2}" --output json
-  assert_output --partial "\"name\":\"${v2}\""
+  run_success "$OCKAM" vault show v2 --output json
+  assert_output --partial "\"name\":\"v2\""
   assert_output --partial "\"is_kms\":false"
 
   run_success "$OCKAM" vault list --output json
-  assert_output --partial "\"name\":\"${v1}\""
-  assert_output --partial "\"name\":\"${v2}\""
+  assert_output --partial "\"name\":\"v1\""
+  assert_output --partial "\"name\":\"v2\""
   assert_output --partial "\"is_kms\":false"
 }
 
@@ -44,40 +42,33 @@ teardown() {
   run_success "$OCKAM" vault create
 
   # Create with specific name
-  v=$(random_str)
-
-  run_success "$OCKAM" vault create "${v}"
-  run_success "$OCKAM" vault delete "${v}" --yes
-  run_failure "$OCKAM" vault show "${v}"
+  run_success "$OCKAM" vault create v
+  run_success "$OCKAM" vault delete v --yes
+  run_failure "$OCKAM" vault show v
 
   # Deleting a vault can only be done if no identity is using it
-  v=$(random_str)
-  i=$(random_str)
+  run_success "$OCKAM" vault create v
+  run_success "$OCKAM" identity create i --vault v
+  run_failure "$OCKAM" vault delete v --yes
 
-  run_success "$OCKAM" vault create "${v}"
-  run_success "$OCKAM" identity create "${i}" --vault "${v}"
-  run_failure "$OCKAM" vault delete "${v}" --yes
-
-  run_success "$OCKAM" identity delete "${i}" --yes
-  run_success "$OCKAM" vault delete "${v}" --yes
-  run_failure "$OCKAM" vault show "${v}"
+  run_success "$OCKAM" identity delete i --yes
+  run_success "$OCKAM" vault delete v --yes
+  run_failure "$OCKAM" vault show v
 }
 
 @test "vault - move a vault" {
   # Create a first vault with no path
-  v=$(random_str)
-  run_success "$OCKAM" vault create "${v}"
+  run_success "$OCKAM" vault create v1
 
   # Since this is the first vault it is stored in the main database
   # and cannot be moved
-  run_failure "$OCKAM" vault move "${v}" --path "$OCKAM_HOME/new-vault-path"
+  run_failure "$OCKAM" vault move v1 --path "$OCKAM_HOME/new-vault-path"
 
-  # Create a vault with random name at a specific path
-  v=$(random_str)
-  run_success "$OCKAM" vault create "${v}" --path "$OCKAM_HOME/vault-path"
+  # Create a vault at a specific path
+  run_success "$OCKAM" vault create v2 --path "$OCKAM_HOME/vault-path"
 
   # Move to a different path
-  run_success "$OCKAM" vault move "${v}" --path "$OCKAM_HOME/new-vault-path"
-  run_success "$OCKAM" vault show --output json "${v}"
+  run_success "$OCKAM" vault move v2 --path "$OCKAM_HOME/new-vault-path"
+  run_success "$OCKAM" vault show --output json v2
   assert_output --partial new-vault-path
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -54,7 +54,7 @@ teardown() {
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
 
   run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port" --via "$relay_name"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
@@ -88,7 +88,7 @@ teardown() {
   assert_output --partial "forward_to_$relay_name"
 
   port="$(random_port)"
-  run_success $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --via $relay_name
+  run_success $OCKAM tcp-inlet create --at /node/green --from $port --via $relay_name
 
   # Green can't establish secure channel with blue, because it didn't exchange credential with it.
   run_failure curl -sfI -m 3 "127.0.0.1:$port"
@@ -121,7 +121,7 @@ teardown() {
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
   assert_output --partial "forward_to_$relay_name"
 
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:$port" --via "$relay_name"
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port" --via "$relay_name"
   # Green can't establish secure channel with blue, because it isn't a member
   run_failure curl -sfI -m 3 "127.0.0.1:$port"
 }
@@ -158,7 +158,7 @@ teardown() {
   assert_output --partial "forward_to_$relay_name"
 
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
-              | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
+              | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
@@ -191,7 +191,7 @@ teardown() {
   assert_output --partial "forward_to_$relay_name"
 
   run_success "$OCKAM" tcp-inlet create --at /node/green \
-    --from "127.0.0.1:$port" --via "$relay_name" --allow '(= subject.app "app1")'
+    --from "$port" --via "$relay_name" --allow '(= subject.app "app1")'
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
@@ -225,10 +225,10 @@ teardown() {
   run_success "$OCKAM" node create blue
   sleep 1
   run_success "$OCKAM" relay create "${relay_name}" --to /node/blue
-  run_success "$OCKAM" tcp-outlet create --at /node/blue --to "127.0.0.1:$PYTHON_SERVER_PORT"
+  run_success "$OCKAM" tcp-outlet create --at /node/blue --to "$PYTHON_SERVER_PORT"
 
   run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:${port}" \
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "${port}" \
     --to "/project/default/service/forward_to_${relay_name}/secure/api/service/outlet"
 
   # generate 10MB of random data
@@ -260,7 +260,7 @@ teardown() {
     --at "/ip4/127.0.0.1/tcp/${socat_port}/secure/api"
 
   run_success "$OCKAM" node create green
-  run_success "$OCKAM" tcp-inlet create --at /node/green --from "127.0.0.1:${inlet_port}" \
+  run_success "$OCKAM" tcp-inlet create --at /node/green --from "${inlet_port}" \
     --via "${relay_name}"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
@@ -28,7 +28,7 @@ teardown() {
 
   run_success "$OCKAM" node create green
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
-    | $OCKAM tcp-inlet create --at /node/green --from 127.0.0.1:$port --to -/service/outlet"
+    | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/setup_suite.bash
@@ -7,7 +7,6 @@ setup_suite() {
   load ../load/base.bash
   load ../load/orchestrator.bash
 
-  mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
   get_project_data
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
@@ -68,7 +68,7 @@ teardown() {
   $OCKAM identity create edge_identity
   $OCKAM project enroll "$ADMIN_HOME/edge.ticket" --identity edge_identity
   $OCKAM node create edge_plane1 --identity edge_identity
-  $OCKAM tcp-inlet create --at /node/edge_plane1 --from "127.0.0.1:$port_1" \
+  $OCKAM tcp-inlet create --at /node/edge_plane1 --from "$port_1" \
     --via "$relay_name" --allow '(= subject.component "control")'
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port_1"
 
@@ -76,7 +76,7 @@ teardown() {
   $OCKAM identity create x_identity
   $OCKAM project enroll "$ADMIN_HOME/x.ticket" --identity x_identity
   $OCKAM node create x --identity x_identity
-  $OCKAM tcp-inlet create --at /node/x --from "127.0.0.1:$port_2" \
+  $OCKAM tcp-inlet create --at /node/x --from "$port_2" \
     --via "$relay_name" --allow '(= subject.component "control")'
   run curl -sfI -m 5 "127.0.0.1:$port_2"
   assert_failure 28 # timeout error
@@ -116,7 +116,7 @@ teardown() {
   run_success "$OCKAM" identity create telegraf
   run_success "$OCKAM" project enroll "${ADMIN_HOME}/telegraf.ticket" --identity telegraf
   run_success "$OCKAM" node create telegraf --identity telegraf
-  run_success "$OCKAM" tcp-inlet create --at /node/telegraf --from "127.0.0.1:${INFLUX_PORT}" \
+  run_success "$OCKAM" tcp-inlet create --at /node/telegraf --from "${INFLUX_PORT}" \
     --via $relay_name --allow '(= subject.component "influxdb")'
 
   run_success kill_telegraf_instance

--- a/implementations/rust/ockam/ockam_command/tests/bats/serial/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/serial/setup_suite.bash
@@ -7,7 +7,6 @@ setup_suite() {
   load ../load/base.bash
   load ../load/orchestrator.bash
 
-  mkdir -p $OCKAM_HOME_BASE/.tmp
   setup_python_server
   get_project_data
 


### PR DESCRIPTION
It also moves the `random_port` calls right before the port is used, so we don't hold to that value longer than necessary.