### PR TITLE
influxdb inlet (auth proxy)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,6 +4688,7 @@ dependencies = [
  "hex",
  "home",
  "http-body-util",
+ "httparse",
  "hyper 1.4.1",
  "hyper-util",
  "indexmap 2.5.0",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -59,6 +59,7 @@ gethostname = "0.5.0"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 home = "0.5"
 http-body-util = "0"
+httparse = "1.9.4"
 hyper = { version = "1", default-features = false, features = ["server", "http1"] }
 hyper-util = { version = "0", default-features = false, features = ["server", "http1", "tokio"] }
 indicatif = "0.17"

--- a/implementations/rust/ockam/ockam_api/src/http_auth/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/http_auth/mod.rs
@@ -1,0 +1,366 @@
+use std::io::Write;
+
+use httparse::{Header, Status};
+use ockam_core::async_trait;
+use ockam_node::Context;
+use ockam_transport_tcp::{Direction, PortalInterceptor, PortalInterceptorFactory};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use ockam::errcode::{Kind, Origin};
+
+use tracing::{debug, error};
+
+use crate::TokenLeaseRefresher;
+
+#[derive(Debug, Clone, PartialEq)]
+enum RequestState {
+    ParsingHeader(Option<Vec<u8>>),
+    ParsingChunkedHeader(Option<Vec<u8>>),
+    RemainingInChunk(usize),
+    RemainingBody(usize),
+}
+
+struct HttpAuthInterceptorState {
+    state: RequestState,
+}
+
+struct HttpAuthInterceptor {
+    state: Arc<Mutex<HttpAuthInterceptorState>>,
+    token_refresher: TokenLeaseRefresher,
+}
+
+impl HttpAuthInterceptor {
+    fn new(token_refresher: TokenLeaseRefresher) -> Self {
+        let state = HttpAuthInterceptorState {
+            state: RequestState::ParsingHeader(None),
+        };
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            token_refresher,
+        }
+    }
+}
+
+pub struct HttpAuthInterceptorFactory {
+    token_refresher: TokenLeaseRefresher,
+}
+
+impl HttpAuthInterceptorFactory {
+    pub fn new(token_refresher: TokenLeaseRefresher) -> Self {
+        Self { token_refresher }
+    }
+}
+
+impl PortalInterceptorFactory for HttpAuthInterceptorFactory {
+    fn create(&self) -> Arc<dyn PortalInterceptor> {
+        Arc::new(HttpAuthInterceptor::new(self.token_refresher.clone()))
+    }
+}
+
+fn attach_auth_token_and_serialize_into(
+    req: &httparse::Request,
+    token: &str,
+    buffer: &mut Vec<u8>,
+) {
+    debug!("Serializing http req header");
+    write!(
+        buffer,
+        "{} {} HTTP/1.{}\r\n",
+        req.method.unwrap(),
+        req.path.unwrap(),
+        req.version.unwrap()
+    )
+    .unwrap();
+
+    write!(buffer, "Authorization: Token {}\r\n", token).unwrap();
+    for h in &*req.headers {
+        if !h.name.eq_ignore_ascii_case("Authorization") {
+            write!(buffer, "{}: ", h.name).unwrap();
+            buffer.extend_from_slice(h.value);
+            buffer.extend_from_slice(b"\r\n");
+        }
+    }
+    buffer.extend_from_slice(b"\r\n");
+}
+
+fn body_state(method: &str, headers: &[Header]) -> ockam_core::Result<RequestState> {
+    match method.to_uppercase().as_str() {
+        "POST" | "PUT" => {
+            for h in headers {
+                if h.name.eq_ignore_ascii_case("Content-Length") {
+                    if let Ok(str) = std::str::from_utf8(h.value) {
+                        return str.parse().map(RequestState::RemainingBody).map_err(|e| {
+                            ockam_core::Error::new(Origin::Transport, Kind::Invalid, e)
+                        });
+                    }
+                } else if h.name.eq_ignore_ascii_case("Transfer-Encoding")
+                    && String::from_utf8(h.value.to_vec()).is_ok_and(|s| s.contains("chunked"))
+                {
+                    return Ok(RequestState::ParsingChunkedHeader(None));
+                }
+            }
+            // Not content-length, no chunked encoding, fail.
+            Err(ockam_core::Error::new(
+                Origin::Transport,
+                Kind::Invalid,
+                "No Content-Length nor chunked Transfer-Encoding",
+            ))
+        }
+        _ => Ok(RequestState::ParsingHeader(None)),
+    }
+}
+
+impl RequestState {
+    /* Parse the incoming data,  attaching an Authorization header token to it.
+     * data is received in chunks, and there is no warranty on what we get on each:
+     * incomplete requests,  multiple requests, etc.
+     */
+    fn process_http_buffer(&mut self, buf: &[u8], token: &str) -> ockam_core::Result<Vec<u8>> {
+        let mut acc = Vec::with_capacity(buf.len());
+        let mut cursor = buf;
+        loop {
+            if cursor.is_empty() {
+                return Ok(acc);
+            }
+            match self {
+                RequestState::ParsingHeader(prev) => {
+                    let (to_parse, prev_size): (&[u8], usize) = if let Some(b) = prev {
+                        let prev_size = b.len();
+                        b.extend_from_slice(cursor);
+                        (b, prev_size)
+                    } else {
+                        (cursor, 0usize)
+                    };
+                    let mut headers = [httparse::EMPTY_HEADER; 64];
+                    let mut req = httparse::Request::new(&mut headers);
+                    match req.parse(to_parse) {
+                        Ok(httparse::Status::Partial) if prev_size == 0 => {
+                            // No previous buffered, need to copy and own the unparsed data
+                            *self = RequestState::ParsingHeader(Some(cursor.to_vec()));
+                            return Ok(acc);
+                        }
+                        Ok(httparse::Status::Partial) => {
+                            // There was a previous buffer, and we already added the newly data to it
+                            return Ok(acc);
+                        }
+                        Ok(httparse::Status::Complete(body_offset)) => {
+                            cursor = &cursor[body_offset - prev_size..];
+                            attach_auth_token_and_serialize_into(&req, token, &mut acc);
+                            *self = body_state(req.method.unwrap(), req.headers)?;
+                        }
+                        Err(e) => {
+                            error!("Error parsing header: {:?}", e);
+                            return Err(ockam_core::Error::new(
+                                Origin::Transport,
+                                Kind::Invalid,
+                                e,
+                            ));
+                        }
+                    }
+                }
+                RequestState::RemainingBody(remaining) => {
+                    if *remaining <= cursor.len() {
+                        acc.extend_from_slice(&cursor[..*remaining]);
+                        cursor = &cursor[*remaining..];
+                        *self = RequestState::ParsingHeader(None);
+                    } else {
+                        acc.extend_from_slice(cursor);
+                        *remaining -= cursor.len();
+                        return Ok(acc);
+                    }
+                }
+                RequestState::ParsingChunkedHeader(prev) => {
+                    let (to_parse, prev_size): (&[u8], usize) = if let Some(b) = prev {
+                        let prev_size = b.len();
+                        b.extend_from_slice(cursor);
+                        (b, prev_size)
+                    } else {
+                        (cursor, 0usize)
+                    };
+                    match httparse::parse_chunk_size(to_parse) {
+                        Ok(Status::Complete((2, 0))) => {
+                            // this is just a final \r\n.  The spec said it should end in a 0-sized
+                            // chunk.. but having seen this on the wild as well.
+                            acc.extend_from_slice(&to_parse[..2]);
+                            cursor = &cursor[2 - prev_size..];
+                            *self = RequestState::ParsingHeader(None);
+                        }
+                        Ok(Status::Complete((3, 0))) => {
+                            // this is just a proper 0\r\n final chunk.
+                            acc.extend_from_slice(&to_parse[..3]);
+                            cursor = &cursor[3 - prev_size..];
+                            // There must be a final \r\n.  And no more chunks,
+                            // so just reuse the RemainingBody state for this
+                            *self = RequestState::RemainingBody(2);
+                        }
+                        Ok(Status::Complete((pos, chunk_size))) => {
+                            acc.extend_from_slice(&to_parse[..pos]);
+                            cursor = &cursor[pos - prev_size..];
+                            let complete_size = chunk_size + 2; //chunks ends in \r\n
+                            *self =
+                                RequestState::RemainingInChunk(complete_size.try_into().unwrap());
+                        }
+                        Ok(Status::Partial) if prev_size == 0 => {
+                            // No previous buffered, need to copy and own the unparsed data
+                            *self = RequestState::ParsingChunkedHeader(Some(cursor.to_vec()));
+                            return Ok(acc);
+                        }
+                        Ok(Status::Partial) => {
+                            // There was a previous buffer, and we already added the newly data to it
+                            return Ok(acc);
+                        }
+                        Err(e) => {
+                            error!("Error parsing chunk size: {:?}.  Buffer: {:?}", e, prev);
+                            return Err(ockam_core::Error::new(
+                                Origin::Transport,
+                                Kind::Invalid,
+                                format!("Can't parse chunked body {:?}", e),
+                            ));
+                        }
+                    }
+                }
+                RequestState::RemainingInChunk(size) => {
+                    if cursor.len() >= *size {
+                        acc.extend_from_slice(&cursor[..*size]);
+                        cursor = &cursor[*size..];
+                        *self = RequestState::ParsingChunkedHeader(None);
+                    } else {
+                        acc.extend_from_slice(cursor);
+                        *size -= cursor.len();
+                        return Ok(acc);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PortalInterceptor for HttpAuthInterceptor {
+    async fn intercept(
+        &self,
+        _context: &mut Context,
+        direction: Direction,
+        buffer: &[u8],
+    ) -> ockam_core::Result<Option<Vec<u8>>> {
+        match direction {
+            Direction::FromOutletToInlet => ockam_core::Result::Ok(Some(buffer.to_vec())),
+
+            Direction::FromInletToOutlet => {
+                let mut guard = self.state.lock().await;
+                let token = self.token_refresher.get_token().await;
+                if token.is_none() {
+                    error!("No authorization token available");
+                }
+                let out = guard
+                    .state
+                    .process_http_buffer(buffer, &token.unwrap_or_default())?;
+                Ok(Some(out))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REQ: &str = "POST / HTTP/1.1\r\n\
+Host: www.example.com\r\n\
+User-Agent: Mozilla/5.0\r\n\
+Accept-Encoding: gzip, deflate, br\r\n\
+Transfer-Encoding: gzip, chunked\r\n\r\n\
+4\r\nWiki\r\n7\r\npedia i\r\n0\r\n\r\n";
+
+    const TOKEN: &str = "SAMPLE-TOKEN";
+
+    const EXPECTED: &str = "POST / HTTP/1.1\r\n\
+Authorization: Token SAMPLE-TOKEN\r\n\
+Host: www.example.com\r\n\
+User-Agent: Mozilla/5.0\r\n\
+Accept-Encoding: gzip, deflate, br\r\n\
+Transfer-Encoding: gzip, chunked\r\n\r\n\
+4\r\nWiki\r\n7\r\npedia i\r\n0\r\n\r\n";
+
+    #[test]
+    fn parse_post_with_chunked_transfers() {
+        let mut data = Vec::new();
+        data.extend_from_slice(REQ.as_bytes());
+        data.extend_from_slice(REQ.as_bytes());
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(
+                String::from_utf8(result).unwrap(),
+                EXPECTED.to_owned() + EXPECTED
+            );
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+
+    #[test]
+    fn parse_post_with_content_length() {
+        let req = "POST /test HTTP/1.1\r\n\
+Host: foo.example\r\n\
+Content-Type: application/x-www-form-urlencoded\r\n\
+Content-Length: 27\r\n\r\n\
+field1=value1&field2=value2";
+        let expected_r = format!(
+            "POST /test HTTP/1.1\r\n\
+Authorization: Token {}\r\n\
+Host: foo.example\r\n\
+Content-Type: application/x-www-form-urlencoded\r\n\
+Content-Length: 27\r\n\r\n\
+field1=value1&field2=value2",
+            TOKEN
+        );
+
+        let data = [req.as_bytes(), req.as_bytes()].concat();
+        let expected = [expected_r.as_bytes(), expected_r.as_bytes()].concat();
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(
+                String::from_utf8(result).unwrap(),
+                String::from_utf8(expected.clone()).unwrap()
+            );
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+
+    #[test]
+    fn parse_get_requests() {
+        let req = "GET /home/user/example.txt HTTP/1.1\r\n\r\n";
+        let mut data = Vec::new();
+        data.extend_from_slice(req.as_bytes());
+        data.extend_from_slice(req.as_bytes());
+
+        let mut expected = format!(
+            "GET /home/user/example.txt HTTP/1.1\r\nAuthorization: Token {}\r\n\r\n",
+            TOKEN
+        );
+        expected = expected.clone() + &expected;
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(String::from_utf8(result).unwrap(), expected);
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/mod.rs
@@ -1,4 +1,6 @@
 #[allow(clippy::module_inception)]
 mod influxdb_token_lease;
+mod token_lease_refresher;
 
 pub use influxdb_token_lease::*;
+pub use token_lease_refresher::*;

--- a/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/token_lease_refresher.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb_token_lease/token_lease_refresher.rs
@@ -1,0 +1,131 @@
+use chrono::DateTime;
+use ockam::{compat::time::now, Address, Mailboxes};
+use ockam_core::{api::Error, AllowAll, DenyAll};
+use ockam_node::Context;
+use std::{cmp::max, sync::Arc, time::Duration};
+use tokio::sync::RwLock;
+
+use crate::{
+    cloud::{CredentialsEnabled, ProjectNodeClient},
+    nodes::InMemoryNode,
+    InfluxDbTokenLease,
+};
+
+// The default timeouts are too high.  Set shorter timeouts, so if
+// the project is unresponsible or connection got lost for some reason
+// (like in a project restart), it recover faster.
+const SECURE_CHANNEL_TIMEOUT: Duration = Duration::from_secs(10);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Clone)]
+pub struct TokenLeaseRefresher {
+    token: Arc<RwLock<Option<String>>>,
+}
+
+impl TokenLeaseRefresher {
+    pub async fn new(
+        ctx: &Context,
+        node_manager: Arc<InMemoryNode>,
+    ) -> Result<TokenLeaseRefresher, Error> {
+        let token = Arc::new(RwLock::new(None));
+        let project = node_manager
+            .cli_state
+            .projects()
+            .get_default_project()
+            .await
+            .map_err(|e| {
+                Error::new_without_path().with_message(format!("No default project {}", e))
+            })?;
+        let project_identifier = project
+            .project_identifier()
+            .ok_or(Error::new_without_path().with_message("Project not configured"))?;
+        let project_multiaddr = project.project_multiaddr().map_err(|e| {
+            Error::new_without_path()
+                .with_message(format!("Project multiaddr not configured {:}", e))
+        })?;
+        let identity_name = node_manager
+            .cli_state
+            .get_default_identity_name()
+            .await
+            .map_err(|e| {
+                Error::new_without_path().with_message(format!("Error retrieving identity {:}", e))
+            })?;
+        let caller_identifier = node_manager
+            .cli_state
+            .get_identifier_by_name(&identity_name)
+            .await
+            .map_err(|e| {
+                Error::new_without_path()
+                    .with_message(format!("Error retrieving identifier {:}", e))
+            })?;
+
+        let project_client = node_manager
+            .make_project_node_client(
+                &project_identifier,
+                project_multiaddr,
+                &caller_identifier,
+                CredentialsEnabled::On,
+            )
+            .await
+            .map_err(|e| {
+                Error::new_without_path()
+                    .with_message(format!("Error creating project client {:}", e))
+            })?
+            .with_request_timeout(&REQUEST_TIMEOUT)
+            .with_secure_channel_timeout(&SECURE_CHANNEL_TIMEOUT);
+        let mailboxes = Mailboxes::main(
+            Address::random_tagged("LeaseRetriever"),
+            Arc::new(DenyAll),
+            Arc::new(AllowAll),
+        );
+        let new_ctx = ctx.new_detached_with_mailboxes(mailboxes).await?;
+
+        let token_clone = token.clone();
+        ockam_node::spawn(async move {
+            // TODO should it just loop again?
+            if let Err(err) = refresh_loop(token_clone, new_ctx, project_client).await {
+                error!("Token refresher terminated with error: {:}", err);
+            }
+        });
+        Ok(Self { token })
+    }
+
+    pub async fn get_token(&self) -> Option<String> {
+        self.token.read().await.clone()
+    }
+}
+
+async fn refresh_loop(
+    token: Arc<RwLock<Option<String>>>,
+    ctx: Context,
+    project_client: ProjectNodeClient,
+) -> Result<(), Error> {
+    loop {
+        debug!("refreshing token");
+        let token_result = project_client.create_token(&ctx).await;
+        let now_t = now()?;
+        let wait_secs = match token_result {
+            Ok(new_token) => {
+                let expires = DateTime::parse_from_rfc3339(&new_token.expires).map_err(|e| {
+                Error::new_without_path()
+                    .with_message(format!("Can't parse the expiration date for the just created token. Something is broken {:}", e))
+                })?;
+                let expires_unix = expires.timestamp() as u64;
+                let duration = expires_unix - now_t;
+
+                info!("Auth Token obtained expires at {}", new_token.expires);
+                let mut t = token.write().await;
+                *t = Some(new_token.token);
+                // We request a new token once reaching half its duration, with a minimum
+                // of 5 seconds.
+                max(duration / 2, 5)
+            }
+            Err(err) => {
+                warn!("Error retrieving token {:}", err);
+                15
+            }
+        };
+        debug!("waiting for {} seconds before refreshing token", wait_secs);
+        ctx.sleep_long_until(now_t + wait_secs).await;
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/lib.rs
+++ b/implementations/rust/ockam/ockam_api/src/lib.rs
@@ -28,6 +28,7 @@ pub mod echoer;
 pub mod enroll;
 pub mod error;
 pub mod hop;
+pub mod http_auth;
 pub mod kafka;
 pub mod minicbor_url;
 pub mod nodes;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -36,28 +36,27 @@ pub struct CreateInlet {
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
     #[n(4)] pub(crate) authorized: Option<Identifier>,
-    /// A prefix route that will be applied before outlet_addr, and won't be used
-    /// to monitor the state of the connection
-    #[n(5)] pub(crate) prefix_route: Route,
-    /// A suffix route that will be applied after outlet_addr, and won't be used
-    /// to monitor the state of the connection
-    #[n(6)] pub(crate) suffix_route: Route,
     /// The maximum duration to wait for an outlet to be available
-    #[n(7)] pub(crate) wait_for_outlet_duration: Option<Duration>,
+    #[n(5)] pub(crate) wait_for_outlet_duration: Option<Duration>,
     /// The expression for the access control policy for this inlet.
     /// If not set, the policy set for the [TCP inlet resource type](ockam_abac::ResourceType::TcpInlet)
     /// will be used.
-    #[n(8)] pub(crate) policy_expression: Option<PolicyExpression>,
+    #[n(6)] pub(crate) policy_expression: Option<PolicyExpression>,
     /// Create the inlet and wait for the outlet to connect
-    #[n(9)] pub(crate) wait_connection: bool,
+    #[n(7)] pub(crate) wait_connection: bool,
     /// The identifier to be used to create the secure channel.
     /// If not set, the node's identifier will be used.
-    #[n(10)] pub(crate) secure_channel_identifier: Option<Identifier>,
+    #[n(8)] pub(crate) secure_channel_identifier: Option<Identifier>,
     /// Enable UDP NAT puncture.
-    #[n(11)] pub enable_udp_puncture: bool,
+    #[n(9)] pub enable_udp_puncture: bool,
     /// Disable fallback to TCP.
     /// TCP won't be used to transfer data between the Inlet and the Outlet.
-    #[n(12)] pub disable_tcp_fallback: bool,
+    #[n(10)] pub disable_tcp_fallback: bool,
+
+    /// If enabled it instruct the creation of HTTP inlet, that is, TCP inlet +
+    /// a http interceptor that modify incoming requests, adding to them an Authorization
+    /// token.
+    #[n(11)] pub is_http_auth_inlet: bool,
 }
 
 impl CreateInlet {
@@ -66,25 +65,23 @@ impl CreateInlet {
         listen: HostnamePort,
         to: MultiAddr,
         alias: String,
-        prefix_route: Route,
-        suffix_route: Route,
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        is_http_auth_inlet: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
             outlet_addr: to,
             alias,
             authorized: None,
-            prefix_route,
-            suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
             wait_connection,
             secure_channel_identifier: None,
             enable_udp_puncture,
             disable_tcp_fallback,
+            is_http_auth_inlet,
         }
     }
 
@@ -93,26 +90,24 @@ impl CreateInlet {
         listen: HostnamePort,
         to: MultiAddr,
         alias: String,
-        prefix_route: Route,
-        suffix_route: Route,
         auth: Option<Identifier>,
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        is_http_auth_inlet: bool,
     ) -> Self {
         Self {
             listen_addr: listen,
             outlet_addr: to,
             alias,
             authorized: auth,
-            prefix_route,
-            suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
             wait_connection,
             secure_channel_identifier: None,
             enable_udp_puncture,
             disable_tcp_fallback,
+            is_http_auth_inlet,
         }
     }
 
@@ -142,14 +137,6 @@ impl CreateInlet {
 
     pub fn alias(&self) -> String {
         self.alias.clone()
-    }
-
-    pub fn prefix_route(&self) -> &Route {
-        &self.prefix_route
-    }
-
-    pub fn suffix_route(&self) -> &Route {
-        &self.suffix_route
     }
 
     pub fn wait_for_outlet_duration(&self) -> Option<Duration> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
@@ -1,7 +1,7 @@
 use ockam::identity::Identifier;
 use ockam_abac::PolicyExpression;
 use ockam_core::api::{Reply, Request};
-use ockam_core::{async_trait, route};
+use ockam_core::async_trait;
 use ockam_multiaddr::proto::Project as ProjectProto;
 use ockam_multiaddr::{MultiAddr, Protocol};
 use ockam_node::Context;
@@ -27,6 +27,7 @@ impl Inlets for BackgroundNodeClient {
         secure_channel_identifier: &Option<Identifier>,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        is_http_auth_inlet: bool,
     ) -> miette::Result<Reply<InletStatus>> {
         let request = {
             let via_project = outlet_addr.matches(0, &[ProjectProto::CODE.into()]);
@@ -35,23 +36,21 @@ impl Inlets for BackgroundNodeClient {
                     listen_addr.clone(),
                     outlet_addr.clone(),
                     alias.into(),
-                    route![],
-                    route![],
                     wait_connection,
                     enable_udp_puncture,
                     disable_tcp_fallback,
+                    is_http_auth_inlet,
                 )
             } else {
                 CreateInlet::to_node(
                     listen_addr.clone(),
                     outlet_addr.clone(),
                     alias.into(),
-                    route![],
-                    route![],
                     authorized_identifier.clone(),
                     wait_connection,
                     enable_udp_puncture,
                     disable_tcp_fallback,
+                    is_http_auth_inlet,
                 )
             };
             if let Some(e) = policy_expression.as_ref() {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
@@ -25,6 +25,7 @@ pub trait Inlets {
         secure_channel_identifier: &Option<Identifier>,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        is_http_auth_inlet: bool,
     ) -> miette::Result<Reply<InletStatus>>;
 
     async fn show_inlet(&self, ctx: &Context, alias: &str) -> miette::Result<Reply<InletStatus>>;

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -226,6 +226,7 @@ impl AppState {
                 &None,
                 false,
                 false,
+                false,
             )
             .await
             .map_err(|err| {

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/mod.rs
@@ -1,0 +1,40 @@
+use clap::{Args, Subcommand};
+
+use create::CreateCommand;
+
+use crate::{docs, Command, CommandGlobalOpts};
+
+pub(crate) mod create;
+
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+
+/// Manage InfluxDB Inlets
+#[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+)]
+pub struct InfluxDBInletCommand {
+    #[command(subcommand)]
+    pub subcommand: InfluxDBInletSubCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum InfluxDBInletSubCommand {
+    Create(CreateCommand),
+}
+
+impl InfluxDBInletCommand {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        match self.subcommand {
+            InfluxDBInletSubCommand::Create(c) => c.run(opts),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match &self.subcommand {
+            InfluxDBInletSubCommand::Create(c) => c.name(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/static/long_about.txt
@@ -1,0 +1,1 @@
+A Http inlet is a way of defining where a node should be listening for connections, and where it should forward that traffic to. It is one end (tcp-outlet being the other) of a portal, which receives Http data, attach an authorization token header to it, chunks and wraps them into Ockam Routing messages and sends them along the supplied route.

--- a/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
@@ -1,0 +1,1 @@
+pub mod inlet;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -78,3 +78,5 @@ pub mod value_parsers;
 mod vault;
 mod version;
 mod worker;
+
+mod influxdb;

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -118,6 +118,8 @@ pub struct NodeConfig {
     #[serde(flatten)]
     pub tcp_inlets: TcpInlets,
     #[serde(flatten)]
+    pub influxdb_inlets: InfluxDBInlets,
+    #[serde(flatten)]
     pub kafka_inlet: KafkaInlet,
     #[serde(flatten)]
     pub kafka_outlet: KafkaOutlet,
@@ -268,6 +270,7 @@ impl NodeConfig {
             self.relays.into_parsed_commands(node_name)?.into(),
             self.tcp_inlets.into_parsed_commands(node_name)?.into(),
             self.tcp_outlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
             self.kafka_inlet.into_parsed_commands(node_name)?.into(),
             self.kafka_outlet.into_parsed_commands(node_name)?.into(),
         ];
@@ -297,6 +300,7 @@ impl NodeConfig {
             self.relays.into_parsed_commands(node_name)?.into(),
             self.tcp_inlets.into_parsed_commands(node_name)?.into(),
             self.tcp_outlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
             self.kafka_inlet.into_parsed_commands(node_name)?.into(),
             self.kafka_outlet.into_parsed_commands(node_name)?.into(),
         ])

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
@@ -1,0 +1,97 @@
+use miette::{miette, Result};
+use ockam_api::colors::color_primary;
+use serde::{Deserialize, Serialize};
+
+use crate::run::parser::building_blocks::{ArgsToCommands, ResourceNameOrMap};
+
+use crate::influxdb::inlet::create::CreateCommand;
+use crate::run::parser::resource::utils::parse_cmd_from_args;
+use crate::{influxdb::inlet, Command, OckamSubcommand};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InfluxDBInlets {
+    #[serde(alias = "influxdb-inlets", alias = "influxdb-inlet")]
+    pub influxdb_inlets: Option<ResourceNameOrMap>,
+}
+
+impl InfluxDBInlets {
+    fn get_subcommand(args: &[String]) -> Result<CreateCommand> {
+        if let OckamSubcommand::InfluxDBInlet(cmd) = parse_cmd_from_args(CreateCommand::NAME, args)?
+        {
+            let inlet::InfluxDBInletSubCommand::Create(c) = cmd.subcommand;
+            return Ok(c);
+        }
+        Err(miette!(format!(
+            "Failed to parse {} command",
+            color_primary(CreateCommand::NAME)
+        )))
+    }
+
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: Option<&String>,
+    ) -> Result<Vec<CreateCommand>> {
+        match self.influxdb_inlets {
+            Some(c) => {
+                let mut cmds =
+                    c.into_commands_with_name_arg(Self::get_subcommand, Some("alias"))?;
+                if let Some(node_name) = default_node_name.as_ref() {
+                    for cmd in cmds.iter_mut() {
+                        if cmd.at.is_none() {
+                            cmd.at = Some(node_name.to_string())
+                        }
+                    }
+                }
+                Ok(cmds)
+            }
+            None => Ok(vec![]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam::transport::HostnamePort;
+
+    #[test]
+    fn tcp_inlet_config() {
+        let named = r#"
+            influxdb_inlets:
+              ti1:
+                from: 6060
+                at: n
+              ti2:
+                from: '6061'
+                alias: my_inlet
+        "#;
+        let parsed: InfluxDBInlets = serde_yaml::from_str(named).unwrap();
+        let default_node_name = "n1".to_string();
+        let cmds = parsed
+            .into_parsed_commands(Some(&default_node_name))
+            .unwrap();
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[0].alias, "ti1");
+        assert_eq!(cmds[0].from, HostnamePort::new("127.0.0.1", 6060));
+        assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
+        assert_eq!(cmds[1].alias, "my_inlet");
+        assert_eq!(cmds[1].from, HostnamePort::new("127.0.0.1", 6061));
+        assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
+
+        let unnamed = r#"
+            influxdb_inlets:
+              - from: 6060
+                at: n
+              - from: '6061'
+        "#;
+        let parsed: InfluxDBInlets = serde_yaml::from_str(unnamed).unwrap();
+        let cmds = parsed
+            .into_parsed_commands(Some(&default_node_name))
+            .unwrap();
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[0].from, HostnamePort::new("127.0.0.1", 6060));
+        assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
+        assert_eq!(cmds[1].from, HostnamePort::new("127.0.0.1", 6061));
+        assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
@@ -1,4 +1,5 @@
 pub use identities::Identities;
+pub use influxdb_inlets::InfluxDBInlets;
 pub use kafka_inlet::KafkaInlet;
 pub use kafka_outlet::KafkaOutlet;
 pub use node::Node;
@@ -12,6 +13,7 @@ pub use traits::*;
 pub use vaults::Vaults;
 
 mod identities;
+mod influxdb_inlets;
 mod kafka_inlet;
 mod kafka_outlet;
 mod node;

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -22,6 +22,7 @@ use crate::enroll::EnrollCommand;
 use crate::environment::EnvironmentCommand;
 use crate::flow_control::FlowControlCommand;
 use crate::identity::IdentityCommand;
+use crate::influxdb::inlet::InfluxDBInletCommand;
 use crate::kafka::consumer::KafkaConsumerCommand;
 use crate::kafka::inlet::KafkaInletCommand;
 use crate::kafka::outlet::KafkaOutletCommand;
@@ -87,6 +88,9 @@ pub enum OckamSubcommand {
     TcpOutlet(TcpOutletCommand),
     TcpInlet(TcpInletCommand),
 
+    #[command(name = "influxdb-inlet")]
+    InfluxDBInlet(InfluxDBInletCommand),
+
     Rendezvous(RendezvousCommand),
 
     KafkaInlet(KafkaInletCommand),
@@ -145,6 +149,8 @@ impl OckamSubcommand {
             OckamSubcommand::TcpConnection(c) => c.run(opts),
             OckamSubcommand::TcpOutlet(c) => c.run(opts),
             OckamSubcommand::TcpInlet(c) => c.run(opts),
+
+            OckamSubcommand::InfluxDBInlet(c) => c.run(opts),
 
             OckamSubcommand::Rendezvous(c) => c.run(opts),
 
@@ -293,6 +299,7 @@ impl OckamSubcommand {
             OckamSubcommand::TcpConnection(c) => c.name(),
             OckamSubcommand::TcpOutlet(c) => c.name(),
             OckamSubcommand::TcpInlet(c) => c.name(),
+            OckamSubcommand::InfluxDBInlet(c) => c.name(),
             OckamSubcommand::Rendezvous(c) => c.name(),
             OckamSubcommand::KafkaInlet(c) => c.name(),
             OckamSubcommand::KafkaOutlet(c) => c.name(),


### PR DESCRIPTION
Assuming the identity is enrolled in a project that has influxdb addon enabled, like:
```
[configure influxdb'  addon]
$ ockam project addon configure  influxdb -e http://some.influxdb.instance:8086 -t $TOKEN -o $ORG_ID --permissions '$PERMISSIONS'
```

An http authentication inlet is started as:
```
[create a node, and a http-inlet on it.   it creates a tcp-outlet behind the scenes]
$ ockam node create n1
$ ockam http-inlet create --at /node/n1 --from 8087  --to /project/default/service/forward_to_influxdb/secure/api/service/outlet 
```
Then sending influxdb' request (writes, queries) to  `localhost:8087`  will cause the request to be sent to upstream influxdb instance (the outlet would be pointing to influxdb),  but with the request modified to include an `Authentication` header with a token obtained from the project' token lease manager.   This token is rotated as needed, without clients having to worry about that. 

The same  can be done through a node' config file as well: 
```
name: n1
http-inlets:
  influxdb:
    from: 0.0.0.0:8087
    to:  /project/default/service/forward_to_influxdb/secure/api/service/outlet
```

Notes:
* It requires a secure channel between inlet->outlet, even if both are on the same node (the first case, where we implicitly create the tcp outlet).  That's something to maybe improve, right now is mandatory.
* Right now, it doesn't support serving https,  as tcp-inlets doesn't support that _yet_ .  So influxdb' clients must be configured to use http (upstream can be http or https).
* Right now the original Token sent by clients is just discarded (it can be anything).   Perhaps we could require a custom string there instead (like "OCKAM-MANAGED" or something.  As long as clients don't complaint that that isn't a valid token when reading it from config)