### PR TITLE
fix influxdb example

### DIFF
--- a/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/metrics_corp/run.sh
+++ b/examples/command/portals/databases/influxdb/amazon_timestream/aws_cli/metrics_corp/run.sh
@@ -81,7 +81,7 @@ run() {
     aws ec2 wait instance-running --instance-ids "$instance_id"
     ip=$(aws ec2 describe-instances --instance-ids "$instance_id" --query 'Reservations[0].Instances[0].PublicIpAddress')
 
-    scp -o StrictHostKeyChecking=no -i ./key.pem "ec2-user@$ip:token.txt" ../datastream_corp/token.txt
+    while ! scp -o StrictHostKeyChecking=no -i ./key.pem "ec2-user@$ip:token.txt" ../datastream_corp/token.txt; do sleep 10; done
 }
 
 cleanup() {


### PR DESCRIPTION
We generate a token.txt file during metrics_corp EC2 initialisation, we need to ensure we only request for the token file when it's generated else the example fails, this PR ensures that we continuously request for the token file till it's generated.