### PR TITLE
feat(rust): print a resolved configuration file when it cannot be parsed

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
@@ -1,4 +1,5 @@
 use miette::IntoDiagnostic;
+use ockam_core::errcode::{Kind, Origin};
 use serde::Deserialize;
 
 use crate::run::parser::Variables;
@@ -10,6 +11,17 @@ pub trait ConfigParser<'de>: Deserialize<'de> {
     }
     /// Parses a given yaml configuration
     fn parse(contents: &'de str) -> miette::Result<Self> {
-        serde_yaml::from_str(contents).into_diagnostic()
+        serde_yaml::from_str(contents)
+            .map_err(|e| {
+                ockam_core::Error::new(
+                    Origin::Api,
+                    Kind::Serialization,
+                    format!(
+                        "could not parse the node configuration file: {e:?}\n\n{}",
+                        contents
+                    ),
+                )
+            })
+            .into_diagnostic()
     }
 }


### PR DESCRIPTION
This will help diagnose deserialization errors like this one:
```
data did not match any variant of untagged enum ResourceNameOrMap
```
Which can happen if an environment variable is empty for example. 

We now return the content that was tried to be parsed.