### PR TITLE
fix: make sure that there is always one default project

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -51,29 +51,12 @@ impl Projects {
         }
 
         self.store_project_model(project.model()).await?;
-
-        // If there is no previous default project set this project as the default
-        let default_project = self.projects_repository.get_default_project().await?;
-        if default_project.is_none() {
-            self.projects_repository
-                .set_default_project(project.project_id())
-                .await?
-        };
-
         Ok(project)
     }
 
     #[instrument(skip_all, fields(project_id = project.id))]
     pub async fn store_project_model(&self, project: &ProjectModel) -> Result<()> {
         self.projects_repository.store_project(project).await?;
-
-        // If there is no previous default project set this project as the default
-        let default_project = self.projects_repository.get_default_project().await?;
-        if default_project.is_none() {
-            self.projects_repository
-                .set_default_project(&project.id)
-                .await?
-        };
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -52,7 +52,7 @@ teardown() {
   run "$OCKAM" identity create m3
   run "$OCKAM" identity create m4
   run "$OCKAM" identity create m5
-  run "$OCKAM" identity create m7
+  run "$OCKAM" identity create m6
 
   account_authority_full=$($OCKAM identity show account_authority --full --encoding hex)
   account_authority_identifier=$($OCKAM identity show account_authority)
@@ -120,14 +120,14 @@ EOF
 
   # admin can enroll new enrollers
   token3=$($OCKAM project ticket --identity admin --enroller)
-  run_success "$OCKAM" project enroll $token3 --identity m7
+  run_success "$OCKAM" project enroll $token3 --identity m6
   assert_output --partial "enroller"
 
   # New enroller can enroll members
-  run_success "$OCKAM" project ticket --identity m7
+  run_success "$OCKAM" project ticket --identity m6
 
   # Enroller can't enroll new enrollers
-  run "$OCKAM" project ticket --enroller --identity m7
+  run "$OCKAM" project ticket --enroller --identity m6
   assert_failure
 
   run "$OCKAM" project enroll $token2 --identity m5


### PR DESCRIPTION
There is currently a possibility of a race condition when importing a project. That project might be stored but not yet seen as the default project. This is now part of the same transaction.

This will hopefully fix an issue with one flaky bats test:
```
not ok 4 authority - standalone authority, admin, enrollers, members in 4311ms
# (from function `assert_success' in file /nix/store/xkl4yd5bq2ksz22f3g6dsdwvzppb7r4k-bats-with-libraries-1.11.0/share/bats/bats-assert/src/assert_success.bash, line 42,
#  from function `run_success' in file implementations/rust/ockam/ockam_command/tests/bats/local/../load/base.bash, line 113,
#  in test file implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats, line 100)
#   `run_success "$OCKAM" project enroll --identity admin' failed
# (Not all processes could be identified, non-owned process info
#  will not be shown, you would have to be root to see it all.)
# (Not all processes could be identified, non-owned process info
#  will not be shown, you would have to be root to see it all.)
#
# -- command failed --
# status : 70
# output (16 lines):
#
#
#        Error:
#        ─────────────────────────────────────────────────────────────────────────────────────
#
#        A default project or project parameter is required. Run 'ockam project list' to get a list of available projects. You might also need to pass an enrollment ticket or path to the command.
#        Please report this issue, with a copy of your logs, to https://github.com/build-trust/ockam/issues
#
```