### PR TITLE
Exposed and added `ockam-relay` attribute validation for relay service

### DIFF
--- a/implementations/rust/ockam/ockam/src/relay_service/options.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/options.rs
@@ -1,7 +1,10 @@
+use crate::alloc::string::ToString;
+use alloc::string::String;
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::flow_control::{FlowControlId, FlowControls};
 use ockam_core::{Address, AllowAll, IncomingAccessControl};
+use ockam_identity::{Identifier, IdentitiesAttributes};
 
 /// Trust Options for a Forwarding Service
 pub struct RelayServiceOptions {
@@ -9,6 +12,13 @@ pub struct RelayServiceOptions {
     pub(super) relays_incoming_access_control: Arc<dyn IncomingAccessControl>,
     pub(super) consumer_service: Vec<FlowControlId>,
     pub(super) consumer_relay: Vec<FlowControlId>,
+    pub(super) prefix: String,
+    pub(super) authority_validation: Option<AuthorityValidation>,
+}
+
+pub(super) struct AuthorityValidation {
+    pub(super) authority: Identifier,
+    pub(super) identities_attributes: Arc<IdentitiesAttributes>,
 }
 
 impl RelayServiceOptions {
@@ -19,6 +29,8 @@ impl RelayServiceOptions {
             relays_incoming_access_control: Arc::new(AllowAll),
             consumer_service: vec![],
             consumer_relay: vec![],
+            prefix: "".to_string(),
+            authority_validation: None,
         }
     }
 
@@ -69,6 +81,25 @@ impl RelayServiceOptions {
         access_control: Arc<dyn IncomingAccessControl>,
     ) -> Self {
         self.relays_incoming_access_control = access_control;
+        self
+    }
+
+    /// Set Authority and IdentitiesAttributes
+    pub fn authority(
+        mut self,
+        authority: Identifier,
+        identities_attributes: Arc<IdentitiesAttributes>,
+    ) -> Self {
+        self.authority_validation = Some(AuthorityValidation {
+            authority,
+            identities_attributes,
+        });
+        self
+    }
+
+    /// Set Prefix for the Relay Service
+    pub fn prefix(mut self, prefix: &str) -> Self {
+        self.prefix = prefix.to_string();
         self
     }
 

--- a/implementations/rust/ockam/ockam/src/relay_service/options.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/options.rs
@@ -14,6 +14,7 @@ pub struct RelayServiceOptions {
     pub(super) consumer_relay: Vec<FlowControlId>,
     pub(super) prefix: String,
     pub(super) authority_validation: Option<AuthorityValidation>,
+    pub(super) aliases: Vec<Address>,
 }
 
 pub(super) struct AuthorityValidation {
@@ -31,6 +32,7 @@ impl RelayServiceOptions {
             consumer_relay: vec![],
             prefix: "".to_string(),
             authority_validation: None,
+            aliases: vec![],
         }
     }
 
@@ -100,6 +102,12 @@ impl RelayServiceOptions {
     /// Set Prefix for the Relay Service
     pub fn prefix(mut self, prefix: &str) -> Self {
         self.prefix = prefix.to_string();
+        self
+    }
+
+    /// Add an alias for the Relay Service
+    pub fn alias(mut self, alias: impl Into<Address>) -> Self {
+        self.aliases.push(alias.into());
         self
     }
 

--- a/implementations/rust/ockam/ockam/src/relay_service/relay_service.rs
+++ b/implementations/rust/ockam/ockam/src/relay_service/relay_service.rs
@@ -1,15 +1,16 @@
+use crate::alloc::string::ToString;
 use crate::relay_service::relay::Relay;
 use crate::{Context, RelayServiceOptions};
-use core::str::from_utf8;
+use alloc::string::String;
 use ockam_core::compat::boxed::Box;
-use ockam_core::{Address, Any, DenyAll, Result, Routed, Worker};
+use ockam_core::{Address, DenyAll, Encodable, Result, Routed, Worker};
+use ockam_identity::IdentitySecureChannelLocalInfo;
 use ockam_node::WorkerBuilder;
 
 /// Alias worker to register remote workers under local names.
 ///
 /// To talk with this worker, you can use the
-/// [`RemoteRelay`](crate::remote::RemoteRelay) which is a
-/// compatible client for this server.
+/// [`RemoteRelay`](crate::remote::RemoteRelay) which is a compatible client for this server.
 #[non_exhaustive]
 pub struct RelayService {
     options: RelayServiceOptions,
@@ -46,34 +47,82 @@ impl RelayService {
 #[crate::worker]
 impl Worker for RelayService {
     type Context = Context;
-    type Message = Any;
+    type Message = String;
 
     async fn handle_message(
         &mut self,
         ctx: &mut Self::Context,
-        msg: Routed<Self::Message>,
+        message: Routed<Self::Message>,
     ) -> Result<()> {
-        let forward_route = msg.return_route();
-        let payload = msg.payload();
+        let secure_channel_local_info =
+            IdentitySecureChannelLocalInfo::find_info(message.local_message()).ok();
 
-        let random_address = Address::random_tagged("Relay.service");
+        let forward_route = message.return_route();
+        let requested_relay_address = message.into_body()?;
 
-        // TODO: assume that the first byte is length, ignore it.
-        // We have to improve this actually parse the payload.
-        let address = match payload.get(1..) {
-            Some(address) => match from_utf8(address) {
-                Ok(v) if v != "register" => Address::from_string(v),
-                _ => random_address,
-            },
-            None => random_address,
+        let requested_relay_name = if requested_relay_address == "register" {
+            Address::random_tagged("Relay.service")
+                .address()
+                .to_string()
+        } else {
+            requested_relay_address
         };
 
+        debug!(%requested_relay_name, "Relay creation request");
+
+        // Verify the relay usage only when an authority is set, otherwise allow any relay name
+        if let Some(authority_validation) = &self.options.authority_validation {
+            if let Some(secure_channel_local_info) = secure_channel_local_info {
+                let attributes = authority_validation
+                    .identities_attributes
+                    .get_attributes(
+                        &secure_channel_local_info.their_identity_id(),
+                        &authority_validation.authority,
+                    )
+                    .await?;
+
+                if let Some(attributes) = attributes {
+                    let ockam_relay = attributes
+                        .attrs()
+                        .get("ockam-relay".as_bytes())
+                        .and_then(|a| String::from_utf8(a.clone()).ok());
+
+                    if let Some(ockam_relay) = ockam_relay {
+                        match ockam_relay.as_str() {
+                            "*" => {
+                                // allow any relay name
+                            }
+                            allowed_name => {
+                                if allowed_name != requested_relay_name {
+                                    warn!(%allowed_name, %requested_relay_name, "Relay creation request not authorized, relay name does not match the attribute, dropping.");
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    } else {
+                        warn!(%attributes, "Relay creation request not authorized, missing or invalid `ockam-relay` attribute, dropping.");
+                        return Ok(());
+                    }
+                } else {
+                    warn!("Relay creation request not authorized, missing `ockam-relay` attribute, no other attribute was found, dropping.");
+                    return Ok(());
+                }
+            } else {
+                warn!("Relay creation request not authenticated, dropping.");
+                return Ok(());
+            }
+        }
+
+        let final_relay_name = self.options.prefix.clone() + &requested_relay_name;
+        let payload = final_relay_name.clone().encode()?;
+        let final_relay_address = Address::from_string(final_relay_name);
+
         self.options
-            .setup_flow_control_for_relay(ctx.flow_controls(), &address);
+            .setup_flow_control_for_relay(ctx.flow_controls(), &final_relay_address);
 
         Relay::create(
             ctx,
-            address,
+            final_relay_address,
             forward_route,
             payload.to_vec(),
             self.options.relays_incoming_access_control.clone(),

--- a/implementations/rust/ockam/ockam/src/remote/mod.rs
+++ b/implementations/rust/ockam/ockam/src/remote/mod.rs
@@ -11,11 +11,9 @@ pub use info::*;
 pub use options::*;
 
 use crate::remote::addresses::Addresses;
-use core::time::Duration;
-use ockam_core::compat::{string::String, vec::Vec};
+use ockam_core::compat::string::String;
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::Route;
-use ockam_node::DelayedEvent;
 
 /// This Worker is responsible for registering on Ockam Orchestrator and forwarding messages to local Worker
 pub struct RemoteRelay {
@@ -25,7 +23,4 @@ pub struct RemoteRelay {
     registration_route: Route,
     registration_payload: String,
     flow_control_id: Option<FlowControlId>,
-    // We only use Heartbeat for static RemoteRelay
-    heartbeat: Option<DelayedEvent<Vec<u8>>>,
-    heartbeat_interval: Duration,
 }

--- a/implementations/rust/ockam/ockam/src/remote/worker.rs
+++ b/implementations/rust/ockam/ockam/src/remote/worker.rs
@@ -39,10 +39,6 @@ impl Worker for RemoteRelay {
             )
             .await?;
 
-            if let Some(heartbeat) = &mut self.heartbeat {
-                heartbeat.schedule(self.heartbeat_interval).await?;
-            }
-
             Ok(())
         } else if msg.msg_addr() == self.addresses.main_remote {
             let return_route = msg.return_route();
@@ -87,10 +83,6 @@ impl Worker for RemoteRelay {
                         self.completion_msg_sent = true;
                     }
 
-                    if let Some(heartbeat) = &mut self.heartbeat {
-                        heartbeat.schedule(self.heartbeat_interval).await?;
-                    }
-
                     Ok(())
                 }
                 Ok(next) if next == &self.addresses.main_remote => {
@@ -106,12 +98,6 @@ impl Worker for RemoteRelay {
                     // Send the message on its onward_route
                     ctx.forward_from_address(local_message, self.addresses.main_internal.clone())
                         .await?;
-
-                    // We received message from the other node, our registration is still alive, let's reset
-                    // heartbeat timer
-                    if let Some(heartbeat) = &mut self.heartbeat {
-                        heartbeat.schedule(self.heartbeat_interval).await?;
-                    }
 
                     Ok(())
                 }

--- a/implementations/rust/ockam/ockam/src/remote/worker.rs
+++ b/implementations/rust/ockam/ockam/src/remote/worker.rs
@@ -3,7 +3,6 @@ use crate::{Context, OckamError};
 use ockam_core::compat::{
     boxed::Box,
     string::{String, ToString},
-    vec::Vec,
 };
 use ockam_core::{Any, Decodable, Result, Routed, Worker};
 use tracing::{debug, info};
@@ -56,12 +55,12 @@ impl Worker for RemoteRelay {
                 Err(_) => {
                     debug!("RemoteRelay received service message");
 
-                    let payload = Vec::<u8>::decode(local_message.payload_ref())
+                    let payload = String::decode(local_message.payload_ref())
                         .map_err(|_| OckamError::InvalidHubResponse)?;
-                    let payload =
-                        String::from_utf8(payload).map_err(|_| OckamError::InvalidHubResponse)?;
                     // using ends_with() instead of == to allow for prefixes
-                    if !payload.ends_with(&self.registration_payload) {
+                    if self.registration_payload != "register"
+                        && !payload.ends_with(&self.registration_payload)
+                    {
                         return Err(OckamError::InvalidHubResponse)?;
                     }
 

--- a/implementations/rust/ockam/ockam_abac/src/resource.rs
+++ b/implementations/rust/ockam/ockam_abac/src/resource.rs
@@ -51,6 +51,9 @@ pub enum ResourceType {
     #[n(5)]
     #[strum(serialize = "kafka-producer")]
     KafkaProducer,
+    #[n(6)]
+    #[strum(serialize = "relay")]
+    Relay,
 }
 
 impl ResourceType {

--- a/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/relays.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/secure_channel_map/relays.rs
@@ -1,8 +1,7 @@
 use crate::kafka::secure_channel_map::controller::{
     InnerSecureChannelControllerImpl, KafkaSecureChannelControllerImpl,
 };
-use ockam_multiaddr::proto::Project;
-use ockam_multiaddr::{MultiAddr, Protocol};
+use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 use tokio::sync::MutexGuard;
 
@@ -13,21 +12,12 @@ impl KafkaSecureChannelControllerImpl {
         relay_service: MultiAddr,
         alias: String,
     ) -> ockam_core::Result<()> {
-        let is_rust_node = {
-            // we might create a relay in the producer passing through a project relay
-            !(relay_service.starts_with(Project::CODE)
-                && relay_service
-                    .last()
-                    .map_or(false, |p| p.code() == Project::CODE))
-        };
-
         let relay_info = inner
             .node_manager
             .create_relay(
                 context,
                 &relay_service,
                 alias.clone(),
-                is_rust_node,
                 None,
                 Some(alias.clone()),
             )

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
@@ -21,28 +21,24 @@ pub struct CreateRelay {
     #[n(1)] pub(crate) address: MultiAddr,
     /// Relay alias.
     #[n(2)] pub(crate) alias: String,
-    /// Forwarding service is at rust node.
-    #[n(3)] pub(crate) at_rust_node: bool,
     /// An authorised identity for secure channels.
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
-    #[n(4)] pub(crate) authorized: Option<Identifier>,
+    #[n(3)] pub(crate) authorized: Option<Identifier>,
     /// Relay address.
-    #[n(5)] pub(crate) relay_address: Option<String>,
+    #[n(4)] pub(crate) relay_address: Option<String>,
 }
 
 impl CreateRelay {
     pub fn new(
         address: MultiAddr,
         alias: String,
-        at_rust_node: bool,
         auth: Option<Identifier>,
         relay_address: Option<String>,
     ) -> Self {
         Self {
             address,
             alias,
-            at_rust_node,
             authorized: auth,
             relay_address,
         }
@@ -54,10 +50,6 @@ impl CreateRelay {
 
     pub fn alias(&self) -> &str {
         &self.alias
-    }
-
-    pub fn at_rust_node(&self) -> bool {
-        self.at_rust_node
     }
 
     pub fn authorized(&self) -> Option<Identifier> {
@@ -81,21 +73,18 @@ pub struct RelayInfo {
     #[n(5)] connection_status: ConnectionStatus,
     #[n(6)] destination_address: MultiAddr,
     #[n(7)] alias: String,
-    #[n(8)] at_rust_node: bool,
-    #[n(9)] last_failure: Option<String>,
+    #[n(8)] last_failure: Option<String>,
 }
 
 impl RelayInfo {
     pub fn new(
         destination_address: MultiAddr,
         alias: String,
-        at_rust_node: bool,
         connection_status: ConnectionStatus,
     ) -> Self {
         Self {
             destination_address,
             alias,
-            at_rust_node,
             forwarding_route: None,
             remote_address: None,
             worker_address: None,
@@ -114,7 +103,6 @@ impl RelayInfo {
             connection_status: self.connection_status,
             destination_address: self.destination_address,
             alias: self.alias,
-            at_rust_node: self.at_rust_node,
             last_failure: self.last_failure,
         }
     }
@@ -128,7 +116,6 @@ impl RelayInfo {
             connection_status: self.connection_status,
             destination_address: self.destination_address,
             alias: self.alias,
-            at_rust_node: self.at_rust_node,
             last_failure: Some(last_failure),
         }
     }
@@ -143,10 +130,6 @@ impl RelayInfo {
 
     pub fn alias(&self) -> &str {
         &self.alias
-    }
-
-    pub fn at_rust_node(&self) -> bool {
-        self.at_rust_node
     }
 
     pub fn forwarding_route(&self) -> &Option<String> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -163,7 +163,6 @@ impl OutletInfo {
 pub struct RegistryRelayInfo {
     pub(crate) destination_address: MultiAddr,
     pub(crate) alias: String,
-    pub(crate) at_rust_node: bool,
     pub(crate) session: Session,
 }
 
@@ -172,7 +171,6 @@ impl From<RegistryRelayInfo> for RelayInfo {
         let relay_info = RelayInfo::new(
             registry_relay_info.destination_address.clone(),
             registry_relay_info.alias.clone(),
-            registry_relay_info.at_rust_node,
             registry_relay_info.session.connection_status(),
         );
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/default_address.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/default_address.rs
@@ -3,6 +3,7 @@ pub struct DefaultAddress;
 impl DefaultAddress {
     pub const OUTLET_SERVICE: &'static str = "outlet";
     pub const RELAY_SERVICE: &'static str = "forwarding_service";
+    pub const STATIC_RELAY_SERVICE: &'static str = "static_forwarding_service";
     pub const UPPERCASE_SERVICE: &'static str = "uppercase";
     pub const ECHO_SERVICE: &'static str = "echo";
     pub const HOP_SERVICE: &'static str = "hop";
@@ -18,6 +19,7 @@ impl DefaultAddress {
 
     pub fn is_valid(name: &str) -> bool {
         matches!(name, |Self::OUTLET_SERVICE| Self::RELAY_SERVICE
+            | Self::STATIC_RELAY_SERVICE
             | Self::UPPERCASE_SERVICE
             | Self::ECHO_SERVICE
             | Self::HOP_SERVICE
@@ -36,6 +38,7 @@ impl DefaultAddress {
         [
             Self::OUTLET_SERVICE,
             Self::RELAY_SERVICE,
+            Self::STATIC_RELAY_SERVICE,
             Self::UPPERCASE_SERVICE,
             Self::ECHO_SERVICE,
             Self::HOP_SERVICE,
@@ -63,6 +66,9 @@ mod test {
         assert!(!DefaultAddress::is_valid("foo"));
         assert!(DefaultAddress::is_valid(DefaultAddress::OUTLET_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::RELAY_SERVICE));
+        assert!(DefaultAddress::is_valid(
+            DefaultAddress::STATIC_RELAY_SERVICE
+        ));
         assert!(DefaultAddress::is_valid(DefaultAddress::UPPERCASE_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::ECHO_SERVICE));
         assert!(DefaultAddress::is_valid(DefaultAddress::HOP_SERVICE));

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -192,6 +192,7 @@ impl NodeManager {
             .await?;
 
         let options = RelayServiceOptions::new()
+            .alias(DefaultAddress::STATIC_RELAY_SERVICE)
             .service_as_consumer(api_flow_control_id)
             .relay_as_consumer(api_flow_control_id)
             .prefix("forward_to_");

--- a/implementations/rust/ockam/ockam_api/src/session/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/mod.rs
@@ -134,10 +134,8 @@ impl Medic {
                                 .with_payload(encoded_message);
 
                             let sender = ctx.clone();
-                            self.pings.spawn(async move {
-                                log::trace!("sending ping");
-                                (key, sender.forward(local_message).await)
-                            });
+                            self.pings
+                                .spawn(async move { (key, sender.forward(local_message).await) });
                         };
                     } else {
                         // We reached the maximum number of failures

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
@@ -88,7 +88,6 @@ impl AppState {
                             context,
                             &project_address,
                             relay_alias.clone(),
-                            false,
                             None,
                             Some(relay_alias),
                         )

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -170,9 +170,7 @@ impl CreateCommand {
             .map(|p| p.name().to_string());
         let at = Self::parse_arg_at(&opts.state, self.at, default_project_name.as_deref()).await?;
         self.project_relay |= at.starts_with(Project::CODE);
-        let relay_name = Self::parse_arg_relay_name(self.relay_name, !self.project_relay)?;
         self.at = at.to_string();
-        self.relay_name = relay_name;
         Ok(self)
     }
 
@@ -193,15 +191,6 @@ impl CreateCommand {
         }
         let ma = MultiAddr::from_str(&at).map_err(|_| Error::arg_validation("at", at, None))?;
         process_nodes_multiaddr(&ma, state).await
-    }
-
-    fn parse_arg_relay_name(relay_name: impl Into<String>, at_rust_node: bool) -> Result<String> {
-        let relay_name = relay_name.into();
-        if at_rust_node {
-            Ok(format!("forward_to_{relay_name}"))
-        } else {
-            Ok(relay_name)
-        }
     }
 }
 
@@ -257,16 +246,5 @@ mod tests {
         assert!(res.contains("/ip4/127.0.0.1/tcp/"));
 
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_parse_arg_relay_name() {
-        // `--at` is a local route
-        let res = CreateCommand::parse_arg_relay_name("relay", true).unwrap();
-        assert_eq!(res, "forward_to_relay");
-
-        // `--at` is a remote route
-        let res = CreateCommand::parse_arg_relay_name("relay", false).unwrap();
-        assert_eq!(res, "relay");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -100,7 +100,6 @@ impl Command for CreateCommand {
                     alias.clone(),
                     cmd.authorized,
                     Some(cmd.relay_address.unwrap_or(alias)),
-                    !cmd.project_relay,
                 )
                 .await
                 .map_err(Error::Retry)?

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/relay.bats
@@ -53,13 +53,13 @@ teardown() {
 
   # Create and show it
   run_success "$OCKAM" relay create blue --at /node/n1 --to /node/n2
-  run_success "$OCKAM" relay show forward_to_blue --at /node/n2 --output json
+  run_success "$OCKAM" relay show blue --at /node/n2 --output json
   assert_output --regexp "\"relay_route\".* => 0#forward_to_blue"
   assert_output --partial "\"remote_address\":\"/service/forward_to_blue\""
   assert_output --regexp "\"worker_address\":\"/service/.*"
 
   ## Try to show a non-existing relay
-  run_failure "$OCKAM" relay show forward_to_r --at /node/n2
+  run_failure "$OCKAM" relay show red --at /node/n2
   assert_output --partial "not found"
 
   # Create another one and list both
@@ -69,11 +69,11 @@ teardown() {
   assert_output --partial "\"remote_address\":\"forward_to_red\""
 
   # Delete the first
-  run_success "$OCKAM" relay delete -y forward_to_blue --at /node/n2
+  run_success "$OCKAM" relay delete -y blue --at /node/n2
   run_success "$OCKAM" relay list --to /node/n2 --output json
   refute_output --partial "\"remote_address\":\"forward_to_blue\""
   assert_output --partial "\"remote_address\":\"forward_to_red\""
 
   ## Try to delete twice
-  run_failure "$OCKAM" relay delete -y forward_to_blue --at /node/n2
+  run_failure "$OCKAM" relay delete -y blue --at /node/n2
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
@@ -62,3 +62,20 @@ teardown() {
   run_success "$OCKAM" relay create $relay_name_blue --to /node/admin_node
   run_success "$OCKAM" relay create $relay_name_green --to /node/admin_node
 }
+
+@test "relay - create relay between rust nodes requires credentials" {
+  relay_name=$(random_str)
+  relay_ticket_path="$OCKAM_HOME/relay.ticket"
+
+  run_success bash -c "$OCKAM project ticket --usage-count 1 --relay $relay_name > $relay_ticket_path"
+
+  setup_home_dir
+  $OCKAM project enroll $relay_ticket_path
+
+  run_success "$OCKAM" node create blue
+  run_success "$OCKAM" node create red
+
+  # fail with a different relay name
+  run_failure "$OCKAM" relay create --at /node/blue/secure/api --to red unauthorized_relay_name
+  run_success "$OCKAM" relay create --at /node/blue/secure/api --to red $relay_name
+}

--- a/tools/stress-test/src/execution.rs
+++ b/tools/stress-test/src/execution.rs
@@ -29,7 +29,7 @@ impl State {
                 let context = self.context.clone();
                 join_set.spawn(async move {
                     let id = Self::random_id();
-                    node.create_relay(&context, &project_addr, id.clone(), false, None, Some(id))
+                    node.create_relay(&context, &project_addr, id.clone(), None, Some(id))
                         .await
                 });
             }


### PR DESCRIPTION
Currently, rust relays are used for demo purposes only, this PR allows rust relays to work exactly as project relays.
Rust relays are exposed (both `static_forwarding_service` and `forwarding_service`).
These services require both project membership and `ockam-relay` credential attribute, like projects.
`forward_to_` prefix is applied at service level rather than client level.