### PR TITLE
Added  TLS Inlet support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,6 +5038,7 @@ name = "ockam_transport_tcp"
 version = "0.123.0"
 dependencies = [
  "cfg-if",
+ "log",
  "minicbor",
  "ockam_core",
  "ockam_macros",
@@ -5045,7 +5046,9 @@ dependencies = [
  "ockam_transport_core",
  "opentelemetry",
  "rand",
+ "rustls 0.23.12",
  "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.3",
  "serde",
  "socket2 0.5.7",
  "tokio",

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
@@ -17,6 +17,9 @@ pub const OCKAM_ROLE_ATTRIBUTE_KEY: &str = "ockam-role";
 /// the corresponding key is [`OCKAM_ROLE_ATTRIBUTE_KEY`]
 pub const OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE: &str = "enroller";
 
+/// Identity attribute key that indicates the privileges to access the project TLS certificate
+pub const OCKAM_TLS_ATTRIBUTE_KEY: &str = "ockam-tls-certificate";
+
 pub struct DirectAuthenticatorError(pub String);
 
 pub type DirectAuthenticatorResult<T> = Either<T, DirectAuthenticatorError>;

--- a/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/inlet_controller.rs
@@ -142,6 +142,7 @@ impl KafkaInletController {
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -54,10 +54,12 @@ pub struct CreateInlet {
     /// If not set, the node's identifier will be used.
     #[n(10)] pub(crate) secure_channel_identifier: Option<Identifier>,
     /// Enable UDP NAT puncture.
-    #[n(11)] pub enable_udp_puncture: bool,
+    #[n(11)] pub(crate) enable_udp_puncture: bool,
     /// Disable fallback to TCP.
     /// TCP won't be used to transfer data between the Inlet and the Outlet.
-    #[n(12)] pub disable_tcp_fallback: bool,
+    #[n(12)] pub(crate) disable_tcp_fallback: bool,
+    /// TLS certificate provider route.
+    #[n(13)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
 }
 
 impl CreateInlet {
@@ -85,6 +87,7 @@ impl CreateInlet {
             secure_channel_identifier: None,
             enable_udp_puncture,
             disable_tcp_fallback,
+            tls_certificate_provider: None,
         }
     }
 
@@ -113,7 +116,12 @@ impl CreateInlet {
             secure_channel_identifier: None,
             enable_udp_puncture,
             disable_tcp_fallback,
+            tls_certificate_provider: None,
         }
+    }
+
+    pub fn set_tls_certificate_provider(&mut self, provider: MultiAddr) {
+        self.tls_certificate_provider = Some(provider);
     }
 
     pub fn set_wait_ms(&mut self, ms: u64) {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -21,6 +21,7 @@ pub mod tcp_outlets;
 mod transport;
 pub mod workers;
 
+mod certificate_provider;
 mod http;
 mod manager;
 mod trust;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/certificate_provider.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/certificate_provider.rs
@@ -1,0 +1,143 @@
+use crate::nodes::NodeManager;
+use minicbor::{Decode, Decoder, Encode};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{Any, NeutralMessage, Routed};
+use ockam_multiaddr::MultiAddr;
+use ockam_node::{Context, MessageSendReceiveOptions};
+use ockam_transport_tcp::{TlsCertificate, TlsCertificateProvider};
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::Weak;
+use std::time::Duration;
+use tonic::async_trait;
+
+#[derive(Clone)]
+pub(crate) struct ProjectCertificateProvider {
+    node_manager: Weak<NodeManager>,
+    to: MultiAddr,
+}
+
+impl Debug for ProjectCertificateProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProjectCertificateProvider {{ to: {:?} }}", self.to)
+    }
+}
+
+impl ProjectCertificateProvider {
+    pub fn new(node_manager: Weak<NodeManager>, to: MultiAddr) -> Self {
+        Self { node_manager, to }
+    }
+}
+
+impl Display for ProjectCertificateProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "certificate retrieval from: {}", self.to)
+    }
+}
+
+#[derive(Encode, Decode)]
+struct CertificateRequest {}
+
+#[derive(Debug, Encode, Decode)]
+#[rustfmt::skip]
+#[cbor(map)]
+struct CertificateResponse {
+    #[n(1)] kind: ReplyKind,
+    #[n(2)] certificate: Option<TlsCertificate>,
+}
+
+#[derive(Debug, Encode, Decode, PartialEq)]
+#[rustfmt::skip]
+#[cbor(index_only)]
+enum ReplyKind {
+    #[n(0)] Ready,
+    #[n(1)] NotReady,
+    #[n(2)] Unsupported,
+}
+
+#[async_trait]
+impl TlsCertificateProvider for ProjectCertificateProvider {
+    async fn get_certificate(&self, context: &Context) -> ockam_core::Result<TlsCertificate> {
+        debug!("requesting TLS certificate from: {}", self.to);
+        let node_manager = self.node_manager.upgrade().ok_or_else(|| {
+            ockam_core::Error::new(Origin::Transport, Kind::Invalid, "NodeManager shut down")
+        })?;
+        let connection = {
+            node_manager
+                .make_connection(
+                    context,
+                    &self.to,
+                    node_manager.node_identifier.clone(),
+                    None,
+                    None,
+                )
+                .await?
+        };
+
+        let options = MessageSendReceiveOptions::new().with_timeout(Duration::from_secs(30));
+
+        let payload = {
+            let mut buffer = Vec::new();
+            minicbor::Encoder::new(&mut buffer).encode(&CertificateRequest {})?;
+            buffer
+        };
+
+        let reply: Routed<Any> = context
+            .send_and_receive_extended(connection.route()?, NeutralMessage::from(payload), options)
+            .await?;
+
+        let payload = reply.into_payload();
+        let reply: CertificateResponse = Decoder::new(&payload).decode()?;
+
+        match reply.kind {
+            ReplyKind::Ready => {
+                if let Some(certificate) = reply.certificate {
+                    Ok(certificate)
+                } else {
+                    Err(ockam_core::Error::new(
+                        Origin::Transport,
+                        Kind::Invalid,
+                        "invalid reply from certificate provider",
+                    ))
+                }
+            }
+            ReplyKind::Unsupported => Err(ockam_core::Error::new(
+                Origin::Transport,
+                Kind::NotReady,
+                "certificate",
+            )),
+            ReplyKind::NotReady => Err(ockam_core::Error::new(
+                Origin::Transport,
+                Kind::NotReady,
+                "certificate",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn check_orchestrator_encoding_not_ready() {
+        let payload = hex::decode("A10101").unwrap();
+        let reply: CertificateResponse = Decoder::new(&payload).decode().unwrap();
+        assert_eq!(reply.kind, ReplyKind::NotReady);
+        assert!(reply.certificate.is_none());
+    }
+
+    #[test]
+    fn check_orchestrator_encoding_ready() {
+        let payload =
+            hex::decode("a2010002a2014a66756c6c5f636861696e024b707269766174655f6b6579").unwrap();
+        let reply: CertificateResponse = Decoder::new(&payload).decode().unwrap();
+        assert_eq!(reply.kind, ReplyKind::Ready);
+        assert_eq!(
+            reply.certificate,
+            Some(TlsCertificate {
+                full_chain_pem: "full_chain".as_bytes().to_vec(),
+                private_key_pem: "private_key".as_bytes().to_vec()
+            })
+        );
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/kafka_services.rs
@@ -216,6 +216,7 @@ impl InMemoryNode {
             None,
             false,
             false,
+            None,
         )
         .await?;
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
@@ -27,6 +27,7 @@ impl Inlets for BackgroundNodeClient {
         secure_channel_identifier: &Option<Identifier>,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        tls_certificate_provider: &Option<MultiAddr>,
     ) -> miette::Result<Reply<InletStatus>> {
         let request = {
             let via_project = outlet_addr.matches(0, &[ProjectProto::CODE.into()]);
@@ -59,6 +60,9 @@ impl Inlets for BackgroundNodeClient {
             }
             if let Some(identifier) = secure_channel_identifier {
                 payload.set_secure_channel_identifier(identifier.clone())
+            }
+            if let Some(tls_provider) = tls_certificate_provider {
+                payload.set_tls_certificate_provider(tls_provider.clone())
             }
             payload.set_wait_ms(wait_for_outlet_timeout.as_millis() as u64);
             Request::post("/node/inlet").body(payload)

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/in_memory_node.rs
@@ -28,6 +28,7 @@ impl InMemoryNode {
         secure_channel_identifier: Option<Identifier>,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        tls_certificate_provider: Option<MultiAddr>,
     ) -> Result<InletStatus> {
         self.node_manager
             .create_inlet(
@@ -44,6 +45,7 @@ impl InMemoryNode {
                 secure_channel_identifier,
                 enable_udp_puncture,
                 disable_tcp_fallback,
+                tls_certificate_provider,
             )
             .await
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
@@ -25,6 +25,7 @@ pub trait Inlets {
         secure_channel_identifier: &Option<Identifier>,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        tls_certificate_provider: &Option<MultiAddr>,
     ) -> miette::Result<Reply<InletStatus>>;
 
     async fn show_inlet(&self, ctx: &Context, alias: &str) -> miette::Result<Reply<InletStatus>>;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
@@ -39,6 +39,7 @@ impl NodeManager {
         enable_udp_puncture: bool,
         // TODO: Introduce mode enum
         disable_tcp_fallback: bool,
+        tls_certificate_provider: Option<MultiAddr>,
     ) -> Result<InletStatus> {
         info!("Handling request to create inlet portal");
         debug! {
@@ -118,6 +119,7 @@ impl NodeManager {
             policy_expression,
             secure_channel_identifier,
             disable_tcp_fallback,
+            tls_certificate_provider,
             inlet: None,
             connection: None,
             main_route: None,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
@@ -30,6 +30,7 @@ impl NodeManagerWorker {
             secure_channel_identifier,
             enable_udp_puncture,
             disable_tcp_fallback,
+            tls_certificate_provider,
         } = create_inlet;
         match self
             .node_manager
@@ -47,6 +48,7 @@ impl NodeManagerWorker {
                 secure_channel_identifier,
                 enable_udp_puncture,
                 disable_tcp_fallback,
+                tls_certificate_provider,
             )
             .await
         {

--- a/implementations/rust/ockam/ockam_api/tests/latency.rs
+++ b/implementations/rust/ockam/ockam_api/tests/latency.rs
@@ -163,6 +163,7 @@ pub fn measure_buffer_latency_two_nodes_portal() {
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -57,6 +57,7 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
             None,
             false,
             false,
+            None,
         )
         .await?;
 
@@ -132,6 +133,7 @@ fn portal_node_goes_down_reconnect() {
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 
@@ -286,6 +288,7 @@ fn portal_low_bandwidth_connection_keep_working_for_60s() {
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 
@@ -397,6 +400,7 @@ fn portal_heavy_load_exchanged() {
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 
@@ -547,6 +551,7 @@ fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disrup
                     None,
                     false,
                     false,
+                    None,
                 )
                 .await?;
 

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -226,6 +226,7 @@ impl AppState {
                 &None,
                 false,
                 false,
+                &None,
             )
             .await
             .map_err(|err| {

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -69,7 +69,7 @@ pub struct TicketCommand {
     enroller: bool,
 
     /// Allows the access to the TLS certificate of the Project, this flag is transformed into the attributes `--attribute ockam-tls-certificate=true`
-    #[arg(long = "tls")]
+    #[arg(long = "tls", hide = true)]
     tls: bool,
 
     #[command(flatten)]

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use ockam::Context;
 use ockam_api::authenticator::direct::{
-    OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
+    OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY, OCKAM_TLS_ATTRIBUTE_KEY,
 };
 use ockam_api::authenticator::enrollment_tokens::TokenIssuer;
 use ockam_api::cli_state::enrollments::EnrollmentTicket;
@@ -67,6 +67,10 @@ pub struct TicketCommand {
     /// Add the enroller role to your ticket. If you specify it, this flag is transformed into the attributes `--attribute ockam-role=enroller`. This role allows the Identity using the ticket to enroll other Identities into the Project, typically something that only admins can do
     #[arg(long = "enroller")]
     enroller: bool,
+
+    /// Allows the access to the TLS certificate of the Project, this flag is transformed into the attributes `--attribute ockam-tls-certificate=true`
+    #[arg(long = "tls")]
+    tls: bool,
 
     #[command(flatten)]
     retry_opts: RetryOpts,
@@ -155,6 +159,11 @@ impl TicketCommand {
                 OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE.to_string(),
             );
         }
+
+        if self.tls {
+            attributes.insert(OCKAM_TLS_ATTRIBUTE_KEY.to_string(), "true".to_string());
+        }
+
         Ok(attributes)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -129,14 +129,14 @@ pub struct CreateCommand {
     )]
     pub no_tcp_fallback: bool,
 
-    #[arg(long, value_name = "BOOL", default_value_t = false)]
+    #[arg(long, value_name = "BOOL", default_value_t = false, hide = true)]
     /// Enable TLS for the TCP Inlet.
     /// Uses the default project TLS certificate provider, `/project/default/service/tls_certificate_provider`.
     /// To specify a different certificate provider, use `--tls-certificate-provider`.
     /// Requires `ockam-tls-certificate` credential attribute.
     pub tls: bool,
 
-    #[arg(long, value_name = "ROUTE")]
+    #[arg(long, value_name = "ROUTE", hide = true)]
     /// Enable TLS for the TCP Inlet using the provided certificate provider.
     /// Requires `ockam-tls-certificate` credential attribute.
     pub tls_certificate_provider: Option<MultiAddr>,

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -287,25 +287,25 @@ teardown() {
   kill -QUIT $socat_pid
 }
 
-@test "portals - create a local TLS inlet, https works without skipping verification" {
-  port="$(random_port)"
-
-  ticket=$($OCKAM project ticket --usage-count 10 --tls)
-  setup_home_dir
-  run_success "$OCKAM" project enroll "${ticket}"
-
-  run_success "$OCKAM" node create blue
-  run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
-  run_success "$OCKAM" tcp-inlet create --tls --from $port --to /secure/api/service/outlet
-
-  # first wait for the connection without validation
-  run_success curl -sfI --insecure --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
-    "https://127.0.0.1:${port}"
-
-  # extract certificate subject
-  subject=$(openssl s_client -showcerts -connect  "127.0.0.1:${port}" </dev/null 2>&1 | \
-    grep -o 'subject=CN=.*' | sed -E 's/.*CN=[*][.](.*)/\1/')
-
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
-    "https://arbitrary-name.${subject}:${port}"
-}
+#@test "portals - create a local TLS inlet, https works without skipping verification" {
+#  port="$(random_port)"
+#
+#  ticket=$($OCKAM project ticket --usage-count 10 --tls)
+#  setup_home_dir
+#  run_success "$OCKAM" project enroll "${ticket}"
+#
+#  run_success "$OCKAM" node create blue
+#  run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
+#  run_success "$OCKAM" tcp-inlet create --tls --from $port --to /secure/api/service/outlet
+#
+#  # first wait for the connection without validation
+#  run_success curl -sfI --insecure --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+#    "https://127.0.0.1:${port}"
+#
+#  # extract certificate subject
+#  subject=$(openssl s_client -showcerts -connect  "127.0.0.1:${port}" </dev/null 2>&1 | \
+#    grep -o 'subject=CN=.*' | sed -E 's/.*CN=[*][.](.*)/\1/')
+#
+#  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+#    "https://arbitrary-name.${subject}:${port}"
+#}

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -286,3 +286,26 @@ teardown() {
 
   kill -QUIT $socat_pid
 }
+
+@test "portals - create a local TLS inlet, https works without skipping verification" {
+  port="$(random_port)"
+
+  ticket=$($OCKAM project ticket --usage-count 10 --tls)
+  setup_home_dir
+  run_success "$OCKAM" project enroll "${ticket}"
+
+  run_success "$OCKAM" node create blue
+  run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
+  run_success "$OCKAM" tcp-inlet create --tls --from $port --to /secure/api/service/outlet
+
+  # first wait for the connection without validation
+  run_success curl -sfI --insecure --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+    "https://127.0.0.1:${port}"
+
+  # extract certificate subject
+  subject=$(openssl s_client -showcerts -connect  "127.0.0.1:${port}" </dev/null 2>&1 | \
+    grep -o 'subject=CN=.*' | sed -E 's/.*CN=[*][.](.*)/\1/')
+
+  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+    "https://arbitrary-name.${subject}:${port}"
+}

--- a/implementations/rust/ockam/ockam_core/src/error/code.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/code.rs
@@ -315,6 +315,10 @@ pub enum Kind {
     //
     // That said, until we finish migrating over to this, it's expected that
     // we'll need to add several new variants to all of these.
+    /// Indicate that the resource is not ready yet.
+    ///
+    /// Specifics should be available on error payload.
+    NotReady = 17,
 }
 
 // Helper macro for converting a number into an enum variant with that value.
@@ -392,7 +396,8 @@ impl Kind {
             Protocol,
             Serialization,
             Other,
-            Parse
+            Parse,
+            NotReady
         })
     }
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_tcp/Cargo.toml
@@ -32,6 +32,7 @@ ring = ["tokio-rustls/ring"]
 
 [dependencies]
 cfg-if = "1.0.0"
+log = "0.4.21"
 minicbor = "0.24"
 ockam_core = { path = "../ockam_core", version = "^0.116.0" }
 ockam_macros = { path = "../ockam_macros", version = "^0.34.0" }
@@ -39,7 +40,9 @@ ockam_node = { path = "../ockam_node", version = "^0.125.0" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.90.0" }
 opentelemetry = { version = "0.24.0", features = ["logs", "metrics", "trace"], optional = true }
 rand = "0.8"
+rustls = { version = "0.23", default-features = false }
 rustls-native-certs = "0.7"
+rustls-pemfile = "2.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 socket2 = { version = "0.5.6", features = ["all"] }
 tokio = { version = "1.39", features = ["rt-multi-thread", "sync", "net", "macros", "time", "io-util"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -30,9 +30,9 @@ pub(crate) use workers::*;
 
 pub use options::{TcpConnectionOptions, TcpListenerOptions};
 pub use portal::{
-    Direction, PortalInletInterceptor, PortalInterceptor, PortalInterceptorFactory,
-    PortalInterceptorWorker, PortalInternalMessage, PortalMessage, PortalOutletInterceptor,
-    MAX_PAYLOAD_SIZE,
+    new_certificate_provider_cache, Direction, PortalInletInterceptor, PortalInterceptor,
+    PortalInterceptorFactory, PortalInterceptorWorker, PortalInternalMessage, PortalMessage,
+    PortalOutletInterceptor, TlsCertificate, TlsCertificateProvider, MAX_PAYLOAD_SIZE,
 };
 pub use protocol_version::*;
 pub use registry::*;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -1,12 +1,21 @@
 use crate::portal::addresses::{Addresses, PortalType};
+use crate::portal::tls_certificate::TlsCertificateProvider;
+use crate::portal::{ReadHalfMaybeTls, WriteHalfMaybeTls};
 use crate::{portal::TcpPortalWorker, TcpInlet, TcpInletOptions, TcpRegistry};
+use log::warn;
 use ockam_core::compat::net::SocketAddr;
 use ockam_core::compat::sync::{Arc, RwLock};
-use ockam_core::{async_trait, compat::boxed::Box};
-use ockam_core::{Address, Processor, Result, Route};
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::{async_trait, compat::boxed::Box, Result};
+use ockam_core::{Address, Processor, Route};
 use ockam_node::Context;
 use ockam_transport_core::{HostnamePort, TransportError};
+use rustls::pki_types::CertificateDer;
+use std::io::BufReader;
+use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::time::Instant;
+use tokio_rustls::{TlsAcceptor, TlsStream};
 use tracing::{debug, error, instrument};
 
 /// State shared between `TcpInletListenProcessor` and `TcpInlet` to allow manipulating its state
@@ -80,7 +89,81 @@ impl TcpInletListenProcessor {
             outlet_shared_state,
         ))
     }
+
+    /// Returns a TLS acceptor, in case of failure it retries until the timeout is hit.
+    /// The timeout is not a hard limit and may be surpassed.
+    async fn create_acceptor(
+        context: &Context,
+        certificate_provider: &Arc<dyn TlsCertificateProvider>,
+        timeout: Duration,
+    ) -> Result<TlsAcceptor> {
+        let now = Instant::now();
+
+        loop {
+            if now.elapsed() > timeout {
+                return Err(ockam_core::Error::new(
+                    Origin::Transport,
+                    Kind::Timeout,
+                    "TLS certificated retrieval timed out",
+                ));
+            }
+
+            let certificate = match certificate_provider.get_certificate(context).await {
+                Ok(certificate) => certificate,
+                Err(error) => {
+                    if error.code().kind == Kind::Timeout {
+                        warn!("TLS certificate retrieval timed out. Retrying in 60 seconds.");
+                    } else {
+                        warn!("Cannot retrieve certificate: {error}. Retrying in 60 seconds.");
+                    }
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    continue;
+                }
+            };
+
+            let chain = {
+                let mut reader = BufReader::new(certificate.full_chain_pem.as_slice());
+                let chain = rustls_pemfile::certs(&mut reader);
+                let chain: std::io::Result<Vec<CertificateDer<'static>>> = chain.collect();
+                chain.unwrap()
+            };
+
+            let private_key = {
+                let mut reader = BufReader::new(certificate.private_key_pem.as_slice());
+                let mut private_keys = rustls_pemfile::pkcs8_private_keys(&mut reader);
+
+                match private_keys.next() {
+                    Some(Ok(private_key)) => private_key.into(),
+
+                    Some(Err(error)) => {
+                        return Err(ockam_core::Error::new(
+                            Origin::Transport,
+                            Kind::Parse,
+                            error,
+                        ));
+                    }
+
+                    None => {
+                        return Err(ockam_core::Error::new(
+                            Origin::Transport,
+                            Kind::Parse,
+                            "No private key found in the provided certificate",
+                        ));
+                    }
+                }
+            };
+
+            let config = rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(chain, private_key)
+                .map_err(|error| ockam_core::Error::new(Origin::Transport, Kind::Parse, error))?;
+
+            return Ok(TlsAcceptor::from(Arc::new(config)));
+        }
+    }
 }
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 #[async_trait]
 impl Processor for TcpInletListenProcessor {
@@ -120,10 +203,32 @@ impl Processor for TcpInletListenProcessor {
             outlet_shared_state.route.next()?,
         );
 
+        let streams = if let Some(certificate_provider) = &self.options.tls_certificate_provider {
+            let (rx, tx) = tokio::io::split(TlsStream::from(
+                Self::create_acceptor(ctx, certificate_provider, DEFAULT_TIMEOUT)
+                    .await?
+                    .accept(stream)
+                    .await
+                    .map_err(|error| {
+                        ockam_core::Error::new(Origin::Transport, Kind::Protocol, error)
+                    })?,
+            ));
+            (
+                ReadHalfMaybeTls::ReadHalfWithTls(rx),
+                WriteHalfMaybeTls::WriteHalfWithTls(tx),
+            )
+        } else {
+            let (rx, tx) = stream.into_split();
+            (
+                ReadHalfMaybeTls::ReadHalfNoTls(rx),
+                WriteHalfMaybeTls::WriteHalfNoTls(tx),
+            )
+        };
+
         TcpPortalWorker::start_new_inlet(
             ctx,
             self.registry.clone(),
-            stream,
+            streams,
             HostnamePort::from(socket_addr),
             outlet_shared_state.route,
             addresses,

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/mod.rs
@@ -6,6 +6,7 @@ mod outlet_listener;
 mod portal_message;
 mod portal_receiver;
 mod portal_worker;
+mod tls_certificate;
 
 pub(crate) use inlet_listener::*;
 pub use interceptor::{
@@ -16,3 +17,4 @@ pub(crate) use outlet_listener::*;
 pub use portal_message::*;
 pub(crate) use portal_receiver::*;
 pub(crate) use portal_worker::*;
+pub use tls_certificate::*;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/options.rs
@@ -1,4 +1,5 @@
 use crate::portal::addresses::Addresses;
+use crate::TlsCertificateProvider;
 use ockam_core::compat::sync::Arc;
 use ockam_core::flow_control::{FlowControlId, FlowControls};
 use ockam_core::{Address, AllowAll, IncomingAccessControl, OutgoingAccessControl};
@@ -9,6 +10,7 @@ pub struct TcpInletOptions {
     pub(super) incoming_access_control: Arc<dyn IncomingAccessControl>,
     pub(super) outgoing_access_control: Arc<dyn OutgoingAccessControl>,
     pub(super) is_paused: bool,
+    pub(super) tls_certificate_provider: Option<Arc<dyn TlsCertificateProvider>>,
 }
 
 impl TcpInletOptions {
@@ -18,12 +20,23 @@ impl TcpInletOptions {
             incoming_access_control: Arc::new(AllowAll),
             outgoing_access_control: Arc::new(AllowAll),
             is_paused: false,
+            tls_certificate_provider: None,
         }
     }
 
     /// Set TCP inlet to paused mode after start. No unpause call [`TcpInlet::unpause`]
     pub fn paused(mut self) -> Self {
         self.is_paused = true;
+        self
+    }
+
+    /// Set TLS certificate provider.
+    /// Whe omitted the inlet will be clear-text
+    pub fn with_tls_certificate_provider(
+        mut self,
+        tls_certificate: Arc<dyn TlsCertificateProvider>,
+    ) -> Self {
+        self.tls_certificate_provider = Some(tls_certificate);
         self
     }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/tls_certificate.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/tls_certificate.rs
@@ -1,0 +1,305 @@
+use core::fmt::{Debug, Display, Formatter};
+use log::warn;
+use minicbor::{Decode, Encode};
+use ockam_core::async_trait;
+use ockam_node::Context;
+use serde::{Deserialize, Serialize};
+use std::ops::Sub;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+/// Refresh the certificate every day.
+pub const DEFAULT_CACHE_RETENTION: Duration = Duration::from_secs(60 * 60 * 24);
+
+/// When certificate refresh fails, retry every 12 hours.
+pub const DEFAULT_RETRY_INTERVAL: Duration = Duration::from_secs(60 * 60 * 12);
+
+/// Structure representing typical TLS certificates with the relative private key
+/// to allow easy deployment
+#[derive(Encode, Decode, Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct TlsCertificate {
+    /// Public certificate chain, in PEM format.
+    #[cbor(with = "minicbor::bytes")]
+    #[n(1)] pub full_chain_pem: Vec<u8>,
+    /// Private key, in PEM format.
+    #[cbor(with = "minicbor::bytes")]
+    #[n(2)] pub private_key_pem: Vec<u8>,
+}
+
+#[async_trait]
+/// TLS certificate provider abstraction, to keep the implementation opaque
+/// to the TCP transport.
+pub trait TlsCertificateProvider: Send + Sync + Display + Debug + 'static {
+    /// Returns a TLS certificate
+    async fn get_certificate(&self, context: &Context) -> ockam_core::Result<TlsCertificate>;
+}
+
+/// This interface is used to make the testing simpler.
+/// It's used as a static template.
+trait Clock: Sync + Send + 'static {
+    fn now(&self) -> Instant;
+}
+
+struct DefaultClock;
+
+impl Clock for DefaultClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+struct CacheEntry {
+    timestamp: Instant,
+    last_retrieval_failure: Option<Instant>,
+    certificate: TlsCertificate,
+}
+
+/// Creates a cache for [`TlsCertificateProvider`].
+/// The cache will keep the certificate up to [`DEFAULT_CACHE_RETENTION`], afterward it will try
+/// to refresh the certificate, but it'll return the previous one in case of failure.
+pub fn new_certificate_provider_cache(
+    certificate_provider: Arc<dyn TlsCertificateProvider>,
+) -> Arc<dyn TlsCertificateProvider> {
+    TlsCertificateCache::new_extended(
+        certificate_provider,
+        DEFAULT_CACHE_RETENTION,
+        DEFAULT_RETRY_INTERVAL,
+        DefaultClock {},
+    )
+}
+
+struct TlsCertificateCache<T: Clock> {
+    last_certificate: Arc<Mutex<Option<CacheEntry>>>,
+    certificate_provider: Arc<dyn TlsCertificateProvider>,
+    cache_retention: Duration,
+    retry_interval: Duration,
+    clock: T,
+}
+
+impl<T: Clock> TlsCertificateCache<T> {
+    pub fn new_extended(
+        certificate_provider: Arc<dyn TlsCertificateProvider>,
+        cache_retention: Duration,
+        retry_interval: Duration,
+        clock: T,
+    ) -> Arc<dyn TlsCertificateProvider> {
+        Arc::new(Self {
+            last_certificate: Default::default(),
+            certificate_provider,
+            cache_retention,
+            retry_interval,
+            clock,
+        })
+    }
+}
+
+impl<T: Clock> Display for TlsCertificateCache<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.certificate_provider, f)
+    }
+}
+
+impl<T: Clock> Debug for TlsCertificateCache<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TlsCertificateCache")
+            .field("cache_retention", &self.cache_retention)
+            .field("retry_interval", &self.retry_interval)
+            .field("certificate_provider", &self.certificate_provider)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<T: Clock> TlsCertificateProvider for TlsCertificateCache<T> {
+    async fn get_certificate(&self, context: &Context) -> ockam_core::Result<TlsCertificate> {
+        let mut guard = self.last_certificate.lock().await;
+
+        let now = self.clock.now();
+        if let Some(entry) = guard.as_ref() {
+            if now.sub(entry.timestamp) < self.cache_retention {
+                return Ok(entry.certificate.clone());
+            }
+
+            // if recently failed, use the cache until the retry_interval is elapsed
+            if let Some(last_retrieval_failure) = entry.last_retrieval_failure {
+                if now.sub(last_retrieval_failure) < self.retry_interval {
+                    return Ok(entry.certificate.clone());
+                }
+            }
+        }
+
+        let certificate = match self.certificate_provider.get_certificate(context).await {
+            Ok(certificate) => {
+                *guard = Some(CacheEntry {
+                    timestamp: now,
+                    last_retrieval_failure: None,
+                    certificate: certificate.clone(),
+                });
+                certificate
+            }
+            Err(error) => {
+                // At this point, the cache retention is expired but certificate refresh failed,
+                // to avoid disruption the code returns the previous certificate.
+                // We attempt certificate refresh again only after `retry_interval` is elapsed.
+                if let Some(entry) = guard.as_mut() {
+                    warn!("Cannot refresh the certificate: {error}. Reusing previous one.");
+                    entry.last_retrieval_failure = Some(now);
+                    entry.certificate.clone()
+                } else {
+                    return Err(error);
+                }
+            }
+        };
+
+        Ok(certificate)
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use ockam_core::errcode::{Kind, Origin};
+    use ockam_node::Context;
+    use std::ops::AddAssign;
+    use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+    use std::sync::Arc;
+    use tokio::time::Duration;
+
+    #[derive(Debug)]
+    struct TestCertificateProvider {
+        counter: Arc<AtomicU8>,
+        return_certificate: Arc<AtomicBool>,
+    }
+
+    impl Display for TestCertificateProvider {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "TestCertificateProvider")
+        }
+    }
+
+    #[async_trait]
+    impl TlsCertificateProvider for TestCertificateProvider {
+        async fn get_certificate(&self, _context: &Context) -> ockam_core::Result<TlsCertificate> {
+            let counter = self.counter.fetch_add(1, Ordering::Relaxed);
+            if self.return_certificate.load(Ordering::Relaxed) {
+                Ok(TlsCertificate {
+                    full_chain_pem: format!("test-{counter}").into_bytes(),
+                    private_key_pem: format!("test-{counter}").into_bytes(),
+                })
+            } else {
+                Err(ockam_core::Error::new(
+                    Origin::Transport,
+                    Kind::Timeout,
+                    "timeout",
+                ))
+            }
+        }
+    }
+
+    struct TestClock {
+        now: Arc<std::sync::Mutex<Instant>>,
+    }
+
+    impl Clock for TestClock {
+        fn now(&self) -> Instant {
+            *self.now.lock().unwrap()
+        }
+    }
+
+    #[ockam_macros::test]
+    async fn test_tls_certificate(context: &mut Context) -> ockam_core::Result<()> {
+        let return_certificate = Arc::new(AtomicBool::new(true));
+        let get_certificate_counter = Arc::new(AtomicU8::new(0));
+        let certificate_provider = Arc::new(TestCertificateProvider {
+            counter: get_certificate_counter.clone(),
+            return_certificate: return_certificate.clone(),
+        });
+
+        let now = Arc::new(std::sync::Mutex::new(Instant::now()));
+
+        // creates a cache of 10 minutes, with 1 minute retry upon failure
+        let cache = TlsCertificateCache::new_extended(
+            certificate_provider,
+            Duration::from_secs(60 * 10),
+            Duration::from_secs(60),
+            TestClock { now: now.clone() },
+        );
+
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 0);
+
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-0");
+        assert_eq!(certificate.private_key_pem, b"test-0");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 1);
+
+        // advance the time by 9 minutes and 59 seconds, should return the previous certificate
+        now.lock()
+            .unwrap()
+            .add_assign(Duration::from_secs(60 * 9 + 59));
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-0");
+        assert_eq!(certificate.private_key_pem, b"test-0");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 1);
+
+        // 1 more second, and the certificate should be refreshed
+        now.lock().unwrap().add_assign(Duration::from_secs(1));
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-1");
+        assert_eq!(certificate.private_key_pem, b"test-1");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 2);
+
+        // 1 more second, and the certificate should be refreshed
+        now.lock().unwrap().add_assign(Duration::from_secs(1));
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-1");
+        assert_eq!(certificate.private_key_pem, b"test-1");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 2);
+
+        // advance the time by 10 minutes, this time the certificate provider will fail
+        now.lock().unwrap().add_assign(Duration::from_secs(60 * 10));
+        return_certificate.store(false, Ordering::Relaxed);
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-1");
+        assert_eq!(certificate.private_key_pem, b"test-1");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 3);
+
+        // advance the time by 59 seconds, the old certificate is returned without another
+        // refresh attempt
+        now.lock().unwrap().add_assign(Duration::from_secs(59));
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-1");
+        assert_eq!(certificate.private_key_pem, b"test-1");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 3);
+
+        // advance the time by 1 second, another failed refresh attempt
+        now.lock().unwrap().add_assign(Duration::from_secs(1));
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-1");
+        assert_eq!(certificate.private_key_pem, b"test-1");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 4);
+
+        // advance the time by 60 second, a successful refresh
+        now.lock().unwrap().add_assign(Duration::from_secs(60));
+        return_certificate.store(true, Ordering::Relaxed);
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-4");
+        assert_eq!(certificate.private_key_pem, b"test-4");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 5);
+
+        // advance 9 minutes and 59 seconds, same certificate is returned
+        now.lock()
+            .unwrap()
+            .add_assign(Duration::from_secs(9 * 60 + 59));
+        return_certificate.store(true, Ordering::Relaxed);
+        let certificate = cache.get_certificate(context).await.unwrap();
+        assert_eq!(certificate.full_chain_pem, b"test-4");
+        assert_eq!(certificate.private_key_pem, b"test-4");
+        assert_eq!(get_certificate_counter.load(Ordering::Relaxed), 5);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add TLS Inlet support. The TLS certificate is fetched from the project at regular intervals (by default 1 day) and kept in-memory.


```
Create TCP Inlets

Usage: ockam tcp-inlet create [OPTIONS]

Options:
...
      --tls
          Enable TLS for the TCP Inlet. Uses the default project TLS certificate provider,
          `/project/default/service/tls_certificate_provider`. To specify a different certificate
          provider, use `--tls-certificate-provider`. Requires `ockam-tls-certificate` credential
          attribute

      --tls-certificate-provider <ROUTE>
          Enable TLS for the TCP Inlet using the provided certificate provider. Requires
          `ockam-tls-certificate` credential attribute
```


```
Usage: ockam project ticket [OPTIONS]

Options:
...
      --tls
          Allows the access to the TLS certificate of the Project, this flag is transformed into the
          attributes `--attribute ockam-tls-certificate=true`
```

I've hidden the TLS-related parameter and commented out the bat test, so we can merge it as a disabled feature until we deploy.