### PR TITLE
fix(rust): node create can be created with a configuration file in the foreground

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/message/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/message/mod.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 
 pub use send::SendCommand;
 
-use crate::CommandGlobalOpts;
+use crate::{Command, CommandGlobalOpts};
 
 mod send;
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -13,7 +13,7 @@ use tracing::instrument;
 use ockam_api::cli_state::random_name;
 use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
-use ockam_core::{opentelemetry_context_parser, AsyncTryClone, OpenTelemetryContext};
+use ockam_core::{opentelemetry_context_parser, OpenTelemetryContext};
 use ockam_node::Context;
 
 use crate::node::create::config::ConfigArgs;
@@ -158,23 +158,22 @@ impl Command for CreateCommand {
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
         self.parse_args()?;
-        let ctx = ctx.async_try_clone().await.into_diagnostic()?;
         if self.has_name_arg() {
             if self.foreground_args.foreground {
-                self.foreground_mode(&ctx, opts).await?
+                self.foreground_mode(ctx, opts).await?
             } else {
-                self.background_mode(&ctx, opts).await?
+                self.background_mode(ctx, opts).await?
             }
         } else {
-            self.run_config(&ctx, opts).await?
+            self.run_config(ctx, opts).await?
         }
         Ok(())
     }
 }
 
 impl CreateCommand {
-    // Return true if the `name` argument is a node name, false if it's a config file path or URL
-    // Or if the node configuration was provided inline
+    /// Return true if the `name` argument is a node name, false if it's a config file path or URL,
+    /// or if the node configuration was provided inline
     fn has_name_arg(&self) -> bool {
         is_url(&self.name).is_none()
             && std::fs::metadata(&self.name).is_err()

--- a/implementations/rust/ockam/ockam_command/src/project/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/mod.rs
@@ -50,7 +50,7 @@ pub enum ProjectSubcommand {
     Information(InfoCommand),
     Ticket(TicketCommand),
     Addon(AddonCommand),
-    Enroll(Box<EnrollCommand>),
+    Enroll(EnrollCommand),
 }
 
 impl ProjectCommand {

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -54,7 +54,6 @@ impl Config {
     /// For more details about the parsing, see the [parser](crate::run::parser) module.
     /// You can also check examples of valid configuration files in the demo folder of this module.
     pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
-        // Parse commands and run them
         for cmd in self.parse_commands()? {
             cmd.run(ctx, opts).await?
         }
@@ -62,18 +61,18 @@ impl Config {
     }
 
     // Build commands and return validation errors
-    pub fn parse_commands(self) -> miette::Result<Vec<ParsedCommands>> {
+    fn parse_commands(self) -> miette::Result<Vec<ParsedCommands>> {
         Ok(vec![
-            self.vaults.parse_commands()?.into(),
-            self.identities.parse_commands()?.into(),
-            self.project_enroll.parse_commands()?.into(),
-            self.nodes.parse_commands()?.into(),
-            self.relays.parse_commands(&None)?.into(),
-            self.policies.parse_commands()?.into(),
-            self.tcp_outlets.parse_commands(&None)?.into(),
-            self.tcp_inlets.parse_commands(&None)?.into(),
-            self.kafka_inlet.parse_commands(&None)?.into(),
-            self.kafka_outlet.parse_commands(&None)?.into(),
+            self.vaults.into_parsed_commands()?.into(),
+            self.identities.into_parsed_commands()?.into(),
+            self.project_enroll.into_parsed_commands()?.into(),
+            self.nodes.into_parsed_commands()?.into(),
+            self.relays.into_parsed_commands(&None)?.into(),
+            self.policies.into_parsed_commands()?.into(),
+            self.tcp_outlets.into_parsed_commands(&None)?.into(),
+            self.tcp_inlets.into_parsed_commands(&None)?.into(),
+            self.kafka_inlet.into_parsed_commands(&None)?.into(),
+            self.kafka_outlet.into_parsed_commands(&None)?.into(),
         ])
     }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
@@ -27,7 +27,10 @@ impl KafkaInlet {
         )))
     }
 
-    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: &Option<String>,
+    ) -> Result<Vec<CreateCommand>> {
         match self.kafka_inlet {
             Some(c) => {
                 let mut cmds = c.into_commands(Self::get_subcommand)?;
@@ -64,7 +67,7 @@ mod tests {
         let parsed: KafkaInlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
@@ -84,7 +87,7 @@ mod tests {
         "#;
         let parsed: KafkaInlet = serde_yaml::from_str(unnamed).unwrap();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
@@ -29,7 +29,10 @@ impl KafkaOutlet {
         )))
     }
 
-    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: &Option<String>,
+    ) -> Result<Vec<CreateCommand>> {
         match self.kafka_outlet {
             Some(c) => {
                 let mut cmds = c.into_commands(Self::get_subcommand)?;
@@ -64,7 +67,7 @@ mod tests {
         let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
@@ -81,7 +84,7 @@ mod tests {
         let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds[0].node_opts.at_node, Some(default_node_name));
     }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
@@ -27,7 +27,7 @@ impl Nodes {
         )))
     }
 
-    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
         match self.nodes {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -45,7 +45,7 @@ mod tests {
     fn single_node_config() {
         let test = |c: &str| {
             let parsed: Nodes = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands().unwrap();
+            let cmds = parsed.into_parsed_commands().unwrap();
             assert_eq!(cmds.len(), 1);
             let cmd = cmds.into_iter().next().unwrap();
             assert_eq!(cmd.name, "n1");
@@ -76,7 +76,7 @@ mod tests {
     fn multiple_node_config() {
         let test = |c: &str| {
             let parsed: Nodes = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands().unwrap();
+            let cmds = parsed.into_parsed_commands().unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].name, "n1");
             assert_eq!(cmds[1].name, "n2");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/policies.rs
@@ -27,7 +27,7 @@ impl Policies {
         )))
     }
 
-    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
         match self.policies {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -48,7 +48,7 @@ mod tests {
               expression: (= subject.component "c1")
         "#;
         let parsed: Policies = serde_yaml::from_str(config).unwrap();
-        let cmds = parsed.parse_commands().unwrap();
+        let cmds = parsed.into_parsed_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");
         assert_eq!(cmds[0].resource.as_ref().unwrap().as_str(), "r1");
@@ -70,7 +70,7 @@ mod tests {
                 expression: (= subject.component "c3")
         "#;
         let parsed: Policies = serde_yaml::from_str(config).unwrap();
-        let cmds = parsed.parse_commands().unwrap();
+        let cmds = parsed.into_parsed_commands().unwrap();
         assert_eq!(cmds.len(), 3);
 
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n1");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
@@ -1,10 +1,12 @@
 use miette::{miette, Result};
 use ockam_api::colors::color_primary;
+
 use serde::{Deserialize, Serialize};
 
 use crate::project::EnrollCommand;
 
 use crate::run::parser::resource::utils::parse_cmd_from_args;
+use crate::run::parser::resource::Resource;
 use crate::{Command, OckamSubcommand};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -12,24 +14,38 @@ pub struct ProjectEnroll {
     pub ticket: Option<String>,
 }
 
+impl Resource<EnrollCommand> for ProjectEnroll {
+    const COMMAND_NAME: &'static str = EnrollCommand::NAME;
+
+    fn args(self) -> Vec<String> {
+        if let Some(path_or_contents) = &self.ticket {
+            vec![path_or_contents.clone()]
+        } else {
+            vec![]
+        }
+    }
+}
+
 impl ProjectEnroll {
+    pub fn into_parsed_commands(self) -> Result<Vec<EnrollCommand>> {
+        let args = self.args();
+        if args.is_empty() {
+            Ok(vec![])
+        } else {
+            Ok(vec![Self::get_subcommand(&args)?])
+        }
+    }
+
     fn get_subcommand(args: &[String]) -> Result<EnrollCommand> {
         if let OckamSubcommand::Project(cmd) = parse_cmd_from_args(EnrollCommand::NAME, args)? {
             if let crate::project::ProjectSubcommand::Enroll(c) = cmd.subcommand {
-                return Ok(*c);
+                return Ok(c);
             }
         }
         Err(miette!(format!(
             "Failed to parse {} command",
             color_primary(EnrollCommand::NAME)
         )))
-    }
-
-    pub fn parse_commands(self) -> Result<Vec<EnrollCommand>> {
-        match self.ticket {
-            Some(path_or_contents) => Ok(vec![Self::get_subcommand(&[path_or_contents])?]),
-            None => Ok(vec![]),
-        }
     }
 }
 
@@ -53,7 +69,7 @@ mod tests {
         // As contents
         let config = format!("ticket: {enrollment_ticket_hex}");
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
-        let cmds = parsed.parse_commands().unwrap();
+        let cmds = parsed.into_parsed_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].enrollment_ticket.as_ref().unwrap(),
@@ -67,7 +83,7 @@ mod tests {
         file.write_all(enrollment_ticket_hex.as_bytes()).unwrap();
         let config = format!("ticket: {}", file_path.to_str().unwrap());
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
-        let cmds = parsed.parse_commands().unwrap();
+        let cmds = parsed.into_parsed_commands().unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].enrollment_ticket.as_ref().unwrap(),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/relays.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/relays.rs
@@ -27,7 +27,10 @@ impl Relays {
         )))
     }
 
-    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: &Option<String>,
+    ) -> Result<Vec<CreateCommand>> {
         match self.relays {
             Some(c) => {
                 let mut cmds = c.into_commands(Self::get_subcommand)?;
@@ -57,7 +60,7 @@ mod tests {
             let parsed: Relays = serde_yaml::from_str(c).unwrap();
             let default_node_name = "n1".to_string();
             let cmds = parsed
-                .parse_commands(&Some(default_node_name.clone()))
+                .into_parsed_commands(&Some(default_node_name.clone()))
                 .unwrap();
             assert_eq!(cmds.len(), 1);
             let cmd = cmds.into_iter().next().unwrap();
@@ -97,7 +100,7 @@ mod tests {
             let parsed: Relays = serde_yaml::from_str(c).unwrap();
             let default_node_name = "n1".to_string();
             let cmds = parsed
-                .parse_commands(&Some(default_node_name.clone()))
+                .into_parsed_commands(&Some(default_node_name.clone()))
                 .unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].relay_name, "r1");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
@@ -27,7 +27,10 @@ impl TcpInlets {
         )))
     }
 
-    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: &Option<String>,
+    ) -> Result<Vec<CreateCommand>> {
         match self.tcp_inlets {
             Some(c) => {
                 let mut cmds =
@@ -67,7 +70,7 @@ mod tests {
         let parsed: TcpInlets = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].alias, "ti1");
@@ -91,7 +94,7 @@ mod tests {
         "#;
         let parsed: TcpInlets = serde_yaml::from_str(unnamed).unwrap();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourceNameOrMap};
 
 use crate::run::parser::resource::utils::parse_cmd_from_args;
+
 use crate::tcp::outlet::create::CreateCommand;
 use crate::{tcp::outlet, Command, OckamSubcommand};
 
@@ -27,7 +28,10 @@ impl TcpOutlets {
         )))
     }
 
-    pub fn parse_commands(self, default_node_name: &Option<String>) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: &Option<String>,
+    ) -> Result<Vec<CreateCommand>> {
         match self.tcp_outlets {
             Some(c) => {
                 let mut cmds = c.into_commands_with_name_arg(Self::get_subcommand, Some("from"))?;
@@ -64,7 +68,7 @@ mod tests {
         let parsed: TcpOutlets = serde_yaml::from_str(config).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .parse_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(&Some(default_node_name.clone()))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].from.clone().unwrap(), "to1");

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -1,56 +1,49 @@
-use std::sync::Arc;
+use std::process::Stdio;
 
 use async_trait::async_trait;
-use miette::Result;
+use miette::{IntoDiagnostic, Result};
+use tokio::process::Child;
+use tracing::debug;
 
+use ockam_core::AsyncTryClone;
 use ockam_node::Context;
 
+use crate::run::parser::resource::utils::{binary_path, subprocess_stdio};
 use crate::{Command, CommandGlobalOpts};
 
-/// List of parsed commands
-/// Each command can be validated then executed
-pub struct ParsedCommands {
-    pub commands: Vec<Arc<dyn ParsedCommand>>,
-}
+/// This trait defines the methods that a resource must implement before it's parsed into a Command.
+///
+/// The resource is the layer between the configuration data and the parsed command.
+pub trait Resource<C: ParsedCommand>: Sized + Send + Sync + 'static {
+    const COMMAND_NAME: &'static str;
 
-impl ParsedCommands {
-    /// Create a list of parsed commands
-    pub fn new<C: ParsedCommand + Send + 'static>(commands: Vec<C>) -> Self {
-        ParsedCommands {
-            commands: commands
-                .into_iter()
-                .map(|c| {
-                    let b: Arc<dyn ParsedCommand> = Arc::new(c);
-                    b
-                })
-                .collect::<Vec<Arc<dyn ParsedCommand>>>(),
-        }
+    fn args(self) -> Vec<String> {
+        vec![]
     }
 
-    /// Validate and run each command
-    pub async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
-        for cmd in self.commands.iter() {
-            if cmd.is_valid(ctx, opts).await? {
-                cmd.run(ctx, opts).await?;
-                // Newline between commands
-                opts.terminal.write_line("")?;
-            }
-        }
-        Ok(())
+    fn run_in_subprocess(self, quiet: bool) -> Result<Child> {
+        let args = self.args();
+        let args = Self::COMMAND_NAME
+            .split(' ')
+            .chain(args.iter().map(|s| s.as_str()));
+        let handle = tokio::process::Command::new(binary_path())
+            .args(args)
+            .stdout(subprocess_stdio(quiet))
+            .stderr(subprocess_stdio(quiet))
+            .stdin(Stdio::null())
+            .spawn()
+            .into_diagnostic()?;
+        Ok(handle)
     }
 }
 
-impl<C: ParsedCommand> From<Vec<C>> for ParsedCommands {
-    fn from(cmds: Vec<C>) -> ParsedCommands {
-        ParsedCommands::new(cmds)
-    }
-}
-
-/// This trait represents a command which can be validated then executed
+/// This trait represents a Clap command which can be validated and executed
 #[async_trait]
 pub trait ParsedCommand: Send + Sync + 'static {
     /// Returns true if the command can be executed, false otherwise.
-    async fn is_valid(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<bool>;
+    async fn is_valid(&self, _ctx: &Context, _opts: &CommandGlobalOpts) -> Result<bool> {
+        Ok(true)
+    }
 
     /// Execute the command
     async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()>;
@@ -69,6 +62,47 @@ where
     }
 
     async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
+        debug!("Running command: {}", self.name());
         Ok(self.clone().async_run_with_retry(ctx, opts.clone()).await?)
+    }
+}
+
+/// List of parsed commands
+/// Each command can be validated then executed
+pub struct ParsedCommands {
+    pub commands: Vec<Box<dyn ParsedCommand>>,
+}
+
+impl ParsedCommands {
+    /// Create a list of parsed commands
+    pub fn new<C: ParsedCommand + Send + 'static>(commands: Vec<C>) -> Self {
+        ParsedCommands {
+            commands: commands
+                .into_iter()
+                .map(|c| {
+                    let b: Box<dyn ParsedCommand> = Box::new(c);
+                    b
+                })
+                .collect::<Vec<Box<dyn ParsedCommand>>>(),
+        }
+    }
+
+    /// Validate and run each command
+    pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
+        for cmd in self.commands.into_iter() {
+            if cmd.is_valid(ctx, opts).await? {
+                let ctx = ctx.async_try_clone().await.into_diagnostic()?;
+                cmd.run(&ctx, opts).await?;
+                // Newline between commands
+                opts.terminal.write_line("")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<C: ParsedCommand> From<Vec<C>> for ParsedCommands {
+    fn from(cmds: Vec<C>) -> ParsedCommands {
+        ParsedCommands::new(cmds)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use miette::IntoDiagnostic;
 use once_cell::sync::Lazy;
+use std::process::Stdio;
 
 use crate::{OckamCommand, OckamSubcommand};
 
@@ -10,7 +11,7 @@ static BINARY_PATH: Lazy<String> = Lazy::new(|| {
         .expect("Failed to get the binary path")
 });
 
-fn binary_path() -> &'static str {
+pub fn binary_path() -> &'static str {
     &BINARY_PATH
 }
 
@@ -25,4 +26,16 @@ pub fn parse_cmd_from_args(cmd: &str, args: &[String]) -> miette::Result<OckamSu
     Ok(OckamCommand::try_parse_from(args)
         .into_diagnostic()?
         .subcommand)
+}
+
+pub fn subprocess_stdio(quiet: bool) -> Stdio {
+    if quiet {
+        // If we're running in quiet mode, we don't need to propagate
+        // the stdout/stderr to the child process
+        Stdio::null()
+    } else {
+        // Otherwise, we need to inherit the stdout/stderr of the parent process
+        // to see the output written in the child process
+        Stdio::inherit()
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/vaults.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/vaults.rs
@@ -1,10 +1,12 @@
 use miette::{miette, Result};
+
 use ockam_api::colors::color_primary;
 use serde::{Deserialize, Serialize};
 
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourcesContainer};
 
 use crate::run::parser::resource::utils::parse_cmd_from_args;
+
 use crate::vault::CreateCommand;
 use crate::{vault, Command, OckamSubcommand};
 
@@ -27,7 +29,7 @@ impl Vaults {
         )))
     }
 
-    pub fn parse_commands(self) -> Result<Vec<CreateCommand>> {
+    pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
         match self.vaults {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),
@@ -45,7 +47,7 @@ mod tests {
     fn single_vault_config() {
         let test = |c: &str| {
             let parsed: Vaults = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands().unwrap();
+            let cmds = parsed.into_parsed_commands().unwrap();
             assert_eq!(cmds.len(), 1);
             assert_eq!(cmds[0].name.as_ref().unwrap(), "v1");
         };
@@ -76,7 +78,7 @@ mod tests {
     fn multiple_vaults_config() {
         let test = |c: &str| {
             let parsed: Vaults = serde_yaml::from_str(c).unwrap();
-            let cmds = parsed.parse_commands().unwrap();
+            let cmds = parsed.into_parsed_commands().unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].name.as_ref().unwrap(), "v1");
             assert_eq!(cmds[1].name.as_ref().unwrap(), "v2");

--- a/implementations/rust/ockam/ockam_command/src/shared_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/shared_args.rs
@@ -33,12 +33,17 @@ pub struct TrustOpts {
 #[derive(Clone, Debug, Args, Default, PartialEq)]
 pub struct RetryOpts {
     /// Number of times to retry the command
-    #[arg(hide = true, long)]
+    #[arg(hide = true, long, alias = "retry")]
     retry_count: Option<u32>,
 
     /// Delay between retries
     #[arg(hide = true, long, value_parser = duration_parser)]
-    pub retry_delay: Option<Duration>,
+    retry_delay: Option<Duration>,
+
+    /// Disable retry for the command,
+    /// no matter if it's enabled via arguments or environment variables
+    #[arg(hide = true, long, default_value_t = false)]
+    no_retry: bool,
 }
 
 impl RetryOpts {
@@ -47,6 +52,9 @@ impl RetryOpts {
     /// If the value is not set, it will try to get the value from
     /// the `OCKAM_COMMAND_RETRY_COUNT` environment variable
     pub fn retry_count(&self) -> Option<u32> {
+        if self.no_retry {
+            return None;
+        }
         match self.retry_count {
             Some(count) => Some(count),
             None => get_env::<String>("OCKAM_COMMAND_RETRY_COUNT")
@@ -61,6 +69,9 @@ impl RetryOpts {
     /// If the value is not set, it will try to get the value from
     /// the `OCKAM_COMMAND_RETRY_DELAY` environment variable
     pub fn retry_delay(&self) -> Option<Duration> {
+        if self.no_retry {
+            return None;
+        }
         match self.retry_delay {
             Some(delay) => Some(delay),
             None => get_env::<String>("OCKAM_COMMAND_RETRY_DELAY")

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -148,7 +148,7 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        config.project_enroll.parse_commands().unwrap();
-        config.tcp_inlets.parse_commands(&None).unwrap();
+        config.project_enroll.into_parsed_commands().unwrap();
+        config.tcp_inlets.into_parsed_commands(&None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -150,9 +150,9 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        config.project_enroll.parse_commands().unwrap();
-        config.policies.parse_commands().unwrap();
-        config.tcp_outlets.parse_commands(&None).unwrap();
-        config.relays.parse_commands(&None).unwrap();
+        config.project_enroll.into_parsed_commands().unwrap();
+        config.policies.into_parsed_commands().unwrap();
+        config.tcp_outlets.into_parsed_commands(&None).unwrap();
+        config.relays.into_parsed_commands(&None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::ops::Add;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -327,7 +328,10 @@ pub trait Command: Clone + Sized + Send + Sync + 'static {
                         return Ok(());
                     }
                 };
-            let retry_delay_jitter = Duration::from_secs(2);
+            let retry_delay_jitter = min(
+                Duration::from_secs_f64(retry_delay.as_secs_f64() * 0.5),
+                Duration::from_secs(5),
+            );
             while retry_count > 0 {
                 let cmd = self.clone();
                 match cmd.async_run(ctx, opts.clone()).await {

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -1,6 +1,7 @@
 //! Helpers to display version information
 
 use clap::crate_version;
+use ockam_core::env::get_env_with_default;
 
 pub(crate) struct Version;
 
@@ -11,7 +12,8 @@ impl Version {
 
     pub(crate) fn short() -> &'static str {
         let crate_version = crate_version!();
-        let git_hash = env!("GIT_HASH");
+        let na_hash = "N/A".to_string();
+        let git_hash = get_env_with_default("GIT_HASH", na_hash.clone()).unwrap_or(na_hash);
         let message = format!("{crate_version}\ncompiled from: {git_hash}");
         Box::leak(message.into_boxed_str())
     }

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -1,39 +1,5 @@
 #!/bin/bash
 
-# Disable the opentelemetry export to improve performances
-export OCKAM_OPENTELEMETRY_EXPORT=false
-
-# Set QUIET to 1 to suppress user-facing logging written at stderr
-export QUIET=1
-
-# Ockam binary to use
-if [[ -z $OCKAM ]]; then
-  export OCKAM=ockam
-fi
-
-# Setup base directory for CLI state
-if [[ -z $OCKAM_HOME ]]; then
-  export OCKAM_HOME_BASE="$HOME/.ockam"
-else
-  export OCKAM_HOME_BASE="$OCKAM_HOME"
-fi
-if [ ! -d "$OCKAM_HOME_BASE" ]; then
-  echo "Ockam CLI directory $OCKAM_HOME_BASE does not exist. Creating..." >&3
-  mkdir -p "$OCKAM_HOME_BASE"
-fi
-mkdir -p "$OCKAM_HOME_BASE/.tmp"
-
-if [[ -z $BATS_LIB ]]; then
-  export BATS_LIB=$(brew --prefix)/lib # macos
-  # export BATS_LIB=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
-fi
-
-if [[ -z $PYTHON_SERVER_PORT ]]; then
-  export PYTHON_SERVER_PORT=5000
-fi
-
-mkdir -p "$HOME/.bats-tests"
-
 # Load bats extensions
 load_bats_ext() {
   load "$BATS_LIB/bats-support/load.bash"
@@ -43,6 +9,11 @@ load_bats_ext() {
 setup_python_server() {
   p=$(python_pid_file_path)
   if [[ ! -f "$p" ]]; then
+    if ! [ -x "$(command -v uploadserver)" ]; then
+      echo 'Error: uploadserver is not installed.' >&2
+      exit 1
+    fi
+
     # Create python server in the OCKAM_HOME_BASE directory
     pushd $OCKAM_HOME_BASE
     touch "$p"
@@ -143,3 +114,37 @@ run_failure() {
 }
 
 bats_require_minimum_version 1.5.0
+
+# Disable the opentelemetry export to improve performances
+export OCKAM_OPENTELEMETRY_EXPORT=false
+
+# Set QUIET to 1 to suppress user-facing logging written at stderr
+export QUIET=1
+
+# Ockam binary to use
+if [[ -z $OCKAM ]]; then
+  export OCKAM=ockam
+fi
+
+# Setup base directory for CLI state
+if [[ -z $OCKAM_HOME ]]; then
+  export OCKAM_HOME_BASE="$HOME/.ockam"
+else
+  export OCKAM_HOME_BASE="$OCKAM_HOME"
+fi
+if [ ! -d "$OCKAM_HOME_BASE" ]; then
+  echo "Ockam CLI directory $OCKAM_HOME_BASE does not exist. Creating..." >&3
+  mkdir -p "$OCKAM_HOME_BASE"
+fi
+mkdir -p "$OCKAM_HOME_BASE/.tmp"
+
+if [[ -z $BATS_LIB ]]; then
+  export BATS_LIB=$(brew --prefix)/lib # macos
+  # export BATS_LIB=$NVM_DIR/versions/node/v18.8.0/lib/node_modules # linux
+fi
+
+if [[ -z $PYTHON_SERVER_PORT ]]; then
+  export PYTHON_SERVER_PORT=$(random_port)
+fi
+
+mkdir -p "$HOME/.bats-tests"

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/message.bats
@@ -15,6 +15,9 @@ teardown() {
 # ===== TESTS
 
 @test "message - send messages between local nodes" {
+  # Fail to send a message to a non-existent node
+  run_failure "$OCKAM" message send "$msg" --no-retry --timeout 5 --to /node/n1/service/uppercase
+
   # Send from a temporary node to a background node
   run_success "$OCKAM" node create n1
   msg=$(random_str)

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/message.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/message.bats
@@ -48,7 +48,7 @@ teardown() {
 
   # m2 is not a member, must not be able to contact the project' service
   run_success "$OCKAM" identity create m2
-  run_failure "$OCKAM" message send --timeout 5 --identity m2 --to /project/default/service/echo "$msg"
+  run_failure "$OCKAM" message send --no-retry --timeout 5 --identity m2 --to /project/default/service/echo "$msg"
 }
 
 @test "message - send a hex encoded message to a project node from an embedded node" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/projects.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/projects.bats
@@ -131,7 +131,7 @@ teardown() {
   assert_output "hello"
 
   # m2 is not a member,  must not be able to contact the project' service
-  run_failure $OCKAM message send --timeout 5 --identity m2 --to /project/default/service/echo hello
+  run_failure $OCKAM message send --no-retry --timeout 5 --identity m2 --to /project/default/service/echo hello
 }
 
 @test "projects - list addons" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/trust.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/trust.bats
@@ -50,13 +50,13 @@ teardown() {
   run_success "$OCKAM" node create attacker --identity attacker --authority-identity $attacker_identity
 
   # Fail, attacker won't present any credential
-  run_failure $OCKAM message send --timeout 2 --from attacker --identity attacker --to "/dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo" $msg
+  run_failure $OCKAM message send --no-retry --timeout 2 --from attacker --identity attacker --to "/dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo" $msg
 
   # Fail, attacker will present an invalid credential (self signed rather than signed by authority)
   attacker_cred=$($OCKAM credential issue --as attacker --for $attacker_identifier --encoding hex)
   run_success "$OCKAM" credential store --at attacker --issuer "$attacker_identifier" --scope "test" --credential $attacker_cred
 
-  run_failure $OCKAM message send --timeout 2 --from attacker --identity attacker --to "/dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo" $msg
+  run_failure $OCKAM message send --no-retry --timeout 2 --from attacker --identity attacker --to "/dnsaddr/127.0.0.1/tcp/$port/secure/api/service/echo" $msg
 }
 
 @test "trust - online authority; Credential Exchange is performed" {
@@ -99,5 +99,5 @@ teardown() {
   run_success "$OCKAM" message send --timeout 2 --identity bob --to "/dnsaddr/127.0.0.1/tcp/$auth_port/secure/api/service/echo" $msg
   assert_output "$msg"
 
-  run_failure "$OCKAM" message send --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$node_port/secure/api/service/echo $msg
+  run_failure "$OCKAM" message send --no-retry --timeout 2 --identity attacker --to /dnsaddr/127.0.0.1/tcp/$node_port/secure/api/service/echo $msg
 }


### PR DESCRIPTION
The issue happens when we create a foreground node passing a configuration file that has a ticket. 

```yaml
# config.yaml
name: my-node
ticket: path-to-ticket
```

```bash
ockam node create -f config.yaml
```

The commands generated from the configuration file are run in the same process, sharing the same ockam context, which means that there is a global state of workers addresses that enters in a conflict state when multiple InMemoryNodes are run. Since workers are not cleaned up properly (only the top level workers are removed AFAIK), there is no easy way to isolate InMemoryNodes within the same process.

This PR solves that problem by running the commands that create InMemoryNode instances in separate processes. The affected commands are `project enroll` and `node create`.