### PR TITLE
feat: tag undecrypted Kafka messages

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/controller.rs
@@ -89,7 +89,7 @@ impl KafkaSecureChannelControllerImpl {
         let decrypted_content = match decrypt_response {
             DecryptionResponse::Ok(p) => p,
             DecryptionResponse::Err(cause) => {
-                error!("cannot decrypt kafka message: closing connection");
+                error!("cannot decrypt kafka message: {:?}", cause);
                 return Err(cause);
             }
         };


### PR DESCRIPTION
This allows the clients to decide what to do with those messages:

-  Stop processing
- Drop them.