### PR TITLE
feat(rust): use a different logger to log tracing/logging errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f248c29a6d4bc5d065c9e9068d858761a0dcd796759f7801cc14db35db23abd8"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "log",
+ "nu-ansi-term 0.49.0",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +4407,7 @@ dependencies = [
  "dialoguer",
  "either",
  "fake",
+ "flexi_logger",
  "futures 0.3.30",
  "gethostname 0.4.3",
  "hex",
@@ -4403,6 +4419,7 @@ dependencies = [
  "indicatif",
  "itertools 0.12.1",
  "kafka-protocol",
+ "log",
  "miette",
  "minicbor",
  "mockall",

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -215,6 +215,7 @@ This file contains attributions for any 3rd-party open source code used in this 
 | ff | MIT, Apache-2.0 | https://crates.io/crates/ff |
 | fiat-crypto | MIT, Apache-2.0, BSD-1-Clause | https://crates.io/crates/fiat-crypto |
 | flate2 | MIT, Apache-2.0 | https://crates.io/crates/flate2 |
+| flexi_logger | MIT, Apache-2.0 | https://crates.io/crates/flexi_logger |
 | flume | Apache-2.0, MIT | https://crates.io/crates/flume |
 | fnv | Apache-2.0, MIT | https://crates.io/crates/fnv |
 | foreign-types | MIT, Apache-2.0 | https://crates.io/crates/foreign-types |

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -40,6 +40,7 @@ colorful = "0.2"
 colors-transform = "0.2"
 dialoguer = "0.11"
 either = { version = "1.11.0", default-features = false }
+flexi_logger = "0.28"
 futures = { version = "0.3.30", features = [] }
 gethostname = "0.4.3"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
@@ -50,6 +51,7 @@ hyper-util = { version = "0", default-features = false, features = ["server", "h
 indicatif = "0.17"
 itertools = "0.12.1"
 kafka-protocol = "0.10"
+log = "0.4"
 miette = "7"
 minicbor = { version = "0.24.0", features = ["alloc", "derive"] }
 nix = { version = "0.28", features = ["signal"] }

--- a/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
@@ -42,3 +42,9 @@ pub(crate) const DEFAULT_FOREGROUND_EXPORT_SCHEDULED_DELAY: Duration = Duration:
 
 // Maximum time between the export of batches
 pub(crate) const DEFAULT_BACKGROUND_EXPORT_SCHEDULED_DELAY: Duration = Duration::from_secs(1);
+
+// Size of the queue used to batch spans.
+pub(crate) const DEFAULT_SPAN_EXPORT_QUEUE_SIZE: u16 = 2048;
+
+// Size of the queue used to batch logs.
+pub(crate) const DEFAULT_LOG_EXPORT_QUEUE_SIZE: u16 = 2048;

--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -86,6 +86,14 @@ pub(crate) const OCKAM_FOREGROUND_LOG_EXPORT_SCHEDULED_DELAY: &str =
 pub(crate) const OCKAM_BACKGROUND_LOG_EXPORT_SCHEDULED_DELAY: &str =
     "OCKAM_BACKGROUND_LOG_EXPORT_SCHEDULED_DELAY";
 
+/// Size of the queue used to batch spans.
+/// Accepted values, u16. For example: 2048
+pub(crate) const OCKAM_SPAN_EXPORT_QUEUE_SIZE: &str = "OCKAM_SPAN_EXPORT_QUEUE_SIZE";
+
+/// Size of the queue used to batch log records.
+/// Accepted values, u16. For example: 2048
+pub(crate) const OCKAM_LOG_EXPORT_QUEUE_SIZE: &str = "OCKAM_LOG_EXPORT_QUEUE_SIZE";
+
 ///
 /// OPENTELEMETRY COLLECTOR ERRORS CONFIGURATION
 ///

--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -28,6 +28,10 @@ pub struct ExportingConfiguration {
     span_export_scheduled_delay: Duration,
     /// Maximum time to wait until sending the current batch of logs
     log_export_scheduled_delay: Duration,
+    /// Size of the queue used to batch spans
+    span_export_queue_size: u16,
+    /// Size of the queue used to batch logs
+    log_export_queue_size: u16,
     /// Url of the OpenTelemetry collector
     opentelemetry_endpoint: Url,
     /// True if the user is an Ockam developer
@@ -66,6 +70,16 @@ impl ExportingConfiguration {
         self.span_export_scheduled_delay
     }
 
+    /// Size of the queue used for batching spans
+    pub fn span_export_queue_size(&self) -> u16 {
+        self.span_export_queue_size
+    }
+
+    /// Size of the queue used for batching log records
+    pub fn log_export_queue_size(&self) -> u16 {
+        self.log_export_queue_size
+    }
+
     /// Return the URL where to export spans and log records
     pub fn opentelemetry_endpoint(&self) -> Url {
         self.opentelemetry_endpoint.clone()
@@ -83,6 +97,8 @@ impl ExportingConfiguration {
             log_export_timeout: span_export_timeout()?,
             span_export_scheduled_delay: foreground_span_export_scheduled_delay()?,
             log_export_scheduled_delay: foreground_log_export_scheduled_delay()?,
+            span_export_queue_size: span_export_queue_size()?,
+            log_export_queue_size: log_export_queue_size()?,
             opentelemetry_endpoint: opentelemetry_endpoint()?,
             is_ockam_developer: is_ockam_developer()?,
         })
@@ -99,6 +115,8 @@ impl ExportingConfiguration {
             log_export_timeout: log_export_timeout()?,
             span_export_scheduled_delay: background_span_export_scheduled_delay()?,
             log_export_scheduled_delay: background_log_export_scheduled_delay()?,
+            span_export_queue_size: span_export_queue_size()?,
+            log_export_queue_size: log_export_queue_size()?,
             opentelemetry_endpoint: opentelemetry_endpoint()?,
             is_ockam_developer: is_ockam_developer()?,
         })
@@ -112,6 +130,8 @@ impl ExportingConfiguration {
             log_export_timeout: DEFAULT_EXPORT_TIMEOUT,
             span_export_scheduled_delay: DEFAULT_FOREGROUND_EXPORT_SCHEDULED_DELAY,
             log_export_scheduled_delay: DEFAULT_FOREGROUND_EXPORT_SCHEDULED_DELAY,
+            span_export_queue_size: DEFAULT_SPAN_EXPORT_QUEUE_SIZE,
+            log_export_queue_size: DEFAULT_LOG_EXPORT_QUEUE_SIZE,
             opentelemetry_endpoint: Self::default_opentelemetry_endpoint()?,
             is_ockam_developer: is_ockam_developer()?,
         })
@@ -236,6 +256,16 @@ fn background_span_export_scheduled_delay() -> ockam_core::Result<Duration> {
         OCKAM_BACKGROUND_SPAN_EXPORT_SCHEDULED_DELAY,
         DEFAULT_BACKGROUND_EXPORT_SCHEDULED_DELAY,
     )
+}
+
+/// Return the size of the queue used to batch spans, defined by an environment variable
+fn span_export_queue_size() -> ockam_core::Result<u16> {
+    get_env_with_default(OCKAM_SPAN_EXPORT_QUEUE_SIZE, DEFAULT_SPAN_EXPORT_QUEUE_SIZE)
+}
+
+/// Return the size of the queue used to batch log records, defined by an environment variable
+fn log_export_queue_size() -> ockam_core::Result<u16> {
+    get_env_with_default(OCKAM_LOG_EXPORT_QUEUE_SIZE, DEFAULT_LOG_EXPORT_QUEUE_SIZE)
 }
 
 /// Return the export timeout for log records, defined by an environment variable

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_configuration.rs
@@ -144,6 +144,11 @@ impl LoggingConfiguration {
         }
     }
 
+    /// Set the log level crates
+    pub fn set_log_level(self, level: Level) -> LoggingConfiguration {
+        LoggingConfiguration { level, ..self }
+    }
+
     /// Create an EnvFilter which keeps only the log messages
     ///
     ///  - for the configured level
@@ -319,7 +324,7 @@ fn get_log_level(
         None => get_env_with_default(
             variable_name,
             LevelVar {
-                level: Level::TRACE,
+                level: Level::DEBUG,
             },
         )
         .map(|l| l.level),

--- a/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/trace_code.rs
@@ -22,7 +22,10 @@ where
     let guard = LoggingTracing::setup_with_exporters(
         spans_exporter.clone(),
         InMemoryLogsExporter::default(),
-        &LoggingConfiguration::off().unwrap().set_all_crates(),
+        &LoggingConfiguration::off()
+            .unwrap()
+            .set_all_crates()
+            .set_log_level(tracing_core::metadata::Level::TRACE),
         &ExportingConfiguration::foreground(true).unwrap(),
         "test",
         None,

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -15,7 +15,7 @@ CLI Behavior
 Logging
 - OCKAM_LOG (deprecated, use OCKAM_LOGGING and OCKAM_LOG_LEVEL instead): a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`.
 - OCKAM_LOGGING: set this variable to any value in order to enable logging.
-- OCKAM_LOG_LEVEL: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`. Default value: `trace`.
+- OCKAM_LOG_LEVEL: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`. Default value: `debug`.
 - OCKAM_LOG_FORMAT: a `string` that overrides the default format of the logs: `default`, `json`, or `pretty`. Default value: `default`.
 - OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB. Default value `100`.
 - OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node. Default value `60`.
@@ -31,7 +31,9 @@ Tracing
 - OCKAM_LOG_EXPORT_TIMEOUT: Timeout for trying to export log records. Default value: `5s`.
 - OCKAM_FOREGROUND_SPAN_EXPORT_SCHEDULED_DELAY: Timeout for exporting the current batch of spans. Default value: `1000s` (this value is high to avoid a deadlock in the tracing library).
 - OCKAM_BACKGROUND_SPAN_EXPORT_SCHEDULED_DELAY: Timeout for exporting the current batch of spans. Default value: `5s`.
-- OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `console`.
+- OCKAM_SPAN_EXPORT_QUEUE_SIZE: Size of the queue used to store batched spans before export. When the queue is full, spans are dropped. Default value: `2048`
+- OCKAM_LOG_EXPORT_QUEUE_SIZE: Size of the queue used to store batched log records before export. When the queue is full, log records are dropped. Default value: `2048`
+- OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `logfile`.
 
 Devs Usage
 - OCKAM: a `string` that defines the path to the ockam binary to use.


### PR DESCRIPTION
When too many log messages are being emitted, the queue batching logs messages can become full. In that case a global error handler logs the error. However logging the error uses the same logging infrastructure as the one that is currently full, which creates a stack overflow error.

This PR fixes this issue by:

 1. Setting the default log level to 'debug'. This will make this situation less likely to happen by default (the log level was set to 'trace' by default before), which is is something that I tested on the problematic example.

 2. Introducing 2 new configuration parameters to increase the queue sizes for spans and log records if necessary. Note that, when a queue is full, additional spans and logs are being dropped.

 3. Use a different library to log error messages raised by the `tracing` library. The logging errors go to a file named `logging_tracing_errors` (in a node logging directory). That file is rolled every 3 days in order to limit the amount of data potentially logged. I unfortunately had to use a different library (which introduces another dependency to the project) since when a logging error happens we can not rely on the main logging configuration that's instantiated globally.

 4. I also fixed the documentation showing the default value for the global error handler for logging errors. It should have been `logfile` instead of `console`.

