### PR TITLE
Create an exporter project member when the authority node starts

### DIFF
--- a/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_storage.ex
+++ b/implementations/elixir/ockam/ockam/lib/ockam/credential/attribute_storage.ex
@@ -5,6 +5,7 @@ defmodule Ockam.Credential.AttributeStorageETS do
   init() should be called once by the controlling process to create a table
   """
   alias Ockam.Credential.AttributeSet
+  require Logger
 
   @table __MODULE__
 
@@ -80,6 +81,8 @@ defmodule Ockam.Credential.AttributeStorageETS do
   """
   @spec put_attribute_set(identity_id(), AttributeSet.t()) :: :ok | {:error, any()}
   def put_attribute_set(id, attribute_set) do
+    Logger.debug("saving attributes #{inspect(attribute_set)} for identity #{inspect(id)}")
+
     with_table(fn ->
       true = :ets.insert(@table, {id, attribute_set})
       :ok

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -88,7 +88,7 @@ impl Authority {
                     .await?;
                 Some(AccountAuthorityInfo::new(
                     acc_authority_identifier,
-                    configuration.project_id(),
+                    configuration.project_identifier(),
                     configuration.enforce_admin_checks,
                 ))
             } else {
@@ -232,7 +232,7 @@ impl Authority {
             self.secure_channels.identities().identities_attributes(),
             self.secure_channels.identities().credentials(),
             &self.identifier,
-            configuration.project_id(),
+            configuration.project_identifier(),
             ttl,
             self.account_authority.clone(),
             configuration.disable_trust_context_id,

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -88,7 +88,7 @@ impl Authority {
                     .await?;
                 Some(AccountAuthorityInfo::new(
                     acc_authority_identifier,
-                    configuration.project_identifier(),
+                    configuration.project_id(),
                     configuration.enforce_admin_checks,
                 ))
             } else {
@@ -232,7 +232,7 @@ impl Authority {
             self.secure_channels.identities().identities_attributes(),
             self.secure_channels.identities().credentials(),
             &self.identifier,
-            configuration.project_identifier(),
+            configuration.project_id(),
             ttl,
             self.account_authority.clone(),
             configuration.disable_trust_context_id,

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -22,7 +22,7 @@ pub struct Configuration {
     pub database_path: PathBuf,
 
     /// Project id on the Orchestrator node
-    pub project_id: String,
+    pub project_identifier: String,
 
     /// listener address for the TCP listener, for example "127.0.0.1:4000"
     pub tcp_listener_address: InternetAddress,
@@ -66,8 +66,8 @@ impl Configuration {
     }
 
     /// Return the project id as bytes
-    pub(crate) fn project_id(&self) -> String {
-        self.project_id.clone()
+    pub(crate) fn project_identifier(&self) -> String {
+        self.project_identifier.clone()
     }
 
     /// Return the address for the TCP listener

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -21,8 +21,8 @@ pub struct Configuration {
     /// path where the database should be stored
     pub database_path: PathBuf,
 
-    /// Project identifier on the Orchestrator node
-    pub project_identifier: String,
+    /// Project id on the Orchestrator node
+    pub project_id: String,
 
     /// listener address for the TCP listener, for example "127.0.0.1:4000"
     pub tcp_listener_address: InternetAddress,
@@ -65,9 +65,9 @@ impl Configuration {
         self.identifier.clone()
     }
 
-    /// Return the project identifier as bytes
-    pub(crate) fn project_identifier(&self) -> String {
-        self.project_identifier.clone()
+    /// Return the project id as bytes
+    pub(crate) fn project_id(&self) -> String {
+        self.project_id.clone()
     }
 
     /// Return the address for the TCP listener

--- a/implementations/rust/ockam/ockam_api/src/authority_node/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/node.rs
@@ -1,22 +1,15 @@
 use crate::authority_node::{Authority, Configuration};
-use crate::CliState;
 use ockam_core::Result;
 use ockam_node::Context;
-use std::collections::BTreeMap;
 use tracing::info;
 
 /// Start all the necessary services for an authority node
 pub async fn start_node(
     ctx: &Context,
-    cli_state: &CliState,
     configuration: &Configuration,
+    authority: Authority,
 ) -> Result<()> {
     debug!("starting authority node");
-    // create the authority identity
-    // or retrieve it from disk if the node has already been started before
-    // The trusted identities in the configuration are used to pre-populate an attribute storage
-    // containing those identities and their attributes
-    let authority = Authority::create(configuration).await?;
 
     debug!("starting services");
     // start a secure channel listener (this also starts a TCP transport)
@@ -51,20 +44,6 @@ pub async fn start_node(
     authority
         .start_echo_service(ctx, &secure_channel_flow_control_id)
         .await?;
-
-    // Create an identity for exporting opentelemetry traces
-    let exporter = "ockam-opentelemetry-exporter";
-    let exporter_identity = match cli_state.get_named_identity(&exporter).await {
-        Ok(exporter) => exporter,
-        Err(_) => cli_state.create_identity_with_name(&exporter).await?,
-    };
-
-    let mut attributes = BTreeMap::new();
-    attributes.insert("ockam-relay".to_string(), "ockam-opentelemetry".to_string());
-    authority
-        .add_member(&exporter_identity.identifier(), &attributes)
-        .await?;
-    info!("added the ockam-opentelemetry-exporter ({}) identity as a member with the permission to create a relay named ockam-opentelemetry", exporter_identity.identifier());
 
     debug!("echo service started");
 

--- a/implementations/rust/ockam/ockam_api/src/authority_node/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/node.rs
@@ -1,10 +1,16 @@
 use crate::authority_node::{Authority, Configuration};
+use crate::CliState;
 use ockam_core::Result;
 use ockam_node::Context;
+use std::collections::BTreeMap;
 use tracing::info;
 
 /// Start all the necessary services for an authority node
-pub async fn start_node(ctx: &Context, configuration: &Configuration) -> Result<()> {
+pub async fn start_node(
+    ctx: &Context,
+    cli_state: &CliState,
+    configuration: &Configuration,
+) -> Result<()> {
     debug!("starting authority node");
     // create the authority identity
     // or retrieve it from disk if the node has already been started before
@@ -45,6 +51,21 @@ pub async fn start_node(ctx: &Context, configuration: &Configuration) -> Result<
     authority
         .start_echo_service(ctx, &secure_channel_flow_control_id)
         .await?;
+
+    // Create an identity for exporting opentelemetry traces
+    let exporter = "ockam-opentelemetry-exporter";
+    let exporter_identity = match cli_state.get_named_identity(&exporter).await {
+        Ok(exporter) => exporter,
+        Err(_) => cli_state.create_identity_with_name(&exporter).await?,
+    };
+
+    let mut attributes = BTreeMap::new();
+    attributes.insert("ockam-relay".to_string(), "ockam-opentelemetry".to_string());
+    authority
+        .add_member(&exporter_identity.identifier(), &attributes)
+        .await?;
+    info!("added the ockam-opentelemetry-exporter ({}) identity as a member with the permission to create a relay named ockam-opentelemetry", exporter_identity.identifier());
+
     debug!("echo service started");
 
     info!("authority node started");

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -50,9 +50,7 @@ impl Projects {
                 .await?;
         }
 
-        self.projects_repository
-            .store_project(project.model())
-            .await?;
+        self.store_project_model(project.model()).await?;
 
         // If there is no previous default project set this project as the default
         let default_project = self.projects_repository.get_default_project().await?;
@@ -63,6 +61,20 @@ impl Projects {
         };
 
         Ok(project)
+    }
+
+    #[instrument(skip_all, fields(project_id = project.id))]
+    pub async fn store_project_model(&self, project: &ProjectModel) -> Result<()> {
+        self.projects_repository.store_project(project).await?;
+
+        // If there is no previous default project set this project as the default
+        let default_project = self.projects_repository.get_default_project().await?;
+        if default_project.is_none() {
+            self.projects_repository
+                .set_default_project(&project.id)
+                .await?
+        };
+        Ok(())
     }
 
     #[instrument(skip_all, fields(project_id = project_id))]

--- a/implementations/rust/ockam/ockam_api/tests/authority.rs
+++ b/implementations/rust/ockam/ockam_api/tests/authority.rs
@@ -1,5 +1,4 @@
-use crate::common::common::default_configuration;
-use ockam_api::authority_node;
+use crate::common::common::{default_configuration, start_authority_node};
 use ockam_api::nodes::service::default_address::DefaultAddress;
 use ockam_core::{Address, Result};
 use ockam_node::Context;
@@ -9,8 +8,7 @@ mod common;
 #[ockam_macros::test]
 async fn authority_starts_with_default_configuration(ctx: &mut Context) -> Result<()> {
     let configuration = default_configuration().await?;
-
-    authority_node::start_node(ctx, &configuration).await?;
+    start_authority_node(ctx, &configuration).await?;
 
     let workers = ctx.list_workers().await?;
 
@@ -27,10 +25,8 @@ async fn authority_starts_with_default_configuration(ctx: &mut Context) -> Resul
 #[ockam_macros::test]
 async fn authority_starts_direct_authenticator(ctx: &mut Context) -> Result<()> {
     let mut configuration = default_configuration().await?;
-
     configuration.no_direct_authentication = false;
-
-    authority_node::start_node(ctx, &configuration).await?;
+    start_authority_node(ctx, &configuration).await?;
 
     let workers = ctx.list_workers().await?;
 
@@ -47,10 +43,8 @@ async fn authority_starts_direct_authenticator(ctx: &mut Context) -> Result<()> 
 #[ockam_macros::test]
 async fn authority_starts_enrollment_token(ctx: &mut Context) -> Result<()> {
     let mut configuration = default_configuration().await?;
-
     configuration.no_token_enrollment = false;
-
-    authority_node::start_node(ctx, &configuration).await?;
+    start_authority_node(ctx, &configuration).await?;
 
     let workers = ctx.list_workers().await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -29,7 +29,7 @@ pub async fn default_configuration() -> Result<Configuration> {
         identifier: "I4dba4b2e53b2ed95967b3bab350b6c9ad9c624e5a1b2c3d4e5f6a6b5c4d3e2f1"
             .try_into()?,
         database_path,
-        project_identifier: "123456".to_string(),
+        project_id: "123456".to_string(),
         tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
         secure_channel_listener_name: None,
         authenticator_name: None,
@@ -91,7 +91,7 @@ pub async fn start_authority(
         .credentials()
         .credentials_creation();
     let admin_attrs = AttributesBuilder::with_schema(CredentialSchemaIdentifier(0))
-        .with_attribute("project", configuration.project_identifier.clone())
+        .with_attribute("project", configuration.project_id.clone())
         .build();
     let mut admins = vec![];
     for _ in 0..number_of_admins {

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -132,7 +132,7 @@ pub async fn start_authority(
         "common.rs about to call authority::start_node with {:?}",
         configuration.account_authority.is_some()
     );
-    authority_node::start_node(ctx, &configuration).await?;
+    start_authority_node(ctx, &configuration).await?;
 
     Ok(AuthorityInfo {
         authority_identifier: configuration.identifier.clone(),
@@ -157,4 +157,8 @@ pub fn change_client_identifier(
         client.request_timeout(),
     );
     AuthorityNodeClient::new(client)
+}
+
+pub async fn start_authority_node(ctx: &Context, configuration: &Configuration) -> Result<()> {
+    authority_node::start_node(ctx, &ockam_api::CliState::test().await?, &configuration).await
 }

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+
 use ockam::identity::models::CredentialSchemaIdentifier;
 use ockam::identity::utils::AttributesBuilder;
 use ockam::identity::{
@@ -29,7 +30,7 @@ pub async fn default_configuration() -> Result<Configuration> {
         identifier: "I4dba4b2e53b2ed95967b3bab350b6c9ad9c624e5a1b2c3d4e5f6a6b5c4d3e2f1"
             .try_into()?,
         database_path,
-        project_id: "123456".to_string(),
+        project_identifier: "123456".to_string(),
         tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
         secure_channel_listener_name: None,
         authenticator_name: None,
@@ -91,7 +92,7 @@ pub async fn start_authority(
         .credentials()
         .credentials_creation();
     let admin_attrs = AttributesBuilder::with_schema(CredentialSchemaIdentifier(0))
-        .with_attribute("project", configuration.project_id.clone())
+        .with_attribute("project", configuration.project_identifier.clone())
         .build();
     let mut admins = vec![];
     for _ in 0..number_of_admins {
@@ -160,5 +161,6 @@ pub fn change_client_identifier(
 }
 
 pub async fn start_authority_node(ctx: &Context, configuration: &Configuration) -> Result<()> {
-    authority_node::start_node(ctx, &ockam_api::CliState::test().await?, &configuration).await
+    let authority = Authority::create(configuration).await?;
+    authority_node::start_node(ctx, configuration, authority).await
 }

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -53,12 +53,12 @@ pub struct CreateCommand {
 
     /// TCP listener address
     #[arg(
-        display_order = 900,
-        long,
-        short,
-        id = "SOCKET_ADDRESS",
-        default_value = "127.0.0.1:4000",
-        value_parser = internet_address_parser
+    display_order = 900,
+    long,
+    short,
+    id = "SOCKET_ADDRESS",
+    default_value = "127.0.0.1:4000",
+    value_parser = internet_address_parser
     )]
     tcp_listener_address: InternetAddress,
 
@@ -329,7 +329,7 @@ impl CreateCommand {
             disable_trust_context_id: self.disable_trust_context_id,
         };
 
-        authority_node::start_node(ctx, &configuration)
+        authority_node::start_node(ctx, &opts.state, &configuration)
             .await
             .into_diagnostic()?;
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -15,6 +15,9 @@ pub struct Node {
     pub name: Option<ArgValue>,
     #[serde(alias = "skip-is-running-check")]
     pub skip_is_running_check: Option<ArgValue>,
+    pub foreground: Option<ArgValue>,
+    #[serde(alias = "child-process")]
+    pub child_process: Option<ArgValue>,
     #[serde(alias = "exit-on-eof")]
     pub exit_on_eof: Option<ArgValue>,
     #[serde(alias = "tcp-listener-address")]
@@ -59,6 +62,12 @@ impl Node {
         }
         if let Some(skip_is_running_check) = self.skip_is_running_check {
             args.insert("skip-is-running-check".to_string(), skip_is_running_check);
+        }
+        if let Some(foreground) = self.foreground {
+            args.insert("foreground".to_string(), foreground);
+        }
+        if let Some(child_process) = self.child_process {
+            args.insert("child-process".to_string(), child_process);
         }
         if let Some(exit_on_eof) = self.exit_on_eof {
             args.insert("exit-on-eof".to_string(), exit_on_eof);

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -28,8 +28,8 @@ impl ParsedCommands {
     }
 
     /// Validate and run each command
-    pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
-        for cmd in self.commands.into_iter() {
+    pub async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
+        for cmd in self.commands.iter() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
                 // Newline between commands

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -162,10 +162,3 @@ force_kill_node() {
   run_failure "$OCKAM" node create --node-config "{name: n}" --variable MY_VAR=
   assert_output --partial "Empty value for variable 'MY_VAR'"
 }
-
-@test "node - create a node with an inline configuration" {
-  n="$(random_str)"
-  # Create node, check that it has one of the default services running
-  run_success "$OCKAM" node create --node-config "{name: $n, tcp-outlets: {db-outlet: {to: '127.0.0.1:5432', at: $n}}}"
-  assert_output --partial "Node ${n} created successfully"
-}

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -162,3 +162,10 @@ force_kill_node() {
   run_failure "$OCKAM" node create --node-config "{name: n}" --variable MY_VAR=
   assert_output --partial "Empty value for variable 'MY_VAR'"
 }
+
+@test "node - create a node with an inline configuration" {
+  n="$(random_str)"
+  # Create node, check that it has one of the default services running
+  run_success "$OCKAM" node create --node-config "{name: $n, tcp-outlets: {db-outlet: {to: '127.0.0.1:5432', at: $n}}}"
+  assert_output --partial "Node ${n} created successfully"
+}

--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/cache_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/cache_retriever.rs
@@ -9,7 +9,7 @@ use ockam_core::compat::boxed::Box;
 use ockam_core::compat::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{Address, Result};
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 /// Credential is considered already expired if it expires in less than this gap to account for a machine with a
 /// wrong time
@@ -115,6 +115,7 @@ impl CredentialRetrieverCreator for CachedCredentialRetrieverCreator {
 #[async_trait]
 impl CredentialRetriever for CachedCredentialRetriever {
     async fn initialize(&self) -> Result<()> {
+        trace!("using a cached credential retriever");
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/memory_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/memory_retriever.rs
@@ -1,6 +1,7 @@
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::sync::Arc;
 use ockam_core::{async_trait, Address, Result};
+use tracing::trace;
 
 use crate::models::CredentialAndPurposeKey;
 use crate::{CredentialRetriever, CredentialRetrieverCreator, Identifier};
@@ -20,6 +21,7 @@ impl MemoryCredentialRetriever {
 #[async_trait]
 impl CredentialRetriever for MemoryCredentialRetriever {
     async fn initialize(&self) -> Result<()> {
+        trace!("using a memory credential retriever");
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever_trait_impl.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever_trait_impl.rs
@@ -29,6 +29,13 @@ impl CredentialRetriever for RemoteCredentialRetriever {
         let now = now()?;
         // Check if it's still valid
         if last_presented_credential.expires_at > now + self.timing_options.clock_skew_gap {
+            debug!(
+                "The last presented credential is still valid, with attributes {:?}",
+                last_presented_credential
+                    .credential
+                    .get_credential_data()?
+                    .subject_attributes
+            );
             // Valid, let's return it
             return Ok(last_presented_credential.credential);
         }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
@@ -242,11 +242,9 @@ impl CommonStateMachine {
         their_identifier: &Identifier,
         credentials: Vec<CredentialAndPurposeKey>,
     ) -> Result<()> {
+        debug!("verifying {} credentials", credentials.len());
         if let Some(authority) = &authority {
-            debug!(
-                "Got an Authority to check the credentials. There are {} credentials to check",
-                credentials.len()
-            );
+            debug!("Got an Authority to check the credentials");
             for credential in &credentials {
                 let result = identities
                     .credentials()
@@ -264,6 +262,12 @@ impl CommonStateMachine {
                     return Err(IdentityError::SecureChannelVerificationFailedIncorrectCredential)?;
                 }
             }
+            if credentials.is_empty() {
+                debug!(
+                    "no credentials were received from the authority {} for {}",
+                    authority, their_identifier
+                );
+            };
         } else if !credentials.is_empty() {
             warn!("credentials were presented, but Authority is missing");
             // we cannot validate credentials without an Authority


### PR DESCRIPTION
This PR let the authority node create a project member which is used with an additional node started when a project is created. That node:

 - Supports a TCP outlet directed to the OpenTelemetry collector
 - Creates a relay named `ockam-opentelemetry` and which is used by a background node running an inlet where commands are executed (see #7936)

Two command line arguments have been added to the `ockam authority create` command in order to be able to persist a default project used to make the `ockam-opentelemetry-exporter` a project member:

 - `--project-access-route` Multiaddr to the project.
 - `--project-identity-identifier-file` path to the file that contains the project identifier. That file is created by the project node when it starts for the first time.
 