### PR TITLE
fix(rust): printing multi-line logs generated by commands stdout output

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/mod.rs
@@ -49,14 +49,12 @@ impl<T: TerminalWriter + Debug, W> Terminal<T, W> {
         if !self.logging_enabled {
             return;
         }
-        let msg = strip_ansi_escapes::strip_str(msg.as_ref());
-        let msg = msg
-            .trim()
-            .trim_start_matches(['✔', '✗', '>', '!'])
-            .trim_end_matches(['\n', '\r'])
-            .trim();
-        if !msg.is_empty() {
-            info!("{msg}");
+        for line in msg.as_ref().lines() {
+            let msg = strip_ansi_escapes::strip_str(line);
+            let msg = msg.trim().trim_start_matches(['✔', '✗', '>', '!']).trim();
+            if !msg.is_empty() {
+                info!("{msg}");
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -10,6 +10,7 @@ use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
 
 use crate::node::CreateCommand;
+use crate::run::parser::resource::utils::subprocess_stdio;
 use crate::shared_args::TrustOpts;
 use crate::{Command as CommandTrait, CommandGlobalOpts};
 
@@ -169,22 +170,10 @@ pub async fn run_ockam(args: Vec<String>, quiet: bool) -> miette::Result<()> {
             .into()
     });
 
-    let stdio = || {
-        if quiet {
-            // If we're running in quiet mode, we don't need to propagate
-            // the stdout/stderr to the child process
-            Stdio::null()
-        } else {
-            // Otherwise, we need to inherit the stdout/stderr of the parent process
-            // to see the output written in the child process
-            Stdio::inherit()
-        }
-    };
-
     Command::new(ockam_exe)
         .args(args)
-        .stdout(stdio())
-        .stderr(stdio())
+        .stdout(subprocess_stdio(quiet))
+        .stderr(subprocess_stdio(quiet))
         .stdin(Stdio::null())
         .spawn()
         .into_diagnostic()


### PR DESCRIPTION
## Before

```
$ node create -f -v

ockam_api::ui::terminal: Created a new Node named integrated-trumpetfish
   ✔ Marked integrated-trumpetfish as your default Node, on this machine
ockam_api::ui::terminal: To exit and stop the Node, please press Ctrl+C
```

## Now

Split multi-line messages, process them to remove ansi chars, and prints them in separate log lines.

```
$ node create -f -v

ockam_api::ui::terminal: Created a new Node named superb-scup
ockam_api::ui::terminal: Marked superb-scup as your default Node, on this machine
ockam_api::ui::terminal: To exit and stop the Node, please press Ctrl+C
```

