### PR TITLE
(feat): use simple boolean expressions for `allow` options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wast",
+ "winnow",
 ]
 
 [[package]]

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -678,6 +678,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | windows_x86_64_gnullvm | MIT, Apache-2.0 | https://crates.io/crates/windows_x86_64_gnullvm |
 | windows_x86_64_msvc | MIT, Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
 | windows_x86_64_msvc | MIT, Apache-2.0 | https://crates.io/crates/windows_x86_64_msvc |
+| winnow | MIT | https://crates.io/crates/winnow |
 | winreg | MIT | https://crates.io/crates/winreg |
 | winsafe | MIT | https://crates.io/crates/winsafe |
 | x11-clipboard | MIT | https://crates.io/crates/x11-clipboard |

--- a/examples/command/portals/ai/amazon_bedrock/ai_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_bedrock/ai_corp/run_ockam.sh
@@ -37,7 +37,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "localhost:3000"
-  allow: '(= subject.ai-inlet "true")'
+  allow: 'ai-inlet'
 
 relay: ai
 EOF

--- a/examples/command/portals/ai/amazon_bedrock/health_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_bedrock/health_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:3000
   via: ai
-  allow: '(= subject.ai-outlet "true")'
+  allow: 'ai-outlet'
 EOF
 
 ockam node create inlet.yaml

--- a/examples/command/portals/ai/amazon_ec2/ai_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_ec2/ai_corp/run_ockam.sh
@@ -37,7 +37,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "localhost:3000"
-  allow: '(= subject.ai-inlet "true")'
+  allow: 'ai-inlet'
 
 relay: ai
 EOF

--- a/examples/command/portals/ai/amazon_ec2/health_corp/run_ockam.sh
+++ b/examples/command/portals/ai/amazon_ec2/health_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:3000
   via: ai
-  allow: '(= subject.ai-outlet "true")'
+  allow: 'ai-outlet'
 EOF
 
 ockam node create inlet.yaml

--- a/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
+++ b/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
@@ -36,7 +36,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to postgres at - localhost:3000.
 ockam node create
 ockam relay create monitoring-api
-ockam policy create --resource-type tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'monitoring-api-inlet'
 ockam tcp-outlet create --to localhost:3000
 
 EOS

--- a/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
+++ b/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
@@ -36,7 +36,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to postgres at - localhost:3000.
 ockam node create
 ockam relay create monitoring-api
-ockam policy create --resource tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
 ockam tcp-outlet create --to localhost:3000
 
 EOS

--- a/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
+++ b/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:3000
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'monitoring-api-outlet'
 ockam tcp-inlet create --from 0.0.0.0:3000 --via monitoring-api
 
 EOS

--- a/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
+++ b/examples/command/portals/apis/nodejs/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:3000
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:3000 --via monitoring-api
 
 EOS

--- a/examples/command/portals/apis/python/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
+++ b/examples/command/portals/apis/python/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
@@ -36,7 +36,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to the python flask api at - localhost:5000.
 ockam node create
 ockam relay create monitoring-api
-ockam policy create --resource tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
 ockam tcp-outlet create --to localhost:5000
 
 EOS

--- a/examples/command/portals/apis/python/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
+++ b/examples/command/portals/apis/python/amazon_ec2/aws_cli/monitoring_corp/run_ockam.sh
@@ -36,7 +36,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to the python flask api at - localhost:5000.
 ockam node create
 ockam relay create monitoring-api
-ockam policy create --resource-type tcp-outlet --expression '(= subject.monitoring-api-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'monitoring-api-inlet'
 ockam tcp-outlet create --to localhost:5000
 
 EOS

--- a/examples/command/portals/apis/python/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
+++ b/examples/command/portals/apis/python/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to the Python API.
 # This makes the remote API available on all localhost IPs at - 0.0.0.0:5000
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:5000 --via monitoring-api
 
 EOS

--- a/examples/command/portals/apis/python/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
+++ b/examples/command/portals/apis/python/amazon_ec2/aws_cli/travel_app_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to the Python API.
 # This makes the remote API available on all localhost IPs at - 0.0.0.0:5000
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.monitoring-api-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'monitoring-api-outlet'
 ockam tcp-inlet create --from 0.0.0.0:5000 --via monitoring-api
 
 EOS

--- a/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/analysis_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:1222
   via: gitlab
-  allow: '(= subject.gitlab-outlet "true")'
+  allow: 'gitlab-outlet'
 EOF
 
 ockam node create inlet.yaml

--- a/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/bank_corp/run_ockam.sh
+++ b/examples/command/portals/coderepos/gitlab/amazon_ec2/aws_cli/bank_corp/run_ockam.sh
@@ -37,7 +37,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "localhost:222"
-  allow: '(= subject.gitlab-inlet "true")'
+  allow: 'gitlab-inlet'
 
 relay: gitlab
 EOF

--- a/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/datastream_corp/run_ockam.sh
+++ b/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/datastream_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:8086
   via: influxdb
-  allow: '(= subject.influxdb-outlet "true")'
+  allow: 'influxdb-outlet'
 EOF
 ockam node create inlet.yaml
 rm inlet.yaml

--- a/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/metrics_corp/run_ockam.sh
+++ b/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/metrics_corp/run_ockam.sh
@@ -52,7 +52,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "$INFLUXDB_ADDRESS:8086"
-  allow: '(= subject.influxdb-inlet "true")'
+  allow: 'influxdb-inlet'
 relay: influxdb
 EOF
 ockam node create outlet.yaml

--- a/examples/command/portals/databases/mongodb/amazon_vpc/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/amazon_vpc/analysis_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to MongoDB.
 # This makes the remote MongoDB available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 EOS

--- a/examples/command/portals/databases/mongodb/amazon_vpc/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/amazon_vpc/analysis_corp/run_ockam.sh
@@ -33,7 +33,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to MongoDB.
 # This makes the remote MongoDB available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'mongodb-outlet'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 EOS

--- a/examples/command/portals/databases/mongodb/amazon_vpc/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/amazon_vpc/bank_corp/run_ockam.sh
@@ -48,7 +48,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # This makes the remote mongodb available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
 ockam tcp-outlet create --to "127.0.0.1:27017"
 
 EOS

--- a/examples/command/portals/databases/mongodb/amazon_vpc/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/amazon_vpc/bank_corp/run_ockam.sh
@@ -48,7 +48,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # This makes the remote mongodb available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'mongodb-inlet'
 ockam tcp-outlet create --to "127.0.0.1:27017"
 
 EOS

--- a/examples/command/portals/databases/mongodb/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/docker/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to MongoDB.
 # This makes the remote MongoDB available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/docker/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to MongoDB.
 # This makes the remote MongoDB available on all localhost IPs at - 0.0.0.0:17017
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'mongodb-outlet'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/docker/bank_corp/run_ockam.sh
@@ -33,7 +33,7 @@ echo "Enrolled!"
 # Create a TCP Portal Outlet to MongoDB at - mongodb:27017.
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'mongodb-inlet'
 ockam tcp-outlet create --to mongodb:27017
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/docker/bank_corp/run_ockam.sh
@@ -33,7 +33,7 @@ echo "Enrolled!"
 # Create a TCP Portal Outlet to MongoDB at - mongodb:27017.
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
 ockam tcp-outlet create --to mongodb:27017
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/kubernetes/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Inlet to mongodb.
 # This makes the remote mongodb available on localhost:17017
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'mongodb-outlet'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/kubernetes/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Inlet to mongodb.
 # This makes the remote mongodb available on localhost:17017
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.mongodb-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.mongodb-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:17017 --via mongodb
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/kubernetes/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Outlet to mongodb at - localhost:27017.
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'mongodb-inlet'
 ockam tcp-outlet create --to 127.0.0.1:27017
 
 # Run the container forever.

--- a/examples/command/portals/databases/mongodb/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/mongodb/kubernetes/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Outlet to mongodb at - localhost:27017.
 ockam node create
 ockam relay create mongodb
-ockam policy create --resource tcp-outlet --expression '(= subject.mongodb-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.mongodb-inlet "true")'
 ockam tcp-outlet create --to 127.0.0.1:27017
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/analysis_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:15432
   via: postgres
-  allow: '(= subject.postgres-outlet "true")'
+  allow: 'postgres-outlet'
 EOF
 
 ockam node create inlet.yaml

--- a/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_aurora/aws_cli/bank_corp/run_ockam.sh
@@ -37,7 +37,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "$POSTGRES_ADDRESS:5432"
-  allow: '(= subject.postgres-inlet "true")'
+  allow: 'postgres-inlet'
 
 relay: postgres
 EOF

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/analysis_corp/run_ockam.sh
@@ -36,7 +36,7 @@ cat << EOF > inlet.yaml
 tcp-inlet:
   from: 0.0.0.0:15432
   via: postgres
-  allow: '(= subject.postgres-outlet "true")'
+  allow: 'postgres-outlet'
 EOF
 
 ockam node create inlet.yaml

--- a/examples/command/portals/databases/postgres/amazon_rds/aws_cli/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/amazon_rds/aws_cli/bank_corp/run_ockam.sh
@@ -37,7 +37,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 cat << EOF > outlet.yaml
 tcp-outlet:
   to: "$POSTGRES_ADDRESS:5432"
-  allow: '(= subject.postgres-inlet "true")'
+  allow: 'postgres-inlet'
 
 relay: postgres
 EOF

--- a/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:15432
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.postgres-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on all localhost IPs at - 0.0.0.0:15432
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.postgres-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'postgres-outlet'
 ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to postgres at - postgres:5432.
 ockam node create
 ockam relay create postgres
-ockam policy create --resource tcp-outlet --expression '(= subject.postgres-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.postgres-inlet "true")'
 ockam tcp-outlet create --to postgres:5432
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/docker/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll "$ENROLLMENT_TICKET"
 # Create a TCP Portal Outlet to postgres at - postgres:5432.
 ockam node create
 ockam relay create postgres
-ockam policy create --resource-type tcp-outlet --expression '(= subject.postgres-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'postgres-inlet'
 ockam tcp-outlet create --to postgres:5432
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on localhost:15432
 ockam node create
-ockam policy create --resource tcp-inlet --expression '(= subject.postgres-outlet "true")'
+ockam policy create --resource-type tcp-inlet --expression '(= subject.postgres-outlet "true")'
 ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/analysis_corp/run_ockam.sh
@@ -26,7 +26,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Inlet to postgres.
 # This makes the remote postgres available on localhost:15432
 ockam node create
-ockam policy create --resource-type tcp-inlet --expression '(= subject.postgres-outlet "true")'
+ockam policy create --resource-type tcp-inlet --allow 'postgres-outlet'
 ockam tcp-inlet create --from 0.0.0.0:15432 --via postgres
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Outlet to postgres at - localhost:5432.
 ockam node create
 ockam relay create postgres
-ockam policy create --resource tcp-outlet --expression '(= subject.postgres-inlet "true")'
+ockam policy create --resource-type tcp-outlet --expression '(= subject.postgres-inlet "true")'
 ockam tcp-outlet create --to 5432
 
 # Run the container forever.

--- a/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
+++ b/examples/command/portals/databases/postgres/kubernetes/bank_corp/run_ockam.sh
@@ -29,7 +29,7 @@ ockam project enroll /etc/ockam/enrollment/ticket
 # Create a TCP Portal Outlet to postgres at - localhost:5432.
 ockam node create
 ockam relay create postgres
-ockam policy create --resource-type tcp-outlet --expression '(= subject.postgres-inlet "true")'
+ockam policy create --resource-type tcp-outlet --allow 'postgres-inlet'
 ockam tcp-outlet create --to 5432
 
 # Run the container forever.

--- a/implementations/rust/ockam/ockam_abac/Cargo.toml
+++ b/implementations/rust/ockam/ockam_abac/Cargo.toml
@@ -15,7 +15,7 @@ description = "Attribute based authorization control"
 [features]
 default = ["std"]
 no_std = ["ockam_core/no_std", "ockam_identity/no_std", "ockam_executor"]
-alloc = ["ockam_core/alloc", "ockam_identity/alloc"]
+alloc = ["ockam_core/alloc", "ockam_identity/alloc", "winnow/alloc"]
 repl = ["rustyline", "rustyline-derive", "std"]
 std = [
   "ockam_core/std",
@@ -31,6 +31,7 @@ std = [
   "wast",
   "strum/std",
   "serde/std",
+  "winnow",
 ]
 
 [dependencies]
@@ -55,6 +56,7 @@ str-buf = "3.0.3"
 tokio = { version = "1.37", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 wast = { version = "206.0.0", default-features = false, optional = true }
+winnow = { version = "0.6.7", default-features = false, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", default-features = false, features = ["rust-crypto"] }

--- a/implementations/rust/ockam/ockam_abac/src/abac/abac.rs
+++ b/implementations/rust/ockam/ockam_abac/src/abac/abac.rs
@@ -4,6 +4,7 @@ use ockam_core::compat::fmt::Debug;
 use ockam_core::compat::fmt::Formatter;
 use ockam_core::compat::str;
 use ockam_core::compat::sync::Arc;
+use ockam_core::compat::vec::vec;
 use ockam_core::Result;
 use ockam_core::{Error, RelayMessage};
 
@@ -147,7 +148,7 @@ impl Abac {
         // add the identifier itself as a subject parameter
         // it's important to do it before we put other attributes, so it can't be overwritten
         environment.put(
-            format!("{}.{}", SUBJECT_KEY, ABAC_IDENTIFIER_KEY),
+            subject_identifier_attribute().to_string(),
             str(identifier.to_string()),
         );
 
@@ -158,7 +159,7 @@ impl Abac {
         {
             Some(attrs) => {
                 environment.put(
-                    format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY),
+                    subject_has_credential_attribute().to_string(),
                     Expr::CONST_TRUE,
                 );
 
@@ -209,7 +210,7 @@ impl Abac {
             }
             None => {
                 environment.put(
-                    format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY),
+                    subject_has_credential_attribute().to_string(),
                     Expr::CONST_FALSE,
                 );
             }
@@ -246,4 +247,23 @@ impl Abac {
             }
         }
     }
+}
+
+/// Return a policy expression checking if the subject has a valid credential
+pub fn subject_has_credential_policy_expression() -> Expr {
+    Expr::List(vec![
+        Expr::Ident("=".to_string()),
+        subject_has_credential_attribute(),
+        Expr::Bool(true),
+    ])
+}
+
+/// Identifier for the subject 'has_credential' attribute
+pub fn subject_has_credential_attribute() -> Expr {
+    Expr::Ident(format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY))
+}
+
+/// Identifier for the subject 'identifier' attribute
+pub fn subject_identifier_attribute() -> Expr {
+    Expr::Ident(format!("{}.{}", SUBJECT_KEY, ABAC_IDENTIFIER_KEY))
 }

--- a/implementations/rust/ockam/ockam_abac/src/abac/abac.rs
+++ b/implementations/rust/ockam/ockam_abac/src/abac/abac.rs
@@ -193,7 +193,8 @@ impl Abac {
                                     "attribute already present"
                                 }
                             } else {
-                                environment.put(format!("subject.{key}"), str(s.to_string()));
+                                environment
+                                    .put(format!("{}.{key}", SUBJECT_KEY), str(s.to_string()));
                             }
                         }
                         Err(e) => {

--- a/implementations/rust/ockam/ockam_abac/src/boolean_expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/boolean_expr.rs
@@ -1,0 +1,469 @@
+use core::fmt::{Display, Formatter};
+use ockam_core::compat::str::FromStr;
+use winnow::error::{ContextError, ErrMode, StrContext};
+use winnow::Parser;
+
+use crate::Expr;
+use crate::ParseError;
+use Expr::*;
+
+/// A BooleanExpr models a boolean expression made of:
+///
+///  - Names.
+///  - Binary operators: and, or.
+///  - Unary operator: not.
+///  - Optional parentheses: 'and' takes precedence over 'or', and 'not' over 'and'.
+///
+/// A BooleanExpr can be:
+///
+///  - Parsed from a string
+///  - Printed as a string
+///  - Transformed into a policy expression where names become boolean attributes set to the value 'true'.
+///
+#[derive(Debug, Clone)]
+pub enum BooleanExpr {
+    Name(String),
+    Or(Box<BooleanExpr>, Box<BooleanExpr>),
+    And(Box<BooleanExpr>, Box<BooleanExpr>),
+    Not(Box<BooleanExpr>),
+    Empty,
+}
+
+impl PartialEq for BooleanExpr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (BooleanExpr::Name(n1), BooleanExpr::Name(n2)) => n1 == n2,
+            (BooleanExpr::Or(e1, e2), BooleanExpr::Or(e3, e4)) => e1 == e3 && e2 == e4,
+            (BooleanExpr::And(e1, e2), BooleanExpr::And(e3, e4)) => e1 == e3 && e2 == e4,
+            (BooleanExpr::Not(e1), BooleanExpr::Not(e2)) => e1 == e2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for BooleanExpr {}
+
+impl Display for BooleanExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        fn to_nested_string(b: &BooleanExpr) -> String {
+            match b {
+                BooleanExpr::Name(s) => s.clone(),
+                BooleanExpr::Or(e1, e2) => format!("({e1} or {e2})"),
+                BooleanExpr::And(e1, e2) => format!("({e1} and {e2})"),
+                BooleanExpr::Not(e) => format!("(not {e})"),
+                BooleanExpr::Empty => "".to_string(),
+            }
+        }
+
+        match self {
+            BooleanExpr::Name(s) => f.write_str(&s),
+            BooleanExpr::Or(e1, e2) => f.write_str(&format!(
+                "{} or {}",
+                to_nested_string(e1),
+                to_nested_string(e2)
+            )),
+            BooleanExpr::And(e1, e2) => f.write_str(&format!(
+                "{} and {}",
+                to_nested_string(e1),
+                to_nested_string(e2)
+            )),
+            BooleanExpr::Not(e) => f.write_str(&format!("not {}", to_nested_string(e))),
+            BooleanExpr::Empty => f.write_str(""),
+        }
+    }
+}
+
+impl TryFrom<&str> for BooleanExpr {
+    type Error = ParseError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        let input = input.to_string();
+        let mut i = input.as_str();
+        BooleanExpr::parse(&mut i)
+    }
+}
+
+impl FromStr for BooleanExpr {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl TryFrom<String> for BooleanExpr {
+    type Error = ParseError;
+
+    fn try_from(input: String) -> Result<Self, Self::Error> {
+        Self::try_from(input.as_str())
+    }
+}
+
+impl BooleanExpr {
+    /// Create a name to be used in a boolean expression.
+    pub fn name(s: &str) -> BooleanExpr {
+        BooleanExpr::Name(s.to_string())
+    }
+
+    /// Create the disjunction of 2 boolean expressions.
+    pub fn or(e1: BooleanExpr, e2: BooleanExpr) -> BooleanExpr {
+        BooleanExpr::Or(Box::new(e1), Box::new(e2))
+    }
+
+    /// Create the conjunction of 2 boolean expressions.
+    pub fn and(e1: BooleanExpr, e2: BooleanExpr) -> BooleanExpr {
+        BooleanExpr::And(Box::new(e1), Box::new(e2))
+    }
+
+    /// Create the negation of 2 boolean expressions.
+    pub fn not(e: BooleanExpr) -> BooleanExpr {
+        BooleanExpr::Not(Box::new(e))
+    }
+
+    /// Create a empty BooleanExpr (it is mostly useful to reduce a possibly empty list of BooleanExpr)
+    pub fn empty() -> BooleanExpr {
+        BooleanExpr::Empty
+    }
+
+    /// Transform this boolean expression into a policy expression
+    /// by using names as attributes and setting them to the value 'true'
+    ///
+    /// Note: there is no attempt to normalize the expression and for example
+    /// transform `not a` into `= subject.a "false"`
+    pub fn to_expression(&self) -> Expr {
+        match self {
+            BooleanExpr::Name(s) => List(vec![
+                Ident("=".to_string()),
+                Ident(format!("subject.{}", s)),
+                Str("true".to_string()),
+            ]),
+            BooleanExpr::Or(e1, e2) => List(vec![
+                Ident("or".to_string()),
+                e1.to_expression(),
+                e2.to_expression(),
+            ]),
+            BooleanExpr::And(e1, e2) => List(vec![
+                Ident("and".to_string()),
+                e1.to_expression(),
+                e2.to_expression(),
+            ]),
+            BooleanExpr::Not(e) => List(vec![Ident("not".to_string()), e.to_expression()]),
+            BooleanExpr::Empty => List(vec![]),
+        }
+    }
+
+    /// Parse a string as a boolean expression
+    pub fn parse(input: &mut &str) -> Result<BooleanExpr, ParseError> {
+        parsers::expr
+            .parse_next(input)
+            .map_err(|e| {
+                let messages = match e {
+                    ErrMode::Backtrack(c) => {
+                        let context: ContextError<StrContext> = c;
+                        context
+                            .context()
+                            .map(|c| format!("{c}"))
+                            .take(1)
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    }
+                    e => format!("{e:?}"),
+                };
+                ParseError::message(messages)
+            })
+            .and_then(|expr| {
+                if input.is_empty() {
+                    Ok(expr)
+                } else {
+                    Err(ParseError::message(format!(
+                        "successfully parsed: `{expr}`, but `{input}` cannot be parsed"
+                    )))
+                }
+            })
+    }
+}
+
+/// Parsers for boolean expressions.
+///
+/// The grammar is:
+///
+///    expr : and_expr (or and_expr)*
+///    and_expr : not_expr (or not_expr)*
+///    not_expr : not not_expr | parenthesized | name
+///    parenthesized : '(' expr ')'
+///    name : (alphanum | '_' | '-')+
+mod parsers {
+    use crate::boolean_expr::BooleanExpr;
+    use winnow::ascii::multispace0;
+    use winnow::combinator::{alt, delimited, separated};
+    use winnow::error::StrContext;
+    use winnow::stream::AsChar;
+    use winnow::token::{literal, take_while};
+    use winnow::{PResult, Parser};
+
+    /// Top-level parser for boolean expressions as a series of 'or-ed' and-expressions
+    pub fn expr(i: &mut &str) -> PResult<BooleanExpr> {
+        fn or_separated(i: &mut &str) -> PResult<Vec<BooleanExpr>> {
+            separated(1.., and_expr, or).parse_next(i)
+        }
+
+        Ok(or_separated
+            .context(StrContext::Expected("expression (or expression)*".into()))
+            .parse_next(i)?
+            .into_iter()
+            .reduce(|e, acc| BooleanExpr::or(e, acc))
+            .unwrap_or(BooleanExpr::empty()))
+    }
+
+    /// Parser for an and expression as a series of 'and-ed' not-expressions
+    pub fn and_expr(i: &mut &str) -> PResult<BooleanExpr> {
+        fn and_separated(i: &mut &str) -> PResult<Vec<BooleanExpr>> {
+            separated(1.., not_expr, and).parse_next(i)
+        }
+
+        Ok(and_separated
+            .context(StrContext::Expected("expression (and expression)*".into()))
+            .parse_next(i)?
+            .into_iter()
+            .reduce(|e, acc| BooleanExpr::and(e, acc))
+            .unwrap_or(BooleanExpr::empty()))
+    }
+
+    /// Parser for a not expression as either:
+    ///  - a nested not expression
+    ///  - a parenthesized expression
+    ///  - a single name
+    pub fn not_expr(i: &mut &str) -> PResult<BooleanExpr> {
+        fn nested_not_expr(i: &mut &str) -> PResult<BooleanExpr> {
+            (not, not_expr)
+                .parse_next(i)
+                .map(|(_, e)| BooleanExpr::not(e))
+        }
+        fn parenthesized(i: &mut &str) -> PResult<BooleanExpr> {
+            delimited(open_paren, expr, close_paren).parse_next(i)
+        }
+        alt([nested_not_expr, parenthesized, name])
+            .context(StrContext::Expected("not expression".into()))
+            .parse_next(i)
+    }
+
+    // LEXED VALUES
+
+    /// Parse a name
+    pub fn name(input: &mut &str) -> PResult<BooleanExpr> {
+        take_while(1.., |c| AsChar::is_alphanum(c) || c == '_' || c == '-')
+            .context(StrContext::Expected(
+                "an alphanumerical name separated with '-' or '_'".into(),
+            ))
+            .parse_next(input)
+            .map(|vs| BooleanExpr::Name(vs.to_string()))
+    }
+
+    /// Parse the 'and' operator
+    pub fn and<'a>(input: &mut &'a str) -> PResult<&'a str> {
+        delimited(multispace0, literal("and"), multispace0).parse_next(input)
+    }
+
+    /// Parse the 'or' operator
+    pub fn or<'a>(input: &mut &'a str) -> PResult<&'a str> {
+        delimited(multispace0, literal("or"), multispace0).parse_next(input)
+    }
+
+    /// Parse the 'not' operator
+    pub fn not<'a>(input: &mut &'a str) -> PResult<&'a str> {
+        delimited(multispace0, literal("not"), multispace0).parse_next(input)
+    }
+
+    /// Parse an open parentheses '('
+    pub fn open_paren<'a>(input: &mut &'a str) -> PResult<&'a str> {
+        delimited(multispace0, literal("("), multispace0).parse_next(input)
+    }
+
+    /// Parse a close parentheses ')'
+    pub fn close_paren<'a>(input: &mut &'a str) -> PResult<&'a str> {
+        delimited(multispace0, literal(")"), multispace0).parse_next(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+    use core::fmt::Debug;
+    use parsers::*;
+    use winnow::Parser;
+
+    #[test]
+    fn boolean_expr_to_expr() {
+        let boolean_expr = BooleanExpr::and(
+            BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+            BooleanExpr::not(BooleanExpr::name("c")),
+        );
+        let expr = parse(
+            "and (or (= subject.a \"true\") (= subject.b \"true\") (not (= subject.c \"true\")))",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(boolean_expr.to_expression(), expr);
+    }
+
+    #[test]
+    fn boolean_expr_to_string() {
+        let boolean_expr = BooleanExpr::name("a");
+        let expr = "a".to_string();
+        assert_eq!(boolean_expr.to_string(), expr);
+
+        let boolean_expr = BooleanExpr::and(BooleanExpr::name("a"), BooleanExpr::name("b"));
+        let expr = "a and b".to_string();
+        assert_eq!(boolean_expr.to_string(), expr);
+
+        let boolean_expr = BooleanExpr::and(
+            BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+            BooleanExpr::not(BooleanExpr::name("c")),
+        );
+        let expr = "(a or b) and (not c)".to_string();
+        assert_eq!(boolean_expr.to_string(), expr);
+    }
+
+    #[test]
+    fn parse_name() {
+        test_parse_name("name");
+        test_parse_name("name");
+        test_parse_name("a-b");
+        test_parse_name("a-b-c");
+        test_parse_name("a_b-c");
+        test_parse_name("0a1_2b-3c4");
+        test_parse_name("___reserved");
+    }
+
+    #[test]
+    fn parse_boolean_expr() {
+        test_parse_expr(
+            &mut "a and b",
+            BooleanExpr::and(BooleanExpr::name("a"), BooleanExpr::name("b")),
+        );
+        test_parse_expr(
+            &mut "a and b and c",
+            BooleanExpr::and(
+                BooleanExpr::and(BooleanExpr::name("a"), BooleanExpr::name("b")),
+                BooleanExpr::name("c"),
+            ),
+        );
+        test_parse_expr(
+            &mut "a or b",
+            BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+        );
+        test_parse_expr(
+            &mut "a or b or c",
+            BooleanExpr::or(
+                BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+                BooleanExpr::name("c"),
+            ),
+        );
+        test_parse_expr(&mut "not a", BooleanExpr::not(BooleanExpr::name("a")));
+        test_parse_expr(
+            &mut "not (not a)",
+            BooleanExpr::not(BooleanExpr::not(BooleanExpr::name("a"))),
+        );
+        test_parse_expr(&mut "(not a)", BooleanExpr::not(BooleanExpr::name("a")));
+        test_parse_expr(&mut "( ( (a )))", BooleanExpr::name("a"));
+        test_parse_expr(
+            &mut "(a and b)",
+            BooleanExpr::and(BooleanExpr::name("a"), BooleanExpr::name("b")),
+        );
+        test_parse_expr(
+            &mut "(a or b)",
+            BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+        );
+        test_parse_expr(
+            &mut "(a or b) and (not c)",
+            BooleanExpr::and(
+                BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+                BooleanExpr::not(BooleanExpr::name("c")),
+            ),
+        );
+        test_parse_expr(
+            &mut "((a or b) and (not c))",
+            BooleanExpr::and(
+                BooleanExpr::or(BooleanExpr::name("a"), BooleanExpr::name("b")),
+                BooleanExpr::not(BooleanExpr::name("c")),
+            ),
+        );
+
+        // check the precedence of operators: not > and > or
+        test_parse_expr(
+            &mut "a or b and not c",
+            BooleanExpr::or(
+                BooleanExpr::name("a"),
+                BooleanExpr::and(
+                    BooleanExpr::name("b"),
+                    BooleanExpr::not(BooleanExpr::name("c")),
+                ),
+            ),
+        );
+    }
+
+    #[test]
+    fn parse_boolean_expr_errors() {
+        test_parse_error(
+            &mut "na*me",
+            "successfully parsed: `na`, but `*me` cannot be parsed",
+        );
+        test_parse_error(
+            &mut "()",
+            "expected `an alphanumerical name separated with '-' or '_'`",
+        );
+        test_parse_error(
+            &mut "a and",
+            "successfully parsed: `a`, but ` and` cannot be parsed",
+        );
+        test_parse_error(
+            &mut "a and b not c",
+            "successfully parsed: `a and b`, but ` not c` cannot be parsed",
+        );
+        test_parse_error(
+            &mut "(a and b) or (c and d))",
+            "successfully parsed: `(a and b) or (c and d)`, but `)` cannot be parsed",
+        );
+    }
+
+    /// HELPERS
+
+    /// Test the parsing of a name
+    fn test_parse_name(input: &str) {
+        let i = input.to_string();
+        test_parse(
+            &mut name,
+            &mut i.as_str(),
+            BooleanExpr::Name(input.to_string()),
+        )
+    }
+
+    /// Test the parsing of a boolean expression
+    fn test_parse_expr(input: &mut &str, expected: BooleanExpr) {
+        let i = input.to_string();
+        test_parse(&mut expr, &mut i.as_str(), expected)
+    }
+
+    /// Test a parser with a successful input
+    fn test_parse<'a, O: Debug + PartialEq + Eq, E: Debug>(
+        parser: &mut impl Parser<&'a str, O, E>,
+        input: &mut &'a str,
+        expected: O,
+    ) {
+        match parser.parse_next(input) {
+            Ok(actual) => assert_eq!(actual, expected),
+            Err(e) => assert!(false, "error {e:?}"),
+        }
+    }
+
+    /// Test a parser with a failing input
+    fn test_parse_error(input: &mut &str, expected: &str) {
+        let input_copy = input.to_string();
+        match BooleanExpr::parse(input) {
+            Ok(actual) => assert!(false, "there should be an error '{expected}', when parsing {input_copy}. This expression was parsed instead {actual:?}"),
+            Err(ParseError::Message(e)) => assert!(e.contains(expected), "actual error message:\n{e}\nexpected message:\n{expected}"),
+            Err(e) => assert!(false, "expected a Message ParseError, got: {e}"),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_abac/src/boolean_expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/boolean_expr.rs
@@ -1,4 +1,4 @@
-use crate::Expr;
+use crate::{Expr, SUBJECT_KEY};
 #[cfg(feature = "std")]
 use core::str::FromStr;
 use minicbor::{Decode, Encode};
@@ -122,6 +122,12 @@ impl TryFrom<String> for BooleanExpr {
     }
 }
 
+impl From<BooleanExpr> for Expr {
+    fn from(value: BooleanExpr) -> Self {
+        value.to_expression()
+    }
+}
+
 impl BooleanExpr {
     /// Create a name to be used in a boolean expression.
     pub fn name(s: &str) -> BooleanExpr {
@@ -158,7 +164,7 @@ impl BooleanExpr {
         match self {
             BooleanExpr::Name(s) => List(vec![
                 Ident("=".to_string()),
-                Ident(format!("subject.{}", s)),
+                Ident(format!("{}.{}", SUBJECT_KEY, s)),
                 Str("true".to_string()),
             ]),
             BooleanExpr::Or(e1, e2) => List(vec![

--- a/implementations/rust/ockam/ockam_abac/src/eval.rs
+++ b/implementations/rust/ockam/ockam_abac/src/eval.rs
@@ -295,29 +295,29 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::abac::{ABAC_HAS_CREDENTIAL_KEY, SUBJECT_KEY};
-    use crate::{eval, Env, Expr};
+    use crate::{
+        eval, subject_has_credential_attribute, subject_has_credential_policy_expression, Env, Expr,
+    };
 
     #[test]
     fn test() {
         let mut environment = Env::new();
 
-        let check_credential_expression =
-            Expr::Ident(format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY));
+        let check_credential_expression = subject_has_credential_policy_expression();
 
         let res = eval(&check_credential_expression, &environment);
 
         assert!(res.is_err());
 
         environment.put(
-            format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY),
+            subject_has_credential_attribute().to_string(),
             Expr::CONST_FALSE,
         );
         let res = eval(&check_credential_expression, &environment).unwrap();
         matches!(res, Expr::Bool(false));
 
         environment.put(
-            format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY),
+            subject_has_credential_attribute().to_string(),
             Expr::CONST_TRUE,
         );
 

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -20,6 +20,8 @@ pub mod expr;
 pub mod resource;
 
 mod abac;
+mod boolean_expr;
+
 pub use abac::*;
 
 pub use env::Env;

--- a/implementations/rust/ockam/ockam_abac/src/lib.rs
+++ b/implementations/rust/ockam/ockam_abac/src/lib.rs
@@ -21,9 +21,11 @@ pub mod resource;
 
 mod abac;
 mod boolean_expr;
+mod policy_expr;
 
 pub use abac::*;
 
+pub use boolean_expr::*;
 pub use env::Env;
 pub use error::{EvalError, ParseError};
 pub use eval::eval;
@@ -31,6 +33,7 @@ pub use expr::Expr;
 pub use policy::{
     storage::*, Policies, PolicyAccessControl, ResourcePolicy, ResourceTypePolicy, Resources,
 };
+pub use policy_expr::*;
 pub use resource::{Resource, ResourceType};
 pub use types::{Action, ResourceName, Subject};
 

--- a/implementations/rust/ockam/ockam_abac/src/policy/incoming.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/incoming.rs
@@ -24,6 +24,7 @@ impl IncomingAccessControl for IncomingPolicyAccessControl {
             )
             .await?
         {
+            debug!("found the policy {expr:?} to be used for incoming access control");
             expr
         } else {
             // If no expression exists for this resource and action, access is denied:

--- a/implementations/rust/ockam/ockam_abac/src/policy/outgoing.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/outgoing.rs
@@ -33,6 +33,7 @@ impl OutgoingAccessControl for OutgoingPolicyAccessControl {
             )
             .await?
         {
+            debug!("found the policy {expr:?} to be used for outgoing access control");
             expr
         } else {
             // If no expression exists for this resource and action, access is denied:

--- a/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
@@ -1,10 +1,9 @@
-use crate::abac::{ABAC_HAS_CREDENTIAL_KEY, SUBJECT_KEY};
 use crate::policy::ResourceTypePolicy;
 use crate::{
-    Action, Env, Expr, PolicyAccessControl, Resource, ResourceName, ResourcePoliciesRepository,
-    ResourcePolicy, ResourceType, ResourceTypePoliciesRepository,
+    subject_has_credential_policy_expression, Action, Env, Expr, PolicyAccessControl, Resource,
+    ResourceName, ResourcePoliciesRepository, ResourcePolicy, ResourceType,
+    ResourceTypePoliciesRepository,
 };
-use ockam_core::compat::format;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
@@ -158,7 +157,7 @@ impl Policies {
         resource_type: &ResourceType,
         action: &Action,
     ) -> Result<()> {
-        let expression = Expr::Ident(format!("{}.{}", SUBJECT_KEY, ABAC_HAS_CREDENTIAL_KEY));
+        let expression = subject_has_credential_policy_expression();
         self.resource_types_policies_repository
             .store_policy(resource_type, action, &expression)
             .await

--- a/implementations/rust/ockam/ockam_abac/src/policy_expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy_expr.rs
@@ -19,6 +19,12 @@ pub enum PolicyExpression {
     BooleanExpression(#[n(0)] BooleanExpr),
 }
 
+impl From<PolicyExpression> for Expr {
+    fn from(value: PolicyExpression) -> Self {
+        value.to_expression()
+    }
+}
+
 impl PolicyExpression {
     /// Return the policy expression corresponding to either a fully expanded policy expression
     /// or a boolean expression

--- a/implementations/rust/ockam/ockam_abac/src/policy_expr.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy_expr.rs
@@ -1,0 +1,110 @@
+use crate::policy_expr::PolicyExpression::{BooleanExpression, FullExpression};
+use crate::{BooleanExpr, Expr};
+#[cfg(feature = "std")]
+use core::str::FromStr;
+use minicbor::{Decode, Encode};
+#[cfg(feature = "std")]
+use ockam_core::compat::fmt::{Display, Formatter};
+#[cfg(feature = "std")]
+use ockam_core::Result;
+
+/// A Policy expression can either be represented with
+///   - A full expression with string valued attributes, contain operator, etc...
+///   - A simpler boolean expression with just and / or / not operators acting on boolean attributes
+#[derive(Debug, Clone, Decode, Encode)]
+pub enum PolicyExpression {
+    #[n(0)]
+    FullExpression(#[n(0)] Expr),
+    #[n(1)]
+    BooleanExpression(#[n(0)] BooleanExpr),
+}
+
+impl PolicyExpression {
+    /// Return the policy expression corresponding to either a fully expanded policy expression
+    /// or a boolean expression
+    pub fn to_expression(&self) -> Expr {
+        match self {
+            FullExpression(e) => e.clone(),
+            BooleanExpression(e) => e.to_expression(),
+        }
+    }
+}
+
+impl PartialEq for PolicyExpression {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (FullExpression(e1), FullExpression(e2)) => e1 == e2,
+            (BooleanExpression(e1), BooleanExpression(e2)) => e1 == e2,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PolicyExpression {}
+
+#[cfg(feature = "std")]
+impl Display for PolicyExpression {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FullExpression(e) => e.fmt(f),
+            BooleanExpression(e) => e.fmt(f),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl TryFrom<&str> for PolicyExpression {
+    type Error = crate::ParseError;
+
+    /// Try to parse the expression first as a simple boolean expression,
+    /// then as a full policy expression
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        match BooleanExpr::try_from(input) {
+            Ok(expression) => Ok(BooleanExpression(expression)),
+            Err(e1) => match Expr::try_from(input) {
+                Ok(expression) => Ok(FullExpression(expression)),
+                Err(e2) => Err(crate::ParseError::message(format!("Cannot parse the expression as either a simple boolean expression or a full policy expression:\n - {e1}\n - {e2}")))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl FromStr for PolicyExpression {
+    type Err = crate::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+#[cfg(feature = "std")]
+impl TryFrom<String> for PolicyExpression {
+    type Error = crate::ParseError;
+
+    fn try_from(input: String) -> Result<Self, Self::Error> {
+        Self::try_from(input.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::PolicyExpression::{BooleanExpression, FullExpression};
+    use crate::{BooleanExpr, Expr, PolicyExpression};
+    use core::str::FromStr;
+
+    #[test]
+    fn from_str() {
+        let full_expression = "(= subject.test = \"true\")";
+        assert_eq!(
+            PolicyExpression::from_str(full_expression).unwrap(),
+            FullExpression(Expr::from_str(full_expression).unwrap())
+        );
+
+        let boolean_expression = "test";
+        assert_eq!(
+            PolicyExpression::from_str(boolean_expression).unwrap(),
+            BooleanExpression(BooleanExpr::from_str(boolean_expression).unwrap())
+        );
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -3,7 +3,7 @@ use minicbor::Decoder;
 use ockam_core::compat::net::IpAddr;
 
 use ockam::compat::tokio::sync::Mutex;
-use ockam_abac::Expr;
+use ockam_abac::PolicyExpression;
 use ockam_core::api::{Request, ResponseHeader, Status};
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::net::SocketAddr;
@@ -28,7 +28,7 @@ type BrokerId = i32;
 #[derive(Debug, Clone)]
 pub(crate) struct KafkaInletController {
     inner: Arc<Mutex<KafkaInletMapInner>>,
-    policy_expression: Option<Expr>,
+    policy_expression: Option<PolicyExpression>,
 }
 
 #[derive(Debug)]
@@ -49,7 +49,7 @@ impl KafkaInletController {
         remote_interceptor_route: Route,
         bind_ip: IpAddr,
         port_range: PortRange,
-        policy_expression: Option<Expr>,
+        policy_expression: Option<PolicyExpression>,
     ) -> KafkaInletController {
         Self {
             inner: Arc::new(Mutex::new(KafkaInletMapInner {
@@ -119,7 +119,7 @@ impl KafkaInletController {
         to: MultiAddr,
         prefix: Route,
         suffix: Route,
-        policy_expression: Option<Expr>,
+        policy_expression: Option<PolicyExpression>,
     ) -> Result<SocketAddr> {
         let mut payload = CreateInlet::to_node(
             socket_address.to_string(),

--- a/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/mod.rs
@@ -13,9 +13,8 @@ mod secure_channel_map;
 
 pub(crate) use inlet_controller::KafkaInletController;
 use ockam::identity::Identifier;
-use ockam_abac::expr::{eq, ident, or, str};
-use ockam_abac::Expr;
-use ockam_abac::{ABAC_HAS_CREDENTIAL_KEY, ABAC_IDENTIFIER_KEY, SUBJECT_KEY};
+use ockam_abac::expr::{eq, or, str};
+use ockam_abac::{subject_has_credential_policy_expression, subject_identifier_attribute, Expr};
 use ockam_core::Address;
 pub(crate) use outlet_service::prefix_relay::PrefixRelayService;
 pub(crate) use outlet_service::OutletManagerService;
@@ -31,13 +30,13 @@ pub fn kafka_outlet_address(broker_id: i32) -> Address {
     format!("kafka_outlet_{}", broker_id).into()
 }
 pub fn kafka_default_policy_expression() -> Expr {
-    Expr::Ident(format!("{SUBJECT_KEY}.{ABAC_HAS_CREDENTIAL_KEY}"))
+    subject_has_credential_policy_expression()
 }
 
 pub fn kafka_policy_expression(project_identifier: &Identifier) -> Expr {
     or([
         eq([
-            ident(format!("{}.{}", SUBJECT_KEY, ABAC_IDENTIFIER_KEY)),
+            subject_identifier_attribute(),
             str(project_identifier.to_string()),
         ]),
         kafka_default_policy_expression(),

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_controller.rs
@@ -3,7 +3,7 @@ use crate::nodes::models::portal::{CreateOutlet, OutletStatus};
 use crate::nodes::NODEMANAGER_ADDR;
 use minicbor::Decoder;
 use ockam::compat::tokio::sync::Mutex;
-use ockam_abac::Expr;
+use ockam_abac::PolicyExpression;
 use ockam_core::api::{Request, ResponseHeader, Status};
 use ockam_core::compat::collections::HashMap;
 use ockam_core::compat::sync::Arc;
@@ -22,7 +22,7 @@ type BrokerId = i32;
 #[derive(Debug, Clone)]
 pub(crate) struct KafkaOutletController {
     inner: Arc<Mutex<KafkaOutletMapInner>>,
-    policy_expression: Option<Expr>,
+    policy_expression: Option<PolicyExpression>,
 }
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ struct KafkaOutletMapInner {
 }
 
 impl KafkaOutletController {
-    pub(crate) fn new(policy_expression: Option<Expr>) -> KafkaOutletController {
+    pub(crate) fn new(policy_expression: Option<PolicyExpression>) -> KafkaOutletController {
         Self {
             inner: Arc::new(Mutex::new(KafkaOutletMapInner {
                 broker_map: HashMap::new(),
@@ -68,7 +68,7 @@ impl KafkaOutletController {
         context: &Context,
         socket_address: SocketAddr,
         worker_address: Address,
-        policy_expression: Option<Expr>,
+        policy_expression: Option<PolicyExpression>,
     ) -> Result<SocketAddr> {
         let hostname_port = HostnamePort::from_socket_addr(socket_address)?;
         let mut payload = CreateOutlet::new(hostname_port, false, Some(worker_address), false);

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
@@ -4,8 +4,8 @@ use crate::kafka::protocol_aware::OutletInterceptorImpl;
 use crate::kafka::KAFKA_OUTLET_INTERCEPTOR_ADDRESS;
 use ockam::identity::{Identifier, SecureChannels};
 use ockam::{Any, Context, Result, Routed, Worker};
-use ockam_abac::Expr;
 use ockam_abac::IncomingAbac;
+use ockam_abac::PolicyExpression;
 use ockam_core::flow_control::{FlowControlId, FlowControlOutgoingAccessControl, FlowControls};
 use ockam_core::{Address, IncomingAccessControl};
 use ockam_node::WorkerBuilder;
@@ -27,7 +27,7 @@ impl OutletManagerService {
         secure_channels: Arc<SecureChannels>,
         authority_identifier: Identifier,
         default_secure_channel_listener_flow_control_id: FlowControlId,
-        policy_expression: Option<Expr>,
+        policy_expression: Option<PolicyExpression>,
     ) -> Result<()> {
         let flow_controls = context.flow_controls();
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/policies.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/policies.rs
@@ -1,5 +1,7 @@
 use minicbor::{Decode, Encode};
-use ockam_abac::{Action, Expr, ResourceName, ResourcePolicy, ResourceType, ResourceTypePolicy};
+use ockam_abac::{
+    Action, Expr, PolicyExpression, ResourceName, ResourcePolicy, ResourceType, ResourceTypePolicy,
+};
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Error;
 use serde::Serialize;
@@ -11,11 +13,11 @@ use std::str::FromStr;
 #[cbor(map)]
 pub struct SetPolicyRequest {
     #[n(1)] pub resource: ResourceTypeOrName,
-    #[n(2)] pub expression: Expr,
+    #[n(2)] pub expression: PolicyExpression,
 }
 
 impl SetPolicyRequest {
-    pub fn new(resource: ResourceTypeOrName, expression: Expr) -> Self {
+    pub fn new(resource: ResourceTypeOrName, expression: PolicyExpression) -> Self {
         Self {
             resource,
             expression,

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use minicbor::{Decode, Encode};
 use ockam::identity::Identifier;
 use ockam::route;
-use ockam_abac::Expr;
+use ockam_abac::PolicyExpression;
 use ockam_core::{Address, IncomingAccessControl, OutgoingAccessControl, Route};
 use ockam_multiaddr::MultiAddr;
 use ockam_transport_tcp::HostnamePort;
@@ -49,7 +49,7 @@ pub struct CreateInlet {
     /// The expression for the access control policy for this inlet.
     /// If not set, the policy set for the [TCP inlet resource type](ockam_abac::ResourceType::TcpInlet)
     /// will be used.
-    #[n(8)] pub(crate) policy_expression: Option<Expr>,
+    #[n(8)] pub(crate) policy_expression: Option<PolicyExpression>,
     /// Create the inlet and wait for the outlet to connect
     #[n(9)] pub(crate) wait_connection: bool,
 }
@@ -102,7 +102,7 @@ impl CreateInlet {
         self.wait_for_outlet_duration = Some(Duration::from_millis(ms))
     }
 
-    pub fn set_policy_expression(&mut self, expression: Expr) {
+    pub fn set_policy_expression(&mut self, expression: PolicyExpression) {
         self.policy_expression = Some(expression);
     }
 
@@ -152,7 +152,7 @@ pub struct CreateOutlet {
     /// The expression for the access control policy for this outlet.
     /// If not set, the policy set for the [TCP outlet resource type](ockam_abac::ResourceType::TcpOutlet)
     /// will be used.
-    #[n(5)] pub policy_expression: Option<Expr>,
+    #[n(5)] pub policy_expression: Option<PolicyExpression>,
 }
 
 impl CreateOutlet {
@@ -171,7 +171,7 @@ impl CreateOutlet {
         }
     }
 
-    pub fn set_policy_expression(&mut self, expression: Expr) {
+    pub fn set_policy_expression(&mut self, expression: PolicyExpression) {
         self.policy_expression = Some(expression);
     }
 }
@@ -307,5 +307,5 @@ pub enum OutletAccessControl {
             Arc<dyn OutgoingAccessControl>,
         ),
     ),
-    PolicyExpression(Option<Expr>),
+    WithPolicyExpression(Option<PolicyExpression>),
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 
 use crate::cli_state::random_name;
 use ockam::{Address, Context, Result};
+use ockam_abac::PolicyExpression::FullExpression;
 use ockam_core::api::{Error, Response};
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::compat::rand::random_string;
@@ -192,6 +193,7 @@ impl InMemoryNode {
                 }
             }
         };
+        let outlet_policy_expression = outlet_policy_expression.map(FullExpression);
 
         OutletManagerService::create(
             context,
@@ -207,7 +209,7 @@ impl InMemoryNode {
             false,
             Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into()),
             false,
-            OutletAccessControl::PolicyExpression(outlet_policy_expression.clone()),
+            OutletAccessControl::WithPolicyExpression(outlet_policy_expression.clone()),
         )
         .await?;
 
@@ -310,6 +312,7 @@ impl InMemoryNode {
         } else {
             Some(kafka_default_policy_expression())
         };
+        let inlet_policy_expression = inlet_policy_expression.map(FullExpression);
 
         let inlet_controller = KafkaInletController::new(
             outlet_node_multiaddr.clone(),
@@ -411,7 +414,7 @@ impl NodeManager {
                 false,
                 Some(KAFKA_OUTLET_BOOTSTRAP_ADDRESS.into()),
                 false,
-                OutletAccessControl::PolicyExpression(outlet_policy_expression),
+                OutletAccessControl::WithPolicyExpression(outlet_policy_expression),
             )
             .await
         {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -390,7 +390,7 @@ impl NodeManager {
                     .store_policy_for_resource_name(
                         &resource.resource_name,
                         &action,
-                        &expression.to_expression(),
+                        &expression.into(),
                     )
                     .await?;
             }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -19,7 +19,7 @@ use ockam::identity::{
 };
 use ockam::{RelayService, RelayServiceOptions};
 use ockam_abac::expr::str;
-use ockam_abac::{Action, Env, Expr, Policies, Resource, Resources};
+use ockam_abac::{Action, Env, Policies, PolicyExpression, Resource, Resources};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::{
     AllowAll, AsyncTryClone, CachedIncomingAccessControl, CachedOutgoingAccessControl,
@@ -369,7 +369,7 @@ impl NodeManager {
         authority: Option<Identifier>,
         resource: Resource,
         action: Action,
-        expression: Option<Expr>,
+        expression: Option<PolicyExpression>,
     ) -> ockam_core::Result<(
         Arc<dyn IncomingAccessControl>,
         Arc<dyn OutgoingAccessControl>,
@@ -387,7 +387,11 @@ impl NodeManager {
             let policies = self.policies();
             if let Some(expression) = expression {
                 policies
-                    .store_policy_for_resource_name(&resource.resource_name, &action, &expression)
+                    .store_policy_for_resource_name(
+                        &resource.resource_name,
+                        &action,
+                        &expression.to_expression(),
+                    )
                     .await?;
             }
             self.resources().store_resource(&resource).await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/policy.rs
@@ -71,20 +71,12 @@ impl NodeManager {
         match resource {
             ResourceTypeOrName::Type(resource_type) => {
                 self.policies()
-                    .store_policy_for_resource_type(
-                        &resource_type,
-                        &action,
-                        &expression.to_expression(),
-                    )
+                    .store_policy_for_resource_type(&resource_type, &action, &expression.into())
                     .await
             }
             ResourceTypeOrName::Name(resource_name) => {
                 self.policies()
-                    .store_policy_for_resource_name(
-                        &resource_name,
-                        &action,
-                        &expression.to_expression(),
-                    )
+                    .store_policy_for_resource_name(&resource_name, &action, &expression.into())
                     .await
             }
         }

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
 use ockam::abac::PolicyExpression::FullExpression;
+use ockam::abac::SUBJECT_KEY;
 use tracing::{debug, error, info, warn};
 
 use ockam_api::address::get_free_address;
@@ -207,7 +208,7 @@ impl AppState {
         // is the enroller of its project and not any enrolled
         // identity.
         let expr = eq([
-            ident(format!("subject.{}", OCKAM_ROLE_ATTRIBUTE_KEY)),
+            ident(format!("{}.{}", SUBJECT_KEY, OCKAM_ROLE_ATTRIBUTE_KEY)),
             str(OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE),
         ]);
 

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
+use ockam::abac::PolicyExpression::FullExpression;
 use tracing::{debug, error, info, warn};
 
 use ockam_api::address::get_free_address;
@@ -218,7 +219,7 @@ impl AppState {
                     .into_diagnostic()?,
                 &inlet_alias,
                 &None,
-                &Some(expr),
+                &Some(FullExpression(expr)),
                 Duration::from_secs(5),
                 true,
             )

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -28,7 +28,8 @@ discord channel https://discord.ockam.io
 ";
 
 static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
-static HEADER_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[A-Za-z][A-Za-z0-9 ]+:$".into()));
+static HEADER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new("^(Examples|Learn More|Feedback):$".into()));
 static THEME: Lazy<SyntectTheme> = Lazy::new(|| {
     let mut theme_set = ThemeSet::load_defaults();
     let default_theme = theme_set.themes.remove("base16-ocean.dark").unwrap_or(
@@ -107,13 +108,17 @@ fn process_terminal_docs(input: String) -> String {
         }
         // The line is not part of a fenced block, so process normally.
         else {
-            // Replace headers with bold and underline text
+            // Bold and underline known headers
             if HEADER_RE.is_match(line) {
                 output.push(line.to_string().bold().underlined().to_string());
             }
-            // Replace subheaders with underlined text
+            // Underline H4 headers
             else if line.starts_with("#### ") {
                 output.push(line.replace("#### ", "").underlined().to_string());
+            }
+            // Remove H5 headers prefix
+            else if line.starts_with("##### ") {
+                output.push(line.replace("##### ", "").to_string());
             }
             // No processing
             else {
@@ -141,10 +146,8 @@ impl FencedCodeBlockHighlighter<'_> {
     }
 
     fn in_fenced_block(&mut self, line: &str) -> bool {
-        if line.contains("```sh") {
-            self.in_fenced_block = true;
-        } else if line.contains("```\n") {
-            self.in_fenced_block = false;
+        if line.contains("```") {
+            self.in_fenced_block = !self.in_fenced_block;
         }
         self.in_fenced_block
     }

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -6,18 +6,26 @@ use colorful::Colorful;
 use miette::IntoDiagnostic;
 
 use ockam::Context;
-use ockam_abac::{Action, Expr, ResourceName, ResourceType};
+use ockam_abac::{Action, PolicyExpression, ResourceName, ResourceType};
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::policies::ResourceTypeOrName;
 use ockam_api::nodes::{BackgroundNodeClient, Policies};
 use ockam_api::{fmt_ok, fmt_warn};
 
+use crate::docs;
 use crate::node::util::initialize_default_node;
 use crate::{Command, CommandGlobalOpts};
 
 use super::resource_type_parser;
 
+const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
+const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
 #[derive(Clone, Debug, Args)]
+#[command(
+long_about = docs::about(LONG_ABOUT),
+after_long_help = docs::after_help(AFTER_LONG_HELP)
+)]
 pub struct CreateCommand {
     #[arg(long, display_order = 900, id = "NODE_NAME")]
     pub at: Option<String>,
@@ -33,7 +41,7 @@ pub struct CreateCommand {
     pub resource: Option<ResourceName>,
 
     #[arg(long)]
-    pub expression: Expr,
+    pub expression: PolicyExpression,
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_command/src/policy/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/create.rs
@@ -40,8 +40,8 @@ pub struct CreateCommand {
     #[arg(long)]
     pub resource: Option<ResourceName>,
 
-    #[arg(long)]
-    pub expression: PolicyExpression,
+    #[arg(long, visible_alias = "expression", id = "POLICY_EXPRESSION")]
+    pub allow: PolicyExpression,
 }
 
 #[async_trait]
@@ -68,7 +68,7 @@ impl Command for CreateCommand {
             .into_diagnostic()?;
 
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.at).await?;
-        node.add_policy(ctx, &resource, &Action::HandleMessage, &self.expression)
+        node.add_policy(ctx, &resource, &Action::HandleMessage, &self.allow)
             .await?;
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/policy/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/policy/static/create/after_long_help.txt
@@ -1,0 +1,71 @@
+# Policy expressions
+
+Policies can be specified using 2 formats:
+
+  - A simple boolean expression
+  - A complete policy expression
+
+# Boolean expressions
+
+A boolean expression contains names and boolean operators: `and`, `or`, `not`.
+Here are some examples of boolean expressions:
+```
+a
+a and b
+a or b
+(a and b) or (b or (not c))
+```
+
+The names must contain can contain letters, digits, and separators like,: `.`, `-`, or `_`.
+However a name cannot start with a digit or a `.`.
+For example:
+```
+web
+internal_web1
+external.db-production
+```
+
+A boolean expression is transformed as a full policy expression before being stored.
+Names are transformed to attributes on a `subject` and set to the value `true`. For example, the expression `a and b`
+becomes:
+```
+(and (= subject.a "true") (= subject.b "true"))
+```
+
+# Policy expressions
+
+A policy expression is an expression containing identifiers and operators, which can eventually be evaluated to
+a boolean value given an environment (a list of key/value pairs) assigning a value to each name.
+
+For example, the expression `(= subject.component "db")` will evaluate to `true` given an environment containing the
+name `subject.component` and the value `"db"`. The type of values associated to names are:
+
+  - `string`.
+  - `bool`.
+  - `float`.
+  - `int`.
+  - a list of values with one of the types above.
+
+The structure of a policy expression consists in an operator followed by one or several arguments:
+```
+(operator argument1 argument2)
+```
+
+## Operators
+
+Here is the list of available operators:
+
+  Operator   | Arity  | Example                       | Description
+  --------   | -----  | ----------------------------  | -------
+  `and`      | 2      | `(and (= a 1) (= b 2))`       | true if both expressions are true.
+  `or`       | 2      | `(or (= a 1) (= b 2))`        | true if one expression is true.
+  `not`      | 1      | `(not (= a 1))`               | true if the expression is false.
+  `if`       | 3      | `(if (= a 1) (= b 2) (= c 3)` | if the first expression is true return the value of the second expression. Otherwise return the value of the third expression.
+  `<`        | 2      | `(< a 1)`                     | true if a value  is strictly less than another value.
+  `>`        | 2      | `(> a 1)`                     | true if a value is strictly greater than another value.
+  `=`        | 2      | `(= a "value")`               | true if a value is equal to another value.
+  `!=`       | 2      | `(!= a "value")`              | true if a value is not equal to another value.
+  `member?`  | 2      | `(member? a ["db1", "db2"])`  | true if a value is contained in a list of other values.
+  `exists?`  | n >= 1 | `(exists? a b c)`             | true if one of the identifiers has an associated value in the environment.
+
+```

--- a/implementations/rust/ockam/ockam_command/src/policy/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/policy/static/create/after_long_help.txt
@@ -1,14 +1,13 @@
-# Policy expressions
-
 Policies can be specified using 2 formats:
 
   - A simple boolean expression
   - A complete policy expression
 
-# Boolean expressions
+#### Boolean expressions
 
 A boolean expression contains names and boolean operators: `and`, `or`, `not`.
 Here are some examples of boolean expressions:
+
 ```
 a
 a and b
@@ -19,6 +18,7 @@ a or b
 The names must contain can contain letters, digits, and separators like,: `.`, `-`, or `_`.
 However a name cannot start with a digit or a `.`.
 For example:
+
 ```
 web
 internal_web1
@@ -28,11 +28,12 @@ external.db-production
 A boolean expression is transformed as a full policy expression before being stored.
 Names are transformed to attributes on a `subject` and set to the value `true`. For example, the expression `a and b`
 becomes:
+
 ```
 (and (= subject.a "true") (= subject.b "true"))
 ```
 
-# Policy expressions
+#### Policy expressions
 
 A policy expression is an expression containing identifiers and operators, which can eventually be evaluated to
 a boolean value given an environment (a list of key/value pairs) assigning a value to each name.
@@ -47,11 +48,12 @@ name `subject.component` and the value `"db"`. The type of values associated to 
   - a list of values with one of the types above.
 
 The structure of a policy expression consists in an operator followed by one or several arguments:
+
 ```
 (operator argument1 argument2)
 ```
 
-## Operators
+#### Operators
 
 Here is the list of available operators:
 

--- a/implementations/rust/ockam/ockam_command/src/policy/static/create/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/policy/static/create/long_about.txt
@@ -1,0 +1,1 @@
+This command creates a new policy associated to a resource.

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -434,7 +434,7 @@ mod tests {
                         args: vec![
                             ("from".to_string(), "4000".into()),
                             ("via".to_string(), "db".into()),
-                            ("allow".to_string(), "(= subject.component \"db\")".into()),
+                            ("allow".to_string(), "component.db".into()),
                         ]
                         .into_iter()
                         .collect(),
@@ -471,7 +471,7 @@ mod tests {
                     Args {
                         args: vec![
                             ("to".to_string(), "5432".into()),
-                            ("allow".to_string(), "(= subject.component \"web\")".into()),
+                            ("allow".to_string(), "component.web".into()),
                         ]
                         .into_iter()
                         .collect(),

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.portal.inlet.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.portal.inlet.yaml
@@ -9,4 +9,4 @@ tcp-inlets:
   web-inlet:
     from: $OCKAM_PORT
     via: db
-    allow: '(= subject.component "db")'
+    allow: 'component.db'

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.portal.outlet.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/2.portal.outlet.yaml
@@ -10,4 +10,4 @@ relays: db
 tcp-outlets:
   db-outlet:
     to: $PG_PORT
-    allow: '(= subject.component "web")'
+    allow: 'component.web'

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/3.two-way-portal.customer.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/3.two-way-portal.customer.yaml
@@ -11,9 +11,9 @@ relays: $CUSTOMER
 tcp-outlets:
   from: $NAME_OF_SERVICE
   to: $ADDRESS_OF_SERVICE
-  allow: '(= subject.from-saas "inlet")'
+  allow: 'inlet'
 
 tcp-inlets:
   from: $ADDRESS_OF_INLET_TO_SAAS
   via: saas
-  allow: '(= subject.to-saas "outlet")'
+  allow: 'outlet'

--- a/implementations/rust/ockam/ockam_command/src/run/demo_config_files/3.two-way-portal.sass.yaml
+++ b/implementations/rust/ockam/ockam_command/src/run/demo_config_files/3.two-way-portal.sass.yaml
@@ -10,10 +10,10 @@ relays: saas
 
 tcp-outlets:
   to: $ADDRESS_OF_SAAS_SERVICE
-  allow: '(= subject.to-saas "inlet")'
+  allow: 'inlet'
 
 tcp-inlets:
   from: $ADDRESS_OF_INLET_TO_SERVICE_AT_CUSTOMER
   to: $NAME_OF_SERVICE_AT_CUSTOMER
   via: $CUSTOMER
-  allow: '(= subject.from-saas "outlet")'
+  allow: 'outlet'

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
@@ -52,10 +52,7 @@ mod tests {
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");
         assert_eq!(cmds[0].resource.as_ref().unwrap().as_str(), "r1");
-        assert_eq!(
-            &cmds[0].expression.to_string(),
-            "(= subject.component \"c1\")"
-        );
+        assert_eq!(&cmds[0].allow.to_string(), "(= subject.component \"c1\")");
     }
 
     #[test]
@@ -78,29 +75,20 @@ mod tests {
 
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");
         assert_eq!(cmds[0].resource.as_ref().unwrap().as_str(), "r1");
-        assert_eq!(
-            &cmds[0].expression.to_string(),
-            "(= subject.component \"c1\")"
-        );
+        assert_eq!(&cmds[0].allow.to_string(), "(= subject.component \"c1\")");
 
         assert_eq!(cmds[1].at.as_ref().unwrap(), "n2");
         assert_eq!(
             &cmds[1].resource.as_ref().unwrap().to_string(),
             "tcp-outlet"
         );
-        assert_eq!(
-            &cmds[1].expression.to_string(),
-            "(= subject.component \"c2\")"
-        );
+        assert_eq!(&cmds[1].allow.to_string(), "(= subject.component \"c2\")");
 
         assert_eq!(cmds[2].at.as_ref().unwrap(), "n3");
         assert_eq!(
             &cmds[2].resource_type.as_ref().unwrap().to_string(),
             "tcp-inlet"
         );
-        assert_eq!(
-            &cmds[2].expression.to_string(),
-            "(= subject.component \"c3\")"
-        );
+        assert_eq!(&cmds[2].allow.to_string(), "(= subject.component \"c3\")");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -83,8 +83,13 @@ pub struct CreateCommand {
     /// If you don't provide it, the policy set for the "tcp-inlet" resource type will be used.
     ///
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-inlet`.
-    #[arg(hide = true, long = "allow", display_order = 900, id = "EXPRESSION")]
-    pub policy_expression: Option<PolicyExpression>,
+    #[arg(
+        hide = true,
+        visible_alias = "policy_expression",
+        display_order = 900,
+        id = "POLICY_EXPRESSION"
+    )]
+    pub allow: Option<PolicyExpression>,
 
     /// Time to wait for the outlet to be available.
     #[arg(long, display_order = 900, id = "WAIT", default_value = "5s", value_parser = duration_parser)]
@@ -147,7 +152,7 @@ impl Command for CreateCommand {
                         &cmd.to(),
                         &cmd.alias,
                         &cmd.authorized,
-                        &cmd.policy_expression,
+                        &cmd.allow,
                         cmd.connection_wait,
                         !cmd.no_connection_wait,
                     )

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -13,7 +13,7 @@ use tracing::trace;
 
 use ockam::identity::Identifier;
 use ockam::Context;
-use ockam_abac::Expr;
+use ockam_abac::PolicyExpression;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::journeys::{
     JourneyEvent, NODE_NAME, TCP_INLET_ALIAS, TCP_INLET_AT, TCP_INLET_CONNECTION_STATUS,
@@ -84,7 +84,7 @@ pub struct CreateCommand {
     ///
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-inlet`.
     #[arg(hide = true, long = "allow", display_order = 900, id = "EXPRESSION")]
-    pub policy_expression: Option<Expr>,
+    pub policy_expression: Option<PolicyExpression>,
 
     /// Time to wait for the outlet to be available.
     #[arg(long, display_order = 900, id = "WAIT", default_value = "5s", value_parser = duration_parser)]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -12,7 +12,7 @@ use tokio::try_join;
 use crate::node::util::initialize_default_node;
 use crate::{docs, Command, CommandGlobalOpts};
 use ockam::Context;
-use ockam_abac::Expr;
+use ockam_abac::PolicyExpression;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::journeys::{
     JourneyEvent, NODE_NAME, TCP_OUTLET_AT, TCP_OUTLET_FROM, TCP_OUTLET_TO,
@@ -61,7 +61,7 @@ pub struct CreateCommand {
     ///
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-outlet`.
     #[arg(hide = true, long = "allow", display_order = 904, id = "EXPRESSION")]
-    pub policy_expression: Option<Expr>,
+    pub policy_expression: Option<PolicyExpression>,
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -60,8 +60,13 @@ pub struct CreateCommand {
     /// If you don't provide it, the policy set for the "tcp-outlet" resource type will be used.
     ///
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-outlet`.
-    #[arg(hide = true, long = "allow", display_order = 904, id = "EXPRESSION")]
-    pub policy_expression: Option<PolicyExpression>,
+    #[arg(
+        hide = true,
+        visible_alias = "policy_expression",
+        display_order = 904,
+        id = "POLICY_EXPRESSION"
+    )]
+    pub allow: Option<PolicyExpression>,
 }
 
 #[async_trait]
@@ -77,13 +82,7 @@ impl Command for CreateCommand {
         let send_req = async {
             let from = self.from.map(Address::from);
             let res = node
-                .create_outlet(
-                    ctx,
-                    self.to.clone(),
-                    self.tls,
-                    from.as_ref(),
-                    self.policy_expression,
-                )
+                .create_outlet(ctx, self.to.clone(), self.tls, from.as_ref(), self.allow)
                 .await?;
             *is_finished.lock().await = true;
             Ok(res)

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "policies - create resource type policy, backwards compatibility" {
-  run_success $OCKAM policy create --resource tcp-outlet --expression '(= subject.component "global_value")'
+  run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "global_value")'
   run_success $OCKAM policy show tcp-outlet
   assert_output --partial "tcp-outlet"
   assert_output --partial '(= subject.component \"global_value\")'
@@ -48,4 +48,17 @@ teardown() {
   run_success $OCKAM policy delete my_policy -y
   run_success $OCKAM policy show my_policy
   refute_output --partial "my_policy"
+}
+
+@test "policies - create policy with a boolean expression" {
+  run_success $OCKAM policy create --resource my_policy --expression 'component.db or component.web'
+  run_success $OCKAM policy show my_policy
+  assert_output --partial "my_policy"
+  assert_output --partial '"expression":"(or (= subject.component.db \"true\") (= subject.component.web \"true\"))"}'
+}
+
+@test "policies - create policy with an incorrect policy expression" {
+  run_failure $OCKAM policy create --resource my_policy --expression 'component.db or'
+  assert_output --partial "invalid value 'component.db or'"
+  assert_output --partial 'successfully parsed: `component.db`, but ` or` cannot be parsed'
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
@@ -15,7 +15,7 @@ teardown() {
 # ===== TESTS
 
 @test "policies - create resource type policy, backwards compatibility" {
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "global_value")'
+  run_success $OCKAM policy create --resource tcp-outlet --expression '(= subject.component "global_value")'
   run_success $OCKAM policy show tcp-outlet
   assert_output --partial "tcp-outlet"
   assert_output --partial '(= subject.component \"global_value\")'
@@ -51,14 +51,14 @@ teardown() {
 }
 
 @test "policies - create policy with a boolean expression" {
-  run_success $OCKAM policy create --resource my_policy --expression 'component.db or component.web'
+  run_success $OCKAM policy create --resource my_policy --allow 'component.db or component.web'
   run_success $OCKAM policy show my_policy
   assert_output --partial "my_policy"
   assert_output --partial '"expression":"(or (= subject.component.db \"true\") (= subject.component.web \"true\"))"}'
 }
 
 @test "policies - create policy with an incorrect policy expression" {
-  run_failure $OCKAM policy create --resource my_policy --expression 'component.db or'
+  run_failure $OCKAM policy create --resource my_policy --allow 'component.db or'
   assert_output --partial "invalid value 'component.db or'"
   assert_output --partial 'successfully parsed: `component.db`, but ` or` cannot be parsed'
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/fixtures/node-create.3.customer.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/fixtures/node-create.3.customer.config.yaml
@@ -3,9 +3,9 @@ relays: to-$CUSTOMER
 tcp-outlets:
   from: $CUSTOMER_SERVICE_NAME
   to: "127.0.0.1:$CUSTOMER_OUTLET_PORT"
-  allow: '(= subject.from-saas "inlet")'
+  allow: 'inlet'
 
 tcp-inlets:
   from: "127.0.0.1:$CUSTOMER_INLET_PORT"
   via: to-$SAAS_RELAY_NAME
-  allow: '(= subject.to-saas "outlet")'
+  allow: 'outlet'

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/fixtures/node-create.3.saas.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/fixtures/node-create.3.saas.config.yaml
@@ -2,10 +2,10 @@ relays: to-$SAAS_RELAY_NAME
 
 tcp-outlets:
   to: "127.0.0.1:$SAAS_OUTLET_PORT"
-  allow: '(= subject.to-saas "inlet")'
+  allow: 'inlet'
 
 tcp-inlets:
   from: "127.0.0.1:$SAAS_INLET_PORT"
   to: $CUSTOMER_SERVICE_NAME
   via: to-$CUSTOMER
-  allow: '(= subject.from-saas "outlet")'
+  allow: 'outlet'

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
@@ -28,7 +28,7 @@ teardown() {
   setup_home_dir
   run_success $OCKAM project enroll $db_ticket
   run_success $OCKAM relay create $relay_name
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "web")'
+  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.web'
   run_success $OCKAM tcp-outlet create --to $PYTHON_SERVER_PORT
 
   # WebApp - Has the right attribute, so it should be able to connect
@@ -58,7 +58,7 @@ teardown() {
   run_success $OCKAM project enroll $db_ticket
   run_success $OCKAM relay create $relay_name
   ### Set wrong resource type policy
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "NOT_web")'
+  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.NOT_web'
   run_success $OCKAM tcp-outlet create --to $PYTHON_SERVER_PORT
 
   # WebApp
@@ -72,10 +72,10 @@ teardown() {
 
   # Update resource type policy and try again. Now the policy is satisfied
   export OCKAM_HOME=$DB_OCKAM_HOME
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression '(= subject.component "web")'
+  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.web'
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Update the policy for the outlet and try again. It will fail because the local policy is not satisfied
-  run_success $OCKAM policy create --resource outlet --expression '(= subject.component "NOT_web")'
+  run_success $OCKAM policy create --resource outlet --expression 'componen.NOT_web'
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
@@ -28,7 +28,7 @@ teardown() {
   setup_home_dir
   run_success $OCKAM project enroll $db_ticket
   run_success $OCKAM relay create $relay_name
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.web'
+  run_success $OCKAM policy create --resource-type tcp-outlet --allow 'component.web'
   run_success $OCKAM tcp-outlet create --to $PYTHON_SERVER_PORT
 
   # WebApp - Has the right attribute, so it should be able to connect
@@ -58,7 +58,7 @@ teardown() {
   run_success $OCKAM project enroll $db_ticket
   run_success $OCKAM relay create $relay_name
   ### Set wrong resource type policy
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.NOT_web'
+  run_success $OCKAM policy create --resource-type tcp-outlet --allow 'component.NOT_web'
   run_success $OCKAM tcp-outlet create --to $PYTHON_SERVER_PORT
 
   # WebApp
@@ -72,10 +72,10 @@ teardown() {
 
   # Update resource type policy and try again. Now the policy is satisfied
   export OCKAM_HOME=$DB_OCKAM_HOME
-  run_success $OCKAM policy create --resource-type tcp-outlet --expression 'component.web'
+  run_success $OCKAM policy create --resource-type tcp-outlet --allow 'component.web'
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Update the policy for the outlet and try again. It will fail because the local policy is not satisfied
-  run_success $OCKAM policy create --resource outlet --expression 'componen.NOT_web'
+  run_success $OCKAM policy create --resource-type outlet --allow 'componen.NOT_web'
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 }

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/node_migration_set.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/node_migration_set.rs
@@ -2,8 +2,9 @@ use crate::database::migrations::migration_20240111100001_add_authority_tables::
 use crate::database::migrations::migration_20240111100002_delete_trust_context::PolicyTrustContextId;
 use crate::database::migrations::migration_20240212100000_split_policies::SplitPolicies;
 use crate::database::migrations::node_migrations::migration_20231231100000_node_name_identity_attributes::NodeNameIdentityAttributes;
-use ockam_core::Result;
 use crate::database::migration_20240313100000_remove_orphan_resources::RemoveOrphanResources;
+use crate::database::migration_20240503100000_update_policy_expressions::UpdatePolicyExpressions;
+use ockam_core::Result;
 
 use crate::database::migrations::migration_set::MigrationSet;
 use crate::database::migrations::{Migrator, RustMigration};
@@ -20,6 +21,7 @@ impl MigrationSet for NodeMigrationSet {
             Box::new(PolicyTrustContextId),
             Box::new(SplitPolicies),
             Box::new(RemoveOrphanResources),
+            Box::new(UpdatePolicyExpressions),
         ];
         let mut migrator = migrate!("./src/storage/database/migrations/node_migrations/sql")?;
         migrator.set_rust_migrations(rust_migrations)?;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust.rs
@@ -10,3 +10,5 @@ pub mod migration_20240111100002_delete_trust_context;
 pub mod migration_20240212100000_split_policies;
 /// This migration removes orphan resources
 pub mod migration_20240313100000_remove_orphan_resources;
+/// This migration updates the policy expressions so that they start with an operator
+pub mod migration_20240503100000_update_policy_expressions;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240503100000_update_policy_expressions.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/migration_20240503100000_update_policy_expressions.rs
@@ -1,0 +1,153 @@
+use crate::database::migrations::RustMigration;
+use crate::database::{FromSqlxError, ToVoid};
+use ockam_core::{async_trait, Result};
+use sqlx::*;
+
+/// This migration makes sure that policy expressions that were created as subject.has_credential
+/// now start with an operator: (= subject.has_credential "true")
+#[derive(Debug)]
+pub struct UpdatePolicyExpressions;
+
+#[async_trait]
+impl RustMigration for UpdatePolicyExpressions {
+    fn name(&self) -> &str {
+        Self::name()
+    }
+
+    fn version(&self) -> i64 {
+        Self::version()
+    }
+
+    async fn migrate(&self, connection: &mut SqliteConnection) -> Result<bool> {
+        Self::migrate_policy_expressions(connection).await
+    }
+}
+
+impl UpdatePolicyExpressions {
+    /// Migration version
+    pub fn version() -> i64 {
+        20240503100000
+    }
+
+    /// Migration name
+    pub fn name() -> &'static str {
+        "migration_20240503100000_update_policy_expressions"
+    }
+
+    pub(crate) async fn migrate_policy_expressions(
+        connection: &mut SqliteConnection,
+    ) -> Result<bool> {
+        let mut transaction = Connection::begin(&mut *connection).await.into_core()?;
+        query("UPDATE resource_policy SET expression = '(= subject.has_credential \"true\")' WHERE expression = 'subject.has_credential'").execute(&mut *transaction).await.void()?;
+        query("UPDATE resource_type_policy SET expression = '(= subject.has_credential \"true\")' WHERE expression = 'subject.has_credential'").execute(&mut *transaction).await.void()?;
+
+        // Commit
+        transaction.commit().await.void()?;
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::database::migrations::node_migration_set::NodeMigrationSet;
+    use crate::database::{MigrationSet, SqlxDatabase};
+    use crate::storage::database::sqlx_types::ToSqlxType;
+    use ockam_core::compat::rand::random_string;
+    use sqlx::query::Query;
+    use sqlx::sqlite::{SqliteArguments, SqliteRow};
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_migration() -> Result<()> {
+        // create the database pool and migrate the tables
+        let db_file = NamedTempFile::new().unwrap();
+
+        let pool = SqlxDatabase::create_connection_pool(db_file.path()).await?;
+
+        let mut connection = pool.acquire().await.into_core()?;
+
+        NodeMigrationSet
+            .create_migrator()?
+            .migrate_up_to_skip_last_rust_migration(&pool, UpdatePolicyExpressions::version())
+            .await?;
+
+        // insert some policies
+        let policy1 = insert_resource_policy("tcp-outlet");
+        let policy2 = insert_resource_policy("tcp-inlet");
+        let policy3 = insert_resource_type_policy("tcp-outlet");
+        let policy4 = insert_resource_type_policy("tcp-inlet");
+
+        policy1.execute(&mut *connection).await.void()?;
+        policy2.execute(&mut *connection).await.void()?;
+        policy3.execute(&mut *connection).await.void()?;
+        policy4.execute(&mut *connection).await.void()?;
+
+        // apply migrations
+        NodeMigrationSet
+            .create_migrator()?
+            .migrate_up_to(&pool, UpdatePolicyExpressions::version())
+            .await?;
+
+        // check that the update was successful for resource policies
+        let rows: Vec<SqliteRow> = query("SELECT expression FROM resource_policy")
+            .fetch_all(&mut *connection)
+            .await
+            .into_core()?;
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|e| {
+            let s: String = e.get(0);
+            assert_eq!(s, *"(= subject.has_credential \"true\")");
+            true
+        }));
+
+        // check that the update was successful for resource type policies
+        let rows: Vec<SqliteRow> = query("SELECT expression FROM resource_type_policy")
+            .fetch_all(&mut *connection)
+            .await
+            .into_core()?;
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|e| {
+            let s: String = e.get(0);
+            assert_eq!(s, *"(= subject.has_credential \"true\")");
+            true
+        }));
+        Ok(())
+    }
+
+    #[derive(FromRow)]
+    #[allow(dead_code)]
+    struct ResourceTypePolicyRow {
+        resource_type: String,
+        action: String,
+        expression: String,
+        node_name: String,
+    }
+
+    /// HELPERS
+    fn insert_resource_policy(resource: &str) -> Query<'static, Sqlite, SqliteArguments<'static>> {
+        let action = "handle_message";
+        let expression = "subject.has_credential";
+        let node_name = random_string();
+        query("INSERT INTO resource_policy (resource_name, action, expression, node_name) VALUES (?, ?, ?, ?)")
+            .bind(resource.to_sql())
+            .bind(action.to_sql())
+            .bind(expression.to_sql())
+            .bind(node_name.to_sql())
+    }
+
+    fn insert_resource_type_policy(
+        resource: &str,
+    ) -> Query<'static, Sqlite, SqliteArguments<'static>> {
+        let action = "handle_message";
+        let expression = "subject.has_credential";
+        let node_name = random_string();
+        query("INSERT INTO resource_type_policy (resource_type, action, expression, node_name) VALUES (?, ?, ?, ?)")
+            .bind(resource.to_sql())
+            .bind(action.to_sql())
+            .bind(expression.to_sql())
+            .bind(node_name.to_sql())
+    }
+}


### PR DESCRIPTION
This PR introduces simplified boolean expressions to describe policy expressions.

# Boolean expression

A boolean expression takes the form of names which are attribute names ("attribute" in the sense of credential attribute) combined with boolean operators: `and`, `or`, `not`. For example:
```
(a or b) and (not c)
```
Such an expression is eventually transformed into a full policy expression when stored on a `Resource` or a `ResourceType`:
```
(and (or (= subject.a "true") (= subject.b "true")) (not (= subject.c "true")))
```
As you can see each attribute name is expected to contain the value "true" when evaluated.

# Command line arguments

The commands accepting policy expressions: `tcp-inlet create`, `tcp-outlet create`, and `resource-type create` now use
the `allow` instead of the `expression` option (because it reads better if we use boolean expressions in examples). `expression` is still supported for background compatibility.

An `allow` option accepts both formats: boolean expressions and full policy expressions. If the expression fails to be parsed we return an error message explaining that both formats are supported.

Note that, in order to get a genuine error when an incorrect boolean expression is entered, like `a or1 b`, the parser for full policy expressions had to be improved. Indeed, by default the expression `a or1 b` is successfully parsed by the `Expr` parser as `List([Ident("a"), Ident("or1), Ident("b")])`. The parser now expects that the first element of an `Expr` is an expression operator, like `=`, `or`, `and`, etc... Eventually, it will be a good idea to re-implement this parser to only parse valid expressions.

# Command line help

The help for the `ockam policy create` command presents the expected format for policy expressions.

# Examples

All the examples have been migrated to the new notation. I have also updated the examples to use `ockam policy create --resource-type` instead of `ockam policy create --resource` which is deprecated.

# Migration

Because of the restriction on `Expr` parsing, the previously hard-coded policy expression `subject.has_credential` is not a valid `Expr` anymore. There is a new migration to transform those expressions into `(= subject.has_credential "true")`.

# Implementation notes

 - The type `PolicyExpression` has be introduced to represent expressions which can be parsed from either a boolean expression or a policy expression.
 - I have refactored a few places when the `has_credential` policy was redefined.
