### PR TITLE
feat(rust): add the possibility to start a node in foreground mode with a configuration

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -15,6 +15,9 @@ pub struct Node {
     pub name: Option<ArgValue>,
     #[serde(alias = "skip-is-running-check")]
     pub skip_is_running_check: Option<ArgValue>,
+    pub foreground: Option<ArgValue>,
+    #[serde(alias = "child-process")]
+    pub child_process: Option<ArgValue>,
     #[serde(alias = "exit-on-eof")]
     pub exit_on_eof: Option<ArgValue>,
     #[serde(alias = "tcp-listener-address")]
@@ -59,6 +62,12 @@ impl Node {
         }
         if let Some(skip_is_running_check) = self.skip_is_running_check {
             args.insert("skip-is-running-check".to_string(), skip_is_running_check);
+        }
+        if let Some(foreground) = self.foreground {
+            args.insert("foreground".to_string(), foreground);
+        }
+        if let Some(child_process) = self.child_process {
+            args.insert("child-process".to_string(), child_process);
         }
         if let Some(exit_on_eof) = self.exit_on_eof {
             args.insert("exit-on-eof".to_string(), exit_on_eof);

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -28,8 +28,8 @@ impl ParsedCommands {
     }
 
     /// Validate and run each command
-    pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
-        for cmd in self.commands.into_iter() {
+    pub async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
+        for cmd in self.commands.iter() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
                 // Newline between commands


### PR DESCRIPTION
This PR allows the `ockam node create` command to take a configuration and run the node in the foreground (with the `-f` or `--foreground` flag). 

Since the execution of the command creating and starting a node eventually blocks, we run all the other commands in a separate thread. Those commands are retried because at the time when they execute the node not be up yet.