### PR TITLE
chore(rust): Replace all the occurence of `read_metadata` with `get_metadata`

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/mod.rs
@@ -307,7 +307,7 @@ impl ConnectionBuilder {
                     // last piece only if it's a terminal (a service connecting to another node)
                     if last_pass && is_last {
                         let is_terminal = ctx
-                            .read_metadata(address.clone())
+                            .get_metadata(address.clone())
                             .await
                             .ok()
                             .flatten()

--- a/implementations/rust/ockam/ockam_node/src/context/context.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context.rs
@@ -233,11 +233,11 @@ impl Context {
     }
 
     /// Read metadata for the provided address
-    pub async fn read_metadata(
+    pub async fn get_metadata(
         &self,
         address: impl Into<Address>,
     ) -> Result<Option<AddressMetadata>> {
-        let (msg, mut reply) = NodeMessage::read_metadata(address.into());
+        let (msg, mut reply) = NodeMessage::get_metadata(address.into());
         self.sender
             .send(msg)
             .await

--- a/implementations/rust/ockam/ockam_node/src/messages.rs
+++ b/implementations/rust/ockam/ockam_node/src/messages.rs
@@ -199,7 +199,7 @@ impl NodeMessage {
     }
 
     /// Creates a [NodeMessage::ReadMetadata] message and reply receiver
-    pub fn read_metadata(address: Address) -> (Self, SmallReceiver<NodeReplyResult>) {
+    pub fn get_metadata(address: Address) -> (Self, SmallReceiver<NodeReplyResult>) {
         let (tx, rx) = small_channel();
         (Self::GetMetadata(address, tx), rx)
     }

--- a/implementations/rust/ockam/ockam_node/tests/router.rs
+++ b/implementations/rust/ockam/ockam_node/tests/router.rs
@@ -94,7 +94,7 @@ async fn provide_and_read_processor_address_metadata(context: &mut Context) -> R
         .start(context)
         .await?;
 
-    let meta = context.read_metadata("processor_address").await?.unwrap();
+    let meta = context.get_metadata("processor_address").await?.unwrap();
 
     assert!(!meta.is_terminal);
 
@@ -106,11 +106,11 @@ async fn provide_and_read_processor_address_metadata(context: &mut Context) -> R
         ]
     );
 
-    assert_eq!(context.read_metadata("non-existing-worker").await?, None);
+    assert_eq!(context.get_metadata("non-existing-worker").await?, None);
 
     context.stop_processor("processor_address").await?;
     ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    assert_eq!(context.read_metadata("processor_address",).await?, None);
+    assert_eq!(context.get_metadata("processor_address",).await?, None);
 
     context.stop().await
 }
@@ -209,7 +209,7 @@ async fn provide_and_read_address_metadata(context: &mut Context) -> Result<()> 
         .start(context)
         .await?;
 
-    let meta = context.read_metadata("worker_address").await?.unwrap();
+    let meta = context.get_metadata("worker_address").await?.unwrap();
 
     assert!(!meta.is_terminal);
 
@@ -221,11 +221,11 @@ async fn provide_and_read_address_metadata(context: &mut Context) -> Result<()> 
         ]
     );
 
-    assert_eq!(context.read_metadata("non-existing-worker").await?, None);
+    assert_eq!(context.get_metadata("non-existing-worker").await?, None);
 
     context.stop_worker("worker_address").await?;
     ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    assert_eq!(context.read_metadata("worker_address").await?, None);
+    assert_eq!(context.get_metadata("worker_address").await?, None);
 
     context.stop().await
 }
@@ -242,7 +242,7 @@ async fn provide_and_read_address_metadata_worker_alias(context: &mut Context) -
         .start(context)
         .await?;
 
-    let meta = context.read_metadata("alias").await?.unwrap();
+    let meta = context.get_metadata("alias").await?.unwrap();
 
     assert!(!meta.is_terminal);
 
@@ -253,7 +253,7 @@ async fn provide_and_read_address_metadata_worker_alias(context: &mut Context) -
 
     context.stop_worker("main").await?;
     ockam_node::compat::tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    assert_eq!(context.read_metadata("alias").await?, None);
+    assert_eq!(context.get_metadata("alias").await?, None);
 
     context.stop().await
 }


### PR DESCRIPTION


<!-- Thank you for sending a pull request :heart: -->

## Current behavior

`read_metadata` is present in repo.

## Proposed changes

replaced it `get_metadata`
Closes #8372 