### PR TITLE
feat(rust): node config improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +847,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes 1.7.1",
  "fastrand 2.1.0",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.0",
@@ -1581,6 +1591,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "colorful"
@@ -3023,6 +3043,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.7.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,7 +3319,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3303,6 +3342,7 @@ dependencies = [
  "bytes 1.7.1",
  "futures-channel",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -4111,6 +4151,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b34bd91b9e5c5b06338d392463e1318d683cf82ec3d3af4014609be6e2108d"
+dependencies = [
+ "assert-json-diff",
+ "bytes 1.7.1",
+ "colored",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4674,6 +4738,7 @@ dependencies = [
  "indoc",
  "miette",
  "minicbor",
+ "mockito",
  "ockam",
  "ockam_abac",
  "ockam_api",
@@ -6775,6 +6840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7820,7 +7891,7 @@ dependencies = [
  "axum",
  "base64 0.21.7",
  "bytes 1.7.1",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.29",

--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journeys.rs
@@ -195,7 +195,7 @@ impl CliState {
                     &project_multiaddr.to_string(),
                 );
             }
-            if let Ok(project_identifier) = project.project_identifier() {
+            if let Some(project_identifier) = project.project_identifier() {
                 CurrentSpan::set_attribute(
                     APPLICATION_EVENT_PROJECT_IDENTIFIER,
                     &project_identifier.to_string(),
@@ -207,7 +207,7 @@ impl CliState {
                     &authority_multiaddr.to_string(),
                 );
             }
-            if let Ok(authority_identifier) = project.authority_identifier() {
+            if let Some(authority_identifier) = project.authority_identifier() {
                 CurrentSpan::set_attribute(
                     APPLICATION_EVENT_PROJECT_AUTHORITY_IDENTIFIER,
                     &authority_identifier.to_string(),

--- a/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/projects.rs
@@ -38,13 +38,13 @@ impl Projects {
 
     #[instrument(skip_all, fields(project_id = project.project_id()))]
     pub async fn store_project(&self, project: Project) -> Result<Project> {
-        if let Ok(project_identity) = project.project_identity() {
+        if let Some(project_identity) = project.project_identity() {
             self.identities_verification
                 .update_identity_ignore_older(project_identity)
                 .await?;
         }
 
-        if let Ok(authority_identity) = project.authority_identity() {
+        if let Some(authority_identity) = project.authority_identity() {
             self.identities_verification
                 .update_identity_ignore_older(authority_identity)
                 .await?;

--- a/implementations/rust/ockam/ockam_api/src/cloud/project/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project/project.rs
@@ -132,31 +132,12 @@ impl Project {
     }
 
     /// Return the identity of the project's node
-    pub fn project_identity(&self) -> Result<&Identity> {
-        match &self.project_identity {
-            Some(project_identity) => Ok(project_identity),
-            None => Err(Error::new(
-                Origin::Api,
-                Kind::NotFound,
-                format!(
-                    "no identity has been set for the project {}",
-                    self.model.name
-                ),
-            )),
-        }
+    pub fn project_identity(&self) -> Option<&Identity> {
+        self.project_identity.as_ref()
     }
 
-    pub fn project_identifier(&self) -> Result<Identifier> {
-        self.model.identity.clone().ok_or_else(|| {
-            Error::new(
-                Origin::Api,
-                Kind::NotFound,
-                format!(
-                    "no identifier has been set for the project {}",
-                    self.model.name
-                ),
-            )
-        })
+    pub fn project_identifier(&self) -> Option<Identifier> {
+        self.model.identity.clone()
     }
 
     pub fn project_multiaddr(&self) -> Result<&MultiAddr> {
@@ -178,22 +159,12 @@ impl Project {
     }
 
     /// Return the identity of the project's authority
-    pub fn authority_identity(&self) -> Result<&Identity> {
-        match &self.authority_identity {
-            Some(authority_identity) => Ok(authority_identity),
-            None => Err(Error::new(
-                Origin::Api,
-                Kind::NotFound,
-                format!(
-                    "no identity has been set for the project authority: {:?}",
-                    self
-                ),
-            )),
-        }
+    pub fn authority_identity(&self) -> Option<&Identity> {
+        self.authority_identity.as_ref()
     }
 
-    pub fn authority_identifier(&self) -> Result<Identifier> {
-        Ok(self.authority_identity()?.identifier().clone())
+    pub fn authority_identifier(&self) -> Option<Identifier> {
+        self.authority_identity().map(|i| i.identifier().clone())
     }
 
     pub fn authority_multiaddr(&self) -> Result<&MultiAddr> {

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
@@ -66,9 +66,13 @@ impl CreateServiceInvitation {
             expires_at,
             project_id: project.project_id().to_string(),
             recipient_email: recipient_email.clone(),
-            project_identity: project.project_identifier()?,
+            project_identity: project
+                .project_identifier()
+                .ok_or(ApiError::core("no project identifier"))?,
             project_route: project.project_multiaddr()?.to_string(),
-            project_authority_identity: project.authority_identifier()?,
+            project_authority_identity: project
+                .authority_identifier()
+                .ok_or(ApiError::core("no authority identifier"))?,
             project_authority_route: project_authority_route.to_string(),
             shared_node_identity: node_identifier,
             shared_node_route: service_route.as_ref().to_string(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -337,7 +337,9 @@ impl NodeManager {
         let project = self.cli_state.projects().get_project_by_name(name).await?;
         Ok((
             project.project_multiaddr()?.clone(),
-            project.project_identifier()?,
+            project
+                .project_identifier()
+                .ok_or(ApiError::core("no project identifier"))?,
         ))
     }
 
@@ -440,7 +442,10 @@ impl NodeManager {
         let project = self.wait_until_project_is_ready(ctx, project).await?;
 
         self.make_authority_node_client(
-            &project.authority_identifier().into_diagnostic()?,
+            &project
+                .authority_identifier()
+                .ok_or(ApiError::core("no authority identifier"))
+                .into_diagnostic()?,
             project.authority_multiaddr().into_diagnostic()?,
             &caller_identifier,
             credential_retriever_creator,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
@@ -72,7 +72,10 @@ impl InletSessionReplacer {
                         .get_project_by_name(&p)
                         .await
                     {
-                        Some(p.authority_identifier()?)
+                        Some(
+                            p.authority_identifier()
+                                .ok_or(ApiError::core("no authority identifier"))?,
+                        )
                     } else {
                         None
                     }

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -105,6 +105,7 @@ which = "6.0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
+mockito = "1.5.0"
 ockam_macros = { path = "../ockam_macros", version = "^0.34.0" }
 proptest = "1.5.0"
 tempfile = "3.10.1"

--- a/implementations/rust/ockam/ockam_command/src/lease/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/mod.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use miette::IntoDiagnostic;
+use miette::{miette, IntoDiagnostic};
 
 pub use create::CreateCommand;
 pub use list::ListCommand;
@@ -83,7 +83,9 @@ async fn create_project_client(
         .await?;
 
     node.create_project_client(
-        &project.project_identifier().into_diagnostic()?,
+        &project
+            .project_identifier()
+            .ok_or(miette!("The project has no identifier"))?,
         project.project_multiaddr().into_diagnostic()?,
         Some(identity.clone()),
         CredentialsEnabled::On,

--- a/implementations/rust/ockam/ockam_command/src/node/create/background.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/background.rs
@@ -8,7 +8,6 @@ use ockam_api::colors::color_primary;
 use ockam_api::fmt_warn;
 use ockam_api::logs::CurrentSpan;
 use ockam_api::nodes::BackgroundNodeClient;
-use ockam_api::terminal::notification::NotificationHandler;
 use ockam_core::OpenTelemetryContext;
 
 use crate::node::show::get_node_resources;
@@ -47,14 +46,7 @@ impl CreateCommand {
                 color_primary(&node_name)
             ));
         }
-        {
-            let _notification_handler =
-                NotificationHandler::start(&opts.state, opts.terminal.clone());
-            match &self.identity {
-                Some(name) => opts.state.get_named_identity(name).await?,
-                None => opts.state.get_or_create_default_named_identity().await?,
-            };
-        }
+        self.get_or_create_identity(&opts, &self.identity).await?;
 
         // Create node and wait for it to be up
         let cmd_with_trace_context = CreateCommand {

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -227,7 +227,7 @@ impl NodeConfig {
                 .project_enroll
                 .run_in_subprocess(
                     &opts.global_args,
-                    vec![("identity".to_string(), ArgValue::from(identity_name))]
+                    vec![("identity".into(), identity_name.into())]
                         .into_iter()
                         .collect(),
                 )?

--- a/implementations/rust/ockam/ockam_command/src/project/info.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/info.rs
@@ -30,7 +30,7 @@ impl InfoCommand {
     }
 
     pub fn name(&self) -> String {
-        "project info".into()
+        "project information".into()
     }
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -70,7 +70,9 @@ pub async fn get_projects_secure_channels_from_config_lookup(
                 .context(format!("Failed to get project {name}"))?;
             (
                 project.project_multiaddr()?.clone(),
-                project.project_identifier()?,
+                project
+                    .project_identifier()
+                    .ok_or(miette!("The project has no identifier"))?,
             )
         };
 
@@ -162,7 +164,9 @@ async fn check_project_node_accessible(
     spinner_option: Option<ProgressBar>,
 ) -> Result<Project> {
     let project_route = project.project_multiaddr()?;
-    let project_identifier = project.project_identifier()?;
+    let project_identifier = project
+        .project_identifier()
+        .ok_or(miette!("The project has no identifier"))?;
     let project_node = node
         .create_project_client(
             &project_identifier,

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -169,9 +169,7 @@ mod tests {
                         items: vec![(
                             "i2".to_string(),
                             Args {
-                                args: vec![("vault".to_string(), "v2".into())]
-                                    .into_iter()
-                                    .collect(),
+                                args: vec![("vault".into(), "v2".into())].into_iter().collect(),
                             },
                         )]
                         .into_iter()
@@ -192,24 +190,18 @@ mod tests {
                 policies: Some(UnnamedResources::List(vec![
                     Args {
                         args: vec![
-                            ("at".to_string(), "n1".into()),
-                            ("resource".to_string(), "r1".into()),
-                            (
-                                "expression".to_string(),
-                                "(= subject.component \"c1\")".into(),
-                            ),
+                            ("at".into(), "n1".into()),
+                            ("resource".into(), "r1".into()),
+                            ("expression".into(), "(= subject.component \"c1\")".into()),
                         ]
                         .into_iter()
                         .collect(),
                     },
                     Args {
                         args: vec![
-                            ("at".to_string(), "n2".into()),
-                            ("resource".to_string(), "r2".into()),
-                            (
-                                "expression".to_string(),
-                                "(= subject.component \"c2\")".into(),
-                            ),
+                            ("at".into(), "n2".into()),
+                            ("resource".into(), "r2".into()),
+                            ("expression".into(), "(= subject.component \"c2\")".into()),
                         ]
                         .into_iter()
                         .collect(),
@@ -222,20 +214,15 @@ mod tests {
                         (
                             "to1".to_string(),
                             Args {
-                                args: vec![
-                                    ("to".to_string(), "6060".into()),
-                                    ("at".to_string(), "n".into()),
-                                ]
-                                .into_iter()
-                                .collect(),
+                                args: vec![("to".into(), "6060".into()), ("at".into(), "n".into())]
+                                    .into_iter()
+                                    .collect(),
                             },
                         ),
                         (
                             "to2".to_string(),
                             Args {
-                                args: vec![("to".to_string(), "6061".into())]
-                                    .into_iter()
-                                    .collect(),
+                                args: vec![("to".into(), "6061".into())].into_iter().collect(),
                             },
                         ),
                     ]
@@ -250,8 +237,8 @@ mod tests {
                             "ti1".to_string(),
                             Args {
                                 args: vec![
-                                    ("from".to_string(), "6060".into()),
-                                    ("at".to_string(), "n".into()),
+                                    ("from".into(), "6060".into()),
+                                    ("at".into(), "n".into()),
                                 ]
                                 .into_iter()
                                 .collect(),
@@ -260,9 +247,7 @@ mod tests {
                         (
                             "ti2".to_string(),
                             Args {
-                                args: vec![("from".to_string(), "6061".into())]
-                                    .into_iter()
-                                    .collect(),
+                                args: vec![("from".into(), "6061".into())].into_iter().collect(),
                             },
                         ),
                     ]
@@ -274,10 +259,10 @@ mod tests {
                 kafka_inlet: Some(ResourceNameOrMap::RandomlyNamedMap(
                     UnnamedResources::Single(Args {
                         args: vec![
-                            ("from".to_string(), "9092".into()),
-                            ("at".to_string(), "n".into()),
-                            ("to".to_string(), "/project/project_name".into()),
-                            ("port-range".to_string(), "1000-2000".into()),
+                            ("from".into(), "9092".into()),
+                            ("at".into(), "n".into()),
+                            ("to".into(), "/project/project_name".into()),
+                            ("port-range".into(), "1000-2000".into()),
                         ]
                         .into_iter()
                         .collect(),
@@ -288,8 +273,8 @@ mod tests {
                 kafka_outlet: Some(ResourceNameOrMap::RandomlyNamedMap(
                     UnnamedResources::Single(Args {
                         args: vec![
-                            ("bootstrap-server".to_string(), "192.168.1.1:9092".into()),
-                            ("at".to_string(), "n".into()),
+                            ("bootstrap-server".into(), "192.168.1.1:9092".into()),
+                            ("at".into(), "n".into()),
                         ]
                         .into_iter()
                         .collect(),
@@ -376,9 +361,7 @@ mod tests {
                 items: vec![(
                     "db-outlet".to_string(),
                     Args {
-                        args: vec![("to".to_string(), "5432".into())]
-                            .into_iter()
-                            .collect(),
+                        args: vec![("to".into(), "5432".into())].into_iter().collect(),
                     },
                 ),]
                 .into_iter()
@@ -391,9 +374,7 @@ mod tests {
                 items: vec![(
                     "web-inlet".to_string(),
                     Args {
-                        args: vec![("from".to_string(), "4000".into())]
-                            .into_iter()
-                            .collect(),
+                        args: vec![("from".into(), "4000".into())].into_iter().collect(),
                     },
                 ),]
                 .into_iter()
@@ -435,9 +416,9 @@ mod tests {
                     "web-inlet".to_string(),
                     Args {
                         args: vec![
-                            ("from".to_string(), "4000".into()),
-                            ("via".to_string(), "db".into()),
-                            ("allow".to_string(), "component.db".into()),
+                            ("from".into(), "4000".into()),
+                            ("via".into(), "db".into()),
+                            ("allow".into(), "component.db".into()),
                         ]
                         .into_iter()
                         .collect(),
@@ -473,8 +454,8 @@ mod tests {
                     "db-outlet".to_string(),
                     Args {
                         args: vec![
-                            ("to".to_string(), "5432".into()),
-                            ("allow".to_string(), "component.web".into()),
+                            ("to".into(), "5432".into()),
+                            ("allow".into(), "component.web".into()),
                         ]
                         .into_iter()
                         .collect(),

--- a/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
@@ -296,6 +296,30 @@ impl From<&str> for ArgValue {
     }
 }
 
+impl From<String> for ArgValue {
+    fn from(s: String) -> Self {
+        if let Ok(v) = s.parse::<isize>() {
+            return ArgValue::Int(v);
+        }
+        if let Ok(v) = s.parse::<bool>() {
+            return ArgValue::Bool(v);
+        }
+        ArgValue::String(s)
+    }
+}
+
+impl From<bool> for ArgValue {
+    fn from(b: bool) -> Self {
+        ArgValue::Bool(b)
+    }
+}
+
+impl From<isize> for ArgValue {
+    fn from(i: isize) -> Self {
+        ArgValue::Int(i)
+    }
+}
+
 impl Display for ArgValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -42,34 +42,34 @@ impl Resource<CreateCommand> for Node {
             args.insert("name".into(), name);
         }
         if let Some(skip_is_running_check) = self.skip_is_running_check {
-            args.insert("skip-is-running-check".to_string(), skip_is_running_check);
+            args.insert("skip-is-running-check".into(), skip_is_running_check);
         }
         if let Some(foreground) = self.foreground {
-            args.insert("foreground".to_string(), foreground);
+            args.insert("foreground".into(), foreground);
         }
         if let Some(child_process) = self.child_process {
-            args.insert("child-process".to_string(), child_process);
+            args.insert("child-process".into(), child_process);
         }
         if let Some(exit_on_eof) = self.exit_on_eof {
-            args.insert("exit-on-eof".to_string(), exit_on_eof);
+            args.insert("exit-on-eof".into(), exit_on_eof);
         }
         if let Some(tcp_listener_address) = self.tcp_listener_address {
-            args.insert("tcp-listener-address".to_string(), tcp_listener_address);
+            args.insert("tcp-listener-address".into(), tcp_listener_address);
         }
         if let Some(enable_http_server) = self.http_server {
-            args.insert("http-server".to_string(), enable_http_server);
+            args.insert("http-server".into(), enable_http_server);
         }
         if let Some(http_server_port) = self.http_server_port {
-            args.insert("http-server-port".to_string(), http_server_port);
+            args.insert("http-server-port".into(), http_server_port);
         }
         if let Some(identity) = self.identity {
-            args.insert("identity".to_string(), identity);
+            args.insert("identity".into(), identity);
         }
         if let Some(project) = self.project {
-            args.insert("project".to_string(), project);
+            args.insert("project".into(), project);
         }
         if let Some(opentelemetry_context) = self.opentelemetry_context {
-            args.insert("opentelemetry-context".to_string(), opentelemetry_context);
+            args.insert("opentelemetry-context".into(), opentelemetry_context);
         }
         if args.is_empty() {
             return vec![];
@@ -78,7 +78,7 @@ impl Resource<CreateCommand> for Node {
         // Convert the map into a list of cli args
         let mut cmd_args = vec![];
         // Remove "name" from the arguments and use it as a positional argument
-        if let Some(name) = args.remove(Self::NAME_ARG) {
+        if let Some(name) = args.remove(&Self::NAME_ARG.into()) {
             cmd_args.push(name.to_string());
         }
         cmd_args.extend(as_command_args(args));

--- a/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/variables.rs
@@ -34,7 +34,7 @@ impl Variables {
     fn load(&self) -> Result<()> {
         if let Some(vars) = &self.variables {
             for (k, v) in vars {
-                if std::env::var(k).is_ok() {
+                if std::env::var(k.as_str()).is_ok() {
                     warn!("Loading variable '{k}' from environment");
                     eprintln!("{}", fmt_warn!("Loading variable '{k}' from environment"));
                     continue;
@@ -43,7 +43,7 @@ impl Variables {
                 if v.is_empty() {
                     return Err(miette!("Empty value for variable '{k}'"));
                 }
-                std::env::set_var(k, v);
+                std::env::set_var(k.as_str(), v);
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -2,7 +2,7 @@
 
 function orchestrator_setup_suite() {
   export OCKAM_COMMAND_RETRY_COUNT=3
-  export OCKAM_COMMAND_RETRY_DELAY=5s
+  export OCKAM_COMMAND_RETRY_DELAY=1s
 
   setup_python_server
   get_project_data

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -201,3 +201,16 @@ force_kill_node() {
   run_success $OCKAM node create --http-server-port $port
   run_success curl -fsI -m 2 127.0.0.1:$port
 }
+
+@test "node - fail to create node with invalid name" {
+  run_failure "$OCKAM" node create n!
+  run_failure "$OCKAM" node create n.1
+  run_failure "$OCKAM" node create ./config.yaml
+  run_failure "$OCKAM" node create node.yaml
+
+  # The previous will work if the file exists
+    cat <<EOF >"$OCKAM_HOME/node.yaml"
+name: n1
+EOF
+  run_success "$OCKAM" node create "$OCKAM_HOME/node.yaml"
+}

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -86,13 +86,6 @@ force_kill_node() {
   run_success "$OCKAM" node create n
 }
 
-@test "node - fail to create node when not existing identity is passed" {
-  # Background node
-  run_failure "$OCKAM" node create --identity i
-  # Foreground node
-  run_failure "$OCKAM" node create -f --identity i
-}
-
 @test "node - fail to create two foreground nodes with the same name" {
   run_success "$OCKAM" node create n -f &
   sleep 1
@@ -209,7 +202,7 @@ force_kill_node() {
   run_failure "$OCKAM" node create node.yaml
 
   # The previous will work if the file exists
-    cat <<EOF >"$OCKAM_HOME/node.yaml"
+  cat <<EOF >"$OCKAM_HOME/node.yaml"
 name: n1
 EOF
   run_success "$OCKAM" node create "$OCKAM_HOME/node.yaml"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -217,7 +217,7 @@ EOF
   # Create enrollment ticket that can be reused a few times
   $OCKAM project ticket >"$OCKAM_HOME/enrollment.ticket"
 
-    cat <<EOF >"$OCKAM_HOME/config.yaml"
+  cat <<EOF >"$OCKAM_HOME/config.yaml"
 ticket: other.ticket
 name: n2
 identity: i2

--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -5,6 +5,7 @@ rm -rf "$HOME/.bats-tests"
 mkdir -p "$HOME/.bats-tests"
 
 export BATS_TEST_TIMEOUT=300
+export BATS_TEST_RETRIES=2
 
 current_directory=$(dirname "$0")
 


### PR DESCRIPTION
- Add validation for `node create` positional argument (name or conf): we'll now return an error if the node name is not valid (e.g. `node create config.yaml` and the config file doesn't exist.
- Refactor `ArgKey` as a struct instead of a type. This simplifies some data conversions and makes the code more readable
- The command args now have precedence over config values. This means that we now have a lot of combinations to run a node with a config file. For example: `node create n1 --identity i1 --configuration "{name: api-service-inlet}"` will use the name from the command arg, instead of the one defined in the config
- If an identity is passed to `node create`, the identity will be created if it doesn't exist, so that running the command in foreground/background/config modes, the behaviour will be the same