### PR TITLE
feat(rust): scope some repositories to a given node name

### DIFF
--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -26,7 +26,9 @@ pub use env::Env;
 pub use error::{EvalError, ParseError};
 pub use eval::eval;
 pub use expr::Expr;
-pub use policy::{storage::*, Policies, PolicyAccessControl, ResourcePolicy, ResourceTypePolicy};
+pub use policy::{
+    storage::*, Policies, PolicyAccessControl, ResourcePolicy, ResourceTypePolicy, Resources,
+};
 pub use resource::{Resource, ResourceType};
 pub use types::{Action, ResourceName, Subject};
 

--- a/implementations/rust/ockam/ockam_abac/src/policy/mod.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/mod.rs
@@ -4,6 +4,7 @@ mod outgoing;
 mod policies;
 mod resource_policy;
 mod resource_type_policy;
+mod resources;
 pub(crate) mod storage;
 
 pub use access_control::*;
@@ -13,3 +14,4 @@ pub use outgoing::*;
 pub use policies::Policies;
 pub use resource_policy::ResourcePolicy;
 pub use resource_type_policy::ResourceTypePolicy;
+pub use resources::Resources;

--- a/implementations/rust/ockam/ockam_abac/src/policy/resources.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/resources.rs
@@ -1,0 +1,28 @@
+use crate::{Resource, ResourceName, ResourcesRepository};
+use ockam_core::compat::sync::Arc;
+use ockam_core::Result;
+
+#[derive(Clone)]
+pub struct Resources {
+    resources_repository: Arc<dyn ResourcesRepository>,
+}
+
+impl Resources {
+    pub fn new(resources_repository: Arc<dyn ResourcesRepository>) -> Self {
+        Self {
+            resources_repository,
+        }
+    }
+
+    pub async fn store_resource(&self, resource: &Resource) -> Result<()> {
+        self.resources_repository.store_resource(resource).await?;
+        Ok(())
+    }
+
+    pub async fn delete_resource(&self, resource_name: &ResourceName) -> Result<()> {
+        self.resources_repository
+            .delete_resource(resource_name)
+            .await?;
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -65,14 +65,13 @@ impl Authority {
         // create the database
         let database_path = &configuration.database_path;
         Self::create_ockam_directory_if_necessary(database_path)?;
-        let database = SqlxDatabase::create_with_node_name(database_path, "authority").await?;
-
+        let database = SqlxDatabase::create(database_path).await?;
         let members = Arc::new(AuthorityMembersSqlxDatabase::new(database.clone()));
         let tokens = Arc::new(AuthorityEnrollmentTokenSqlxDatabase::new(database.clone()));
 
         Self::bootstrap_repository(members.clone(), configuration).await?;
 
-        let identities = Identities::create(database).build();
+        let identities = Identities::create_with_node(database, "authority").build();
 
         let secure_channels = SecureChannels::from_identities(identities.clone());
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -76,10 +76,6 @@ impl CliState {
         Self::make_application_database_path(&self.dir)
     }
 
-    pub fn set_node_name(&mut self, node_name: impl AsRef<str>) {
-        self.database.set_node_name(node_name.as_ref());
-    }
-
     pub fn subscribe_to_notifications(&self) -> Receiver<Notification> {
         self.notifications.subscribe()
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/identities_attributes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/identities_attributes.rs
@@ -6,15 +6,21 @@ use std::sync::Arc;
 
 impl CliState {
     /// Return the service managing identities attributes
-    pub fn identities_attributes(&self) -> Arc<IdentitiesAttributes> {
+    pub fn identities_attributes(&self, node_name: &str) -> Arc<IdentitiesAttributes> {
         Arc::new(IdentitiesAttributes::new(
-            self.identity_attributes_repository(),
+            self.identity_attributes_repository(node_name),
         ))
     }
 
     /// The identity attributes repository cannot be accessed directly
     /// outside of the identities_attributes service
-    fn identity_attributes_repository(&self) -> Arc<dyn IdentityAttributesRepository> {
-        Arc::new(IdentityAttributesSqlxDatabase::new(self.database()))
+    fn identity_attributes_repository(
+        &self,
+        node_name: &str,
+    ) -> Arc<dyn IdentityAttributesRepository> {
+        Arc::new(IdentityAttributesSqlxDatabase::new(
+            self.database(),
+            node_name,
+        ))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/policies.rs
@@ -3,10 +3,13 @@ use ockam_abac::{Policies, ResourcePolicySqlxDatabase, ResourceTypePolicySqlxDat
 use std::sync::Arc;
 
 impl CliState {
-    pub fn policies(&self) -> Policies {
+    pub fn policies(&self, node_name: &str) -> Policies {
         Policies::new(
-            Arc::new(ResourcePolicySqlxDatabase::new(self.database())),
-            Arc::new(ResourceTypePolicySqlxDatabase::new(self.database())),
+            Arc::new(ResourcePolicySqlxDatabase::new(self.database(), node_name)),
+            Arc::new(ResourceTypePolicySqlxDatabase::new(
+                self.database(),
+                node_name,
+            )),
         )
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/repositories.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/repositories.rs
@@ -1,6 +1,8 @@
 use ockam::identity::storage::{PurposeKeysRepository, PurposeKeysSqlxDatabase};
-use ockam::identity::{ChangeHistoryRepository, ChangeHistorySqlxDatabase};
-use ockam_abac::{ResourcesRepository, ResourcesSqlxDatabase};
+use ockam::identity::{
+    ChangeHistoryRepository, ChangeHistorySqlxDatabase, CredentialRepository,
+    CredentialSqlxDatabase,
+};
 use ockam_core::compat::sync::Arc;
 use ockam_vault::storage::{SecretsRepository, SecretsSqlxDatabase};
 
@@ -46,10 +48,6 @@ impl CliState {
         Arc::new(ProjectsSqlxDatabase::new(self.database()))
     }
 
-    pub(super) fn resources_repository(&self) -> Arc<dyn ResourcesRepository> {
-        Arc::new(ResourcesSqlxDatabase::new(self.database()))
-    }
-
     pub(super) fn spaces_repository(&self) -> Arc<dyn SpacesRepository> {
         Arc::new(SpacesSqlxDatabase::new(self.database()))
     }
@@ -60,5 +58,9 @@ impl CliState {
 
     pub(super) fn user_journey_repository(&self) -> Arc<dyn JourneysRepository> {
         Arc::new(JourneysSqlxDatabase::new(self.application_database()))
+    }
+
+    pub fn cached_credentials_repository(&self, node_name: &str) -> Arc<dyn CredentialRepository> {
+        Arc::new(CredentialSqlxDatabase::new(self.database(), node_name))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/resources.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/resources.rs
@@ -1,17 +1,12 @@
-use super::Result;
 use crate::CliState;
-use ockam_abac::{Resource, ResourceName};
+use ockam_abac::{Resources, ResourcesSqlxDatabase};
+use std::sync::Arc;
 
 impl CliState {
-    pub async fn store_resource(&self, resource: &Resource) -> Result<()> {
-        self.resources_repository().store_resource(resource).await?;
-        Ok(())
-    }
-
-    pub async fn delete_resource(&self, resource_name: &ResourceName) -> Result<()> {
-        self.resources_repository()
-            .delete_resource(resource_name)
-            .await?;
-        Ok(())
+    pub fn resources(&self, node_name: &str) -> Resources {
+        Resources::new(Arc::new(ResourcesSqlxDatabase::new(
+            self.database(),
+            node_name,
+        )))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
@@ -9,7 +9,7 @@ impl CliState {
     pub async fn secure_channels(&self, node_name: &str) -> Result<Arc<SecureChannels>> {
         debug!("create the secure channels service");
         let vault = self.get_node_vault(node_name).await?.vault().await?;
-        let identities = Identities::create(self.database())
+        let identities = Identities::create_with_node(self.database(), node_name)
             .with_vault(vault)
             .build();
         Ok(SecureChannels::from_identities(identities))

--- a/implementations/rust/ockam/ockam_api/src/cli_state/test_support.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/test_support.rs
@@ -6,9 +6,7 @@ use std::path::PathBuf;
 impl CliState {
     /// Return a test CliState with a random root directory
     pub async fn test() -> Result<Self> {
-        let mut state = Self::create(Self::test_dir()?).await?;
-        state.set_node_name(random_name());
-        Ok(state)
+        Self::create(Self::test_dir()?).await
     }
 
     /// Return a random root directory

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
@@ -70,14 +70,12 @@ impl NodeManager {
         let action = Action::from_str(action)?;
         match resource {
             ResourceTypeOrName::Type(resource_type) => {
-                self.cli_state
-                    .policies()
+                self.policies()
                     .store_policy_for_resource_type(&resource_type, &action, &expression)
                     .await
             }
             ResourceTypeOrName::Name(resource_name) => {
-                self.cli_state
-                    .policies()
+                self.policies()
                     .store_policy_for_resource_name(&resource_name, &action, &expression)
                     .await
             }
@@ -93,13 +91,11 @@ impl NodeManager {
         let action = Action::from_str(action)?;
         Ok(match resource {
             ResourceTypeOrName::Type(resource_type) => self
-                .cli_state
                 .policies()
                 .get_policy_for_resource_type(&resource_type, &action)
                 .await?
                 .map(|p| p.into()),
             ResourceTypeOrName::Name(resource_name) => self
-                .cli_state
                 .policies()
                 .get_policy_for_resource_name(&resource_name, &action)
                 .await?
@@ -112,7 +108,6 @@ impl NodeManager {
             Some(resource) => match resource {
                 ResourceTypeOrName::Type(resource_type) => {
                     let resource_type_policies = self
-                        .cli_state
                         .policies()
                         .get_policies_for_resource_type(&resource_type)
                         .await?;
@@ -120,7 +115,6 @@ impl NodeManager {
                 }
                 ResourceTypeOrName::Name(resource_name) => {
                     let resource_policies = self
-                        .cli_state
                         .policies()
                         .get_policies_for_resource_name(&resource_name)
                         .await?;
@@ -129,7 +123,7 @@ impl NodeManager {
             },
             None => {
                 let (resource_policies, resource_type_policies) =
-                    self.cli_state.policies().get_policies().await?;
+                    self.policies().get_policies().await?;
                 Ok(PoliciesList::new(resource_policies, resource_type_policies))
             }
         }
@@ -139,14 +133,12 @@ impl NodeManager {
         let action = Action::from_str(action)?;
         match resource {
             ResourceTypeOrName::Type(resource_type) => {
-                self.cli_state
-                    .policies()
+                self.policies()
                     .delete_policy_for_resource_type(&resource_type, &action)
                     .await
             }
             ResourceTypeOrName::Name(resource_name) => {
-                self.cli_state
-                    .policies()
+                self.policies()
                     .delete_policy_for_resource_name(&resource_name, &action)
                     .await
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/portals.rs
@@ -285,7 +285,7 @@ impl NodeManager {
         if let Some(deleted_outlet) = self.registry.outlets.remove(worker_addr).await {
             debug!(%worker_addr, "Successfully removed outlet from node registry");
 
-            self.cli_state
+            self.resources()
                 .delete_resource(&worker_addr.address().into())
                 .await?;
 
@@ -455,7 +455,7 @@ impl NodeManager {
         if let Some(inlet_to_delete) = self.registry.inlets.remove(alias).await {
             debug!(%alias, "Successfully removed inlet from node registry");
             inlet_to_delete.session.close().await?;
-            self.cli_state.delete_resource(&alias.into()).await?;
+            self.resources().delete_resource(&alias.into()).await?;
             Ok(InletStatus::new(
                 inlet_to_delete.bind_addr,
                 None,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -405,7 +405,7 @@ impl NodeManager {
 impl NodeManager {
     /// Build a SecureChannels struct for a specific vault
     pub(crate) async fn build_secure_channels(&self, vault: Vault) -> Result<Arc<SecureChannels>> {
-        let identities = Identities::create(self.cli_state.database())
+        let identities = Identities::create_with_node(self.cli_state.database(), &self.node_name)
             .with_vault(vault)
             .build();
         Ok(Arc::new(SecureChannels::new(

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -95,8 +95,7 @@ impl AppState {
         application_state_callback: ApplicationStateCallback,
         notification_callback: NotificationCallback,
     ) -> Result<AppState> {
-        let mut cli_state = CliState::with_default_dir()?;
-        cli_state.set_node_name(NODE_NAME);
+        let cli_state = CliState::with_default_dir()?;
         let rt = Arc::new(Runtime::new().expect("cannot create a tokio runtime"));
         let (context, mut executor) = NodeBuilder::new()
             .no_logging()

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -265,8 +265,7 @@ impl CreateCommand {
             self.guard_node_is_not_already_running(&opts).await?;
         }
 
-        let mut state = opts.state.clone();
-        state.set_node_name(&self.node_name);
+        let state = opts.state.clone();
 
         // Create the authority identity if it has not been created before
         // If no name is specified on the command line, use "authority"

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -42,11 +42,8 @@ impl ListCommand {
             Some(name) => name,
             None => opts.state.get_default_node().await?.name(),
         };
-        let mut opts = opts.clone();
-        opts.state.set_node_name(&node_name);
-
         let database = opts.state.database();
-        let storage = CredentialSqlxDatabase::new(database);
+        let storage = CredentialSqlxDatabase::new(database, &node_name);
 
         let credentials = storage.get_all().await.into_diagnostic()?;
 

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -58,11 +58,9 @@ impl StoreCommand {
             .get_node_or_default(&self.node_opts.at_node)
             .await?
             .name();
-        let mut state = opts.state.clone();
-        state.set_node_name(node_name);
-
+        let state = opts.state.clone();
         let database = state.database();
-        let storage = CredentialSqlxDatabase::new(database);
+        let storage = CredentialSqlxDatabase::new(database, &node_name);
 
         opts.terminal
             .write_line(&fmt_log!("Storing credential...\n"))?;

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -75,8 +75,7 @@ impl CreateCommand {
         let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
 
         // Set node_name so that node can isolate its data in the storage from other nodes
-        let mut state = opts.state.clone();
-        state.set_node_name(&node_name);
+        let state = opts.state.clone();
 
         let node_info = state
             .start_node_with_optional_values(

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities.rs
@@ -157,14 +157,23 @@ impl Identities {
     /// Return a builder for identities with a specific database
     #[cfg(feature = "storage")]
     pub fn create(database: SqlxDatabase) -> IdentitiesBuilder {
+        Self::create_with_node(database, "default")
+    }
+
+    /// Return a builder for identities with a specific database
+    #[cfg(feature = "storage")]
+    pub fn create_with_node(database: SqlxDatabase, node_name: &str) -> IdentitiesBuilder {
         IdentitiesBuilder {
             vault: Vault::create_with_database(database.clone()),
             change_history_repository: Arc::new(ChangeHistorySqlxDatabase::new(database.clone())),
             identity_attributes_repository: Arc::new(IdentityAttributesSqlxDatabase::new(
                 database.clone(),
+                node_name,
             )),
             purpose_keys_repository: Arc::new(PurposeKeysSqlxDatabase::new(database.clone())),
-            cached_credentials_repository: Arc::new(CredentialSqlxDatabase::new(database)),
+            cached_credentials_repository: Arc::new(CredentialSqlxDatabase::new(
+                database, node_name,
+            )),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/identities/identities_builder.rs
@@ -28,8 +28,8 @@ pub async fn identities() -> Result<Arc<Identities>> {
 
 /// Return identities backed by a specific database
 #[cfg(feature = "storage")]
-pub fn create(database: SqlxDatabase) -> Arc<Identities> {
-    Identities::create(database).build()
+pub fn create(database: SqlxDatabase, node_name: &str) -> Arc<Identities> {
+    Identities::create_with_node(database, node_name).build()
 }
 
 impl IdentitiesBuilder {


### PR DESCRIPTION
We realized some time ago that some data needed to be segregated by node name in the database:

 - Resources (type, policies).
 - Identity attributes.
 - Credentials.

We fixed this by using mutation and allowing a database to temporarily have a `node_name` which could be used by the repositories needing it (the ones storing the data mentioned above).

This is problematic because:

 - This introduces some temporal coupling: we need to think of setting the right node name before invoking any operation that could potential touch resources, identity attributes or credentials.
 - This creates more potential states in the system: now _any_ repository can potentially use a node name to store data, while in reality only a few of them need this. 

This PR addresses this issue by:

 - Adding a `node_name` directly on the `XXXSqlDatabase` implementations needing it. For example in `CredentialSqlxDatabase` because credentials are segregated by node name in the database.
 - Changing the various builder functions so that a `node_name` is passed as a parameter as necessary. Typically, in the `NodeManager` we create storage that is scoped to a specific node.

This is still not great:

 - The fact that we share some storage, for example for the list of all identities, and that we segregate some, for example credentials, is the result of building a command line application and a `NodeManager` on top of the functions provided by  the `ockam_identities` crates. So, the constraints introduced at a "high" level in the architecture have some consequences on the "low" level of the architecture.
 
 - Concretely speaking, the `Identities` struct is mostly node agnostic but not entirely. When we use it to create an identity, that identity is accessible by any node. On the other hand if we use it to store a credential, it's node specific. One thing we could potentially do is revisit this choice and make every repository under `Identities` node specific. But this would be a much larger refactoring.
