### PR TITLE
refactor(rust): rename `node-config` argument of `node create` command to `configuration`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -42,7 +42,7 @@ after_long_help = docs::after_help(AFTER_LONG_HELP)
 pub struct CreateCommand {
     /// Name of the node or a configuration to set up the node.
     /// The configuration can be either a path to a local file or a URL.
-    #[arg(value_name = "NAME_OR_CONFIG", hide_default_value = true, default_value_t = random_name())]
+    #[arg(value_name = "NAME_OR_CONFIGURATION", hide_default_value = true, default_value_t = random_name())]
     pub name: String,
 
     #[command(flatten)]
@@ -106,7 +106,7 @@ impl Default for CreateCommand {
             skip_is_running_check: false,
             name: random_name(),
             config_args: ConfigArgs {
-                node_config: None,
+                configuration: None,
                 enrollment_ticket: None,
                 variables: vec![],
             },
@@ -177,7 +177,7 @@ impl CreateCommand {
     fn has_name_arg(&self) -> bool {
         is_url(&self.name).is_none()
             && std::fs::metadata(&self.name).is_err()
-            && self.config_args.node_config.is_none()
+            && self.config_args.configuration.is_none()
     }
 
     fn parse_args(&self) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -19,8 +19,8 @@ use tracing::{debug, instrument, Span};
 #[derive(Clone, Debug, Args, Default)]
 pub struct ConfigArgs {
     /// Inline node configuration
-    #[arg(long, value_name = "YAML")]
-    pub node_config: Option<String>,
+    #[arg(long, visible_alias = "node-config", value_name = "YAML")]
+    pub configuration: Option<String>,
 
     /// A path, URL or inlined hex-encoded enrollment ticket to use for the Ockam Identity associated to this node.
     /// When passed, the identity will be given a project membership credential.
@@ -64,7 +64,7 @@ impl CreateCommand {
     ///  - an inline configuration
     #[instrument(skip_all, fields(app.event.command.configuration_file))]
     pub async fn get_node_config(&self) -> miette::Result<NodeConfig> {
-        let contents = match self.config_args.node_config.clone() {
+        let contents = match self.config_args.configuration.clone() {
             Some(contents) => contents,
             None => async_parse_path_or_url(&self.name).await?,
         };

--- a/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
+++ b/implementations/rust/ockam/ockam_command/src/node/static/create/after_long_help.txt
@@ -9,7 +9,7 @@ $ ockam node create n
 $ ockam node create config.yaml
 
 # To create a new node with an inline configuration
-$ ockam node create --node-config "{name: n1, tcp-outlet: {db-outlet: {to: '127.0.0.1:5432'}}}"
+$ ockam node create --configuration "{name: n1, tcp-outlet: {db-outlet: {to: '127.0.0.1:5432'}}}"
 ```
 
 An example of a configuration file is:

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -140,7 +140,7 @@ force_kill_node() {
 }
 
 @test "node - create a node with an inline configuration" {
-  run_success "$OCKAM" node create --node-config "{name: n, tcp-outlets: {db-outlet: {to: 5432, at: n}}}"
+  run_success "$OCKAM" node create --configuration "{name: n, tcp-outlets: {db-outlet: {to: 5432, at: n}}}"
   run_success $OCKAM node show n --output json
   assert_output --partial "\"name\":\"n\""
   assert_output --partial "127.0.0.1:5432"
@@ -149,14 +149,14 @@ force_kill_node() {
 @test "node - node in foreground with configuration is deleted if something fails" {
   # The config file has a typo in the "to" address to trigger an error after the node is created.
   # The command should return an error and the node should be deleted.
-  run_failure "$OCKAM" node create --node-config "{name: n, tcp-outlets: {db-outlet: {to: \"localhosst:3000\"}}}"
+  run_failure "$OCKAM" node create --configuration "{name: n, tcp-outlets: {db-outlet: {to: \"localhosst:3000\"}}}"
   run_success $OCKAM node show n --output json
   assert_output --partial "[]"
 }
 
 @test "node - create two nodes with the same inline configuration" {
-  run_success "$OCKAM" node create --node-config "{tcp-outlets: {to: 8080}}"
-  run_success "$OCKAM" node create --node-config "{tcp-outlets: {to: 8080}}"
+  run_success "$OCKAM" node create --configuration "{tcp-outlets: {to: 8080}}"
+  run_success "$OCKAM" node create --configuration "{tcp-outlets: {to: 8080}}"
 
   # each node must have its own outlet
   node_names="$($OCKAM node list --output json | jq -r 'map(.node_name) | join(" ")')"
@@ -167,7 +167,7 @@ force_kill_node() {
 }
 
 @test "node - return error if passed variable has no value" {
-  run_failure "$OCKAM" node create --node-config "{name: n}" --variable MY_VAR=
+  run_failure "$OCKAM" node create --configuration "{name: n}" --variable MY_VAR=
   assert_output --partial "Empty value for variable 'MY_VAR'"
 }
 


### PR DESCRIPTION
Keeps the old arg name `--node-config` as a valid alias for backward compatibility.