### PR TITLE
chore(rust): Added `rust_crypto` in default-features 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,6 +4589,7 @@ dependencies = [
  "ockam_executor",
  "ockam_identity",
  "ockam_node",
+ "ockam_transport_tcp",
  "ockam_vault",
  "once_cell",
  "quickcheck",

--- a/implementations/rust/ockam/ockam_abac/Cargo.toml
+++ b/implementations/rust/ockam/ockam_abac/Cargo.toml
@@ -49,9 +49,7 @@ minicbor = { version = "0.24.1", features = ["derive", "alloc"] }
 ockam_core = { version = "0.112.0", path = "../ockam_core", default-features = false }
 ockam_identity = { version = "0.116.0", path = "../ockam_identity", default-features = false }
 ockam_node = { version = "0.121.0", path = "../ockam_node", default-features = false }
-once_cell = { version = "1.19.0", default-features = false, features = [
-  "alloc",
-] }
+once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 
@@ -64,20 +62,10 @@ rustyline = { version = "14.0.0", optional = true }
 rustyline-derive = { version = "0.10.0", optional = true }
 sqlx-build-trust = { version = "0.7.8", optional = true }
 str-buf = "3.0.3"
-tokio = { version = "1.39", default-features = false, optional = true, features = [
-  "sync",
-  "time",
-  "rt",
-  "rt-multi-thread",
-  "macros",
-] }
-tracing = { version = "0.1", default-features = false, features = [
-  "attributes",
-] }
+tokio = { version = "1.39", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"] }
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 wast = { version = "214.0.0", default-features = false, optional = true }
-winnow = { version = "0.6.18", default-features = false, optional = true, features = [
-  "alloc",
-] }
+winnow = { version = "0.6.18", default-features = false, optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 ockam_vault = { path = "../ockam_vault", default-features = false }

--- a/implementations/rust/ockam/ockam_abac/Cargo.toml
+++ b/implementations/rust/ockam/ockam_abac/Cargo.toml
@@ -13,14 +13,22 @@ repository = "https://github.com/build-trust/ockam/tree/develop/implementations/
 description = "Attribute based authorization control"
 
 [features]
-default = ["std"]
+default = ["std", "rust-crypto"]
 no_std = ["ockam_core/no_std", "ockam_identity/no_std", "ockam_executor"]
 alloc = ["ockam_core/alloc", "ockam_identity/alloc", "winnow/alloc"]
 repl = ["rustyline", "rustyline-derive", "std"]
+rust-crypto = [
+  "ockam_vault?/rust-crypto",
+  "ockam_transport_tcp?/ring",
+  "ockam_identity/rust-crypto",
+]
+aws-lc = ["ockam_vault/aws-lc", "ockam_transport_tcp/aws-lc"]
 std = [
   "ockam_core/std",
   "ockam_identity/std",
   "ockam_node/std",
+  "ockam_vault/std",
+  "ockam_transport_tcp?/std",
   "minicbor/std",
   "tracing/std",
   "either/use_std",
@@ -38,27 +46,41 @@ std = [
 cfg-if = "1.0.0"
 either = { version = "1.13.0", default-features = false }
 minicbor = { version = "0.24.1", features = ["derive", "alloc"] }
-ockam_core = { version = "0.114.0", path = "../ockam_core", default-features = false }
-ockam_identity = { version = "0.118.0", path = "../ockam_identity", default-features = false }
-ockam_node = { version = "0.123.0", path = "../ockam_node", default-features = false }
-once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
+ockam_core = { version = "0.112.0", path = "../ockam_core", default-features = false }
+ockam_identity = { version = "0.116.0", path = "../ockam_identity", default-features = false }
+ockam_node = { version = "0.121.0", path = "../ockam_node", default-features = false }
+once_cell = { version = "1.19.0", default-features = false, features = [
+  "alloc",
+] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 strum = { version = "0.26.3", default-features = false, features = ["derive"] }
 
 # optional:
-ockam_executor = { version = "0.83.0", path = "../ockam_executor", default-features = false, optional = true }
-regex = { version = "1.10.6", default-features = false, optional = true }
+ockam_executor = { version = "0.81.0", path = "../ockam_executor", default-features = false, optional = true }
+ockam_transport_tcp = { path = "../ockam_transport_tcp", version = "^0.119.0", default-features = false, optional = true }
+ockam_vault = { path = "../ockam_vault", version = "^0.114.0", default-features = false, optional = true }
+regex = { version = "1.10.5", default-features = false, optional = true }
 rustyline = { version = "14.0.0", optional = true }
 rustyline-derive = { version = "0.10.0", optional = true }
 sqlx-build-trust = { version = "0.7.8", optional = true }
 str-buf = "3.0.3"
-tokio = { version = "1.39", default-features = false, optional = true, features = ["sync", "time", "rt", "rt-multi-thread", "macros"] }
-tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+tokio = { version = "1.39", default-features = false, optional = true, features = [
+  "sync",
+  "time",
+  "rt",
+  "rt-multi-thread",
+  "macros",
+] }
+tracing = { version = "0.1", default-features = false, features = [
+  "attributes",
+] }
 wast = { version = "214.0.0", default-features = false, optional = true }
-winnow = { version = "0.6.18", default-features = false, optional = true, features = ["alloc"] }
+winnow = { version = "0.6.18", default-features = false, optional = true, features = [
+  "alloc",
+] }
 
 [dev-dependencies]
-ockam_vault = { path = "../ockam_vault", default-features = false, features = ["rust-crypto"] }
+ockam_vault = { path = "../ockam_vault", default-features = false }
 quickcheck = "1.0.3"
 rand = "0.8.5"
 tempfile = "3.10.1"


### PR DESCRIPTION
## Current behavior

Crate `ockam_abac` gave out unusual error on running `ockam build --package ockam_abac`.
<details>
<summary>Error</summary>

```
    Blocking waiting for file lock on build directory
   Compiling ockam_core v0.112.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_core)
   Compiling ockam_node v0.121.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_node)
   Compiling ockam_transport_core v0.86.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_transport_core)
   Compiling ockam_executor v0.81.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_executor)
   Compiling ockam_vault v0.114.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_vault)
error: One feature must be enabled: "aws-lc" or "rust-crypto"
 --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/mod.rs:4:1
  |
4 | compile_error! {"One feature must be enabled: \"aws-lc\" or \"rust-crypto\""}
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
 --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:6:5
  |
6 | use aes_gcm::aead::consts::{U0, U12, U16};
  |     ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
 --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:7:5
  |
7 | use aes_gcm::aead::{Aead, Nonce, Payload, Tag};
  |     ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
 --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:8:5
  |
8 | use aes_gcm::aes::cipher::Unsigned;
  |     ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0432]: unresolved import `aes_gcm`
 --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:9:5
  |
9 | use aes_gcm::{AeadCore, AeadInPlace, AesGcm, KeyInit};
  |     ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0432]: unresolved import `aes_gcm`
  --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:53:13
   |
53 |         use aes_gcm::Aes256Gcm;
   |             ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
  --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:54:24
   |
54 |         type AesType = aes_gcm::aes::Aes256;
   |                        ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
  --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:87:10
   |
87 |     ) -> aes_gcm::aead::Result<Tag<Self>> {
   |          ^^^^^^^ use of undeclared crate or module `aes_gcm`

error[E0433]: failed to resolve: use of undeclared crate or module `aes_gcm`
  --> implementations/rust/ockam/ockam_vault/src/software/vault_for_secure_channels/aes_rs.rs:97:10
   |
97 |     ) -> aes_gcm::aead::Result<()> {
   |          ^^^^^^^ use of undeclared crate or module `aes_gcm`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `ockam_vault` (lib) due to 9 previous errors
warning: build failed, waiting for other jobs to finish...
```

</details>

## Proposed changes

I added `rust_crypto` to default-features(in Cargo.toml) to solve the issue.

<details>
<summary>Output (build)</summary>

```bash
cargo build --package ockam_abac
```

```
   Compiling inout v0.1.3
   Compiling universal-hash v0.5.1
   Compiling opaque-debug v0.3.1
   Compiling aead v0.5.2
   Compiling polyval v0.6.2
   Compiling cipher v0.4.4
   Compiling ghash v0.5.1
   Compiling ctr v0.9.2
   Compiling aes v0.8.4
   Compiling aes-gcm v0.10.3
   Compiling ockam_vault v0.114.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_vault)
   Compiling ockam_identity v0.116.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_identity)
   Compiling ockam_abac v0.62.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_abac)
    Finished dev [unoptimized + debuginfo] target(s) in 13.38s
```

</details>

<details>
<summary>Output (test)</summary>

```bash
cargo test --package ockam_abac
```

```
   Compiling aho-corasick v1.1.3
   Compiling regex-automata v0.4.7
   Compiling regex v1.10.5
   Compiling tracing-subscriber v0.3.18
   Compiling env_logger v0.8.4
   Compiling quickcheck v1.0.3
   Compiling tracing-opentelemetry v0.24.0
   Compiling tracing-error v0.2.0
   Compiling ockam_core v0.112.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_core)
   Compiling ockam_transport_core v0.86.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_transport_core)
   Compiling ockam_executor v0.81.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_executor)
   Compiling ockam_node v0.121.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_node)
   Compiling ockam_vault v0.114.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_vault)
   Compiling ockam_identity v0.116.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_identity)
   Compiling ockam_abac v0.62.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_abac)
    Finished test [unoptimized + debuginfo] target(s) in 27.18s
     Running unittests src/lib.rs (target/debug/deps/ockam_abac-fbe99f89263cf2e0)

running 19 tests
test boolean_expr::tests::boolean_expr_to_string ... ok
test eval::tests::test ... ok
test boolean_expr::tests::parse_name ... ok
test boolean_expr::tests::parse_boolean_expr_errors ... ok
test boolean_expr::tests::parse_boolean_expr ... ok
test boolean_expr::tests::boolean_expr_to_expr ... ok
test expr::tests::first_identifier_must_be_an_operation ... ok
test policy_expr::tests::from_str ... ok
test expr::tests::evil ... ok
test expr::tests::symm_eq ... ok
test expr::tests::dual ... ok
test expr::tests::malformed ... ok
test expr::tests::write_read ... ok
test expr::tests::trans_lt ... ok
test expr::tests::trans_eq ... ok
test expr::tests::trans_gt ... ok
test policy::storage::resource_repository_sql::test::test_repository ... ok
test policy::storage::resource_type_policy_repository_sql::test::test_repository ... ok
test policy::storage::resource_policy_repository_sql::test::test_repository ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s

   Doc-tests ockam_abac

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

</details>

Addresses #5491 