### PR TITLE
feat: make it possible to configure the default timeout for client requests

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/secure_channel.rs
@@ -6,7 +6,7 @@ use minicbor::{CborLen, Decode, Encode};
 use serde::Serialize;
 
 use ockam::identity::models::CredentialAndPurposeKey;
-use ockam::identity::{Identifier, SecureChannel, SecureChannelListener, DEFAULT_TIMEOUT};
+use ockam::identity::{Identifier, SecureChannel, SecureChannelListener};
 use ockam_core::flow_control::FlowControlId;
 use ockam_core::{route, Address, Result};
 use ockam_multiaddr::MultiAddr;
@@ -41,7 +41,7 @@ impl CreateSecureChannelRequest {
         Self {
             addr: addr.to_owned(),
             authorized_identifiers,
-            timeout: Some(DEFAULT_TIMEOUT),
+            timeout: None,
             identity_name,
             credential,
         }

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -64,6 +64,7 @@ Devs Usage
 - OCKAM_DEVELOPER: a `boolean` specifying if the current user is an Ockam developer (for more accurate metrics).
 - OCKAM_OPENTELEMETRY_EXPORT_DEBUG: a `boolean` specifying if debug messages must be printed to the console when the OpenTelemetry export is configured.
 - OCKAM_OPENTELEMETRY_EXPORT_VIA_PORTAL: a `boolean` specifying if traces must be exported via a portal when a project exists (this feature flag is set to `false` for now)
+- OCKAM_DEFAULT_TIMEOUT: a `Duration` used to timeout secure channels creation and API requests. Default value: `120s`.
 
 Internal (to enable some special behavior in the logic)
 - OCKAM_HELP_RENDER_MARKDOWN: a `boolean` to control the markdown rendering of the commands documentation.

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -6,9 +6,9 @@ use tokio::{sync::Mutex, try_join};
 
 use crate::{docs, CommandGlobalOpts};
 use ockam::identity::models::CredentialAndPurposeKey;
-use ockam::identity::DEFAULT_TIMEOUT;
 use ockam::{identity::Identifier, route, Context};
 use ockam_api::address::extract_address_value;
+use ockam_api::cloud::get_default_timeout;
 use ockam_api::colors::OckamColor;
 use ockam_api::nodes::models::secure_channel::{
     CreateSecureChannelRequest, CreateSecureChannelResponse,
@@ -93,7 +93,7 @@ impl CreateCommand {
             node,
             &meta,
             Some(identity_name),
-            Some(DEFAULT_TIMEOUT),
+            Some(get_default_timeout().into_diagnostic()?),
         )
         .await?;
         clean_projects_multiaddr(to, projects_sc)

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -15,7 +15,7 @@ use core::fmt::Formatter;
 use core::time::Duration;
 
 /// This is the default timeout for creating a secure channel
-pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+pub(super) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Trust options for a Secure Channel
 pub struct SecureChannelOptions {

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
@@ -101,7 +101,7 @@ impl SecureClient {
         &self.client_identifier
     }
 
-    /// Secure Channel cretion timeout
+    /// Secure Channel creation timeout
     pub fn secure_channel_timeout(&self) -> Duration {
         self.secure_channel_timeout
     }
@@ -109,6 +109,22 @@ impl SecureClient {
     /// Request timeout
     pub fn request_timeout(&self) -> Duration {
         self.request_timeout
+    }
+
+    /// Change the secure channel creation timeout
+    pub fn with_secure_channel_timeout(self, timeout: &Duration) -> Self {
+        Self {
+            secure_channel_timeout: *timeout,
+            ..self
+        }
+    }
+
+    /// Change the request timeout
+    pub fn with_request_timeout(self, timeout: &Duration) -> Self {
+        Self {
+            request_timeout: *timeout,
+            ..self
+        }
     }
 }
 


### PR DESCRIPTION
This PR allows some configuration of the timeout used by secure clients (accessing the Controller, or the project node, or the authority node):

 - Via an environment variable `OCKAM_DEFAULT_TIMEOUT` by default
 - From inside the code with additional `with_request_timeout/with_secure_channel_timeout` methods
 - From the command line for the `ockam enroll` command, if it is needed to specifically increase the timeout for this command.

I am not sure if all of this is necessary but I would like to experiment on the failing bats tests.