### PR TITLE
feat(rust): lease commands/service improvements

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/influxdb/token_lessor_node_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/token_lessor_node_service.rs
@@ -177,9 +177,7 @@ impl InfluxDBTokenLessorNodeServiceTrait for InMemoryNode {
     async fn create_token(&self, ctx: &Context, at: &MultiAddr) -> miette::Result<LeaseToken> {
         let req = Request::post("").to_vec().into_diagnostic()?;
         let bytes = self.send_message(ctx, at, req, None).await?;
-        let res =
-            Response::parse_response_reply::<LeaseToken>(bytes.as_slice()).into_diagnostic()?;
-        Ok(res.success().into_diagnostic()?)
+        Response::parse_response_body::<LeaseToken>(bytes.as_slice()).into_diagnostic()
     }
 
     async fn get_token(
@@ -192,9 +190,7 @@ impl InfluxDBTokenLessorNodeServiceTrait for InMemoryNode {
             .to_vec()
             .into_diagnostic()?;
         let bytes = self.send_message(ctx, at, req, None).await?;
-        let res =
-            Response::parse_response_reply::<LeaseToken>(bytes.as_slice()).into_diagnostic()?;
-        Ok(res.success().into_diagnostic()?)
+        Response::parse_response_body::<LeaseToken>(bytes.as_slice()).into_diagnostic()
     }
 
     async fn revoke_token(
@@ -207,16 +203,15 @@ impl InfluxDBTokenLessorNodeServiceTrait for InMemoryNode {
             .to_vec()
             .into_diagnostic()?;
         let bytes = self.send_message(ctx, at, req, None).await?;
-        let res = Response::parse_response_reply::<()>(bytes.as_slice()).into_diagnostic()?;
-        Ok(res.success().into_diagnostic()?)
+        Response::parse_response_reply_with_empty_body(bytes.as_slice())
+            .and_then(|r| r.success())
+            .into_diagnostic()
     }
 
     async fn list_tokens(&self, ctx: &Context, at: &MultiAddr) -> miette::Result<Vec<LeaseToken>> {
         let req = Request::get("").to_vec().into_diagnostic()?;
         let bytes = self.send_message(ctx, at, req, None).await?;
-        let res = Response::parse_response_reply::<Vec<LeaseToken>>(bytes.as_slice())
-            .into_diagnostic()?;
-        Ok(res.success().into_diagnostic()?)
+        Response::parse_response_body::<Vec<LeaseToken>>(bytes.as_slice()).into_diagnostic()
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/ui/colors.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/colors.rs
@@ -4,6 +4,7 @@ use r3bl_rs_utils_core::UnicodeString;
 use r3bl_tui::{
     ColorWheel, ColorWheelConfig, ColorWheelSpeed, GradientGenerationPolicy, TextColorizationPolicy,
 };
+use std::fmt::Display;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum OckamColor {
@@ -53,11 +54,11 @@ macro_rules! color {
     };
 }
 
-pub fn color_primary(input: impl AsRef<str>) -> CString {
-    input.as_ref().color(OckamColor::PrimaryResource.color())
+pub fn color_primary(input: impl Display) -> CString {
+    input.to_string().color(OckamColor::PrimaryResource.color())
 }
 
-pub fn color_primary_alt(input: impl AsRef<str>) -> String {
+pub fn color_primary_alt(input: impl Display) -> String {
     let gradient_steps = Vec::from(
         [
             OckamColor::OckamBlue.value(),
@@ -65,35 +66,38 @@ pub fn color_primary_alt(input: impl AsRef<str>) -> String {
         ]
         .map(String::from),
     );
-    let colored_output = ColorWheel::new(vec![ColorWheelConfig::Rgb(
+    ColorWheel::new(vec![ColorWheelConfig::Rgb(
         gradient_steps,
         ColorWheelSpeed::Fast,
         15,
     )])
     .colorize_into_string(
-        &UnicodeString::from(input.as_ref()),
+        &UnicodeString::from(input.to_string()),
         GradientGenerationPolicy::ReuseExistingGradientAndResetIndex,
         TextColorizationPolicy::ColorEachCharacter(None),
-    );
-    colored_output
+    )
 }
 
-pub fn color_ok(input: impl AsRef<str>) -> CString {
-    input.as_ref().color(OckamColor::FmtOKBackground.color())
+pub fn color_ok(input: impl Display) -> CString {
+    input.to_string().color(OckamColor::FmtOKBackground.color())
 }
 
-pub fn color_warn(input: impl AsRef<str>) -> CString {
-    input.as_ref().color(OckamColor::FmtWARNBackground.color())
+pub fn color_warn(input: impl Display) -> CString {
+    input
+        .to_string()
+        .color(OckamColor::FmtWARNBackground.color())
 }
 
-pub fn color_error(input: impl AsRef<str>) -> CString {
-    input.as_ref().color(OckamColor::FmtERRORBackground.color())
+pub fn color_error(input: impl Display) -> CString {
+    input
+        .to_string()
+        .color(OckamColor::FmtERRORBackground.color())
 }
 
-pub fn color_email(input: impl AsRef<str>) -> CString {
-    input.as_ref().color(OckamColor::PrimaryResource.color())
+pub fn color_email(input: impl Display) -> CString {
+    input.to_string().color(OckamColor::PrimaryResource.color())
 }
 
-pub fn color_uri(input: impl AsRef<str>) -> String {
+pub fn color_uri(input: impl Display) -> String {
     color_primary_alt(input)
 }

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
@@ -33,7 +33,7 @@ macro_rules! fmt_log {
         $crate::terminal::PADDING,
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{}",
         $crate::terminal::PADDING,
         format!($input, $($args),+))
@@ -50,7 +50,7 @@ macro_rules! fmt_ok {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         "✔"
@@ -70,7 +70,7 @@ macro_rules! fmt_para {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         "│"
@@ -90,7 +90,7 @@ macro_rules! fmt_list {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         "│"
@@ -109,7 +109,7 @@ macro_rules! fmt_heading {
         $crate::terminal::PADDING,
         "─".repeat($crate::terminal::get_separator_width()).dim().light_gray())
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("\n{}{}\n{}{}",
         $crate::terminal::PADDING,
         format!($input, $($args),+),
@@ -142,7 +142,7 @@ macro_rules! fmt_info {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         ">"
@@ -162,7 +162,7 @@ macro_rules! fmt_warn {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         "!"
@@ -182,7 +182,7 @@ macro_rules! fmt_err {
             .bold(),
         format!($input))
     };
-    ($input:expr, $($args:expr),+) => {
+    ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{} {}",
         $crate::terminal::ICON_PADDING,
         "✗"

--- a/implementations/rust/ockam/ockam_command/src/lease/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/create.rs
@@ -2,10 +2,11 @@ use crate::shared_args::{IdentityOpts, TimeoutArg, TrustOpts};
 use crate::{docs, Command, CommandGlobalOpts};
 use async_trait::async_trait;
 use clap::Args;
-use ockam_api::fmt_log;
+use colorful::Colorful;
+use ockam_api::colors::color_primary;
 use ockam_api::influxdb::token_lessor_node_service::InfluxDBTokenLessorNodeServiceTrait;
 use ockam_api::nodes::InMemoryNode;
-use ockam_api::output::Output;
+use ockam_api::{fmt_log, fmt_ok};
 use ockam_multiaddr::MultiAddr;
 use ockam_node::Context;
 
@@ -50,10 +51,17 @@ impl Command for CreateCommand {
 
         let res = node.create_token(ctx, &cmd.at).await?;
 
+        let plain = fmt_ok!("A token with id {}\n", color_primary(&res.id))
+            + &fmt_log!(
+                "was issued for the identifier {}\n",
+                color_primary(&res.issued_for)
+            )
+            + &fmt_log!("and will expire at {}", color_primary(res.expires_at()?));
+
         opts.terminal
             .stdout()
-            .machine(res.token.to_string())
-            .plain(res.item()?)
+            .machine(&res.token)
+            .plain(plain)
             .json_obj(res)?
             .write_line()?;
 

--- a/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/revoke.rs
@@ -17,13 +17,13 @@ const HELP_DETAIL: &str = "";
 #[derive(Clone, Debug, Args)]
 #[command(help_template = docs::after_help(HELP_DETAIL))]
 pub struct RevokeCommand {
+    /// ID of the token to revoke
+    #[arg(id = "token_id", value_name = "TOKEN_ID")]
+    pub token_id: String,
+
     /// The route to the node that will be used to create the token
     #[arg(long, value_name = "ROUTE", default_value_t = super::lease_at_default_value())]
     pub at: MultiAddr,
-
-    /// ID of the token to revoke
-    #[arg(long, short, id = "token_id", value_name = "TOKEN_ID")]
-    pub token_id: String,
 
     #[command(flatten)]
     pub timeout: TimeoutArg,

--- a/implementations/rust/ockam/ockam_command/src/lease/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/show.rs
@@ -16,13 +16,13 @@ const HELP_DETAIL: &str = "";
 #[derive(Clone, Debug, Args)]
 #[command(help_template = docs::after_help(HELP_DETAIL))]
 pub struct ShowCommand {
+    /// ID of the token to retrieve
+    #[arg(value_name = "TOKEN_ID")]
+    pub token_id: String,
+
     /// The route to the node that will be used to create the token
     #[arg(long, value_name = "ROUTE", default_value_t = super::lease_at_default_value())]
     pub at: MultiAddr,
-
-    /// ID of the token to retrieve
-    #[arg(short, long, value_name = "TOKEN_ID")]
-    pub token_id: String,
 
     #[command(flatten)]
     pub timeout: TimeoutArg,
@@ -54,7 +54,7 @@ impl Command for ShowCommand {
             .write_line(&fmt_log!("Retrieving influxdb token...\n"))?;
 
         let (at, _meta) = clean_nodes_multiaddr(&cmd.at, &opts.state).await?;
-        let res = node.create_token(ctx, &at).await?;
+        let res = node.get_token(ctx, &at, &cmd.token_id).await?;
 
         opts.terminal
             .stdout()


### PR DESCRIPTION
- refactor influxdb api client to better handle error responses
- improve output for lease commands
- the `token_id` arg of lease commands is now the first positional arg, instead of a named arg (i.e. `lease show <token-id>` instead of `lease show --token-id <token-id>`)