### PR TITLE
refactor(rust): improve output of `project enroll` and `credential` commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/ui/output/encode_format.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/encode_format.rs
@@ -14,21 +14,17 @@ pub enum EncodeFormat {
 }
 
 impl EncodeFormat {
-    /// Print an encodable value on the console
-    pub fn println_value<T>(&self, e: &T) -> Result<()>
+    pub fn encode_value<T>(&self, value: &T) -> Result<String>
     where
         T: Encode<()> + CborLen<()> + Output,
     {
-        let o = match self {
-            EncodeFormat::Plain => e.item().wrap_err("Failed serialize output")?,
+        Ok(match self {
+            EncodeFormat::Plain => value.item().wrap_err("Failed serialize output")?,
             EncodeFormat::Hex => {
                 let bytes =
-                    ockam_core::cbor_encode_preallocate(e).expect("Unable to encode response");
+                    ockam_core::cbor_encode_preallocate(value).expect("Unable to encode response");
                 hex::encode(bytes)
             }
-        };
-
-        println!("{o}");
-        Ok(())
+        })
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/credential/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/list.rs
@@ -1,11 +1,10 @@
 use clap::Args;
-use colorful::Colorful;
 use miette::IntoDiagnostic;
 
 use ockam::identity::{CredentialSqlxDatabase, Identifier};
-use ockam_api::colors::OckamColor;
+use ockam_api::colors::color_primary;
 
-use crate::credential::CredentialOutput;
+use crate::credential::LocalCredentialOutput;
 use crate::node::NodeOpts;
 use crate::util::async_cmd;
 use crate::util::parsers::identity_identifier_parser;
@@ -49,18 +48,22 @@ impl ListCommand {
 
         let credentials = credentials
             .into_iter()
-            .map(|c| CredentialOutput::from_credential(c.0, c.1, true))
-            .collect::<Result<Vec<CredentialOutput>>>()?;
+            .map(|c| LocalCredentialOutput::from_credential(c.0, c.1, true))
+            .collect::<Result<Vec<LocalCredentialOutput>>>()?;
 
         let list = opts.terminal.build_list(
             &credentials,
             &format!(
-                "No Credentials found for vault: {}",
-                node_name.color(OckamColor::PrimaryResource.color())
+                "No Credentials found for node: {}",
+                color_primary(node_name)
             ),
         )?;
 
-        opts.terminal.stdout().plain(list).write_line()?;
+        opts.terminal
+            .stdout()
+            .plain(list)
+            .json_obj(credentials)?
+            .write_line()?;
 
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -1,12 +1,14 @@
 use clap::{Args, Subcommand};
 use colorful::core::StrMarker;
 use colorful::Colorful;
+use serde::Serialize;
 use serde_json::json;
 
 pub(crate) use issue::IssueCommand;
-use ockam::identity::models::{CredentialAndPurposeKey, CredentialSchemaIdentifier};
+use ockam::identity::models::CredentialAndPurposeKey;
 use ockam::identity::{Identifier, TimestampInSeconds};
 use ockam_api::output::Output;
+use ockam_api::terminal::fmt;
 use ockam_core::compat::collections::HashMap;
 pub(crate) use store::StoreCommand;
 pub(crate) use verify::VerifyCommand;
@@ -63,24 +65,18 @@ impl CredentialCommand {
     }
 }
 
+#[derive(Serialize)]
 pub struct CredentialOutput {
-    credential: String,
-    scope: String,
-    subject: Identifier,
-    issuer: Identifier,
-    created_at: TimestampInSeconds,
-    expires_at: TimestampInSeconds,
-    is_verified: bool,
-    schema: CredentialSchemaIdentifier,
-    attributes: HashMap<String, String>,
+    pub credential: String,
+    pub subject: Identifier,
+    pub issuer: Identifier,
+    pub created_at: TimestampInSeconds,
+    pub expires_at: TimestampInSeconds,
+    pub attributes: HashMap<String, String>,
 }
 
 impl CredentialOutput {
-    pub fn from_credential(
-        credential: CredentialAndPurposeKey,
-        scope: String,
-        is_verified: bool,
-    ) -> Result<Self> {
+    pub fn from_credential(credential: CredentialAndPurposeKey) -> Result<Self> {
         let str = hex::encode(credential.encode_as_cbor_bytes()?);
         let credential_data = credential.credential.get_credential_data()?;
         let purpose_key_data = credential.purpose_key_attestation.get_attestation_data()?;
@@ -91,33 +87,96 @@ impl CredentialOutput {
         })?;
 
         let mut attributes = HashMap::<String, String>::default();
-        for (k, v) in &credential_data.subject_attributes.map {
-            match (
-                String::from_utf8(k.as_slice().to_vec()),
-                String::from_utf8(v.as_slice().to_vec()),
-            ) {
-                (Ok(k), Ok(v)) => _ = attributes.insert(k, v),
-                _ => continue,
-            }
+        for (k, v) in credential_data.subject_attributes.map {
+            let k = String::from_utf8(k.to_vec()).unwrap_or("**binary**".to_string());
+            let v = String::from_utf8(v.to_vec()).unwrap_or("**binary**".to_string());
+            attributes.insert(k, v);
         }
 
-        let s = Self {
+        Ok(Self {
             credential: str,
-            scope,
             subject,
             issuer: purpose_key_data.subject,
             created_at: credential_data.created_at,
             expires_at: credential_data.expires_at,
-            is_verified,
-            schema: credential_data.subject_attributes.schema,
             attributes,
+        })
+    }
+}
+
+impl Output for CredentialOutput {
+    fn item(&self) -> ockam_api::Result<String> {
+        let attributes = json!(self.attributes).to_string();
+
+        let output = format!(
+            "{pad}Credential:\n\
+             {pad}{ind}subject: {subject}\n\
+             {pad}{ind}issuer: {issuer}\n\
+             {pad}{ind}created at: {created_at}\n\
+             {pad}{ind}expires at: {expires_at}\n\
+             {pad}{ind}attributes: {attributes}\n\
+             {pad}{ind}:credential {credential}",
+            pad = fmt::PADDING,
+            ind = fmt::INDENTATION,
+            subject = self.subject,
+            issuer = self.issuer,
+            created_at = self.created_at.0,
+            expires_at = self.expires_at.0,
+            attributes = attributes,
+            credential = self.credential,
+        );
+
+        Ok(output)
+    }
+
+    fn as_list_item(&self) -> ockam_api::Result<String> {
+        let attributes = json!(self.attributes).to_string();
+
+        let output = format!(
+            "Credential:\n\
+             {ind}subject: {subject}\n\
+             {ind}issuer: {issuer}\n\
+             {ind}created at: {created_at}\n\
+             {ind}expires at: {expires_at}\n\
+             {ind}attributes: {attributes}\n\
+             {ind}credential: {credential}",
+            ind = fmt::INDENTATION,
+            subject = self.subject,
+            issuer = self.issuer,
+            created_at = self.created_at.0,
+            expires_at = self.expires_at.0,
+            attributes = attributes,
+            credential = self.credential,
+        );
+
+        Ok(output)
+    }
+}
+
+#[derive(Serialize)]
+pub struct LocalCredentialOutput {
+    credential: CredentialOutput,
+    scope: String,
+    is_verified: bool,
+}
+
+impl LocalCredentialOutput {
+    pub fn from_credential(
+        credential: CredentialAndPurposeKey,
+        scope: String,
+        is_verified: bool,
+    ) -> Result<Self> {
+        let s = Self {
+            credential: CredentialOutput::from_credential(credential)?,
+            scope,
+            is_verified,
         };
 
         Ok(s)
     }
 }
 
-impl Output for CredentialOutput {
+impl Output for LocalCredentialOutput {
     fn item(&self) -> ockam_api::Result<String> {
         let is_verified = if self.is_verified {
             "✔︎".light_green()
@@ -125,28 +184,35 @@ impl Output for CredentialOutput {
             "✕".light_red()
         };
 
-        let attributes = json!(self.attributes).to_string();
+        let output = format!(
+            "{output}\n\
+             {pad}{ind}is verified: {is_verified}\n\
+             {pad}{ind}scope: {scope}",
+            output = self.credential.item()?,
+            pad = fmt::PADDING,
+            ind = fmt::INDENTATION,
+            is_verified = is_verified,
+            scope = self.scope,
+        );
+
+        Ok(output)
+    }
+
+    fn as_list_item(&self) -> ockam_api::Result<String> {
+        let is_verified = if self.is_verified {
+            "✔︎".light_green()
+        } else {
+            "✕".light_red()
+        };
 
         let output = format!(
-            "Credential:\n\
-            \tscope:       {scope}\n\
-            \tsubject:     {subject}\n\
-            \tissuer:      {issuer}\n\
-            \tis_verified: {is_verified}\n\
-            \tcreated_at:  {created_at}\n\
-            \texpires_at:  {expires_at}\n\
-            \tschema:      {schema}\n\
-            \tattributes:  {attributes}\n\
-            \tbinary:      {credential}",
-            scope = self.scope,
-            subject = self.subject,
-            issuer = self.issuer,
+            "{output}\n\
+             {ind}is verified: {is_verified}\n\
+             {ind}scope: {scope}",
+            output = self.credential.as_list_item()?,
+            ind = fmt::INDENTATION,
             is_verified = is_verified,
-            created_at = self.created_at.0,
-            expires_at = self.expires_at.0,
-            schema = self.schema.0,
-            attributes = attributes,
-            credential = self.credential
+            scope = self.scope,
         );
 
         Ok(output)

--- a/implementations/rust/ockam/ockam_command/src/credential/verify.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/verify.rs
@@ -46,7 +46,7 @@ impl VerifyCommand {
     }
 
     async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let (is_valid, plain_text) = match verify_credential(
+        let (is_valid, plain) = match verify_credential(
             &opts,
             self.issuer(),
             &self.credential,
@@ -55,15 +55,12 @@ impl VerifyCommand {
         .await
         {
             Ok(_) => (true, fmt_ok!("Credential is valid")),
-            Err(e) => (
-                false,
-                fmt_err!("Credential is not valid\n") + &fmt_log!("{}", e),
-            ),
+            Err(e) => (false, fmt_err!("{e}")),
         };
 
         opts.terminal
             .stdout()
-            .plain(plain_text)
+            .plain(plain)
             .json(serde_json::json!({ "is_valid": is_valid }))
             .machine(is_valid.to_string())
             .write_line()?;
@@ -110,7 +107,7 @@ pub async fn verify_credential(
         .await;
 
         *is_finished.lock().await = true;
-        result.map_err(|e| e.wrap_err("Credential is invalid"))
+        result.map_err(|e| e.wrap_err("Credential is not valid"))
     };
 
     let output_messages = vec!["Verifying credential...".to_string()];

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -98,7 +98,7 @@ EOF
   run_success $OCKAM project import --project-file $OCKAM_HOME/project.json
 
   run_success "$OCKAM" project enroll --identity admin
-  assert_output --partial "ockam-relay=*"
+  assert_output --partial "\"ockam-relay\":\"*\""
   assert_output --partial "admin"
 
   # m1 is a member (its on the set of pre-trusted identifiers) so it can get it's own credential


### PR DESCRIPTION
- Add `json` output to `project enroll`, which includes data about the credential and its attributes associated with the token used
- To keep the output consistent, I've refactored the struct used in `credential` commands to display the same plain + json output