### PR TITLE
fix(rust): do not set invited projects as default

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -648,12 +648,11 @@ impl NodeInfo {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::cloud::project::models::ProjectModel;
     use crate::config::lookup::InternetAddress;
     use std::net::SocketAddr;
     use std::str::FromStr;
-
-    use super::*;
 
     #[tokio::test]
     async fn test_create_node() -> Result<()> {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -62,23 +62,7 @@ impl Projects {
 
     #[instrument(skip_all, fields(project_id = project_id))]
     pub async fn delete_project(&self, project_id: &str) -> Result<()> {
-        // delete the project
-        let project_exists = self
-            .projects_repository
-            .get_project(project_id)
-            .await
-            .is_ok();
         self.projects_repository.delete_project(project_id).await?;
-
-        // set another project as the default project
-        if project_exists {
-            let other_projects = self.projects_repository.get_projects().await?;
-            if let Some(other_project) = other_projects.first() {
-                self.projects_repository
-                    .set_default_project(&other_project.id)
-                    .await?;
-            }
-        }
         Ok(())
     }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
@@ -66,11 +66,11 @@ impl ProjectsSqlxDatabase {
         let non_admin_emails: Vec<String> = users_roles
             .iter()
             .filter(|user_role| user_role.role != RoleInShare::Admin)
-            .map(|user_role| user_role.email.to_string())
+            .map(|user_role| user_role.email.to_string().to_lowercase())
             .collect();
 
         // Check if any of the emails are in the user table
-        let q = query_scalar(r#"SELECT EXISTS(SELECT 1 FROM "user" WHERE email IN ($1))"#)
+        let q = query_scalar(r#"SELECT EXISTS(SELECT 1 FROM "user" WHERE LOWER(email) IN ($1))"#)
             .bind(non_admin_emails.join(","));
         let shared: Boolean = q.fetch_one(transaction).await.into_core()?;
         Ok(shared.to_bool())
@@ -607,7 +607,7 @@ mod test {
                     name: "name".to_string(),
                     picture: "picture".to_string(),
                     updated_at: "2024-07-29T17:56:24.585Z".to_string(),
-                    email: "me@ockam.io".try_into().unwrap(),
+                    email: "Me@ockam.io".try_into().unwrap(),
                     email_verified: false,
                 })
                 .await

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
@@ -33,7 +33,7 @@ impl UsersRepository for UsersSqlxDatabase {
         let mut transaction = self.database.begin().await.into_core()?;
 
         let query1 = query_scalar(
-            r#"SELECT EXISTS(SELECT email FROM "user" WHERE is_default = $1 AND email = $2)"#,
+            r#"SELECT EXISTS(SELECT email FROM "user" WHERE is_default = $1 AND email = LOWER($2))"#,
         )
         .bind(true)
         .bind(&user.email);
@@ -68,14 +68,14 @@ impl UsersRepository for UsersSqlxDatabase {
     }
 
     async fn set_default_user(&self, email: &EmailAddress) -> Result<()> {
-        let query = query(r#"UPDATE "user" SET is_default = $1 WHERE email = $2"#)
+        let query = query(r#"UPDATE "user" SET is_default = $1 WHERE email = LOWER($2)"#)
             .bind(true)
             .bind(email);
         query.execute(&*self.database.pool).await.void()
     }
 
     async fn get_user(&self, email: &EmailAddress) -> Result<Option<UserInfo>> {
-        let query = query_as(r#"SELECT email, sub, nickname, name, picture, updated_at, email_verified, is_default FROM "user" WHERE email = $1"#).bind(email);
+        let query = query_as(r#"SELECT email, sub, nickname, name, picture, updated_at, email_verified, is_default FROM "user" WHERE email = LOWER($1)"#).bind(email);
         let row: Option<UserRow> = query
             .fetch_optional(&*self.database.pool)
             .await
@@ -92,7 +92,7 @@ impl UsersRepository for UsersSqlxDatabase {
     }
 
     async fn delete_user(&self, email: &EmailAddress) -> Result<()> {
-        let query1 = query(r#"DELETE FROM "user" WHERE email = $1"#).bind(email);
+        let query1 = query(r#"DELETE FROM "user" WHERE email = LOWER($1)"#).bind(email);
         query1.execute(&*self.database.pool).await.void()
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -21,7 +21,7 @@ pub struct ResetCommand {
     yes: bool,
 
     /// Remove your spaces from the Orchestrator
-    #[arg(long, short)]
+    #[arg(long)]
     all: bool,
 }
 


### PR DESCRIPTION
By ordering the projects before storing them, we make sure we don't assign an invited project as the local default project.