### PR TITLE
feat(rust): improvements for commands' output to standardize their formatting

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -88,10 +88,12 @@ impl CliState {
         self.notify(Notification::progress(message));
     }
 
-    pub fn notify_progress_finish<'a>(&self, message: impl Into<Option<&'a str>>) {
-        self.notify(Notification::progress_finish(
-            message.into().map(|s| s.to_string()),
-        ));
+    pub fn notify_progress_finish(&self, message: impl Into<String>) {
+        self.notify(Notification::progress_finish(Some(message.into())));
+    }
+
+    pub fn notify_progress_finish_and_clear(&self) {
+        self.notify(Notification::progress_finish(None));
     }
 
     fn notify(&self, notification: Notification) {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use minicbor::{Decode, Encode};
 use ockam::identity::Identifier;
-use ockam::route;
 use ockam_abac::PolicyExpression;
 use ockam_core::{Address, IncomingAccessControl, OutgoingAccessControl, Route};
 use ockam_multiaddr::MultiAddr;
@@ -265,8 +264,8 @@ impl OutletStatus {
     }
 
     pub fn worker_address(&self) -> Result<MultiAddr, ockam_core::Error> {
-        route_to_multiaddr(&route![self.worker_addr.to_string()])
-            .ok_or_else(|| ApiError::core("Invalid Worker Address"))
+        try_address_to_multiaddr(&self.worker_addr)
+            .map_err(|_| ApiError::core("Invalid Worker Address"))
     }
 
     pub fn worker_name(&self) -> Result<String, ockam_core::Error> {
@@ -282,9 +281,9 @@ impl Display for OutletStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Outlet {} at {}",
+            "Outlet at {} is connected to {}",
             color_primary(
-                try_address_to_multiaddr(&self.worker_addr)
+                self.worker_address()
                     .map_err(|_| std::fmt::Error)?
                     .to_string()
             ),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -38,6 +38,7 @@ use crate::nodes::{NodeManager, NODEMANAGER_ADDR};
 pub struct InMemoryNode {
     pub(crate) node_manager: Arc<NodeManager>,
     persistent: bool,
+    /// Optional timeout duration for establishing secure channels and awaiting responses
     timeout: Option<Duration>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/ui/output/encode_format.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/encode_format.rs
@@ -4,8 +4,7 @@ use clap::ValueEnum;
 use miette::WrapErr;
 use minicbor::Encode;
 
-/// Data can be encoded in 2 formats
-///
+/// Data can be encoded in two formats:
 ///  - Plain: no encoding, the output is simply printed as a string
 ///  - Hex: the output is serialized using CBOR and the resulting bytes are represented as some HEX text
 #[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]

--- a/implementations/rust/ockam/ockam_command/src/admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/mod.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::{docs, CommandGlobalOpts};
 
 mod subscription;

--- a/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/admin/subscription.rs
@@ -9,8 +9,8 @@ use ockam_api::cloud::subscription::Subscriptions;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 
+use crate::shared_args::IdentityOpts;
 use crate::subscription::get_subscription_by_id_or_space_id;
-use crate::util::api::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -168,11 +168,9 @@ impl SubscriptionCommand {
                     .into_diagnostic()?
                     .success()
                     .into_diagnostic()?;
-                let output = opts.terminal.build_list(
-                    &response,
-                    "Subscriptions",
-                    "No Subscriptions found",
-                )?;
+                let output = opts
+                    .terminal
+                    .build_list(&response, "No Subscriptions found")?;
                 opts.terminal.write_line(output)?
             }
             SubscriptionSubcommand::Unsubscribe {

--- a/implementations/rust/ockam/ockam_command/src/arguments.rs
+++ b/implementations/rust/ockam/ockam_command/src/arguments.rs
@@ -14,7 +14,7 @@ pub fn has_version_flag(input: &[String]) -> bool {
 /// For example:
 ///
 /// ockam secure-channel create --from me --to /node/node-1/service/api |
-//     ockam message send hello --from me --to -/service/uppercase
+///     ockam message send hello --from me --to -/service/uppercase
 ///
 pub fn replace_hyphen_with_stdin(s: String) -> String {
     let input_stream = std::io::stdin();

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -9,7 +9,7 @@ use ockam_core::compat::collections::HashMap;
 
 use crate::output::CredentialAndPurposeKeyDisplay;
 use crate::util::async_cmd;
-use crate::util::duration::duration_parser;
+use crate::util::parsers::duration_parser;
 use crate::{util::parsers::identity_identifier_parser, CommandGlobalOpts, Result};
 
 #[derive(Clone, Debug, Args)]
@@ -18,6 +18,7 @@ pub struct IssueCommand {
     #[arg(long = "as", value_name = "IDENTITY_NAME")]
     pub as_identity: Option<String>,
 
+    /// Identifier of the Identity that the credential is issued for
     #[arg(long = "for", value_name = "IDENTIFIER", value_parser = identity_identifier_parser)]
     pub identity_identifier: Identifier,
 
@@ -25,7 +26,7 @@ pub struct IssueCommand {
     #[arg(short, long = "attribute", value_name = "ATTRIBUTE")]
     pub attributes: Vec<String>,
 
-    /// Name of the Vault that will be used to issue the credential.
+    /// The name of the Vault that will be used to issue the credential.
     #[arg(value_name = "VAULT_NAME")]
     pub vault: Option<String>,
 
@@ -33,6 +34,7 @@ pub struct IssueCommand {
     #[arg(long = "encoding", value_enum, default_value = "plain")]
     encode_format: EncodeFormat,
 
+    /// Time to live for the credential
     #[arg(long, value_name = "TTL", default_value = "30m", value_parser = duration_parser)]
     ttl: std::time::Duration,
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -54,7 +54,6 @@ impl ListCommand {
 
         let list = opts.terminal.build_list(
             &credentials,
-            "Credentials",
             &format!(
                 "No Credentials found for vault: {}",
                 node_name.color(OckamColor::PrimaryResource.color())

--- a/implementations/rust/ockam/ockam_command/src/credential/store.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/store.rs
@@ -120,9 +120,7 @@ impl StoreCommand {
 
         let output_messages = vec![format!("Storing credential...")];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (credential, _) = try_join!(send_req, progress_output)?;
 

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -115,9 +115,7 @@ pub async fn verify_credential(
 
     let output_messages = vec!["Verifying credential...".to_string()];
 
-    let progress_output = opts
-        .terminal
-        .progress_output(&output_messages, &is_finished);
+    let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
     let (credential_and_purpose_key, _) = try_join!(send_req, progress_output)?;
 

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -415,7 +415,7 @@ async fn get_user_space(
     };
 
     let message = vec!["Checking for any existing Spaces...".to_string()];
-    let progress_output = opts.terminal.progress_output(&message, &is_finished);
+    let progress_output = opts.terminal.loop_messages(&message, &is_finished);
 
     let (spaces, _) = try_join!(get_spaces, progress_output)?;
 
@@ -444,7 +444,7 @@ async fn get_user_space(
                 "Creating a new Space {}...",
                 color_primary(space_name.clone())
             )];
-            let progress_output = opts.terminal.progress_output(&message, &is_finished);
+            let progress_output = opts.terminal.loop_messages(&message, &is_finished);
             let (space, _) = try_join!(create_space, progress_output)?;
             opts.terminal.write_line(&fmt_ok!(
                 "Created a new Space named {}.",
@@ -494,7 +494,7 @@ async fn get_user_project(
     };
 
     let message = vec!["Checking for existing Projects...".to_string()];
-    let progress_output = opts.terminal.progress_output(&message, &is_finished);
+    let progress_output = opts.terminal.loop_messages(&message, &is_finished);
 
     let (projects, _) = try_join!(get_projects, progress_output)?;
 
@@ -528,7 +528,7 @@ async fn get_user_project(
                 "Creating a new Project {}...",
                 color_primary(&project_name)
             )];
-            let progress_output = opts.terminal.progress_output(&message, &is_finished);
+            let progress_output = opts.terminal.loop_messages(&message, &is_finished);
             let (project, _) = try_join!(get_project, progress_output)?;
 
             opts.terminal.write_line(&fmt_ok!(

--- a/implementations/rust/ockam/ockam_command/src/global_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/global_args.rs
@@ -34,15 +34,20 @@ pub struct GlobalArgs {
     )]
     pub verbose: u8,
 
-    /// Output without any colors
+    /// Disable colors in output
     #[arg(global = true, long, default_value_t = no_color_default_value())]
     pub no_color: bool,
 
-    /// Disable tty functionality
+    /// Disable tty functionality, like interactive prompts.
     #[arg(global = true, long, default_value_t = no_input_default_value())]
     pub no_input: bool,
 
-    /// Output format
+    /// Specifies the output format of the command. Defaults to 'plain' if not explicitly set.
+    /// The 'plain' format is a piece of plain text, the content of which may change based on whether
+    /// the stdout is a tty or not. For instance, if stdout is redirected to a file, the output
+    /// is usually an identifier that can be used as input for other commands. If stdout is a tty,
+    /// the output will contain human-readable information about the command execution.
+    /// The 'json' format is a one-line JSON object, which can be made more readable using a tool like jq.
     #[arg(global = true, long = "output", value_enum, default_value = "plain")]
     pub output_format: OutputFormat,
 

--- a/implementations/rust/ockam/ockam_command/src/identity/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/create.rs
@@ -28,7 +28,7 @@ pub struct CreateCommand {
     #[arg(hide_default_value = true, default_value_t = random_name())]
     pub name: String,
 
-    /// Vault name to store the identity key
+    /// The name of the Vault where the Identity key will be stored
     #[arg(long, value_name = "VAULT_NAME")]
     pub vault: Option<String>,
 

--- a/implementations/rust/ockam/ockam_command/src/identity/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/list.rs
@@ -47,11 +47,9 @@ impl ListCommand {
             identities_list.push(identity_output);
         }
 
-        let list = opts.terminal.build_list(
-            &identities_list,
-            "Identities",
-            "No identities found on this system.",
-        )?;
+        let list = opts
+            .terminal
+            .build_list(&identities_list, "No identities found on this system.")?;
 
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -157,11 +157,9 @@ impl ShowCommand {
             identities.push(identity_list_output);
         }
 
-        let list = opts.terminal.build_list(
-            &identities,
-            "Identities",
-            "No identities found on this system.",
-        )?;
+        let list = opts
+            .terminal
+            .build_list(&identities, "No identities found on this system.")?;
 
         opts.terminal
             .clone()

--- a/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/direct/command.rs
@@ -94,7 +94,7 @@ pub async fn async_run(
                 .color(OckamColor::PrimaryResource.color())
         ),
     ];
-    let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+    let progress_output = opts.terminal.loop_messages(&msgs, &is_finished);
     let (_, _) = try_join!(send_req, progress_output)?;
 
     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
@@ -150,7 +150,7 @@ impl Command for CreateCommand {
                     .color(OckamColor::PrimaryResource.color())
             ),
         ];
-        let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&msgs, &is_finished);
         if let Some(direct_future) = direct_future {
             let (_, _) = try_join!(direct_future, progress_output)?;
         } else {
@@ -176,7 +176,7 @@ impl Command for CreateCommand {
                     "Kafka clients v3.7.0 and earlier are supported."
                         .color(OckamColor::FmtWARNBackground.color())
                 ) + &fmt_log!(
-                    "{}: '{}'.\n",
+                    "{}: '{}'.",
                     "You can find the version you have with"
                         .color(OckamColor::FmtWARNBackground.color()),
                     "kafka-topics.sh --version".color(OckamColor::Success.color())

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -72,7 +72,7 @@ impl Command for CreateCommand {
                     .color(OckamColor::PrimaryResource.color())
             ),
         ];
-        let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&msgs, &is_finished);
         let (_, _) = try_join!(send_req, progress_output)?;
 
         opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/kafka/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/util.rs
@@ -94,7 +94,7 @@ pub async fn async_run(
                 .color(OckamColor::PrimaryResource.color())
         ),
     ];
-    let progress_output = opts.terminal.progress_output(&msgs, &is_finished);
+    let progress_output = opts.terminal.loop_messages(&msgs, &is_finished);
     let (_, _) = try_join!(send_req, progress_output)?;
 
     let script_to_run = if kafka_entity == "KafkaProducer" {
@@ -122,7 +122,7 @@ pub async fn async_run(
                 "Kafka clients v3.7.0 and earlier are supported."
                     .color(OckamColor::FmtWARNBackground.color())
             ) + &fmt_log!(
-                "{}: '{}'.\n",
+                "{}: '{}'.",
                 "You can find the version you have with"
                     .color(OckamColor::FmtWARNBackground.color()),
                 script_to_run.color(OckamColor::Success.color())

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -11,7 +11,7 @@ use ockam_api::colors::OckamColor;
 use ockam_api::{fmt_log, fmt_ok, InfluxDbTokenLease};
 
 use crate::lease::create_project_client;
-use crate::util::api::{IdentityOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, TrustOpts};
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -59,16 +59,14 @@ impl CreateCommand {
 
         let output_messages = vec!["Creating influxdb token...".to_string()];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (resp_token, _) = try_join!(send_req, progress_output)?;
 
         opts.terminal
             .stdout()
             .machine(resp_token.token.to_string())
-            .json(serde_json::to_string_pretty(&resp_token).into_diagnostic()?)
+            .json(serde_json::to_string(&resp_token).into_diagnostic()?)
             .plain(
                 fmt_ok!("Created influxdb token\n")
                     + &fmt_log!(
@@ -86,7 +84,7 @@ impl CreateCommand {
                             .color(OckamColor::PrimaryResource.color())
                     )
                     + &fmt_log!(
-                        "Expires at {}\n",
+                        "Expires at {}",
                         PrimitiveDateTime::parse(&resp_token.expires, &Iso8601::DEFAULT)
                             .into_diagnostic()?
                             .to_string()

--- a/implementations/rust/ockam/ockam_command/src/lease/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/list.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use tokio::try_join;
 
 use crate::lease::create_project_client;
-use crate::util::api::{IdentityOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, TrustOpts};
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -52,18 +52,14 @@ impl ListCommand {
 
         let output_messages = vec![format!("Listing Tokens...\n")];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (tokens, _) = try_join!(send_req, progress_output)?;
 
-        let plain = opts.terminal.build_list(
-            &tokens,
-            "Tokens",
-            "No active tokens found within service.",
-        )?;
-        let json = serde_json::to_string_pretty(&tokens).into_diagnostic()?;
+        let plain = opts
+            .terminal
+            .build_list(&tokens, "No active tokens found within service.")?;
+        let json = serde_json::to_string(&tokens).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/lease/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/mod.rs
@@ -7,7 +7,7 @@ use ockam_api::cloud::{CredentialsEnabled, ProjectNodeClient};
 use ockam_api::nodes::InMemoryNode;
 pub use show::ShowCommand;
 
-use crate::util::api::{IdentityOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, TrustOpts};
 use crate::CommandGlobalOpts;
 
 use self::revoke::RevokeCommand;

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_api::InfluxDbTokenLease;
 
 use crate::lease::create_project_client;
-use crate::util::api::{IdentityOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, TrustOpts};
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -4,7 +4,7 @@ use ockam::Context;
 use ockam_api::InfluxDbTokenLease;
 
 use crate::lease::create_project_client;
-use crate::util::api::{IdentityOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, TrustOpts};
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 use ockam_api::output::Output;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -61,6 +61,7 @@ mod secure_channel;
 mod service;
 #[cfg(feature = "orchestrator")]
 mod share;
+mod shared_args;
 mod sidecar;
 mod space;
 mod status;

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -20,7 +20,7 @@ use crate::node::create::config::ConfigArgs;
 use crate::node::foreground::ForegroundArgs;
 use crate::node::util::NodeManagerDefaults;
 use crate::service::config::Config;
-use crate::util::api::TrustOpts;
+use crate::shared_args::TrustOpts;
 use crate::util::embedded_node_that_is_not_stopped;
 use crate::util::{async_cmd, local_cmd};
 use crate::value_parsers::is_url;

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -90,12 +90,11 @@ impl CreateCommand {
             .json(serde_json::to_string(&node_resources).into_diagnostic()?)
             .write_line()?;
 
-        opts.terminal
-            .write_line(fmt_log!("To see more details on this Node, run:"))?
-            .write_line(fmt_log!(
-                "{}",
-                color_primary(format!("ockam node show {}", node_name))
-            ))?;
+        opts.terminal.write_line(fmt_log!(
+            "To see more details on this Node, run: {}",
+            color_primary(format!("ockam node show {}", node_name))
+        ))?;
+
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/src/node/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/list.rs
@@ -77,9 +77,7 @@ pub async fn get_nodes_info(
                 .to_string()
                 .color(OckamColor::PrimaryResource.color())
         )];
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (node, _) = try_join!(get_node_status, progress_output)?;
 
@@ -95,9 +93,9 @@ pub fn print_nodes_info(
 ) -> miette::Result<()> {
     let plain = opts
         .terminal
-        .build_list(&nodes, "Nodes", "No nodes found on this system.")?;
+        .build_list(&nodes, "No nodes found on this system.")?;
 
-    let json = serde_json::to_string_pretty(&nodes).into_diagnostic()?;
+    let json = serde_json::to_string(&nodes).into_diagnostic()?;
 
     opts.terminal
         .clone()

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -39,7 +39,8 @@ before_help = docs::before_help(PREVIEW_TAG),
 after_long_help = docs::after_help(AFTER_LONG_HELP)
 )]
 pub struct ShowCommand {
-    /// Name of the node to retrieve the details from
+    /// The name of the node from which to fetch the details.
+    /// If not provided, the default node is used.
     node_name: Option<String>,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -203,8 +203,8 @@ fn append_info_if_errors(node_starts_output: &mut Vec<String>) {
         "\n\n".to_string()
             + &fmt_err!("You can check the status of failed nodes using the command\n")
             + &fmt_log!(
-                "{}",
-                "ockam node show\n".color(OckamColor::PrimaryResource.color())
+                "{}\n",
+                "ockam node show".color(OckamColor::PrimaryResource.color())
             )
             + &fmt_log!("or check the logs with the command\n")
             + &fmt_log!(

--- a/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
@@ -10,9 +10,11 @@ $ ockam node create config.yaml
 
 # To create a new node with an inline configuration
 $ ockam node create --node-config "{name: n1, tcp-outlet: {db-outlet: {to: '127.0.0.1:5432'}}}"
+```
 
 An example of a configuration file is:
 
+```sh
 # variables can be used and overridden with environment variables
 variables:
   NODE_PORT: 3333
@@ -42,5 +44,4 @@ tcp-inlet:
   web-inlet:
     # Arguments to the ockam tcp-outlet create command
     from: $CLIENT_PORT
-
 ```

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -6,14 +6,12 @@ use miette::{miette, Context as _};
 use rand::random;
 use tracing::info;
 
-use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
 
-use crate::node::show::is_node_up;
 use crate::node::CreateCommand;
-use crate::util::api::TrustOpts;
-use crate::CommandGlobalOpts;
+use crate::shared_args::TrustOpts;
+use crate::{Command as CommandTrait, CommandGlobalOpts};
 
 pub struct NodeManagerDefaults {
     pub node_name: String,
@@ -54,10 +52,8 @@ pub async fn initialize_default_node(
 ) -> miette::Result<()> {
     if opts.state.get_default_node().await.is_err() {
         let cmd = CreateCommand::default();
-        let node_name = cmd.name.clone();
-        cmd.spawn_background_node(opts).await?;
-        let mut node = BackgroundNodeClient::create_to_node(ctx, &opts.state, &node_name).await?;
-        is_node_up(ctx, &mut node, true).await?;
+        cmd.async_run(ctx, opts.clone()).await?;
+        opts.terminal.write_line("")?;
     }
     Ok(())
 }

--- a/implementations/rust/ockam/ockam_command/src/operation/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/operation/util.rs
@@ -16,8 +16,8 @@ pub async fn check_for_project_completion(
     node: &InMemoryNode,
     project: Project,
 ) -> miette::Result<Project> {
-    let spinner_option = opts.terminal.progress_spinner();
-    if let Some(spinner) = spinner_option.as_ref() {
+    let pb = opts.terminal.progress_bar();
+    if let Some(spinner) = pb.as_ref() {
         let message = format!(
             "Configuring project...\n{}\n{}",
             fmt_log!("This usually takes 15 seconds, but may sometimes take up to 4 minutes."),
@@ -34,7 +34,7 @@ pub async fn check_for_project_completion(
         .wait_until_project_creation_operation_is_complete(ctx, project)
         .await?;
 
-    if let Some(spinner) = spinner_option.as_ref() {
+    if let Some(spinner) = pb.as_ref() {
         spinner.finish_and_clear();
     }
 
@@ -48,8 +48,8 @@ pub async fn check_for_operation_completion(
     operation_id: &str,
     operation_name: &str,
 ) -> miette::Result<()> {
-    let spinner_option = opts.terminal.progress_spinner();
-    if let Some(spinner) = spinner_option.as_ref() {
+    let pb = opts.terminal.progress_bar();
+    if let Some(spinner) = pb.as_ref() {
         let message = format!(
             "Waiting for {operation_name} to finish ...\n{}",
             fmt_para!(
@@ -65,7 +65,7 @@ pub async fn check_for_operation_completion(
         .wait_until_operation_is_complete(ctx, operation_id)
         .await;
 
-    if let Some(spinner) = spinner_option.as_ref() {
+    if let Some(spinner) = pb.as_ref() {
         spinner.finish_and_clear();
     }
 

--- a/implementations/rust/ockam/ockam_command/src/policy/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/list.rs
@@ -54,16 +54,13 @@ impl ListCommand {
             Ok(policies)
         };
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (policies, _) = try_join!(get_policies, progress_output)?;
 
         if policies.resource_type_policies().is_empty() && policies.resource_policies().is_empty() {
             let list = opts.terminal.build_list(
                 policies.resource_type_policies(),
-                "",
                 &format!("No policies on Node {}", &node.node_name()),
             )?;
             opts.terminal.stdout().plain(list).write_line()?;
@@ -76,14 +73,12 @@ impl ListCommand {
             if !policies.resource_type_policies().is_empty() {
                 plain = opts.terminal.build_list(
                     policies.resource_type_policies(),
-                    &format!("Resource type policies on Node {}", &node.node_name()),
                     &format!("No resource type policies on Node {}", &node.node_name()),
                 )?;
             }
             if !policies.resource_policies().is_empty() {
                 plain.push_str(&opts.terminal.build_list(
                     policies.resource_policies(),
-                    &format!("Resource policies on Node {}", &node.node_name()),
                     &format!("No resource policies on Node {}", &node.node_name()),
                 )?);
             }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/list.rs
@@ -48,7 +48,6 @@ impl AddonListSubcommand {
         let addons = controller.list_addons(ctx, &project_id).await?;
         let output = opts.terminal.build_list(
             &addons,
-            &format!("Addons for project {project_name}"),
             &format!("No addons enabled for project {project_name}"),
         )?;
         opts.terminal.stdout().plain(output).write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/mod.rs
@@ -15,7 +15,7 @@ use crate::project::addon::configure_okta::AddonConfigureOktaSubcommand;
 use crate::project::addon::disable::AddonDisableSubcommand;
 use crate::project::addon::list::AddonListSubcommand;
 use crate::project::util::check_project_readiness;
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::{CommandGlobalOpts, Result};
 
 mod configure_influxdb;

--- a/implementations/rust/ockam/ockam_command/src/project/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/create.rs
@@ -7,9 +7,9 @@ use ockam_api::nodes::InMemoryNode;
 
 use crate::operation::util::check_for_project_completion;
 use crate::project::util::check_project_readiness;
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
-use crate::util::parsers::validate_project_name;
+use crate::util::parsers::project_name_parser;
 use crate::{docs, CommandGlobalOpts};
 use ockam_api::output::Output;
 
@@ -28,7 +28,7 @@ pub struct CreateCommand {
     pub space_name: String,
 
     /// Name of the project - must be unique within parent Space
-    #[arg(display_order = 1002, default_value_t = random_name(), hide_default_value = true, value_parser = validate_project_name)]
+    #[arg(display_order = 1002, default_value_t = random_name(), hide_default_value = true, value_parser = project_name_parser)]
     pub project_name: String,
 
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -6,7 +6,7 @@ use ockam_api::cloud::project::ProjectsOrchestratorApi;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -22,7 +22,7 @@ use ockam_api::terminal::fmt;
 use ockam_api::{fmt_log, fmt_ok};
 
 use crate::enroll::OidcServiceExt;
-use crate::util::api::{IdentityOpts, RetryOpts, TrustOpts};
+use crate::shared_args::{IdentityOpts, RetryOpts, TrustOpts};
 use crate::value_parsers::parse_enrollment_ticket;
 use crate::{docs, Command, CommandGlobalOpts, Error, Result};
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -6,7 +6,7 @@ use ockam_api::cloud::project::ProjectsOrchestratorApi;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, output::ProjectConfigCompact, CommandGlobalOpts};
 
@@ -40,7 +40,7 @@ impl InfoCommand {
         opts.terminal
             .stdout()
             .plain(info.item()?)
-            .json(serde_json::to_string_pretty(&info).into_diagnostic()?)
+            .json(serde_json::to_string(&info).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/project/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/list.rs
@@ -8,7 +8,7 @@ use ockam::Context;
 use ockam_api::cloud::project::ProjectsOrchestratorApi;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -50,16 +50,12 @@ impl ListCommand {
         .with_current_context();
 
         let output_messages = vec![format!("Listing projects...\n",)];
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (projects, _) = try_join!(get_projects, progress_output)?;
 
-        let plain = &opts
-            .terminal
-            .build_list(&projects, "Projects", "No projects found")?;
-        let json = serde_json::to_string_pretty(&projects).into_diagnostic()?;
+        let plain = &opts.terminal.build_list(&projects, "No projects found")?;
+        let json = serde_json::to_string(&projects).into_diagnostic()?;
 
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -11,9 +11,9 @@ use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::AsyncTryClone;
 
 use crate::output::ProjectConfigCompact;
+use crate::shared_args::{IdentityOpts, RetryOpts};
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::api::{IdentityOpts, RetryOpts};
 use crate::{docs, Command, CommandGlobalOpts, Error};
 
 const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
@@ -129,7 +129,7 @@ impl ShowCommandTui for ShowTui {
         self.terminal()
             .stdout()
             .plain(project_output.item()?)
-            .json(serde_json::to_string_pretty(&project_output).into_diagnostic()?)
+            .json(serde_json::to_string(&project_output).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -19,9 +19,8 @@ use ockam_api::output::OutputFormat;
 use ockam_api::{fmt_log, fmt_ok};
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::api::RetryOpts;
-use crate::util::api::{IdentityOpts, TrustOpts};
-use crate::util::duration::duration_parser;
+use crate::shared_args::{IdentityOpts, RetryOpts, TrustOpts};
+use crate::util::parsers::duration_parser;
 use crate::{docs, Command, CommandGlobalOpts, Error, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/ticket/long_about.txt");

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -107,28 +107,16 @@ pub async fn check_project_readiness(
     let retry_strategy = FixedInterval::from_millis(5000)
         .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
 
-    let spinner_option = opts.terminal.progress_spinner();
-    let project = check_project_ready(
-        ctx,
-        node,
-        project,
-        retry_strategy.clone(),
-        spinner_option.clone(),
-    )
-    .await?;
-    let project = check_project_node_accessible(
-        ctx,
-        node,
-        project,
-        retry_strategy.clone(),
-        spinner_option.clone(),
-    )
-    .await?;
+    let pb = opts.terminal.progress_bar();
     let project =
-        check_authority_node_accessible(ctx, node, project, retry_strategy, spinner_option.clone())
+        check_project_ready(ctx, node, project, retry_strategy.clone(), pb.clone()).await?;
+    let project =
+        check_project_node_accessible(ctx, node, project, retry_strategy.clone(), pb.clone())
             .await?;
+    let project =
+        check_authority_node_accessible(ctx, node, project, retry_strategy, pb.clone()).await?;
 
-    if let Some(spinner) = spinner_option.as_ref() {
+    if let Some(spinner) = pb.as_ref() {
         spinner.finish_and_clear();
     }
     Ok(project)

--- a/implementations/rust/ockam/ockam_command/src/project/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/version.rs
@@ -7,7 +7,7 @@ use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/add.rs
@@ -10,7 +10,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
 
 use crate::project_member::{create_authority_client, create_member_attributes, get_project};
-use crate::util::api::{IdentityOpts, RetryOpts};
+use crate::shared_args::{IdentityOpts, RetryOpts};
 use crate::{docs, Command, CommandGlobalOpts, Error};
 
 const LONG_ABOUT: &str = include_str!("./static/add/long_about.txt");

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -11,7 +11,7 @@ use ockam_api::{fmt_err, fmt_ok};
 use ockam_multiaddr::MultiAddr;
 
 use super::{create_authority_client, get_project};
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list.rs
@@ -7,7 +7,7 @@ use ockam_api::authenticator::direct::Members;
 use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use ockam_api::output::Output;
 
@@ -68,11 +68,9 @@ impl Output for MemberOutput {
 }
 
 fn print_members(opts: &CommandGlobalOpts, member_ids: Vec<MemberOutput>) -> miette::Result<()> {
-    let plain = opts.terminal.build_list(
-        &member_ids,
-        "Members",
-        "No members found on that Authority node.",
-    )?;
+    let plain = opts
+        .terminal
+        .build_list(&member_ids, "No members found on that Authority node.")?;
 
     opts.terminal.clone().stdout().plain(plain).write_line()?;
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_multiaddr::MultiAddr;
 
 use super::{create_authority_client, get_project};
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts, Result};
 use ockam_api::output::Output;
 
@@ -70,11 +70,9 @@ fn print_member_ids(
     opts: &CommandGlobalOpts,
     member_ids: Vec<IdentifierOutput>,
 ) -> miette::Result<()> {
-    let plain = opts.terminal.build_list(
-        &member_ids,
-        "Member Ids",
-        "No members found on that Authority node.",
-    )?;
+    let plain = opts
+        .terminal
+        .build_list(&member_ids, "No members found on that Authority node.")?;
 
     opts.terminal.clone().stdout().plain(plain).write_line()?;
 

--- a/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
@@ -17,7 +17,7 @@ use ockam_api::nodes::NodeManager;
 use ockam_api::CliState;
 use ockam_multiaddr::{proto, MultiAddr, Protocol};
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts};
 
 mod add;

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -59,19 +59,16 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (relays, _) = try_join!(get_relays, progress_output)?;
         trace!(?relays, "Relays retrieved");
 
         let plain = opts.terminal.build_list(
             &relays,
-            &format!("Relays on Node {}", node.node_name()),
             &format!("No Relays found on node {}.", node.node_name()),
         )?;
-        let json = serde_json::to_string_pretty(&relays).into_diagnostic()?;
+        let json = serde_json::to_string(&relays).into_diagnostic()?;
 
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -94,26 +94,26 @@ async fn delete_orchestrator_resources_impl(
     if spaces.is_empty() {
         return Ok(());
     }
-    let spinner = opts.terminal.progress_spinner();
-    if let Some(s) = spinner.as_ref() {
+    let pb = opts.terminal.progress_bar();
+    if let Some(s) = pb.as_ref() {
         s.set_message("Deleting spaces from the Orchestrator..")
     };
     for space in spaces {
-        if let Some(s) = spinner.as_ref() {
+        if let Some(s) = pb.as_ref() {
             s.set_message(format!(
                 "Deleting space {}...",
                 color!(space.name, OckamColor::PrimaryResource)
             ))
         };
         node.delete_space(ctx, &space.id).await?;
-        if let Some(s) = spinner.as_ref() {
+        if let Some(s) = pb.as_ref() {
             s.set_message(format!(
                 "Space {} deleted from the Orchestrator",
                 color!(space.name, OckamColor::PrimaryResource)
             ))
         };
     }
-    if let Some(s) = spinner {
+    if let Some(s) = pb {
         s.finish_with_message("Orchestrator spaces deleted")
     }
     Ok(())

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -22,7 +22,7 @@ use crate::node::util::initialize_default_node;
 use crate::project::util::{
     clean_projects_multiaddr, get_projects_secure_channels_from_config_lookup,
 };
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::{async_cmd, clean_nodes_multiaddr, exitcode};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
@@ -142,9 +142,7 @@ impl CreateCommand {
 
         let output_messages = vec!["Creating Secure Channel...".to_string()];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (secure_channel, _) = try_join!(create_secure_channel, progress_output)?;
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/list.rs
@@ -94,9 +94,7 @@ impl ListCommand {
         };
 
         let output_messages = vec!["Retrieving secure channel identifiers...\n".to_string()];
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (channel_identifiers, _) = try_join!(get_secure_channel_identifiers, progress_output)?;
 
@@ -117,9 +115,7 @@ impl ListCommand {
                     .to_string()
                     .color(OckamColor::PrimaryResource.color())
             )];
-            let progress_output = opts
-                .terminal
-                .progress_output(&output_messages, &is_finished);
+            let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
             let (secure_channel_output, _) = try_join!(get_secure_channel_output, progress_output)?;
 
@@ -128,7 +124,6 @@ impl ListCommand {
 
         let list = opts.terminal.build_list(
             &responses,
-            &format!("Secure Channels on {}", node.node_name()),
             &format!("No secure channels found on {}", node.node_name()),
         )?;
         opts.terminal.stdout().plain(list).write_line()?;

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/create.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic, WrapErr};
+use minicbor::Decoder;
 
 use crate::{docs, CommandGlobalOpts};
 use ockam::identity::Identifier;
@@ -9,7 +10,7 @@ use ockam_api::colors::OckamColor;
 use ockam_api::nodes::models::secure_channel::CreateSecureChannelListenerRequest;
 use ockam_api::nodes::{BackgroundNodeClient, NODEMANAGER_ADDR};
 use ockam_api::{fmt_log, fmt_ok};
-use ockam_core::api::{Request, Status};
+use ockam_core::api::{Request, ResponseHeader, Status};
 use ockam_core::{Address, Route};
 
 use crate::node::util::initialize_default_node;
@@ -110,7 +111,8 @@ pub async fn create_listener(
         .await
         .into_diagnostic()?;
 
-    let response = api::parse_create_secure_channel_listener_response(&resp)?;
+    let mut dec = Decoder::new(&resp);
+    let response = dec.decode::<ResponseHeader>().into_diagnostic()?;
 
     match response.status() {
         Some(Status::Ok) => {

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/listener/list.rs
@@ -57,15 +57,12 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (secure_channel_listeners, _) = try_join!(get_listeners, progress_output)?;
 
         let list = opts.terminal.build_list(
             &secure_channel_listeners,
-            &format!("Secure Channel Listeners at Node {}", node.node_name()),
             &format!(
                 "No secure channel listeners found at node {}.",
                 node.node_name()

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/show.rs
@@ -52,7 +52,7 @@ impl ShowCommand {
         opts.terminal
             .stdout()
             .plain(response.item()?)
-            .json(serde_json::to_string_pretty(&response).into_diagnostic()?)
+            .json(serde_json::to_string(&response).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/service/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/list.rs
@@ -46,18 +46,15 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (services, _) = try_join!(get_services, progress_output)?;
 
         let plain = opts.terminal.build_list(
             &services,
-            &format!("Services on {}", node.node_name()),
             &format!("No services found on {}", node.node_name()),
         )?;
-        let json = serde_json::to_string_pretty(&services).into_diagnostic()?;
+        let json = serde_json::to_string(&services).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/share/accept.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/accept.rs
@@ -7,7 +7,7 @@ use ockam::Context;
 use ockam_api::cloud::share::Invitations;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -47,9 +47,7 @@ impl AcceptCommand {
 
         let output_messages = vec![format!("Accepting share invitation...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (accepted, _) = try_join!(get_accepted_invitation, progress_output)?;
 
@@ -57,7 +55,7 @@ impl AcceptCommand {
             "Accepted invite {} for {} {}",
             accepted.id, accepted.scope, accepted.target_id
         );
-        let json = serde_json::to_string_pretty(&accepted).into_diagnostic()?;
+        let json = serde_json::to_string(&accepted).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/share/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/create.rs
@@ -11,7 +11,7 @@ use ockam_api::cloud::share::{Invitations, RoleInShare, ShareScope};
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -69,9 +69,7 @@ impl CreateCommand {
 
         let output_messages = vec![format!("Creating invitation...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (sent, _) = try_join!(get_sent_invitation, progress_output)?;
 
@@ -85,7 +83,7 @@ impl CreateCommand {
             sent.expires_at,
             sent.recipient_email
         );
-        let json = serde_json::to_string_pretty(&sent).into_diagnostic()?;
+        let json = serde_json::to_string(&sent).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/share/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/list.rs
@@ -7,7 +7,7 @@ use ockam::Context;
 use ockam_api::cloud::share::{InvitationListKind, Invitations};
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -50,18 +50,14 @@ impl ListCommand {
 
         let output_messages = vec![format!("Listing shares...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (shares, _) = try_join!(get_invitations, progress_output)?;
 
         if let Some(sent) = shares.sent.as_ref() {
             let opts = opts.clone();
-            let plain = opts
-                .terminal
-                .build_list(sent, "Sent Shares", "No sent shares found.")?;
-            let json = serde_json::to_string_pretty(sent).into_diagnostic()?;
+            let plain = opts.terminal.build_list(sent, "No sent shares found.")?;
+            let json = serde_json::to_string(sent).into_diagnostic()?;
             opts.terminal
                 .stdout()
                 .plain(plain)
@@ -71,12 +67,10 @@ impl ListCommand {
 
         if let Some(received) = shares.received.as_ref() {
             let opts = opts.clone();
-            let plain = opts.terminal.build_list(
-                received,
-                "Received Shares",
-                "No received shares found.",
-            )?;
-            let json = serde_json::to_string_pretty(received).into_diagnostic()?;
+            let plain = opts
+                .terminal
+                .build_list(received, "No received shares found.")?;
+            let json = serde_json::to_string(received).into_diagnostic()?;
             opts.terminal
                 .stdout()
                 .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/share/service.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/service.rs
@@ -12,7 +12,7 @@ use ockam_api::cloud::share::{CreateServiceInvitation, Invitations};
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -80,9 +80,7 @@ impl ServiceCreateCommand {
 
         let output_messages = vec![format!("Creating invitation...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (sent, _) = try_join!(get_sent_invitation, progress_output)?;
 
@@ -96,7 +94,7 @@ impl ServiceCreateCommand {
             sent.expires_at,
             sent.recipient_email
         );
-        let json = serde_json::to_string_pretty(&sent).into_diagnostic()?;
+        let json = serde_json::to_string(&sent).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/share/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/share/show.rs
@@ -9,7 +9,7 @@ use ockam_api::cloud::share::Invitations;
 use ockam_api::fmt_ok;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -51,15 +51,13 @@ impl ShowCommand {
 
         let output_messages = vec![format!("Showing invitation...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (response, _) = try_join!(get_invitation_with_access, progress_output)?;
 
         // TODO: Emit connection details
         let plain = fmt_ok!("Invite {}", response.invitation.id);
-        let json = serde_json::to_string_pretty(&response).into_diagnostic()?;
+        let json = serde_json::to_string(&response).into_diagnostic()?;
         opts.terminal
             .stdout()
             .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/shared_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/shared_args.rs
@@ -1,0 +1,86 @@
+use crate::util::parsers::duration_parser;
+use clap::Args;
+use ockam_core::env::get_env;
+use ockam_multiaddr::MultiAddr;
+use std::time::Duration;
+
+#[derive(Clone, Debug, Args)]
+pub struct IdentityOpts {
+    /// Run the command as the given Identity name
+    #[arg(global = true, value_name = "IDENTITY_NAME", long)]
+    pub identity: Option<String>,
+}
+
+#[derive(Clone, Debug, Args, Default, PartialEq)]
+pub struct TrustOpts {
+    /// Project name to use for the command
+    #[arg(long = "project", value_name = "PROJECT_NAME")]
+    pub project_name: Option<String>,
+
+    /// Hex encoded Identity
+    #[arg(long, value_name = "IDENTITY")]
+    pub authority_identity: Option<String>,
+
+    /// Address to the Authority node
+    #[arg(long)]
+    pub authority_route: Option<MultiAddr>,
+
+    /// Expect credential manually saved to the storage
+    #[arg(long)]
+    pub credential_scope: Option<String>,
+}
+
+#[derive(Clone, Debug, Args, Default, PartialEq)]
+pub struct RetryOpts {
+    /// Number of times to retry the command
+    #[arg(hide = true, long)]
+    retry_count: Option<u32>,
+
+    /// Delay between retries
+    #[arg(hide = true, long, value_parser = duration_parser)]
+    pub retry_delay: Option<Duration>,
+}
+
+impl RetryOpts {
+    /// Get the number of times to retry the command
+    ///
+    /// If the value is not set, it will try to get the value from
+    /// the `OCKAM_COMMAND_RETRY_COUNT` environment variable
+    pub fn retry_count(&self) -> Option<u32> {
+        match self.retry_count {
+            Some(count) => Some(count),
+            None => get_env::<String>("OCKAM_COMMAND_RETRY_COUNT")
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse().ok()),
+        }
+    }
+
+    /// Get the delay between retries
+    ///
+    /// If the value is not set, it will try to get the value from
+    /// the `OCKAM_COMMAND_RETRY_DELAY` environment variable
+    pub fn retry_delay(&self) -> Option<Duration> {
+        match self.retry_delay {
+            Some(delay) => Some(delay),
+            None => get_env::<String>("OCKAM_COMMAND_RETRY_DELAY")
+                .ok()
+                .flatten()
+                .and_then(|v| duration_parser(&v).ok()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct TimeoutArg {
+    /// Override the default timeout duration that the command will wait for a response
+    #[arg(long, value_name = "TIMEOUT", default_value = "5s", value_parser = duration_parser)]
+    pub(crate) timeout: Duration,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct OptionalTimeoutArg {
+    /// Override the default timeout duration that the command will wait for a response
+    #[arg(long, value_name = "TIMEOUT", default_value = "5s", value_parser = duration_parser)]
+    pub(crate) timeout: Option<Duration>,
+}

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -7,8 +7,9 @@ use ockam_api::cli_state::random_name;
 use ockam_api::cloud::space::Spaces;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::{self, IdentityOpts};
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
+use crate::util::validators::cloud_resource_name_validator;
 use crate::{docs, CommandGlobalOpts};
 use ockam_api::output::Output;
 
@@ -85,7 +86,7 @@ impl CreateCommand {
 }
 
 fn validate_space_name(s: &str) -> Result<String, String> {
-    match api::validate_cloud_resource_name(s) {
+    match cloud_resource_name_validator(s) {
         Ok(_) => Ok(s.to_string()),
         Err(_e) => Err(String::from(
             "space name can contain only alphanumeric characters and the '-', '_' and '.' separators. \

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -12,9 +12,9 @@ use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{color, fmt_ok};
 use ockam_core::AsyncTryClone;
 
+use crate::shared_args::IdentityOpts;
 use crate::terminal::tui::DeleteCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::api::IdentityOpts;
 use crate::util::async_cmd;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");

--- a/implementations/rust/ockam/ockam_command/src/space/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/list.rs
@@ -8,7 +8,7 @@ use ockam::Context;
 use ockam_api::cloud::space::Spaces;
 use ockam_api::nodes::InMemoryNode;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 
@@ -52,18 +52,15 @@ impl ListCommand {
 
         let output_messages = vec![format!("Listing Spaces...\n",)];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (spaces, _) = try_join!(get_spaces, progress_output)?;
 
         let plain = opts.terminal.build_list(
             &spaces,
-            "Spaces",
             "No spaces found. Run 'ockam enroll' to get a space and a project",
         )?;
-        let json = serde_json::to_string_pretty(&spaces).into_diagnostic()?;
+        let json = serde_json::to_string(&spaces).into_diagnostic()?;
 
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/space/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/show.rs
@@ -9,9 +9,9 @@ use ockam_api::nodes::InMemoryNode;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::AsyncTryClone;
 
+use crate::shared_args::IdentityOpts;
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::api::IdentityOpts;
 use crate::util::async_cmd;
 use ockam_api::output::Output;
 

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -43,6 +43,7 @@ use crate::secure_channel::SecureChannelCommand;
 use crate::service::ServiceCommand;
 #[cfg(feature = "orchestrator")]
 use crate::share::ShareCommand;
+use crate::shared_args::RetryOpts;
 use crate::sidecar::SidecarCommand;
 use crate::space::SpaceCommand;
 use crate::status::StatusCommand;
@@ -51,7 +52,6 @@ use crate::tcp::connection::TcpConnectionCommand;
 use crate::tcp::inlet::TcpInletCommand;
 use crate::tcp::listener::TcpListenerCommand;
 use crate::tcp::outlet::TcpOutletCommand;
-use crate::util::api::RetryOpts;
 use crate::util::async_cmd;
 use crate::vault::VaultCommand;
 use crate::worker::WorkerCommand;

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -9,7 +9,7 @@ use ockam_api::cloud::ControllerClient;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::output::Output;
 
-use crate::util::api::IdentityOpts;
+use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts, Result};
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -1,125 +1,96 @@
+use async_trait::async_trait;
 use clap::Args;
-use colorful::Colorful;
-use indoc::formatdoc;
 use miette::IntoDiagnostic;
-use serde_json::json;
+use serde::Serialize;
+use std::fmt::Write;
+use std::net::SocketAddrV4;
 
+use colorful::Colorful;
 use ockam_api::address::extract_address_value;
+use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_api::nodes::{models, BackgroundNodeClient};
-use ockam_api::output::OutputFormat;
+use ockam_api::output::Output;
+use ockam_api::{fmt_log, fmt_ok};
 use ockam_core::api::Request;
+use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
+use crate::docs;
 use crate::node::util::initialize_default_node;
-use crate::util::async_cmd;
-use crate::{docs, CommandGlobalOpts};
+use crate::{Command, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
-#[derive(Clone, Debug, Args)]
-#[command(after_long_help = docs::after_help(AFTER_LONG_HELP))]
-pub struct TcpConnectionNodeOpts {
-    /// Node that will initiate the connection
-    #[arg(global = true, short, long, value_name = "NODE", value_parser = extract_address_value)]
-    pub from: Option<String>,
-}
-
 /// Create a TCP connection
 #[derive(Args, Clone, Debug)]
-#[command(arg_required_else_help = true)]
+#[command(arg_required_else_help = true, after_long_help = docs::after_help(AFTER_LONG_HELP))]
 pub struct CreateCommand {
-    #[command(flatten)]
-    node_opts: TcpConnectionNodeOpts,
+    /// Node that will initiate the connection
+    #[arg(long, value_name = "NODE", value_parser = extract_address_value)]
+    pub from: Option<String>,
 
     /// The address to connect to
     #[arg(id = "to", short, long, value_name = "ADDRESS")]
     pub address: String,
 }
 
-impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        async_cmd(&self.name(), opts.clone(), |ctx| async move {
-            self.async_run(&ctx, opts).await
-        })
-    }
+#[async_trait]
+impl Command for CreateCommand {
+    const NAME: &'static str = "tcp-connection create";
 
-    pub fn name(&self) -> String {
-        "tcp-connection create".into()
-    }
-
-    #[allow(unused)]
-    async fn print_output(
-        &self,
-        opts: &CommandGlobalOpts,
-        response: &TransportStatus,
-    ) -> miette::Result<()> {
-        // if output format is json, write json to stdout.
-        match opts.global_args.output_format {
-            OutputFormat::Plain => {
-                if !opts.terminal.is_tty() {
-                    println!("{}", response.multiaddr().into_diagnostic()?);
-                    return Ok(());
-                }
-                let from = opts
-                    .state
-                    .get_node_or_default(&self.node_opts.from)
-                    .await?
-                    .name();
-                let to = response.socket_addr().into_diagnostic()?;
-                if opts.global_args.no_color {
-                    println!("\n  TCP Connection:");
-                    println!("    From: /node/{from}");
-                    println!("    To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port());
-                    println!("    Address: {}", response.multiaddr().into_diagnostic()?);
-                } else {
-                    println!("\n  TCP Connection:");
-                    println!("{}", format!("    From: /node/{from}").light_magenta());
-                    println!(
-                        "{}",
-                        format!("    To: {} (/ip4/{}/tcp/{})", to, to.ip(), to.port())
-                            .light_magenta()
-                    );
-                    println!(
-                        "{}",
-                        format!("    Address: {}", response.multiaddr().into_diagnostic()?)
-                            .light_magenta()
-                    );
-                }
-            }
-            OutputFormat::Json => {
-                let json = json!([{"route": response.multiaddr().into_diagnostic()? }]);
-                println!("{json}");
-            }
-        }
-        Ok(())
-    }
-
-    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
         initialize_default_node(ctx, &opts).await?;
-        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.from).await?;
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &self.from).await?;
         let payload = models::transport::CreateTcpConnection::new(self.address.clone());
         let request = Request::post("/node/tcp/connection").body(payload);
-
         let transport_status: TransportStatus = node.ask(ctx, request).await?;
-        let from = opts
-            .state
-            .get_node_or_default(&self.node_opts.from)
-            .await?
-            .name();
-        let to = transport_status.socket_addr().into_diagnostic()?;
-        let plain = formatdoc! {r#"
-        TCP Connection:
-            From: /node/{from}
-            To: {to} (/ip4/{}/tcp/{})
-            Address: {}
-    "#, to.ip(), to.port(), transport_status.multiaddr().into_diagnostic()?};
-        let json = json!([{"route": transport_status.multiaddr().into_diagnostic()? }]);
+
+        let output = TcpConnection::new(
+            node.node_name(),
+            transport_status.socket_addr().into_diagnostic()?,
+            transport_status.multiaddr().into_diagnostic()?,
+        );
+
         opts.terminal
             .stdout()
-            .plain(plain)
-            .json(json)
+            .plain(output.item()?)
+            .machine(output.address.to_string())
+            .json(serde_json::to_string(&output)?)
             .write_line()?;
         Ok(())
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct TcpConnection {
+    from: String,
+    to: SocketAddrV4,
+    address: MultiAddr,
+}
+
+impl TcpConnection {
+    pub fn new(from: String, to: SocketAddrV4, address: MultiAddr) -> Self {
+        Self { from, to, address }
+    }
+}
+
+impl Output for TcpConnection {
+    fn item(&self) -> ockam_api::Result<String> {
+        let mut output = String::new();
+        writeln!(
+            output,
+            "{}",
+            fmt_ok!(
+                "A TCP connection was created at the node {}",
+                color_primary(&self.from)
+            ),
+        )?;
+        writeln!(
+            output,
+            "{}",
+            fmt_log!("to the address {}", color_primary(self.to.to_string()))
+        )?;
+        Ok(output)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/list.rs
@@ -54,15 +54,12 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (transports, _) = try_join!(get_transports, progress_output)?;
 
         let list = opts.terminal.build_list(
             &transports,
-            &format!("TCP Connections on {}", node.node_name()),
             &format!(
                 "No TCP Connections found on {}",
                 node.node_name().color(OckamColor::PrimaryResource.color())

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/mod.rs
@@ -5,7 +5,7 @@ pub(crate) use delete::DeleteCommand;
 pub(crate) use list::ListCommand;
 
 use crate::tcp::connection::show::ShowCommand;
-use crate::CommandGlobalOpts;
+use crate::{Command, CommandGlobalOpts};
 
 mod create;
 mod delete;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/list.rs
@@ -54,15 +54,12 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (inlets, _) = try_join!(get_inlets, progress_output)?;
 
         let plain = opts.terminal.build_list(
             &inlets,
-            "Inlets",
             &format!("No TCP Inlets found on {}", node.node_name()),
         )?;
         let json = serde_json::to_string(&inlets).into_diagnostic()?;

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/show.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use indoc::formatdoc;
@@ -11,8 +12,7 @@ use ockam_api::nodes::BackgroundNodeClient;
 
 use crate::node::NodeOpts;
 use crate::tcp::util::alias_parser;
-use crate::util::async_cmd;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
@@ -32,18 +32,11 @@ pub struct ShowCommand {
     node_opts: NodeOpts,
 }
 
-impl ShowCommand {
-    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        async_cmd(&self.name(), opts.clone(), |ctx| async move {
-            self.async_run(&ctx, opts).await
-        })
-    }
+#[async_trait]
+impl Command for ShowCommand {
+    const NAME: &'static str = "tcp-inlet show";
 
-    pub fn name(&self) -> String {
-        "tcp-inlet show".into()
-    }
-
-    pub async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.node_opts.at_node).await?;
         let inlet_status = node
             .show_inlet(ctx, &self.alias)

--- a/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/listener/list.rs
@@ -52,15 +52,12 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (transports, _) = try_join!(get_transports, progress_output)?;
 
         let list = opts.terminal.build_list(
             &transports,
-            &format!("TCP Listeners on {}", node.node_name()),
             &format!(
                 "No TCP Listeners found on {}",
                 node.node_name().color(OckamColor::PrimaryResource.color())

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -57,9 +57,7 @@ impl ListCommand {
             color_primary(node.node_name())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (outlets, _) = try_join!(send_req, progress_output)?;
 
@@ -70,11 +68,7 @@ impl ListCommand {
             );
             match outlets.is_empty() {
                 true => empty_message,
-                false => opts.terminal.build_list(
-                    &outlets,
-                    &format!("TCP Outlets on node {}", color_primary(node.node_name())),
-                    &empty_message,
-                )?,
+                false => opts.terminal.build_list(&outlets, &empty_message)?,
             }
         };
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use core::fmt::Write;
 use std::net::SocketAddr;
 
@@ -15,12 +16,11 @@ use ockam_core::AsyncTryClone;
 use ockam_multiaddr::MultiAddr;
 
 use crate::tcp::util::alias_parser;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 use ockam_api::output::Output;
 
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::async_cmd;
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
@@ -42,24 +42,17 @@ pub struct ShowCommand {
     pub at: Option<String>,
 }
 
-impl ShowCommand {
-    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        async_cmd(&self.name(), opts.clone(), |ctx| async move {
-            self.async_run(&ctx, opts).await
-        })
-    }
+#[async_trait]
+impl Command for ShowCommand {
+    const NAME: &'static str = "tcp-outlet show";
 
-    pub fn name(&self) -> String {
-        "tcp-outlet show".into()
-    }
-
-    pub async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        ShowTui::run(
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        Ok(ShowTui::run(
             ctx.async_try_clone().await.into_diagnostic()?,
             opts,
             self.clone(),
         )
-        .await
+        .await?)
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/duration.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/duration.rs
@@ -1,9 +1,0 @@
-use std::time::Duration;
-
-use clap::error::{Error, ErrorKind};
-
-use ockam_core::env::parse_duration;
-
-pub(crate) fn duration_parser(arg: &str) -> Result<Duration, clap::Error> {
-    parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))
-}

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -25,9 +25,9 @@ use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
 use crate::{CommandGlobalOpts, Result};
 
 pub mod api;
-pub mod duration;
 pub mod exitcode;
 pub mod parsers;
+pub mod validators;
 
 pub fn local_cmd(res: miette::Result<()>) -> miette::Result<()> {
     if let Err(error) = &res {

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -1,13 +1,16 @@
+use clap::error::{Error, ErrorKind};
 use std::net::SocketAddr;
 use std::str::FromStr;
+use std::time::Duration;
 
 use miette::miette;
 
 use ockam::identity::Identifier;
 use ockam_api::config::lookup::InternetAddress;
+use ockam_core::env::parse_duration;
 use ockam_transport_tcp::resolve_peer;
 
-use crate::util::api;
+use crate::util::validators::cloud_resource_name_validator;
 use crate::Result;
 
 /// Helper function for parsing a socket from user input
@@ -38,8 +41,8 @@ pub(crate) fn internet_address_parser(input: &str) -> Result<InternetAddress> {
     Ok(InternetAddress::new(input).ok_or_else(|| miette!("Invalid address: {input}"))?)
 }
 
-pub(crate) fn validate_project_name(s: &str) -> Result<String> {
-    match api::validate_cloud_resource_name(s) {
+pub(crate) fn project_name_parser(s: &str) -> Result<String> {
+    match cloud_resource_name_validator(s) {
         Ok(_) => Ok(s.to_string()),
         Err(_e)=> Err(miette!(
             "project name can contain only alphanumeric characters and the '-', '_' and '.' separators. \
@@ -47,6 +50,10 @@ pub(crate) fn validate_project_name(s: &str) -> Result<String> {
             occur at the start or end of the name, nor they can occur in sequence.",
         ))?,
     }
+}
+
+pub(crate) fn duration_parser(arg: &str) -> std::result::Result<Duration, clap::Error> {
+    parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))
 }
 
 #[cfg(test)]

--- a/implementations/rust/ockam/ockam_command/src/util/validators.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/validators.rs
@@ -1,0 +1,64 @@
+use miette::miette;
+use regex::Regex;
+
+pub(crate) fn cloud_resource_name_validator(s: &str) -> miette::Result<()> {
+    let project_name_regex = Regex::new(r"^[a-zA-Z0-9]+([a-zA-Z0-9-_\.]?[a-zA-Z0-9])*$").unwrap();
+    let is_project_name_valid = project_name_regex.is_match(s);
+    if !is_project_name_valid {
+        Err(miette!("Invalid name"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_validate_cloud_resource_name() {
+        let valid_names: Vec<&str> = vec![
+            "name",
+            "0001",
+            "321_11-11-22",
+            "0_0",
+            "6.9",
+            "0-9",
+            "name_with_underscores",
+            "name-with-dashes",
+            "name.with.dots",
+            "name1with2numbers3",
+            "11name22with33numbers00",
+            "76123long.name_with-underscores.and-dashes_and3dots00and.numbers",
+        ];
+        for name in valid_names {
+            assert!(cloud_resource_name_validator(name).is_ok());
+        }
+
+        let invalid_names: Vec<&str> = vec![
+            "name with spaces in between",
+            " name-with-leading-space",
+            "name.with.trailing.space ",
+            " name-with-leading-and-trailing-space ",
+            "     name_with_multiple_leading_space",
+            "name__with_consecutive_underscore",
+            "_name_with_leading_underscore",
+            "name-with-trailing-underscore_",
+            "name_with_consecutive---dashes",
+            "name_with_trailing_dashes--",
+            "---name_with_leading_dashes",
+            "name-with-consecutive...dots",
+            "name.with.trailing.dots....",
+            ".name_with-leading.dot",
+            "name_.with._consecutive-_-dots.-.dashes-._underscores",
+            "1 2 3 4",
+            "  1234",
+            "_",
+            "__",
+            ". _ .",
+        ];
+        for name in invalid_names {
+            assert!(cloud_resource_name_validator(name).is_err());
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/vault/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/list.rs
@@ -37,9 +37,7 @@ impl ListCommand {
             .into_iter()
             .map(|v| VaultOutput::new(&v))
             .collect::<Vec<_>>();
-        let plain = opts
-            .terminal
-            .build_list(&vaults, "Vaults", "No Vaults found")?;
+        let plain = opts.terminal.build_list(&vaults, "No Vaults found")?;
         let json = serde_json::to_string(&vaults).into_diagnostic()?;
         opts.terminal
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/worker/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/worker/list.rs
@@ -56,15 +56,12 @@ impl ListCommand {
             node.node_name().color(OckamColor::PrimaryResource.color())
         )];
 
-        let progress_output = opts
-            .terminal
-            .progress_output(&output_messages, &is_finished);
+        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
 
         let (workers, _) = try_join!(get_workers, progress_output)?;
 
         let list = opts.terminal.build_list(
             &workers.list,
-            &format!("Workers on {}", node.node_name()),
             &format!("No workers found on {}.", node.node_name()),
         )?;
         opts.terminal.stdout().plain(list).write_line()?;

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -21,8 +21,8 @@ teardown() {
   run_success "$OCKAM" node create n2 --verbose
 
   run_success "$OCKAM" node list
-  assert_output --partial "\"node_name\": \"n1\""
-  assert_output --partial "\"status\": \"running\""
+  assert_output --partial "\"node_name\":\"n1\""
+  assert_output --partial "\"status\":\"running\""
 
   run_success "$OCKAM" node stop n1
   assert_output --partial "Node with name n1 was stopped"

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/relay.bats
@@ -39,8 +39,8 @@ teardown() {
   run_success $OCKAM relay create red --at /node/n1 --to /node/n2
 
   run_success $OCKAM relay list --to /node/n2 --output json
-  assert_output --partial "\"remote_address\": \"forward_to_blue\""
-  assert_output --partial "\"remote_address\": \"forward_to_red\""
+  assert_output --partial "\"remote_address\":\"forward_to_blue\""
+  assert_output --partial "\"remote_address\":\"forward_to_red\""
 
   # Test listing node with no relays
   run_success $OCKAM relay list --to /node/n1
@@ -65,14 +65,14 @@ teardown() {
   # Create another one and list both
   run_success "$OCKAM" relay create red --at /node/n1 --to /node/n2
   run_success "$OCKAM" relay list --to /node/n2 --output json
-  assert_output --partial "\"remote_address\": \"forward_to_blue\""
-  assert_output --partial "\"remote_address\": \"forward_to_red\""
+  assert_output --partial "\"remote_address\":\"forward_to_blue\""
+  assert_output --partial "\"remote_address\":\"forward_to_red\""
 
   # Delete the first
   run_success "$OCKAM" relay delete -y forward_to_blue --at /node/n2
   run_success "$OCKAM" relay list --to /node/n2 --output json
-  refute_output --partial "\"remote_address\": \"forward_to_blue\""
-  assert_output --partial "\"remote_address\": \"forward_to_red\""
+  refute_output --partial "\"remote_address\":\"forward_to_blue\""
+  assert_output --partial "\"remote_address\":\"forward_to_red\""
 
   ## Try to delete twice
   run_failure "$OCKAM" relay delete -y forward_to_blue --at /node/n2

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/tcp.bats
@@ -21,7 +21,8 @@ teardown() {
 
   # Create tcp-connection and check output
   run_success "$OCKAM" tcp-connection create --from n1 --to "$addr" --output json
-  assert_output --regexp '[{"route":"/dnsaddr/localhost/tcp/[[:digit:]]+/worker/[[:graph:]]+"}]'
+  assert_output --partial "n1"
+  assert_output --partial $addr
 
   # Check that the connection is listed
   run_success "$OCKAM" tcp-connection list --at n1


### PR DESCRIPTION
## Output changes

- `list` commands: I've removed the header that was shown in a box. These commands now print the items without any header
- `tcp-inlet|outlet create`: I changed the formatting of the output to use a "narrative" format, instead of showing a list of values.
- I extended the docs for some arguments (global arguments and command specific arguments)
- All arguments that have json output now print the json struct in a single line (the `pretty-print` can be done with jq if the user needs it)

![image](https://github.com/build-trust/ockam/assets/12375782/3d4813f7-0d3b-42e4-8975-6546cba2110d)

## Fixes

- `tcp-inlet|outlet create`: the `allow` argument was set as positional, and it should be a named argument. I also changed the alias to match the arg name we use at `policy create` (`expression` instead of `policy_expression`)