### PR TITLE
Add the possibility to use a larger timeout for retrieving credentials

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/project/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project/project.rs
@@ -184,8 +184,8 @@ impl Project {
                 Origin::Api,
                 Kind::NotFound,
                 format!(
-                    "no identity has been set for the project authority {}",
-                    self.model.name
+                    "no identity has been set for the project authority: {:?}",
+                    self
                 ),
             )),
         }

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -2,13 +2,15 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::time::Duration;
 
-use ockam::identity::{CredentialRetrieverCreator, Identifier, SecureChannels, SecureClient};
+use ockam::identity::{
+    get_default_timeout, CredentialRetrieverCreator, Identifier, SecureChannels, SecureClient,
+};
 use ockam::tcp::TcpTransport;
 use ockam_core::compat::sync::Arc;
 use ockam_core::env::{get_env, get_env_with_default, FromString};
 use ockam_core::{Result, Route};
 use ockam_multiaddr::MultiAddr;
-use ockam_node::{Context, DEFAULT_TIMEOUT};
+use ockam_node::Context;
 
 use crate::error::ApiError;
 use crate::multiaddr_to_transport_route;
@@ -16,7 +18,6 @@ use crate::nodes::NodeManager;
 
 pub const OCKAM_CONTROLLER_ADDR: &str = "OCKAM_CONTROLLER_ADDR";
 pub const DEFAULT_CONTROLLER_ADDRESS: &str = "/dnsaddr/orchestrator.ockam.io/tcp/6252/service/api";
-pub const OCKAM_DEFAULT_TIMEOUT: &str = "OCKAM_DEFAULT_TIMEOUT";
 
 /// If it's present, its contents will be used and will have priority over the contents
 /// from ./static/controller.id.
@@ -122,8 +123,8 @@ impl NodeManager {
                 controller_route,
                 &controller_identifier,
                 caller_identifier,
-                get_default_timeout()?,
-                get_default_timeout()?,
+                get_default_timeout(),
+                get_default_timeout(),
             ),
         })
     }
@@ -151,8 +152,8 @@ impl NodeManager {
                 authority_route,
                 authority_identifier,
                 caller_identifier,
-                get_default_timeout()?,
-                get_default_timeout()?,
+                get_default_timeout(),
+                get_default_timeout(),
             ),
         })
     }
@@ -180,8 +181,8 @@ impl NodeManager {
                 project_route,
                 project_identifier,
                 caller_identifier,
-                get_default_timeout()?,
-                get_default_timeout()?,
+                get_default_timeout(),
+                get_default_timeout(),
             ),
         })
     }
@@ -207,8 +208,8 @@ impl NodeManager {
                 route,
                 identifier,
                 caller_identifier,
-                get_default_timeout()?,
-                get_default_timeout()?,
+                get_default_timeout(),
+                get_default_timeout(),
             ),
         })
     }
@@ -238,10 +239,6 @@ impl NodeManager {
             ))
         })
     }
-}
-
-pub fn get_default_timeout() -> Result<Duration> {
-    get_env_with_default::<Duration>(OCKAM_DEFAULT_TIMEOUT, DEFAULT_TIMEOUT)
 }
 
 pub struct AuthorityNodeClient {

--- a/implementations/rust/ockam/ockam_api/src/enroll/ockam_oidc_provider.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/ockam_oidc_provider.rs
@@ -1,3 +1,4 @@
+use ockam::identity::get_default_timeout;
 use ockam_core::env::get_env_with_default;
 use ockam_core::Result;
 use std::time::Duration;
@@ -22,7 +23,7 @@ pub struct OckamOidcProvider {
 
 impl Default for OckamOidcProvider {
     fn default() -> Self {
-        OckamOidcProvider::new(Duration::from_secs(120))
+        OckamOidcProvider::new(get_default_timeout())
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use miette::{miette, IntoDiagnostic};
 use minicbor::{Decode, Encode};
+use ockam::identity::get_default_timeout;
 
 use ockam::tcp::{TcpConnection, TcpConnectionOptions, TcpTransport};
 use ockam_core::api::{Reply, Request};
@@ -11,7 +12,6 @@ use ockam_node::api::Client;
 use ockam_node::Context;
 
 use crate::cli_state::CliState;
-use crate::cloud::get_default_timeout;
 use crate::nodes::NODEMANAGER_ADDR;
 
 /// This struct represents a Client to a node that has been started
@@ -74,7 +74,7 @@ impl BackgroundNodeClient {
             cli_state: cli_state.clone(),
             node_name: node_name.to_string(),
             to: NODEMANAGER_ADDR.into(),
-            timeout: Some(get_default_timeout().into_diagnostic()?),
+            timeout: Some(get_default_timeout()),
             tcp_transport: Arc::new(tcp_transport.clone()),
         })
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -286,3 +286,22 @@ impl Default for NodeManagerDefaults {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[ockam::test]
+    async fn test_start_twice(ctx: &mut Context) -> Result<()> {
+        let cli = CliState::test().await?;
+
+        let node_manager1 = InMemoryNode::start(ctx, &cli).await;
+        assert!(node_manager1.is_ok());
+
+        let node_manager2 = InMemoryNode::start(ctx, &cli).await;
+        if let Err(e) = node_manager2 {
+            panic!("cannot start the node manager a second time: {e:?}");
+        }
+        Ok(())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/node_services.rs
@@ -202,6 +202,10 @@ impl NodeManager {
             )));
         }
 
+        if ctx.is_worker_registered_at(addr.clone()).await? {
+            ctx.stop_worker(addr.clone()).await?
+        };
+
         let (incoming_ac, outgoing_ac) = self
             .access_control(
                 ctx,

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -550,11 +550,6 @@ async fn get_user_project(
     let project = check_project_readiness(opts, ctx, node, project).await?;
     // store the updated project
     opts.state.projects().store_project(project.clone()).await?;
-    // set the project as the default one
-    opts.state
-        .projects()
-        .set_default_project(project.project_id())
-        .await?;
 
     opts.terminal.write_line(&fmt_ok!(
         "Marked this new Project as your default Project, on this machine."

--- a/implementations/rust/ockam/ockam_command/src/error.rs
+++ b/implementations/rust/ockam/ockam_command/src/error.rs
@@ -191,7 +191,7 @@ impl miette::ReportHandler for ErrorReportHandler {
         };
 
         // TODO: Display the cause of the error in a nicely formatted way; skip for now.
-        // Self::print_causes(f, error)?;
+        Self::print_causes(f, error)?;
 
         let code_message = format!("Error code: {}", code_as_str).dark_gray();
         let version_message = format!("version: {}", Version::short()).dark_gray();

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -62,7 +62,7 @@ pub struct EnrollCommand {
     pub retry_opts: RetryOpts,
 
     /// Override the default timeout duration in environments where enrollment can take a long time
-    #[arg(long, value_name = "TIMEOUT", default_value = "120s", value_parser = duration_parser)]
+    #[arg(long, value_name = "TIMEOUT", default_value = "240s", value_parser = duration_parser)]
     pub timeout: Duration,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -103,7 +103,7 @@ pub async fn check_project_readiness(
     node: &InMemoryNode,
     project: Project,
 ) -> Result<Project> {
-    // Total of 10 Mins sleep strategy with 5 second intervals between each retry
+    // Total of 20 Mins sleep strategy with 5 second intervals between each retry
     let retry_strategy = FixedInterval::from_millis(5000)
         .take((ORCHESTRATOR_AWAIT_TIMEOUT.as_millis() / 5000) as usize);
 

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -5,10 +5,10 @@ use serde_json::json;
 use tokio::{sync::Mutex, try_join};
 
 use crate::{docs, CommandGlobalOpts};
+use ockam::identity::get_default_timeout;
 use ockam::identity::models::CredentialAndPurposeKey;
 use ockam::{identity::Identifier, route, Context};
 use ockam_api::address::extract_address_value;
-use ockam_api::cloud::get_default_timeout;
 use ockam_api::colors::OckamColor;
 use ockam_api::nodes::models::secure_channel::{
     CreateSecureChannelRequest, CreateSecureChannelResponse,
@@ -93,7 +93,7 @@ impl CreateCommand {
             node,
             &meta,
             Some(identity_name),
-            Some(get_default_timeout().into_diagnostic()?),
+            Some(get_default_timeout()),
         )
         .await?;
         clean_projects_multiaddr(to, projects_sc)

--- a/implementations/rust/ockam/ockam_command/src/shared_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/shared_args.rs
@@ -85,13 +85,13 @@ impl RetryOpts {
 #[derive(Debug, Clone, Args)]
 pub struct TimeoutArg {
     /// Override the default timeout duration that the command will wait for a response
-    #[arg(long, value_name = "TIMEOUT", default_value = "5s", value_parser = duration_parser)]
+    #[arg(long, value_name = "TIMEOUT", default_value = "10s", value_parser = duration_parser)]
     pub(crate) timeout: Duration,
 }
 
 #[derive(Debug, Clone, Args)]
 pub struct OptionalTimeoutArg {
     /// Override the default timeout duration that the command will wait for a response
-    #[arg(long, value_name = "TIMEOUT", default_value = "5s", value_parser = duration_parser)]
+    #[arg(long, value_name = "TIMEOUT", default_value = "10s", value_parser = duration_parser)]
     pub(crate) timeout: Option<Duration>,
 }

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -354,6 +354,11 @@ pub trait Command: Clone + Sized + Send + Sync + 'static {
                     Ok(_) => break,
                     Err(Error::Retry(inner)) => {
                         retry_count -= 1;
+                        // return the last error if there are no more retries
+                        if retry_count == 0 {
+                            return Err(inner);
+                        };
+
                         let delay = retry_delay.add(jitter(retry_delay_jitter));
                         warn!(
                             "Command failed, retrying in {} seconds: {inner:?}",

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -123,6 +123,9 @@ bats_require_minimum_version 1.5.0
 # Disable the opentelemetry export to improve performances
 export OCKAM_OPENTELEMETRY_EXPORT=false
 
+# Set a high timeout for CI tests
+export OCKAM_DEFAULT_TIMEOUT=5m
+
 # Set QUIET to 1 to suppress user-facing logging written at stderr
 export QUIET=1
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -126,6 +126,9 @@ export OCKAM_OPENTELEMETRY_EXPORT=false
 # Set a high timeout for CI tests
 export OCKAM_DEFAULT_TIMEOUT=5m
 
+# Set OCKAM_LOGGING to true so that command logs are persisted
+export OCKAM_LOGGING=true
+
 # Set QUIET to 1 to suppress user-facing logging written at stderr
 export QUIET=1
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/README.md
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/README.md
@@ -1,2 +1,2 @@
 This suite includes tests to exercise the functionalities of the orchestrator. Tests that only require the orchestrator
-to generate enrollment tickets and enroll identities are in the `with_orchestrator` suite.
+to generate enrollment tickets and enroll identities are in the `orchestrator_enroll` suite.

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/fixtures/node-create.basic.config.yaml
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/fixtures/node-create.basic.config.yaml
@@ -1,3 +1,8 @@
+variables:
+  NODE_NAME: n1
+
+name: $NODE_NAME
+
 relay: $RELAY_NAME
 
 tcp-outlet:

--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -4,8 +4,7 @@ set -e
 rm -rf "$HOME/.bats-tests"
 mkdir -p "$HOME/.bats-tests"
 
-export BATS_TEST_RETRIES=2
-export BATS_TEST_TIMEOUT=240
+export BATS_TEST_TIMEOUT=300
 
 current_directory=$(dirname "$0")
 

--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
@@ -14,8 +14,8 @@ use ockam_transport_core::Transport;
 use crate::models::CredentialAndPurposeKey;
 use crate::utils::now;
 use crate::{
-    CachedCredentialRetriever, Identifier, RemoteCredentialRetrieverInfo, SecureChannels,
-    SecureClient, TimestampInSeconds, DEFAULT_CREDENTIAL_CLOCK_SKEW_GAP,
+    get_default_timeout, CachedCredentialRetriever, Identifier, RemoteCredentialRetrieverInfo,
+    SecureChannels, SecureClient, TimestampInSeconds, DEFAULT_CREDENTIAL_CLOCK_SKEW_GAP,
 };
 
 /// This is the default interval before a credential expiration when we'll query for
@@ -28,9 +28,6 @@ pub const DEFAULT_MIN_REFRESH_CREDENTIAL_INTERVAL: Duration = Duration::from_sec
 
 /// Default timeout for requesting credential from the authority
 pub const DEFAULT_CREDENTIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
-
-/// Default timeout for creating secure channel to the authority
-pub const DEFAULT_CREDENTIAL_SECURE_CHANNEL_CREATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Start refresh in the background before it expires
 pub const DEFAULT_CREDENTIAL_PROACTIVE_REFRESH_GAP: TimestampInSeconds = TimestampInSeconds(60);
@@ -54,8 +51,8 @@ pub struct RemoteCredentialRetrieverTimingOptions {
 impl Default for RemoteCredentialRetrieverTimingOptions {
     fn default() -> Self {
         Self {
-            request_timeout: DEFAULT_CREDENTIAL_REQUEST_TIMEOUT,
-            secure_channel_creation_timeout: DEFAULT_CREDENTIAL_SECURE_CHANNEL_CREATION_TIMEOUT,
+            request_timeout: get_default_timeout(),
+            secure_channel_creation_timeout: get_default_timeout(),
             min_refresh_interval: DEFAULT_MIN_REFRESH_CREDENTIAL_INTERVAL,
             proactive_refresh_gap: DEFAULT_PROACTIVE_REFRESH_CREDENTIAL_TIME_GAP,
             clock_skew_gap: DEFAULT_CREDENTIAL_CLOCK_SKEW_GAP,

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake_worker.rs
@@ -234,7 +234,7 @@ impl HandshakeWorker {
                         Ok(their_identifier) => Some(their_identifier),
                         Err(err) => {
                             error!(
-                            "Timeout {:?} reached when creating secure channel for: {}. Encryptor: {}",
+                            "Timeout {:?} or error reached when creating secure channel for: {}. Encryptor: {}. Error: {err:?}",
                             timeout, my_identifier, addresses.encryptor
                         );
 

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/options.rs
@@ -1,3 +1,5 @@
+use cfg_if::cfg_if;
+
 use ockam_core::compat::sync::Arc;
 use ockam_core::compat::vec::Vec;
 use ockam_core::flow_control::{FlowControlId, FlowControlOutgoingAccessControl, FlowControls};
@@ -13,9 +15,15 @@ use crate::{
 use core::fmt;
 use core::fmt::Formatter;
 use core::time::Duration;
+#[cfg(feature = "std")]
+use ockam_core::env::get_env_with_default;
 
 /// This is the default timeout for creating a secure channel
 pub(super) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Environment variable name for changing the default timeout used to create secure channels
+/// or make a request
+pub const OCKAM_DEFAULT_TIMEOUT: &str = "OCKAM_DEFAULT_TIMEOUT";
 
 /// Trust options for a Secure Channel
 pub struct SecureChannelOptions {
@@ -323,5 +331,18 @@ impl SecureChannelListenerOptions {
         );
 
         Arc::new(ac)
+    }
+}
+
+/// Return a default timeout for creating secure channels or make a request
+pub fn get_default_timeout() -> Duration {
+    cfg_if! {
+        if #[cfg(feature = "std")] {
+            get_env_with_default::<Duration>(OCKAM_DEFAULT_TIMEOUT, DEFAULT_TIMEOUT)
+              .ok()
+              .unwrap_or(DEFAULT_TIMEOUT)
+        } else {
+            DEFAULT_TIMEOUT
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/callback.rs
+++ b/implementations/rust/ockam/ockam_node/src/callback.rs
@@ -14,7 +14,9 @@ pub struct CallbackReceiver<T> {
 impl<T> CallbackReceiver<T> {
     /// Waits for a message indefinitely
     pub async fn receive(self) -> ockam_core::Result<T> {
-        self.receiver.await.map_err(|_| channel_closed())
+        self.receiver
+            .await
+            .map_err(|e| channel_closed(format!("receive failed: {e:?}")))
     }
 
     /// Waits for a message with a timeout
@@ -22,14 +24,17 @@ impl<T> CallbackReceiver<T> {
         let result = crate::compat::timeout(timeout, self.receiver).await;
         match result {
             Ok(Ok(data)) => Ok(data),
-            Ok(Err(_)) => Err(channel_closed()),
+            Ok(Err(e)) => Err(channel_closed(format!(
+                "receive, with timeout {:?}, failed: {e:?}",
+                timeout
+            ))),
             Err(_) => Err(Error::new(Origin::Node, Kind::Timeout, "timeout")),
         }
     }
 }
 
-fn channel_closed() -> Error {
-    Error::new(Origin::Node, Kind::Cancelled, "channel closed")
+fn channel_closed(e: String) -> Error {
+    Error::new(Origin::Node, Kind::Cancelled, e)
 }
 
 /// The sender side of a callback
@@ -37,10 +42,12 @@ pub struct CallbackSender<T> {
     sender: OneshotSender<T>,
 }
 
-impl<T> CallbackSender<T> {
+impl<T: Debug> CallbackSender<T> {
     /// Send a message to the callback
     pub fn send(self, data: T) -> ockam_core::Result<()> {
-        self.sender.send(data).map_err(|_| channel_closed())
+        self.sender
+            .send(data)
+            .map_err(|e| channel_closed(format!("sending data failed: {e:?}")))
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/callback.rs
+++ b/implementations/rust/ockam/ockam_node/src/callback.rs
@@ -1,6 +1,8 @@
 use crate::channel_types;
 use crate::channel_types::{OneshotReceiver, OneshotSender};
 use core::time::Duration;
+use ockam_core::compat::fmt::Debug;
+use ockam_core::compat::string::String;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Error;
 

--- a/implementations/rust/ockam/ockam_node/src/context/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context.rs
@@ -153,6 +153,22 @@ impl Context {
             .take_workers()
     }
 
+    /// Return true if a worker is already registered at this address
+    pub async fn is_worker_registered_at(&self, address: Address) -> Result<bool> {
+        let (msg, mut reply_rx) = NodeMessage::is_worker_registered_at(address.clone());
+
+        self.sender
+            .send(msg)
+            .await
+            .map_err(NodeError::from_send_err)?;
+
+        reply_rx
+            .recv()
+            .await
+            .ok_or_else(|| NodeError::NodeState(NodeReason::Unknown).internal())??
+            .take_worker_is_registered()
+    }
+
     /// Send a shutdown acknowledgement to the router
     pub(crate) async fn send_stop_ack(&self) -> Result<()> {
         self.sender

--- a/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
@@ -130,7 +130,7 @@ impl Context {
             MessageWait::Timeout(timeout_duration) => {
                 timeout(timeout_duration, async { self.next_from_mailbox().await })
                     .await
-                    .map_err(|e| NodeError::Data.with_elapsed(e))?
+                    .map_err(|_| NodeError::Data.with_timeout(timeout_duration))?
             }
             MessageWait::Blocking => self.next_from_mailbox().await,
         }

--- a/implementations/rust/ockam/ockam_node/src/error.rs
+++ b/implementations/rust/ockam/ockam_node/src/error.rs
@@ -1,5 +1,6 @@
-use crate::tokio::{sync::mpsc::error::SendError, time::error::Elapsed};
+use crate::tokio::sync::mpsc::error::SendError;
 use core::fmt;
+use core::time::Duration;
 use ockam_core::{
     compat::error::Error as StdError,
     errcode::{Kind, Origin},
@@ -56,10 +57,15 @@ impl NodeError {
         .context("SendError", err)
     }
 
-    /// Create an ockam_core::Error from a tokio::Elapsed
+    /// Create an ockam_core::Error an elapsed timeout
     #[track_caller]
-    pub(crate) fn with_elapsed(self, err: Elapsed) -> Error {
-        Error::new(Origin::Node, Kind::Timeout, err).context("Type", self)
+    pub(crate) fn with_timeout(self, duration: Duration) -> Error {
+        Error::new(
+            Origin::Node,
+            Kind::Timeout,
+            format!("timeout: {duration:?}"),
+        )
+        .context("Type", self)
     }
 }
 

--- a/implementations/rust/ockam/ockam_node/src/router/record.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/record.rs
@@ -324,7 +324,7 @@ impl AddressRecord {
                 .await
                 .map_err(|_| NodeError::NodeState(NodeReason::Unknown).internal())?;
         } else {
-            self.sender = None;
+            self.drop_sender();
         }
         self.state = AddressState::Stopping;
         Ok(())


### PR DESCRIPTION
This PR tries to improve the reliability of the Orchestrator command tests:

1. By having the possibility to set higher timeouts when creating secure channels and making requests

2. By allowing an `InMemoryNode` to be restarted in case of a command retry
    - In order to do this we must be able to restart services with fixed address names like the "echoer" service or the `Medic` collector. 
    
3. By returning the last error for a retried command (otherwise some commands are shown as successful when they should fail)

Additionally, I:

 - Added more details to some errors.
 - Made sure that commands are logged when running the CI test suite.