### PR TITLE
feat(rust): improve output of `node create` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -88,12 +88,14 @@ impl CliState {
         self.notify(Notification::message(message));
     }
 
-    pub fn notify_progress_set(&self, message: impl Into<String>) {
-        self.notify(Notification::progress_set(message));
+    pub fn notify_progress(&self, message: impl Into<String>) {
+        self.notify(Notification::progress(message));
     }
 
-    pub fn notify_progress_finish(&self, message: impl Into<Option<String>>) {
-        self.notify(Notification::progress_finish(message));
+    pub fn notify_progress_finish<'a>(&self, message: impl Into<Option<&'a str>>) {
+        self.notify(Notification::progress_finish(
+            message.into().map(|s| s.to_string()),
+        ));
     }
 
     fn notify(&self, notification: Notification) {

--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -153,8 +153,8 @@ fn exporting_enabled(
             Ok(ExportingEnabled::On)
         } else {
             if !quiet {
-                println!("Exporting OpenTelemetry events is disabled because the OpenTelemetry collector endpoint at {} cannot be reached after {}ms", endpoint, connection_check_timeout.as_millis());
-                println!("You can disable the export of OpenTelemetry events with: `export OCKAM_OPENTELEMETRY_EXPORT=false` to avoid this connection check.");
+                eprintln!("Exporting OpenTelemetry events is disabled because the OpenTelemetry collector endpoint at {} cannot be reached after {}ms", endpoint, connection_check_timeout.as_millis());
+                eprintln!("You can disable the export of OpenTelemetry events with: `export OCKAM_OPENTELEMETRY_EXPORT=false` to avoid this connection check.");
             }
             Ok(ExportingEnabled::Off)
         }

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
@@ -210,10 +210,9 @@ impl<W: TerminalWriter + Debug> Terminal<W, ToStdErr> {
     }
 
     pub fn write_line(&self, msg: impl AsRef<str>) -> Result<&Self> {
-        if self.quiet || !self.stdout.is_tty() || self.output_format != OutputFormat::Plain {
+        if self.quiet {
             return Ok(self);
         }
-
         self.stderr
             .write_line(msg)
             .map_err(|e| miette!("Unable to write to stderr, {e}"))?;

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
@@ -14,7 +14,7 @@ const REPORTING_CHANNEL_POLL_DELAY: Duration = Duration::from_millis(100);
 #[derive(Debug, Clone, PartialEq)]
 pub enum Notification {
     Message(String),
-    ProgressSet(String),
+    Progress(String),
     ProgressFinish(Option<String>),
 }
 
@@ -22,7 +22,7 @@ impl Notification {
     pub fn contents(&self) -> Option<&str> {
         match self {
             Notification::Message(contents) => Some(contents),
-            Notification::ProgressSet(contents) => Some(contents),
+            Notification::Progress(contents) => Some(contents),
             Notification::ProgressFinish(contents) => contents.as_deref(),
         }
     }
@@ -31,8 +31,8 @@ impl Notification {
         Self::Message(contents.into())
     }
 
-    pub fn progress_set(contents: impl Into<String>) -> Self {
-        Self::ProgressSet(contents.into())
+    pub fn progress(contents: impl Into<String>) -> Self {
+        Self::Progress(contents.into())
     }
 
     pub fn progress_finish(contents: impl Into<Option<String>>) -> Self {
@@ -108,7 +108,7 @@ impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
             Notification::Message(contents) => {
                 let _ = self.terminal.write_line(contents);
             }
-            Notification::ProgressSet(contents) => {
+            Notification::Progress(contents) => {
                 if self.terminal.can_use_progress_spinner() {
                     if self.progress_bar.is_none() {
                         self.progress_bar = self.terminal.progress_spinner();

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -202,7 +202,7 @@ impl CreateCommand {
         }
         args.push(self.node_name.to_string());
 
-        run_ockam(args).await
+        run_ockam(args, opts.global_args.quiet).await
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -139,10 +139,6 @@ impl CommandGlobalOpts {
         cmd: &OckamSubcommand,
         is_tty: bool,
     ) -> miette::Result<LoggingConfiguration> {
-        if global_args.quiet {
-            return LoggingConfiguration::off().into_diagnostic();
-        };
-
         let log_path = cmd.log_path();
         let crates = crates_filter().into_diagnostic()?;
         if cmd.is_background_node() {

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -119,7 +119,8 @@ impl EnrollCommand {
         display_header(&opts);
 
         let identity = {
-            let _progress_display = NotificationHandler::start(&opts.state, opts.terminal.clone());
+            let _notification_handler =
+                NotificationHandler::start(&opts.state, opts.terminal.clone());
             opts.state
                 .get_named_identity_or_default(&self.identity)
                 .await?

--- a/implementations/rust/ockam/ockam_command/src/global_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/global_args.rs
@@ -18,7 +18,7 @@ pub struct GlobalArgs {
     )]
     help: Option<bool>,
 
-    /// Do not print any log messages and disable confirmation prompts. This is useful for scripting and automation, where you don't want the process to block on stdin
+    /// Do not print any log messages to stderr and disable confirmation prompts. This is useful for scripting and automation, where you don't want the process to block on stdin
     #[arg(global = true, long, short, default_value_t = quiet_default_value())]
     pub quiet: bool,
 

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -46,7 +46,7 @@ impl Command for CreateCommand {
     const NAME: &'static str = "identity create";
 
     async fn async_run(self, _ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        let _progress_display = NotificationHandler::start(&opts.state, opts.terminal.clone());
+        let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
         let vault = match &self.vault {
             Some(vault_name) => opts.state.get_or_create_named_vault(vault_name).await?,
             None => opts.state.get_or_create_default_named_vault().await?,

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -1,17 +1,13 @@
-use std::collections::HashMap;
-
 use colorful::Colorful;
 use miette::miette;
-use tokio::sync::Mutex;
-use tokio::try_join;
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument};
 
 use ockam::Context;
 use ockam_api::cli_state::journeys::{JourneyEvent, NODE_NAME};
-use ockam_api::colors::OckamColor;
+use ockam_api::colors::color_primary;
 use ockam_api::logs::CurrentSpan;
 use ockam_api::nodes::BackgroundNodeClient;
-use ockam_api::{color, fmt_log, fmt_ok};
+use ockam_api::{fmt_log, fmt_warn};
 use ockam_core::OpenTelemetryContext;
 
 use crate::node::show::is_node_up;
@@ -27,82 +23,59 @@ impl CreateCommand {
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
-        if !self.skip_is_running_check {
-            self.guard_node_is_not_already_running(&opts).await?;
-        }
-
-        if let Some(identity_name) = &self.identity {
-            opts.state.get_named_identity(identity_name).await?;
-        }
-
         let node_name = self.name.clone();
+        debug!(%node_name, "creating node in background mode");
         CurrentSpan::set_attribute(NODE_NAME, node_name.as_str());
-        debug!("create node in background mode");
 
-        opts.terminal.write_line(&fmt_log!(
-            "Creating Node {}...\n",
-            color!(&node_name, OckamColor::PrimaryResource)
-        ))?;
-
+        // Early checks
         if self.child_process {
             return Err(miette!(
                 "Cannot create a background node from another background node"
             ));
         }
+        if !self.skip_is_running_check {
+            self.guard_node_is_not_already_running(&opts).await?;
+        }
+        if let Some(identity_name) = &self.identity {
+            opts.state.get_named_identity(identity_name).await?;
+        }
 
-        let is_finished: Mutex<bool> = Mutex::new(false);
-
-        let opentelemetry_context = OpenTelemetryContext::current();
+        // Create node and wait for it to be up
         let cmd_with_trace_context = CreateCommand {
             opentelemetry_context: self
                 .opentelemetry_context
                 .clone()
-                .or(Some(opentelemetry_context)),
+                .or(Some(OpenTelemetryContext::current())),
             ..self.clone()
         };
-
-        let send_req = async {
-            cmd_with_trace_context.spawn_background_node(&opts).await?;
-            let mut node =
-                BackgroundNodeClient::create_to_node(ctx, &opts.state, &node_name).await?;
-            let is_node_up = is_node_up(ctx, &mut node, true).await?;
-            *is_finished.lock().await = true;
-            Ok(is_node_up)
-        };
-
-        let output_messages = vec![
-            format!("Creating node..."),
-            format!("Starting services..."),
-            format!("Loading any pre-trusted identities..."),
-        ];
-
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
-
-        let (_response, _) = try_join!(send_req, progress_output)?;
-
-        let mut attributes = HashMap::new();
-        attributes.insert(NODE_NAME, node_name.clone());
+        cmd_with_trace_context.spawn_background_node(&opts).await?;
+        let mut node = BackgroundNodeClient::create_to_node(ctx, &opts.state, &node_name).await?;
+        let is_up = is_node_up(ctx, &mut node, true).await?;
         opts.state
-            .add_journey_event(JourneyEvent::NodeCreated, attributes)
+            .add_journey_event(
+                JourneyEvent::NodeCreated,
+                [(NODE_NAME, node_name.clone())].into(),
+            )
             .await?;
 
-        opts.clone()
-            .terminal
-            .stdout()
-            .plain(
-                fmt_ok!(
-                    "Node {} created successfully\n\n",
-                    node_name.color(OckamColor::PrimaryResource.color())
-                ) + &fmt_log!("To see more details on this node, run:\n")
-                    + &fmt_log!(
-                        "{}",
-                        "ockam node show".color(OckamColor::PrimaryResource.color())
-                    ),
-            )
-            .write_line()?;
-
+        // Output
+        if !is_up {
+            opts.terminal
+                .clone()
+                .stdout()
+                .plain(fmt_warn!(
+                    "Node was {} created but is not reachable",
+                    color_primary(&node_name)
+                ))
+                .write_line()?;
+        }
+        opts.terminal
+            .write_line("")?
+            .write_line(fmt_log!("To see more details on this Node, run:"))?
+            .write_line(fmt_log!(
+                "{}",
+                color_primary(format!("ockam node show {}", node_name))
+            ))?;
         Ok(())
     }
 
@@ -116,7 +89,6 @@ impl CreateCommand {
 
         // Construct the argument list and re-execute the ockam
         // CLI in foreground mode to start the newly created node
-        info!("spawning a new node {}", &self.name);
         spawn_node(opts, self).await?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -127,8 +127,8 @@ impl NodeConfig {
 
     pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
         // Parse then run commands
-        for cmd in self.parse_commands()? {
-            cmd.run(ctx, opts).await?
+        for section in self.parse_commands()? {
+            section.run(ctx, opts).await?
         }
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -32,6 +32,8 @@ impl ParsedCommands {
         for cmd in self.commands.into_iter() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
+                // Newline between commands
+                opts.terminal.write_line("")?;
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -56,7 +56,6 @@ force_kill_node() {
 @test "node - is restarted with default services" {
   # Create node, check that it has one of the default services running
   run_success "$OCKAM" node create n
-  assert_output --partial "Node n created successfully"
 
   # Stop node, restart it, and check that the service is up again
   $OCKAM node stop n
@@ -128,7 +127,6 @@ force_kill_node() {
 }
 
 @test "node - background node logs to file" {
-  QUIET=0
   run_success "$OCKAM" node create n
   run_success ls -l "$OCKAM_HOME/nodes/n"
   assert_output --partial "stdout"
@@ -142,9 +140,10 @@ force_kill_node() {
 }
 
 @test "node - create a node with an inline configuration" {
-  n="$(random_str)"
-  run_success "$OCKAM" node create --node-config "{name: $n, tcp-outlets: {db-outlet: {to: '127.0.0.1:5432', at: $n}}}"
-  assert_output --partial "Node ${n} created successfully"
+  run_success "$OCKAM" node create --node-config "{name: n, tcp-outlets: {db-outlet: {to: 5432, at: n}}}"
+  run_success $OCKAM node show n --output json
+  assert_output --partial "\"name\": \"n\""
+  assert_output --partial "127.0.0.1:5432"
 }
 
 @test "node - create two nodes with the same inline configuration" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
@@ -25,7 +25,7 @@ teardown() {
 
   # create some state in the OCKAM_HOME directory
   refute_output --partial "nodes"
-  QUIET=0 "$OCKAM" node create -vv
+  run_success "$OCKAM" node create -vv
   run_success ls "$OCKAM_HOME"
   assert_output --partial "database.sqlite3"
   assert_output --partial "application_database.sqlite3"


### PR DESCRIPTION
## Current output

It always returns the same:

![image](https://github.com/build-trust/ockam/assets/12375782/bbab33c5-8a60-4d34-a46e-ef4b11092cf7)

And when creating a foreground node, it doesn't show anything at all.

## New output

When creating a node on a clean state (no vaults, no identities):

![image](https://github.com/build-trust/ockam/assets/12375782/7fe3efd9-d397-4780-a35e-95001910e4fd)

When creating a node afterward:

![image](https://github.com/build-trust/ockam/assets/12375782/afacd910-3cd7-419d-8722-89b81fc9978d)

Finally, there is also new content when we create a foreground node, in line with what we see in background nodes:

![image](https://github.com/build-trust/ockam/assets/12375782/9153f212-8cba-4351-896e-17ce76756d04)
 