### PR TITLE
feat(rust): integrate space's subscription data in command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/subscription.rs
@@ -1,10 +1,14 @@
-use minicbor::{CborLen, Decode, Encode};
-use serde::{Deserialize, Serialize};
-use std::fmt::Write;
-
 use crate::cloud::{ControllerClient, HasSecureClient};
 use crate::output::Output;
+use minicbor::{CborLen, Decode, Encode};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter, Write};
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
 
+use crate::colors::color_primary;
+use crate::date::parse_date;
+use crate::terminal::fmt;
 use ockam_core::api::{Error, Reply, Request, Status};
 use ockam_core::{self, async_trait, Result};
 use ockam_node::Context;
@@ -50,14 +54,119 @@ impl ActivateSubscription {
     }
 }
 
-#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Debug)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Clone, Debug, Eq)]
 #[cbor(map)]
 pub struct Subscription {
     #[n(1)]
+    pub name: String,
+    #[n(2)]
+    pub is_free_trial: bool,
+    #[n(3)]
+    pub marketplace: Option<String>,
+    #[n(4)]
+    start_date: Option<String>,
+    #[n(5)]
+    end_date: Option<String>,
+}
+
+impl PartialEq for Subscription {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare the dates using as unix timestamps, using a tolerance of 1 second
+        let start_date_eq = match (self.start_date(), other.start_date()) {
+            (Some(start_date), Some(other_start_date)) => {
+                let start_date = start_date.unix_timestamp();
+                let other_start_date = other_start_date.unix_timestamp();
+                (start_date - other_start_date).abs() <= 1
+            }
+            (None, None) => true,
+            _ => false,
+        };
+        self.name == other.name
+            && self.is_free_trial == other.is_free_trial
+            && self.marketplace == other.marketplace
+            && start_date_eq
+    }
+}
+
+impl Subscription {
+    pub fn new(
+        name: String,
+        is_free_trial: bool,
+        marketplace: Option<String>,
+        start_date: Option<OffsetDateTime>,
+        end_date: Option<OffsetDateTime>,
+    ) -> Self {
+        Self {
+            name,
+            is_free_trial,
+            marketplace,
+            start_date: start_date.and_then(|date| date.format(&Iso8601::DEFAULT).ok()),
+            end_date: end_date.and_then(|date| date.format(&Iso8601::DEFAULT).ok()),
+        }
+    }
+
+    pub fn end_date(&self) -> Option<OffsetDateTime> {
+        self.end_date
+            .as_ref()
+            .and_then(|date| parse_date(date).ok())
+    }
+
+    pub fn start_date(&self) -> Option<OffsetDateTime> {
+        self.start_date
+            .as_ref()
+            .and_then(|date| parse_date(date).ok())
+    }
+}
+
+impl Display for Subscription {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Subscription: {}", color_primary(&self.name))?;
+        if self.is_free_trial {
+            writeln!(f, " (free trial)")?;
+        } else {
+            writeln!(f)?;
+        }
+
+        if let (Some(start_date), Some(end_date)) = (self.start_date(), self.end_date()) {
+            writeln!(
+                f,
+                "{}Started at {}, expires at {}",
+                fmt::INDENTATION,
+                color_primary(start_date.to_string()),
+                color_primary(end_date.to_string()),
+            )?;
+        }
+
+        if let Some(marketplace) = &self.marketplace {
+            writeln!(
+                f,
+                "{}Marketplace: {}",
+                fmt::INDENTATION,
+                color_primary(marketplace)
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Output for Subscription {
+    fn item(&self) -> crate::Result<String> {
+        Ok(self.padded_display())
+    }
+}
+
+/// This struct is now deprecated and used only in the legacy [Subscriptions] API endpoints.
+/// The commands using this API were already removed, but the Controller still supports it.
+/// This struct along with the [Subscriptions] trait can be removed once the Controller stops
+/// supporting the legacy API.
+#[derive(Encode, Decode, CborLen, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[cbor(map)]
+pub struct SubscriptionLegacy {
+    #[n(1)]
     pub id: String,
     #[n(2)]
-    marketplace: String,
+    pub marketplace: String,
     #[n(3)]
     pub status: String,
     #[n(4)]
@@ -70,20 +179,20 @@ pub struct Subscription {
     pub space_id: Option<String>,
 }
 
-impl Output for Subscription {
+impl Output for SubscriptionLegacy {
     fn item(&self) -> crate::Result<String> {
         let mut w = String::new();
-        write!(w, "Subscription")?;
-        write!(w, "\n  Id: {}", self.id)?;
-        write!(w, "\n  Status: {}", self.status)?;
+        write!(w, "{}Id: {}", fmt::PADDING, self.id)?;
+        write!(w, "{}Status: {}", fmt::PADDING, self.status)?;
         write!(
             w,
-            "\n  Space id: {}",
+            "{}Space id: {}",
+            fmt::PADDING,
             self.space_id.clone().unwrap_or("N/A".to_string())
         )?;
-        write!(w, "\n  Entitlements: {}", self.entitlements)?;
-        write!(w, "\n  Metadata: {}", self.metadata)?;
-        write!(w, "\n  Contact info: {}", self.contact_info)?;
+        write!(w, "{}Entitlements: {}", fmt::PADDING, self.entitlements)?;
+        write!(w, "{}Metadata: {}", fmt::PADDING, self.metadata)?;
+        write!(w, "{}Contact info: {}", fmt::PADDING, self.contact_info)?;
         Ok(w)
     }
 }
@@ -95,41 +204,41 @@ pub trait Subscriptions {
         ctx: &Context,
         space_id: String,
         subscription_data: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 
     async fn unsubscribe(
         &self,
         ctx: &Context,
         subscription_id: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 
     async fn update_subscription_contact_info(
         &self,
         ctx: &Context,
         subscription_id: String,
         contact_info: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 
     async fn update_subscription_space(
         &self,
         ctx: &Context,
         subscription_id: String,
         new_space_id: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 
-    async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<Subscription>>>;
+    async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<SubscriptionLegacy>>>;
 
     async fn get_subscription(
         &self,
         ctx: &Context,
         subscription_id: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 
     async fn get_subscription_by_space_id(
         &self,
         ctx: &Context,
         space_id: String,
-    ) -> Result<Reply<Subscription>>;
+    ) -> Result<Reply<SubscriptionLegacy>>;
 }
 
 #[async_trait]
@@ -140,7 +249,7 @@ impl Subscriptions for ControllerClient {
         ctx: &Context,
         space_id: String,
         subscription_data: String,
-    ) -> Result<Reply<Subscription>> {
+    ) -> Result<Reply<SubscriptionLegacy>> {
         let req_body = ActivateSubscription::existing(space_id, subscription_data);
         trace!(target: TARGET, space_id = ?req_body.space_id, space_name = ?req_body.space_name, "activating subscription");
         let req = Request::post("/v0/activate").body(req_body);
@@ -152,7 +261,7 @@ impl Subscriptions for ControllerClient {
         &self,
         ctx: &Context,
         subscription_id: String,
-    ) -> Result<Reply<Subscription>> {
+    ) -> Result<Reply<SubscriptionLegacy>> {
         trace!(target: TARGET, subscription = %subscription_id, "unsubscribing");
         let req = Request::put(format!("/v0/{subscription_id}/unsubscribe"));
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
@@ -164,7 +273,7 @@ impl Subscriptions for ControllerClient {
         ctx: &Context,
         subscription_id: String,
         contact_info: String,
-    ) -> Result<Reply<Subscription>> {
+    ) -> Result<Reply<SubscriptionLegacy>> {
         trace!(target: TARGET, subscription = %subscription_id, "updating subscription contact info");
         let req = Request::put(format!("/v0/{subscription_id}/contact_info")).body(contact_info);
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
@@ -176,14 +285,14 @@ impl Subscriptions for ControllerClient {
         ctx: &Context,
         subscription_id: String,
         new_space_id: String,
-    ) -> Result<Reply<Subscription>> {
+    ) -> Result<Reply<SubscriptionLegacy>> {
         trace!(target: TARGET, subscription = %subscription_id, new_space_id = %new_space_id, "updating subscription space");
         let req = Request::put(format!("/v0/{subscription_id}/space_id")).body(new_space_id);
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
     }
 
     #[instrument(skip_all)]
-    async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<Subscription>>> {
+    async fn get_subscriptions(&self, ctx: &Context) -> Result<Reply<Vec<SubscriptionLegacy>>> {
         trace!(target: TARGET, "listing subscriptions");
         let req = Request::get("/v0/");
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
@@ -194,7 +303,7 @@ impl Subscriptions for ControllerClient {
         &self,
         ctx: &Context,
         subscription_id: String,
-    ) -> Result<Reply<Subscription>> {
+    ) -> Result<Reply<SubscriptionLegacy>> {
         trace!(target: TARGET, subscription = %subscription_id, "getting subscription");
         let req = Request::get(format!("/v0/{subscription_id}"));
         self.get_secure_client().ask(ctx, API_SERVICE, req).await
@@ -205,8 +314,9 @@ impl Subscriptions for ControllerClient {
         &self,
         ctx: &Context,
         space_id: String,
-    ) -> Result<Reply<Subscription>> {
-        let subscriptions: Vec<Subscription> = self.get_subscriptions(ctx).await?.success()?;
+    ) -> Result<Reply<SubscriptionLegacy>> {
+        let subscriptions: Vec<SubscriptionLegacy> =
+            self.get_subscriptions(ctx).await?.success()?;
         let subscription = subscriptions
             .into_iter()
             .find(|s| s.space_id == Some(space_id.clone()));
@@ -222,15 +332,13 @@ impl Subscriptions for ControllerClient {
 
 #[cfg(test)]
 pub mod tests {
+    use super::*;
+    use crate::schema::tests::validate_with_schema;
     use quickcheck::{quickcheck, Arbitrary, Gen, TestResult};
 
-    use crate::schema::tests::validate_with_schema;
-
-    use super::*;
-
     quickcheck! {
-        fn subcription(s: Subscription) -> TestResult {
-            validate_with_schema("subscription", s)
+        fn subcription_legacy(s: SubscriptionLegacy) -> TestResult {
+            validate_with_schema("subscription_legacy", s)
         }
 
         fn activate_subcription(s: ActivateSubscription) -> TestResult {
@@ -238,9 +346,9 @@ pub mod tests {
         }
     }
 
-    impl Arbitrary for Subscription {
+    impl Arbitrary for SubscriptionLegacy {
         fn arbitrary(g: &mut Gen) -> Self {
-            Subscription {
+            SubscriptionLegacy {
                 id: String::arbitrary(g),
                 marketplace: String::arbitrary(g),
                 status: String::arbitrary(g),
@@ -248,6 +356,18 @@ pub mod tests {
                 metadata: String::arbitrary(g),
                 contact_info: String::arbitrary(g),
                 space_id: bool::arbitrary(g).then(|| String::arbitrary(g)),
+            }
+        }
+    }
+
+    impl Arbitrary for Subscription {
+        fn arbitrary(g: &mut Gen) -> Self {
+            Subscription {
+                name: String::arbitrary(g),
+                is_free_trial: bool::arbitrary(g),
+                marketplace: Option::arbitrary(g),
+                start_date: Option::arbitrary(g),
+                end_date: Option::arbitrary(g),
             }
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/date.rs
+++ b/implementations/rust/ockam/ockam_api/src/date.rs
@@ -1,0 +1,21 @@
+use crate::ApiError;
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
+
+/// Transform a string that represents an Iso8601 date into a `time::OffsetDateTime`
+pub fn parse_date(date: &str) -> ockam_core::Result<OffsetDateTime> {
+    // Add the Z timezone to the date, as the `time` crate requires it
+    let date = if date.ends_with('Z') {
+        date.to_string()
+    } else {
+        format!("{}Z", date)
+    };
+    OffsetDateTime::parse(&date, &Iso8601::DEFAULT).map_err(|e| ApiError::core(e.to_string()))
+}
+
+/// Check if a string that represents an Iso8601 date is expired, using the `time` crate
+pub fn is_expired(date: &str) -> ockam_core::Result<bool> {
+    let date = parse_date(date)?;
+    let now = OffsetDateTime::now_utc();
+    Ok(date < now)
+}

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -43,6 +43,7 @@ pub mod logs;
 mod schema;
 mod session;
 
+mod date;
 mod rendezvous_healthcheck;
 pub mod test_utils;
 mod ui;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -241,10 +241,4 @@ impl Output for ServiceStatus {
         writeln!(f, "{}{}", fmt::PADDING, self)?;
         Ok(f)
     }
-
-    fn as_list_item(&self) -> crate::Result<String> {
-        let mut f = String::new();
-        writeln!(f, "{}", self)?;
-        Ok(f)
-    }
 }

--- a/implementations/rust/ockam/ockam_api/src/schema/schema.cddl
+++ b/implementations/rust/ockam/ockam_api/src/schema/schema.cddl
@@ -19,13 +19,11 @@ space = {
     1: space_id
     2: space_name
     3: [+ user]
+    ?4: subscription
 }
 user = text
 
-
 spaces = [* space]
-
-
 
 create_space = {
    ?0: 3888657,
@@ -237,6 +235,14 @@ onetime_code = {
 ;;; Subscription ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 subscription = {
+  1: text,       ;; name
+  2: bool,       ;; is_free_trial
+  ?3: text,      ;; marketplace
+  ?4: text,      ;; start_date
+  ?5: text,      ;; end_date
+}
+
+subscription_legacy = {
      1: text,       ;; id
      2: text,       ;; marketplace
      3: text,       ;; status

--- a/implementations/rust/ockam/ockam_api/src/ui/output/utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/utils.rs
@@ -5,10 +5,14 @@ use colorful::Colorful;
 use ockam::identity::TimestampInSeconds;
 
 pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
-    data.iter()
-        .map(AsRef::as_ref)
-        .collect::<Vec<_>>()
-        .join(", ")
+    if data.is_empty() {
+        "-".to_string()
+    } else {
+        data.iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 pub fn human_readable_time(time: TimestampInSeconds) -> String {

--- a/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
@@ -191,30 +191,32 @@ impl MemberOutput {
             attributes,
         }
     }
+}
 
-    fn to_string(&self, padding: &str) -> ockam_api::Result<String> {
+impl Output for MemberOutput {
+    fn item(&self) -> ockam_api::Result<String> {
         let mut f = String::new();
         writeln!(
             f,
             "{}{}",
-            padding,
+            fmt::PADDING,
             color_primary(self.identifier.to_string())
         )?;
 
         if self.attributes.attrs().is_empty() {
-            writeln!(f, "{}Has no attributes", padding)?;
+            writeln!(f, "{}Has no attributes", fmt::PADDING)?;
         } else {
             let attributes = self.attributes.deserialized_key_value_attrs();
             writeln!(
                 f,
                 "{}With attributes: {}",
-                padding,
+                fmt::PADDING,
                 color_primary(attributes.join(", "))
             )?;
             writeln!(
                 f,
                 "{}{}Added at: {}",
-                padding,
+                fmt::PADDING,
                 fmt::INDENTATION,
                 color_warn(self.attributes.added_at().to_string())
             )?;
@@ -222,7 +224,7 @@ impl MemberOutput {
                 writeln!(
                     f,
                     "{}{}Expires at: {}",
-                    padding,
+                    fmt::PADDING,
                     fmt::INDENTATION,
                     color_warn(expires_at.to_string())
                 )?;
@@ -231,22 +233,12 @@ impl MemberOutput {
                 writeln!(
                     f,
                     "{}{}Attested by: {}",
-                    padding,
+                    fmt::PADDING,
                     fmt::INDENTATION,
                     color_primary(attested_by.to_string())
                 )?;
             }
         }
         Ok(f)
-    }
-}
-
-impl Output for MemberOutput {
-    fn item(&self) -> ockam_api::Result<String> {
-        self.to_string(fmt::PADDING)
-    }
-
-    fn as_list_item(&self) -> ockam_api::Result<String> {
-        self.to_string("")
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -21,7 +21,7 @@ pub struct ResetCommand {
     yes: bool,
 
     /// Remove your spaces from the Orchestrator
-    #[arg(long)]
+    #[arg(long, short)]
     all: bool,
 }
 

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -1,17 +1,16 @@
+use async_trait::async_trait;
 use clap::Args;
-use colorful::Colorful;
 use miette::miette;
 
 use ockam::Context;
 use ockam_api::cli_state::random_name;
 use ockam_api::cloud::space::Spaces;
 use ockam_api::nodes::InMemoryNode;
+use ockam_api::output::Output;
 
 use crate::shared_args::IdentityOpts;
-use crate::util::async_cmd;
 use crate::util::validators::cloud_resource_name_validator;
-use crate::{docs, CommandGlobalOpts};
-use ockam_api::output::Output;
+use crate::{docs, Command, CommandGlobalOpts, Result};
 
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
@@ -35,61 +34,52 @@ pub struct CreateCommand {
     pub identity_opts: IdentityOpts,
 }
 
-impl CreateCommand {
-    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        async_cmd(&self.name(), opts.clone(), |ctx| async move {
-            self.async_run(&ctx, opts).await
-        })
-    }
+#[async_trait]
+impl Command for CreateCommand {
+    const NAME: &'static str = "space create";
 
-    pub fn name(&self) -> String {
-        "space crate".into()
-    }
-
-    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
         if !opts
             .state
             .is_identity_enrolled(&self.identity_opts.identity_name)
             .await?
         {
-            return Err(miette!(
-                "Please enroll using 'ockam enroll' before using this command"
-            ));
+            return Err(
+                miette!("Please enroll using 'ockam enroll' before using this command").into(),
+            );
         };
 
-        opts.terminal.write_line(format!(
-            "\n{}",
-            "Creating a trial space for you (everything in it will be deleted in 15 days) ..."
-                .light_magenta(),
-        ))?;
-        opts.terminal.write_line(format!(
-            "{}",
-            "To learn more about production ready spaces in Ockam Orchestrator, contact us at: hello@ockam.io".light_magenta()
-        ))?;
-
         let node = InMemoryNode::start(ctx, &opts.state).await?;
-        let space = node
-            .create_space(
+
+        let space = {
+            let pb = opts.terminal.progress_bar();
+            if let Some(pb) = pb.as_ref() {
+                pb.set_message("Creating a Space for you...");
+            }
+            node.create_space(
                 ctx,
                 &self.name,
                 self.admins.iter().map(|a| a.as_ref()).collect(),
             )
-            .await?;
-
+            .await?
+        };
+        if let Ok(msg) = space.subscription_status_message(true) {
+            opts.terminal.write_line(msg)?;
+        }
         opts.terminal
             .stdout()
             .plain(space.item()?)
-            .json(serde_json::json!(&space))
+            .json_obj(&space)?
             .write_line()?;
         Ok(())
     }
 }
 
-fn validate_space_name(s: &str) -> Result<String, String> {
+fn validate_space_name(s: &str) -> std::result::Result<String, String> {
     match cloud_resource_name_validator(s) {
         Ok(_) => Ok(s.to_string()),
         Err(_e) => Err(String::from(
-            "space name can contain only alphanumeric characters and the '-', '_' and '.' separators. \
+            "The Space name can contain only alphanumeric characters and the '-', '_' and '.' separators. \
             Separators must occur between alphanumeric characters. This implies that separators can't \
             occur at the start or end of the name, nor they can occur in sequence.",
         ))

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -1,21 +1,19 @@
+use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
-use miette::IntoDiagnostic;
 
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 use ockam::Context;
 use ockam_api::cloud::space::Spaces;
 use ockam_api::colors::OckamColor;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{color, fmt_ok};
-use ockam_core::AsyncTryClone;
 
 use crate::shared_args::IdentityOpts;
 use crate::terminal::tui::DeleteCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::async_cmd;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -39,41 +37,29 @@ pub struct DeleteCommand {
     yes: bool,
 }
 
-impl DeleteCommand {
-    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        async_cmd(&self.name(), opts.clone(), |ctx| async move {
-            self.async_run(&ctx, opts).await
-        })
-    }
+#[async_trait]
+impl Command for DeleteCommand {
+    const NAME: &'static str = "space delete";
 
-    pub fn name(&self) -> String {
-        "space delete".into()
-    }
-
-    async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        DeleteTui::run(
-            ctx.async_try_clone().await.into_diagnostic()?,
-            opts,
-            self.clone(),
-        )
-        .await
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        Ok(DeleteTui::run(ctx, opts, self).await?)
     }
 }
 
-pub struct DeleteTui {
-    ctx: Context,
+pub struct DeleteTui<'a> {
+    ctx: &'a Context,
     opts: CommandGlobalOpts,
     node: InMemoryNode,
     cmd: DeleteCommand,
 }
 
-impl DeleteTui {
+impl<'a> DeleteTui<'a> {
     pub async fn run(
-        ctx: Context,
+        ctx: &'a Context,
         opts: CommandGlobalOpts,
         cmd: DeleteCommand,
     ) -> miette::Result<()> {
-        let node = InMemoryNode::start(&ctx, &opts.state).await?;
+        let node = InMemoryNode::start(ctx, &opts.state).await?;
         let tui = Self {
             ctx,
             opts,
@@ -85,7 +71,7 @@ impl DeleteTui {
 }
 
 #[ockam_core::async_trait]
-impl DeleteCommandTui for DeleteTui {
+impl<'a> DeleteCommandTui for DeleteTui<'a> {
     const ITEM_NAME: PluralTerm = PluralTerm::Space;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
@@ -116,7 +102,7 @@ impl DeleteCommandTui for DeleteTui {
     }
 
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
-        self.node.delete_space_by_name(&self.ctx, item_name).await?;
+        self.node.delete_space_by_name(self.ctx, item_name).await?;
 
         self.terminal()
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/space/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/mod.rs
@@ -5,7 +5,7 @@ pub use delete::DeleteCommand;
 pub use list::ListCommand;
 pub use show::ShowCommand;
 
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 
 mod create;
 mod delete;

--- a/implementations/rust/ockam/ockam_command/src/subscription.rs
+++ b/implementations/rust/ockam/ockam_command/src/subscription.rs
@@ -3,7 +3,7 @@ use clap::{Args, Subcommand};
 use miette::{miette, IntoDiagnostic};
 
 use ockam::Context;
-use ockam_api::cloud::subscription::{Subscription, Subscriptions};
+use ockam_api::cloud::subscription::{SubscriptionLegacy, Subscriptions};
 use ockam_api::cloud::ControllerClient;
 
 use ockam_api::nodes::InMemoryNode;
@@ -92,7 +92,7 @@ pub(crate) async fn get_subscription_by_id_or_space_id(
     ctx: &Context,
     subscription_id: Option<String>,
     space_id: Option<String>,
-) -> Result<Option<Subscription>> {
+) -> Result<Option<SubscriptionLegacy>> {
     match (subscription_id, space_id) {
         (Some(subscription_id), _) => Ok(Some(
             controller

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -1,6 +1,10 @@
 //! Helpers to display version information
 
 use clap::crate_version;
+use ockam_api::colors::color_primary;
+use serde::ser::SerializeStruct;
+use serde::Serialize;
+use std::fmt::Display;
 
 pub(crate) struct Version;
 
@@ -10,12 +14,38 @@ impl Version {
     }
 
     pub(crate) fn short() -> &'static str {
-        let crate_version = crate_version!();
-        let mut git_hash = env!("GIT_HASH");
-        if git_hash.is_empty() {
-            git_hash = "N/A";
-        }
-        let message = format!("{crate_version}\ncompiled from: {git_hash}");
+        let message = format!("{}\ncompiled from: {}", Self::version(), Self::hash());
         Box::leak(message.into_boxed_str())
+    }
+
+    fn version() -> &'static str {
+        crate_version!()
+    }
+
+    fn hash() -> &'static str {
+        option_env!("GIT_HASH").unwrap_or("N/A")
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}, compiled from: {}",
+            color_primary(Self::version()),
+            color_primary(Self::hash())
+        )
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Version", 2)?;
+        state.serialize_field("version", Self::version())?;
+        state.serialize_field("hash", &Self::hash())?;
+        state.end()
     }
 }

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240703100000_add_subscriptions.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240703100000_add_subscriptions.sql
@@ -1,0 +1,9 @@
+-- This migration adds the subscriptions table based on the following rust struct
+CREATE TABLE subscription (
+    space_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    is_free_trial BOOLEAN NOT NULL,
+    marketplace TEXT,
+    start_date INTEGER,
+    end_date INTEGER
+);

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20240703100000_add_subscriptions.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20240703100000_add_subscriptions.sql
@@ -1,0 +1,9 @@
+-- This migration adds the subscriptions table based on the following rust struct
+CREATE TABLE subscription (
+    space_id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    is_free_trial INTEGER NOT NULL,
+    marketplace TEXT,
+    start_date INTEGER,
+    end_date INTEGER
+);


### PR DESCRIPTION
Adds the subscription data to the `space`, `status` and `enroll` commands. This PR also improves the output construction of those commands, which led me to improve the `Output` trait.

## Changes to the `Output` trait

In this PR you can see that the `Subscription` struct is used in three different kinds of outputs (see images below for examples):

1. As a standalone item (it's individual representation)
2. As part of other structs in their individual representation (e.g. in the `space show` command)
3. As part of other structs in their list representation (e.g. in the `space list` command)

Now, we want to reuse the output of the individual representation, but there are some differences we need to keep in mind: in `2.` the subscription is padded + indented; in `3.` the subscription is padded.

The `Output` trait lets you define the output for `1.` and `3.` but not for `2.` and, in this case, the only difference between them is the left spacing. And I think this is also true for a lot of other structs. 

That being said, I've extended the `Output` trait a little to make these "left-spacing" transformations easier. You can check the [`Subscription`](https://github.com/build-trust/ockam/pull/8296/files#diff-8d38b9822d9dba78bcd7e2fe4b524aa028ef0d7872d598270242522a397c0f89R85-R121) struct as an example of how to reuse the `Display` representation and how it's also integrated in the [`Space`'s `Display` impl](https://github.com/build-trust/ockam/pull/8296/files#diff-ac92631eb44c2b0ea45d6c7ef8bb4dec67639f735f6a46d708a61b483125d2feR64).

## `enroll`

Free trial + and the space has been just created:

![image](https://github.com/build-trust/ockam/assets/12375782/53487f37-700f-4a89-bcee-a592f90464e2)

Free trial + the space already existed:

![image](https://github.com/build-trust/ockam/assets/12375782/eab3ab82-84a3-43fe-b1f7-e6e7e99bf12e)

Not a free trial subscription:

![image](https://github.com/build-trust/ockam/assets/12375782/50501063-ec4a-47e9-9191-ed5d89004e8d)

## `space` and `status`

![image](https://github.com/build-trust/ockam/assets/12375782/6baa3056-5ea5-43f6-8495-e04a9dde7eef)

![image](https://github.com/user-attachments/assets/65dfc312-96e6-47e4-9cb5-11c992cdcfcf)

