### PR TITLE
feat(rust): wait until the default node is up when initializing it

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -141,6 +141,17 @@ pub async fn get_node_resources(
     }
 }
 
+// Wait for a node to be up. We wait until the IS_NODE_ACCESSIBLE_TIMEOUT is passed and return `false`
+// if the node is not up after that time.
+pub async fn wait_until_node_is_up(
+    ctx: &Context,
+    cli_state: &CliState,
+    node_name: String,
+) -> Result<bool> {
+    let mut node = BackgroundNodeClient::create(ctx, cli_state, &Some(node_name)).await?;
+    is_node_up(ctx, &mut node, true).await
+}
+
 /// Send message(s) to a node to determine if it is 'up' and
 /// responding to requests.
 ///

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -9,6 +9,7 @@ use tracing::info;
 use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
 
+use crate::node::show::wait_until_node_is_up;
 use crate::node::CreateCommand;
 use crate::run::parser::resource::utils::subprocess_stdio;
 use crate::shared_args::TrustOpts;
@@ -56,6 +57,8 @@ pub async fn initialize_default_node(
         cmd.async_run(ctx, opts.clone()).await?;
         opts.terminal.write_line("")?;
     }
+    let node_name = opts.state.get_default_node().await?;
+    wait_until_node_is_up(ctx, &opts.state, node_name.name()).await?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR makes sure that we wait for the default node to be up when initializing it. This avoids connection errors when several concurrent processes try to initialize a default node and use it.