### PR TITLE
fix(rust): foreground nodes write all logs to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
  "tracing",
 ]
@@ -3228,7 +3228,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "log",
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3244,7 +3244,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.2.0",
  "hyper-util",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -3625,7 +3625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.4",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4431,7 +4431,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "semver 1.0.22",
@@ -5792,7 +5792,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
@@ -5972,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",
@@ -5984,9 +5984,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -7303,7 +7303,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.10",
+ "rustls 0.21.11",
  "tokio",
 ]
 
@@ -7313,7 +7313,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.2",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -92,7 +92,7 @@ r3bl_tuify = "0.1.25"
 rand = "0.8"
 regex = "1.10.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "blocking"] }
-rustls = "0.22.2"
+rustls = "0.22.4"
 rustls-native-certs = "0.7.0"
 rustls-pki-types = "1.4.1"
 semver = "1.0.22"

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -49,7 +49,7 @@ impl CommandGlobalOpts {
     ) -> miette::Result<Self> {
         let terminal = Terminal::from(global_args);
         let logging_configuration =
-            Self::make_logging_configuration(global_args, cmd, terminal.is_tty())?;
+            Self::make_logging_configuration(global_args, cmd, terminal.clone().stdout().is_tty())?;
         let tracing_configuration = Self::make_tracing_configuration(global_args, cmd)?;
         let tracing_guard =
             Self::setup_logging_tracing(cmd, &logging_configuration, &tracing_configuration);

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -226,7 +226,7 @@ impl OckamSubcommand {
         match self {
             OckamSubcommand::Node(cmd) => match &cmd.subcommand {
                 NodeSubcommand::Create(cmd) => {
-                    if cmd.child_process {
+                    if cmd.child_process || !cmd.foreground {
                         CliState::default_node_dir(&cmd.name).ok()
                     } else {
                         None
@@ -236,7 +236,7 @@ impl OckamSubcommand {
             },
             OckamSubcommand::Authority(cmd) => match &cmd.subcommand {
                 AuthoritySubcommand::Create(cmd) => {
-                    if cmd.child_process {
+                    if cmd.child_process || !cmd.foreground {
                         CliState::default_node_dir(&cmd.node_name).ok()
                     } else {
                         None


### PR DESCRIPTION
When running `node create --foreground`, we were writing to stdout the logs of the `node create` command, and the rest was being written to a file, like in a regular `node create` call.

The expected behavior is:

- `node create`: write to stdout the output of the command, the rest (i.e. the background node's output) to the log file
- `node create -f` write all to stdout, so the user can then redirect the output as desired (e.g. `&> my.log`)

It also fixes a bug to disable log coloring when redirecting stdout to a non-tty stream.