### PR TITLE
fix(rust): return alphabetical-only random strings in bats' random_str function

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -79,7 +79,7 @@ to_uppercase() {
 
 # Returns a random name
 random_str() {
-  echo "$(openssl rand -hex 4)"
+  echo "$(LC_ALL=C tr -dc 'a-zA-Z' </dev/urandom | head -c 10)"
 }
 
 # Returns a random port


### PR DESCRIPTION
The previous implementation could generate invalid relay names, causing flakiness in some tests.