### PR TITLE
feat(elixir): proxy with recoverable tcp client

### DIFF
--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/api_endpoint_target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/api_endpoint_target.ex
@@ -14,6 +14,6 @@ defmodule Ockam.Healthcheck.APIEndpointTarget do
     :method,
     :body,
     :healthcheck_worker,
-    api_worker: "api"
+    api_route: ["api"]
   ]
 end

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/metrics.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/metrics.ex
@@ -17,7 +17,7 @@ defmodule Ockam.Healthcheck.Metrics do
           :target_port,
           :target_method,
           :target_path,
-          :api_worker,
+          :api_route,
           :healthcheck_worker
         ],
         tag_values: &expand_target/1
@@ -33,7 +33,7 @@ defmodule Ockam.Healthcheck.Metrics do
           :target_port,
           :target_method,
           :target_path,
-          :api_worker,
+          :api_route,
           :healthcheck_worker
         ],
         tag_values: &expand_target/1
@@ -49,7 +49,7 @@ defmodule Ockam.Healthcheck.Metrics do
           :target_port,
           :target_method,
           :target_path,
-          :api_worker,
+          :api_route,
           :healthcheck_worker,
           :reason
         ],
@@ -80,7 +80,7 @@ defmodule Ockam.Healthcheck.Metrics do
       target_port: Map.get(target, :port, 0),
       target_method: Map.get(target, :method, ""),
       target_path: Map.get(target, :path, ""),
-      api_worker: Map.get(target, :api_worker, ""),
+      api_route: Map.get(target, :api_route, ""),
       healthcheck_worker: Map.get(target, :healthcheck_worker, "")
     })
   end

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/scheduled_target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/scheduled_target.ex
@@ -27,7 +27,7 @@ defmodule Ockam.Healthcheck.ScheduledTarget do
         } = target
       )
       when is_integer(port) do
-    api_worker = Map.get(target, "api_worker", "api")
+    api_route = Map.get(target, "api_route", ["api"])
     body = target |> Map.get("body") |> decode_body()
     method = String.to_existing_atom(method)
 
@@ -40,7 +40,7 @@ defmodule Ockam.Healthcheck.ScheduledTarget do
          path: path,
          method: method,
          body: body,
-         api_worker: api_worker,
+         api_route: api_route,
          healthcheck_worker: healthcheck_worker
        },
        crontab: crontab
@@ -49,7 +49,7 @@ defmodule Ockam.Healthcheck.ScheduledTarget do
 
   def parse(%{"name" => name, "host" => host, "port" => port, "crontab" => crontab} = target)
       when is_integer(port) do
-    api_worker = Map.get(target, "api_worker", "api")
+    api_route = Map.get(target, "api_route", ["api"])
     healthcheck_worker = Map.get(target, "healthcheck_worker", "healthcheck")
 
     {:ok,
@@ -58,7 +58,7 @@ defmodule Ockam.Healthcheck.ScheduledTarget do
          name: name,
          host: host,
          port: port,
-         api_worker: api_worker,
+         api_route: api_route,
          healthcheck_worker: healthcheck_worker
        },
        crontab: crontab

--- a/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
+++ b/implementations/elixir/ockam/ockam_healthcheck/lib/healthcheck/target.ex
@@ -11,7 +11,7 @@ defmodule Ockam.Healthcheck.Target do
     :name,
     :host,
     :port,
-    api_worker: "api",
+    api_route: ["api"],
     healthcheck_worker: "healthcheck"
   ]
 end

--- a/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/application_test.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/application_test.exs
@@ -12,7 +12,7 @@ defmodule Ockam.Healthcheck.Application.Test do
     [{"name": "mytarget",
       "host":"localhost",
       "port": 4000,
-      "api_worker": "api",
+      "api_route": ["api"],
       "healthcheck_worker": "healthcheck",
       "crontab": "* * * * *"}]
     """
@@ -35,8 +35,9 @@ defmodule Ockam.Healthcheck.Application.Test do
            } = target
 
     ## Default fields
-    assert %ScheduledTarget{target: %Target{api_worker: "api", healthcheck_worker: "healthcheck"}} =
-             target
+    assert %ScheduledTarget{
+             target: %Target{api_route: ["api"], healthcheck_worker: "healthcheck"}
+           } = target
 
     encoded_body = "ZHRlc3Q="
 
@@ -47,7 +48,7 @@ defmodule Ockam.Healthcheck.Application.Test do
       "path": "/",
       "method": "post",
       "body": "#{encoded_body}",
-      "api_worker": "api",
+      "api_route": ["api"],
       "healthcheck_worker": "healthcheck",
       "crontab": "* * * * *"}]
     """
@@ -61,7 +62,7 @@ defmodule Ockam.Healthcheck.Application.Test do
                port: 4000,
                method: :post,
                body: body,
-               api_worker: "api",
+               api_route: ["api"],
                healthcheck_worker: "healthcheck",
                path: "/"
              },

--- a/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
+++ b/implementations/elixir/ockam/ockam_healthcheck/test/healthcheck/healthcheck_test.exs
@@ -38,7 +38,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: port,
-      api_worker: "api",
+      api_route: ["api"],
       healthcheck_worker: "healthcheck"
     }
 
@@ -81,7 +81,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: port,
-      api_worker: "api",
+      api_route: ["api"],
       healthcheck_worker: "not_healthcheck"
     }
 
@@ -124,7 +124,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: port,
-      api_worker: "api",
+      api_route: ["api"],
       healthcheck_worker: "endpoint",
       path: "/ok",
       method: :get
@@ -168,7 +168,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: port,
-      api_worker: "api",
+      api_route: ["api"],
       healthcheck_worker: "endpoint",
       path: "/error",
       method: :get
@@ -212,7 +212,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: port,
-      api_worker: "not_api",
+      api_route: ["not_api"],
       healthcheck_worker: "healthcheck"
     }
 
@@ -225,7 +225,7 @@ defmodule Ockam.Healthcheck.Test do
       name: "target",
       host: "localhost",
       port: 1234,
-      api_worker: "api",
+      api_route: ["api"],
       healthcheck_worker: "healthcheck"
     }
 

--- a/implementations/elixir/ockam/ockam_services/lib/services/provider/proxy.ex
+++ b/implementations/elixir/ockam/ockam_services/lib/services/provider/proxy.ex
@@ -21,24 +21,11 @@ defmodule Ockam.Services.Provider.Proxy do
 
   @impl true
   def child_spec(:proxy, args) do
-    :os.env()
-    |> Enum.map(fn {name, val} -> {to_string(name), to_string(val)} end)
-    |> Enum.filter(fn {name, _val} -> String.starts_with?(name, "SERVICE_PROXY_") end)
-    |> Enum.map(fn {name, val} ->
-      proxy_name = String.trim(name, "SERVICE_PROXY_")
-      init_args = make_init_args(proxy_name, val, args)
-
+    [
       %{
-        id: String.to_atom("proxy_#{proxy_name}"),
-        start: {Proxy, :start_link, [init_args]}
+        id: String.to_atom("proxy_#{Keyword.fetch!(args, :address)}"),
+        start: {Proxy, :start_link, [args]}
       }
-    end)
-  end
-
-  def make_init_args(proxy_name, val, args) do
-    Keyword.merge(args,
-      address: proxy_name,
-      forward_route: val
-    )
+    ]
   end
 end


### PR DESCRIPTION
* change the proxy worker to replace just itself from  the destination and return route, instead of replacing the route entirely
* update the healthchecker code to accept a route rather than just an address to establish secure channels to
