### PR TITLE
refactor(rust): rename `enable/disable-` args to follow the convention of `color/no-color`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -70,16 +70,26 @@ pub struct CreateCommand {
 
     /// Enable the HTTP server for the node that will listen to in a random free port.
     /// To specify a port, use `--http-server-port` instead.
-    #[arg(long, value_name = "BOOL", default_value_t = false)]
-    pub enable_http_server: bool,
+    #[arg(
+        long,
+        visible_alias = "enable-http-server",
+        value_name = "BOOL",
+        default_value_t = false
+    )]
+    pub http_server: bool,
 
     /// Enable the HTTP server at the given port.
-    #[arg(long, value_name = "PORT", conflicts_with = "enable_http_server")]
+    #[arg(long, value_name = "PORT", conflicts_with = "http_server")]
     pub http_server_port: Option<u16>,
 
     /// Enable UDP transport puncture.
-    #[arg(long, value_name = "BOOL", default_value_t = false)]
-    pub enable_udp: bool,
+    #[arg(
+        long,
+        visible_alias = "enable-udp",
+        value_name = "BOOL",
+        default_value_t = false
+    )]
+    pub udp: bool,
 
     /// A configuration in JSON format to set up the node services.
     /// Node configuration is run asynchronously and may take several
@@ -115,9 +125,9 @@ impl Default for CreateCommand {
                 variables: vec![],
             },
             tcp_listener_address: node_manager_defaults.tcp_listener_address,
-            enable_http_server: false,
-            enable_udp: false,
+            http_server: false,
             http_server_port: None,
+            udp: false,
             launch_config: None,
             identity: None,
             trust_opts: node_manager_defaults.trust_opts,

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -84,7 +84,7 @@ impl CreateCommand {
 
         let http_server_port = if let Some(port) = self.http_server_port {
             Some(port)
-        } else if self.enable_http_server {
+        } else if self.http_server {
             if let Some(addr) = node_info.http_server_address() {
                 Some(addr.port())
             } else {
@@ -94,7 +94,7 @@ impl CreateCommand {
             None
         };
 
-        let udp_transport = if self.enable_udp {
+        let udp_transport = if self.udp {
             Some(UdpTransport::create(ctx).await.into_diagnostic()?)
         } else {
             None

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,13 +1,11 @@
-use std::env::current_exe;
-use std::process::{Command, Stdio};
-
 use miette::IntoDiagnostic;
 use miette::{miette, Context as _};
-use rand::random;
-use tracing::info;
-
 use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
+use rand::random;
+use std::env::current_exe;
+use std::process::{Command, Stdio};
+use tracing::info;
 
 use crate::node::show::wait_until_node_is_up;
 use crate::node::CreateCommand;
@@ -76,9 +74,9 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         name,
         identity: identity_name,
         tcp_listener_address: address,
-        enable_http_server,
+        http_server,
         http_server_port,
-        enable_udp,
+        udp,
         launch_config,
         trust_opts,
         opentelemetry_context,
@@ -147,8 +145,8 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         args.push(opentelemetry_context.to_string());
     }
 
-    if enable_http_server {
-        args.push("--enable-http-server".to_string());
+    if http_server {
+        args.push("--http-server".to_string());
     }
 
     if let Some(http_server_port) = http_server_port {
@@ -156,8 +154,8 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         args.push(http_server_port.to_string());
     }
 
-    if enable_udp {
-        args.push("--enable-udp".to_string());
+    if udp {
+        args.push("--udp".to_string());
     }
 
     args.push(name.to_owned());

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -23,8 +23,8 @@ pub struct Node {
     pub exit_on_eof: Option<ArgValue>,
     #[serde(alias = "tcp-listener-address")]
     pub tcp_listener_address: Option<ArgValue>,
-    #[serde(alias = "enable-http-server")]
-    pub enable_http_server: Option<ArgValue>,
+    #[serde(alias = "http-server", alias = "enable-http-server")]
+    pub http_server: Option<ArgValue>,
     #[serde(alias = "http-server-port")]
     pub http_server_port: Option<ArgValue>,
     pub identity: Option<ArgValue>,
@@ -54,8 +54,8 @@ impl Resource<CreateCommand> for Node {
         if let Some(tcp_listener_address) = self.tcp_listener_address {
             args.insert("tcp-listener-address".to_string(), tcp_listener_address);
         }
-        if let Some(enable_http_server) = self.enable_http_server {
-            args.insert("enable-http-server".to_string(), enable_http_server);
+        if let Some(enable_http_server) = self.http_server {
+            args.insert("http-server".to_string(), enable_http_server);
         }
         if let Some(http_server_port) = self.http_server_port {
             args.insert("http-server-port".to_string(), http_server_port);

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -111,13 +111,23 @@ pub struct CreateCommand {
     no_connection_wait: bool,
 
     /// Enable UDP NAT puncture.
-    #[arg(long, value_name = "BOOL", default_value_t = false)]
-    pub enable_udp_puncture: bool,
+    #[arg(
+        long,
+        visible_alias = "enable-udp-puncture",
+        value_name = "BOOL",
+        default_value_t = false
+    )]
+    pub udp: bool,
 
     /// Disable fallback to TCP.
     /// TCP won't be used to transfer data between the Inlet and the Outlet.
-    #[arg(long, value_name = "BOOL", default_value_t = false)]
-    pub disable_tcp_fallback: bool,
+    #[arg(
+        long,
+        visible_alias = "disable-tcp-fallback",
+        value_name = "BOOL",
+        default_value_t = false
+    )]
+    pub no_tcp_fallback: bool,
 }
 
 pub(crate) fn default_from_addr() -> HostnamePort {
@@ -162,8 +172,8 @@ impl Command for CreateCommand {
                         cmd.connection_wait,
                         !cmd.no_connection_wait,
                         &cmd.secure_channel_identifier(&opts.state).await?,
-                        cmd.enable_udp_puncture,
-                        cmd.disable_tcp_fallback,
+                        cmd.udp,
+                        cmd.no_tcp_fallback,
                     )
                     .await?;
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -180,7 +180,7 @@ force_kill_node() {
 }
 
 @test "node - check the contents returned from the HTTP server endpoints" {
-  run_success $OCKAM node create --enable-http-server
+  run_success $OCKAM node create --http-server
   run_success $OCKAM node show --output json
   cmd_output="$output"
   http_addr="$(echo $cmd_output | jq -r .http_server_address)"
@@ -190,7 +190,7 @@ force_kill_node() {
 }
 
 @test "node - the HTTP server is enabled with a boolean flag and a random port is assigned to it" {
-  run_success $OCKAM node create --enable-http-server
+  run_success $OCKAM node create --http-server
   run_success $OCKAM node show --output json
   http_addr="$(echo $output | jq -r .http_server_address)"
   run_success curl -fsI -m 2 $http_addr

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/rendezvous_server.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/rendezvous_server.bats
@@ -36,11 +36,11 @@ teardown() {
 
   export OCKAM_RENDEZVOUS_SERVER="127.0.0.1:$port"
 
-  run_success "$OCKAM" node create bob --enable-udp
+  run_success "$OCKAM" node create bob --udp
   run_success "$OCKAM" tcp-outlet create --at bob --to "$PYTHON_SERVER_PORT"
 
-  run_success "$OCKAM" node create alice --enable-udp
-  run_success "$OCKAM" tcp-inlet create --at alice --enable-udp-puncture --disable-tcp-fallback --from "$inlet_port" --to /node/bob/secure/api/service/outlet
+  run_success "$OCKAM" node create alice --udp
+  run_success "$OCKAM" tcp-inlet create --at alice --udp --no-tcp-fallback --from "$inlet_port" --to /node/bob/secure/api/service/outlet
 
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }


### PR DESCRIPTION
Adds the `color/no-color` naming convention as the default argument name but also keeps the old arg names as valid aliases for backward compatibility. Example:

```bash
ockam node create --http-server
ockam node create --enable-http-server
```