### PR TITLE
chore(rust): added minicbor to std features of `ockam_multiaddr`

### DIFF
--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -25,12 +25,16 @@ description = "An implementation of multiformats.io/multiaddr"
 
 [features]
 default = ["std"]
-std = ["ockam_core/std", "unsigned-varint/std", "serde?/std"]
+std = ["ockam_core/std", "unsigned-varint/std", "serde?/std", "minicbor/std"]
 cbor = ["minicbor"]
 
 [dependencies]
-minicbor = { version = "0.24.1", default-features = false, features = ["alloc"], optional = true }
-once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
+minicbor = { version = "0.24.1", default-features = false, features = [
+  "alloc",
+], optional = true }
+once_cell = { version = "1.19.0", default-features = false, features = [
+  "alloc",
+] }
 serde = { version = "1.0.204", default-features = false, optional = true }
 tinyvec = { version = "1.8.0", features = ["alloc"] }
 unsigned-varint = "0.8.0"

--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -29,12 +29,8 @@ std = ["ockam_core/std", "unsigned-varint/std", "serde?/std", "minicbor/std"]
 cbor = ["minicbor"]
 
 [dependencies]
-minicbor = { version = "0.24.1", default-features = false, features = [
-  "alloc",
-], optional = true }
-once_cell = { version = "1.19.0", default-features = false, features = [
-  "alloc",
-] }
+minicbor = { version = "0.24.1", default-features = false, features = ["alloc"], optional = true }
+once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.204", default-features = false, optional = true }
 tinyvec = { version = "1.8.0", features = ["alloc"] }
 unsigned-varint = "0.8.0"


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

On running `cargo build --package ockam_multiaddr`, we get an error related to `minicbor`

<details>
<summary>Error</summary>

```bash
cargo build --package ockam_multiaddr
```
```
   Compiling ockam_multiaddr v0.56.0 (/home/psychopunk_sage/dev/OpenSource/ockam/implementations/rust/ockam/ockam_multiaddr)
error[E0433]: failed to resolve: use of undeclared crate or module `minicbor`
   --> implementations/rust/ockam/ockam_multiaddr/src/lib.rs:743:9
    |
743 | impl<C> minicbor::CborLen<C> for MultiAddr {
    |         ^^^^^^^^ use of undeclared crate or module `minicbor`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `ockam_multiaddr` (lib) due to 1 previous error
```

</details>

## Proposed changes

Added `minicbor` to features remove the error 
NOW:

<details>
<summary>Output (build)</summary>

```bash
cargo build --package ockam_multiaddr
```
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
```

</details>

<details>
<summary>Output (test)</summary>

```bash
cargo test --package ockam_multiaddr
```
```
    Finished test [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests src/lib.rs (target/debug/deps/ockam_multiaddr-969901207d331dc6)

running 2 tests
test tests::split_off ... ok
test tests::self_multiaddr ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/bench.rs (target/debug/deps/bench-c3d03d2efd2d4f76)

running 1 test
test benchmark ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

     Running tests/id.rs (target/debug/deps/id-0cfb2c94a3e05fa4)

running 9 tests
test operations ... ok
test cbor ... ok
test push_back_value ... ok
test to_bytes_from_bytes ... ok
test serde_text ... ok
test match_test ... ok
test serde_binary ... ok
test push_front_value ... ok
test to_str_from_str ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s

   Doc-tests ockam_multiaddr

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

```

</details>

Fixes #5491 