### PR TITLE
ci(rust): Add get started examples back to tests

### DIFF
--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -1,0 +1,31 @@
+name: Examples Test
+
+on:
+  push:
+    branches: develop
+  pull_request:
+    branches: develop
+
+jobs:
+  test:
+    name: tcp inlet and outlet test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
+
+      - name: Run Cargo test
+        working-directory: ./examples/rust/tcp_inlet_and_outlet
+        run: |
+          cargo test -- --test-threads=1 --nocapture


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Current behavior

Currently get started examples test are not present in the github workflows...

## Proposed changes

<!-- Please describe the changes proposed in this pull request. -->
<!-- If this pull request resolves an already recorded bug or a feature request, please add a link to that issue. -->
Added test to workflow.
Port clash issue (solved): https://github.com/build-trust/ockam/pull/8304
Closes #4015