### PR TITLE
ci: Instead of `Docker` use `Nix` to build release

### DIFF
--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -442,9 +442,7 @@ jobs:
         run: cargo install --version 0.2.4 cross
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v2
-        with:
-          nix_version: latest
+        uses: DeterminateSystems/nix-installer-action@033f039e5c752cb1cbc6ac1dd2e59c4ca58adf00
 
       - name: Build NIFs
         run: |
@@ -456,7 +454,7 @@ jobs:
             exit
           fi
 
-          nix develop ./tools/nix#rust --command "cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release  --no-default-features -F aws-lc"
+          nix develop ./tools/nix#rust --command cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release --no-default-features -F aws-lc
 
       - name: List
         run: |

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -431,16 +431,32 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_branch }}
 
-      - name: Install Nix
+      - name: Install Rust toolchain
         run: |
-          sh <(curl -L https://nixos.org/nix/install) --daemon
+          # This will allow us update to rust version indicated in our rust-toolchain.toml file
+          rustup show
+          rustup target add ${{ matrix.job.target }}
 
-      - name: Build NIFs (using Nix)
+      - name: Install Cross
+        if: matrix.job.use-cross == true
+        run: cargo install --version 0.2.4 cross
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v2
+        with:
+          nix_version: latest
+
+      - name: Build NIFs
         run: |
           set -ex
 
-          nix-env -iA nixpkgs.rustup nixpkgs.cargo nixpkgs.nix
-          nix-shell --run "cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release"
+          if [[ '${{ matrix.job.use-cross }}' == 'true' ]]; then
+            # When building using cross use rust crypto (slower) since the cross image doesn't have an up-to-date libclang
+            cross build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release --no-default-features -F rust-crypto
+            exit
+          fi
+
+          nix develop ./tools/nix#rust --command "cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release  --no-default-features -F aws-lc"
 
       - name: List
         run: |

--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Import GPG key
         uses: build-trust/.github/actions/import_gpg@ae127cb92387ed76f24d4d1c6d6bfc2d382f7946
         with:
-          gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
-          gpg_password: '${{ secrets.GPG_PASSPHRASE }}'
-          gpg_name: '${{ secrets.GPG_USER_NAME }}'
-          gpg_email: '${{ secrets.GPG_EMAIL }}'
+          gpg_private_key: "${{ secrets.GPG_PRIVATE_KEY }}"
+          gpg_password: "${{ secrets.GPG_PASSPHRASE }}"
+          gpg_name: "${{ secrets.GPG_USER_NAME }}"
+          gpg_email: "${{ secrets.GPG_EMAIL }}"
 
       - name: Get Release Text
         id: release_version
         env:
-          GIT_TAG: '${{ github.event.inputs.git_tag }}'
+          GIT_TAG: "${{ github.event.inputs.git_tag }}"
         run: |
           cargo install tomlq@0.1.0
           set -x
@@ -163,14 +163,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          release_name: 'Ockam v${{ steps.release_version.outputs.version }}'
-          tag_name: '${{ steps.release_version.outputs.tag_name }}'
-          body_path: 'release_note.md'
+          release_name: "Ockam v${{ steps.release_version.outputs.version }}"
+          tag_name: "${{ steps.release_version.outputs.tag_name }}"
+          body_path: "release_note.md"
           prerelease: true
 
       - name: Echo Link
         run: echo "${{ steps.release_upload_url.outputs.html_url }}"
-
 
   build_release:
     name: Build Binaries
@@ -195,214 +194,209 @@ jobs:
       matrix:
         build: [linux_arm64, linux_86, linux_armv7, macos_silicon, macos_86]
         include:
-        - build: linux_arm64
-          os: ubuntu-22.04
-          toolchain: stable
-          target: aarch64-unknown-linux-musl
-          build_app: false
-          use-cross-build: true
-        - build: linux_armv7
-          os: ubuntu-22.04
-          toolchain: stable
-          target: armv7-unknown-linux-musleabihf
-          use-cross-build: true
-          build_app: false
-        - build: linux_86
-          os: ubuntu-22.04
-          toolchain: stable
-          target: x86_64-unknown-linux-musl
-          use-cross-build: true
-          build_app: false
-        - build: linux_86_gnu
-          os: ubuntu-22.04
-          toolchain: stable
-          target: x86_64-unknown-linux-gnu
-          use-cross-build: false
-          build_app: true
-          build_command: false
-        - build: macos_silicon
-          os: macos-14
-          toolchain: stable
-          target: aarch64-apple-darwin
-          use-cross-build: false
-          build_app: true
-        - build: macos_86
-          os: macos-14
-          toolchain: stable
-          target: x86_64-apple-darwin
-          use-cross-build: false
-          build_app: true
+          - build: linux_arm64
+            os: ubuntu-22.04
+            toolchain: stable
+            target: aarch64-unknown-linux-musl
+            build_app: false
+            use-cross-build: true
+          - build: linux_armv7
+            os: ubuntu-22.04
+            toolchain: stable
+            target: armv7-unknown-linux-musleabihf
+            use-cross-build: true
+            build_app: false
+          - build: linux_86
+            os: ubuntu-22.04
+            toolchain: stable
+            target: x86_64-unknown-linux-musl
+            use-cross-build: true
+            build_app: false
+          - build: linux_86_gnu
+            os: ubuntu-22.04
+            toolchain: stable
+            target: x86_64-unknown-linux-gnu
+            use-cross-build: false
+            build_app: true
+            build_command: false
+          - build: macos_silicon
+            os: macos-14
+            toolchain: stable
+            target: aarch64-apple-darwin
+            use-cross-build: false
+            build_app: true
+          - build: macos_86
+            os: macos-14
+            toolchain: stable
+            target: x86_64-apple-darwin
+            use-cross-build: false
+            build_app: true
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      with:
-        ref: ${{ github.event.inputs.release_branch }}
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          ref: ${{ github.event.inputs.release_branch }}
 
-    - name: Echo Link
-      run: echo "${{ needs.create_release.outputs.upload_url }}"
+      - name: Echo Link
+        run: echo "${{ needs.create_release.outputs.upload_url }}"
 
-    - name: Apple Signing Initialization
-      if: ${{ matrix.os == 'macos-14' }}
-      shell: bash
-      env:
-        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-        BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      run: |
-        set -ex
-        # Switch to xcode 15
-        sudo xcode-select --switch /Applications/Xcode_15.0.app/
+      - name: Apple Signing Initialization
+        if: ${{ matrix.os == 'macos-14' }}
+        shell: bash
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          set -ex
+          # Switch to xcode 15
+          sudo xcode-select --switch /Applications/Xcode_15.0.app/
 
-        # create variables
-        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        PP_PATH=$RUNNER_TEMP/build_pp.provisionprofile
-        KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.provisionprofile
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-        # import certificate and provisioning profile from secrets
-        echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-        echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+          # import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
 
-        # create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-        security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-        # import certificate to keychain
-        security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-        security list-keychain -d user -s $KEYCHAIN_PATH
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
 
-        # apply provisioning profile
-        mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-        cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          # apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
-        # Add keychain path to env
-        echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "$GITHUB_ENV"
+          # Add keychain path to env
+          echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "$GITHUB_ENV"
 
-    - uses: ./.github/actions/build_binaries
-      with:
-        use_cross_build: ${{ matrix.use-cross-build }}
-        toolchain: ${{ matrix.toolchain }}
-        target: ${{ matrix.target }}
-        platform_operating_system: ${{ matrix.os }}
-        build_app: ${{ matrix.build_app }}
+      - uses: ./.github/actions/build_binaries
+        with:
+          use_cross_build: ${{ matrix.use-cross-build }}
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
+          platform_operating_system: ${{ matrix.os }}
+          build_app: ${{ matrix.build_app }}
 
-    - name: Copy Artifacts
-      run: |
-        set -x
+      - name: Copy Artifacts
+        run: |
+          set -x
 
-        cp target/${{ matrix.target }}/release/ockam_command ockam.${{ matrix.target }}
-        echo "ASSET_OCKAM_CLI=ockam.${{ matrix.target }}" >> $GITHUB_ENV
-        if [ -e "implementations/swift/build/Ockam.dmg" ]; then
-          cp "implementations/swift/build/Ockam.dmg" "ockam.app.${{ matrix.target }}.dmg"
-          echo "ASSET_OCKAM_APP_DMG=ockam.app.${{ matrix.target }}.dmg" >> $GITHUB_ENV
-        fi
-        ls $GITHUB_WORKSPACE
+          cp target/${{ matrix.target }}/release/ockam_command ockam.${{ matrix.target }}
+          echo "ASSET_OCKAM_CLI=ockam.${{ matrix.target }}" >> $GITHUB_ENV
+          if [ -e "implementations/swift/build/Ockam.dmg" ]; then
+            cp "implementations/swift/build/Ockam.dmg" "ockam.app.${{ matrix.target }}.dmg"
+            echo "ASSET_OCKAM_APP_DMG=ockam.app.${{ matrix.target }}.dmg" >> $GITHUB_ENV
+          fi
+          ls $GITHUB_WORKSPACE
 
-    - name: Install Cosign
-      uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
-      with:
-        cosign-release: 'v2.0.0'
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
+        with:
+          cosign-release: "v2.0.0"
 
-    - name: Sign Binaries
-      env:
-        PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-        COSIGN_PASSWORD: '${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}'
-      run: |
-        cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_CLI }}" > "${{ env.ASSET_OCKAM_CLI }}.sig"
-        if [ -n "${{ env.ASSET_OCKAM_APP_DMG }}" ]; then
-          cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_APP_DMG }}" > "${{ env.ASSET_OCKAM_APP_DMG }}.sig"
-        fi
+      - name: Sign Binaries
+        env:
+          PRIVATE_KEY: "${{ secrets.COSIGN_PRIVATE_KEY }}"
+          COSIGN_PASSWORD: "${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}"
+        run: |
+          cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_CLI }}" > "${{ env.ASSET_OCKAM_CLI }}.sig"
+          if [ -n "${{ env.ASSET_OCKAM_APP_DMG }}" ]; then
+            cosign sign-blob --yes --key env://PRIVATE_KEY "${{ env.ASSET_OCKAM_APP_DMG }}" > "${{ env.ASSET_OCKAM_APP_DMG }}.sig"
+          fi
 
-    - name: Upload CLI release archive to GitHub
-      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET_OCKAM_CLI }}
-        asset_name: ${{ env.ASSET_OCKAM_CLI }}
-        asset_content_type: application/octet-stream
+      - name: Upload CLI release archive to GitHub
+        uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET_OCKAM_CLI }}
+          asset_name: ${{ env.ASSET_OCKAM_CLI }}
+          asset_content_type: application/octet-stream
 
-    - name: Upload CLI Signature to GitHub
-      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET_OCKAM_CLI }}.sig
-        asset_name: ${{ env.ASSET_OCKAM_CLI }}.sig
-        asset_content_type: application/octet-stream
+      - name: Upload CLI Signature to GitHub
+        uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET_OCKAM_CLI }}.sig
+          asset_name: ${{ env.ASSET_OCKAM_CLI }}.sig
+          asset_content_type: application/octet-stream
 
+      - name: Upload CLI release archive to AWS
+        uses: ./.github/actions/aws_upload
+        with:
+          aws_role: ${{ env.AWS_ROLE }}
+          aws_role_session_name: aws_upload
+          aws_region: ${{ env.AWS_REGION }}
+          bucket_name: ${{ env.BUCKET_NAME }}
+          file_name: ${{ env.ASSET_OCKAM_CLI }}
+          release_version: "v${{ needs.create_release.outputs.version }}"
 
-    - name: Upload CLI release archive to AWS
-      uses: ./.github/actions/aws_upload
-      with:
-        aws_role: ${{ env.AWS_ROLE }}
-        aws_role_session_name: aws_upload
-        aws_region: ${{ env.AWS_REGION }}
-        bucket_name: ${{ env.BUCKET_NAME }}
-        file_name: ${{ env.ASSET_OCKAM_CLI }}
-        release_version: "v${{ needs.create_release.outputs.version }}"
+      - name: Upload CLI Signature to AWS
+        uses: ./.github/actions/aws_upload
+        with:
+          aws_role: ${{ env.AWS_ROLE }}
+          aws_role_session_name: aws_upload
+          aws_region: ${{ env.AWS_REGION }}
+          bucket_name: ${{ env.BUCKET_NAME }}
+          file_name: ${{ env.ASSET_OCKAM_CLI }}.sig
+          release_version: "v${{ needs.create_release.outputs.version }}"
 
+      - name: Upload MacOS App release to GitHub
+        uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+        if: ${{ env.ASSET_OCKAM_APP_DMG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}
+          asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}
+          asset_content_type: application/octet-stream
 
-    - name: Upload CLI Signature to AWS
-      uses: ./.github/actions/aws_upload
-      with:
-        aws_role: ${{ env.AWS_ROLE }}
-        aws_role_session_name: aws_upload
-        aws_region: ${{ env.AWS_REGION }}
-        bucket_name: ${{ env.BUCKET_NAME }}
-        file_name: ${{ env.ASSET_OCKAM_CLI }}.sig
-        release_version: "v${{ needs.create_release.outputs.version }}"
+      - name: Upload MacOS App release Signature to GitHub
+        uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
+        if: ${{ env.ASSET_OCKAM_APP_DMG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
+          asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
+          asset_content_type: application/octet-stream
 
-    - name: Upload MacOS App release to GitHub
-      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
-      if: ${{ env.ASSET_OCKAM_APP_DMG }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}
-        asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}
-        asset_content_type: application/octet-stream
+      - name: Upload MacOS App release to AWS
+        uses: ./.github/actions/aws_upload
+        if: ${{ env.ASSET_OCKAM_APP_DMG }}
+        with:
+          aws_role: ${{ env.AWS_ROLE }}
+          aws_role_session_name: aws_upload
+          aws_region: ${{ env.AWS_REGION }}
+          bucket_name: ${{ env.BUCKET_NAME }}
+          file_name: ${{ env.ASSET_OCKAM_APP_DMG }}
+          release_version: "v${{ needs.create_release.outputs.version }}"
 
-    - name: Upload MacOS App release Signature to GitHub
-      uses: actions/upload-release-asset@ef2adfe8cb8ebfa540930c452c576b3819990faa
-      if: ${{ env.ASSET_OCKAM_APP_DMG }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
-        asset_name: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
-        asset_content_type: application/octet-stream
-
-
-    - name: Upload MacOS App release to AWS
-      uses: ./.github/actions/aws_upload
-      if: ${{ env.ASSET_OCKAM_APP_DMG }}
-      with:
-        aws_role: ${{ env.AWS_ROLE }}
-        aws_role_session_name: aws_upload
-        aws_region: ${{ env.AWS_REGION }}
-        bucket_name: ${{ env.BUCKET_NAME }}
-        file_name: ${{ env.ASSET_OCKAM_APP_DMG }}
-        release_version: "v${{ needs.create_release.outputs.version }}"
-
-
-    - name: Upload MacOS App release Signature to AWS
-      uses: ./.github/actions/aws_upload
-      if: ${{ env.ASSET_OCKAM_APP_DMG }}
-      with:
-        aws_role: ${{ env.AWS_ROLE }}
-        aws_role_session_name: aws_upload
-        aws_region: ${{ env.AWS_REGION }}
-        bucket_name: ${{ env.BUCKET_NAME }}
-        file_name: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
-        release_version: "v${{ needs.create_release.outputs.version }}"
-
+      - name: Upload MacOS App release Signature to AWS
+        uses: ./.github/actions/aws_upload
+        if: ${{ env.ASSET_OCKAM_APP_DMG }}
+        with:
+          aws_role: ${{ env.AWS_ROLE }}
+          aws_role_session_name: aws_upload
+          aws_region: ${{ env.AWS_REGION }}
+          bucket_name: ${{ env.BUCKET_NAME }}
+          file_name: ${{ env.ASSET_OCKAM_APP_DMG }}.sig
+          release_version: "v${{ needs.create_release.outputs.version }}"
 
   build_elixir_nifs:
     name: Build Elixir NIFs
@@ -421,10 +415,14 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
-          - { target: aarch64-apple-darwin        , os: macos-14      }
-          - { target: x86_64-apple-darwin         , os: macos-14      }
+          - {
+              target: aarch64-unknown-linux-gnu,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          - { target: aarch64-apple-darwin, os: macos-14 }
+          - { target: x86_64-apple-darwin, os: macos-14 }
 
     runs-on: ${{ matrix.job.os }}
     steps:
@@ -433,38 +431,16 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_branch }}
 
-      - name: Install Rust toolchain
+      - name: Install Nix
         run: |
-          # This will allow us update to rust version indicated in our rust-toolchain.toml file
-          rustup show
-          rustup target add ${{ matrix.job.target }}
+          sh <(curl -L https://nixos.org/nix/install) --daemon
 
-      - name: Install Cross
-        if: matrix.job.use-cross == true
-        run: cargo install --version 0.2.4 cross
-
-      - shell: bash
-        if: matrix.job.target == 'ubuntu-20.04'
-        run: |
-          set -x
-          use_cross_build=${{ matrix.job.use-cross }}
-          if [[ $use_cross_build != true ]]; then
-            sudo apt update
-            sudo apt -y --no-install-recommends install libclang-dev clang
-          fi
-
-      - name: Build NIFs
+      - name: Build NIFs (using Nix)
         run: |
           set -ex
 
-          if [[ '${{ matrix.job.use-cross }}' == 'true' ]]; then
-            # When building using cross use rust crypto (slower) since the cross image doesn't have an up-to-date libclang
-            cross build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release --no-default-features -F rust-crypto
-            exit
-          fi
-
-          rustup target add ${{ matrix.job.target }}
-          cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release  --no-default-features -F aws-lc
+          nix-env -iA nixpkgs.rustup nixpkgs.cargo nixpkgs.nix
+          nix-shell --run "cargo build --target ${{ matrix.job.target }} -p ockam_rust_elixir_nifs --release"
 
       - name: List
         run: |
@@ -488,12 +464,12 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
         with:
-          cosign-release: 'v2.0.0'
+          cosign-release: "v2.0.0"
 
       - name: Sign NIFs
         env:
-          PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-          COSIGN_PASSWORD: '${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}'
+          PRIVATE_KEY: "${{ secrets.COSIGN_PRIVATE_KEY }}"
+          COSIGN_PASSWORD: "${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}"
         run: |
           cosign sign-blob --yes --key env://PRIVATE_KEY ${{ env.FILE_NAME }} > "${{ env.FILE_NAME }}.sig"
 
@@ -575,12 +551,12 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
         with:
-          cosign-release: 'v2.0.0'
+          cosign-release: "v2.0.0"
 
       - name: Sign Files
         env:
-          PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
-          COSIGN_PASSWORD: '${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}'
+          PRIVATE_KEY: "${{ secrets.COSIGN_PRIVATE_KEY }}"
+          COSIGN_PASSWORD: "${{ secrets.COSIGN_PRIVATE_KEY_PASSWORD }}"
         run: cosign sign-blob --yes --key env://PRIVATE_KEY sha256sums.txt > sha256sums.txt.sig
 
       - name: Upload SHASum File to GitHub


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

<!-- Please describe the current behavior of the code before the changes in this pull request are applied. -->
Currently, we build ockam release assets (Nif build) using our [Docker builder image](https://github.com/build-trust/ockam/blob/f2e399804652c8afe0ffaa82feedb94ebde743a0/.github/workflows/release-binaries.yml#L352-L447),

## Proposed changes

 deprecate usage of docker and use Nix instead
Closes #5943 