### PR TITLE
feat(rust): log commands by default to a file

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -269,14 +269,24 @@ impl CliState {
         Self::make_nodes_dir_path(root_path).join(node_name)
     }
 
+    pub(super) fn make_command_log_path(root_path: &Path, command_name: &str) -> PathBuf {
+        Self::make_commands_log_dir_path(root_path).join(command_name)
+    }
+
     pub(super) fn make_nodes_dir_path(root_path: &Path) -> PathBuf {
         root_path.join("nodes")
+    }
+
+    pub(super) fn make_commands_log_dir_path(root_path: &Path) -> PathBuf {
+        root_path.join("commands")
     }
 
     /// Delete the state files
     fn delete_at(root_path: &Path) -> Result<()> {
         // Delete nodes logs
         let _ = std::fs::remove_dir_all(Self::make_nodes_dir_path(root_path));
+        // Delete command logs
+        let _ = std::fs::remove_dir_all(Self::make_commands_log_dir_path(root_path));
         // Delete the nodes database, keep the application database
         if let Some(path) = Self::make_database_configuration(root_path)?.path() {
             std::fs::remove_file(path)?

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -450,6 +450,14 @@ impl CliState {
     pub fn node_dir(&self, node_name: &str) -> PathBuf {
         Self::make_node_dir_path(&self.dir(), node_name)
     }
+
+    /// Return a log path to be used for a given command
+    pub fn command_log_path(command_name: &str) -> Result<PathBuf> {
+        Ok(Self::make_command_log_path(
+            &CliState::default_dir()?,
+            command_name,
+        ))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Encode, Decode, CborLen)]

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/term.rs
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn test_write() {
         let sut: Terminal<TerminalStream<Term>> =
-            Terminal::new(false, false, false, false, OutputFormat::Plain);
+            Terminal::new(false, false, false, false, false, OutputFormat::Plain);
         sut.write("1").unwrap();
         sut.rewrite("1-r\n").unwrap();
         sut.write_line(&"2".red().to_string()).unwrap();

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -157,6 +157,11 @@ impl CommandGlobalOpts {
             } else {
                 Colored::Off
             };
+            let log_path = if preferred_log_level.is_some() {
+                None
+            } else {
+                Some(CliState::command_log_path(cmd.name().as_str())?)
+            };
             Ok(
                 logging_configuration(preferred_log_level, colored, log_path, crates)
                     .into_diagnostic()?,

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -53,6 +53,7 @@ impl CommandGlobalOpts {
         let tracing_configuration = Self::make_tracing_configuration(cmd)?;
         let terminal = Terminal::new(
             logging_configuration.is_enabled(),
+            logging_configuration.log_dir().is_some(),
             global_args.quiet,
             global_args.no_color,
             global_args.no_input,

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -152,16 +152,18 @@ impl CommandGlobalOpts {
             Ok(LoggingConfiguration::background(log_path, crates).into_diagnostic()?)
         } else {
             let preferred_log_level = verbose_log_level(global_args.verbose);
-            let colored = if !global_args.no_color && is_tty {
-                Colored::On
-            } else {
-                Colored::Off
-            };
-            let log_path = if preferred_log_level.is_some() {
+            let log_path = if preferred_log_level.is_some() || cmd.is_foreground_node() {
                 None
             } else {
                 Some(CliState::command_log_path(cmd.name().as_str())?)
             };
+
+            let colored = if !global_args.no_color && is_tty && log_path.is_none() {
+                Colored::On
+            } else {
+                Colored::Off
+            };
+
             Ok(
                 logging_configuration(preferred_log_level, colored, log_path, crates)
                     .into_diagnostic()?,

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -184,6 +184,20 @@ impl OckamSubcommand {
         }
     }
 
+    /// Return true if this command represents the execution of a foreground node
+    pub fn is_foreground_node(&self) -> bool {
+        match self {
+            OckamSubcommand::Node(cmd) => match &cmd.subcommand {
+                NodeSubcommand::Create(cmd) => !cmd.foreground_args.child_process,
+                _ => false,
+            },
+            OckamSubcommand::Authority(cmd) => match &cmd.subcommand {
+                AuthoritySubcommand::Create(cmd) => !cmd.child_process,
+            },
+            _ => false,
+        }
+    }
+
     /// Return true if this command represents the execution of a background node
     pub fn is_background_node(&self) -> bool {
         match self {

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -126,6 +126,9 @@ export OCKAM_OPENTELEMETRY_EXPORT=false
 # Set QUIET to 1 to suppress user-facing logging written at stderr
 export QUIET=1
 
+# Set NO_COLOR to 1 to suppress colored messages in log files
+export NO_COLOR=1
+
 # Ockam binary to use
 if [[ -z $OCKAM ]]; then
   export OCKAM=ockam

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -126,9 +126,6 @@ export OCKAM_OPENTELEMETRY_EXPORT=false
 # Set QUIET to 1 to suppress user-facing logging written at stderr
 export QUIET=1
 
-# Set NO_COLOR to 1 to suppress colored messages in log files
-export NO_COLOR=1
-
 # Ockam binary to use
 if [[ -z $OCKAM ]]; then
   export OCKAM=ockam


### PR DESCRIPTION
This PR stores the command logs in a new `OCKAM_HOME/commands` directory for later diagnostic.
If one wants to get the logs printed in the console directly, it is still possible to use `-v` to do so.
