### PR TITLE
feat(rust): display router errors as debug messages

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/worker_relay.rs
@@ -131,9 +131,9 @@ where
                         // An error occurred -- log and continue
                         Err(e) => {
                             #[cfg(feature = "debugger")]
-                            error!("Error encountered during '{}' message handling: {:?}", address, e);
+                            trace!("Error encountered during '{}' message handling: {:?}", address, e);
                             #[cfg(not(feature = "debugger"))]
-                            error!("Error encountered during '{}' message handling: {}", address, e);
+                            trace!("Error encountered during '{}' message handling: {}", address, e);
                         }
                     }
                 },


### PR DESCRIPTION
There can be many valid reasons why there is a router "error". For example when a TCP connection is shutdown, there might still be other workers trying to reach the TCP workers. In that case we display an `ERROR`:
```
INFO TcpSendWorker::handle_message{worker=0#374037bd45f1d705d0e80d0ca80eb871}: ockam_transport_tcp::workers::sender: Stopping sender due to closed connection 127.0.0.1:51995
DEBUG TcpSendWorker::handle_message{worker=0#374037bd45f1d705d0e80d0ca80eb871}:TcpSendWorker::stop: ockam_node::context::worker_lifecycle: Shutting down worker 0#374037bd45f1d705d0e80d0ca80eb871
TRACE run_command{command="node create"}:run: ockam_node::router: Received shutdown ACK for address 0#a33e1b7b90d7bdb230eb452790c29a24
TRACE run_command{command="node create"}:run: ockam_core::flow_control::flow_controls::flow_controls_cleanup: Cleanup FlowControls for 0#a33e1b7b90d7bdb230eb452790c29a24
TRACE run_command{command="node create"}:run: ockam_node::router::stop_worker: Stopping worker '0#374037bd45f1d705d0e80d0ca80eb871'
TRACE ockam_node::relay::worker_relay: No more messages for worker 0#374037bd45f1d705d0e80d0ca80eb871
TRACE ockam_node::relay::worker_relay: Sending shutdown ACK
TRACE run_command{command="node create"}:run: ockam_node::router: Received shutdown ACK for address 0#374037bd45f1d705d0e80d0ca80eb871

<many lines later>

ERROR ockam_node::relay::worker_relay: Error encountered during '0#_internal.nodemanager' message handling: operation failed for address 0#374037bd45f1d705d0e80d0ca80eb871
```

This stands out in the logs but this is not actually an `ERROR`, so this PR now displays the message as `TRACE` instead 