### PR TITLE
fixes kafka reject

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/secure_channels.rs
@@ -2,6 +2,7 @@ use crate::kafka::secure_channel_map::controller::{
     InnerSecureChannelControllerImpl, KafkaSecureChannelControllerImpl,
 };
 use crate::kafka::ConsumerResolution;
+use crate::nodes::service::SecureChannelType;
 use crate::DefaultAddress;
 use ockam::identity::SecureChannelRegistryEntry;
 use ockam_core::errcode::{Kind, Origin};
@@ -22,7 +23,15 @@ impl KafkaSecureChannelControllerImpl {
 
         let secure_channel = inner
             .node_manager
-            .create_secure_channel(context, destination, None, None, None, None)
+            .create_secure_channel(
+                context,
+                destination,
+                None,
+                None,
+                None,
+                None,
+                SecureChannelType::KeyExchangeAndMessages,
+            )
             .await?;
 
         Ok(secure_channel.encryptor_address().clone())
@@ -38,7 +47,15 @@ impl KafkaSecureChannelControllerImpl {
 
         let secure_channel = inner
             .node_manager
-            .create_key_exchange_secure_channel(context, destination, None, None, None)
+            .create_secure_channel(
+                context,
+                destination,
+                None,
+                None,
+                None,
+                None,
+                SecureChannelType::KeyExchangeOnly,
+            )
             .await?;
 
         Ok(secure_channel.encryptor_address().clone())

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -9,6 +9,7 @@ use ockam_multiaddr::proto::Project;
 use ockam_multiaddr::{Match, MultiAddr, Protocol};
 use ockam_node::Context;
 
+use crate::nodes::service::SecureChannelType;
 use ockam::identity::Identifier;
 use std::time::Duration;
 
@@ -71,6 +72,7 @@ impl Instantiator for ProjectInstantiator {
                 Some(vec![project_identifier]),
                 None,
                 self.timeout,
+                SecureChannelType::KeyExchangeAndMessages,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/secure.rs
@@ -5,6 +5,7 @@ use crate::nodes::connection::{Changes, Instantiator};
 use crate::nodes::NodeManager;
 use crate::{local_multiaddr_to_route, try_address_to_multiaddr};
 
+use crate::nodes::service::SecureChannelType;
 use ockam::identity::Identifier;
 use ockam_core::{async_trait, route, AsyncTryClone, Error, Route};
 use ockam_multiaddr::proto::Secure;
@@ -60,6 +61,7 @@ impl Instantiator for SecureChannelInstantiator {
                 self.authorized_identities.clone(),
                 None,
                 self.timeout,
+                SecureChannelType::KeyExchangeAndMessages,
             )
             .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -26,6 +26,7 @@ mod trust;
 mod worker;
 
 pub use manager::*;
+pub use secure_channel::SecureChannelType;
 pub use trust::*;
 pub use worker::*;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -10,6 +10,7 @@ use crate::nodes::registry::Registry;
 use crate::nodes::service::http::HttpServer;
 use crate::nodes::service::{
     CredentialRetrieverCreators, NodeManagerCredentialRetrieverOptions, NodeManagerTrustOptions,
+    SecureChannelType,
 };
 
 use crate::session::MedicHandle;
@@ -194,6 +195,7 @@ impl NodeManager {
             None, // Not checking identifiers here in favor of credential check
             None,
             ctx,
+            SecureChannelType::KeyExchangeAndMessages,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -20,6 +20,7 @@ use crate::nodes::models::secure_channel::{
 };
 use crate::nodes::registry::RegistryRelayInfo;
 use crate::nodes::service::in_memory_node::InMemoryNode;
+use crate::nodes::service::secure_channel::SecureChannelType;
 use crate::nodes::BackgroundNodeClient;
 use crate::session::sessions::{ReplacerOutcome, ReplacerOutputKind, Session, SessionReplacer};
 use crate::session::MedicHandle;
@@ -400,6 +401,7 @@ impl SecureChannelsCreation for InMemoryNode {
                 Some(vec![authorized]),
                 credential,
                 timeout,
+                SecureChannelType::KeyExchangeAndMessages,
             )
             .await
             .into_diagnostic()

--- a/implementations/rust/ockam/ockam_api/tests/latency.rs
+++ b/implementations/rust/ockam/ockam_api/tests/latency.rs
@@ -1,3 +1,4 @@
+use ockam_api::nodes::service::SecureChannelType;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -44,6 +45,7 @@ pub fn measure_message_latency_two_nodes() {
                     None,
                     None,
                     None,
+                    SecureChannelType::KeyExchangeAndMessages,
                 )
                 .await
                 .unwrap();

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -368,7 +368,13 @@ impl HandshakeWorker {
 
         // create a separate encryptor worker which will be started independently
         {
-            let rekeying = !self.key_exchange_only;
+            let (rekeying, credential_retriever) = if self.key_exchange_only {
+                // only the initial exchange is needed for key exchange only
+                (false, None)
+            } else {
+                (true, self.credential_retriever.clone())
+            };
+
             self.shared_state.remote_route.write().unwrap().route = self.remote_route()?;
             let encryptor = EncryptorWorker::new(
                 self.role.str(),
@@ -382,7 +388,7 @@ impl HandshakeWorker {
                 ),
                 self.identifier.clone(),
                 self.change_history_repository.clone(),
-                self.credential_retriever.clone(),
+                credential_retriever,
                 handshake_results.presented_credential,
                 self.shared_state.clone(),
             );

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -60,9 +60,6 @@ impl SecureChannelOptions {
         mut self,
         credential_retriever_creator: Arc<dyn CredentialRetrieverCreator>,
     ) -> Result<Self> {
-        if self.key_exchange_only {
-            return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
-        }
         if self.credential_retriever_creator.is_some() {
             return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
         }
@@ -96,15 +93,10 @@ impl SecureChannelOptions {
 
     /// The secure channel will be used to exchange key only.
     /// In this mode, the secure channel cannot be used to exchange messages, and key rotation
-    /// is disabled.
-    ///
-    /// Conflicts with [`with_credential_retriever_creator`] and [`with_credential`]
-    pub fn key_exchange_only(mut self) -> Result<Self> {
-        if self.credential_retriever_creator.is_some() {
-            return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
-        }
+    /// is disabled along with automatic credential refresh.
+    pub fn key_exchange_only(mut self) -> Self {
         self.key_exchange_only = true;
-        Ok(self)
+        self
     }
 }
 
@@ -208,9 +200,6 @@ impl SecureChannelListenerOptions {
         mut self,
         credential_retriever_creator: Arc<dyn CredentialRetrieverCreator>,
     ) -> Result<Self> {
-        if self.key_exchange_only {
-            return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
-        }
         if self.credential_retriever_creator.is_some() {
             return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
         }
@@ -244,15 +233,10 @@ impl SecureChannelListenerOptions {
 
     /// The listener will be used to exchange key only.
     /// In this mode, the secure channel cannot be used to exchange messages, and key rotation
-    /// is disabled.
-    ///
-    /// Conflicts with [`with_credential_retriever_creator`] and [`with_credential`]
-    pub fn key_exchange_only(mut self) -> Result<Self> {
-        if self.credential_retriever_creator.is_some() {
-            return Err(IdentityError::CredentialRetrieverCreatorAlreadySet.into());
-        }
+    /// is disabled along with automatic credential refresh.
+    pub fn key_exchange_only(mut self) -> Self {
         self.key_exchange_only = true;
-        Ok(self)
+        self
     }
 }
 


### PR DESCRIPTION
the key exchange only secure channel doesn't exchange any credential at all, by doing so, every attempt to validate the other identity based on credential will fail.
this pr allow initial credential exchange for key exchange only, fixing credential validation.