### PR TITLE
doc: propagate the `OCKAM_DEVELOPER` environment variable in docker examples

### DIFF
--- a/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/run.sh
+++ b/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/apis/nodejs/amazon_ec2
 
 run() {

--- a/examples/command/portals/apis/python/amazon_ec2/aws_cli/run.sh
+++ b/examples/command/portals/apis/python/amazon_ec2/aws_cli/run.sh
@@ -9,7 +9,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/apis/python/amazon_ec2
 
 run() {

--- a/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/run.sh
+++ b/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/coderepos/gitlab/amazon_ec2
 
 run() {

--- a/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/README.md
+++ b/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/README.md
@@ -5,5 +5,5 @@ This hands-on example uses Ockam to create an end-to-end encrypted portal to Inf
 We connect a nodejs app in one Amazon VPC with a Amazon Timestream managed InfluxDB database in another Amazon VPC.
 The example uses AWS CLI to create these VPCs.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/influxdb/timestream

--- a/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/run.sh
+++ b/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/databases/influxdb/timestream
 
 run() {

--- a/examples/command/portals/databases/mongodb/amazon_vpc/README.md
+++ b/examples/command/portals/databases/mongodb/amazon_vpc/README.md
@@ -5,5 +5,5 @@ This hands-on example uses Ockam to create an end-to-end encrypted portal to Mon
 We connect a nodejs app in one Amazon VPC with a Amazon VPC managed Mongo database in another Amazon VPC.
 The example uses AWS CLI to create these VPCs.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/mongodb/amazon_vpc

--- a/examples/command/portals/databases/mongodb/docker/analysis_corp/docker-compose.yml
+++ b/examples/command/portals/databases/mongodb/docker/analysis_corp/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       dockerfile: ../ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - analysis_corp
 

--- a/examples/command/portals/databases/mongodb/docker/bank_corp/docker-compose.yml
+++ b/examples/command/portals/databases/mongodb/docker/bank_corp/docker-compose.yml
@@ -23,5 +23,6 @@ services:
       dockerfile: ../ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - bank_corp

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/README.md
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/README.md
@@ -5,5 +5,5 @@ This hands-on example uses Ockam to create an end-to-end encrypted portal to pos
 We connect a nodejs app in one Amazon VPC with a Amazon RDS managed Postgres database in another Amazon VPC.
 The example uses AWS CLI to create these VPCs.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/databases/postgres/rds

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/run.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/run.sh
@@ -8,7 +8,7 @@ set -e
 #
 # The example uses AWS CLI to create these VPCs.
 #
-# You can read a detailed walkthough of this example at:
+# You can read a detailed walkthrough of this example at:
 # https://docs.ockam.io/portals/databases/postgres/rds
 
 run() {

--- a/examples/command/portals/databases/postgres/docker/analysis_corp/docker-compose.yml
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       dockerfile: ../ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - analysis_corp
 

--- a/examples/command/portals/databases/postgres/docker/bank_corp/docker-compose.yml
+++ b/examples/command/portals/databases/postgres/docker/bank_corp/docker-compose.yml
@@ -27,5 +27,6 @@ services:
       dockerfile: ../ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - bank_corp

--- a/examples/command/portals/kafka/apache/docker/README.md
+++ b/examples/command/portals/kafka/apache/docker/README.md
@@ -2,9 +2,12 @@
 
 In this hands-on example we send end-to-end encrypted messages _through_ Apache Kafka.
 
-[<mark style="color:blue;">Ockam</mark>](https://docs.ockam.io/) encrypts messages from a Producer to a specific Consumer. Only that specific Consumer can decrypt these messages. This guarantees that your data cannot be observed or tampered as it passes through Kafka. Operators of Kafka only see end-to-end encrypted data. Any compromise of an operator's infrastructure cannot compromise your business data.
+[<mark style="color:blue;">Ockam</mark>](https://docs.ockam.io/) encrypts messages from a Producer to a specific
+Consumer. Only that specific Consumer can decrypt these messages. This guarantees that your data cannot be observed or
+tampered as it passes through Kafka. Operators of Kafka only see end-to-end encrypted data. Any compromise of an
+operator's infrastructure cannot compromise your business data.
 
 The example uses docker and docker compose to create virtual networks.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/kafka/apache-kafka/docker

--- a/examples/command/portals/kafka/apache/docker/application_team/docker-compose.yml
+++ b/examples/command/portals/kafka/apache/docker/application_team/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       dockerfile: ../kafka_ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${CONSUMER_ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     command:
       - -c
       - (
@@ -40,6 +41,7 @@ services:
       dockerfile: ../kafka_ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${PRODUCER_ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - application_team
     command:

--- a/examples/command/portals/kafka/apache/docker/kafka_operator/docker-compose.yml
+++ b/examples/command/portals/kafka/apache/docker/kafka_operator/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       dockerfile: ../kafka_ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - kafka_operator
 

--- a/examples/command/portals/kafka/redpanda/docker/README.md
+++ b/examples/command/portals/kafka/redpanda/docker/README.md
@@ -2,9 +2,12 @@
 
 In this hands-on example we send end-to-end encrypted messages _through_ Redpanda.
 
-[<mark style="color:blue;">Ockam</mark>](https://docs.ockam.io/) encrypts messages from a Producer to a specific Consumer. Only that specific Consumer can decrypt these messages. This guarantees that your data cannot be observed or tampered as it passes through Redpanda. Operators of Redpanda only see end-to-end encrypted data. Any compromise of an operator's infrastructure cannot compromise your business data.
+[<mark style="color:blue;">Ockam</mark>](https://docs.ockam.io/) encrypts messages from a Producer to a specific
+Consumer. Only that specific Consumer can decrypt these messages. This guarantees that your data cannot be observed or
+tampered as it passes through Redpanda. Operators of Redpanda only see end-to-end encrypted data. Any compromise of an
+operator's infrastructure cannot compromise your business data.
 
 The example uses docker and docker compose to create virtual networks.
 
-You can read a detailed walkthough of this example at:
+You can read a detailed walkthrough of this example at:
 https://docs.ockam.io/portals/kafka/redpanda/docker

--- a/examples/command/portals/kafka/redpanda/docker/application_team/docker-compose.yml
+++ b/examples/command/portals/kafka/redpanda/docker/application_team/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       dockerfile: kafka_client.dockerfile
     environment:
       ENROLLMENT_TICKET: ${CONSUMER_ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - application_team
     command:

--- a/examples/command/portals/kafka/redpanda/docker/redpanda_operator/docker-compose.yml
+++ b/examples/command/portals/kafka/redpanda/docker/redpanda_operator/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       dockerfile: ../ockam.dockerfile
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET:-}
+      OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-}
     networks:
       - redpanda_operator
   redpanda:


### PR DESCRIPTION
This PR:

 - Fixes a typo in examples descriptions.
 - Propagates the `OCKAM_DEVELOPER` environment variable in docker examples