### PR TITLE
feat(rust): improve output for `project show` command

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/output/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/output/mod.rs
@@ -1,8 +1,6 @@
 use core::fmt;
-use core::fmt::Write;
 use std::fmt::Formatter;
 
-use colorful::Colorful;
 use minicbor::Encode;
 use serde::{Serialize, Serializer};
 
@@ -11,33 +9,11 @@ use ockam::identity::models::{
     PurposeKeyAttestationData, PurposePublicKey, VersionedData,
 };
 use ockam::identity::{Credential, Identifier, Identity};
-use ockam_api::cloud::project::Project;
 use ockam_api::output::{human_readable_time, Output};
 
 use ockam_vault::{
     ECDSASHA256CurveP256PublicKey, EdDSACurve25519PublicKey, VerifyingPublicKey, X25519PublicKey,
 };
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ProjectConfigCompact(pub Project);
-
-impl Output for ProjectConfigCompact {
-    fn item(&self) -> ockam_api::Result<String> {
-        let pi = self.0.project_identifier()?.to_string();
-        let ar = self
-            .0
-            .authority_multiaddr()
-            .map(|r| r.to_string())
-            .unwrap_or_else(|_| "N/A".to_string());
-        let ai = self.0.authority_identifier()?.to_string();
-        let mut w = String::new();
-        writeln!(w, "{}: {}", "Project ID".bold(), self.0.project_id())?;
-        writeln!(w, "{}: {}", "Project Identifier".bold(), pi)?;
-        writeln!(w, "{}: {}", "Authority address".bold(), ar)?;
-        write!(w, "{}: {}", "Authority Identifier".bold(), ai)?;
-        Ok(w)
-    }
-}
 
 pub struct X25519PublicKeyDisplay(pub X25519PublicKey);
 

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -8,7 +8,7 @@ use ockam_api::output::Output;
 
 use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
-use crate::{docs, output::ProjectConfigCompact, CommandGlobalOpts};
+use crate::{docs, CommandGlobalOpts};
 
 /// Show project details
 #[derive(Clone, Debug, Args)]
@@ -36,11 +36,10 @@ impl InfoCommand {
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         let node = InMemoryNode::start(ctx, &opts.state).await?;
         let project = node.get_project_by_name(ctx, &self.name).await?;
-        let info = ProjectConfigCompact(project);
         opts.terminal
             .stdout()
-            .plain(info.item()?)
-            .json(serde_json::to_string(&info).into_diagnostic()?)
+            .plain(project.item()?)
+            .json(serde_json::to_string(&project).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/project/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/show.rs
@@ -10,7 +10,6 @@ use ockam_api::output::Output;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::AsyncTryClone;
 
-use crate::output::ProjectConfigCompact;
 use crate::shared_args::{IdentityOpts, RetryOpts};
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
@@ -124,12 +123,11 @@ impl ShowCommandTui for ShowTui {
             .get_project_by_name(&self.ctx, item_name)
             .await
             .map_err(Error::Retry)?;
-        let project_output = ProjectConfigCompact(project);
 
         self.terminal()
             .stdout()
-            .plain(project_output.item()?)
-            .json(serde_json::to_string(&project_output).into_diagnostic()?)
+            .plain(project.item()?)
+            .json(serde_json::to_string(&project).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }


### PR DESCRIPTION
Before we had:

```
➜ ../ockam-binaries/ockam-dev project show
Project ID: a6ee386a-3d2a-4559-8922-c1af69001bd5
Project Identifier: I46f99cb2f80fec4538ad4f6fc51b1d4ba57ea8f5b1e39e87fa6f52c387f4724d
Authority address: /dnsaddr/k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com/tcp/4014/service/api
Authority Identifier: If4c50f7c93f5a272a4f313e6f02b384d2c2e730084978f32ddaa3a7bb8ca201c
```

which was missing a lot of details in the plain output. Now it looks like this (same structure as `node show` and others):

```
➜ ./target/debug/ockam project show
     default:
       Id: a6ee386a-3d2a-4559-8922-c1af69001bd5
       Name: default
       Space: outspoken-hagfish
       Route: /dnsaddr/k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com/tcp/4013/service/api
       Address: k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com:4013
       Identifier: I46f99cb2f80fec4538ad4f6fc51b1d4ba57ea8f5b1e39e87fa6f52c387f4724d
       Version: 0.6.11
       Is running: true
       Authority route: /dnsaddr/k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com/tcp/4014/service/api
       Authority address: k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com:4014
       Authority identifier: If4c50f7c93f5a272a4f313e6f02b384d2c2e730084978f32ddaa3a7bb8ca201c
       Egress allow list: k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com:4013, k8s-hub-nginxing-ba5035edaa-09bff1666a791b25.elb.us-west-1.amazonaws.com:4014
```

The json output now also includes the `egress_allow_list` field.