### PR TITLE
chore(rust)::> used `--locked` argument with `cargo run` argument

### DIFF
--- a/examples/rust/file_transfer/tests/tests.rs
+++ b/examples/rust/file_transfer/tests/tests.rs
@@ -45,7 +45,7 @@ fn medium_file_transfer_large_chunks() -> Result<(), Error> {
 
 fn do_file_transfer(file_size: u32, chunk_size: Option<u32>) -> Result<(), Error> {
     // Spawn receiver, wait for & grab dynamic forwarding address
-    let receiver = CmdBuilder::new("cargo run --example receiver").spawn()?;
+    let receiver = CmdBuilder::new("cargo run --locked --example receiver").spawn()?;
     let fwd_address = receiver.match_stdout(r"(?m)^FWD_(\w+)$")?.swap_remove(0).unwrap();
     println!("Forwarding address: {fwd_address}");
 
@@ -74,7 +74,7 @@ fn do_file_transfer(file_size: u32, chunk_size: Option<u32>) -> Result<(), Error
     }
 
     // Spawn sender
-    let mut cmd_line = format!("cargo run --example sender {source_path} --address {fwd_address}");
+    let mut cmd_line = format!("cargo run --locked --example sender {source_path} --address {fwd_address}");
     if let Some(val) = chunk_size {
         let _ = write!(cmd_line, " --chunk-size {val}");
     }

--- a/examples/rust/get_started/tests/tests.rs
+++ b/examples/rust/get_started/tests/tests.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 #[serial]
 fn run_01_node() -> Result<(), Error> {
     // Run 01-node to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 01-node").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 01-node").run()?;
     assert_eq!(Some(0), exitcode);
     assert!(stdout.contains("Goodbye"));
     Ok(())
@@ -15,7 +15,7 @@ fn run_01_node() -> Result<(), Error> {
 #[serial]
 fn run_02_worker() -> Result<(), Error> {
     // Run to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 02-worker").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 02-worker").run()?;
     assert_eq!(Some(0), exitcode);
     assert!(stdout.contains("Goodbye"));
     Ok(())
@@ -25,7 +25,7 @@ fn run_02_worker() -> Result<(), Error> {
 #[serial]
 fn run_03_routing() -> Result<(), Error> {
     // Run to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 03-routing").run()?;
     assert_eq!(Some(0), exitcode);
     assert!(stdout.contains("Goodbye"));
     Ok(())
@@ -35,7 +35,7 @@ fn run_03_routing() -> Result<(), Error> {
 #[serial]
 fn run_03_routing_many_hops() -> Result<(), Error> {
     // Run to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 03-routing-many-hops").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 03-routing-many-hops").run()?;
     assert_eq!(Some(0), exitcode);
     assert!(stdout.contains("Goodbye"));
     Ok(())
@@ -45,11 +45,12 @@ fn run_03_routing_many_hops() -> Result<(), Error> {
 #[serial]
 fn run_04_routing_over_transport() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-responder").spawn()?;
+    let resp = CmdBuilder::new("cargo run --locked --example 04-routing-over-transport-responder").spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Run initiator to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-routing-over-transport-initiator").run()?;
+    let (exitcode, stdout) =
+        CmdBuilder::new("cargo run --locked --example 04-routing-over-transport-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -61,16 +62,16 @@ fn run_04_routing_over_transport() -> Result<(), Error> {
 #[serial]
 fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-responder").spawn()?;
+    let resp = CmdBuilder::new("cargo run --locked --example 04-routing-over-transport-two-hops-responder").spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Launch middle, wait for it to start up
-    let mid = CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-middle").spawn()?;
+    let mid = CmdBuilder::new("cargo run --locked --example 04-routing-over-transport-two-hops-middle").spawn()?;
     mid.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Run initiator to completion
     let (exitcode, stdout) =
-        CmdBuilder::new("cargo run --example 04-routing-over-transport-two-hops-initiator").run()?;
+        CmdBuilder::new("cargo run --locked --example 04-routing-over-transport-two-hops-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -82,11 +83,11 @@ fn run_04_routing_over_transport_two_hops() -> Result<(), Error> {
 #[serial]
 fn run_04_udp() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 04-udp-transport-responder").spawn()?;
+    let resp = CmdBuilder::new("cargo run --locked --example 04-udp-transport-responder").spawn()?;
     resp.match_stdout(r"(?i)Waiting for incoming UDP datagram")?;
 
     // Run initiator to completion
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 04-udp-transport-initiator").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 04-udp-transport-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -98,16 +99,18 @@ fn run_04_udp() -> Result<(), Error> {
 #[serial]
 fn run_05_secure_channel_over_two_transport_hops() -> Result<(), Error> {
     // Launch responder, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-responder").spawn()?;
+    let resp =
+        CmdBuilder::new("cargo run --locked --example 05-secure-channel-over-two-transport-hops-responder").spawn()?;
     resp.match_stdout("Initializing ockam processor")?;
 
     // Launch middle, wait for it to start up
-    let mid = CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-middle").spawn()?;
+    let mid =
+        CmdBuilder::new("cargo run --locked --example 05-secure-channel-over-two-transport-hops-middle").spawn()?;
     mid.match_stdout("Initializing ockam processor")?;
 
     // Run initiator to completion
     let (exitcode, stdout) =
-        CmdBuilder::new("cargo run --example 05-secure-channel-over-two-transport-hops-initiator").run()?;
+        CmdBuilder::new("cargo run --locked --example 05-secure-channel-over-two-transport-hops-initiator").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -119,15 +122,15 @@ fn run_05_secure_channel_over_two_transport_hops() -> Result<(), Error> {
 #[serial]
 fn run_06_credentials_exchange() -> Result<(), Error> {
     // Launch the issuer, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 06-credentials-exchange-issuer").spawn()?;
+    let resp = CmdBuilder::new("cargo run --locked --example 06-credentials-exchange-issuer").spawn()?;
     resp.match_stdout("issuer started")?;
 
     // Launch the server, wait for it to start up
-    let resp = CmdBuilder::new("cargo run --example 06-credentials-exchange-server").spawn()?;
+    let resp = CmdBuilder::new("cargo run --locked --example 06-credentials-exchange-server").spawn()?;
     resp.match_stdout("server started")?;
 
     // Launch the client, wait for the message to be sent and received
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example 06-credentials-exchange-client").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example 06-credentials-exchange-client").run()?;
     assert_eq!(Some(0), exitcode);
     assert!(stdout.to_lowercase().contains("received"));
 
@@ -137,7 +140,7 @@ fn run_06_credentials_exchange() -> Result<(), Error> {
 #[test]
 #[serial]
 fn run_hello() -> Result<(), Error> {
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example hello").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example hello").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);
@@ -148,7 +151,7 @@ fn run_hello() -> Result<(), Error> {
 #[test]
 #[serial]
 fn vault_and_identity() -> Result<(), Error> {
-    let (exitcode, stdout) = CmdBuilder::new("cargo run --example vault-and-identities").run()?;
+    let (exitcode, stdout) = CmdBuilder::new("cargo run --locked --example vault-and-identities").run()?;
 
     // Assert successful run conditions
     assert_eq!(Some(0), exitcode);

--- a/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
+++ b/examples/rust/tcp_inlet_and_outlet/tests/tests.rs
@@ -7,7 +7,7 @@ fn run_01_inlet_outlet_one_process() -> Result<(), Error> {
     let port = rand::thread_rng().gen_range(10000..65535);
     // Spawn example, wait for it to start up
     let runner = CmdBuilder::new(&format!(
-        "cargo run --example 01-inlet-outlet 127.0.0.1:{port} ockam.io:80"
+        "cargo run --locked --example 01-inlet-outlet 127.0.0.1:{port} ockam.io:80"
     ))
     .spawn()?;
     runner.match_stdout(r"(?i)Starting new processor")?;
@@ -27,12 +27,15 @@ fn run_02_inlet_outlet_separate_processes() -> Result<(), Error> {
     let routing_port = rand::thread_rng().gen_range(10000..65535);
     let inlet_port = rand::thread_rng().gen_range(10000..65535);
     // Spawn outlet, wait for it to start up
-    let outlet = CmdBuilder::new(&format!("cargo run --example 02-outlet ockam.io:80 {routing_port}")).spawn()?;
+    let outlet = CmdBuilder::new(&format!(
+        "cargo run --locked --example 02-outlet ockam.io:80 {routing_port}"
+    ))
+    .spawn()?;
     outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Spawn inlet, wait for it to start up
     let inlet = CmdBuilder::new(&format!(
-        "cargo run --example 02-inlet 127.0.0.1:{inlet_port} {routing_port}"
+        "cargo run --locked --example 02-inlet 127.0.0.1:{inlet_port} {routing_port}"
     ))
     .spawn()?;
     inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
@@ -55,12 +58,15 @@ fn run_03_inlet_outlet_separate_processes_secure_channel() -> Result<(), Error> 
     let routing_port = rand::thread_rng().gen_range(10000..65535);
     let inlet_port = rand::thread_rng().gen_range(10000..65535);
     // Spawn outlet, wait for it to start up
-    let outlet = CmdBuilder::new(&format!("cargo run --example 03-outlet ockam.io:80 {routing_port}")).spawn()?;
+    let outlet = CmdBuilder::new(&format!(
+        "cargo run --locked --example 03-outlet ockam.io:80 {routing_port}"
+    ))
+    .spawn()?;
     outlet.match_stdout(r"(?i)Waiting for incoming TCP connection")?;
 
     // Spawn inlet, wait for it to start up
     let inlet = CmdBuilder::new(&format!(
-        "cargo run --example 03-inlet 127.0.0.1:{inlet_port} {routing_port}"
+        "cargo run --locked --example 03-inlet 127.0.0.1:{inlet_port} {routing_port}"
     ))
     .spawn()?;
     inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
@@ -82,13 +88,16 @@ fn run_03_inlet_outlet_separate_processes_secure_channel() -> Result<(), Error> 
 fn run_04_inlet_outlet_seperate_processes_secure_channel_via_ockam_orchestrator() -> Result<(), Error> {
     let port = rand::thread_rng().gen_range(10000..65535);
     // Spawn outlet, wait for it to start up, grab dynamic forwarding address
-    let outlet = CmdBuilder::new("cargo run --example 04-outlet ockam.io:80").spawn()?;
+    let outlet = CmdBuilder::new("cargo run --locked --example 04-outlet ockam.io:80").spawn()?;
     outlet.match_stdout(r"(?i)RemoteRelay was created on the node")?;
     let fwd_address = outlet.match_stdout(r"(?m)^FWD_(\w+)$")?.swap_remove(0).unwrap();
     println!("Forwarding address: {fwd_address}");
 
     // Spawn inlet, wait for it to start up
-    let inlet = CmdBuilder::new(&format!("cargo run --example 04-inlet 127.0.0.1:{port} {fwd_address}")).spawn()?;
+    let inlet = CmdBuilder::new(&format!(
+        "cargo run --locked --example 04-inlet 127.0.0.1:{port} {fwd_address}"
+    ))
+    .spawn()?;
     inlet.match_stdout(r"(?i)Binding \w+ to 127.0.0.1")?;
 
     // // Run curl and check for a successful run


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior
Currently, things are less reproducible due to potential dependency changes (because of `cargo run`) and potentially less stable if dependency updates introduce breaking changes.
<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->

## Proposed changes
After using `--locked` flag, things become highly reproducible as dependency versions are fixed and more stable as dependency versions are locked.
<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->

Addressed #3005 **pointer 4**