### PR TITLE
fix(rust): graceful stop of a node in the command

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
@@ -205,7 +205,7 @@ impl NodesRepository for NodesSqlxDatabase {
     }
 
     async fn set_no_node_pid(&self, node_name: &str) -> Result<()> {
-        let query = query("UPDATE node SET pid=NULL WHERE name = $1 ").bind(node_name);
+        let query = query("UPDATE node SET pid=NULL WHERE name = $1").bind(node_name);
         query.execute(&*self.database.pool).await.void()
     }
 

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -216,7 +216,6 @@ impl CommandGlobalOpts {
     /// Shutdown resources
     pub fn shutdown(&self) {
         if let Some(tracing_guard) = self.tracing_guard.clone() {
-            tracing_guard.force_flush();
             tracing_guard.shutdown();
         };
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -259,7 +259,7 @@ impl NodeConfig {
             // This prevents the current process from handling the signal and, for example,
             // add a newline to the terminal before the child process has finished writing its output.
         })
-        .expect("Error setting Ctrl+C handler");
+        .expect("Error setting exit signal handler");
 
         // Run the other sections
         let node_name = Some(node_name);

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -1,3 +1,4 @@
+use std::process::exit;
 use std::sync::Arc;
 
 use colorful::Colorful;
@@ -158,15 +159,16 @@ impl CreateCommand {
         .await?;
 
         // Clean up and exit
-        opts.shutdown();
-        let _ = opts.state.stop_node(&node_name, true).await;
         let _ = ctx.stop().await;
-        if !self.foreground_args.child_process {
+        let _ = opts.state.stop_node(&node_name, true).await;
+        if self.foreground_args.child_process {
+            opts.shutdown();
+            exit(0);
+        } else {
             opts.terminal
                 .write_line(fmt_ok!("Node stopped successfully"))?;
+            Ok(())
         }
-
-        Ok(())
     }
 
     async fn start_services(&self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -101,12 +101,7 @@ where
             .await
             .expect("Embedded node child ctx can't be created");
         let result = f(child_ctx).await;
-        let result = if result.is_err() {
-            ctx.stop().await?;
-            result
-        } else {
-            result
-        };
+        let _ = ctx.stop().await;
         result.map_err(|e| {
             ockam_core::Error::new(
                 ockam_core::errcode::Origin::Executor,
@@ -234,7 +229,6 @@ pub fn print_deprecated_warning(opts: &CommandGlobalOpts, old: &str, new: &str) 
 
 #[cfg(test)]
 mod tests {
-
     use std::str::FromStr;
 
     use super::*;


### PR DESCRIPTION
- Refactor foreground node's graceful shutdown: when the exit signal is received, the tracing guard and the ockam context are shutdown as before. But now, if the node was running as a subprocess, it will exit right away; if not, it will return to handle the exit in the current process. This is done to prevent executing the [`stop_node` function](https://github.com/build-trust/ockam/blob/261885f6c572bb349bc2745a52e084fddb9d5d72/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs#L183) twice.
- Another important change in the node shutdown is that the call to `tracing_guard.force_flush()` (part of the `opts.shutdown()` function) was hanging the process, which was preventing the process from exiting. Removing this call shouldn't have any effect, since `tracing_guard.shutdown()` should export any pending spans and the logger/tracer providers will shutdown when dropped. Also, the `opts.shutdown()` is now called when exiting the subprocess. If the command is run in the main process, that function [is called at the top layer](https://github.com/build-trust/ockam/blob/36232453f327c39b9dc00a44289a319d46b3ec8c/implementations/rust/ockam/ockam_command/src/command.rs#L123).
- The `authority create` command was not blocking on an exit signal. As a side effect of the previous changes, it was exiting right after starting. Now this command also has calls the `wait_for_exit_signal` function and handles the graceful shutdown just as the `node create` command.