### PR TITLE
feat(rust): make `default` vault reuse `SqlxDatabase` instance

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -64,6 +64,10 @@ impl CliState {
         self.database.clone()
     }
 
+    pub fn database_ref(&self) -> &SqlxDatabase {
+        &self.database
+    }
+
     pub fn database_path(&self) -> PathBuf {
         Self::make_database_path(&self.dir)
     }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/secure_channels.rs
@@ -8,7 +8,8 @@ use crate::cli_state::Result;
 impl CliState {
     pub async fn secure_channels(&self, node_name: &str) -> Result<Arc<SecureChannels>> {
         debug!("create the secure channels service");
-        let vault = self.get_node_vault(node_name).await?.vault().await?;
+        let named_vault = self.get_node_vault(node_name).await?;
+        let vault = self.make_vault(named_vault).await?;
         let identities = Identities::create_with_node(self.database(), node_name)
             .with_vault(vault)
             .build();

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -345,12 +345,11 @@ impl NodeManager {
             }
         };
         let identifier = named_identity.identifier();
-        let vault = self
+        let named_vault = self
             .cli_state
             .get_named_vault(&named_identity.vault_name())
-            .await?
-            .vault()
             .await?;
+        let vault = self.cli_state.make_vault(named_vault).await?;
         let secure_channels = self.build_secure_channels(vault).await?;
 
         let options =

--- a/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
@@ -72,11 +72,8 @@ pub async fn start_manager_for_tests(
 
     // Premise: we need an identity and a credential before the node manager starts.
     let identifier = cli_state.get_node(&node_name).await?.identifier();
-    let vault = cli_state
-        .get_or_create_default_named_vault()
-        .await?
-        .vault()
-        .await?;
+    let named_vault = cli_state.get_or_create_default_named_vault().await?;
+    let vault = cli_state.make_vault(named_vault).await?;
     let identities = cli_state.make_identities(vault).await?;
 
     let attributes = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA).build();

--- a/implementations/rust/ockam/ockam_command/src/credential/issue.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/issue.rs
@@ -67,12 +67,8 @@ impl IssueCommand {
             .get_identifier_by_optional_name(&self.as_identity)
             .await?;
 
-        let vault = opts
-            .state
-            .get_named_vault_or_default(&self.vault)
-            .await?
-            .vault()
-            .await?;
+        let named_vault = opts.state.get_named_vault_or_default(&self.vault).await?;
+        let vault = opts.state.make_vault(named_vault).await?;
         let identities = opts.state.make_identities(vault).await?;
 
         let mut attributes_builder = AttributesBuilder::with_schema(PROJECT_MEMBER_SCHEMA);


### PR DESCRIPTION
Currently, we always create a new `SqlxDatabase` instance for the Vault, even though typically we use the same sqlite file as the main database. This is at minimum suboptimal and I'm not fully aware what guarantees sqlite gives under these conditions, so not even sure if it's safe. In this PR I implement a naive optimization which will reuse the existing `SqlxDatabase` instance if we see that this instance and the vault point to the same file.
