### PR TITLE
feat(rust): allow to specify 'self' in multiaddr

### DIFF
--- a/implementations/rust/ockam/ockam_multiaddr/src/iter.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/iter.rs
@@ -110,13 +110,18 @@ impl<'a> Iterator for StrIter<'a> {
         if self.string.is_empty() {
             return None;
         }
-        let (prefix, value) = match self.string.split_once('/') {
-            Some(("", s)) => match s.split_once('/') {
-                Some((p, r)) => (p, r),
-                None => (s, ""),
-            },
-            Some((p, s)) => (p, s),
-            None => (self.string, ""),
+        let (prefix, value) = if self.string == "self" {
+            // TODO: once packet generated locally bypass ABAC rules, return None
+            ("secure", "api")
+        } else {
+            match self.string.split_once('/') {
+                Some(("", s)) => match s.split_once('/') {
+                    Some((p, r)) => (p, r),
+                    None => (s, ""),
+                },
+                Some((p, s)) => (p, s),
+                None => (self.string, ""),
+            }
         };
         if let Some(codec) = self.registry.get_by_prefix(prefix) {
             match codec.split_str(prefix, value) {

--- a/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/lib.rs
@@ -798,6 +798,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::{MultiAddr, Protocol, Registry};
     use tinyvec::TinyVec;
 
     #[test]
@@ -814,5 +815,14 @@ mod tests {
         assert!(b.is_inline());
         assert_eq!(a, b);
         assert_eq!(v, t);
+    }
+
+    #[test]
+    fn self_multiaddr() {
+        let multiaddr = MultiAddr::try_from_str("self", Registry::default()).unwrap();
+        assert_eq!("/secure/api", multiaddr.to_string());
+        let proto = multiaddr.first().unwrap();
+        assert_eq!(crate::proto::Secure::CODE, proto.code);
+        assert_eq!(b"api", *proto.data());
     }
 }


### PR DESCRIPTION
implements https://github.com/build-trust/ockam/issues/8044

Currently if you want to specify "the same node" either you specify an empty string "" or "/secure/api" if you need packets to pass ABAC policies.

This syntax introduces some syntatic sugar we can use to avoid the user to use confusing empty string or "/secure/api" when refering a local node.
Once we eliminate the need for "/secure/api" when referring to the same node, we can resolve "self" with an empty multiaddr.