### PR TITLE
feat(elixir): add example of secure channel over udp, tweak udp parsing/serializing

### DIFF
--- a/examples/elixir/get_started/07-secure-channel-over-udp-initiator.exs
+++ b/examples/elixir/get_started/07-secure-channel-over-udp-initiator.exs
@@ -1,0 +1,29 @@
+["setup.exs"] |> Enum.map(&Code.require_file/1)
+
+# Register this process as worker address "app".
+Ockam.Node.register_address("app")
+
+Ockam.Transport.UDP.start()
+
+# Create an identity and a purpose key
+{:ok, identity} = Ockam.Identity.create()
+{:ok, keypair} = Ockam.SecureChannel.Crypto.generate_dh_keypair()
+{:ok, attestation} = Ockam.Identity.attest_purpose_key(identity, keypair)
+
+# Connect to a secure channel listener and perform a handshake.
+alias Ockam.Transport.UDPAddress
+r = [UDPAddress.new("127.0.0.1", 4000), "secure_channel_listener"]
+{:ok, c} = Ockam.SecureChannel.create_channel(route: r,
+                                              identity: identity,
+                                              encryption_options: [static_keypair: keypair, static_key_attestation: attestation])
+
+# Prepare the message.
+message = %{onward_route: [c, "echoer"], return_route: ["app"], payload: "Hello Ockam!"}
+
+# Route the message.
+Ockam.Router.route(message)
+
+# Wait to receive a reply.
+receive do
+  message -> IO.puts("!! Address: app\t Received: #{inspect(message)}")
+end

--- a/examples/elixir/get_started/07-secure-channel-over-udp-responder.exs
+++ b/examples/elixir/get_started/07-secure-channel-over-udp-responder.exs
@@ -16,7 +16,7 @@ Ockam.SecureChannel.create_listener(identity: identity,
                                     address: "secure_channel_listener",
                                     encryption_options: [static_keypair: keypair, static_key_attestation: attestation])
 
-# Start the TCP Transport Add-on for Ockam Routing and a TCP listener on port 4000.
+# Start the UDP Transport Add-on for Ockam Routing and a UDP listener on port 4000.
 {:ok, _} = Ockam.Transport.UDP.start(port: 4000)
 
 Process.sleep(:infinity)

--- a/examples/elixir/get_started/07-secure-channel-over-udp-responder.exs
+++ b/examples/elixir/get_started/07-secure-channel-over-udp-responder.exs
@@ -1,0 +1,22 @@
+["setup.exs", "echoer.exs"] |> Enum.map(&Code.require_file/1)
+
+Logger.configure(level: :debug)
+# Create a Echoer type worker at address "echoer".
+{:ok, _echoer} = Echoer.create(address: "echoer")
+
+
+
+# Create an identity and a purpose key
+{:ok, identity} = Ockam.Identity.create()
+{:ok, keypair} = Ockam.SecureChannel.Crypto.generate_dh_keypair()
+{:ok, attestation} = Ockam.Identity.attest_purpose_key(identity, keypair)
+
+# Create a secure channel listener that will wait for requests to initiate an Authenticated Key Exchange.
+Ockam.SecureChannel.create_listener(identity: identity,
+                                    address: "secure_channel_listener",
+                                    encryption_options: [static_keypair: keypair, static_key_attestation: attestation])
+
+# Start the TCP Transport Add-on for Ockam Routing and a TCP listener on port 4000.
+{:ok, _} = Ockam.Transport.UDP.start(port: 4000)
+
+Process.sleep(:infinity)

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
@@ -64,7 +64,8 @@ defmodule Ockam.Transport.UDP.Listener do
 
   @doc false
   @impl true
-  # The 2 bytes heading indicating the size is necessary on TCP streams,  but is not neccesary on UDP where we map 1 ockam msg per udp datagram
+  # The 2 bytes heading indicating the size is necessary on TCP streams,
+  # but is not neccesary on UDP where we map 1 ockam msg per udp datagram
   # However, rust implementation is adding and expecting it to be there, it's done here as well.
   def handle_info({:udp, socket, from_ip, from_port, <<length::size(16), packet::binary>>}, state)
       when byte_size(packet) == length do

--- a/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/transport/udp/listener.ex
@@ -64,7 +64,7 @@ defmodule Ockam.Transport.UDP.Listener do
 
   @doc false
   @impl true
-  # The 2 bytes heading indicating the size is neccesary on TCP streams,  but is not neccesary on UDP where we map 1 ockam msg per udp datagram
+  # The 2 bytes heading indicating the size is necessary on TCP streams,  but is not neccesary on UDP where we map 1 ockam msg per udp datagram
   # However, rust implementation is adding and expecting it to be there, it's done here as well.
   def handle_info({:udp, socket, from_ip, from_port, <<length::size(16), packet::binary>>}, state)
       when byte_size(packet) == length do


### PR DESCRIPTION
* include a 2-bytes length header on UDP, as done on TCP, to make it compatible with rust' implementation.
* add example of secure channel over udp