### PR TITLE
feat(rust): improve output of `project enroll` command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
@@ -1,5 +1,9 @@
+/// Left padding for all terminal output
 pub const PADDING: &str = "     ";
+/// Left padding for all terminal output that starts with an icon
 pub const ICON_PADDING: &str = "   ";
+/// A two-space indentation for nested terminal output
+pub const INDENTATION: &str = "  ";
 
 #[macro_export]
 macro_rules! fmt_log {

--- a/implementations/rust/ockam/ockam_command/src/node/models/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/models/show.rs
@@ -88,7 +88,6 @@ impl ShowNodeResponse {
 
 impl Display for ShowNodeResponse {
     fn fmt(&self, buffer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let indent = "  ";
         write!(buffer, "{}{}", fmt::PADDING, color_primary(&self.name))?;
         if self.is_default {
             write!(buffer, " (default)")?;
@@ -99,7 +98,7 @@ impl Display for ShowNodeResponse {
             buffer,
             "{}{}The node is {}",
             fmt::PADDING,
-            indent,
+            fmt::INDENTATION,
             self.status
         )?;
         if let Some(node_pid) = self.node_pid {
@@ -111,7 +110,7 @@ impl Display for ShowNodeResponse {
             buffer,
             "{}{}With route {}",
             fmt::PADDING,
-            indent,
+            fmt::INDENTATION,
             color_primary(self.route.short.to_string())
         )?;
         if let Some(verbose) = &self.route.verbose {
@@ -120,19 +119,25 @@ impl Display for ShowNodeResponse {
         writeln!(buffer)?;
 
         if let Some(identity) = &self.identity {
-            writeln!(buffer, "{}{}Identity: {}", fmt::PADDING, indent, identity)?;
+            writeln!(
+                buffer,
+                "{}{}Identity: {}",
+                fmt::PADDING,
+                fmt::INDENTATION,
+                identity
+            )?;
         }
 
         if self.transports.is_empty() {
-            writeln!(buffer, "{}{}No Transports", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}No Transports", fmt::PADDING, fmt::INDENTATION)?;
         } else {
-            writeln!(buffer, "{}{}Transports:", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}Transports:", fmt::PADDING, fmt::INDENTATION)?;
             for t in &self.transports {
                 writeln!(
                     buffer,
                     "{}{}{}, {} at {}",
                     fmt::PADDING,
-                    indent.repeat(2),
+                    fmt::INDENTATION.repeat(2),
                     t.tt,
                     t.mode,
                     color_primary(&t.socket)
@@ -141,30 +146,40 @@ impl Display for ShowNodeResponse {
         }
 
         if self.secure_channel_listeners.is_empty() {
-            writeln!(buffer, "{}{}No Secure Channels", fmt::PADDING, indent)?;
+            writeln!(
+                buffer,
+                "{}{}No Secure Channels",
+                fmt::PADDING,
+                fmt::INDENTATION
+            )?;
         } else {
-            writeln!(buffer, "{}{}Secure Channels:", fmt::PADDING, indent)?;
+            writeln!(
+                buffer,
+                "{}{}Secure Channels:",
+                fmt::PADDING,
+                fmt::INDENTATION
+            )?;
             for s in &self.secure_channel_listeners {
                 writeln!(
                     buffer,
                     "{}{}Listener at {}",
                     fmt::PADDING,
-                    indent.repeat(2),
+                    fmt::INDENTATION.repeat(2),
                     color_primary(&s.address.to_string())
                 )?;
             }
         }
 
         if self.inlets.is_empty() && self.outlets.is_empty() {
-            writeln!(buffer, "{}{}No Portals", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}No Portals", fmt::PADDING, fmt::INDENTATION)?;
         } else {
-            writeln!(buffer, "{}{}Portals:", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}Portals:", fmt::PADDING, fmt::INDENTATION)?;
             for i in &self.inlets {
                 write!(
                     buffer,
                     "{}{}Inlet at {} is {}",
                     fmt::PADDING,
-                    indent.repeat(2),
+                    fmt::INDENTATION.repeat(2),
                     color_primary(&i.listen_address),
                     i.status,
                 )?;
@@ -184,22 +199,22 @@ impl Display for ShowNodeResponse {
                     buffer,
                     "{}{}Outlet {} at {}",
                     fmt::PADDING,
-                    indent.repeat(2),
+                    fmt::INDENTATION.repeat(2),
                     color_primary(o.address.to_string()),
                     color_primary(&o.forward_address.to_string()),
                 )?;
             }
         }
         if self.services.is_empty() {
-            writeln!(buffer, "{}{}No Services", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}No Services", fmt::PADDING, fmt::INDENTATION)?;
         } else {
-            writeln!(buffer, "{}{}Services:", fmt::PADDING, indent)?;
+            writeln!(buffer, "{}{}Services:", fmt::PADDING, fmt::INDENTATION)?;
             for s in &self.services {
                 writeln!(
                     buffer,
                     "{}{}{} service at {}",
                     fmt::PADDING,
-                    indent.repeat(2),
+                    fmt::INDENTATION.repeat(2),
                     color_warn(&s.service_type),
                     color_primary(&s.address.to_string())
                 )?;

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -14,9 +14,9 @@ use ockam_api::authenticator::direct::{
 use ockam_api::authenticator::enrollment_tokens::TokenIssuer;
 use ockam_api::cli_state::enrollments::EnrollmentTicket;
 use ockam_api::colors::color_primary;
-use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::OutputFormat;
+use ockam_api::{fmt_log, fmt_ok};
 use ockam_multiaddr::MultiAddr;
 
 use crate::util::api::RetryOpts;
@@ -122,9 +122,10 @@ impl Command for TicketCommand {
         let ticket = EnrollmentTicket::new(token, Some(project.model().clone()));
         let ticket_serialized = ticket.hex_encoded().into_diagnostic()?;
 
-        opts.terminal.write_line(&fmt_ok!(
-            "{}: {}",
-            "Created enrollment ticket. You can use it to enroll another machine using",
+        opts.terminal
+            .write_line(fmt_ok!("Created enrollment ticket."))?;
+        opts.terminal.write_line(fmt_log!(
+            "You can use it to enroll another machine using: {}",
             color_primary("ockam project enroll")
         ))?;
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -98,8 +98,8 @@ EOF
   run_success $OCKAM project import --project-file $OCKAM_HOME/project.json
 
   run_success "$OCKAM" project enroll --identity admin
-  assert_output --partial '"ockam-relay": "*"'
-  assert_output --partial "$admin_identifier"
+  assert_output --partial "ockam-relay=*"
+  assert_output --partial "admin"
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential
   run_success "$OCKAM" project enroll --identity m1


### PR DESCRIPTION
## Current output

It shows cryptic information that the user won't understand/use. Also the format is not aligned with the rest of the commands. 

![image](https://github.com/build-trust/ockam/assets/12375782/34f70ac0-6ead-44d5-95ef-739285b557fa)

## Proposed output

In this case, it shows less information:
- The identity name instead of the identifier, because it's what we use as the input in the commands
- The creation and expiration dates for the credential
- The attributes associated with the credential

![image](https://github.com/build-trust/ockam/assets/12375782/6ae218e6-eba6-4bdc-92a6-3ce80af7fb7e)
