### PR TITLE
fix(rust): force node termination on bats test

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -209,7 +209,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port" --via "$relay_name"
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 
-  $OCKAM node delete blue --yes
+  $OCKAM node delete blue --yes --force
   run_failure curl -sfI -m 3 "127.0.0.1:$port"
 
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"


### PR DESCRIPTION
the blue node was not being terminated, leading to bats test failing latter on. For now, just force the killing of the node.

It's possible to reproduce the `ockam node delete` returning success, while the node is actually left alive:

this creates a node,  setup a outlet _and_ a relay to orchestrator on it.   Then tries to delete the node.   Operation success but node is left running.   (the addition of the outlet and relay seems to be related to the node not being terminated).  
```
pablo@Pablos-MacBook-Pro ockam % target/debug/ockam node  create blue --tcp-listener-address 127.0.0.1:52111
  ✔ Created a new Node named blue
  ✔ Marked blue as your default Node, on this machine

    To see more details on this Node, run: ockam node show blue
pablo@Pablos-MacBook-Pro ockam %  target/debug/ockam tcp-outlet create --at /node/blue --to 127.0.0.1:19999

  ✔ Created a new TCP Outlet in the Node blue at /service/outlet bound to 127.0.0.1:19999

    You may want to take a look at the ockam relay, ockam tcp-inlet, ockam policy commands next
pablo@Pablos-MacBook-Pro ockam % target/debug/ockam relay create test_relay_bats --to /node/blue
    Creating Relay...

  ✔ Now relaying messages from /project/default/service/forward_to_test_relay_bats → /node/blue/service/a74ad0af90f4fc1ae7444b3305606c76
pablo@Pablos-MacBook-Pro ockam % ps -ax | grep ockam
52621 ttys000    0:00.75 /Users/pablo/src/ockam/target/debug/ockam -vv node create --tcp-listener-address 127.0.0.1:52111 --foreground --child-process --opentelemetry-context {} blue
52644 ttys000    0:00.00 grep ockam
pablo@Pablos-MacBook-Pro ockam % target/debug/ockam node delete blue                                        
  ! Are you sure you want to proceed? yes
  ⠦ Waiting for node blue to stop                                                                                                                                                              ✔ The node with name blue has been deleted
pablo@Pablos-MacBook-Pro ockam % ps -ax | grep ockam                 
52621 ttys000    0:00.80 /Users/pablo/src/ockam/target/debug/ockam -vv node create --tcp-listener-address 127.0.0.1:52111 --foreground --child-process --opentelemetry-context {} blue
52651 ttys000    0:00.00 grep ockam
pablo@Pablos-MacBook-Pro ockam % target/debug/ockam node list                                               
  > No nodes found on this system.
pablo@Pablos-MacBook-Pro ockam % ps -ax | grep ockam                 
52621 ttys000    0:00.85 /Users/pablo/src/ockam/target/debug/ockam -vv node create --tcp-listener-address 127.0.0.1:52111 --foreground --child-process --opentelemetry-context {} blue
```