### PR TITLE
Allow kafka debugging of initial `ApiVersions`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/request.rs
@@ -63,6 +63,17 @@ impl InletInterceptorImpl {
         );
 
         match api_key {
+            ApiKey::ApiVersionsKey => {
+                debug!("api versions request: {:?}", header);
+                self.request_map.lock().unwrap().insert(
+                    header.correlation_id,
+                    RequestInfo {
+                        request_api_key: api_key,
+                        request_api_version: header.request_api_version,
+                    },
+                );
+            }
+
             ApiKey::ProduceKey => {
                 return self
                     .handle_produce_request(context, &mut buffer, &header)

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/response.rs
@@ -6,7 +6,7 @@ use kafka_protocol::messages::fetch_response::FetchResponse;
 use kafka_protocol::messages::find_coordinator_response::FindCoordinatorResponse;
 use kafka_protocol::messages::metadata_response::MetadataResponse;
 use kafka_protocol::messages::response_header::ResponseHeader;
-use kafka_protocol::messages::ApiKey;
+use kafka_protocol::messages::{ApiKey, ApiVersionsResponse};
 use kafka_protocol::protocol::buf::ByteBuf;
 use kafka_protocol::protocol::{Decodable, StrBytes};
 use kafka_protocol::records::{
@@ -68,6 +68,13 @@ impl InletInterceptorImpl {
             );
 
             match request_info.request_api_key {
+                ApiKey::ApiVersionsKey => {
+                    let response: ApiVersionsResponse =
+                        decode_body(&mut buffer, request_info.request_api_version)?;
+                    debug!("api versions response header: {:?}", header);
+                    debug!("api versions response: {:#?}", response);
+                }
+
                 ApiKey::FetchKey => {
                     return self
                         .handle_fetch_response(context, &mut buffer, &request_info, &header)


### PR DESCRIPTION
Allow kafka debugging of initial `ApiVersions`, useful when connection is closed right away
