### PR TITLE
influxdb inlet/outlet auth gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,6 +4689,7 @@ dependencies = [
  "hex",
  "home",
  "http-body-util",
+ "httparse",
  "hyper 1.4.1",
  "hyper-util",
  "indexmap 2.5.0",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -59,6 +59,7 @@ gethostname = "0.5.0"
 hex = { version = "0.4.3", default-features = false, features = ["alloc", "serde"] }
 home = "0.5"
 http-body-util = "0"
+httparse = "1.9.4"
 hyper = { version = "1", default-features = false, features = ["server", "http1"] }
 hyper-util = { version = "0", default-features = false, features = ["server", "http1", "tokio"] }
 indicatif = "0.17"

--- a/implementations/rust/ockam/ockam_api/src/influxdb/gateway/interceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/gateway/interceptor.rs
@@ -1,0 +1,366 @@
+use std::io::Write;
+
+use httparse::{Header, Status};
+use ockam_core::async_trait;
+use ockam_node::Context;
+use ockam_transport_tcp::{Direction, PortalInterceptor, PortalInterceptorFactory};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use ockam::errcode::{Kind, Origin};
+
+use tracing::{debug, error};
+
+use super::token_lease_refresher::TokenLeaseRefresher;
+
+#[derive(Debug, Clone, PartialEq)]
+enum RequestState {
+    ParsingHeader(Option<Vec<u8>>),
+    ParsingChunkedHeader(Option<Vec<u8>>),
+    RemainingInChunk(usize),
+    RemainingBody(usize),
+}
+
+struct HttpAuthInterceptorState {
+    state: RequestState,
+}
+
+struct HttpAuthInterceptor {
+    state: Arc<Mutex<HttpAuthInterceptorState>>,
+    token_refresher: TokenLeaseRefresher,
+}
+
+impl HttpAuthInterceptor {
+    fn new(token_refresher: TokenLeaseRefresher) -> Self {
+        let state = HttpAuthInterceptorState {
+            state: RequestState::ParsingHeader(None),
+        };
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            token_refresher,
+        }
+    }
+}
+
+pub struct HttpAuthInterceptorFactory {
+    token_refresher: TokenLeaseRefresher,
+}
+
+impl HttpAuthInterceptorFactory {
+    pub fn new(token_refresher: TokenLeaseRefresher) -> Self {
+        Self { token_refresher }
+    }
+}
+
+impl PortalInterceptorFactory for HttpAuthInterceptorFactory {
+    fn create(&self) -> Arc<dyn PortalInterceptor> {
+        Arc::new(HttpAuthInterceptor::new(self.token_refresher.clone()))
+    }
+}
+
+fn attach_auth_token_and_serialize_into(
+    req: &httparse::Request,
+    token: &str,
+    buffer: &mut Vec<u8>,
+) {
+    debug!("Serializing http req header");
+    write!(
+        buffer,
+        "{} {} HTTP/1.{}\r\n",
+        req.method.unwrap(),
+        req.path.unwrap(),
+        req.version.unwrap()
+    )
+    .unwrap();
+
+    write!(buffer, "Authorization: Token {}\r\n", token).unwrap();
+    for h in &*req.headers {
+        if !h.name.eq_ignore_ascii_case("Authorization") {
+            write!(buffer, "{}: ", h.name).unwrap();
+            buffer.extend_from_slice(h.value);
+            buffer.extend_from_slice(b"\r\n");
+        }
+    }
+    buffer.extend_from_slice(b"\r\n");
+}
+
+fn body_state(method: &str, headers: &[Header]) -> ockam_core::Result<RequestState> {
+    match method.to_uppercase().as_str() {
+        "POST" | "PUT" => {
+            for h in headers {
+                if h.name.eq_ignore_ascii_case("Content-Length") {
+                    if let Ok(str) = std::str::from_utf8(h.value) {
+                        return str.parse().map(RequestState::RemainingBody).map_err(|e| {
+                            ockam_core::Error::new(Origin::Transport, Kind::Invalid, e)
+                        });
+                    }
+                } else if h.name.eq_ignore_ascii_case("Transfer-Encoding")
+                    && String::from_utf8(h.value.to_vec()).is_ok_and(|s| s.contains("chunked"))
+                {
+                    return Ok(RequestState::ParsingChunkedHeader(None));
+                }
+            }
+            // Not content-length, no chunked encoding, fail.
+            Err(ockam_core::Error::new(
+                Origin::Transport,
+                Kind::Invalid,
+                "No Content-Length nor chunked Transfer-Encoding",
+            ))
+        }
+        _ => Ok(RequestState::ParsingHeader(None)),
+    }
+}
+
+impl RequestState {
+    /* Parse the incoming data,  attaching an Authorization header token to it.
+     * data is received in chunks, and there is no warranty on what we get on each:
+     * incomplete requests,  multiple requests, etc.
+     */
+    fn process_http_buffer(&mut self, buf: &[u8], token: &str) -> ockam_core::Result<Vec<u8>> {
+        let mut acc = Vec::with_capacity(buf.len());
+        let mut cursor = buf;
+        loop {
+            if cursor.is_empty() {
+                return Ok(acc);
+            }
+            match self {
+                RequestState::ParsingHeader(prev) => {
+                    let (to_parse, prev_size): (&[u8], usize) = if let Some(b) = prev {
+                        let prev_size = b.len();
+                        b.extend_from_slice(cursor);
+                        (b, prev_size)
+                    } else {
+                        (cursor, 0usize)
+                    };
+                    let mut headers = [httparse::EMPTY_HEADER; 64];
+                    let mut req = httparse::Request::new(&mut headers);
+                    match req.parse(to_parse) {
+                        Ok(httparse::Status::Partial) if prev_size == 0 => {
+                            // No previous buffered, need to copy and own the unparsed data
+                            *self = RequestState::ParsingHeader(Some(cursor.to_vec()));
+                            return Ok(acc);
+                        }
+                        Ok(httparse::Status::Partial) => {
+                            // There was a previous buffer, and we already added the newly data to it
+                            return Ok(acc);
+                        }
+                        Ok(httparse::Status::Complete(body_offset)) => {
+                            cursor = &cursor[body_offset - prev_size..];
+                            attach_auth_token_and_serialize_into(&req, token, &mut acc);
+                            *self = body_state(req.method.unwrap(), req.headers)?;
+                        }
+                        Err(e) => {
+                            error!("Error parsing header: {:?}", e);
+                            return Err(ockam_core::Error::new(
+                                Origin::Transport,
+                                Kind::Invalid,
+                                e,
+                            ));
+                        }
+                    }
+                }
+                RequestState::RemainingBody(remaining) => {
+                    if *remaining <= cursor.len() {
+                        acc.extend_from_slice(&cursor[..*remaining]);
+                        cursor = &cursor[*remaining..];
+                        *self = RequestState::ParsingHeader(None);
+                    } else {
+                        acc.extend_from_slice(cursor);
+                        *remaining -= cursor.len();
+                        return Ok(acc);
+                    }
+                }
+                RequestState::ParsingChunkedHeader(prev) => {
+                    let (to_parse, prev_size): (&[u8], usize) = if let Some(b) = prev {
+                        let prev_size = b.len();
+                        b.extend_from_slice(cursor);
+                        (b, prev_size)
+                    } else {
+                        (cursor, 0usize)
+                    };
+                    match httparse::parse_chunk_size(to_parse) {
+                        Ok(Status::Complete((2, 0))) => {
+                            // this is just a final \r\n.  The spec said it should end in a 0-sized
+                            // chunk.. but having seen this on the wild as well.
+                            acc.extend_from_slice(&to_parse[..2]);
+                            cursor = &cursor[2 - prev_size..];
+                            *self = RequestState::ParsingHeader(None);
+                        }
+                        Ok(Status::Complete((3, 0))) => {
+                            // this is just a proper 0\r\n final chunk.
+                            acc.extend_from_slice(&to_parse[..3]);
+                            cursor = &cursor[3 - prev_size..];
+                            // There must be a final \r\n.  And no more chunks,
+                            // so just reuse the RemainingBody state for this
+                            *self = RequestState::RemainingBody(2);
+                        }
+                        Ok(Status::Complete((pos, chunk_size))) => {
+                            acc.extend_from_slice(&to_parse[..pos]);
+                            cursor = &cursor[pos - prev_size..];
+                            let complete_size = chunk_size + 2; //chunks ends in \r\n
+                            *self =
+                                RequestState::RemainingInChunk(complete_size.try_into().unwrap());
+                        }
+                        Ok(Status::Partial) if prev_size == 0 => {
+                            // No previous buffered, need to copy and own the unparsed data
+                            *self = RequestState::ParsingChunkedHeader(Some(cursor.to_vec()));
+                            return Ok(acc);
+                        }
+                        Ok(Status::Partial) => {
+                            // There was a previous buffer, and we already added the newly data to it
+                            return Ok(acc);
+                        }
+                        Err(e) => {
+                            error!("Error parsing chunk size: {:?}.  Buffer: {:?}", e, prev);
+                            return Err(ockam_core::Error::new(
+                                Origin::Transport,
+                                Kind::Invalid,
+                                format!("Can't parse chunked body {:?}", e),
+                            ));
+                        }
+                    }
+                }
+                RequestState::RemainingInChunk(size) => {
+                    if cursor.len() >= *size {
+                        acc.extend_from_slice(&cursor[..*size]);
+                        cursor = &cursor[*size..];
+                        *self = RequestState::ParsingChunkedHeader(None);
+                    } else {
+                        acc.extend_from_slice(cursor);
+                        *size -= cursor.len();
+                        return Ok(acc);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PortalInterceptor for HttpAuthInterceptor {
+    async fn intercept(
+        &self,
+        _context: &mut Context,
+        direction: Direction,
+        buffer: &[u8],
+    ) -> ockam_core::Result<Option<Vec<u8>>> {
+        match direction {
+            Direction::FromOutletToInlet => ockam_core::Result::Ok(Some(buffer.to_vec())),
+
+            Direction::FromInletToOutlet => {
+                let mut guard = self.state.lock().await;
+                let token = self.token_refresher.get_token().await;
+                if token.is_none() {
+                    error!("No authorization token available");
+                }
+                let out = guard
+                    .state
+                    .process_http_buffer(buffer, &token.unwrap_or_default())?;
+                Ok(Some(out))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REQ: &str = "POST / HTTP/1.1\r\n\
+Host: www.example.com\r\n\
+User-Agent: Mozilla/5.0\r\n\
+Accept-Encoding: gzip, deflate, br\r\n\
+Transfer-Encoding: gzip, chunked\r\n\r\n\
+4\r\nWiki\r\n7\r\npedia i\r\n0\r\n\r\n";
+
+    const TOKEN: &str = "SAMPLE-TOKEN";
+
+    const EXPECTED: &str = "POST / HTTP/1.1\r\n\
+Authorization: Token SAMPLE-TOKEN\r\n\
+Host: www.example.com\r\n\
+User-Agent: Mozilla/5.0\r\n\
+Accept-Encoding: gzip, deflate, br\r\n\
+Transfer-Encoding: gzip, chunked\r\n\r\n\
+4\r\nWiki\r\n7\r\npedia i\r\n0\r\n\r\n";
+
+    #[test]
+    fn parse_post_with_chunked_transfers() {
+        let mut data = Vec::new();
+        data.extend_from_slice(REQ.as_bytes());
+        data.extend_from_slice(REQ.as_bytes());
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(
+                String::from_utf8(result).unwrap(),
+                EXPECTED.to_owned() + EXPECTED
+            );
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+
+    #[test]
+    fn parse_post_with_content_length() {
+        let req = "POST /test HTTP/1.1\r\n\
+Host: foo.example\r\n\
+Content-Type: application/x-www-form-urlencoded\r\n\
+Content-Length: 27\r\n\r\n\
+field1=value1&field2=value2";
+        let expected_r = format!(
+            "POST /test HTTP/1.1\r\n\
+Authorization: Token {}\r\n\
+Host: foo.example\r\n\
+Content-Type: application/x-www-form-urlencoded\r\n\
+Content-Length: 27\r\n\r\n\
+field1=value1&field2=value2",
+            TOKEN
+        );
+
+        let data = [req.as_bytes(), req.as_bytes()].concat();
+        let expected = [expected_r.as_bytes(), expected_r.as_bytes()].concat();
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(
+                String::from_utf8(result).unwrap(),
+                String::from_utf8(expected.clone()).unwrap()
+            );
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+
+    #[test]
+    fn parse_get_requests() {
+        let req = "GET /home/user/example.txt HTTP/1.1\r\n\r\n";
+        let mut data = Vec::new();
+        data.extend_from_slice(req.as_bytes());
+        data.extend_from_slice(req.as_bytes());
+
+        let mut expected = format!(
+            "GET /home/user/example.txt HTTP/1.1\r\nAuthorization: Token {}\r\n\r\n",
+            TOKEN
+        );
+        expected = expected.clone() + &expected;
+
+        for size in [1, 5, 32, 1024] {
+            let mut result = Vec::new();
+            let mut request_state = RequestState::ParsingHeader(None);
+            for chunk in data.chunks(size) {
+                let data_out = request_state.process_http_buffer(chunk, TOKEN).unwrap();
+                result.extend_from_slice(&data_out);
+            }
+            assert_eq!(String::from_utf8(result).unwrap(), expected);
+            assert_eq!(request_state, RequestState::ParsingHeader(None));
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/influxdb/gateway/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/gateway/mod.rs
@@ -1,0 +1,2 @@
+pub mod interceptor;
+pub mod token_lease_refresher;

--- a/implementations/rust/ockam/ockam_api/src/influxdb/gateway/token_lease_refresher.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/gateway/token_lease_refresher.rs
@@ -1,0 +1,75 @@
+use ockam::{compat::time::now, Address, Mailboxes};
+use ockam_core::{api::Error, AllowAll, DenyAll};
+use ockam_multiaddr::MultiAddr;
+use ockam_node::Context;
+use std::{cmp::max, sync::Arc};
+use tokio::sync::RwLock;
+
+use crate::nodes::InMemoryNode;
+use crate::token_lessor_node_service::InfluxDBTokenLessorNodeServiceTrait;
+
+#[derive(Clone)]
+pub struct TokenLeaseRefresher {
+    token: Arc<RwLock<Option<String>>>,
+}
+
+impl TokenLeaseRefresher {
+    pub async fn new(
+        ctx: &Context,
+        node_manager: Arc<InMemoryNode>,
+        route_to_lessor: MultiAddr,
+    ) -> Result<TokenLeaseRefresher, Error> {
+        let token = Arc::new(RwLock::new(None));
+        let mailboxes = Mailboxes::main(
+            Address::random_tagged("LeaseRetriever"),
+            Arc::new(DenyAll),
+            Arc::new(AllowAll),
+        );
+        let new_ctx = ctx.new_detached_with_mailboxes(mailboxes).await?;
+
+        let token_clone = token.clone();
+        ockam_node::spawn(async move {
+            // TODO should it just loop again?
+            if let Err(err) =
+                refresh_loop(token_clone, new_ctx, node_manager.clone(), route_to_lessor).await
+            {
+                error!("Token refresher terminated with error: {:}", err);
+            }
+        });
+        Ok(Self { token })
+    }
+
+    pub async fn get_token(&self) -> Option<String> {
+        self.token.read().await.clone()
+    }
+}
+
+async fn refresh_loop(
+    token: Arc<RwLock<Option<String>>>,
+    ctx: Context,
+    node_manager: Arc<InMemoryNode>,
+    route_to_lessor: MultiAddr,
+) -> Result<(), Error> {
+    loop {
+        debug!("refreshing token");
+        let token_result = node_manager.create_token(&ctx, &route_to_lessor).await;
+        let now_t = now()?;
+        let wait_secs = match token_result {
+            Ok(new_token) => {
+                let duration = new_token.expires_at as u64 - now_t;
+                debug!("Auth Token obtained expires at {}", new_token.expires_at);
+                let mut t = token.write().await;
+                *t = Some(new_token.token);
+                // We request a new token once reaching half its duration, with a minimum
+                // of 5 seconds.
+                max(duration / 2, 5)
+            }
+            Err(err) => {
+                warn!("Error retrieving token {:}", err);
+                15
+            }
+        };
+        debug!("waiting for {} seconds before refreshing token", wait_secs);
+        ctx.sleep_long_until(now_t + wait_secs).await;
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/influxdb/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/mod.rs
@@ -1,3 +1,4 @@
+pub mod gateway;
 mod influxdb_api_client;
 mod lease_token;
 pub mod token_lessor_node_service;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
@@ -1,0 +1,44 @@
+use minicbor::{CborLen, Decode, Encode};
+use ockam_multiaddr::MultiAddr;
+
+use super::portal::{CreateInlet, CreateOutlet};
+
+/// Request body to create an influxdb inlet
+#[derive(Clone, Debug, Encode, Decode, CborLen)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct CreateInfluxDBInlet {
+    /// The address the portal should listen at.
+    #[n(1)] pub(crate) tcp_inlet: CreateInlet,
+    /// The token leaser service address.
+    #[n(2)] pub(crate) service_address: MultiAddr,
+}
+
+impl CreateInfluxDBInlet {
+    pub fn new(tcp_inlet: CreateInlet, service_address: MultiAddr) -> Self {
+        Self {
+            tcp_inlet,
+            service_address,
+        }
+    }
+}
+
+/// Request body to create an influxdb outlet
+#[derive(Clone, Debug, Encode, Decode, CborLen)]
+#[rustfmt::skip]
+#[cbor(map)]
+pub struct CreateInfluxDBOutlet {
+    /// The address the portal should listen at.
+    #[n(1)] pub(crate) tcp_outlet: CreateOutlet,
+    /// The token leaser service address.
+    #[n(2)] pub(crate) service_address: MultiAddr,
+}
+
+impl CreateInfluxDBOutlet {
+    pub fn new(tcp_outlet: CreateOutlet, service_address: MultiAddr) -> Self {
+        Self {
+            tcp_outlet,
+            service_address,
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/mod.rs
@@ -4,6 +4,7 @@
 //! its own
 pub mod credentials;
 pub mod flow_controls;
+pub mod influxdb_portal;
 pub mod node;
 pub mod policies;
 pub mod portal;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -36,30 +36,27 @@ pub struct CreateInlet {
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
     #[n(4)] pub(crate) authorized: Option<Identifier>,
-    /// A prefix route that will be applied before outlet_addr, and won't be used
-    /// to monitor the state of the connection
-    #[n(5)] pub(crate) prefix_route: Route,
     /// A suffix route that will be applied after outlet_addr, and won't be used
     /// to monitor the state of the connection
-    #[n(6)] pub(crate) suffix_route: Route,
+    #[n(5)] pub(crate) suffix_route: Route,
     /// The maximum duration to wait for an outlet to be available
-    #[n(7)] pub(crate) wait_for_outlet_duration: Option<Duration>,
+    #[n(6)] pub(crate) wait_for_outlet_duration: Option<Duration>,
     /// The expression for the access control policy for this inlet.
     /// If not set, the policy set for the [TCP inlet resource type](ockam_abac::ResourceType::TcpInlet)
     /// will be used.
-    #[n(8)] pub(crate) policy_expression: Option<PolicyExpression>,
+    #[n(7)] pub(crate) policy_expression: Option<PolicyExpression>,
     /// Create the inlet and wait for the outlet to connect
-    #[n(9)] pub(crate) wait_connection: bool,
+    #[n(8)] pub(crate) wait_connection: bool,
     /// The identifier to be used to create the secure channel.
     /// If not set, the node's identifier will be used.
-    #[n(10)] pub(crate) secure_channel_identifier: Option<Identifier>,
+    #[n(9)] pub(crate) secure_channel_identifier: Option<Identifier>,
     /// Enable UDP NAT puncture.
-    #[n(11)] pub(crate) enable_udp_puncture: bool,
+    #[n(10)] pub(crate) enable_udp_puncture: bool,
     /// Disable fallback to TCP.
     /// TCP won't be used to transfer data between the Inlet and the Outlet.
-    #[n(12)] pub(crate) disable_tcp_fallback: bool,
+    #[n(11)] pub(crate) disable_tcp_fallback: bool,
     /// TLS certificate provider route.
-    #[n(13)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
+    #[n(12)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
 }
 
 impl CreateInlet {
@@ -68,19 +65,16 @@ impl CreateInlet {
         listen: HostnamePort,
         to: MultiAddr,
         alias: String,
-        prefix_route: Route,
-        suffix_route: Route,
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        suffix_route: Route,
     ) -> Self {
         Self {
             listen_addr: listen,
             outlet_addr: to,
             alias,
             authorized: None,
-            prefix_route,
-            suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
             wait_connection,
@@ -88,6 +82,7 @@ impl CreateInlet {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider: None,
+            suffix_route,
         }
     }
 
@@ -96,20 +91,17 @@ impl CreateInlet {
         listen: HostnamePort,
         to: MultiAddr,
         alias: String,
-        prefix_route: Route,
-        suffix_route: Route,
         auth: Option<Identifier>,
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
+        suffix_route: Route,
     ) -> Self {
         Self {
             listen_addr: listen,
             outlet_addr: to,
             alias,
             authorized: auth,
-            prefix_route,
-            suffix_route,
             wait_for_outlet_duration: None,
             policy_expression: None,
             wait_connection,
@@ -117,6 +109,7 @@ impl CreateInlet {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider: None,
+            suffix_route,
         }
     }
 
@@ -150,14 +143,6 @@ impl CreateInlet {
 
     pub fn alias(&self) -> String {
         self.alias.clone()
-    }
-
-    pub fn prefix_route(&self) -> &Route {
-        &self.prefix_route
-    }
-
-    pub fn suffix_route(&self) -> &Route {
-        &self.suffix_route
     }
 
     pub fn wait_for_outlet_duration(&self) -> Option<Duration> {

--- a/implementations/rust/ockam/ockam_api/src/nodes/service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service.rs
@@ -9,6 +9,7 @@ pub(crate) mod background_node_client;
 pub mod default_address;
 mod flow_controls;
 pub(crate) mod in_memory_node;
+pub mod influxdb_portal_service;
 pub mod kafka_services;
 pub mod messages;
 mod node_services;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/influxdb_portal_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/influxdb_portal_service.rs
@@ -1,0 +1,310 @@
+use super::NodeManagerWorker;
+use crate::gateway::interceptor::HttpAuthInterceptorFactory;
+use crate::gateway::token_lease_refresher::TokenLeaseRefresher;
+use crate::nodes::models::influxdb_portal::{CreateInfluxDBInlet, CreateInfluxDBOutlet};
+use crate::nodes::models::portal::{
+    CreateInlet, CreateOutlet, InletStatus, OutletAccessControl, OutletStatus,
+};
+use crate::nodes::service::tcp_inlets::create_inlet_payload;
+use crate::nodes::BackgroundNodeClient;
+use crate::{ApiError, DefaultAddress};
+use ockam::flow_control::FlowControls;
+use ockam::identity::Identifier;
+use ockam::{Address, Context, Result, Route};
+use ockam_abac::PolicyExpression;
+use ockam_abac::{Action, Resource, ResourceType};
+use ockam_core::api::{Error, Reply, Request, Response};
+use ockam_core::async_trait;
+use ockam_core::route;
+use ockam_multiaddr::MultiAddr;
+use ockam_transport_core::HostnamePort;
+use ockam_transport_tcp::{PortalInletInterceptor, PortalOutletInterceptor};
+use std::sync::Arc;
+use std::time::Duration;
+
+impl NodeManagerWorker {
+    pub(super) async fn start_influxdb_outlet_service(
+        &self,
+        ctx: &Context,
+        body: CreateInfluxDBOutlet,
+    ) -> Result<Response<OutletStatus>, Response<Error>> {
+        let CreateOutlet {
+            hostname_port,
+            worker_addr,
+            reachable_from_default_secure_channel,
+            policy_expression,
+            tls,
+        } = body.tcp_outlet;
+        let interceptor_addr = self
+            .node_manager
+            .registry
+            .outlets
+            .generate_worker_addr(worker_addr)
+            .await;
+        let outlet_addr: Address = format!("{:}_tcp", interceptor_addr.address()).into();
+        self.create_http_outlet_interceptor(
+            ctx,
+            interceptor_addr,
+            outlet_addr.clone(),
+            policy_expression.clone(),
+            body.service_address,
+        )
+        .await
+        .map_err(|e| Response::bad_request_no_request(&format!("{e:?}")))?;
+
+        match self
+            .node_manager
+            .create_outlet(
+                ctx,
+                hostname_port,
+                tls,
+                Some(outlet_addr),
+                reachable_from_default_secure_channel,
+                OutletAccessControl::WithPolicyExpression(policy_expression),
+            )
+            .await
+        {
+            Ok(outlet_status) => Ok(Response::ok().body(outlet_status)),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
+        }
+    }
+
+    pub(super) async fn start_influxdb_inlet_service(
+        &self,
+        ctx: &Context,
+        body: CreateInfluxDBInlet,
+    ) -> Result<Response<InletStatus>, Response<Error>> {
+        let CreateInlet {
+            listen_addr,
+            outlet_addr,
+            alias,
+            authorized,
+            wait_for_outlet_duration,
+            policy_expression,
+            wait_connection,
+            secure_channel_identifier,
+            enable_udp_puncture,
+            disable_tcp_fallback,
+            tls_certificate_provider,
+            suffix_route,
+        } = body.tcp_inlet.clone();
+        let interceptor_addr = self
+            .create_http_auth_interceptor(
+                ctx,
+                &alias,
+                policy_expression.clone(),
+                body.service_address.clone(),
+            )
+            .await
+            .map_err(|e| Response::bad_request_no_request(&format!("{e:?}")))?;
+        match self
+            .node_manager
+            .create_inlet(
+                ctx,
+                listen_addr,
+                route![interceptor_addr],
+                suffix_route,
+                outlet_addr,
+                alias,
+                policy_expression,
+                wait_for_outlet_duration,
+                authorized,
+                wait_connection,
+                secure_channel_identifier,
+                enable_udp_puncture,
+                disable_tcp_fallback,
+                tls_certificate_provider,
+            )
+            .await
+        {
+            Ok(status) => Ok(Response::ok().body(status)),
+            Err(e) => Err(Response::bad_request_no_request(&format!("{e:?}"))),
+        }
+    }
+
+    async fn create_http_outlet_interceptor(
+        &self,
+        ctx: &Context,
+        interceptor_address: Address,
+        outlet_address: Address,
+        outlet_policy_expression: Option<PolicyExpression>,
+        route_to_lessor: MultiAddr,
+    ) -> Result<(), Error> {
+        let default_secure_channel_listener_flow_control_id = ctx
+            .flow_controls()
+            .get_flow_control_with_spawner(&DefaultAddress::SECURE_CHANNEL_LISTENER.into())
+            .ok_or_else(|| {
+                ApiError::core("Unable to get flow control for secure channel listener")
+            })?;
+
+        let policy_access_control = self
+            .node_manager
+            .policy_access_control(
+                self.node_manager.project_authority().clone(),
+                Resource::new(outlet_address.to_string(), ResourceType::TcpOutlet),
+                Action::HandleMessage,
+                outlet_policy_expression.clone(),
+            )
+            .await?;
+
+        let spawner_flow_control_id = FlowControls::generate_flow_control_id();
+
+        let token_refresher =
+            TokenLeaseRefresher::new(ctx, self.node_manager.clone(), route_to_lessor).await?;
+        let http_interceptor_factory = Arc::new(HttpAuthInterceptorFactory::new(token_refresher));
+
+        PortalOutletInterceptor::create(
+            ctx,
+            interceptor_address.clone(),
+            Some(spawner_flow_control_id.clone()),
+            http_interceptor_factory,
+            Arc::new(policy_access_control.create_outgoing(ctx).await?),
+            Arc::new(policy_access_control.create_incoming()),
+        )
+        .await?;
+
+        // every secure channel can reach this service
+        let flow_controls = ctx.flow_controls();
+        flow_controls.add_consumer(
+            interceptor_address.clone(),
+            &default_secure_channel_listener_flow_control_id,
+        );
+
+        // this spawner flow control id is used to control communication with dynamically created
+        // outlets
+        flow_controls.add_spawner(interceptor_address, &spawner_flow_control_id);
+
+        // allow communication with the kafka bootstrap outlet
+        flow_controls.add_consumer(outlet_address, &spawner_flow_control_id);
+        Ok(())
+    }
+
+    async fn create_http_auth_interceptor(
+        &self,
+        ctx: &Context,
+        inlet_alias: &String,
+        inlet_policy_expression: Option<PolicyExpression>,
+        route_to_lessor: MultiAddr,
+    ) -> Result<Address, Error> {
+        let interceptor_address: Address = (inlet_alias.to_owned() + "_http_interceptor").into();
+        let policy_access_control = self
+            .node_manager
+            .policy_access_control(
+                self.node_manager.project_authority().clone(),
+                Resource::new(interceptor_address.to_string(), ResourceType::TcpInlet),
+                Action::HandleMessage,
+                inlet_policy_expression,
+            )
+            .await?;
+
+        let token_refresher =
+            TokenLeaseRefresher::new(ctx, self.node_manager.clone(), route_to_lessor).await?;
+        let http_interceptor_factory = Arc::new(HttpAuthInterceptorFactory::new(token_refresher));
+
+        PortalInletInterceptor::create(
+            ctx,
+            interceptor_address.clone(),
+            http_interceptor_factory,
+            Arc::new(policy_access_control.create_incoming()),
+            Arc::new(policy_access_control.create_outgoing(ctx).await?),
+        )
+        .await?;
+        Ok(interceptor_address)
+    }
+}
+
+#[async_trait]
+pub trait InfluxDBPortals {
+    #[allow(clippy::too_many_arguments)]
+    async fn create_influxdb_inlet(
+        &self,
+        ctx: &Context,
+        listen_addr: &HostnamePort,
+        outlet_addr: &MultiAddr,
+        alias: &str,
+        authorized_identifier: &Option<Identifier>,
+        policy_expression: &Option<PolicyExpression>,
+        wait_for_outlet_timeout: Duration,
+        wait_connection: bool,
+        secure_channel_identifier: &Option<Identifier>,
+        enable_udp_puncture: bool,
+        disable_tcp_fallback: bool,
+        tls_certificate_provider: &Option<MultiAddr>,
+        suffix_route: Route,
+        token_leaser: MultiAddr,
+    ) -> miette::Result<Reply<InletStatus>>;
+
+    async fn create_influxdb_outlet(
+        &self,
+        ctx: &Context,
+        to: HostnamePort,
+        tls: bool,
+        from: Option<&Address>,
+        policy_expression: Option<PolicyExpression>,
+        token_leaser: MultiAddr,
+    ) -> miette::Result<OutletStatus>;
+}
+
+#[async_trait]
+impl InfluxDBPortals for BackgroundNodeClient {
+    #[instrument(skip(self, ctx))]
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(skip_all)]
+    async fn create_influxdb_outlet(
+        &self,
+        ctx: &Context,
+        to: HostnamePort,
+        tls: bool,
+        from: Option<&Address>,
+        policy_expression: Option<PolicyExpression>,
+        token_leaser: MultiAddr,
+    ) -> miette::Result<OutletStatus> {
+        let mut outlet_payload = CreateOutlet::new(to, tls, from.cloned(), true);
+        if let Some(policy_expression) = policy_expression {
+            outlet_payload.set_policy_expression(policy_expression);
+        }
+        let payload = CreateInfluxDBOutlet::new(outlet_payload, token_leaser);
+        let req = Request::post("/node/influxdb_outlet").body(payload);
+        //TODO: difference between ask and ask_and_get_reply?
+        let result: OutletStatus = self.ask(ctx, req).await?;
+        Ok(result)
+    }
+
+    async fn create_influxdb_inlet(
+        &self,
+        ctx: &Context,
+        listen_addr: &HostnamePort,
+        outlet_addr: &MultiAddr,
+        alias: &str,
+        authorized_identifier: &Option<Identifier>,
+        policy_expression: &Option<PolicyExpression>,
+        wait_for_outlet_timeout: Duration,
+        wait_connection: bool,
+        secure_channel_identifier: &Option<Identifier>,
+        enable_udp_puncture: bool,
+        disable_tcp_fallback: bool,
+        tls_certificate_provider: &Option<MultiAddr>,
+        suffix_route: Route,
+        token_leaser: MultiAddr,
+    ) -> miette::Result<Reply<InletStatus>> {
+        let request = {
+            let inlet_payload = create_inlet_payload(
+                listen_addr,
+                outlet_addr,
+                alias,
+                authorized_identifier,
+                policy_expression,
+                wait_for_outlet_timeout,
+                wait_connection,
+                secure_channel_identifier,
+                enable_udp_puncture,
+                disable_tcp_fallback,
+                tls_certificate_provider,
+                suffix_route,
+            );
+            let payload = CreateInfluxDBInlet::new(inlet_payload, token_leaser);
+            Request::post("/node/influxdb_inlet").body(payload)
+        };
+        self.ask_and_get_reply(ctx, request).await
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
@@ -1,4 +1,5 @@
 use ockam::identity::Identifier;
+use ockam::Route;
 use ockam_abac::PolicyExpression;
 use ockam_core::api::Reply;
 use ockam_core::async_trait;
@@ -26,6 +27,7 @@ pub trait Inlets {
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
         tls_certificate_provider: &Option<MultiAddr>,
+        outlet_suffix_address: Route,
     ) -> miette::Result<Reply<InletStatus>>;
 
     async fn show_inlet(&self, ctx: &Context, alias: &str) -> miette::Result<Reply<InletStatus>>;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/mod.rs
@@ -7,3 +7,5 @@ mod session_replacer;
 
 pub use inlets_trait::*;
 use session_replacer::*;
+
+pub use background_node_client::create_inlet_payload;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
@@ -1,4 +1,4 @@
-use ockam::Result;
+use ockam::{route, Result};
 use ockam_core::api::{Error, Response};
 use ockam_node::Context;
 
@@ -22,8 +22,6 @@ impl NodeManagerWorker {
             outlet_addr,
             alias,
             authorized,
-            prefix_route,
-            suffix_route,
             wait_for_outlet_duration,
             policy_expression,
             wait_connection,
@@ -31,13 +29,14 @@ impl NodeManagerWorker {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider,
+            suffix_route,
         } = create_inlet;
         match self
             .node_manager
             .create_inlet(
                 ctx,
                 listen_addr,
-                prefix_route,
+                route![],
                 suffix_route,
                 outlet_addr,
                 alias,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/worker.rs
@@ -194,6 +194,16 @@ impl NodeManagerWorker {
             }
             (Delete, ["node", "portal"]) => todo!(),
 
+            // ==*== InfluxDB Inlets & Outlets  ==*==
+            (Post, ["node", "influxdb_inlet"]) => encode_response(
+                req,
+                self.start_influxdb_inlet_service(ctx, dec.decode()?).await,
+            )?,
+            (Post, ["node", "influxdb_outlet"]) => encode_response(
+                req,
+                self.start_influxdb_outlet_service(ctx, dec.decode()?).await,
+            )?,
+
             // ==*== Flow Controls ==*==
             (Post, ["node", "flow_controls", "add_consumer"]) => {
                 encode_response(req, self.add_consumer(ctx, dec.decode()?).await)?

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -6,6 +6,7 @@ use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
 use ockam::abac::PolicyExpression::FullExpression;
 use ockam::abac::SUBJECT_KEY;
+use ockam::route;
 use ockam::transport::HostnamePort;
 use ockam_api::address::get_free_address;
 use ockam_api::authenticator::direct::{
@@ -227,6 +228,7 @@ impl AppState {
                 false,
                 false,
                 &None,
+                route![],
             )
             .await
             .map_err(|err| {

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -1,0 +1,163 @@
+use async_trait::async_trait;
+use clap::Args;
+use colorful::Colorful;
+use miette::miette;
+use ockam::{route, Context};
+use ockam_api::nodes::service::influxdb_portal_service::InfluxDBPortals;
+use tracing::trace;
+
+use crate::node::util::initialize_default_node;
+use crate::{Command, CommandGlobalOpts};
+use ockam_api::colors::color_primary;
+use ockam_api::nodes::models::portal::InletStatus;
+use ockam_api::nodes::BackgroundNodeClient;
+use ockam_api::{fmt_info, fmt_log, fmt_ok, fmt_warn, ConnectionStatus};
+use ockam_core::api::{Reply, Status};
+use ockam_multiaddr::MultiAddr;
+
+use crate::tcp::inlet::create::CreateCommand as InletCreateCommand;
+
+// TODO: this is almost an exact copy of tcp::inlet::create,  other than by help descriptions,
+//       names, and a flag.  At some point we should refactor -likely once we start to have more
+//       protocol-specific inlets.
+
+/// Create InflucDB Inlets
+#[derive(Clone, Debug, Args)]
+pub struct InfluxDBCreateCommand {
+    #[command(flatten)]
+    pub inlet_create_command: InletCreateCommand,
+
+    /// The route to the token leaser service
+    #[arg(long, value_name = "ROUTE")]
+    pub token_leaser: MultiAddr,
+}
+
+#[async_trait]
+impl Command for InfluxDBCreateCommand {
+    const NAME: &'static str = "influxdb-inlet create";
+
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        initialize_default_node(ctx, &opts).await?;
+
+        let inlet_cmd = self.inlet_create_command.parse_args(&opts).await?;
+
+        let mut node = BackgroundNodeClient::create(ctx, &opts.state, &inlet_cmd.at).await?;
+
+        inlet_cmd.timeout.timeout.map(|t| node.set_timeout_mut(t));
+
+        let inlet_status = {
+            let pb = opts.terminal.progress_bar();
+            if let Some(pb) = pb.as_ref() {
+                pb.set_message(format!(
+                    "Creating a InfluxDB Inlet at {}...\n",
+                    color_primary(inlet_cmd.from.to_string())
+                ));
+            }
+
+            loop {
+                let result: Reply<InletStatus> = node
+                    .create_influxdb_inlet(
+                        ctx,
+                        &inlet_cmd.from,
+                        &inlet_cmd.to(),
+                        &inlet_cmd.alias,
+                        &inlet_cmd.authorized,
+                        &inlet_cmd.allow,
+                        inlet_cmd.connection_wait,
+                        !inlet_cmd.no_connection_wait,
+                        &inlet_cmd.secure_channel_identifier(&opts.state).await?,
+                        inlet_cmd.udp,
+                        inlet_cmd.no_tcp_fallback,
+                        &inlet_cmd.tls_certificate_provider,
+                        inlet_cmd
+                            .outlet_suffix_address
+                            .as_ref()
+                            .map_or(route![], |s| route![s]),
+                        self.token_leaser.clone(),
+                    )
+                    .await?;
+
+                match result {
+                    Reply::Successful(inlet_status) => {
+                        break inlet_status;
+                    }
+                    Reply::Failed(_, s) => {
+                        if let Some(status) = s {
+                            if status == Status::BadRequest {
+                                Err(miette!("Bad request when creating an inlet"))?
+                            }
+                        };
+                        trace!("the inlet creation returned a non-OK status: {s:?}");
+
+                        if inlet_cmd.retry_wait.as_millis() == 0 {
+                            return Err(miette!("Failed to create TCP inlet"))?;
+                        }
+
+                        if let Some(pb) = pb.as_ref() {
+                            pb.set_message(format!(
+                                "Waiting for TCP Inlet {} to be available... Retrying momentarily\n",
+                                color_primary(&inlet_cmd.to)
+                            ));
+                        }
+                        tokio::time::sleep(inlet_cmd.retry_wait).await
+                    }
+                }
+            }
+        };
+
+        let node_name = node.node_name();
+        inlet_cmd
+            .add_inlet_created_event(&opts, &node_name, &inlet_status)
+            .await?;
+
+        let created_message = fmt_ok!(
+            "Created a new InfluxDB Inlet in the Node {} bound to {}\n",
+            color_primary(&node_name),
+            color_primary(inlet_cmd.from.to_string())
+        );
+
+        let plain = if inlet_cmd.no_connection_wait {
+            created_message + &fmt_log!("It will automatically connect to the TCP Outlet at {} as soon as it is available",
+                color_primary(&inlet_cmd.to)
+            )
+        } else if inlet_status.status == ConnectionStatus::Up {
+            created_message
+                + &fmt_log!(
+                    "sending traffic to the TCP Outlet at {}",
+                    color_primary(&inlet_cmd.to)
+                )
+        } else {
+            fmt_warn!(
+                "A InfluxDB Inlet was created in the Node {} bound to {} but failed to connect to the TCP Outlet at {}\n",
+                color_primary(&node_name),
+                 color_primary(inlet_cmd.from.to_string()),
+                color_primary(&inlet_cmd.to)
+            ) + &fmt_info!("It will retry to connect automatically")
+        };
+
+        opts.terminal
+            .stdout()
+            .plain(plain)
+            .machine(inlet_status.bind_addr.to_string())
+            .json(serde_json::json!(&inlet_status))
+            .write_line()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::run::parser::resource::utils::parse_cmd_from_args;
+
+    use super::*;
+
+    #[test]
+    fn command_can_be_parsed_from_name() {
+        let cmd = parse_cmd_from_args(
+            InfluxDBCreateCommand::NAME,
+            &["--token-leaser".to_string(), "/service/leaser".to_string()],
+        );
+        assert!(cmd.is_ok());
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/mod.rs
@@ -1,0 +1,40 @@
+use clap::{Args, Subcommand};
+
+use create::InfluxDBCreateCommand;
+
+use crate::{docs, Command, CommandGlobalOpts};
+
+pub(crate) mod create;
+
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+
+/// Manage InfluxDB Inlets
+#[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+)]
+pub struct InfluxDBInletCommand {
+    #[command(subcommand)]
+    pub subcommand: InfluxDBInletSubCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum InfluxDBInletSubCommand {
+    Create(InfluxDBCreateCommand),
+}
+
+impl InfluxDBInletCommand {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        match self.subcommand {
+            InfluxDBInletSubCommand::Create(c) => c.run(opts),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match &self.subcommand {
+            InfluxDBInletSubCommand::Create(c) => c.name(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/static/long_about.txt
@@ -1,0 +1,1 @@
+A Http inlet is a way of defining where a node should be listening for connections, and where it should forward that traffic to. It is one end (tcp-outlet being the other) of a portal, which receives Http data, attach an authorization token header to it, chunks and wraps them into Ockam Routing messages and sends them along the supplied route.

--- a/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
@@ -1,0 +1,2 @@
+pub mod inlet;
+pub mod outlet;

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -1,0 +1,102 @@
+use async_trait::async_trait;
+use clap::Args;
+use colorful::Colorful;
+use miette::IntoDiagnostic;
+use ockam::{Address, Context};
+use ockam_api::nodes::service::influxdb_portal_service::InfluxDBPortals;
+
+use crate::node::util::initialize_default_node;
+use crate::{Command, CommandGlobalOpts};
+use ockam_api::colors::color_primary;
+use ockam_api::nodes::BackgroundNodeClient;
+use ockam_api::{fmt_log, fmt_ok};
+use ockam_multiaddr::MultiAddr;
+
+use crate::tcp::outlet::create::CreateCommand as OutletCreateCommand;
+
+/// Create InflucDB Outlets
+#[derive(Clone, Debug, Args)]
+pub struct InfluxDBCreateCommand {
+    #[command(flatten)]
+    pub outlet_create_command: OutletCreateCommand,
+
+    /// The route to the token leaser service
+    #[arg(long, value_name = "ROUTE")]
+    pub token_leaser: MultiAddr,
+}
+
+#[async_trait]
+impl Command for InfluxDBCreateCommand {
+    const NAME: &'static str = "influxdb-outlet create";
+
+    async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        initialize_default_node(ctx, &opts).await?;
+        let outlet_cmd = self.outlet_create_command;
+
+        if let Some(pb) = opts.terminal.progress_bar() {
+            pb.set_message(format!(
+                "Creating a new InfluxDB Outlet to {}...\n",
+                color_primary(outlet_cmd.to.to_string())
+            ));
+        }
+        let node = BackgroundNodeClient::create(ctx, &opts.state, &outlet_cmd.at).await?;
+        let node_name = node.node_name();
+        let outlet_status = node
+            .create_influxdb_outlet(
+                ctx,
+                outlet_cmd.to.clone(),
+                outlet_cmd.tls,
+                outlet_cmd.from.clone().map(Address::from).as_ref(),
+                outlet_cmd.allow.clone(),
+                self.token_leaser.clone(),
+            )
+            .await?;
+        outlet_cmd
+            .add_outlet_created_journey_event(&opts, &node_name, &outlet_status)
+            .await?;
+
+        let worker_addr = outlet_status.worker_address().into_diagnostic()?;
+
+        opts.terminal
+            .stdout()
+            .plain(
+                fmt_ok!(
+                    "Created a new InfluxDB Outlet in the Node {} at {} bound to {}\n\n",
+                    color_primary(&node_name),
+                    color_primary(worker_addr.to_string()),
+                    color_primary(outlet_cmd.to.to_string())
+                ) + &fmt_log!(
+                    "You may want to take a look at the {}, {}, {} commands next",
+                    color_primary("ockam relay"),
+                    color_primary("ockam tcp-inlet"),
+                    color_primary("ockam policy")
+                ),
+            )
+            .machine(worker_addr)
+            .json(serde_json::to_string(&outlet_status).into_diagnostic()?)
+            .write_line()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::run::parser::resource::utils::parse_cmd_from_args;
+
+    use super::*;
+
+    #[test]
+    fn command_can_be_parsed_from_name() {
+        let cmd = parse_cmd_from_args(
+            InfluxDBCreateCommand::NAME,
+            &[
+                "--to".to_string(),
+                "127.0.0.1:5000".to_string(),
+                "--token-leaser".to_string(),
+                "/service/test".to_string(),
+            ],
+        );
+        assert!(cmd.is_ok());
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/mod.rs
@@ -1,0 +1,40 @@
+use clap::{Args, Subcommand};
+
+use create::InfluxDBCreateCommand;
+
+use crate::{docs, Command, CommandGlobalOpts};
+
+pub(crate) mod create;
+
+const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
+
+/// Manage InfluxDB Inlets
+#[derive(Clone, Debug, Args)]
+#[command(
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+)]
+pub struct InfluxDBOutletCommand {
+    #[command(subcommand)]
+    pub subcommand: InfluxDBOutletSubCommand,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum InfluxDBOutletSubCommand {
+    Create(InfluxDBCreateCommand),
+}
+
+impl InfluxDBOutletCommand {
+    pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        match self.subcommand {
+            InfluxDBOutletSubCommand::Create(c) => c.run(opts),
+        }
+    }
+
+    pub fn name(&self) -> String {
+        match &self.subcommand {
+            InfluxDBOutletSubCommand::Create(c) => c.name(),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/static/long_about.txt
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/static/long_about.txt
@@ -1,0 +1,5 @@
+Create a InfluxDB  Outlet that runs adjacent to a the InfluxDB server. The Outlet unwraps Ockam messages and delivers the http request to the server, after attaching authentication information to it.
+
+You must specify the TCP address of the server, that your Outlet should send raw TCP traffic to. You can also name your Outlet by giving it an alias.
+
+When you create a InfluxDB Outlet, on an Ockam node, running on your local machine, it makes the TCP server available from a worker address, to the corresponding TCP Inlet (see `ockam tcp-inlet`).

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -78,3 +78,5 @@ pub mod value_parsers;
 mod vault;
 mod version;
 mod worker;
+
+mod influxdb;

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -118,6 +118,10 @@ pub struct NodeConfig {
     #[serde(flatten)]
     pub tcp_inlets: TcpInlets,
     #[serde(flatten)]
+    pub influxdb_inlets: InfluxDBInlets,
+    #[serde(flatten)]
+    pub influxdb_outlets: InfluxDBOutlets,
+    #[serde(flatten)]
     pub kafka_inlet: KafkaInlet,
     #[serde(flatten)]
     pub kafka_outlet: KafkaOutlet,
@@ -275,6 +279,10 @@ impl NodeConfig {
             self.relays.into_parsed_commands(node_name)?.into(),
             self.tcp_inlets.into_parsed_commands(node_name)?.into(),
             self.tcp_outlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_outlets
+                .into_parsed_commands(node_name)?
+                .into(),
             self.kafka_inlet.into_parsed_commands(node_name)?.into(),
             self.kafka_outlet.into_parsed_commands(node_name)?.into(),
         ];
@@ -304,6 +312,10 @@ impl NodeConfig {
             self.relays.into_parsed_commands(node_name)?.into(),
             self.tcp_inlets.into_parsed_commands(node_name)?.into(),
             self.tcp_outlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_inlets.into_parsed_commands(node_name)?.into(),
+            self.influxdb_outlets
+                .into_parsed_commands(node_name)?
+                .into(),
             self.kafka_inlet.into_parsed_commands(node_name)?.into(),
             self.kafka_outlet.into_parsed_commands(node_name)?.into(),
         ])

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
@@ -1,0 +1,120 @@
+use miette::{miette, Result};
+use ockam_api::colors::color_primary;
+use serde::{Deserialize, Serialize};
+
+use crate::run::parser::building_blocks::{ArgsToCommands, ResourceNameOrMap};
+
+use crate::influxdb::inlet::create::InfluxDBCreateCommand;
+use crate::run::parser::resource::utils::parse_cmd_from_args;
+use crate::{influxdb::inlet, Command, OckamSubcommand};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InfluxDBInlets {
+    #[serde(alias = "influxdb-inlets", alias = "influxdb-inlet")]
+    pub influxdb_inlets: Option<ResourceNameOrMap>,
+}
+
+impl InfluxDBInlets {
+    fn get_subcommand(args: &[String]) -> Result<InfluxDBCreateCommand> {
+        if let OckamSubcommand::InfluxDBInlet(cmd) =
+            parse_cmd_from_args(InfluxDBCreateCommand::NAME, args)?
+        {
+            let inlet::InfluxDBInletSubCommand::Create(c) = cmd.subcommand;
+            return Ok(c);
+        }
+        Err(miette!(format!(
+            "Failed to parse {} command",
+            color_primary(InfluxDBCreateCommand::NAME)
+        )))
+    }
+
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: Option<&String>,
+    ) -> Result<Vec<InfluxDBCreateCommand>> {
+        match self.influxdb_inlets {
+            Some(c) => {
+                let mut cmds =
+                    c.into_commands_with_name_arg(Self::get_subcommand, Some("alias"))?;
+                if let Some(node_name) = default_node_name.as_ref() {
+                    for cmd in cmds.iter_mut() {
+                        if cmd.inlet_create_command.at.is_none() {
+                            cmd.inlet_create_command.at = Some(node_name.to_string())
+                        }
+                    }
+                }
+                Ok(cmds)
+            }
+            None => Ok(vec![]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam::transport::HostnamePort;
+
+    #[test]
+    fn tcp_inlet_config() {
+        let named = r#"
+            influxdb_inlets:
+              ti1:
+                from: 6060
+                at: n
+                token-leaser: /service/test
+              ti2:
+                from: '6061'
+                alias: my_inlet
+                token-leaser: /service/test
+        "#;
+        let parsed: InfluxDBInlets = serde_yaml::from_str(named).unwrap();
+        let default_node_name = "n1".to_string();
+        let cmds = parsed
+            .into_parsed_commands(Some(&default_node_name))
+            .unwrap();
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[0].inlet_create_command.alias, "ti1");
+        assert_eq!(
+            cmds[0].inlet_create_command.from,
+            HostnamePort::new("127.0.0.1", 6060)
+        );
+        assert_eq!(cmds[0].inlet_create_command.at.as_ref().unwrap(), "n");
+        assert_eq!(cmds[1].inlet_create_command.alias, "my_inlet");
+        assert_eq!(
+            cmds[1].inlet_create_command.from,
+            HostnamePort::new("127.0.0.1", 6061)
+        );
+        assert_eq!(
+            cmds[1].inlet_create_command.at.as_ref(),
+            Some(&default_node_name)
+        );
+
+        let unnamed = r#"
+            influxdb_inlets:
+              - from: 6060
+                at: n
+                token-leaser: /service/test
+              - from: '6061'
+                token-leaser: /service/test
+        "#;
+        let parsed: InfluxDBInlets = serde_yaml::from_str(unnamed).unwrap();
+        let cmds = parsed
+            .into_parsed_commands(Some(&default_node_name))
+            .unwrap();
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(
+            cmds[0].inlet_create_command.from,
+            HostnamePort::new("127.0.0.1", 6060)
+        );
+        assert_eq!(cmds[0].inlet_create_command.at.as_ref().unwrap(), "n");
+        assert_eq!(
+            cmds[1].inlet_create_command.from,
+            HostnamePort::new("127.0.0.1", 6061)
+        );
+        assert_eq!(
+            cmds[1].inlet_create_command.at.as_ref(),
+            Some(&default_node_name)
+        );
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_outlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_outlets.rs
@@ -1,0 +1,77 @@
+use miette::{miette, Result};
+use ockam_api::colors::color_primary;
+use serde::{Deserialize, Serialize};
+
+use crate::run::parser::building_blocks::{ArgsToCommands, ResourceNameOrMap};
+
+use crate::influxdb::outlet::create::InfluxDBCreateCommand;
+use crate::run::parser::resource::utils::parse_cmd_from_args;
+use crate::{influxdb::outlet, Command, OckamSubcommand};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InfluxDBOutlets {
+    #[serde(alias = "influxdb-outlets", alias = "influxdb-outlet")]
+    pub influxdb_outlets: Option<ResourceNameOrMap>,
+}
+
+impl InfluxDBOutlets {
+    fn get_subcommand(args: &[String]) -> Result<InfluxDBCreateCommand> {
+        if let OckamSubcommand::InfluxDBOutlet(cmd) =
+            parse_cmd_from_args(InfluxDBCreateCommand::NAME, args)?
+        {
+            let outlet::InfluxDBOutletSubCommand::Create(c) = cmd.subcommand;
+            return Ok(c);
+        }
+        Err(miette!(format!(
+            "Failed to parse {} command",
+            color_primary(InfluxDBCreateCommand::NAME)
+        )))
+    }
+
+    pub fn into_parsed_commands(
+        self,
+        default_node_name: Option<&String>,
+    ) -> Result<Vec<InfluxDBCreateCommand>> {
+        match self.influxdb_outlets {
+            Some(c) => {
+                let mut cmds = c.into_commands_with_name_arg(Self::get_subcommand, Some("from"))?;
+                if let Some(node_name) = default_node_name {
+                    for cmd in cmds.iter_mut() {
+                        if cmd.outlet_create_command.at.is_none() {
+                            cmd.outlet_create_command.at = Some(node_name.to_string())
+                        }
+                    }
+                }
+                Ok(cmds)
+            }
+            None => Ok(vec![]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ockam::transport::HostnamePort;
+
+    #[test]
+    fn tcp_outlet_config() {
+        let named = r#"
+            influxdb_outlets:
+              ti1:
+                to: 127.0.0.1:6060
+                from: my_outlet
+                token-leaser: /service/test
+        "#;
+        let parsed: InfluxDBOutlets = serde_yaml::from_str(named).unwrap();
+        let default_node_name = "n1".to_string();
+        let cmds = parsed
+            .into_parsed_commands(Some(&default_node_name))
+            .unwrap();
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(
+            cmds[0].outlet_create_command.to,
+            HostnamePort::new("127.0.0.1", 6060)
+        );
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/mod.rs
@@ -1,4 +1,6 @@
 pub use identities::Identities;
+pub use influxdb_inlets::InfluxDBInlets;
+pub use influxdb_outlets::InfluxDBOutlets;
 pub use kafka_inlet::KafkaInlet;
 pub use kafka_outlet::KafkaOutlet;
 pub use node::Node;
@@ -12,6 +14,8 @@ pub use traits::*;
 pub use vaults::Vaults;
 
 mod identities;
+mod influxdb_inlets;
+mod influxdb_outlets;
 mod kafka_inlet;
 mod kafka_outlet;
 mod node;

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -22,6 +22,8 @@ use crate::enroll::EnrollCommand;
 use crate::environment::EnvironmentCommand;
 use crate::flow_control::FlowControlCommand;
 use crate::identity::IdentityCommand;
+use crate::influxdb::inlet::InfluxDBInletCommand;
+use crate::influxdb::outlet::InfluxDBOutletCommand;
 use crate::kafka::consumer::KafkaConsumerCommand;
 use crate::kafka::inlet::KafkaInletCommand;
 use crate::kafka::outlet::KafkaOutletCommand;
@@ -87,6 +89,11 @@ pub enum OckamSubcommand {
     TcpOutlet(TcpOutletCommand),
     TcpInlet(TcpInletCommand),
 
+    #[command(name = "influxdb-inlet")]
+    InfluxDBInlet(InfluxDBInletCommand),
+    #[command(name = "influxdb-outlet")]
+    InfluxDBOutlet(InfluxDBOutletCommand),
+
     Rendezvous(RendezvousCommand),
 
     KafkaInlet(KafkaInletCommand),
@@ -144,6 +151,9 @@ impl OckamSubcommand {
             OckamSubcommand::TcpConnection(c) => c.run(opts),
             OckamSubcommand::TcpOutlet(c) => c.run(opts),
             OckamSubcommand::TcpInlet(c) => c.run(opts),
+
+            OckamSubcommand::InfluxDBInlet(c) => c.run(opts),
+            OckamSubcommand::InfluxDBOutlet(c) => c.run(opts),
 
             OckamSubcommand::Rendezvous(c) => c.run(opts),
 
@@ -291,6 +301,8 @@ impl OckamSubcommand {
             OckamSubcommand::TcpConnection(c) => c.name(),
             OckamSubcommand::TcpOutlet(c) => c.name(),
             OckamSubcommand::TcpInlet(c) => c.name(),
+            OckamSubcommand::InfluxDBInlet(c) => c.name(),
+            OckamSubcommand::InfluxDBOutlet(c) => c.name(),
             OckamSubcommand::Rendezvous(c) => c.name(),
             OckamSubcommand::KafkaInlet(c) => c.name(),
             OckamSubcommand::KafkaOutlet(c) => c.name(),

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/create.rs
@@ -122,7 +122,7 @@ impl Command for CreateCommand {
 }
 
 impl CreateCommand {
-    async fn add_outlet_created_journey_event(
+    pub async fn add_outlet_created_journey_event(
         &self,
         opts: &CommandGlobalOpts,
         node_name: &str,


### PR DESCRIPTION
Introduce a influxdb-inlet and influxdb-outlet component.
Both are the same as their tcp counterpart,  but including a http interceptor,  that parses and modify http request on-the-fly, attaching to them a HTTP Authentication header with a token obtained from a lease issuer  service. 