### PR TITLE
feat(rust): add the possibility to pass a node configuration inline

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -38,6 +38,10 @@ pub struct CreateCommand {
     #[arg(hide_default_value = true, default_value_t = random_name())]
     pub name: String,
 
+    /// Inline node configuration
+    #[arg(long, value_name = "YAML")]
+    pub node_config: Option<String>,
+
     /// Run the node in foreground.
     #[arg(display_order = 900, long, short)]
     pub foreground: bool,
@@ -99,6 +103,7 @@ impl Default for CreateCommand {
         Self {
             skip_is_running_check: false,
             name: random_name(),
+            node_config: None,
             exit_on_eof: false,
             tcp_listener_address: node_manager_defaults.tcp_listener_address,
             foreground: false,
@@ -146,12 +151,12 @@ impl Command for CreateCommand {
         let ctx = ctx.async_try_clone().await.into_diagnostic()?;
         if self.has_name_arg() {
             if self.foreground {
-                self.foreground_mode(&ctx, opts).await?;
+                self.foreground_mode(&ctx, opts).await?
             } else {
-                self.background_mode(&ctx, opts).await?;
+                self.background_mode(&ctx, opts).await?
             }
         } else {
-            self.run_config(&ctx, opts).await?;
+            self.run_config(&ctx, opts).await?
         }
         Ok(())
     }
@@ -173,8 +178,11 @@ impl CreateCommand {
     }
 
     // Return true if the `name` argument is a node name, false if it's a config file path or URL
+    // Or if the node configuration was provided inline
     fn has_name_arg(&self) -> bool {
-        is_url(&self.name).is_none() && std::fs::metadata(&self.name).is_err()
+        is_url(&self.name).is_none()
+            && std::fs::metadata(&self.name).is_err()
+            && self.node_config.is_none()
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -6,6 +6,7 @@ use crate::run::parser::Version;
 use crate::value_parsers::async_parse_path_or_url;
 use crate::CommandGlobalOpts;
 use ockam_api::cli_state::journeys::APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE;
+use ockam_api::cli_state::random_name;
 use ockam_node::Context;
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, Span};
@@ -87,6 +88,11 @@ impl NodeConfig {
         // to override the duplicate entries from the config file.
         for (key, value) in &cli_args.variables {
             std::env::set_var(key, value);
+        }
+
+        // Use a random name for the node if none has been specified
+        if self.node.name.is_none() {
+            self.node.name = Some(ArgValue::String(random_name()));
         }
 
         // Set the enrollment ticket from the cli command

--- a/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
@@ -4,4 +4,43 @@ $ ockam node create
 
 # To create a new node with a specific name
 $ ockam node create n
+
+# To create a new node with a configuration file
+$ ockam node create config.yaml
+
+# To create a new node with an inline configuration
+$ ockam node create --node-config "{name: n1, tcp-outlet: {db-outlet: {to: '127.0.0.1:5432'}}}"
+
+An example of a configuration file is:
+
+# variables can be used and overridden with environment variables
+variables:
+  NODE_PORT: 3333
+  SERVICE_PORT: 5000
+  CLIENT_PORT: 15000
+
+# name of the node
+name: n1
+
+# TCP listener address for the node
+tcp-listener-address: 127.0.0.1:$NODE_PORT
+
+# This creates a relay named default
+# by running the ockam relay create command
+relay: default
+
+# List of outlets
+tcp-outlet:
+  # Name of the outlet
+  db-outlet:
+    # Arguments to the ockam tcp-outlet create command
+    to: $SERVICE_PORT
+
+# List of outlets
+tcp-inlet:
+  # Name of the inlet
+  web-inlet:
+    # Arguments to the ockam tcp-outlet create command
+    from: $CLIENT_PORT
+
 ```

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -53,41 +53,37 @@ impl Config {
     ///
     /// For more details about the parsing, see the [parser](crate::run::parser) module.
     /// You can also check examples of valid configuration files in the demo folder of this module.
-    pub async fn run(
-        self,
-        ctx: &Context,
-        opts: &CommandGlobalOpts,
-        overrides: &ValuesOverrides,
-    ) -> miette::Result<()> {
-        // Build commands and return validation errors before running any command.
-        let commands: Vec<ParsedCommands> = vec![
-            self.vaults.parse_commands(overrides)?.into(),
-            self.identities.parse_commands(overrides)?.into(),
-            self.project_enroll.parse_commands(overrides)?.into(),
-            self.nodes.parse_commands(overrides)?.into(),
-            self.relays.parse_commands(overrides)?.into(),
-            self.policies.parse_commands(overrides)?.into(),
-            self.tcp_outlets.parse_commands(overrides)?.into(),
-            self.tcp_inlets.parse_commands(overrides)?.into(),
-            self.kafka_inlet.parse_commands(overrides)?.into(),
-            self.kafka_outlet.parse_commands(overrides)?.into(),
-        ];
-
-        // Run commands
-        for cmd in commands {
+    pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
+        // Parse commands and run them
+        for cmd in self.parse_commands()? {
             cmd.run(ctx, opts).await?
         }
         Ok(())
     }
 
+    // Build commands and return validation errors
+    pub fn parse_commands(self) -> miette::Result<Vec<ParsedCommands>> {
+        Ok(vec![
+            self.vaults.parse_commands()?.into(),
+            self.identities.parse_commands()?.into(),
+            self.project_enroll.parse_commands()?.into(),
+            self.nodes.parse_commands()?.into(),
+            self.relays.parse_commands(&None)?.into(),
+            self.policies.parse_commands()?.into(),
+            self.tcp_outlets.parse_commands(&None)?.into(),
+            self.tcp_inlets.parse_commands(&None)?.into(),
+            self.kafka_inlet.parse_commands(&None)?.into(),
+            self.kafka_outlet.parse_commands(&None)?.into(),
+        ])
+    }
+
     pub async fn parse_and_run(
         ctx: &Context,
         opts: CommandGlobalOpts,
-        overrides: ValuesOverrides,
         contents: &str,
     ) -> miette::Result<()> {
         let config = Config::parse(&Config::resolve(contents)?)?;
-        config.run(ctx, &opts, &overrides).await
+        config.run(ctx, &opts).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -8,7 +8,6 @@ use ockam_api::cli_state::journeys::APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE
 use std::path::PathBuf;
 use tracing::{instrument, Span};
 
-use crate::run::parser::resource::ValuesOverrides;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -83,6 +82,6 @@ impl RunCommand {
             APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE.as_str(),
             &contents,
         );
-        Config::parse_and_run(ctx, opts, ValuesOverrides::default(), &contents).await
+        Config::parse_and_run(ctx, opts, &contents).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/identities.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/identities.rs
@@ -1,13 +1,10 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::identity::CreateCommand;
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourcesContainer};
-use crate::run::parser::resource::traits::CommandsParser;
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::{identity, Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -28,11 +25,8 @@ impl Identities {
             color_primary(CreateCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<CreateCommand> for Identities {
-    fn parse_commands(self, _overrides: &ValuesOverrides) -> Result<Vec<CreateCommand>> {
+    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
         match self.identities {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -50,7 +44,7 @@ mod tests {
     fn single_identity_config() {
         let test = |c: &str| {
             let parsed: Identities = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 1);
             let cmd = cmds.into_iter().next().unwrap();
             assert_eq!(cmd.name, "i1");
@@ -81,7 +75,7 @@ mod tests {
     fn multiple_identity_config() {
         let test = |c: &str| {
             let parsed: Identities = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].name, "i1");
             assert_eq!(cmds[1].name, "i2");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
@@ -6,9 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::kafka::outlet;
 use crate::kafka::outlet::create::CreateCommand;
 use crate::run::parser::building_blocks::{ArgsToCommands, UnnamedResources};
-use crate::run::parser::resource::traits::CommandsParser;
+
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::{Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -30,17 +28,16 @@ impl KafkaOutlet {
             color_primary(CreateCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<CreateCommand> for KafkaOutlet {
-    fn parse_commands(self, overrides: &ValuesOverrides) -> Result<Vec<CreateCommand>> {
+    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
         match self.kafka_outlet {
             Some(c) => {
                 let mut cmds = c.into_commands(Self::get_subcommand)?;
-                if let Some(node_name) = overrides.override_node_name.as_ref() {
+                if let Some(node_name) = default_node_name {
                     for cmd in cmds.iter_mut() {
-                        cmd.node_opts.at_node = Some(node_name.clone())
+                        if cmd.node_opts.at_node.is_none() {
+                            cmd.node_opts.at_node = Some(node_name.clone())
+                        }
                     }
                 }
                 Ok(cmds)
@@ -65,12 +62,27 @@ mod tests {
               at: node_name
         "#;
         let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
-        let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+        let default_node_name = "n1".to_string();
+        let cmds = parsed
+            .parse_commands(&Some(default_node_name.clone()))
+            .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].bootstrap_server,
             SocketAddr::from_str("192.168.0.100:9092").unwrap()
         );
         assert_eq!(cmds[0].node_opts.at_node.as_ref().unwrap(), "node_name");
+
+        // check if the default node name is used when the configuration does not specify it
+        let named = r#"
+            kafka-outlet:
+              bootstrap-server: 192.168.0.100:9092
+        "#;
+        let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
+        let default_node_name = "n1".to_string();
+        let cmds = parsed
+            .parse_commands(&Some(default_node_name.clone()))
+            .unwrap();
+        assert_eq!(cmds[0].node_opts.at_node, Some(default_node_name));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
@@ -1,13 +1,11 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::node::CreateCommand;
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourcesContainer};
-use crate::run::parser::resource::traits::CommandsParser;
+
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::{node, Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -28,11 +26,8 @@ impl Nodes {
             color_primary(CreateCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<CreateCommand> for Nodes {
-    fn parse_commands(self, _overrides: &ValuesOverrides) -> Result<Vec<CreateCommand>> {
+    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
         match self.nodes {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -50,7 +45,7 @@ mod tests {
     fn single_node_config() {
         let test = |c: &str| {
             let parsed: Nodes = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 1);
             let cmd = cmds.into_iter().next().unwrap();
             assert_eq!(cmd.name, "n1");
@@ -81,7 +76,7 @@ mod tests {
     fn multiple_node_config() {
         let test = |c: &str| {
             let parsed: Nodes = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].name, "n1");
             assert_eq!(cmds[1].name, "n2");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
@@ -1,13 +1,11 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::policy::CreateCommand;
 use crate::run::parser::building_blocks::{ArgsToCommands, UnnamedResources};
-use crate::run::parser::resource::traits::CommandsParser;
+
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::{policy, Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -28,11 +26,8 @@ impl Policies {
             color_primary(CreateCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<CreateCommand> for Policies {
-    fn parse_commands(self, _overrides: &ValuesOverrides) -> Result<Vec<CreateCommand>> {
+    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
         match self.policies {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -53,7 +48,7 @@ mod tests {
               expression: (= subject.component "c1")
         "#;
         let parsed: Policies = serde_yaml::from_str(config).unwrap();
-        let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+        let cmds = parsed.parse_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");
         assert_eq!(cmds[0].resource.as_ref().unwrap().as_str(), "r1");
@@ -78,7 +73,7 @@ mod tests {
                 expression: (= subject.component "c3")
         "#;
         let parsed: Policies = serde_yaml::from_str(config).unwrap();
-        let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+        let cmds = parsed.parse_commands().unwrap();
         assert_eq!(cmds.len(), 3);
 
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
@@ -1,12 +1,10 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::project::EnrollCommand;
-use crate::run::parser::resource::traits::CommandsParser;
+
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::{Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -26,11 +24,8 @@ impl ProjectEnroll {
             color_primary(EnrollCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<EnrollCommand> for ProjectEnroll {
-    fn parse_commands(self, _overrides: &ValuesOverrides) -> Result<Vec<EnrollCommand>> {
+    pub fn parse_commands(self) -> Result<Vec<EnrollCommand>> {
         match self.ticket {
             Some(path_or_contents) => Ok(vec![Self::get_subcommand(&[path_or_contents])?]),
             None => Ok(vec![]),
@@ -58,7 +53,7 @@ mod tests {
         // As contents
         let config = format!("ticket: {enrollment_ticket_hex}");
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
-        let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+        let cmds = parsed.parse_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].enrollment_ticket.as_ref().unwrap(),
@@ -72,7 +67,7 @@ mod tests {
         file.write_all(enrollment_ticket_hex.as_bytes()).unwrap();
         let config = format!("ticket: {}", file_path.to_str().unwrap());
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
-        let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+        let cmds = parsed.parse_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].enrollment_ticket.as_ref().unwrap(),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -1,22 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use clap::Args as ClapArgs;
 use miette::Result;
 
 use ockam_node::Context;
 
 use crate::{Command, CommandGlobalOpts};
-
-/// Implementations of this traits return a list of commands of a given type
-/// as if they had been read from arguments coming from the command line.
-#[async_trait]
-pub trait CommandsParser<C>: Clone
-where
-    C: ClapArgs,
-{
-    fn parse_commands(self, overrides: &ValuesOverrides) -> Result<Vec<C>>;
-}
 
 /// List of parsed commands
 /// Each command can be validated then executed
@@ -93,17 +82,5 @@ impl ParsedCommand for EmptyParsedCommand {
 
     async fn is_valid(&self, _ctx: &Context, _opts: &CommandGlobalOpts) -> Result<bool> {
         Ok(false)
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct ValuesOverrides {
-    pub override_node_name: Option<String>,
-}
-
-impl ValuesOverrides {
-    pub fn with_override_node_name(mut self, node_name: &str) -> Self {
-        self.override_node_name = Some(node_name.to_string());
-        self
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/vaults.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/vaults.rs
@@ -1,12 +1,10 @@
-use async_trait::async_trait;
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourcesContainer};
-use crate::run::parser::resource::traits::CommandsParser;
+
 use crate::run::parser::resource::utils::parse_cmd_from_args;
-use crate::run::parser::resource::ValuesOverrides;
 use crate::vault::CreateCommand;
 use crate::{vault, Command, OckamSubcommand};
 
@@ -28,11 +26,8 @@ impl Vaults {
             color_primary(CreateCommand::NAME)
         )))
     }
-}
 
-#[async_trait]
-impl CommandsParser<CreateCommand> for Vaults {
-    fn parse_commands(self, _overrides: &ValuesOverrides) -> Result<Vec<CreateCommand>> {
+    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
         match self.vaults {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -50,7 +45,7 @@ mod tests {
     fn single_vault_config() {
         let test = |c: &str| {
             let parsed: Vaults = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 1);
             assert_eq!(cmds[0].name.as_ref().unwrap(), "v1");
         };
@@ -81,7 +76,7 @@ mod tests {
     fn multiple_vaults_config() {
         let test = |c: &str| {
             let parsed: Vaults = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands(&ValuesOverrides::default()).unwrap();
+            let cmds = parsed.parse_commands().unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].name.as_ref().unwrap(), "v1");
             assert_eq!(cmds[1].name.as_ref().unwrap(), "v2");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/version.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Version {
     #[serde(default = "VersionValue::latest")]
     pub version: VersionValue,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum VersionValue {
     String(String),

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -8,7 +8,6 @@ use ockam_api::fmt_info;
 use crate::{docs, CommandGlobalOpts};
 use ockam_node::Context;
 
-use crate::run::parser::resource::ValuesOverrides;
 use crate::run::Config;
 use crate::tcp::inlet::create::default_from_addr;
 use crate::util::async_cmd;
@@ -92,7 +91,7 @@ impl SecureRelayInlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, ValuesOverrides::default(), &recipe).await
+        Config::parse_and_run(ctx, opts, &recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -130,7 +129,6 @@ mod tests {
     use ockam_api::cli_state::EnrollmentTicket;
 
     use crate::run::parser::config::ConfigParser;
-    use crate::run::parser::resource::CommandsParser;
 
     use super::*;
 
@@ -150,8 +148,7 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        let overrides = ValuesOverrides::default();
-        config.project_enroll.parse_commands(&overrides).unwrap();
-        config.tcp_inlets.parse_commands(&overrides).unwrap();
+        config.project_enroll.parse_commands().unwrap();
+        config.tcp_inlets.parse_commands(&None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -8,7 +8,6 @@ use ockam_api::fmt_info;
 use crate::{docs, CommandGlobalOpts};
 use ockam_node::Context;
 
-use crate::run::parser::resource::ValuesOverrides;
 use crate::run::Config;
 use crate::util::async_cmd;
 use crate::util::parsers::socket_addr_parser;
@@ -91,7 +90,7 @@ impl SecureRelayOutlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, ValuesOverrides::default(), &recipe).await
+        Config::parse_and_run(ctx, opts, &recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -132,7 +131,6 @@ mod tests {
     use ockam_api::cli_state::EnrollmentTicket;
 
     use crate::run::parser::config::ConfigParser;
-    use crate::run::parser::resource::CommandsParser;
 
     use super::*;
 
@@ -152,10 +150,9 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        let overrides = ValuesOverrides::default();
-        config.project_enroll.parse_commands(&overrides).unwrap();
-        config.policies.parse_commands(&overrides).unwrap();
-        config.tcp_outlets.parse_commands(&overrides).unwrap();
-        config.relays.parse_commands(&overrides).unwrap();
+        config.project_enroll.parse_commands().unwrap();
+        config.policies.parse_commands().unwrap();
+        config.tcp_outlets.parse_commands(&None).unwrap();
+        config.relays.parse_commands(&None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -152,3 +152,10 @@ force_kill_node() {
   # It should even create the node directory
   run_failure ls -l "$OCKAM_HOME/nodes/$n"
 }
+
+@test "node - create a node with an inline configuration" {
+  n="$(random_str)"
+  # Create node, check that it has one of the default services running
+  run_success "$OCKAM" node create --node-config "{name: $n, tcp-outlets: {db-outlet: {to: '127.0.0.1:5432', at: $n}}}"
+  assert_output --partial "Node ${n} created successfully"
+}


### PR DESCRIPTION
This PR also simplifies the parsing of commands and removes the `CommandsParser ` which IMO is a premature abstraction since:

 - We don't use it as a trait.
 - It requires a parameter for the default node which is only used in some cases.

I also fixed the logic to use the node name defined in the configuration file on relays/inlets/outlets only if a user has not already specified a value for the corresponding `to`, `at` fields. @adrianbenavides please tell me if I understood correctly this piece of logic. What prompted to do this was the fact that, when I tested the inline configuration, I was not ending up with the node name used for the `at` field for an outlet.

Also I started enriching the help text for `ockam node create` but we know that it deserves a lot more.

