### PR TITLE
indicate ockam version to install, using environment variables

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -281,7 +281,7 @@ add_to_path() {
 }
 
 main() {
-  local _version=""
+  local _version="$OCKAM_VERSION"
   install_path="$HOME/.ockam"
   local _modify_path="true"
 


### PR DESCRIPTION
Allows us install a specific version of Ockam using environment variable instead of using the proposed script flag.
This will help us test our Ockam examples with older and newer version of Ockam