### PR TITLE
feat(rust): allow tickets to specify boolean attributes with no value

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -145,7 +145,8 @@ impl TicketCommand {
         for attr in &self.attributes {
             let mut parts = attr.splitn(2, '=');
             let key = parts.next().ok_or(miette!("key expected"))?;
-            let value = parts.next().ok_or(miette!("value expected)"))?;
+            // If no value is provided we assume that the attribute is a boolean attribute set to "true"
+            let value = parts.next().unwrap_or("true");
             attributes.insert(key.to_string(), value.to_string());
         }
         if let Some(relay_name) = self.allowed_relay_name.clone() {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -85,6 +85,7 @@ pub struct CreateCommand {
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-inlet`.
     #[arg(
         hide = true,
+        long,
         visible_alias = "policy_expression",
         display_order = 900,
         id = "POLICY_EXPRESSION"

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -62,6 +62,7 @@ pub struct CreateCommand {
     /// You can check the fallback policy with `ockam policy show --resource-type tcp-outlet`.
     #[arg(
         hide = true,
+        long,
         visible_alias = "policy_expression",
         display_order = 904,
         id = "POLICY_EXPRESSION"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/policies.bats
@@ -21,8 +21,8 @@ teardown() {
   # Admin
   relay_name="$(random_str)"
   db_ticket=$($OCKAM project ticket --usage-count 10 --relay $relay_name)
-  web_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.web=true)
-  dashboard_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.dashboard=true)
+  web_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.web)
+  dashboard_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.dashboard)
 
   # DB
   setup_home_dir
@@ -50,7 +50,7 @@ teardown() {
   # Admin
   relay_name="$(random_str)"
   db_ticket=$($OCKAM project ticket --usage-count 10 --relay $relay_name)
-  web_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.web=true)
+  web_ticket=$($OCKAM project ticket --usage-count 10 --attribute component.web)
 
   # DB
   setup_home_dir

--- a/implementations/rust/ockam/ockam_command/tests/bats/serial/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/serial/use_cases.bats
@@ -227,15 +227,15 @@ EOF
 
   # On machine A
   MACHINE_A="$OCKAM_HOME"
-  run_success bash -c "$OCKAM project ticket --usage-count 10 --attribute component=db --relay ${relay_name} > ${MACHINE_A}/db.ticket"
-  run_success bash -c "$OCKAM project ticket --usage-count 10 --attribute component=web > ${MACHINE_A}/webapp.ticket"
+  run_success bash -c "$OCKAM project ticket --usage-count 10 --attribute component.db --relay ${relay_name} > ${MACHINE_A}/db.ticket"
+  run_success bash -c "$OCKAM project ticket --usage-count 10 --attribute component.web > ${MACHINE_A}/webapp.ticket"
 
   # Machine B
   setup_home_dir
   run_success $OCKAM identity create db
   run_success $OCKAM project enroll "${MACHINE_A}/db.ticket" --identity db
   run_success $OCKAM node create db --identity db
-  run_success $OCKAM tcp-outlet create --to "$PG_HOST:$PG_PORT" --allow '(= subject.component "web")'
+  run_success $OCKAM tcp-outlet create --to "$PG_HOST:$PG_PORT" --allow 'component.web'
   run_success $OCKAM relay create "$relay_name"
 
   # Machine C
@@ -244,7 +244,7 @@ EOF
   run_success $OCKAM identity create web
   run_success $OCKAM project enroll ${MACHINE_A}/webapp.ticket --identity web
   run_success $OCKAM node create web --identity web
-  run_success $OCKAM tcp-inlet create --from "$OCKAM_PG_PORT_MACHINE_C" --via $relay_name --allow '(= subject.component "db")'
+  run_success $OCKAM tcp-inlet create --from "$OCKAM_PG_PORT_MACHINE_C" --via $relay_name --allow 'component.db'
 
   export FLASK_PORT="$(random_port)"
   export APP_PG_PORT="$OCKAM_PG_PORT_MACHINE_C"


### PR DESCRIPTION
```
ockam project ticket --usage-count 10 --attribute component.web
```
instead of
```
ockam project ticket --usage-count 10 --attribute component.web=true
```

There is also a fix for the `allow` parameter on the `tcp-outlet create` and `tcp-inlet create` commands.