### PR TITLE
Secure Channel persistence

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -14,7 +14,8 @@ use crate::authenticator::{
 };
 use ockam::identity::utils::now;
 use ockam::identity::{
-    Identifier, Identities, SecureChannelListenerOptions, SecureChannels, TrustEveryonePolicy,
+    Identifier, Identities, SecureChannelListenerOptions, SecureChannelSqlxDatabase,
+    SecureChannels, TrustEveryonePolicy,
 };
 use ockam_core::compat::sync::Arc;
 use ockam_core::env::get_env;
@@ -65,17 +66,20 @@ impl Authority {
         debug!(?configuration, "creating the authority");
 
         // create the database
+        let node_name = "authority";
         let database_path = &configuration.database_path;
         Self::create_ockam_directory_if_necessary(database_path)?;
         let database = SqlxDatabase::create(database_path).await?;
         let members = Arc::new(AuthorityMembersSqlxDatabase::new(database.clone()));
         let tokens = Arc::new(AuthorityEnrollmentTokenSqlxDatabase::new(database.clone()));
+        let secure_channel_repository = Arc::new(SecureChannelSqlxDatabase::new(database.clone()));
 
         Self::bootstrap_repository(members.clone(), configuration).await?;
 
-        let identities = Identities::create_with_node(database, "authority").build();
+        let identities = Identities::create_with_node(database, node_name).build();
 
-        let secure_channels = SecureChannels::from_identities(identities.clone());
+        let secure_channels =
+            SecureChannels::from_identities(identities.clone(), secure_channel_repository);
 
         let identifier = configuration.identifier();
         info!(identifier=%identifier, "retrieved the authority identifier");

--- a/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ockam::identity::{Identities, SecureChannels};
+use ockam::identity::{Identities, SecureChannelSqlxDatabase, SecureChannels};
 
 use crate::cli_state::CliState;
 use crate::cli_state::Result;
@@ -12,6 +12,9 @@ impl CliState {
         let identities = Identities::create_with_node(self.database(), node_name)
             .with_vault(vault)
             .build();
-        Ok(SecureChannels::from_identities(identities))
+        Ok(SecureChannels::from_identities(
+            identities,
+            Arc::new(SecureChannelSqlxDatabase::new(self.database())),
+        ))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/controller.rs
@@ -72,13 +72,16 @@ impl KafkaSecureChannelControllerImpl {
         consumer_decryptor_address: &Address,
         encrypted_content: Vec<u8>,
     ) -> ockam_core::Result<Vec<u8>> {
-        let secure_channel_entry = self
-            .get_secure_channel_for(consumer_decryptor_address)
+        let secure_channel_decryptor_api_address = self
+            .get_or_load_secure_channel_decryptor_api_address_for(
+                context,
+                consumer_decryptor_address,
+            )
             .await?;
 
         let decrypt_response = context
             .send_and_receive(
-                route![secure_channel_entry.decryptor_api_address().clone()],
+                route![secure_channel_decryptor_api_address],
                 DecryptionRequest(encrypted_content),
             )
             .await?;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -243,7 +243,8 @@ impl NodeManager {
         };
 
         let options = if secure_channel_type == SecureChannelType::KeyExchangeOnly {
-            options.key_exchange_only()
+            // TODO: Should key exchange channels be persisted automatically?
+            options.key_exchange_only().persist()?
         } else {
             options
         };
@@ -373,7 +374,8 @@ impl NodeManager {
         };
 
         let options = if secure_channel_type == SecureChannelType::KeyExchangeOnly {
-            options.key_exchange_only()
+            // TODO: Should key exchange channels be persisted automatically?
+            options.key_exchange_only().persist()?
         } else {
             options
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -1,13 +1,13 @@
 use std::time::Duration;
 
 use ockam::identity::models::CredentialAndPurposeKey;
-use ockam::identity::TrustEveryonePolicy;
 use ockam::identity::Vault;
 use ockam::identity::{
     Identifier, Identities, SecureChannelListenerOptions, SecureChannelOptions, SecureChannels,
     TrustMultiIdentifiersPolicy,
 };
 use ockam::identity::{SecureChannel, SecureChannelListener};
+use ockam::identity::{SecureChannelSqlxDatabase, TrustEveryonePolicy};
 use ockam::{Address, Result, Route};
 use ockam_core::api::{Error, Response};
 use ockam_core::compat::sync::Arc;
@@ -453,6 +453,7 @@ impl NodeManager {
         Ok(Arc::new(SecureChannels::new(
             identities,
             self.secure_channels.secure_channel_registry(),
+            Arc::new(SecureChannelSqlxDatabase::new(self.cli_state.database())),
         )))
     }
 }

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -1,7 +1,7 @@
 use minicbor::bytes::ByteSlice;
-use ockam::identity::identities;
 use ockam::identity::models::CredentialAndPurposeKey;
 use ockam::identity::utils::now;
+use ockam::identity::{identities, SecureChannelSqlxDatabase};
 use ockam::identity::{
     Identities, SecureChannelListenerOptions, SecureChannelOptions, SecureChannels,
 };
@@ -55,7 +55,10 @@ async fn credential(ctx: &mut Context) -> Result<()> {
         .with_purpose_keys_repository(identities.purpose_keys_repository())
         .with_cached_credential_repository(identities.cached_credentials_repository())
         .build();
-    let secure_channels = SecureChannels::from_identities(identities.clone());
+    let secure_channels = SecureChannels::from_identities(
+        identities.clone(),
+        Arc::new(SecureChannelSqlxDatabase::create().await?),
+    );
     let identities_verification = identities.identities_verification();
 
     // Create the CredentialIssuer:

--- a/implementations/rust/ockam/ockam_identity/src/error.rs
+++ b/implementations/rust/ockam/ockam_identity/src/error.rs
@@ -68,6 +68,14 @@ pub enum IdentityError {
     AddressIsNotSubscribedForThatCredentialRetriever,
     /// Credential retriever couldn't return a credential
     NoCredential,
+    /// Persistence is currently only supported for key exchange only channels
+    PersistentSupportIsLimited,
+    /// Secure Channel not found in the storage
+    PersistentSecureChannelNotFound,
+    /// Unknown Secure Channel Role value
+    UnknownRole,
+    /// Handshake ended up in an internal invalid state
+    HandshakeInternalError,
 }
 
 impl ockam_core::compat::error::Error for IdentityError {}

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/addresses.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/addresses.rs
@@ -6,7 +6,7 @@ use crate::secure_channel::role::Role;
 // and identity secure channel encryptor&decryptor.
 // Now this logic is merged into one encryptor&decryptor pair, but for backwards
 // compatibility each of them have more addresses to simulate old behaviour.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Addresses {
     // Used to send decrypted messages and secure channel creation completion notification
     pub(crate) decryptor_internal: Address,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_state_machine.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// Interface for a state machine in a key exchange protocol
 #[async_trait]
-pub(super) trait StateMachine: Send + Sync + 'static {
+pub(crate) trait StateMachine: Send + Sync + 'static {
     async fn on_event(&mut self, event: Event) -> Result<Action>;
     fn get_handshake_results(&self) -> Option<HandshakeResults>;
 }
@@ -25,21 +25,21 @@ pub(super) trait StateMachine: Send + Sync + 'static {
 /// Events received by the state machine, either initializing the state machine
 /// or receiving a message from the other party
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum Event {
+pub(crate) enum Event {
     Initialize,
     ReceivedMessage(Vec<u8>),
 }
 
 /// Outcome of processing an event: either no action or a message to send to the other party
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum Action {
+pub(crate) enum Action {
     NoAction,
     SendMessage(Vec<u8>),
 }
 
 /// List of possible states for the initiator or responder sides of the exchange
 #[derive(Debug, Clone)]
-pub(super) enum Status {
+pub(crate) enum Status {
     Initial,
     WaitingForMessage1,
     WaitingForMessage2,
@@ -49,7 +49,7 @@ pub(super) enum Status {
 
 /// At the end of a successful handshake a pair of encryption/decryption keys is available
 #[derive(Debug, Clone)]
-pub(super) struct HandshakeKeys {
+pub(crate) struct HandshakeKeys {
     pub(super) encryption_key: AeadSecretKeyHandle,
     pub(super) decryption_key: AeadSecretKeyHandle,
 }
@@ -57,7 +57,7 @@ pub(super) struct HandshakeKeys {
 /// The end result of a handshake with identity/credentials exchange is
 /// a pair of encryption/decryption keys + the identity of the other party
 #[derive(Debug, Clone)]
-pub(super) struct HandshakeResults {
+pub(crate) struct HandshakeResults {
     pub(super) handshake_keys: HandshakeKeys,
     pub(super) their_identifier: Identifier,
     pub(super) presented_credential: Option<CredentialAndPurposeKey>,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/mod.rs
@@ -22,6 +22,7 @@ pub mod trust_policy;
 pub use access_control::*;
 pub(crate) use addresses::*;
 pub use api::*;
+pub(crate) use decryptor::*;
 pub(crate) use encryptor_worker::*;
 pub(crate) use handshake::*;
 pub(crate) use listener::*;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -27,6 +27,8 @@ pub struct SecureChannelOptions {
     pub(crate) credential_retriever_creator: Option<Arc<dyn CredentialRetrieverCreator>>,
     pub(crate) timeout: Duration,
     pub(crate) key_exchange_only: bool,
+    // Secure Channel will be persisted (currently only supported for key_exchange_only = true)
+    pub(crate) is_persistent: bool,
 }
 
 impl fmt::Debug for SecureChannelOptions {
@@ -46,6 +48,7 @@ impl SecureChannelOptions {
             credential_retriever_creator: None,
             timeout: DEFAULT_TIMEOUT,
             key_exchange_only: false,
+            is_persistent: false,
         }
     }
 
@@ -97,6 +100,16 @@ impl SecureChannelOptions {
     pub fn key_exchange_only(mut self) -> Self {
         self.key_exchange_only = true;
         self
+    }
+
+    /// Secure Channel will be persisted after a successful handshake
+    /// NOTE: Currently only supported after setting key_exchange_only = true
+    pub fn persist(mut self) -> Result<Self> {
+        if !self.key_exchange_only {
+            return Err(IdentityError::PersistentSupportIsLimited.into());
+        }
+        self.is_persistent = true;
+        Ok(self)
     }
 }
 
@@ -162,6 +175,8 @@ pub struct SecureChannelListenerOptions {
     // To obtain our credentials
     pub(crate) credential_retriever_creator: Option<Arc<dyn CredentialRetrieverCreator>>,
     pub(crate) key_exchange_only: bool,
+    // Secure Channel will be persisted (currently only supported for key_exchange_only = true)
+    pub(crate) is_persistent: bool,
 }
 
 impl fmt::Debug for SecureChannelListenerOptions {
@@ -183,6 +198,7 @@ impl SecureChannelListenerOptions {
             authority: None,
             credential_retriever_creator: None,
             key_exchange_only: false,
+            is_persistent: false,
         }
     }
 
@@ -237,6 +253,16 @@ impl SecureChannelListenerOptions {
     pub fn key_exchange_only(mut self) -> Self {
         self.key_exchange_only = true;
         self
+    }
+
+    /// Secure Channel will be persisted after a successful handshake
+    /// NOTE: Currently only supported after setting key_exchange_only = true
+    pub fn persist(mut self) -> Result<Self> {
+        if !self.key_exchange_only {
+            return Err(IdentityError::PersistentSupportIsLimited.into());
+        }
+        self.is_persistent = true;
+        Ok(self)
     }
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/role.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/role.rs
@@ -1,9 +1,16 @@
+use crate::IdentityError;
 use core::fmt::{Display, Formatter};
+use ockam_core::Error;
 
-#[derive(Copy, Clone, Debug)]
-pub(crate) enum Role {
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Role {
     Initiator,
     Responder,
+}
+
+impl Role {
+    pub const INITIATOR: &'static str = "initiator";
+    pub const RESPONDER: &'static str = "responder";
 }
 
 impl Display for Role {
@@ -20,18 +27,30 @@ impl Display for Role {
     }
 }
 
+impl TryFrom<&str> for Role {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            Self::INITIATOR => Ok(Self::Initiator),
+            Self::RESPONDER => Ok(Self::Responder),
+            _ => Err(IdentityError::UnknownRole)?,
+        }
+    }
+}
+
 impl Role {
     pub fn is_initiator(&self) -> bool {
         match self {
-            Role::Initiator => true,
-            Role::Responder => false,
+            Self::Initiator => true,
+            Self::Responder => false,
         }
     }
 
     pub fn str(&self) -> &'static str {
         match self {
-            Role::Initiator => "initiator",
-            Role::Responder => "responder",
+            Self::Initiator => Self::INITIATOR,
+            Self::Responder => Self::RESPONDER,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/common.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/common.rs
@@ -1,5 +1,5 @@
 use crate::secure_channel::{Addresses, RemoteRoute};
-use crate::SecureChannelOptions;
+use crate::{Identifier, SecureChannelOptions};
 use core::fmt;
 use core::fmt::Formatter;
 use minicbor::{Decode, Encode};
@@ -12,8 +12,10 @@ use serde::Serialize;
 #[derive(Debug, Clone)]
 pub struct SecureChannel {
     flow_controls: FlowControls,
+    their_identifier: Identifier,
     encryptor_remote_route: Arc<RwLock<RemoteRoute>>,
     addresses: Addresses,
+    is_key_exchange_only: bool,
     flow_control_id: FlowControlId,
 }
 
@@ -37,14 +39,18 @@ impl SecureChannel {
     /// Constructor.
     pub(crate) fn new(
         flow_controls: FlowControls,
+        their_identifier: Identifier,
         encryptor_remote_route: Arc<RwLock<RemoteRoute>>,
         addresses: Addresses,
+        is_key_exchange_only: bool,
         flow_control_id: FlowControlId,
     ) -> Self {
         Self {
             flow_controls,
+            their_identifier,
             encryptor_remote_route,
             addresses,
+            is_key_exchange_only,
             flow_control_id,
         }
     }
@@ -61,6 +67,15 @@ impl SecureChannel {
     /// a message without sending it
     pub fn encryptor_api_address(&self) -> &Address {
         &self.addresses.encryptor_api
+    }
+    /// API [`Address`] of the corresponding `DecryptorWorker` Worker that can be used to decrypt
+    /// a message without sending it
+    pub fn decryptor_api_address(&self) -> &Address {
+        &self.addresses.decryptor_api
+    }
+    /// Remote messaging [`Address`] of the corresponding `DecryptorWorker`
+    pub fn decryptor_remote_address(&self) -> &Address {
+        &self.addresses.decryptor_remote
     }
     /// Update route to the node on the other side in case transport changes happened
     pub fn update_remote_node_route(&self, new_route: Route) -> Result<()> {
@@ -92,6 +107,15 @@ impl SecureChannel {
 
         Ok(())
     }
+    /// This secure channel is used only for handshake, further encryption happens using
+    /// api address. Encryption part may be absent.
+    pub fn is_key_exchange_only(&self) -> bool {
+        self.is_key_exchange_only
+    }
+    /// The Identifier of the other side
+    pub fn their_identifier(&self) -> &Identifier {
+        &self.their_identifier
+    }
 }
 
 /// Result of [`super::SecureChannels::create_secure_channel_listener()`] call.
@@ -101,6 +125,7 @@ impl SecureChannel {
 pub struct SecureChannelListener {
     #[n(1)] address: Address,
     #[n(2)] flow_control_id: FlowControlId,
+    #[n(3)] is_key_exchange_only: bool,
 }
 
 impl fmt::Display for SecureChannelListener {
@@ -115,9 +140,14 @@ impl fmt::Display for SecureChannelListener {
 
 impl SecureChannelListener {
     /// Constructor.
-    pub fn new(address: Address, flow_control_id: FlowControlId) -> Self {
+    pub fn new(
+        address: Address,
+        is_key_exchange_only: bool,
+        flow_control_id: FlowControlId,
+    ) -> Self {
         Self {
             address,
+            is_key_exchange_only,
             flow_control_id,
         }
     }
@@ -130,5 +160,10 @@ impl SecureChannelListener {
     /// Freshly generated [`FlowControlId`]
     pub fn flow_control_id(&self) -> &FlowControlId {
         &self.flow_control_id
+    }
+    /// This secure channel listener is used only for handshake, further encryption happens using
+    /// api address. Encryption part may be absent.
+    pub fn is_key_exchange_only(&self) -> bool {
+        self.is_key_exchange_only
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/mod.rs
@@ -4,8 +4,10 @@ mod common;
 pub mod secure_channels;
 mod secure_channels_builder;
 mod secure_client;
+mod storage;
 
 pub use common::*;
 pub use secure_channels::*;
 pub use secure_channels_builder::*;
 pub use secure_client::*;
+pub use storage::*;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels.rs
@@ -1,24 +1,32 @@
+use core::sync::atomic::AtomicBool;
 use ockam_core::compat::sync::Arc;
+use ockam_core::flow_control::FlowControls;
 use ockam_core::Result;
 use ockam_core::{Address, Route};
-use ockam_node::Context;
+use ockam_node::{Context, WorkerBuilder};
+use tracing::info;
 
 use crate::identities::Identities;
 use crate::models::Identifier;
 use crate::secure_channel::handshake_worker::HandshakeWorker;
 use crate::secure_channel::{
-    Addresses, RemoteRoute, Role, SecureChannelListenerOptions, SecureChannelListenerWorker,
-    SecureChannelOptions, SecureChannelRegistry,
+    Addresses, DecryptorHandler, RemoteRoute, Role, SecureChannelListenerOptions,
+    SecureChannelListenerWorker, SecureChannelOptions, SecureChannelRegistry,
+    SecureChannelSharedState,
 };
 #[cfg(feature = "storage")]
 use crate::SecureChannelsBuilder;
-use crate::{SecureChannel, SecureChannelListener, Vault};
+use crate::{
+    IdentityError, SecureChannel, SecureChannelListener, SecureChannelRegistryEntry,
+    SecureChannelRepository, Vault,
+};
 
 /// Identity implementation
 #[derive(Clone)]
 pub struct SecureChannels {
     pub(crate) identities: Arc<Identities>,
     pub(crate) secure_channel_registry: SecureChannelRegistry,
+    pub(crate) secure_channel_repository: Arc<dyn SecureChannelRepository>,
 }
 
 impl SecureChannels {
@@ -26,16 +34,25 @@ impl SecureChannels {
     pub fn new(
         identities: Arc<Identities>,
         secure_channel_registry: SecureChannelRegistry,
+        secure_channel_repository: Arc<dyn SecureChannelRepository>,
     ) -> Self {
         Self {
             identities,
             secure_channel_registry,
+            secure_channel_repository,
         }
     }
 
     /// Constructor
-    pub fn from_identities(identities: Arc<Identities>) -> Arc<Self> {
-        Arc::new(Self::new(identities, SecureChannelRegistry::default()))
+    pub fn from_identities(
+        identities: Arc<Identities>,
+        secure_channel_repository: Arc<dyn SecureChannelRepository>,
+    ) -> Arc<Self> {
+        Arc::new(Self::new(
+            identities,
+            SecureChannelRegistry::default(),
+            secure_channel_repository,
+        ))
     }
 
     /// Return the identities services associated to this service
@@ -53,12 +70,18 @@ impl SecureChannels {
         self.secure_channel_registry.clone()
     }
 
+    /// Return the secure channel repository
+    pub fn secure_channel_repository(&self) -> Arc<dyn SecureChannelRepository> {
+        self.secure_channel_repository.clone()
+    }
+
     /// Create a builder for secure channels
     #[cfg(feature = "storage")]
     pub async fn builder() -> Result<SecureChannelsBuilder> {
         Ok(SecureChannelsBuilder {
             identities_builder: Identities::builder().await?,
             registry: SecureChannelRegistry::new(),
+            secure_channel_repository: Arc::new(crate::SecureChannelSqlxDatabase::create().await?),
         })
     }
 }
@@ -74,6 +97,7 @@ impl SecureChannels {
     ) -> Result<SecureChannelListener> {
         let address = address.into();
         let options = options.into();
+        let key_exchange_only = options.key_exchange_only;
         let flow_control_id = options.flow_control_id.clone();
 
         SecureChannelListenerWorker::create(
@@ -85,7 +109,11 @@ impl SecureChannels {
         )
         .await?;
 
-        Ok(SecureChannelListener::new(address, flow_control_id))
+        Ok(SecureChannelListener::new(
+            address,
+            key_exchange_only,
+            flow_control_id,
+        ))
     }
 
     /// Initiate a SecureChannel using `Route` to the SecureChannel listener and [`SecureChannelOptions`]
@@ -123,8 +151,14 @@ impl SecureChannels {
             None => None,
         };
 
+        let secure_channel_repository = if options.is_persistent {
+            Some(self.secure_channel_repository())
+        } else {
+            None
+        };
+
         let encryptor_remote_route = RemoteRoute::create();
-        HandshakeWorker::create(
+        let Some(their_identifier) = HandshakeWorker::create(
             ctx,
             Arc::new(self.clone()),
             addresses.clone(),
@@ -138,16 +172,123 @@ impl SecureChannels {
             Some(options.timeout),
             Role::Initiator,
             options.key_exchange_only,
+            secure_channel_repository,
             encryptor_remote_route.clone(),
         )
-        .await?;
+        .await?
+        else {
+            return Err(IdentityError::HandshakeInternalError)?;
+        };
 
         Ok(SecureChannel::new(
             ctx.flow_controls().clone(),
+            their_identifier,
             encryptor_remote_route,
             addresses,
+            options.key_exchange_only,
             flow_control_id,
         ))
+    }
+
+    /// Start a decryptor side for a previously existed and persisted secure channel
+    /// Only decryptor api part is started
+    pub async fn start_persisted_secure_channel_decryptor(
+        &self,
+        ctx: &Context,
+        decryptor_remote_address: &Address,
+    ) -> Result<SecureChannel> {
+        info!(
+            "Starting persisted secure channel: {}",
+            decryptor_remote_address
+        );
+
+        let Some(persisted_secure_channel) = self
+            .secure_channel_repository
+            .get(decryptor_remote_address)
+            .await?
+        else {
+            return Err(IdentityError::PersistentSecureChannelNotFound)?;
+        };
+
+        let decryption_key = persisted_secure_channel.decryption_key_handle().clone();
+
+        self.vault()
+            .secure_channel_vault
+            .load_aead_key(&decryption_key)
+            .await?;
+
+        let my_identifier = persisted_secure_channel.my_identifier();
+        let their_identifier = persisted_secure_channel.their_identifier();
+        let role = persisted_secure_channel.role();
+        let shared_state = SecureChannelSharedState {
+            remote_route: RemoteRoute::create(),                 // Unused
+            should_send_close: Arc::new(AtomicBool::new(false)), // Don't need to send anything
+        };
+
+        let mut addresses = Addresses::generate(role);
+        // FIXME: All other addresses except these two are random and incorrect, we don't use them
+        //  for now though
+        addresses.decryptor_remote = persisted_secure_channel.decryptor_remote().clone();
+        addresses.decryptor_api = persisted_secure_channel.decryptor_api().clone();
+
+        let decryptor_handler = DecryptorHandler::new(
+            self.identities(),
+            None, // We don't need authority, we won't verify any credentials
+            role,
+            true,
+            addresses.clone(),
+            decryption_key,
+            self.vault().secure_channel_vault.clone(),
+            their_identifier.clone(),
+            shared_state.clone(),
+        );
+
+        let decryptor_worker = HandshakeWorker::new(
+            Arc::new(self.clone()),
+            None, // No callback will happen
+            None,
+            my_identifier.clone(),
+            addresses.clone(),
+            role,
+            true,
+            None, // No remote interaction
+            Some(decryptor_handler),
+            None, // We don't need authority, we won't verify any credentials
+            self.identities.change_history_repository(),
+            None, // We don't need credential retriever, we won't present any credentials
+            // Key exchange only secure channel's state is unchanged after the initial creation, so no need to update it
+            None,
+            shared_state.clone(),
+        );
+
+        WorkerBuilder::new(decryptor_worker)
+            .with_address(addresses.decryptor_api.clone()) // We only need API address here
+            .start(ctx)
+            .await?;
+
+        let sc = SecureChannel::new(
+            ctx.flow_controls().clone(),
+            their_identifier.clone(),
+            shared_state.remote_route,
+            addresses.clone(),
+            true,
+            FlowControls::generate_flow_control_id(), // This is random and doesn't matter
+        );
+
+        let info = SecureChannelRegistryEntry::new(
+            addresses.encryptor.clone(),
+            addresses.encryptor_api.clone(),
+            addresses.decryptor_remote.clone(),
+            addresses.decryptor_api.clone(),
+            role.is_initiator(),
+            my_identifier.clone(),
+            their_identifier.clone(),
+            Address::random_local(), // Random, unused for now
+        );
+
+        self.secure_channel_registry.register_channel(info)?;
+
+        Ok(sc)
     }
 
     /// Stop a SecureChannel given an encryptor address

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels_builder.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_channels_builder.rs
@@ -7,7 +7,10 @@ use crate::identities::ChangeHistoryRepository;
 use crate::purpose_keys::storage::PurposeKeysRepository;
 use crate::secure_channel::SecureChannelRegistry;
 use crate::secure_channels::SecureChannels;
-use crate::{CredentialRepository, IdentitiesBuilder, IdentityAttributesRepository, Vault};
+use crate::{
+    CredentialRepository, IdentitiesBuilder, IdentityAttributesRepository, SecureChannelRepository,
+    Vault,
+};
 
 /// This struct supports all the services related to secure channels
 #[derive(Clone)]
@@ -15,6 +18,7 @@ pub struct SecureChannelsBuilder {
     // FIXME: This is very strange dependency
     pub(crate) identities_builder: IdentitiesBuilder,
     pub(crate) registry: SecureChannelRegistry,
+    pub(crate) secure_channel_repository: Arc<dyn SecureChannelRepository>,
 }
 
 /// Create default, in-memory, secure channels (mostly for examples and testing)
@@ -80,6 +84,15 @@ impl SecureChannelsBuilder {
         self
     }
 
+    /// Set a specific secure channels repository
+    pub fn with_secure_channel_repository(
+        mut self,
+        repository: Arc<dyn SecureChannelRepository>,
+    ) -> Self {
+        self.secure_channel_repository = repository;
+        self
+    }
+
     /// Set a specific channel registry
     pub fn with_secure_channels_registry(mut self, registry: SecureChannelRegistry) -> Self {
         self.registry = registry;
@@ -90,6 +103,10 @@ impl SecureChannelsBuilder {
     /// Build secure channels
     pub fn build(self) -> Arc<SecureChannels> {
         let identities = self.identities_builder.build();
-        Arc::new(SecureChannels::new(identities, self.registry.clone()))
+        Arc::new(SecureChannels::new(
+            identities,
+            self.registry,
+            self.secure_channel_repository,
+        ))
     }
 }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/mod.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/mod.rs
@@ -1,0 +1,9 @@
+mod secure_channel_repository;
+
+pub use secure_channel_repository::*;
+
+#[cfg(feature = "storage")]
+mod secure_channel_repository_sql;
+
+#[cfg(feature = "storage")]
+pub use secure_channel_repository_sql::*;

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository.rs
@@ -1,0 +1,84 @@
+use crate::secure_channel::Role;
+use crate::Identifier;
+use async_trait::async_trait;
+use core::fmt::Debug;
+use ockam_core::compat::boxed::Box;
+use ockam_core::{Address, Result};
+use ockam_vault::AeadSecretKeyHandle;
+
+/// Secure Channel that was saved to a storage
+#[derive(Clone, Eq, Debug, PartialEq)]
+pub struct PersistedSecureChannel {
+    role: Role,
+    my_identifier: Identifier,
+    their_identifier: Identifier,
+    decryptor_remote: Address,
+    decryptor_api: Address,
+    decryption_key_handle: AeadSecretKeyHandle,
+}
+
+impl PersistedSecureChannel {
+    pub(crate) fn new(
+        role: Role,
+        my_identifier: Identifier,
+        their_identifier: Identifier,
+        decryptor_remote: Address,
+        decryptor_api: Address,
+        decryption_key_handle: AeadSecretKeyHandle,
+    ) -> Self {
+        Self {
+            role,
+            my_identifier,
+            their_identifier,
+            decryptor_remote,
+            decryptor_api,
+            decryption_key_handle,
+        }
+    }
+
+    /// Role
+    pub fn role(&self) -> Role {
+        self.role
+    }
+
+    /// My identifier
+    pub fn my_identifier(&self) -> &Identifier {
+        &self.my_identifier
+    }
+
+    /// Their identifier
+    pub fn their_identifier(&self) -> &Identifier {
+        &self.their_identifier
+    }
+
+    /// Decryptor remote address. See [`Addresses`]
+    pub fn decryptor_remote(&self) -> &Address {
+        &self.decryptor_remote
+    }
+
+    /// Decryptor api address. See [`Addresses`]
+    pub fn decryptor_api(&self) -> &Address {
+        &self.decryptor_api
+    }
+
+    /// Decryption key
+    pub fn decryption_key_handle(&self) -> &AeadSecretKeyHandle {
+        &self.decryption_key_handle
+    }
+}
+
+/// Repository for persisted Secure Channels
+#[async_trait]
+pub trait SecureChannelRepository: Send + Sync + 'static {
+    /// Get a previously persisted secure channel with given decryptor remote address
+    async fn get(
+        &self,
+        decryptor_remote_address: &Address,
+    ) -> Result<Option<PersistedSecureChannel>>;
+
+    /// Store a secure channel
+    async fn put(&self, secure_channel: PersistedSecureChannel) -> Result<()>;
+
+    /// Delete a secure channel
+    async fn delete(&self, decryptor_remote_address: &Address) -> Result<()>;
+}

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/storage/secure_channel_repository_sql.rs
@@ -1,0 +1,158 @@
+use sqlx::*;
+use tracing::debug;
+
+use crate::secure_channel::Role;
+use crate::Identifier;
+use ockam_core::{async_trait, Address};
+use ockam_core::{Error, Result};
+use ockam_node::database::{FromSqlxError, SqlxDatabase, ToSqlxType, ToVoid};
+use ockam_vault::{AeadSecretKeyHandle, HandleToSecret};
+
+use crate::secure_channels::storage::secure_channel_repository::{
+    PersistedSecureChannel, SecureChannelRepository,
+};
+
+/// Implementation of `CredentialRepository` trait based on an underlying database
+/// using sqlx as its API, and Sqlite as its driver
+#[derive(Clone)]
+pub struct SecureChannelSqlxDatabase {
+    database: SqlxDatabase,
+}
+
+impl SecureChannelSqlxDatabase {
+    /// Create a new database
+    pub fn new(database: SqlxDatabase) -> Self {
+        debug!("create a repository for secure channels");
+        Self { database }
+    }
+
+    /// Create a new in-memory database
+    pub async fn create() -> Result<Self> {
+        Ok(Self::new(SqlxDatabase::in_memory("secure_channel").await?))
+    }
+}
+
+#[async_trait]
+impl SecureChannelRepository for SecureChannelSqlxDatabase {
+    async fn get(
+        &self,
+        decryptor_remote_address: &Address,
+    ) -> Result<Option<PersistedSecureChannel>> {
+        let query = query_as(
+            "SELECT role, my_identifier, their_identifier, decryptor_remote_address, decryptor_api_address, decryption_key_handle FROM secure_channel WHERE decryptor_remote_address=$1"
+            )
+            .bind(decryptor_remote_address.to_string().to_sql());
+        let secure_channel: Option<SecureChannelRow> = query
+            .fetch_optional(&*self.database.pool)
+            .await
+            .into_core()?;
+
+        Ok(secure_channel.map(TryInto::try_into).transpose()?)
+    }
+
+    async fn put(&self, secure_channel: PersistedSecureChannel) -> Result<()> {
+        let query = query(
+            "INSERT OR REPLACE INTO secure_channel (role, my_identifier, their_identifier, decryptor_remote_address, decryptor_api_address, decryption_key_handle) VALUES (?, ?, ?, ?, ?, ?)"
+            )
+            .bind(secure_channel.role().str().to_sql())
+            .bind(secure_channel.my_identifier().to_string().to_sql())
+            .bind(secure_channel.their_identifier().to_sql())
+            .bind(secure_channel.decryptor_remote().to_sql())
+            .bind(secure_channel.decryptor_api().to_sql())
+            .bind(secure_channel.decryption_key_handle().to_sql());
+        query.execute(&*self.database.pool).await.void()
+    }
+
+    async fn delete(&self, decryptor_remote_address: &Address) -> Result<()> {
+        let query = query("DELETE FROM secure_channel WHERE decryptor_remote_address=$1")
+            .bind(decryptor_remote_address.to_string().to_sql());
+        query.execute(&*self.database.pool).await.void()
+    }
+}
+
+// Low-level representation of a table row
+#[derive(FromRow)]
+struct SecureChannelRow {
+    role: String,
+    my_identifier: String,
+    their_identifier: String,
+    decryptor_remote_address: String,
+    decryptor_api_address: String,
+    decryption_key_handle: Vec<u8>,
+}
+
+impl TryFrom<SecureChannelRow> for PersistedSecureChannel {
+    type Error = Error;
+
+    fn try_from(value: SecureChannelRow) -> std::result::Result<Self, Self::Error> {
+        let role = Role::try_from(value.role.as_str())?;
+        let my_identifier = Identifier::try_from(value.my_identifier)?;
+        let their_identifier = Identifier::try_from(value.their_identifier)?;
+        let decryptor_remote_address = Address::from_string(value.decryptor_remote_address);
+        let decryptor_api_address = Address::from_string(value.decryptor_api_address);
+        let decryption_key_handle = HandleToSecret::new(value.decryption_key_handle);
+        let decryption_key_handle = AeadSecretKeyHandle::new(decryption_key_handle);
+
+        Ok(PersistedSecureChannel::new(
+            role,
+            my_identifier,
+            their_identifier,
+            decryptor_remote_address,
+            decryptor_api_address,
+            decryption_key_handle,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::secure_channel::Role;
+    use ockam_core::compat::rand::RngCore;
+    use ockam_core::compat::sync::Arc;
+    use rand::thread_rng;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_secure_channel_repository() -> Result<()> {
+        let repository = Arc::new(SecureChannelSqlxDatabase::create().await?);
+
+        let decryptor_remote = Address::random_local();
+        let decryptor_api = Address::random_local();
+
+        let mut decryption_key_handle = [0u8; 32];
+
+        let mut rng = thread_rng();
+        rng.fill_bytes(&mut decryption_key_handle);
+
+        let decryption_key_handle =
+            AeadSecretKeyHandle::new(HandleToSecret::new(decryption_key_handle.to_vec()));
+
+        let my_identifier = Identifier::try_from(
+            "Ie70dc5545d64724880257acb32b8851e7dd1dd57076838991bc343165df71bfe",
+        )?;
+        let their_identifier = Identifier::try_from(
+            "Ife42b412ecdb7fda4421bd5046e33c1017671ce7a320c3342814f0b99df9ab60",
+        )?;
+
+        let sc = PersistedSecureChannel::new(
+            Role::Initiator,
+            my_identifier,
+            their_identifier,
+            decryptor_remote.clone(),
+            decryptor_api,
+            decryption_key_handle,
+        );
+
+        repository.put(sc.clone()).await?;
+
+        let sc2 = repository.get(&decryptor_remote).await?;
+        assert_eq!(sc2, Some(sc));
+
+        repository.delete(&decryptor_remote).await?;
+        let result = repository.get(&decryptor_remote).await?;
+        assert_eq!(result, None);
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/tests/persistence.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/persistence.rs
@@ -37,7 +37,7 @@ async fn test_key_exchange_only(ctx: &mut Context) -> ockam_core::Result<()> {
         .create_secure_channel(ctx, &alice, route!["bob_listener"], alice_options)
         .await?;
 
-    ctx.sleep(Duration::from_millis(10)).await;
+    ctx.sleep(Duration::from_millis(50)).await;
 
     let bob_channel = secure_channels_bob
         .secure_channel_registry()

--- a/implementations/rust/ockam/ockam_identity/tests/persistence.rs
+++ b/implementations/rust/ockam/ockam_identity/tests/persistence.rs
@@ -1,0 +1,383 @@
+use ockam_core::{route, Address};
+use ockam_identity::{
+    secure_channels, DecryptionRequest, DecryptionResponse, EncryptionRequest, EncryptionResponse,
+    SecureChannelListenerOptions, SecureChannelOptions, SecureChannelSqlxDatabase, SecureChannels,
+};
+use ockam_node::compat::futures::FutureExt;
+use ockam_node::database::SqlxDatabase;
+use ockam_node::{Context, NodeBuilder};
+use ockam_vault::storage::SecretsSqlxDatabase;
+use std::sync::Arc;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+#[ockam_macros::test]
+async fn test_key_exchange_only(ctx: &mut Context) -> ockam_core::Result<()> {
+    let secure_channels_alice = secure_channels().await?;
+    let secure_channels_bob = secure_channels().await?;
+
+    let alice = secure_channels_alice
+        .identities()
+        .identities_creation()
+        .create_identity()
+        .await?;
+    let bob = secure_channels_bob
+        .identities()
+        .identities_creation()
+        .create_identity()
+        .await?;
+
+    let bob_options = SecureChannelListenerOptions::new().key_exchange_only();
+    secure_channels_bob
+        .create_secure_channel_listener(ctx, &bob, "bob_listener", bob_options)
+        .await?;
+
+    let alice_options = SecureChannelOptions::new().key_exchange_only();
+    let alice_channel = secure_channels_alice
+        .create_secure_channel(ctx, &alice, route!["bob_listener"], alice_options)
+        .await?;
+
+    ctx.sleep(Duration::from_millis(10)).await;
+
+    let bob_channel = secure_channels_bob
+        .secure_channel_registry()
+        .get_channel_list()[0]
+        .clone();
+
+    let msg1_alice = vec![1u8; 32];
+    let msg2_alice = vec![2u8; 32];
+
+    let msg1_bob = vec![1u8; 32];
+    let msg2_bob = vec![2u8; 32];
+
+    let EncryptionResponse::Ok(encrypted_msg1_alice) = ctx
+        .send_and_receive(
+            route![alice_channel.encryptor_api_address().clone()],
+            EncryptionRequest(msg1_alice.clone()),
+        )
+        .await?
+    else {
+        panic!()
+    };
+    let EncryptionResponse::Ok(encrypted_msg2_alice) = ctx
+        .send_and_receive(
+            route![alice_channel.encryptor_api_address().clone()],
+            EncryptionRequest(msg2_alice.clone()),
+        )
+        .await?
+    else {
+        panic!()
+    };
+    let EncryptionResponse::Ok(encrypted_msg1_bob) = ctx
+        .send_and_receive(
+            route![bob_channel.encryptor_api_address().clone()],
+            EncryptionRequest(msg1_bob.clone()),
+        )
+        .await?
+    else {
+        panic!()
+    };
+    let EncryptionResponse::Ok(encrypted_msg2_bob) = ctx
+        .send_and_receive(
+            route![bob_channel.encryptor_api_address().clone()],
+            EncryptionRequest(msg2_bob.clone()),
+        )
+        .await?
+    else {
+        panic!()
+    };
+
+    let DecryptionResponse::Ok(decrypted_msg1_alice) = ctx
+        .send_and_receive(
+            route![bob_channel.decryptor_api_address().clone()],
+            DecryptionRequest(encrypted_msg1_alice),
+        )
+        .await?
+    else {
+        panic!()
+    };
+
+    let DecryptionResponse::Ok(decrypted_msg2_alice) = ctx
+        .send_and_receive(
+            route![bob_channel.decryptor_api_address().clone()],
+            DecryptionRequest(encrypted_msg2_alice),
+        )
+        .await?
+    else {
+        panic!()
+    };
+
+    let DecryptionResponse::Ok(decrypted_msg1_bob) = ctx
+        .send_and_receive(
+            route![alice_channel.decryptor_api_address().clone()],
+            DecryptionRequest(encrypted_msg1_bob),
+        )
+        .await?
+    else {
+        panic!()
+    };
+
+    let DecryptionResponse::Ok(decrypted_msg2_bob) = ctx
+        .send_and_receive(
+            route![alice_channel.decryptor_api_address().clone()],
+            DecryptionRequest(encrypted_msg2_bob),
+        )
+        .await?
+    else {
+        panic!()
+    };
+
+    assert_eq!(msg1_alice, decrypted_msg1_alice);
+    assert_eq!(msg2_alice, decrypted_msg2_alice);
+    assert_eq!(msg1_bob, decrypted_msg1_bob);
+    assert_eq!(msg2_bob, decrypted_msg2_bob);
+
+    Ok(())
+}
+
+#[test]
+fn test_persistence() -> ockam_core::Result<()> {
+    let (_db_file_alice, db_file_alice_path) = NamedTempFile::new().unwrap().keep().unwrap();
+    let db_file_alice_path_clone = db_file_alice_path.clone();
+
+    let (_db_file_bob, db_file_bob_path) = NamedTempFile::new().unwrap().keep().unwrap();
+    let db_file_bob_path_clone = db_file_bob_path.clone();
+
+    struct PassBetweenEnv {
+        decryptor_api_address_alice: Address,
+        decryptor_remote_address_alice: Address,
+        decryptor_api_address_bob: Address,
+        decryptor_remote_address_bob: Address,
+        msg1_alice: Vec<u8>,
+        msg2_alice: Vec<u8>,
+        msg1_bob: Vec<u8>,
+        msg2_bob: Vec<u8>,
+        encrypted_msg1_alice: Vec<u8>,
+        encrypted_msg2_alice: Vec<u8>,
+        encrypted_msg1_bob: Vec<u8>,
+        encrypted_msg2_bob: Vec<u8>,
+    }
+
+    let (ctx1, mut executor1) = NodeBuilder::new().build();
+    let data = executor1
+        .execute(async move {
+            let data = std::panic::AssertUnwindSafe(async {
+                let db_alice = SqlxDatabase::create(db_file_alice_path_clone.as_path()).await?;
+                let secure_channel_repository_alice =
+                    Arc::new(SecureChannelSqlxDatabase::new(db_alice.clone()));
+                let secrets_repository_alice = Arc::new(SecretsSqlxDatabase::new(db_alice));
+                let db_bob = SqlxDatabase::create(db_file_bob_path_clone.as_path()).await?;
+                let secure_channel_repository_bob =
+                    Arc::new(SecureChannelSqlxDatabase::new(db_bob.clone()));
+                let secrets_repository_bob = Arc::new(SecretsSqlxDatabase::new(db_bob));
+
+                let secure_channels_alice = SecureChannels::builder()
+                    .await?
+                    .with_secure_channel_repository(secure_channel_repository_alice.clone())
+                    .with_secrets_repository(secrets_repository_alice)
+                    .build();
+                let secure_channels_bob = SecureChannels::builder()
+                    .await?
+                    .with_secure_channel_repository(secure_channel_repository_bob.clone())
+                    .with_secrets_repository(secrets_repository_bob)
+                    .build();
+
+                let alice = secure_channels_alice
+                    .identities()
+                    .identities_creation()
+                    .create_identity()
+                    .await?;
+                let bob = secure_channels_bob
+                    .identities()
+                    .identities_creation()
+                    .create_identity()
+                    .await?;
+
+                let bob_options = SecureChannelListenerOptions::new()
+                    .key_exchange_only()
+                    .persist()?;
+                secure_channels_bob
+                    .create_secure_channel_listener(&ctx1, &bob, "bob_listener", bob_options)
+                    .await?;
+
+                let alice_options = SecureChannelOptions::new().key_exchange_only().persist()?;
+                let alice_channel = secure_channels_alice
+                    .create_secure_channel(&ctx1, &alice, route!["bob_listener"], alice_options)
+                    .await?;
+
+                ctx1.sleep(Duration::from_millis(50)).await;
+
+                let bob_channel = secure_channels_bob
+                    .secure_channel_registry()
+                    .get_channel_list()[0]
+                    .clone();
+
+                let msg1_alice = vec![1u8; 32];
+                let msg2_alice = vec![2u8; 32];
+
+                let msg1_bob = vec![1u8; 32];
+                let msg2_bob = vec![2u8; 32];
+
+                let EncryptionResponse::Ok(encrypted_msg1_alice) = ctx1
+                    .send_and_receive(
+                        route![alice_channel.encryptor_api_address().clone()],
+                        EncryptionRequest(msg1_alice.clone()),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+                let EncryptionResponse::Ok(encrypted_msg2_alice) = ctx1
+                    .send_and_receive(
+                        route![alice_channel.encryptor_api_address().clone()],
+                        EncryptionRequest(msg2_alice.clone()),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+                let EncryptionResponse::Ok(encrypted_msg1_bob) = ctx1
+                    .send_and_receive(
+                        route![bob_channel.encryptor_api_address().clone()],
+                        EncryptionRequest(msg1_bob.clone()),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+                let EncryptionResponse::Ok(encrypted_msg2_bob) = ctx1
+                    .send_and_receive(
+                        route![bob_channel.encryptor_api_address().clone()],
+                        EncryptionRequest(msg2_bob.clone()),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+
+                let data = PassBetweenEnv {
+                    decryptor_api_address_alice: alice_channel.decryptor_api_address().clone(),
+                    decryptor_remote_address_alice: alice_channel
+                        .decryptor_remote_address()
+                        .clone(),
+                    decryptor_api_address_bob: bob_channel.decryptor_api_address().clone(),
+                    decryptor_remote_address_bob: bob_channel.decryptor_messaging_address().clone(),
+                    msg1_alice,
+                    msg2_alice,
+                    msg1_bob,
+                    msg2_bob,
+                    encrypted_msg1_alice,
+                    encrypted_msg2_alice,
+                    encrypted_msg1_bob,
+                    encrypted_msg2_bob,
+                };
+
+                Result::<PassBetweenEnv, ockam_core::Error>::Ok(data)
+            })
+            .catch_unwind()
+            .await;
+
+            ctx1.stop().await?;
+
+            data.unwrap()
+        })
+        .unwrap()
+        .unwrap();
+
+    let (ctx2, mut executor2) = NodeBuilder::new().build();
+    executor2
+        .execute(async move {
+            let res = std::panic::AssertUnwindSafe(async {
+                let db_alice = SqlxDatabase::create(db_file_alice_path.as_path()).await?;
+                let secure_channel_repository_alice =
+                    Arc::new(SecureChannelSqlxDatabase::new(db_alice.clone()));
+                let secrets_repository_alice = Arc::new(SecretsSqlxDatabase::new(db_alice));
+                let db_bob = SqlxDatabase::create(db_file_bob_path.as_path()).await?;
+                let secure_channel_repository_bob =
+                    Arc::new(SecureChannelSqlxDatabase::new(db_bob.clone()));
+                let secrets_repository_bob = Arc::new(SecretsSqlxDatabase::new(db_bob));
+
+                let secure_channels_alice = SecureChannels::builder()
+                    .await?
+                    .with_secure_channel_repository(secure_channel_repository_alice.clone())
+                    .with_secrets_repository(secrets_repository_alice)
+                    .build();
+                let secure_channels_bob = SecureChannels::builder()
+                    .await?
+                    .with_secure_channel_repository(secure_channel_repository_bob.clone())
+                    .with_secrets_repository(secrets_repository_bob)
+                    .build();
+
+                secure_channels_alice
+                    .start_persisted_secure_channel_decryptor(
+                        &ctx2,
+                        &data.decryptor_remote_address_alice,
+                    )
+                    .await?;
+
+                secure_channels_bob
+                    .start_persisted_secure_channel_decryptor(
+                        &ctx2,
+                        &data.decryptor_remote_address_bob,
+                    )
+                    .await?;
+
+                let DecryptionResponse::Ok(decrypted_msg1_alice) = ctx2
+                    .send_and_receive(
+                        route![data.decryptor_api_address_bob.clone()],
+                        DecryptionRequest(data.encrypted_msg1_alice),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+
+                let DecryptionResponse::Ok(decrypted_msg2_alice) = ctx2
+                    .send_and_receive(
+                        route![data.decryptor_api_address_bob.clone()],
+                        DecryptionRequest(data.encrypted_msg2_alice),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+
+                let DecryptionResponse::Ok(decrypted_msg1_bob) = ctx2
+                    .send_and_receive(
+                        route![data.decryptor_api_address_alice.clone()],
+                        DecryptionRequest(data.encrypted_msg1_bob),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+
+                let DecryptionResponse::Ok(decrypted_msg2_bob) = ctx2
+                    .send_and_receive(
+                        route![data.decryptor_api_address_alice.clone()],
+                        DecryptionRequest(data.encrypted_msg2_bob),
+                    )
+                    .await?
+                else {
+                    panic!()
+                };
+
+                assert_eq!(data.msg1_alice, decrypted_msg1_alice);
+                assert_eq!(data.msg2_alice, decrypted_msg2_alice);
+                assert_eq!(data.msg1_bob, decrypted_msg1_bob);
+                assert_eq!(data.msg2_bob, decrypted_msg2_bob);
+
+                ockam_core::Result::<()>::Ok(())
+            })
+            .catch_unwind()
+            .await;
+
+            ctx2.stop().await?;
+
+            res.unwrap()
+        })
+        .unwrap()
+        .unwrap();
+
+    Ok(())
+}

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/20240527100000_add_sc_persistence.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/20240527100000_add_sc_persistence.sql
@@ -1,0 +1,20 @@
+CREATE TABLE secure_channel
+(
+    role                        TEXT NOT NULL,
+    my_identifier               TEXT NOT NULL,
+    their_identifier            TEXT NOT NULL,
+    decryptor_remote_address    TEXT PRIMARY KEY,
+    decryptor_api_address       TEXT NOT NULL,
+    decryption_key_handle       BLOB NOT NULL
+    -- TODO: Add date?
+);
+
+CREATE UNIQUE INDEX secure_channel_decryptor_api_address_index ON secure_channel(decryptor_remote_address);
+
+-- This table stores aead secrets
+CREATE TABLE aead_secret
+(
+    handle      BLOB PRIMARY KEY, -- Secret handle
+    type        TEXT NOT NULL,    -- Secret type
+    secret      BLOB NOT NULL     -- Secret binary
+);

--- a/implementations/rust/ockam/ockam_vault/src/error.rs
+++ b/implementations/rust/ockam/ockam_vault/src/error.rs
@@ -33,6 +33,8 @@ pub enum VaultError {
     InvalidSha256Len,
     /// Invalid Signature Size
     InvalidSignatureSize,
+    /// Aead secret was not found in the storage
+    AeadSecretNotFound,
 }
 
 impl ockam_core::compat::error::Error for VaultError {}
@@ -54,6 +56,7 @@ impl core::fmt::Display for VaultError {
             Self::KeyNotFound => write!(f, "key not found"),
             Self::InvalidSha256Len => write!(f, "invalid sha256 len"),
             Self::InvalidSignatureSize => write!(f, "invalid signature len"),
+            Self::AeadSecretNotFound => write!(f, "aead secret was not found in the storage"),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/types.rs
+++ b/implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/types.rs
@@ -38,6 +38,9 @@ impl BufferSecret {
 
 cfg_if! {
     if #[cfg(any(not(feature = "disable_default_noise_protocol"), feature = "OCKAM_XX_25519_AES256_GCM_SHA256"))] {
+        /// AEAD type string.
+        pub const AEAD_TYPE: &str = "AES256_GCM";
+
         /// AES256 private key length.
         pub const AES256_SECRET_LENGTH: usize = 32;
 
@@ -51,6 +54,9 @@ cfg_if! {
         #[derive(Eq, PartialEq, Clone, Zeroize, ZeroizeOnDrop)]
         pub struct AeadSecret(pub [u8; AEAD_SECRET_LENGTH]);
     } else if #[cfg(feature = "OCKAM_XX_25519_AES128_GCM_SHA256")] {
+        /// AEAD type string.
+        pub const AEAD_TYPE: &'static str = "AES128_GCM";
+
         /// AES128 private key length.
         pub const AES128_SECRET_LENGTH: usize = 16;
 

--- a/implementations/rust/ockam/ockam_vault/src/software/vault_for_signing/vault_for_signing.rs
+++ b/implementations/rust/ockam/ockam_vault/src/software/vault_for_signing/vault_for_signing.rs
@@ -140,7 +140,6 @@ impl VaultForSigning for SoftwareVaultForSigning {
         self.secrets
             .delete_signing_secret(&signing_secret_key_handle)
             .await
-            .map(|s| s.is_some())
     }
 }
 

--- a/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository.rs
@@ -1,4 +1,7 @@
-use crate::{SigningSecret, SigningSecretKeyHandle, X25519SecretKey, X25519SecretKeyHandle};
+use crate::{
+    AeadSecret, AeadSecretKeyHandle, SigningSecret, SigningSecretKeyHandle, X25519SecretKey,
+    X25519SecretKeyHandle,
+};
 use ockam_core::async_trait;
 use ockam_core::compat::boxed::Box;
 use ockam_core::compat::vec::Vec;
@@ -15,10 +18,7 @@ pub trait SecretsRepository: Send + Sync + 'static {
     ) -> Result<()>;
 
     /// Delete a signing secret
-    async fn delete_signing_secret(
-        &self,
-        handle: &SigningSecretKeyHandle,
-    ) -> Result<Option<SigningSecret>>;
+    async fn delete_signing_secret(&self, handle: &SigningSecretKeyHandle) -> Result<bool>;
 
     /// Get a signing secret
     async fn get_signing_secret(
@@ -37,10 +37,7 @@ pub trait SecretsRepository: Send + Sync + 'static {
     ) -> Result<()>;
 
     /// Get a X25519 secret
-    async fn delete_x25519_secret(
-        &self,
-        handle: &X25519SecretKeyHandle,
-    ) -> Result<Option<X25519SecretKey>>;
+    async fn delete_x25519_secret(&self, handle: &X25519SecretKeyHandle) -> Result<bool>;
 
     /// Get a X25519 secret
     async fn get_x25519_secret(
@@ -50,6 +47,19 @@ pub trait SecretsRepository: Send + Sync + 'static {
 
     /// Get the list of all X25519 secret handles
     async fn get_x25519_secret_handles(&self) -> Result<Vec<X25519SecretKeyHandle>>;
+
+    /// Store AEAD secret.
+    async fn store_aead_secret(
+        &self,
+        handle: &AeadSecretKeyHandle,
+        secret: AeadSecret,
+    ) -> Result<()>;
+
+    /// Delete AEAD secret.
+    async fn delete_aead_secret(&self, handle: &AeadSecretKeyHandle) -> Result<bool>;
+
+    /// Get AEAD secret.
+    async fn get_aead_secret(&self, handle: &AeadSecretKeyHandle) -> Result<Option<AeadSecret>>;
 
     /// Delete all secrets
     async fn delete_all(&self) -> Result<()>;

--- a/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_vault/src/storage/secrets_repository_sql.rs
@@ -1,5 +1,6 @@
 use sqlx::*;
 use tracing::debug;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use ockam_core::async_trait;
 use ockam_core::compat::vec::Vec;
@@ -10,8 +11,9 @@ use ockam_node::database::{FromSqlxError, SqlxDatabase, SqlxType, ToSqlxType, To
 use crate::storage::secrets_repository::SecretsRepository;
 
 use crate::{
-    ECDSASHA256CurveP256SecretKey, EdDSACurve25519SecretKey, HandleToSecret, SigningSecret,
-    SigningSecretKeyHandle, X25519SecretKey, X25519SecretKeyHandle,
+    AeadSecret, AeadSecretKeyHandle, ECDSASHA256CurveP256SecretKey, EdDSACurve25519SecretKey,
+    HandleToSecret, SigningSecret, SigningSecretKeyHandle, X25519SecretKey, X25519SecretKeyHandle,
+    AEAD_TYPE,
 };
 
 /// Implementation of a secrets repository using a SQL database
@@ -55,27 +57,11 @@ impl SecretsRepository for SecretsSqlxDatabase {
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn delete_signing_secret(
-        &self,
-        handle: &SigningSecretKeyHandle,
-    ) -> Result<Option<SigningSecret>> {
-        let mut transaction = self.database.begin().await.into_core()?;
-        let query1 =
-            query_as("SELECT handle, secret_type, secret FROM signing_secret WHERE handle=?")
-                .bind(handle.to_sql());
-        let row: Option<SigningSecretRow> =
-            query1.fetch_optional(&mut *transaction).await.into_core()?;
-        let secret = row.map(|r| r.signing_secret()).transpose()?;
+    async fn delete_signing_secret(&self, handle: &SigningSecretKeyHandle) -> Result<bool> {
+        let query = query("DELETE FROM signing_secret WHERE handle = ?").bind(handle.to_sql());
+        let res = query.execute(&*self.database.pool).await.into_core()?;
 
-        let result = if let Some(secret) = secret {
-            let query = query("DELETE FROM signing_secret WHERE handle = ?").bind(handle.to_sql());
-            query.execute(&mut *transaction).await.void()?;
-            Some(secret)
-        } else {
-            None
-        };
-        transaction.commit().await.void()?;
-        Ok(result)
+        Ok(res.rows_affected() != 0)
     }
 
     async fn get_signing_secret(
@@ -113,26 +99,11 @@ impl SecretsRepository for SecretsSqlxDatabase {
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn delete_x25519_secret(
-        &self,
-        handle: &X25519SecretKeyHandle,
-    ) -> Result<Option<X25519SecretKey>> {
-        let mut transaction = self.database.begin().await.into_core()?;
-        let query1 = query_as("SELECT handle, secret FROM x25519_secret WHERE handle=?")
-            .bind(handle.to_sql());
-        let row: Option<X25519SecretRow> =
-            query1.fetch_optional(&mut *transaction).await.into_core()?;
-        let secret = row.map(|r| r.x25519_secret()).transpose()?;
+    async fn delete_x25519_secret(&self, handle: &X25519SecretKeyHandle) -> Result<bool> {
+        let query = query("DELETE FROM x25519_secret WHERE handle = ?").bind(handle.to_sql());
+        let res = query.execute(&*self.database.pool).await.into_core()?;
 
-        let result = if let Some(secret) = secret {
-            let query = query("DELETE FROM x25519_secret WHERE handle = ?").bind(handle.to_sql());
-            query.execute(&mut *transaction).await.void()?;
-            Some(secret)
-        } else {
-            None
-        };
-        transaction.commit().await.void()?;
-        Ok(result)
+        Ok(res.rows_affected() != 0)
     }
 
     async fn get_x25519_secret(
@@ -157,6 +128,37 @@ impl SecretsRepository for SecretsSqlxDatabase {
             .collect::<Result<Vec<_>>>()?)
     }
 
+    async fn store_aead_secret(
+        &self,
+        handle: &AeadSecretKeyHandle,
+        secret: AeadSecret,
+    ) -> Result<()> {
+        let query =
+            query("INSERT OR REPLACE INTO aead_secret(handle, type, secret) VALUES (?, ?, ?)")
+                .bind(handle.to_sql())
+                .bind(AEAD_TYPE.to_sql())
+                .bind(secret.to_sql());
+        query.execute(&*self.database.pool).await.void()
+    }
+
+    async fn delete_aead_secret(&self, handle: &AeadSecretKeyHandle) -> Result<bool> {
+        let query = query("DELETE FROM aead_secret WHERE handle = ?").bind(handle.to_sql());
+        let res = query.execute(&*self.database.pool).await.into_core()?;
+
+        Ok(res.rows_affected() != 0)
+    }
+
+    async fn get_aead_secret(&self, handle: &AeadSecretKeyHandle) -> Result<Option<AeadSecret>> {
+        let query = query_as("SELECT secret FROM aead_secret WHERE handle=? AND type=?")
+            .bind(handle.to_sql())
+            .bind(AEAD_TYPE.to_sql());
+        let row: Option<AeadSecretRow> = query
+            .fetch_optional(&*self.database.pool)
+            .await
+            .into_core()?;
+        Ok(row.map(|r| r.aead_secret()).transpose()?)
+    }
+
     async fn delete_all(&self) -> Result<()> {
         let mut transaction = self.database.begin().await.into_core()?;
         let query1 = query("DELETE FROM signing_secret");
@@ -164,6 +166,10 @@ impl SecretsRepository for SecretsSqlxDatabase {
 
         let query2 = query("DELETE FROM x25519_secret");
         query2.execute(&mut *transaction).await.void()?;
+
+        let query3 = query("DELETE FROM aead_secret");
+        query3.execute(&mut *transaction).await.void()?;
+
         transaction.commit().await.void()
     }
 }
@@ -189,6 +195,12 @@ impl ToSqlxType for X25519SecretKeyHandle {
     }
 }
 
+impl ToSqlxType for AeadSecretKeyHandle {
+    fn to_sql(&self) -> SqlxType {
+        self.0 .0.to_sql()
+    }
+}
+
 impl ToSqlxType for HandleToSecret {
     fn to_sql(&self) -> SqlxType {
         self.value().to_sql()
@@ -201,7 +213,13 @@ impl ToSqlxType for X25519SecretKey {
     }
 }
 
-#[derive(FromRow)]
+impl ToSqlxType for AeadSecret {
+    fn to_sql(&self) -> SqlxType {
+        self.0.to_vec().to_sql()
+    }
+}
+
+#[derive(FromRow, Zeroize, ZeroizeOnDrop)]
 struct SigningSecretRow {
     handle: Vec<u8>,
     secret_type: String,
@@ -210,7 +228,7 @@ struct SigningSecretRow {
 
 impl SigningSecretRow {
     fn signing_secret(&self) -> Result<SigningSecret> {
-        let secret: [u8; 32] = self.secret.clone().try_into().map_err(|_| {
+        let secret = self.secret.clone().try_into().map_err(|_| {
             ockam_core::Error::new(
                 Origin::Api,
                 Kind::Serialization,
@@ -249,7 +267,7 @@ impl SigningSecretRow {
     }
 }
 
-#[derive(FromRow)]
+#[derive(FromRow, Zeroize, ZeroizeOnDrop)]
 struct X25519SecretRow {
     handle: Vec<u8>,
     secret: Vec<u8>,
@@ -257,7 +275,7 @@ struct X25519SecretRow {
 
 impl X25519SecretRow {
     fn x25519_secret(&self) -> Result<X25519SecretKey> {
-        let secret: [u8; 32] = self.secret.clone().try_into().map_err(|_| {
+        let secret = self.secret.as_slice().try_into().map_err(|_| {
             ockam_core::Error::new(
                 Origin::Api,
                 Kind::Serialization,
@@ -271,6 +289,25 @@ impl X25519SecretRow {
         Ok(X25519SecretKeyHandle(HandleToSecret::new(
             self.handle.clone(),
         )))
+    }
+}
+
+#[derive(FromRow, Zeroize, ZeroizeOnDrop)]
+struct AeadSecretRow {
+    secret: Vec<u8>,
+}
+
+impl AeadSecretRow {
+    fn aead_secret(&self) -> Result<AeadSecret> {
+        let secret = self.secret.as_slice().try_into().map_err(|_| {
+            ockam_core::Error::new(
+                Origin::Api,
+                Kind::Serialization,
+                "cannot convert an AEAD secret to array",
+            )
+        })?;
+
+        Ok(AeadSecret(secret))
     }
 }
 
@@ -339,6 +376,37 @@ mod test {
         repository.delete_x25519_secret(&handle1).await?;
 
         let result = repository.get_x25519_secret(&handle1).await?;
+        assert!(result.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_aead_secrets_repository() -> Result<()> {
+        let repository = create_repository().await?;
+
+        let handle1 = AeadSecretKeyHandle::new(HandleToSecret::new(vec![1, 2, 3]));
+        let secret1 = AeadSecret([1; 32]);
+
+        let handle2 = AeadSecretKeyHandle::new(HandleToSecret::new(vec![4, 5, 6]));
+        let secret2 = AeadSecret([2; 32]);
+
+        repository
+            .store_aead_secret(&handle1, secret1.clone())
+            .await?;
+        repository
+            .store_aead_secret(&handle2, secret2.clone())
+            .await?;
+
+        let result = repository.get_aead_secret(&handle1).await?;
+        assert!(result == Some(secret1));
+
+        let result = repository.get_aead_secret(&handle2).await?;
+        assert!(result == Some(secret2));
+
+        repository.delete_aead_secret(&handle1).await?;
+
+        let result = repository.get_aead_secret(&handle1).await?;
         assert!(result.is_none());
 
         Ok(())

--- a/implementations/rust/ockam/ockam_vault/src/traits/vault_for_secure_channels.rs
+++ b/implementations/rust/ockam/ockam_vault/src/traits/vault_for_secure_channels.rs
@@ -59,6 +59,12 @@ pub trait VaultForSecureChannels: Send + Sync + 'static {
         aad: &[u8],
     ) -> Result<Vec<u8>>;
 
+    /// Persist an existing AEAD key.
+    async fn persist_aead_key(&self, secret_key_handle: &AeadSecretKeyHandle) -> Result<()>;
+
+    /// Load an AEAD key from the storage.
+    async fn load_aead_key(&self, secret_key_handle: &AeadSecretKeyHandle) -> Result<()>;
+
     /// Generate a fresh static (persisted) X25519 Key.
     async fn generate_static_x25519_secret_key(&self) -> Result<X25519SecretKeyHandle>;
 

--- a/implementations/rust/ockam/ockam_vault/src/types/hashes.rs
+++ b/implementations/rust/ockam/ockam_vault/src/types/hashes.rs
@@ -9,6 +9,17 @@ pub const SHA256_LENGTH: usize = 32;
 /// SHA-256 Output.
 pub struct Sha256Output(pub [u8; SHA256_LENGTH]);
 
+/// Handle to an AES-256 Secret Key.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct AeadSecretKeyHandle(pub AeadSecretKeyHandleType);
+
+impl AeadSecretKeyHandle {
+    /// Constructor
+    pub fn new(handle: HandleToSecret) -> Self {
+        Self(AeadSecretKeyHandleType::new(handle))
+    }
+}
+
 cfg_if! {
     if #[cfg(any(not(feature = "disable_default_noise_protocol"), feature = "OCKAM_XX_25519_AES256_GCM_SHA256"))] {
         /// Hash used for Noise handshake.
@@ -24,9 +35,15 @@ cfg_if! {
         #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
         pub struct Aes256GcmSecretKeyHandle(pub HandleToSecret);
 
+        impl Aes256GcmSecretKeyHandle {
+            /// Constructor
+            pub fn new(handle: HandleToSecret) -> Self {
+                Self(handle)
+            }
+        }
+
         /// Handle to a AEAD Secret Key.
-        #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
-        pub struct AeadSecretKeyHandle(pub Aes256GcmSecretKeyHandle);
+        pub type AeadSecretKeyHandleType = Aes256GcmSecretKeyHandle;
     } else if #[cfg(feature = "OCKAM_XX_25519_AES128_GCM_SHA256")] {
         /// Hash used for Noise handshake.
         pub struct HashOutput(pub Sha256Output);
@@ -41,9 +58,15 @@ cfg_if! {
         #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
         pub struct Aes128GcmSecretKeyHandle(pub HandleToSecret);
 
+        impl Aes128GcmSecretKeyHandle {
+            /// Constructor
+            pub fn new(handle: HandleToSecret) -> Self {
+                Self(handle)
+            }
+        }
+
         /// Handle to a AEAD Secret Key.
-        #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
-        pub struct AeadSecretKeyHandle(pub Aes128GcmSecretKeyHandle);
+        pub type AeadSecretKeyHandleType = Aes128GcmSecretKeyHandle;
     } else if #[cfg(feature = "OCKAM_XX_25519_ChaChaPolyBLAKE2s")] {
         /// Blake2s digest length
         pub const BLAKE2S_LENGTH: usize = 32;
@@ -64,8 +87,14 @@ cfg_if! {
         #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
         pub struct Chacha20Poly1305SecretKeyHandle(pub HandleToSecret);
 
+        impl Chacha20Poly1305SecretKeyHandle {
+            /// Constructor
+            pub fn new(handle: HandleToSecret) -> Self {
+                Self(handle)
+            }
+        }
+
         /// Handle to a AEAD Secret Key.
-        #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
-        pub struct AeadSecretKeyHandle(pub Chacha20Poly1305SecretKeyHandle);
+        pub type AeadSecretKeyHandleType = Chacha20Poly1305SecretKeyHandle;
     }
 }


### PR DESCRIPTION
- Create basic persistence for Secure Channel decryptor side
- The decryption key is saved to SQLite storage
- Only decryption API mailbox is started when starting a previously persisted secure channel
- Added usage of persisted secure channels to kafka use case