### PR TITLE
refactor(rust): Usage of `Terminal` struct in-place of `println!`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/show.rs
@@ -1,8 +1,11 @@
 use clap::Args;
 
+use colorful::Colorful;
 use ockam::Context;
+use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::transport::TransportStatus;
 use ockam_api::nodes::BackgroundNodeClient;
+use ockam_api::{fmt_log, fmt_ok};
 use ockam_core::api::Request;
 
 use crate::node::NodeOpts;
@@ -45,16 +48,32 @@ impl ShowCommand {
             )
             .await?;
 
-        println!("TCP Connection:");
-        println!("  Type: {}", transport_status.tt);
-        println!("  Mode: {}", transport_status.tm);
-        println!("  Socket address: {}", transport_status.socket_addr);
-        println!("  Worker address: {}", transport_status.worker_addr);
-        println!(
-            "  Processor address: {}",
-            transport_status.processor_address
-        );
-        println!("  Flow Control Id: {}", transport_status.flow_control_id);
+        opts.terminal
+            .stdout()
+            .plain(
+                fmt_ok!("TCP Connection:\n")
+                    + &fmt_log!(
+                        "  Type: {}\n",
+                        color_primary(transport_status.tt.to_string())
+                    )
+                    + &fmt_log!(
+                        "  Mode: {}\n",
+                        color_primary(transport_status.tm.to_string())
+                    )
+                    + &fmt_log!(
+                        "  Socket address: {}\n",
+                        color_primary(&transport_status.socket_addr)
+                    )
+                    + &fmt_log!(
+                        "  Processor address: {}\n",
+                        color_primary(&transport_status.processor_address)
+                    )
+                    + &fmt_log!(
+                        "  Flow Control Id: {}\n",
+                        color_primary(transport_status.flow_control_id.to_string())
+                    ),
+            )
+            .write_line()?;
 
         Ok(())
     }


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

The `tcp-connection show` command is using `println` to print the command's output, which is a strategy that is being deprecated.

## Proposed changes

Instead, the `Terminal` struct should be used to handle the output of every command.

Closes #6595 

