### PR TITLE
feat(rust): `node create` raises an error if a passed variable has no value

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -5,6 +5,7 @@ use crate::run::parser::resource::*;
 use crate::run::parser::Version;
 use crate::value_parsers::async_parse_path_or_url;
 use crate::CommandGlobalOpts;
+use miette::miette;
 use ockam_api::cli_state::journeys::APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE;
 use ockam_api::cli_state::random_name;
 use ockam_node::Context;
@@ -39,6 +40,9 @@ impl CreateCommand {
         // Set environment variables from the cli command args
         // This needs to be done before parsing the configuration
         for (key, value) in &self.variables {
+            if value.is_empty() {
+                return Err(miette!("Empty value for variable '{key}'"));
+            }
             std::env::set_var(key, value);
         }
         // Parse the configuration
@@ -87,6 +91,9 @@ impl NodeConfig {
         // Set environment variables from the cli command again
         // to override the duplicate entries from the config file.
         for (key, value) in &cli_args.variables {
+            if value.is_empty() {
+                return Err(miette!("Empty value for variable '{key}'"));
+            }
             std::env::set_var(key, value);
         }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
@@ -22,7 +22,7 @@ impl Variables {
             .map(|c| c.to_string())
             .map_err(|e| {
                 miette!(
-                    "Failed to resolve variable {}: {}",
+                    "Failed to resolve variable '{}': {}",
                     color_primary(&e.var_name),
                     e.cause
                 )
@@ -40,6 +40,9 @@ impl Variables {
                     continue;
                 }
                 let v = v.to_string();
+                if v.is_empty() {
+                    return Err(miette!("Empty value for variable '{k}'"));
+                }
                 std::env::set_var(k, v);
             }
         }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -157,3 +157,8 @@ force_kill_node() {
     assert_output --partial 8080
   done
 }
+
+@test "node - return error if passed variable has no value" {
+  run_failure "$OCKAM" node create --node-config "{name: n}" --variable MY_VAR=
+  assert_output --partial "Empty value for variable 'MY_VAR'"
+}


### PR DESCRIPTION
Currently, if we run the following, it will return a cryptic error when parsing the config file:

```
# Assuming VAL doesn't exist
ockam node create --node-config "{name: n}" --variable MY_VAR=$VAL

> Error: data did not match any variant of untagged enum ResourcesContainer
```

Now, it will return a more specific error:

```
# Assuming VAL doesn't exist
ockam node create --node-config "{name: n}" --variable MY_VAR=$VAL

> Error: Empty value for variable 'MY_VAR'
```
