### PR TITLE
feat(rust): the config of `node create` accepts an `identity`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -2,6 +2,7 @@ use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
+use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_api::terminal::notification::NotificationHandler;
 use ockam_api::terminal::{Terminal, TerminalStream};
@@ -105,8 +106,8 @@ impl DeleteCommandTui for DeleteTui {
         self.terminal()
             .stdout()
             .plain(fmt_ok!(
-                "Node with name {} has been deleted",
-                item_name.light_magenta()
+                "The node with name {} has been deleted",
+                color_primary(item_name)
             ))
             .machine(item_name)
             .json(serde_json::json!({ "name": &item_name }))

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -111,7 +111,7 @@ async fn stop_node(opts: CommandGlobalOpts, node_name: &str, force: bool) -> mie
     let res = opts.state.stop_node(node_name, force).await;
     let output = if res.is_ok() {
         fmt_ok!(
-            "Node with name {} was stopped",
+            "The node with name {} was stopped",
             color!(node_name, OckamColor::PrimaryResource)
         )
     } else {

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -65,7 +65,7 @@ impl Config {
         Ok(vec![
             self.vaults.into_parsed_commands()?.into(),
             self.identities.into_parsed_commands()?.into(),
-            self.project_enroll.into_parsed_commands()?.into(),
+            self.project_enroll.into_parsed_commands(None)?.into(),
             self.nodes.into_parsed_commands()?.into(),
             self.relays.into_parsed_commands(None)?.into(),
             self.policies.into_parsed_commands()?.into(),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -100,6 +100,17 @@ impl Node {
             .unwrap_or(None)
     }
 
+    /// Return the identity name if defined
+    pub fn identity(&self) -> Option<String> {
+        self.identity
+            .clone()
+            .map(|v| match v {
+                ArgValue::String(s) => Some(s),
+                _ => None,
+            })
+            .unwrap_or(None)
+    }
+
     pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
         Ok(vec![Self::get_subcommand(&self.args())?])
     }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -20,8 +20,13 @@ pub trait Resource<C: ParsedCommand>: Sized + Send + Sync + 'static {
         vec![]
     }
 
-    fn run_in_subprocess(self, global_args: &GlobalArgs) -> Result<Child> {
+    fn run_in_subprocess(
+        self,
+        global_args: &GlobalArgs,
+        mut extra_args: Vec<String>,
+    ) -> Result<Child> {
         let mut args = self.args();
+        args.append(&mut extra_args);
         if global_args.quiet {
             args.push("--quiet".to_string());
         }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -143,7 +143,7 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        config.project_enroll.into_parsed_commands().unwrap();
+        config.project_enroll.into_parsed_commands(None).unwrap();
         config.tcp_inlets.into_parsed_commands(None).unwrap();
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -147,7 +147,7 @@ mod tests {
         };
         let config_recipe = cmd.create_config_recipe();
         let config = Config::parse(config_recipe.as_str()).unwrap();
-        config.project_enroll.into_parsed_commands().unwrap();
+        config.project_enroll.into_parsed_commands(None).unwrap();
         config.policies.into_parsed_commands().unwrap();
         config.tcp_outlets.into_parsed_commands(None).unwrap();
         config.relays.into_parsed_commands(None).unwrap();

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -25,7 +25,7 @@ teardown() {
   assert_output --partial "\"status\":\"running\""
 
   run_success "$OCKAM" node stop n1
-  assert_output --partial "Node with name n1 was stopped"
+  assert_output --partial "n1 was stopped"
 
   run_success "$OCKAM" node start n1
 


### PR DESCRIPTION
This identity can be used in the config commands that accept an optional identity. For now, only the `project ticket` command supports this option.

The identity can be defined in the node configuration:

```bash
ockam node create config.yaml --identity i
```

or passed as a command arg:

```yaml
name: n
identity: i

ticket: $TICKET

relay: my-relay
```