### PR TITLE
fix(rust): allow the creation of a sqlite database with a relative path

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/storage/database/database_configuration.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/database_configuration.rs
@@ -180,7 +180,7 @@ impl DatabaseConfiguration {
 
     fn create_sqlite_on_disk_connection_string(path: &Path) -> String {
         let url_string = &path.to_string_lossy().to_string();
-        format!("sqlite:file://{url_string}?mode=rwc")
+        format!("sqlite://{url_string}?mode=rwc")
     }
 
     fn create_postgres_connection_string(


### PR DESCRIPTION
This PR allows the invocation of command with a relative path for `OCKAM_HOME`. For example:
```
OCKAM_HOME=ockam_home ockam reset -y
```
