### PR TITLE
chore(rust)::> used portpicker crate to avoid port clash in ockam examples

### DIFF
--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -1,10 +1,8 @@
-use example_test_helper::{CmdBuilder, Error};
-use ockam::compat::rand;
-use ockam::compat::rand::Rng;
+use example_test_helper::{find_available_port, CmdBuilder, Error};
 
 #[test]
 fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
-    let port = rand::thread_rng().gen_range(10000..65535);
+    let port = find_available_port();
     // Spawn example, wait for it to start up
     let runner = CmdBuilder::new(&format!(
         "cargo run --locked --example 01-inlet-outlet 127.0.0.1:{port} ockam.io:80"
@@ -24,8 +22,8 @@ fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
 
 #[test]
 fn run_02_inlet_outlet_separate_processes() -> Result<(), Error> {
-    let routing_port = rand::thread_rng().gen_range(10000..65535);
-    let inlet_port = rand::thread_rng().gen_range(10000..65535);
+    let routing_port = find_available_port();
+    let inlet_port = find_available_port();
     // Spawn outlet, wait for it to start up
     let outlet = CmdBuilder::new(&format!(
         "cargo run --locked --example 02-outlet ockam.io:80 {routing_port}"
@@ -55,8 +53,8 @@ fn run_02_inlet_outlet_separate_processes() -> Result<(), Error> {
 #[test]
 #[ignore]
 fn run_03_inlet_outlet_separate_processes_secure_channel() -> Result<(), Error> {
-    let routing_port = rand::thread_rng().gen_range(10000..65535);
-    let inlet_port = rand::thread_rng().gen_range(10000..65535);
+    let routing_port = find_available_port();
+    let inlet_port = find_available_port();
     // Spawn outlet, wait for it to start up
     let outlet = CmdBuilder::new(&format!(
         "cargo run --locked --example 03-outlet ockam.io:80 {routing_port}"
@@ -85,8 +83,8 @@ fn run_03_inlet_outlet_separate_processes_secure_channel() -> Result<(), Error> 
 
 #[test]
 #[ignore]
-fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_orchestrator() -> Result<(), Error> {
-    let port = rand::thread_rng().gen_range(10000..65535);
+fn run_04_inlet_outlet_separate_processes_secure_channel_via_ockam_orchestrator() -> Result<(), Error> {
+    let port = find_available_port();
     // Spawn outlet, wait for it to start up, grab dynamic forwarding address
     let outlet = CmdBuilder::new("cargo run --locked --example 04-outlet ockam.io:80").spawn()?;
     outlet.match_stdout(r"(?i)RemoteRelay was created on the node")?;

--- a/tools/docs/example_test_helper/src/lib.rs
+++ b/tools/docs/example_test_helper/src/lib.rs
@@ -46,6 +46,7 @@ use cfg_if::cfg_if;
 use duct::unix::HandleExt;
 use duct::{cmd, Handle};
 use regex::Regex;
+use std::net::TcpListener;
 use std::time::SystemTime;
 use std::{fs, io};
 use std::{fs::File, io::Read, thread::sleep, time::Duration};
@@ -324,6 +325,12 @@ impl CmdRunner {
         }
         Err(Error::Timeout)
     }
+}
+
+pub fn find_available_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to address");
+    let address = listener.local_addr().expect("Failed to get local address");
+    address.port()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior
Some tests in `examples/rust/*` could clash on TCP ports when run in parallel.

<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->

## Proposed changes
Use [`portpicker`](https://crates.io/crates/portpicker) crate to avoid port clash. Now tests will ask the OS for free ports, rather then using hardcoded values.

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

This PR addresses #3005 **pointer 2**