### PR TITLE
feat(rust): improve error handling for nodes created in the foreground with a config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -67,12 +67,12 @@ impl Config {
             self.identities.into_parsed_commands()?.into(),
             self.project_enroll.into_parsed_commands()?.into(),
             self.nodes.into_parsed_commands()?.into(),
-            self.relays.into_parsed_commands(&None)?.into(),
+            self.relays.into_parsed_commands(None)?.into(),
             self.policies.into_parsed_commands()?.into(),
-            self.tcp_outlets.into_parsed_commands(&None)?.into(),
-            self.tcp_inlets.into_parsed_commands(&None)?.into(),
-            self.kafka_inlet.into_parsed_commands(&None)?.into(),
-            self.kafka_outlet.into_parsed_commands(&None)?.into(),
+            self.tcp_outlets.into_parsed_commands(None)?.into(),
+            self.tcp_inlets.into_parsed_commands(None)?.into(),
+            self.kafka_inlet.into_parsed_commands(None)?.into(),
+            self.kafka_outlet.into_parsed_commands(None)?.into(),
         ])
     }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
@@ -29,7 +29,7 @@ impl KafkaInlet {
 
     pub fn into_parsed_commands(
         self,
-        default_node_name: &Option<String>,
+        default_node_name: Option<&String>,
     ) -> Result<Vec<CreateCommand>> {
         match self.kafka_inlet {
             Some(c) => {
@@ -37,7 +37,7 @@ impl KafkaInlet {
                 if let Some(node_name) = default_node_name {
                     for cmd in cmds.iter_mut() {
                         if cmd.node_opts.at_node.is_none() {
-                            cmd.node_opts.at_node = Some(node_name.clone())
+                            cmd.node_opts.at_node = Some(node_name.to_string())
                         }
                     }
                 }
@@ -67,7 +67,7 @@ mod tests {
         let parsed: KafkaInlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
@@ -87,7 +87,7 @@ mod tests {
         "#;
         let parsed: KafkaInlet = serde_yaml::from_str(unnamed).unwrap();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
@@ -31,7 +31,7 @@ impl KafkaOutlet {
 
     pub fn into_parsed_commands(
         self,
-        default_node_name: &Option<String>,
+        default_node_name: Option<&String>,
     ) -> Result<Vec<CreateCommand>> {
         match self.kafka_outlet {
             Some(c) => {
@@ -39,7 +39,7 @@ impl KafkaOutlet {
                 if let Some(node_name) = default_node_name {
                     for cmd in cmds.iter_mut() {
                         if cmd.node_opts.at_node.is_none() {
-                            cmd.node_opts.at_node = Some(node_name.clone())
+                            cmd.node_opts.at_node = Some(node_name.to_string())
                         }
                     }
                 }
@@ -67,7 +67,7 @@ mod tests {
         let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
@@ -84,8 +84,8 @@ mod tests {
         let parsed: KafkaOutlet = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
-        assert_eq!(cmds[0].node_opts.at_node, Some(default_node_name));
+        assert_eq!(cmds[0].node_opts.at_node.as_ref(), Some(&default_node_name));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/relays.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/relays.rs
@@ -29,7 +29,7 @@ impl Relays {
 
     pub fn into_parsed_commands(
         self,
-        default_node_name: &Option<String>,
+        default_node_name: Option<&String>,
     ) -> Result<Vec<CreateCommand>> {
         match self.relays {
             Some(c) => {
@@ -37,7 +37,7 @@ impl Relays {
                 if let Some(node_name) = default_node_name {
                     for cmd in cmds.iter_mut() {
                         if cmd.to.is_none() {
-                            cmd.to = Some(node_name.clone());
+                            cmd.to = Some(node_name.to_string());
                         }
                     }
                 };
@@ -60,7 +60,7 @@ mod tests {
             let parsed: Relays = serde_yaml::from_str(c).unwrap();
             let default_node_name = "n1".to_string();
             let cmds = parsed
-                .into_parsed_commands(&Some(default_node_name.clone()))
+                .into_parsed_commands(Some(&default_node_name))
                 .unwrap();
             assert_eq!(cmds.len(), 1);
             let cmd = cmds.into_iter().next().unwrap();
@@ -68,7 +68,7 @@ mod tests {
 
             // if the 'to' value has not been explicitly set, use the default node name
             if cmd.to != Some("outlet-node".to_string()) {
-                assert_eq!(cmd.to, Some(default_node_name));
+                assert_eq!(cmd.to, Some(default_node_name.to_string()));
             }
         };
 
@@ -100,14 +100,14 @@ mod tests {
             let parsed: Relays = serde_yaml::from_str(c).unwrap();
             let default_node_name = "n1".to_string();
             let cmds = parsed
-                .into_parsed_commands(&Some(default_node_name.clone()))
+                .into_parsed_commands(Some(&default_node_name))
                 .unwrap();
             assert_eq!(cmds.len(), 2);
             assert_eq!(cmds[0].relay_name, "r1");
-            assert_eq!(cmds[0].to, Some(default_node_name.clone()));
+            assert_eq!(cmds[0].to.as_ref(), Some(&default_node_name));
 
             assert_eq!(cmds[1].relay_name, "r2");
-            assert_eq!(cmds[1].to, Some(default_node_name));
+            assert_eq!(cmds[1].to.as_ref(), Some(&default_node_name));
         };
 
         // Name only

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
@@ -29,7 +29,7 @@ impl TcpInlets {
 
     pub fn into_parsed_commands(
         self,
-        default_node_name: &Option<String>,
+        default_node_name: Option<&String>,
     ) -> Result<Vec<CreateCommand>> {
         match self.tcp_inlets {
             Some(c) => {
@@ -38,7 +38,7 @@ impl TcpInlets {
                 if let Some(node_name) = default_node_name.as_ref() {
                     for cmd in cmds.iter_mut() {
                         if cmd.at.is_none() {
-                            cmd.at = Some(node_name.clone())
+                            cmd.at = Some(node_name.to_string())
                         }
                     }
                 }
@@ -70,7 +70,7 @@ mod tests {
         let parsed: TcpInlets = serde_yaml::from_str(named).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].alias, "ti1");
@@ -84,7 +84,7 @@ mod tests {
             cmds[1].from,
             SocketAddr::from_str("127.0.0.1:6061").unwrap()
         );
-        assert_eq!(cmds[1].at, Some(default_node_name.clone()));
+        assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
 
         let unnamed = r#"
             tcp_inlets:
@@ -94,7 +94,7 @@ mod tests {
         "#;
         let parsed: TcpInlets = serde_yaml::from_str(unnamed).unwrap();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(
@@ -106,6 +106,6 @@ mod tests {
             cmds[1].from,
             SocketAddr::from_str("127.0.0.1:6061").unwrap()
         );
-        assert_eq!(cmds[1].at, Some(default_node_name));
+        assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_outlets.rs
@@ -30,7 +30,7 @@ impl TcpOutlets {
 
     pub fn into_parsed_commands(
         self,
-        default_node_name: &Option<String>,
+        default_node_name: Option<&String>,
     ) -> Result<Vec<CreateCommand>> {
         match self.tcp_outlets {
             Some(c) => {
@@ -38,7 +38,7 @@ impl TcpOutlets {
                 if let Some(node_name) = default_node_name {
                     for cmd in cmds.iter_mut() {
                         if cmd.at.is_none() {
-                            cmd.at = Some(node_name.clone())
+                            cmd.at = Some(node_name.to_string())
                         }
                     }
                 }
@@ -68,7 +68,7 @@ mod tests {
         let parsed: TcpOutlets = serde_yaml::from_str(config).unwrap();
         let default_node_name = "n1".to_string();
         let cmds = parsed
-            .into_parsed_commands(&Some(default_node_name.clone()))
+            .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].from.clone().unwrap(), "to1");
@@ -76,6 +76,6 @@ mod tests {
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
         assert_eq!(cmds[1].from.clone().unwrap(), "my_outlet");
         assert_eq!(cmds[1].to, HostnamePort::new("127.0.0.1", 6061));
-        assert_eq!(cmds[1].at, Some(default_node_name));
+        assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -149,6 +149,6 @@ mod tests {
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
         config.project_enroll.into_parsed_commands().unwrap();
-        config.tcp_inlets.into_parsed_commands(&None).unwrap();
+        config.tcp_inlets.into_parsed_commands(None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -152,7 +152,7 @@ mod tests {
         let config = Config::parse(config_recipe.as_str()).unwrap();
         config.project_enroll.into_parsed_commands().unwrap();
         config.policies.into_parsed_commands().unwrap();
-        config.tcp_outlets.into_parsed_commands(&None).unwrap();
-        config.relays.into_parsed_commands(&None).unwrap();
+        config.tcp_outlets.into_parsed_commands(None).unwrap();
+        config.relays.into_parsed_commands(None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -146,6 +146,14 @@ force_kill_node() {
   assert_output --partial "127.0.0.1:5432"
 }
 
+@test "node - node in foreground with configuration is deleted if something fails" {
+  # The config file has a typo in the "to" address to trigger an error after the node is created.
+  # The command should return an error and the node should be deleted.
+  run_failure "$OCKAM" node create --node-config "{name: n, tcp-outlets: {db-outlet: {to: \"localhosst:3000\"}}}"
+  run_success $OCKAM node show n --output json
+  assert_output --partial "[]"
+}
+
 @test "node - create two nodes with the same inline configuration" {
   run_success "$OCKAM" node create --node-config "{tcp-outlets: {to: 8080}}"
   run_success "$OCKAM" node create --node-config "{tcp-outlets: {to: 8080}}"


### PR DESCRIPTION
If a node created in the foreground with a config fails (starting the node, or creating any of the resources from the config), it will return an error and delete the node to clean everything up.

Also, I added a ctrl+c handler for this specific case to avoid leaking the node's output into the next terminal prompt. See the image below:

![image](https://github.com/build-trust/ockam/assets/12375782/42766674-e072-48b4-a025-fd024487a503)
