### PR TITLE
feat(rust): allow kafka portals to anchor trust on identities

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-server.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-server.rs
@@ -84,10 +84,20 @@ async fn main(ctx: Context) -> Result<()> {
         DefaultAddress::ECHO_SERVICE,
         &sc_listener_options.spawner_flow_control_id(),
     );
-    let allow_production_incoming =
-        IncomingAbac::create_name_value(node.identities_attributes(), issuer.clone(), "cluster", "production");
-    let allow_production_outgoing =
-        OutgoingAbac::create_name_value(&ctx, node.identities_attributes(), issuer, "cluster", "production").await?;
+    let allow_production_incoming = IncomingAbac::create_name_value(
+        node.identities_attributes(),
+        Some(issuer.clone()),
+        "cluster",
+        "production",
+    );
+    let allow_production_outgoing = OutgoingAbac::create_name_value(
+        &ctx,
+        node.identities_attributes(),
+        Some(issuer),
+        "cluster",
+        "production",
+    )
+    .await?;
     node.start_worker_with_access_control(
         DefaultAddress::ECHO_SERVICE,
         Echoer,

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-control-plane.rs
@@ -90,14 +90,14 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 3. create an access control policy checking the value of the "component" attribute of the caller
     let incoming_access_control = IncomingAbac::create_name_value(
         node.identities_attributes(),
-        project.authority_identifier(),
+        Some(project.authority_identifier()),
         "component",
         "edge",
     );
     let outgoing_access_control = OutgoingAbac::create_name_value(
         node.context(),
         node.identities_attributes(),
-        project.authority_identifier(),
+        Some(project.authority_identifier()),
         "component",
         "edge",
     )

--- a/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
+++ b/examples/rust/get_started/examples/11-attribute-based-authentication-edge-plane.rs
@@ -90,14 +90,14 @@ async fn start_node(ctx: Context, project_information_path: &str, token: OneTime
     // 3. create an access control policy checking the value of the "component" attribute of the caller
     let incoming_access_control = IncomingAbac::create_name_value(
         identities().await?.identities_attributes(),
-        project.authority_identifier(),
+        Some(project.authority_identifier()),
         "component",
         "control",
     );
     let outgoing_access_control = OutgoingAbac::create_name_value(
         node.context(),
         identities().await?.identities_attributes(),
-        project.authority_identifier(),
+        Some(project.authority_identifier()),
         "component",
         "control",
     )

--- a/implementations/rust/ockam/ockam_abac/src/abac/incoming.rs
+++ b/implementations/rust/ockam/ockam_abac/src/abac/incoming.rs
@@ -26,7 +26,7 @@ impl IncomingAbac {
     /// a message has an authenticated attribute that resolves the expression to `true`
     pub fn create(
         identities_attributes: Arc<IdentitiesAttributes>,
-        authority: Identifier,
+        authority: Option<Identifier>,
         expression: Expr,
     ) -> Self {
         let abac = Abac::new(identities_attributes, authority, Env::new());
@@ -38,7 +38,7 @@ impl IncomingAbac {
     /// a message has an authenticated attribute with the correct name and value
     pub fn create_name_value(
         identities_attributes: Arc<IdentitiesAttributes>,
-        authority: Identifier,
+        authority: Option<Identifier>,
         attribute_name: &str,
         attribute_value: &str,
     ) -> Self {
@@ -56,7 +56,7 @@ impl IncomingAbac {
         identities_attributes: Arc<IdentitiesAttributes>,
         authority: Identifier,
     ) -> Self {
-        Self::create(identities_attributes, authority, true.into())
+        Self::create(identities_attributes, Some(authority), true.into())
     }
 
     /// Returns true if the sender of the message is validated by the expression stored in AbacAccessControl

--- a/implementations/rust/ockam/ockam_abac/src/abac/outgoing.rs
+++ b/implementations/rust/ockam/ockam_abac/src/abac/outgoing.rs
@@ -38,7 +38,7 @@ impl OutgoingAbac {
     pub async fn create(
         ctx: &Context,
         identities_attributes: Arc<IdentitiesAttributes>,
-        authority: Identifier,
+        authority: Option<Identifier>,
         expression: Expr,
     ) -> Result<Self> {
         let ctx = ctx
@@ -58,7 +58,7 @@ impl OutgoingAbac {
     pub async fn create_name_value(
         ctx: &Context,
         identities_attributes: Arc<IdentitiesAttributes>,
-        authority: Identifier,
+        authority: Option<Identifier>,
         attribute_name: &str,
         attribute_value: &str,
     ) -> Result<Self> {
@@ -77,7 +77,7 @@ impl OutgoingAbac {
         identities_attributes: Arc<IdentitiesAttributes>,
         authority: Identifier,
     ) -> Result<Self> {
-        Self::create(ctx, identities_attributes, authority, true.into()).await
+        Self::create(ctx, identities_attributes, Some(authority), true.into()).await
     }
 
     /// Returns true if the sender of the message is validated by the expression stored in AbacAccessControl

--- a/implementations/rust/ockam/ockam_abac/src/policy/access_control.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/access_control.rs
@@ -42,7 +42,7 @@ impl PolicyAccessControl {
     pub fn new(
         policies: Policies,
         identities_attributes: Arc<IdentitiesAttributes>,
-        authority: Identifier,
+        authority: Option<Identifier>,
         env: Env,
         resource: Resource,
         action: Action,

--- a/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
@@ -9,7 +9,7 @@ use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_identity::{Identifier, IdentitiesAttributes};
 use strum::IntoEnumIterator;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 #[derive(Clone)]
 pub struct Policies {
@@ -28,14 +28,14 @@ impl Policies {
         }
     }
 
-    #[instrument(skip_all, fields(resource = %resource, action = %action, env = %env, authority = %authority))]
+    //TODO #[instrument(skip_all, fields(resource = %resource, action = %action, env = %env, authority = %authority))]
     pub fn make_policy_access_control(
         &self,
         identities_attributes: Arc<IdentitiesAttributes>,
         resource: Resource,
         action: Action,
         env: Env,
-        authority: Identifier,
+        authority: Option<Identifier>,
     ) -> PolicyAccessControl {
         debug!(
             "set a policy access control for resource '{}' of type '{}' and action '{}'",

--- a/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
+++ b/implementations/rust/ockam/ockam_abac/src/policy/policies.rs
@@ -9,7 +9,7 @@ use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_identity::{Identifier, IdentitiesAttributes};
 use strum::IntoEnumIterator;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 #[derive(Clone)]
 pub struct Policies {
@@ -28,7 +28,7 @@ impl Policies {
         }
     }
 
-    //TODO #[instrument(skip_all, fields(resource = %resource, action = %action, env = %env, authority = %authority))]
+    #[instrument(skip_all, fields(resource = %resource, action = %action, env = %env, authority = ?authority))]
     pub fn make_policy_access_control(
         &self,
         identities_attributes: Arc<IdentitiesAttributes>,

--- a/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/integration_test.rs
@@ -65,7 +65,7 @@ mod test {
         let consumer_policy_access_control = handler
             .node_manager
             .policy_access_control(
-                project_authority.clone(),
+                Some(project_authority.clone()),
                 Resource::new(listener_address.address(), ResourceType::KafkaConsumer),
                 Action::HandleMessage,
                 None,
@@ -75,7 +75,7 @@ mod test {
         let producer_policy_access_control = handler
             .node_manager
             .policy_access_control(
-                project_authority.clone(),
+                Some(project_authority.clone()),
                 Resource::new(listener_address.address(), ResourceType::KafkaProducer),
                 Action::HandleMessage,
                 None,

--- a/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/outlet_service/interceptor_listener.rs
@@ -5,7 +5,7 @@ use crate::kafka::KAFKA_OUTLET_INTERCEPTOR_ADDRESS;
 use ockam::{Any, Context, Result, Routed, Worker};
 use ockam_abac::PolicyExpression;
 use ockam_core::flow_control::{FlowControlId, FlowControls};
-use ockam_core::{Address, IncomingAccessControl, OutgoingAccessControl};
+use ockam_core::{Address, AllowAll, IncomingAccessControl, OutgoingAccessControl};
 use ockam_node::WorkerBuilder;
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ impl OutletManagerService {
         default_secure_channel_listener_flow_control_id: FlowControlId,
         policy_expression: Option<PolicyExpression>,
         request_incoming_access_control: Arc<dyn IncomingAccessControl>,
-        response_outgoing_access_control: Arc<dyn OutgoingAccessControl>,
+        _response_outgoing_access_control: Arc<dyn OutgoingAccessControl>,
         tls: bool,
     ) -> Result<()> {
         let flow_controls = context.flow_controls();
@@ -44,7 +44,9 @@ impl OutletManagerService {
         let worker = OutletManagerService {
             outlet_controller: KafkaOutletController::new(policy_expression, tls),
             request_incoming_access_control,
-            response_outgoing_access_control,
+            //TODO FIXME: make this work, if needed.
+            //response_outgoing_access_control,
+            response_outgoing_access_control: Arc::new(AllowAll),
             spawner_flow_control_id: spawner_flow_control_id.clone(),
         };
 

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -780,7 +780,7 @@ mod test {
             Resource::new("arbitrary-resource-name", ResourceType::KafkaConsumer),
             Action::HandleMessage,
             Env::new(),
-            authority_identifier.clone(),
+            Some(authority_identifier.clone()),
         );
 
         let producer_policy_access_control = policies.make_policy_access_control(
@@ -788,7 +788,7 @@ mod test {
             Resource::new("arbitrary-resource-name", ResourceType::KafkaProducer),
             Action::HandleMessage,
             Env::new(),
-            authority_identifier.clone(),
+            Some(authority_identifier.clone()),
         );
 
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new(
@@ -858,7 +858,7 @@ mod test {
         let consumer_policy_access_control = handle
             .node_manager
             .policy_access_control(
-                project_authority.clone(),
+                Some(project_authority.clone()),
                 Resource::new("arbitrary-resource-name", ResourceType::KafkaConsumer),
                 Action::HandleMessage,
                 None,
@@ -868,7 +868,7 @@ mod test {
         let producer_policy_access_control = handle
             .node_manager
             .policy_access_control(
-                project_authority.clone(),
+                Some(project_authority.clone()),
                 Resource::new("arbitrary-resource-name", ResourceType::KafkaProducer),
                 Action::HandleMessage,
                 None,

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -41,7 +41,7 @@ mod test {
             Resource::new("arbitrary-resource-name", ResourceType::KafkaConsumer),
             Action::HandleMessage,
             Env::new(),
-            handle.node_manager.identifier(),
+            Some(handle.node_manager.identifier()),
         );
 
         let producer_policy_access_control = policies.make_policy_access_control(
@@ -49,7 +49,7 @@ mod test {
             Resource::new("arbitrary-resource-name", ResourceType::KafkaProducer),
             Action::HandleMessage,
             Env::new(),
-            handle.node_manager.identifier(),
+            Some(handle.node_manager.identifier()),
         );
 
         let secure_channel_controller = KafkaSecureChannelControllerImpl::new(

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -120,14 +120,9 @@ impl InMemoryNode {
         consumer_policy_expression: Option<PolicyExpression>,
         producer_policy_expression: Option<PolicyExpression>,
     ) -> Result<()> {
-        let project_authority = self
-            .project_authority
-            .clone()
-            .ok_or(ApiError::core("NodeManager has no authority"))?;
-
         let consumer_policy_access_control = self
             .policy_access_control(
-                project_authority.clone(),
+                self.project_authority().clone(),
                 Resource::new(
                     format!("kafka-consumer-{}", local_interceptor_address.address()),
                     ResourceType::KafkaConsumer,
@@ -139,7 +134,7 @@ impl InMemoryNode {
 
         let producer_policy_access_control = self
             .policy_access_control(
-                project_authority.clone(),
+                self.project_authority().clone(),
                 Resource::new(
                     format!("kafka-producer-{}", local_interceptor_address.address()),
                     ResourceType::KafkaProducer,
@@ -217,7 +212,7 @@ impl InMemoryNode {
 
         let policy_access_control = self
             .policy_access_control(
-                project_authority,
+                self.project_authority().clone(),
                 Resource::new(
                     local_interceptor_address.to_string(),
                     ResourceType::TcpInlet,
@@ -269,14 +264,9 @@ impl InMemoryNode {
         )
         .await?;
 
-        let project_authority = self
-            .project_authority
-            .clone()
-            .ok_or(ApiError::core("NodeManager has no authority"))?;
-
         let policy_access_control = self
             .policy_access_control(
-                project_authority,
+                self.project_authority().clone(),
                 Resource::new(service_address.to_string(), ResourceType::TcpOutlet),
                 Action::HandleMessage,
                 outlet_policy_expression.clone(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -392,7 +392,7 @@ impl NodeManager {
         let resource_name_str = resource.resource_name.as_str();
         let resource_type_str = resource.resource_type.to_string();
         let action_str = action.as_ref();
-        if let Some(authority) = authority {
+        if authority.is_some() || expression.is_some() {
             let policy_access_control = self
                 .policy_access_control(authority, resource, action, expression)
                 .await?;
@@ -411,6 +411,10 @@ impl NodeManager {
                 }
             }
         } else {
+            // If no expression is given, assume it's AllowAll, but only if no authority
+            // was set neither. Why: not sure, but to behave as it was previusly if there
+            // is an authority set.  If there is no authority, but still some expression,
+            // we use the provided policy expression
             warn! {
                 resource_name = resource_name_str,
                 resource_type = resource_type_str,
@@ -431,7 +435,7 @@ impl NodeManager {
 
     pub async fn policy_access_control(
         &self,
-        authority: Identifier,
+        authority: Option<Identifier>,
         resource: Resource,
         action: Action,
         expression: Option<PolicyExpression>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -412,7 +412,7 @@ impl NodeManager {
             }
         } else {
             // If no expression is given, assume it's AllowAll, but only if no authority
-            // was set neither. Why: not sure, but to behave as it was previusly if there
+            // was set neither. Why: not sure, but to behave as it was previously if there
             // is an authority set.  If there is no authority, but still some expression,
             // we use the provided policy expression
             warn! {


### PR DESCRIPTION
This is a rebase of https://github.com/build-trust/ockam/pull/8072 on top of the latest changes on https://github.com/build-trust/ockam/pull/7938.

Changes are:
* Make authority optional, instead of mandatory for evaluating abac rules
* Propagate that change everywhere
* 🔴 🔴 🔴  Hardcoded  `response_outgoing_access_control`to `AllowAll` in  `interceptor_listener` ⚠️⚠️ ⚠️.   Because couldn't make the standalone, no orchestrator,   example work otherwise. No matter what policy I tried to put there  ( `(= "true" "true")` for example), it end up failing because something not being able to find the identity that the message would be sent to (iiuc `DEBUG ockam_abac::policy::outgoing: identity identifier not found; access denied policy=(= "true3" "true3")`).  So it's something with the setup or with the code, for now I'm letting this here so others can reference and test it.

**Last item requires** 👁️ !!