### PR TITLE
feat(rust): display a malformed transport address

### DIFF
--- a/examples/rust/mitm_node/src/tcp_interceptor/transport/common.rs
+++ b/examples/rust/mitm_node/src/tcp_interceptor/transport/common.rs
@@ -21,9 +21,9 @@ pub(super) fn resolve_peer(peer: String) -> Result<SocketAddr> {
     }
 
     // Nothing worked, return an error
-    Err(TransportError::InvalidAddress)?
+    Err(TransportError::InvalidAddress(peer))?
 }
 
 pub(super) fn parse_socket_addr(s: &str) -> Result<SocketAddr> {
-    Ok(s.parse().map_err(|_| TransportError::InvalidAddress)?)
+    Ok(s.parse().map_err(|_| TransportError::InvalidAddress(s.to_string()))?)
 }

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/handle.rs
@@ -87,11 +87,11 @@ impl BleRouterHandle {
         let servicenames;
 
         // Try to parse as BleAddr
-        if let Ok(p) = crate::parse_ble_addr(peer_str) {
+        if let Ok(p) = crate::parse_ble_addr(peer_str.clone()) {
             peer_addr = p;
             servicenames = vec![];
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(peer_str))?;
         }
 
         Ok((peer_addr, servicenames))

--- a/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/router/mod.rs
@@ -56,7 +56,14 @@ impl BleRouter {
         if let Some(f) = accepts.first().cloned() {
             debug!("BLE registration request: {} => {}", f, self_addr);
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(
+                accepts
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+                    .to_string(),
+            ))?;
         }
 
         for accept in &accepts {
@@ -123,7 +130,7 @@ impl Worker for BleRouter {
                 }
             };
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(msg_addr.to_string()))?;
         }
 
         Ok(())

--- a/implementations/rust/ockam/ockam_transport_ble/src/types.rs
+++ b/implementations/rust/ockam/ockam_transport_ble/src/types.rs
@@ -35,5 +35,5 @@ impl FromStr for BleAddr {
 pub fn parse_ble_addr<S: AsRef<str>>(s: S) -> ockam_core::Result<BleAddr> {
     Ok(s.as_ref()
         .parse()
-        .map_err(|_| TransportError::InvalidAddress)?)
+        .map_err(|_| TransportError::InvalidAddress(s.as_ref().to_string()))?)
 }

--- a/implementations/rust/ockam/ockam_transport_core/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_core/src/error.rs
@@ -1,14 +1,15 @@
 use ockam_core::{
     compat::io,
+    compat::string::String,
     errcode::{Kind, Origin},
     Error,
 };
 
 /// A Transport worker specific error type
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TransportError {
     /// Failed to send a malformed message
-    SendBadMessage = 1,
+    SendBadMessage,
     /// Failed to receive a malformed message
     RecvBadMessage,
     /// Failed to bind to the desired socket
@@ -24,7 +25,7 @@ pub enum TransportError {
     /// Failed to route to an unknown recipient
     UnknownRoute,
     /// Failed to parse the socket address
-    InvalidAddress,
+    InvalidAddress(String),
     /// Failed to read message (buffer exhausted) or failed to send it (size is too big)
     Capacity,
     /// Failed to encode message
@@ -61,7 +62,9 @@ impl core::fmt::Display for TransportError {
             Self::PeerNotFound => write!(f, "connection peer was not found"),
             Self::PeerBusy => write!(f, "connection peer is busy"),
             Self::UnknownRoute => write!(f, "message routing failed (unknown recipient)"),
-            Self::InvalidAddress => write!(f, "failed to parse the socket address"),
+            Self::InvalidAddress(address) => {
+                write!(f, "failed to parse the socket address {}", address)
+            }
             Self::Capacity => write!(f, "failed to read message (buffer exhausted)"),
             Self::Encoding => write!(f, "failed to encode message"),
             Self::Protocol => write!(f, "violation in transport protocol"),
@@ -89,7 +92,7 @@ impl From<TransportError> for Error {
             PeerNotFound => Kind::Misuse,
             PeerBusy => Kind::Io,
             UnknownRoute => Kind::Misuse,
-            InvalidAddress => Kind::Misuse,
+            InvalidAddress(_) => Kind::Misuse,
             Capacity => Kind::ResourceExhausted,
             Encoding => Kind::Serialization,
             Protocol => Kind::Protocol,

--- a/implementations/rust/ockam/ockam_transport_udp/src/transport/bind.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/transport/bind.rs
@@ -63,7 +63,9 @@ impl UdpTransport {
         // This transport only supports IPv4
         if !arguments.bind_address.is_ipv4() {
             error!(local_addr = %arguments.bind_address, "This transport only supports IPv4");
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(
+                arguments.bind_address.to_string(),
+            ))?;
         }
 
         // Bind new socket

--- a/implementations/rust/ockam/ockam_transport_udp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_udp/src/workers/sender.rs
@@ -78,7 +78,7 @@ impl Worker for UdpSenderWorker {
         // into an error state
         if peer.port() == 0 {
             warn!(peer_addr = %peer, "Will not send to address");
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(peer.to_string()))?;
         }
 
         // Send

--- a/implementations/rust/ockam/ockam_transport_uds/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/router/handle.rs
@@ -160,11 +160,11 @@ impl UdsRouterHandle {
         let pathnames;
 
         // Then continue working on resolve_route, so that the UdsRouter can have a complete worker definition which requires `handle_message`
-        if let Ok(p) = parse_socket_addr(peer_str) {
+        if let Ok(p) = parse_socket_addr(peer_str.clone()) {
             peer_addr = p;
             pathnames = vec![];
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(peer_str))?;
         }
 
         Ok((peer_addr, pathnames))

--- a/implementations/rust/ockam/ockam_transport_uds/src/router/uds_router.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/router/uds_router.rs
@@ -95,12 +95,16 @@ impl UdsRouter {
 
         let path = match pair.peer().as_pathname() {
             Some(p) => p,
-            None => return Err(TransportError::InvalidAddress)?,
+            None => return Err(TransportError::InvalidAddress(format!("{:?}", pair.peer())))?,
         };
 
         let str_path = match path.to_str() {
             Some(s) => s,
-            None => return Err(TransportError::InvalidAddress)?,
+            None => {
+                return Err(TransportError::InvalidAddress(
+                    path.to_string_lossy().to_string(),
+                ))?
+            }
         };
 
         let uds_address = Address::new_with_string(UDS, str_path);
@@ -214,7 +218,7 @@ impl UdsRouter {
             Some(p) => p,
             None => {
                 error!("Failed to resolve route.");
-                return Err(TransportError::InvalidAddress)?;
+                return Err(TransportError::InvalidAddress(format!("{:?}", peer_addr)))?;
             }
         };
 
@@ -225,7 +229,9 @@ impl UdsRouter {
                     "Failed to resolve route, invalid path provided: {}",
                     path.display()
                 );
-                return Err(TransportError::InvalidAddress)?;
+                return Err(TransportError::InvalidAddress(
+                    path.to_string_lossy().to_string(),
+                ))?;
             }
         };
 
@@ -296,7 +302,7 @@ impl Worker for UdsRouter {
                 "UDS router received a message for an invalid address: {}",
                 msg_addr
             );
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(msg_addr.to_string()))?;
         }
 
         Ok(())

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/listener.rs
@@ -34,7 +34,7 @@ impl UdsListenProcessor {
             Some(p) => p,
             None => {
                 error!("Error binding to socket address {:?}", addr);
-                return Err(TransportError::InvalidAddress)?;
+                return Err(TransportError::InvalidAddress(format!("{:?}", addr)))?;
             }
         };
         debug!("Binding UnixListener to {}", path.display());

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
@@ -184,7 +184,7 @@ impl Worker for UdsSendWorker {
                 debug!("Failed to determine peer path.");
                 self.stop_and_unregister(ctx).await?;
 
-                return Err(TransportError::InvalidAddress)?;
+                return Err(TransportError::InvalidAddress(format!("{:?}", self.peer)))?;
             }
         };
 

--- a/implementations/rust/ockam/ockam_transport_websocket/src/error.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/error.rs
@@ -6,7 +6,7 @@ use ockam_transport_core::TransportError;
 use tokio_tungstenite::tungstenite::Error as TungsteniteError;
 
 /// A WebSocket connection worker specific error type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub(crate) enum WebSocketError {
     /// A wrapped transport error.
@@ -47,8 +47,12 @@ impl From<TungsteniteError> for WebSocketError {
             TungsteniteError::ConnectionClosed => Self::Transport(TransportError::ConnectionDrop),
             TungsteniteError::AlreadyClosed => Self::Transport(TransportError::ConnectionDrop),
             TungsteniteError::Io(_) => Self::Transport(TransportError::GenericIo),
-            TungsteniteError::Url(_) => Self::Transport(TransportError::InvalidAddress),
-            TungsteniteError::HttpFormat(_) => Self::Transport(TransportError::InvalidAddress),
+            TungsteniteError::Url(u) => {
+                Self::Transport(TransportError::InvalidAddress(u.to_string()))
+            }
+            TungsteniteError::HttpFormat(h) => {
+                Self::Transport(TransportError::InvalidAddress(h.to_string()))
+            }
             TungsteniteError::Capacity(_) => Self::Transport(TransportError::Capacity),
             TungsteniteError::Utf8 => Self::Transport(TransportError::Encoding),
             TungsteniteError::Protocol(_) => Self::Transport(TransportError::Protocol),
@@ -77,7 +81,7 @@ mod test {
         .into_iter()
         .collect::<HashMap<_, _>>();
         for (_expected_code, ws_err) in ws_errors_map {
-            let _err: Error = ws_err.into();
+            let _err: Error = ws_err.clone().into();
             if let WebSocketError::Transport(_) = ws_err {
                 // assert_eq!(err.code(), TransportError::DOMAIN_CODE + expected_code);
             }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/lib.rs
@@ -106,5 +106,5 @@ pub(crate) const CLUSTER_NAME: &str = "_internals.transport.ws";
 fn parse_socket_addr<S: AsRef<str>>(s: S) -> Result<SocketAddr> {
     Ok(s.as_ref()
         .parse()
-        .map_err(|_| TransportError::InvalidAddress)?)
+        .map_err(|_| TransportError::InvalidAddress(s.as_ref().to_string()))?)
 }

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/handle.rs
@@ -84,12 +84,12 @@ impl WebSocketRouterHandle {
             if let Some(p) = iter.find(|x| x.is_ipv4()) {
                 peer_addr = p;
             } else {
-                return Err(TransportError::InvalidAddress)?;
+                return Err(TransportError::InvalidAddress(peer_str))?;
             }
 
             hostnames = vec![peer_str];
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(peer_str))?;
         }
 
         Ok((peer_addr, hostnames))

--- a/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/router/mod.rs
@@ -143,7 +143,7 @@ impl Worker for WebSocketRouter {
                 }
             };
         } else {
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(msg_addr.to_string()))?;
         }
 
         Ok(())
@@ -193,7 +193,14 @@ impl WebSocketRouter {
         // Otherwise, the router is not being used properly and returns an error.
         else {
             error!("Tried to register a new client without passing any `Address`");
-            return Err(TransportError::InvalidAddress)?;
+            return Err(TransportError::InvalidAddress(
+                accepts
+                    .iter()
+                    .map(|a| a.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+                    .to_string(),
+            ))?;
         }
 
         // Do not connect twice.


### PR DESCRIPTION
When an address fails to be resolved we currently have no information about that address.

This PR add a String field to the `InvalidAddress` error in order to report what was attempted to parse.