### PR TITLE
Using hostname rather than socket addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,6 +4897,7 @@ dependencies = [
  "minicbor",
  "ockam_core",
  "regex",
+ "serde",
 ]
 
 [[package]]

--- a/examples/rust/mitm_node/src/tcp_interceptor/transport/common.rs
+++ b/examples/rust/mitm_node/src/tcp_interceptor/transport/common.rs
@@ -1,28 +1,6 @@
-use ockam_core::compat::net::{SocketAddr, ToSocketAddrs};
+use ockam_core::compat::net::SocketAddr;
 use ockam_core::Result;
 use ockam_transport_core::TransportError;
-
-/// Resolve the given peer to a [`SocketAddr`](std::net::SocketAddr)
-pub(super) fn resolve_peer(peer: String) -> Result<SocketAddr> {
-    // Try to parse as SocketAddr
-    if let Ok(p) = parse_socket_addr(&peer) {
-        return Ok(p);
-    }
-
-    // Try to resolve hostname
-    if let Ok(mut iter) = peer.to_socket_addrs() {
-        // Prefer ip4
-        if let Some(p) = iter.find(|x| x.is_ipv4()) {
-            return Ok(p);
-        }
-        if let Some(p) = iter.find(|x| x.is_ipv6()) {
-            return Ok(p);
-        }
-    }
-
-    // Nothing worked, return an error
-    Err(TransportError::InvalidAddress(peer))?
-}
 
 pub(super) fn parse_socket_addr(s: &str) -> Result<SocketAddr> {
     Ok(s.parse().map_err(|_| TransportError::InvalidAddress(s.to_string()))?)

--- a/implementations/rust/ockam/ockam/src/lib.rs
+++ b/implementations/rust/ockam/ockam/src/lib.rs
@@ -106,7 +106,9 @@ pub mod transport {
     #[cfg(feature = "std")]
     pub use ockam_transport_core::resolve_peer;
 
-    pub use ockam_transport_core::{parse_socket_addr, HostnamePort, Transport};
+    pub use ockam_transport_core::{
+        parse_socket_addr, HostnamePort, StaticHostnamePort, Transport,
+    };
 }
 
 // ---

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -107,6 +107,7 @@ tracing-subscriber = { version = "0.3.18", features = ["json"] }
 url = "2.5.2"
 
 ockam_multiaddr = { path = "../ockam_multiaddr", version = "0.56.0", features = ["cbor", "serde"] }
+ockam_transport_core = { path = "../ockam_transport_core" }
 ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.119.0", default-features = false, features = ["std"] }
 tonic = "0.11"
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/tcp_portals.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/tcp_portals.rs
@@ -1,12 +1,12 @@
-use ockam_core::errcode::{Kind, Origin};
-use ockam_core::Address;
-use ockam_multiaddr::MultiAddr;
-use std::net::SocketAddr;
-
 use super::Result;
 use crate::cli_state::TcpInlet;
 use crate::nodes::models::portal::OutletStatus;
 use crate::CliState;
+use ockam_core::errcode::{Kind, Origin};
+use ockam_core::Address;
+use ockam_multiaddr::MultiAddr;
+use ockam_transport_core::HostnamePort;
+use std::net::SocketAddr;
 
 impl CliState {
     /// Create a TCP inlet
@@ -53,12 +53,11 @@ impl CliState {
     pub async fn create_tcp_outlet(
         &self,
         node_name: &str,
-        socket_addr: &SocketAddr,
+        to: &HostnamePort,
         worker_addr: &Address,
         payload: &Option<String>,
     ) -> Result<OutletStatus> {
-        let tcp_outlet_status =
-            OutletStatus::new(*socket_addr, worker_addr.clone(), payload.clone());
+        let tcp_outlet_status = OutletStatus::new(to.clone(), worker_addr.clone(), payload.clone());
 
         self.tcp_portals_repository()
             .store_tcp_outlet(node_name, &tcp_outlet_status)

--- a/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/portal_worker.rs
@@ -766,7 +766,7 @@ mod test {
             MultiAddr::default(),
             route![],
             route![],
-            [255, 255, 255, 255].into(),
+            "255.255.255.255".to_string(),
             PortRange::new(0, 0).unwrap(),
             None,
         );
@@ -905,7 +905,7 @@ mod test {
             MultiAddr::default(),
             route![],
             route![],
-            [127, 0, 0, 1].into(),
+            "127.0.0.1".to_string(),
             PortRange::new(0, 0).unwrap(),
             None,
         );
@@ -1023,7 +1023,7 @@ mod test {
             assert_eq!(0, broker.port);
 
             let address = inlet_map.retrieve_inlet(1).await.expect("inlet not found");
-            assert_eq!("127.0.0.1".to_string(), address.ip().to_string());
+            assert_eq!("127.0.0.1".to_string(), address.hostname());
             assert_eq!(0, address.port());
         } else {
             panic!("invalid message type")

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -30,7 +30,7 @@ mod test {
             MultiAddr::default(),
             route![],
             route![],
-            [127, 0, 0, 1].into(),
+            "127.0.0.1".to_string(),
             PortRange::new(0, 0).unwrap(),
             None,
         );

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -1,7 +1,6 @@
 //! Inlets and outlet request/response types
 
 use std::fmt::{Display, Formatter};
-use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -268,20 +267,16 @@ impl Output for InletStatus {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct OutletStatus {
-    #[n(1)] pub socket_addr: SocketAddr,
+    #[n(1)] pub to: HostnamePort,
     #[n(2)] pub worker_addr: Address,
     /// An optional status payload
     #[n(3)] pub payload: Option<String>,
 }
 
 impl OutletStatus {
-    pub fn new(
-        socket_addr: SocketAddr,
-        worker_addr: Address,
-        payload: impl Into<Option<String>>,
-    ) -> Self {
+    pub fn new(to: HostnamePort, worker_addr: Address, payload: impl Into<Option<String>>) -> Self {
         Self {
-            socket_addr,
+            to,
             worker_addr,
             payload: payload.into(),
         }
@@ -311,7 +306,7 @@ impl Display for OutletStatus {
                     .map_err(|_| std::fmt::Error)?
                     .to_string()
             ),
-            color_primary(self.socket_addr.to_string()),
+            color_primary(self.to.to_string()),
         )
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -25,7 +25,7 @@ use crate::{route_to_multiaddr, try_address_to_multiaddr};
 #[cbor(map)]
 pub struct CreateInlet {
     /// The address the portal should listen at.
-    #[n(1)] pub(crate) listen_addr: String,
+    #[n(1)] pub(crate) listen_addr: HostnamePort,
     /// The peer address.
     /// This can either be the address of an already
     /// created outlet, or a forwarding mechanism via ockam cloud.
@@ -63,7 +63,7 @@ pub struct CreateInlet {
 impl CreateInlet {
     #[allow(clippy::too_many_arguments)]
     pub fn via_project(
-        listen: String,
+        listen: HostnamePort,
         to: MultiAddr,
         alias: String,
         prefix_route: Route,
@@ -90,7 +90,7 @@ impl CreateInlet {
 
     #[allow(clippy::too_many_arguments)]
     pub fn to_node(
-        listen: String,
+        listen: HostnamePort,
         to: MultiAddr,
         alias: String,
         prefix_route: Route,
@@ -128,7 +128,7 @@ impl CreateInlet {
         self.secure_channel_identifier = Some(identifier);
     }
 
-    pub fn listen_addr(&self) -> String {
+    pub fn listen_addr(&self) -> HostnamePort {
         self.listen_addr.clone()
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -4,9 +4,9 @@ use crate::output::Output;
 use crate::terminal::fmt;
 use minicbor::{CborLen, Decode, Encode};
 use ockam_abac::PolicyExpression;
-use ockam_core::compat::net::SocketAddr;
 use ockam_core::Address;
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_core::HostnamePort;
 use serde::Serialize;
 use std::fmt::Display;
 use std::fmt::Write;
@@ -57,14 +57,14 @@ impl DeleteServiceRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaOutletRequest {
-    #[n(1)] bootstrap_server_addr: String,
+    #[n(1)] bootstrap_server_addr: HostnamePort,
     #[n(2)] tls: bool,
     #[n(3)] policy_expression: Option<PolicyExpression>,
 }
 
 impl StartKafkaOutletRequest {
     pub fn new(
-        bootstrap_server_addr: String,
+        bootstrap_server_addr: HostnamePort,
         tls: bool,
         policy_expression: Option<PolicyExpression>,
     ) -> Self {
@@ -75,7 +75,7 @@ impl StartKafkaOutletRequest {
         }
     }
 
-    pub fn bootstrap_server_addr(&self) -> String {
+    pub fn bootstrap_server_addr(&self) -> HostnamePort {
         self.bootstrap_server_addr.clone()
     }
 
@@ -92,7 +92,7 @@ impl StartKafkaOutletRequest {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartKafkaInletRequest {
-    #[n(1)] bind_address: SocketAddr,
+    #[n(1)] bind_address: HostnamePort,
     #[n(2)] brokers_port_range: (u16, u16),
     #[n(3)] kafka_outlet_route: MultiAddr,
     #[n(4)] encrypt_content: bool,
@@ -106,7 +106,7 @@ pub struct StartKafkaInletRequest {
 impl StartKafkaInletRequest {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        bind_address: SocketAddr,
+        bind_address: HostnamePort,
         brokers_port_range: impl Into<(u16, u16)>,
         kafka_outlet_route: MultiAddr,
         encrypt_content: bool,
@@ -129,8 +129,8 @@ impl StartKafkaInletRequest {
         }
     }
 
-    pub fn bind_address(&self) -> SocketAddr {
-        self.bind_address
+    pub fn bind_address(&self) -> HostnamePort {
+        self.bind_address.clone()
     }
     pub fn brokers_port_range(&self) -> (u16, u16) {
         self.brokers_port_range

--- a/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/registry.rs
@@ -8,9 +8,9 @@ use ockam_core::compat::collections::BTreeMap;
 use ockam_core::{Address, Route};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::compat::asynchronous::RwLock;
+use ockam_transport_core::HostnamePort;
 use std::borrow::Borrow;
 use std::fmt::Display;
-use std::net::SocketAddr;
 
 #[derive(Default)]
 pub(crate) struct SecureChannelRegistry {
@@ -142,20 +142,17 @@ impl InletInfo {
 
 #[derive(Clone)]
 pub struct OutletInfo {
-    pub(crate) socket_addr: SocketAddr,
+    pub(crate) to: HostnamePort,
     pub(crate) worker_addr: Address,
 }
 
 impl OutletInfo {
-    pub(crate) fn new(socket_addr: &SocketAddr, worker_addr: Option<&Address>) -> Self {
+    pub(crate) fn new(to: HostnamePort, worker_addr: Option<&Address>) -> Self {
         let worker_addr = match worker_addr {
             Some(addr) => addr.clone(),
             None => Address::from_string(""),
         };
-        Self {
-            socket_addr: *socket_addr,
-            worker_addr,
-        }
+        Self { to, worker_addr }
     }
 }
 
@@ -366,6 +363,6 @@ mod tests {
     }
 
     fn outlet_info(worker_addr: Address) -> OutletInfo {
-        OutletInfo::new(&SocketAddr::from(([127, 0, 0, 1], 0)), Some(&worker_addr))
+        OutletInfo::new(HostnamePort::new("127.0.0.1", 0), Some(&worker_addr))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -377,7 +377,7 @@ impl NodeManager {
             .entries()
             .await
             .iter()
-            .map(|(_, info)| OutletStatus::new(info.socket_addr, info.worker_addr.clone(), None))
+            .map(|(_, info)| OutletStatus::new(info.to.clone(), info.worker_addr.clone(), None))
             .collect()
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_outlets.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_outlets.rs
@@ -104,7 +104,7 @@ impl NodeManager {
             .await;
 
         info!(
-            "Handling request to create outlet portal at {to} with worker {:?}",
+            "Handling request to create outlet portal to {to} with worker {:?}",
             worker_addr
         );
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_outlets.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_outlets.rs
@@ -53,7 +53,7 @@ impl NodeManagerWorker {
         match self.node_manager.delete_outlet(worker_addr).await {
             Ok(res) => match res {
                 Some(outlet_info) => Ok(Response::ok().body(OutletStatus::new(
-                    outlet_info.socket_addr,
+                    outlet_info.to,
                     outlet_info.worker_addr.clone(),
                     None,
                 ))),
@@ -91,7 +91,7 @@ impl NodeManager {
     pub async fn create_outlet(
         &self,
         ctx: &Context,
-        hostname_port: HostnamePort,
+        to: HostnamePort,
         tls: bool,
         worker_addr: Option<Address>,
         reachable_from_default_secure_channel: bool,
@@ -104,9 +104,7 @@ impl NodeManager {
             .await;
 
         info!(
-            "Handling request to create outlet portal at {}:{} with worker {:?}",
-            &hostname_port.hostname(),
-            hostname_port.port(),
+            "Handling request to create outlet portal at {to} with worker {:?}",
             worker_addr
         );
 
@@ -161,10 +159,9 @@ impl NodeManager {
             }
         };
 
-        let socket_addr = hostname_port.to_socket_addr()?;
         let res = self
             .tcp_transport
-            .create_tcp_outlet(worker_addr.clone(), hostname_port, options)
+            .create_tcp_outlet(worker_addr.clone(), to.clone(), options)
             .await;
 
         Ok(match res {
@@ -174,16 +171,16 @@ impl NodeManager {
                     .outlets
                     .insert(
                         worker_addr.clone(),
-                        OutletInfo::new(&socket_addr, Some(&worker_addr)),
+                        OutletInfo::new(to.clone(), Some(&worker_addr)),
                     )
                     .await;
 
                 self.cli_state
-                    .create_tcp_outlet(&self.node_name, &socket_addr, &worker_addr, &None)
+                    .create_tcp_outlet(&self.node_name, &to, &worker_addr, &None)
                     .await?
             }
             Err(e) => {
-                warn!(at = %socket_addr, err = %e, "Failed to create TCP outlet");
+                warn!(at = %to, err = %e, "Failed to create TCP outlet");
                 let message = format!("Failed to create outlet: {}", e);
                 return Err(ockam_core::Error::new(
                     Origin::Node,
@@ -226,7 +223,7 @@ impl NodeManager {
         if let Some(outlet_to_show) = self.registry.outlets.get(worker_addr).await {
             debug!(%worker_addr, "Outlet not found in node registry");
             Some(OutletStatus::new(
-                outlet_to_show.socket_addr,
+                outlet_to_show.to,
                 outlet_to_show.worker_addr.clone(),
                 None,
             ))

--- a/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
@@ -194,7 +194,7 @@ pub async fn start_tcp_echo_server() -> EchoServerHandle {
     }
 
     EchoServerHandle {
-        chosen_addr: HostnamePort::from_socket_addr(chosen_addr).unwrap(),
+        chosen_addr: HostnamePort::from_socket_addr(chosen_addr),
         close,
     }
 }

--- a/implementations/rust/ockam/ockam_api/tests/latency.rs
+++ b/implementations/rust/ockam/ockam_api/tests/latency.rs
@@ -13,6 +13,7 @@ use ockam_core::env::FromString;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{route, Address, AllowAll, Error, NeutralMessage};
 use ockam_multiaddr::MultiAddr;
+use ockam_transport_core::HostnamePort;
 
 /// These tests serve as a benchmark for the message roundtrip latency.
 /// In order for the result to be reliable, use the --profile release
@@ -148,7 +149,7 @@ pub fn measure_buffer_latency_two_nodes_portal() {
                 .node_manager
                 .create_inlet(
                     &first_node.context,
-                    "127.0.0.1:0".to_string(),
+                    HostnamePort::new("127.0.0.1", 0),
                     route![],
                     route![],
                     second_node_listen_address

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -9,6 +9,7 @@ use ockam_core::errcode::{Kind, Origin};
 use ockam_core::{route, Address, AllowAll, Error};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
+use ockam_transport_core::HostnamePort;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -44,7 +45,7 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
         .node_manager
         .create_inlet(
             context,
-            "127.0.0.1:0".to_string(),
+            HostnamePort::new("127.0.0.1", 0),
             route![],
             route![],
             MultiAddr::from_str("/secure/api/service/outlet")?,
@@ -117,7 +118,7 @@ fn portal_node_goes_down_reconnect() {
                 .node_manager
                 .create_inlet(
                     &first_node.context,
-                    "127.0.0.1:0".to_string(),
+                    HostnamePort::new("127.0.0.1", 0),
                     route![],
                     route![],
                     second_node_listen_address
@@ -271,7 +272,7 @@ fn portal_low_bandwidth_connection_keep_working_for_60s() {
                 .node_manager
                 .create_inlet(
                     &first_node.context,
-                    "127.0.0.1:0".to_string(),
+                    HostnamePort::new("127.0.0.1", 0),
                     route![],
                     route![],
                     InternetAddress::from(passthrough_server_handle.chosen_addr)
@@ -382,7 +383,7 @@ fn portal_heavy_load_exchanged() {
                 .node_manager
                 .create_inlet(
                     &first_node.context,
-                    "127.0.0.1:0".to_string(),
+                    HostnamePort::new("127.0.0.1", 0),
                     route![],
                     route![],
                     second_node_listen_address
@@ -532,7 +533,7 @@ fn test_portal_payload_transfer(outgoing_disruption: Disruption, incoming_disrup
                 .node_manager
                 .create_inlet(
                     &first_node.context,
-                    "127.0.0.1:0".to_string(),
+                    HostnamePort::new("127.0.0.1", 0),
                     route![],
                     route![],
                     InternetAddress::from(passthrough_server_handle.chosen_addr)

--- a/implementations/rust/ockam/ockam_api/tests/portals.rs
+++ b/implementations/rust/ockam/ockam_api/tests/portals.rs
@@ -37,10 +37,7 @@ async fn inlet_outlet_local_successful(context: &mut Context) -> ockam::Result<(
         )
         .await?;
 
-    assert_eq!(
-        outlet_status.socket_addr,
-        echo_server_handle.chosen_addr.to_socket_addr()?
-    );
+    assert_eq!(outlet_status.to, echo_server_handle.chosen_addr);
     assert_eq!(outlet_status.worker_addr.address(), "outlet");
 
     let inlet_status = node_manager_handle

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -6,8 +6,7 @@ use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
 use ockam::abac::PolicyExpression::FullExpression;
 use ockam::abac::SUBJECT_KEY;
-use tracing::{debug, error, info, warn};
-
+use ockam::transport::HostnamePort;
 use ockam_api::address::get_free_address;
 use ockam_api::authenticator::direct::{
     OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
@@ -16,6 +15,7 @@ use ockam_api::nodes::service::tcp_inlets::Inlets;
 use ockam_api::ConnectionStatus;
 use ockam_core::api::Reply;
 use ockam_multiaddr::MultiAddr;
+use tracing::{debug, error, info, warn};
 
 use crate::background_node::BackgroundNodeClientTrait;
 use crate::incoming_services::state::{IncomingService, Port};
@@ -215,7 +215,7 @@ impl AppState {
         inlet_node
             .create_inlet(
                 &self.context(),
-                &bind_address.to_string(),
+                &HostnamePort::from(bind_address),
                 &MultiAddr::from_str(&service.service_route(Some(project_name.as_str())))
                     .into_diagnostic()?,
                 &inlet_alias,

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/create.rs
@@ -36,7 +36,7 @@ impl AppState {
         match node_manager
             .create_outlet(
                 &self.context(),
-                HostnamePort::from_socket_addr(socket_addr)?,
+                HostnamePort::from_socket_addr(socket_addr),
                 false,
                 Some(worker_addr.clone()),
                 true,

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/tcp_outlet/state.rs
@@ -4,7 +4,6 @@ use tracing::{debug, error};
 #[cfg(test)]
 use crate::incoming_services::PersistentIncomingService;
 use crate::state::{AppState, ModelState};
-use ockam::transport::HostnamePort;
 use ockam::Address;
 use ockam_api::nodes::models::portal::{OutletAccessControl, OutletStatus};
 
@@ -69,8 +68,7 @@ impl AppState {
             let _ = node_manager
                 .create_outlet(
                     &context,
-                    HostnamePort::from_socket_addr(tcp_outlet.socket_addr)
-                        .expect("cannot parse the socket address as a hostname and port"),
+                    tcp_outlet.to,
                     false,
                     Some(tcp_outlet.worker_addr.clone()),
                     true,

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -529,8 +529,8 @@ impl AppState {
                 .into_iter()
                 .map(|outlet| LocalService {
                     name: outlet.worker_addr.address().to_string(),
-                    address: outlet.socket_addr.ip().to_string(),
-                    port: outlet.socket_addr.port(),
+                    address: outlet.to.hostname().to_string(),
+                    port: outlet.to.port(),
                     scheme: None,
                     shared_with: vec![],
                     available: true,

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -1,7 +1,5 @@
-use std::net::SocketAddr;
-
 use clap::{command, Args};
-
+use ockam::transport::HostnamePort;
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
@@ -9,7 +7,7 @@ use crate::util::print_deprecated_warning;
 use crate::{
     kafka::{kafka_default_consumer_server, kafka_default_project_route, kafka_inlet_default_addr},
     node::NodeOpts,
-    util::parsers::socket_addr_parser,
+    util::parsers::hostname_parser,
     Command, CommandGlobalOpts,
 };
 
@@ -26,8 +24,8 @@ pub struct CreateCommand {
     addr: String,
     /// The address where to bind and where the client will connect to alongside its port, <address>:<port>.
     /// In case just a port is specified, the default loopback address (127.0.0.1) will be used
-    #[arg(long, default_value_t = kafka_default_consumer_server(), value_parser = socket_addr_parser)]
-    bootstrap_server: SocketAddr,
+    #[arg(long, default_value_t = kafka_default_consumer_server(), value_parser = hostname_parser)]
+    bootstrap_server: HostnamePort,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
     #[arg(long)]

--- a/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/mod.rs
@@ -1,9 +1,9 @@
-use std::cmp::min;
-use std::{net::SocketAddr, str::FromStr};
-
+use ockam::transport::{HostnamePort, StaticHostnamePort};
 use ockam_api::nodes::service::default_address::DefaultAddress;
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
+use std::cmp::min;
+use std::str::FromStr;
 
 pub(crate) mod consumer;
 pub(crate) mod inlet;
@@ -11,11 +11,15 @@ pub(crate) mod outlet;
 pub(crate) mod producer;
 pub(crate) mod util;
 
-const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: &str = "127.0.0.1:9092";
+const KAFKA_DEFAULT_BOOTSTRAP_ADDRESS: StaticHostnamePort =
+    StaticHostnamePort::new("127.0.0.1", 9092);
 const KAFKA_DEFAULT_PROJECT_ROUTE: &str = "/project/default";
-const KAFKA_DEFAULT_CONSUMER_SERVER: &str = "127.0.0.1:4000";
-const KAFKA_DEFAULT_INLET_BIND_ADDRESS: &str = "127.0.0.1:4000";
-const KAFKA_DEFAULT_PRODUCER_SERVER: &str = "127.0.0.1:5000";
+const KAFKA_DEFAULT_CONSUMER_SERVER: StaticHostnamePort =
+    StaticHostnamePort::new("127.0.0.1", 4000);
+const KAFKA_DEFAULT_INLET_BIND_ADDRESS: StaticHostnamePort =
+    StaticHostnamePort::new("127.0.0.1", 4000);
+const KAFKA_DEFAULT_PRODUCER_SERVER: StaticHostnamePort =
+    StaticHostnamePort::new("127.0.0.1", 5000);
 
 fn kafka_default_outlet_addr() -> String {
     DefaultAddress::KAFKA_OUTLET.to_string()
@@ -29,26 +33,23 @@ fn kafka_default_project_route() -> MultiAddr {
     MultiAddr::from_str(KAFKA_DEFAULT_PROJECT_ROUTE).expect("Failed to parse default project route")
 }
 
-fn kafka_default_outlet_server() -> String {
-    KAFKA_DEFAULT_BOOTSTRAP_ADDRESS.to_string()
+fn kafka_default_outlet_server() -> HostnamePort {
+    KAFKA_DEFAULT_BOOTSTRAP_ADDRESS.into()
 }
 
-fn kafka_default_consumer_server() -> SocketAddr {
-    SocketAddr::from_str(KAFKA_DEFAULT_CONSUMER_SERVER)
-        .expect("Failed to parse default consumer server")
+fn kafka_default_consumer_server() -> HostnamePort {
+    KAFKA_DEFAULT_CONSUMER_SERVER.into()
 }
 
-fn kafka_default_inlet_bind_address() -> SocketAddr {
-    SocketAddr::from_str(KAFKA_DEFAULT_INLET_BIND_ADDRESS)
-        .expect("Failed to parse default consumer server")
+fn kafka_default_inlet_bind_address() -> HostnamePort {
+    KAFKA_DEFAULT_INLET_BIND_ADDRESS.into()
 }
 
-fn kafka_default_producer_server() -> SocketAddr {
-    SocketAddr::from_str(KAFKA_DEFAULT_PRODUCER_SERVER)
-        .expect("Failed to parse default producer server")
+fn kafka_default_producer_server() -> HostnamePort {
+    KAFKA_DEFAULT_PRODUCER_SERVER.into()
 }
 
-pub(crate) fn make_brokers_port_range(bootstrap_server: &SocketAddr) -> PortRange {
+pub(crate) fn make_brokers_port_range(bootstrap_server: &HostnamePort) -> PortRange {
     let boostrap_server_port = bootstrap_server.port() as u32;
     let start = min(boostrap_server_port + 1, u16::MAX as u32) as u16;
     let end = min(boostrap_server_port + 100, u16::MAX as u32) as u16;
@@ -62,12 +63,12 @@ mod tests {
 
     #[test]
     fn brokers_port_range() {
-        let address = SocketAddr::from_str("127.0.0.1:8080").unwrap();
+        let address = HostnamePort::from_str("127.0.0.1:8080").unwrap();
         let port_range = make_brokers_port_range(&address);
         assert_eq!(port_range.start(), 8081);
         assert_eq!(port_range.end(), 8180);
 
-        let address = SocketAddr::from_str("127.0.0.1:65442").unwrap();
+        let address = HostnamePort::from_str("127.0.0.1:65442").unwrap();
         let port_range = make_brokers_port_range(&address);
         assert_eq!(port_range.start(), 65443);
         assert_eq!(port_range.end(), u16::MAX);

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/create.rs
@@ -6,6 +6,7 @@ use miette::miette;
 use serde::Serialize;
 use std::fmt::Write;
 
+use ockam::transport::HostnamePort;
 use ockam::Context;
 use ockam_abac::PolicyExpression;
 use ockam_api::colors::{color_primary, color_warn};
@@ -35,7 +36,7 @@ pub struct CreateCommand {
 
     /// The address of the kafka bootstrap broker
     #[arg(long, default_value_t = kafka_default_outlet_server())]
-    pub bootstrap_server: String,
+    pub bootstrap_server: HostnamePort,
 
     /// If set, the outlet will establish a TLS connection over TCP
     #[arg(long, id = "BOOLEAN")]
@@ -61,7 +62,7 @@ impl Command for CreateCommand {
             if let Some(pb) = pb.as_ref() {
                 pb.set_message(format!(
                     "Creating Kafka Outlet to bootstrap server {}...\n",
-                    color_primary(&self.bootstrap_server)
+                    color_primary(self.bootstrap_server.to_string())
                 ));
             }
 
@@ -80,7 +81,7 @@ impl Command for CreateCommand {
 
             KafkaOutletOutput {
                 node_name: node.node_name(),
-                bootstrap_server: self.bootstrap_server.clone(),
+                bootstrap_server: self.bootstrap_server.to_string(),
             }
         };
 

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -1,7 +1,5 @@
-use std::net::SocketAddr;
-
 use clap::{command, Args};
-
+use ockam::transport::HostnamePort;
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
@@ -9,7 +7,7 @@ use crate::util::print_deprecated_warning;
 use crate::{
     kafka::{kafka_default_producer_server, kafka_default_project_route, kafka_inlet_default_addr},
     node::NodeOpts,
-    util::parsers::socket_addr_parser,
+    util::parsers::hostname_parser,
     Command, CommandGlobalOpts,
 };
 
@@ -25,8 +23,8 @@ pub struct CreateCommand {
     addr: String,
     /// The address where to bind and where the client will connect to alongside its port, <address>:<port>.
     /// In case just a port is specified, the default loopback address (127.0.0.1) will be used
-    #[arg(long, default_value_t = kafka_default_producer_server(), value_parser = socket_addr_parser)]
-    bootstrap_server: SocketAddr,
+    #[arg(long, default_value_t = kafka_default_producer_server(), value_parser = hostname_parser)]
+    bootstrap_server: HostnamePort,
     /// Local port range dynamically allocated to kafka brokers, must not overlap with the
     /// bootstrap port
     #[arg(long)]

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_inlet.rs
@@ -51,9 +51,9 @@ impl KafkaInlet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ockam::transport::HostnamePort;
     use ockam_core::env::FromString;
     use ockam_multiaddr::MultiAddr;
-    use std::net::SocketAddr;
     use std::str::FromStr;
 
     #[test]
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].from,
-            SocketAddr::from_str("127.0.0.1:9092").unwrap()
+            HostnamePort::from_str("127.0.0.1:9092").unwrap()
         );
         assert_eq!(
             &cmds[0].to,

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/kafka_outlet.rs
@@ -67,7 +67,10 @@ mod tests {
             .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 1);
-        assert_eq!(cmds[0].bootstrap_server, "192.168.0.100:9092".to_string(),);
+        assert_eq!(
+            cmds[0].bootstrap_server.to_string(),
+            "192.168.0.100:9092".to_string(),
+        );
         assert_eq!(cmds[0].node_opts.at_node.as_ref().unwrap(), "node_name");
 
         let named = r#"

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
@@ -51,9 +51,6 @@ impl TcpInlets {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
-    use std::str::FromStr;
-
     use super::*;
 
     #[test]
@@ -74,16 +71,10 @@ mod tests {
             .unwrap();
         assert_eq!(cmds.len(), 2);
         assert_eq!(cmds[0].alias, "ti1");
-        assert_eq!(
-            cmds[0].from,
-            SocketAddr::from_str("127.0.0.1:6060").unwrap()
-        );
+        assert_eq!(cmds[0].from.to_string(), "127.0.0.1:6060".to_string());
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
         assert_eq!(cmds[1].alias, "my_inlet");
-        assert_eq!(
-            cmds[1].from,
-            SocketAddr::from_str("127.0.0.1:6061").unwrap()
-        );
+        assert_eq!(cmds[1].from.to_string(), "127.0.0.1:6061".to_string());
         assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
 
         let unnamed = r#"
@@ -97,15 +88,9 @@ mod tests {
             .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
-        assert_eq!(
-            cmds[0].from,
-            SocketAddr::from_str("127.0.0.1:6060").unwrap()
-        );
+        assert_eq!(cmds[0].from.to_string(), "127.0.0.1:6060".to_string());
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
-        assert_eq!(
-            cmds[1].from,
-            SocketAddr::from_str("127.0.0.1:6061").unwrap()
-        );
+        assert_eq!(cmds[1].from.to_string(), "127.0.0.1:6061".to_string());
         assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -1,8 +1,7 @@
-use std::net::SocketAddr;
-
 use clap::Args;
 use colorful::Colorful;
 use indoc::formatdoc;
+use ockam::transport::HostnamePort;
 use ockam_api::fmt_info;
 
 use crate::{docs, CommandGlobalOpts};
@@ -11,7 +10,7 @@ use ockam_node::Context;
 use crate::run::Config;
 use crate::tcp::inlet::create::default_from_addr;
 use crate::util::async_cmd;
-use crate::util::parsers::socket_addr_parser;
+use crate::util::parsers::hostname_parser;
 
 const LONG_ABOUT: &str = include_str!("./static/secure_relay_inlet/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/secure_relay_inlet/after_long_help.txt");
@@ -28,8 +27,8 @@ pub struct SecureRelayInlet {
     pub service_name: String,
 
     /// Address on which to accept tcp connections.
-    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", default_value_t = default_from_addr(), value_parser = socket_addr_parser)]
-    from: SocketAddr,
+    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", default_value_t = default_from_addr(), value_parser = hostname_parser)]
+    from: HostnamePort,
 
     /// Just print the recipe and exit
     #[arg(long)]
@@ -123,14 +122,10 @@ impl SecureRelayInlet {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
+    use super::*;
+    use crate::run::parser::config::ConfigParser;
     use ockam_api::authenticator::one_time_code::OneTimeCode;
     use ockam_api::cli_state::EnrollmentTicket;
-
-    use crate::run::parser::config::ConfigParser;
-
-    use super::*;
 
     #[test]
     fn test_that_recipe_is_valid() {
@@ -139,7 +134,7 @@ mod tests {
 
         let cmd = SecureRelayInlet {
             service_name: "service_name".to_string(),
-            from: SocketAddr::from_str("127.0.0.1:8080").unwrap(),
+            from: HostnamePort::new("127.0.0.1", 8080),
             dry_run: false,
             enroll: Enroll {
                 enroll_ticket: Some(enrollment_ticket_hex),

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -1,8 +1,7 @@
-use std::net::SocketAddr;
-
 use clap::Args;
 use colorful::Colorful;
 use indoc::formatdoc;
+use ockam::transport::HostnamePort;
 use ockam_api::fmt_info;
 
 use crate::{docs, CommandGlobalOpts};
@@ -10,7 +9,7 @@ use ockam_node::Context;
 
 use crate::run::Config;
 use crate::util::async_cmd;
-use crate::util::parsers::socket_addr_parser;
+use crate::util::parsers::hostname_parser;
 
 const LONG_ABOUT: &str = include_str!("./static/secure_relay_outlet/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/secure_relay_outlet/after_long_help.txt");
@@ -27,8 +26,8 @@ pub struct SecureRelayOutlet {
     pub service_name: String,
 
     /// TCP address to send raw tcp traffic.
-    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS", value_parser = socket_addr_parser)]
-    to: SocketAddr,
+    #[arg(long, display_order = 902, id = "SOCKET_ADDRESS", value_parser = hostname_parser)]
+    to: HostnamePort,
 
     /// Just print the recipe and exit
     #[arg(long)]
@@ -141,7 +140,7 @@ mod tests {
 
         let cmd = SecureRelayOutlet {
             service_name: "service_name".to_string(),
-            to: SocketAddr::from_str("127.0.0.1:8080").unwrap(),
+            to: HostnamePort::from_str("127.0.0.1:8080").unwrap(),
             dry_run: false,
             enroll: Enroll {
                 enroll_ticket: Some(enrollment_ticket_hex),

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -10,6 +9,7 @@ use miette::{miette, IntoDiagnostic};
 use tracing::trace;
 
 use ockam::identity::Identifier;
+use ockam::transport::HostnamePort;
 use ockam::Context;
 use ockam_abac::PolicyExpression;
 use ockam_api::address::extract_address_value;
@@ -33,7 +33,7 @@ use crate::tcp::util::alias_parser;
 use crate::{docs, Command, CommandGlobalOpts, Error};
 
 use crate::util::parsers::duration_parser;
-use crate::util::parsers::socket_addr_parser;
+use crate::util::parsers::hostname_parser;
 use crate::util::{find_available_port, port_is_free_guard, process_nodes_multiaddr};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
@@ -47,8 +47,8 @@ pub struct CreateCommand {
     pub at: Option<String>,
 
     /// Address on which to accept TCP connections.
-    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", hide_default_value = true, default_value_t = default_from_addr(), value_parser = socket_addr_parser)]
-    pub from: SocketAddr,
+    #[arg(long, display_order = 900, id = "SOCKET_ADDRESS", hide_default_value = true, default_value_t = default_from_addr(), value_parser = hostname_parser)]
+    pub from: HostnamePort,
 
     /// Route to a TCP Outlet or the name of the TCP Outlet service you want to connect to.
     ///
@@ -120,9 +120,9 @@ pub struct CreateCommand {
     pub disable_tcp_fallback: bool,
 }
 
-pub(crate) fn default_from_addr() -> SocketAddr {
+pub(crate) fn default_from_addr() -> HostnamePort {
     let port = find_available_port().expect("Failed to find available port");
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
+    HostnamePort::new("127.0.0.1", port)
 }
 
 fn default_to_addr() -> String {
@@ -154,7 +154,7 @@ impl Command for CreateCommand {
                 let result: Reply<InletStatus> = node
                     .create_inlet(
                         ctx,
-                        &cmd.from.to_string(),
+                        &cmd.from,
                         &cmd.to(),
                         &cmd.alias,
                         &cmd.authorized,
@@ -271,7 +271,10 @@ impl CreateCommand {
     }
 
     async fn parse_args(mut self, opts: &CommandGlobalOpts) -> miette::Result<Self> {
-        port_is_free_guard(&self.from)?;
+        let from = ockam_node::compat::asynchronous::resolve_peer(self.from.to_string())
+            .await
+            .into_diagnostic()?;
+        port_is_free_guard(&from)?;
         self.to = Self::parse_arg_to(&opts.state, self.to, self.via.as_ref()).await?;
         if self.to().matches(0, &[proto::Project::CODE.into()]) && self.authorized.is_some() {
             return Err(miette!(

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -77,7 +77,7 @@ impl ListCommand {
             .map(|outlet| {
                 Ok(serde_json::json!({
                     "from": outlet.worker_address()?,
-                    "to": outlet.socket_addr,
+                    "to": outlet.to,
                 }))
             })
             .flat_map(|res: Result<_, ockam_core::Error>| res.ok())

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use core::fmt::Write;
-use std::net::SocketAddr;
 
 use clap::Args;
 use console::Term;
@@ -60,7 +59,7 @@ impl Command for ShowCommand {
 struct OutletInformation {
     node_name: String,
     worker_addr: MultiAddr,
-    socket_addr: SocketAddr,
+    to: String,
 }
 
 impl Output for OutletInformation {
@@ -69,7 +68,7 @@ impl Output for OutletInformation {
         write!(w, "Outlet")?;
         write!(w, "\n  On Node: {}", self.node_name)?;
         write!(w, "\n  From address: {}", self.worker_addr)?;
-        write!(w, "\n  To TCP server: {}", self.socket_addr)?;
+        write!(w, "\n  To TCP server: {}", self.to)?;
         Ok(w)
     }
 }
@@ -144,7 +143,7 @@ impl ShowCommandTui for ShowTui {
         let info = OutletInformation {
             node_name: self.node.node_name(),
             worker_addr: outlet_status.worker_address().into_diagnostic()?,
-            socket_addr: outlet_status.socket_addr,
+            to: outlet_status.to.to_string(),
         };
         self.terminal()
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -1,12 +1,11 @@
 use clap::error::{Error, ErrorKind};
-use std::net::SocketAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
 use miette::miette;
 
 use ockam::identity::Identifier;
-use ockam::transport::resolve_peer;
+use ockam::transport::HostnamePort;
 use ockam_api::config::lookup::InternetAddress;
 use ockam_core::env::parse_duration;
 
@@ -16,17 +15,9 @@ use crate::Result;
 /// Helper function for parsing a socket from user input
 /// It is possible to just input a `port`. In that case the address will be assumed to be
 /// 127.0.0.1:<port>
-pub(crate) fn socket_addr_parser(input: &str) -> Result<SocketAddr> {
-    let addr: Vec<&str> = input.split(':').collect();
-
-    let address = match addr.len() {
-        // Only the port is available
-        1 => format!("127.0.0.1:{}", addr[0]),
-        // Both the ip and port are available
-        _ => input.to_string(),
-    };
-    Ok(resolve_peer(address.to_string())
-        .map_err(|e| miette!("cannot parse the address {address} as a socket address: {e}"))?)
+pub(crate) fn hostname_parser(input: &str) -> Result<HostnamePort> {
+    Ok(HostnamePort::from_str(input)
+        .map_err(|e| miette!("cannot parse the address {input} as a socket address: {e}"))?)
 }
 
 /// Helper fn for parsing an identifier from user input by using
@@ -54,73 +45,4 @@ pub(crate) fn project_name_parser(s: &str) -> Result<String> {
 
 pub(crate) fn duration_parser(arg: &str) -> std::result::Result<Duration, clap::Error> {
     parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))
-}
-
-#[cfg(test)]
-mod tests {
-    use std::net::Ipv6Addr;
-
-    use ockam_core::compat::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-    use super::*;
-
-    #[test]
-    fn test_parse_port_only() {
-        let input = "9000";
-        let result = socket_addr_parser(input);
-        assert!(result.is_ok());
-        assert_eq!(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9000),
-            result.unwrap()
-        );
-    }
-
-    #[test]
-    fn test_ipv4_and_port() {
-        let input = "192.168.0.1:9999";
-        let result = socket_addr_parser(input);
-        assert!(result.is_ok());
-        assert_eq!(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)), 9999),
-            result.unwrap()
-        );
-    }
-
-    #[test]
-    fn test_ipv6_and_port() {
-        let input = "[::1]:9999";
-        let result = socket_addr_parser(input);
-        assert!(result.is_ok());
-        assert_eq!(
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 9999),
-            result.unwrap()
-        );
-    }
-
-    #[test]
-    fn test_localhost() {
-        let input = "localhost:9999";
-        let result = socket_addr_parser(input);
-        assert!(result.is_ok());
-        assert!(result.is_ok());
-        assert_eq!(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 9999),
-            result.unwrap()
-        );
-    }
-
-    #[test]
-    fn test_invalid_inputs() {
-        // Test case 3: Any other format will throw an error
-        let invalid_input = "invalid";
-        assert!(socket_addr_parser(invalid_input).is_err());
-
-        let invalid_input = "192.168.0.1:invalid";
-        assert!(socket_addr_parser(invalid_input).is_err());
-
-        let invalid_input = "192.168.0.1:9999:extra";
-        assert!(socket_addr_parser(invalid_input).is_err());
-        let invalid_input = "192,166,0.1:9999";
-        assert!(socket_addr_parser(invalid_input).is_err());
-    }
 }

--- a/implementations/rust/ockam/ockam_command/src/value_parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/value_parsers.rs
@@ -1,4 +1,4 @@
-use crate::util::parsers::socket_addr_parser;
+use crate::util::parsers::hostname_parser;
 use miette::{miette, Context, IntoDiagnostic};
 use ockam_api::cli_state::EnrollmentTicket;
 use std::str::FromStr;
@@ -68,7 +68,7 @@ pub fn is_url(value: &str) -> Option<Url> {
     }
     // If the value is a socket address, try to parse it as a URL
     if let Some(socket_addr) = value.split('/').next() {
-        if socket_addr.contains(':') && socket_addr_parser(socket_addr).is_ok() {
+        if socket_addr.contains(':') && hostname_parser(socket_addr).is_ok() {
             let uri = format!("http://{value}");
             return Url::parse(&uri).ok();
         }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -147,9 +147,9 @@ force_kill_node() {
 }
 
 @test "node - node in foreground with configuration is deleted if something fails" {
-  # The config file has a typo in the "to" address to trigger an error after the node is created.
+  # The config file has invalid port to trigger an error after the node is created.
   # The command should return an error and the node should be deleted.
-  run_failure "$OCKAM" node create --configuration "{name: n, tcp-outlets: {db-outlet: {to: \"localhosst:3000\"}}}"
+  run_failure "$OCKAM" node create --configuration "{name: n, tcp-outlets: {db-outlet: {to: \"localhost:65536\"}}}"
   run_success $OCKAM node show n --output json
   assert_output --partial "[]"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -81,7 +81,7 @@ teardown() {
 
   run_success $OCKAM tcp-outlet show outlet --at /node/n1
   assert_output --partial "\"worker_addr\":\"/service/outlet\""
-  assert_output --partial "\"socket_addr\":\"127.0.0.1:$port_1\""
+  assert_output --partial "\"to\":\"127.0.0.1:$port_1\""
 
   run_success $OCKAM tcp-outlet delete "outlet" --yes
 

--- a/implementations/rust/ockam/ockam_node/src/compat/asynchronous.rs
+++ b/implementations/rust/ockam/ockam_node/src/compat/asynchronous.rs
@@ -1,0 +1,44 @@
+pub use tokio::sync::Mutex;
+pub use tokio::sync::RwLock;
+
+use ockam_transport_core::TransportError;
+use std::net::SocketAddr;
+use tokio::net::lookup_host;
+
+/// Asynchronously resolve the given peer to a [`SocketAddr`](std::net::SocketAddr)
+pub async fn resolve_peer(peer: impl ToString) -> ockam_core::Result<SocketAddr> {
+    let peer = peer.to_string();
+    // Try to resolve hostname
+    match lookup_host(peer.clone()).await {
+        Ok(mut iter) => {
+            // Prefer ip4
+            if let Some(p) = iter.find(|x| x.is_ipv4()) {
+                return Ok(p);
+            }
+            if let Some(p) = iter.find(|x| x.is_ipv6()) {
+                return Ok(p);
+            }
+            Err(TransportError::InvalidAddress(format!(
+                "cannot resolve address: {peer}. No IP4 or IP6 address found."
+            )))?
+        }
+        Err(e) => Err(TransportError::InvalidAddress(format!(
+            "cannot resolve address: {peer}: {e:?}"
+        )))?,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam_transport_core::HostnamePort;
+
+    #[tokio::test]
+    async fn test_hostname_port() -> ockam_core::Result<()> {
+        let socket_addr = resolve_peer("76.76.21.21:8080".to_string()).await.unwrap();
+        let actual = HostnamePort::from(socket_addr);
+        assert_eq!(actual, HostnamePort::new("76.76.21.21", 8080));
+
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/compat/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/compat/mod.rs
@@ -1,9 +1,6 @@
+/// Async public re-exports and utils
 #[cfg(feature = "std")]
-/// Async Mutex and RwLock
-pub mod asynchronous {
-    pub use tokio::sync::Mutex;
-    pub use tokio::sync::RwLock;
-}
+pub mod asynchronous;
 
 /// FutureExt
 pub mod futures {

--- a/implementations/rust/ockam/ockam_transport_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_transport_core/Cargo.toml
@@ -20,7 +20,7 @@ default = ["std"]
 
 # Feature (enabled by default): "std" enables functionality expected to
 # be available on a standard platform.
-std = ["ockam_core/std", "regex/std"]
+std = ["ockam_core/std", "serde/std", "regex/std"]
 
 # Feature: "no_std" enables functionality required for platforms
 # without the standard library.
@@ -34,3 +34,4 @@ alloc = ["ockam_core/alloc"]
 minicbor = "0.24"
 ockam_core = { path = "../ockam_core", version = "^0.112.0", default-features = false }
 regex = { version = "1.10.3", default-features = false }
+serde = { version = "1.0.203", default-features = false, features = ["derive"] }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -124,7 +124,7 @@ impl Processor for TcpInletListenProcessor {
             ctx,
             self.registry.clone(),
             stream,
-            HostnamePort::from_socket_addr(socket_addr)?,
+            HostnamePort::from_socket_addr(socket_addr),
             outlet_shared_state.route,
             addresses,
             self.options.incoming_access_control.clone(),

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/portal_worker.rs
@@ -378,7 +378,7 @@ impl TcpPortalWorker {
             self.read_half = Some(ReadHalfWithTls(rx));
         } else {
             debug!("Connect to {}", self.hostname_port);
-            let (rx, tx) = connect(self.hostname_port.to_socket_addr()?).await?;
+            let (rx, tx) = connect(&self.hostname_port).await?;
             self.write_half = Some(WriteHalfNoTls(tx));
             self.read_half = Some(ReadHalfNoTls(rx));
         }


### PR DESCRIPTION
Removed every manual hostname resolution except on the Inlet side, where it's resolved once during creation and the result is kept. This addresses a bootstrap failure when creating an outlet for a non-existing hostname, and also dynamically resolves the address at each connection.

Converted all `SocketAddress` usages in command into `HostnamePort`, even in inlets you can specify the local hostname, so for example, you can bind to the local network interface without knowing the IP address.
The previous code did perform some amount of hostname-level validation, but since the validation is hard to get right, (we can't rely on the hostname being an ASCII, since IDN are now a thing, and there are several rules), it's easier to just forward the hostname and fail during connection.
