### PR TITLE
feat(rust): when deleting a node, wait for node's process to finish

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use colorful::Colorful;
 use console::Term;
 use ockam_api::fmt_ok;
+use ockam_api::terminal::notification::NotificationHandler;
 use ockam_api::terminal::{Terminal, TerminalStream};
 
 use crate::terminal::tui::DeleteCommandTui;
@@ -59,6 +60,7 @@ pub struct DeleteTui {
 
 impl DeleteTui {
     pub async fn run(opts: CommandGlobalOpts, cmd: DeleteCommand) -> miette::Result<()> {
+        let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
         let tui = Self { opts, cmd };
         tui.delete().await
     }


### PR DESCRIPTION
When deleting a node, wait until the process is fully terminated. Not doing so can lead to a variety of errors related to node resources not being freed up (e.g. ports) before trying to recreate the same node or a new one.

If the node takes more than 0.5s to stop, a progress message is shown:

```
➜ ockam node delete -y                                                
     ⠹ Waiting for node sound-whippet to stop                                                                                                                           ✔ 
     ✔ Node with name sound-whippet has been deleted
```

It normally takes less than that. In that case, the progress message is not shown.