### PR TITLE
Polvorin/influxdb ux

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/influxdb/token_lessor_node_service.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/token_lessor_node_service.rs
@@ -60,13 +60,13 @@ impl NodeManagerWorker {
 }
 
 impl InMemoryNode {
-    async fn start_influxdb_token_lessor_service(
+    pub async fn start_influxdb_token_lessor_service(
         &self,
         context: &Context,
         address: Address,
         req: StartInfluxDBLeaseManagerRequest,
     ) -> Result<(), Error> {
-        debug!(address = %address.address(), "Starting influxdb token lease manager service");
+        warn!(address = %address.address(), "Starting influxdb token lease manager service");
 
         let default_secure_channel_listener_flow_control_id = context
             .flow_controls()
@@ -143,12 +143,12 @@ impl InMemoryNode {
 #[rustfmt::skip]
 #[cbor(map)]
 pub struct StartInfluxDBLeaseManagerRequest {
-    #[n(1)] influxdb_address: String,
-    #[n(2)] influxdb_org_id: String,
-    #[n(3)] influxdb_token: String,
-    #[n(4)] token_permissions: String,
-    #[n(5)] token_ttl: i32,
-    #[n(6)] policy_expression: Option<PolicyExpression>,
+    #[n(1)] pub influxdb_address: String,
+    #[n(2)] pub influxdb_org_id: String,
+    #[n(3)] pub influxdb_token: String,
+    #[n(4)] pub token_permissions: String,
+    #[n(5)] pub token_ttl: i32,
+    #[n(6)] pub policy_expression: Option<PolicyExpression>,
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use minicbor::{CborLen, Decode, Encode};
-use ockam_abac::PolicyExpression;
 use ockam_multiaddr::MultiAddr;
 
 use super::portal::{CreateInlet, CreateOutlet};
@@ -13,15 +12,18 @@ use super::portal::{CreateInlet, CreateOutlet};
 pub struct CreateInfluxDBInlet {
     /// The address the portal should listen at.
     #[n(1)] pub(crate) tcp_inlet: CreateInlet,
-    /// The token leaser service address.
-    #[n(2)] pub(crate) service_address: MultiAddr,
+    /// shared|per-client
+    #[n(2)] pub(crate) lease_usage: String,
+    // Route to the lease issuer. If not given it's derived from the outlet' route
+    #[n(3)] pub(crate) lease_issuer: Option<MultiAddr>,
 }
 
 impl CreateInfluxDBInlet {
-    pub fn new(tcp_inlet: CreateInlet, service_address: MultiAddr) -> Self {
+    pub fn new(tcp_inlet: CreateInlet, lease_usage: String, lease_issuer: Option<MultiAddr>) -> Self {
         Self {
             tcp_inlet,
-            service_address,
+            lease_usage,
+            lease_issuer
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/influxdb_portal.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use minicbor::{CborLen, Decode, Encode};
+use ockam_abac::PolicyExpression;
 use ockam_multiaddr::MultiAddr;
 
 use super::portal::{CreateInlet, CreateOutlet};
@@ -30,15 +33,30 @@ impl CreateInfluxDBInlet {
 pub struct CreateInfluxDBOutlet {
     /// The address the portal should listen at.
     #[n(1)] pub(crate) tcp_outlet: CreateOutlet,
-    /// The token leaser service address.
-    #[n(2)] pub(crate) service_address: MultiAddr,
+    
+    #[n(2)] pub(crate) influxdb_org_id: String,
+    #[n(3)] pub(crate) influxdb_token: String,
+    #[n(4)] pub(crate)lease_permissions: String,
+    #[n(5)] pub(crate)lease_usage: String,
+    #[n(6)] pub(crate)expires_in: Duration,
 }
 
 impl CreateInfluxDBOutlet {
-    pub fn new(tcp_outlet: CreateOutlet, service_address: MultiAddr) -> Self {
+    pub fn new(
+        tcp_outlet: CreateOutlet,
+        influxdb_org_id: String,
+        influxdb_token: String,
+        lease_permissions: String,
+        lease_usage: String,
+        expires_in: Duration,
+    ) -> Self {
         Self {
             tcp_outlet,
-            service_address,
+            influxdb_org_id,
+            influxdb_token,
+            lease_permissions,
+            lease_usage,
+            expires_in,
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/portal.rs
@@ -36,27 +36,24 @@ pub struct CreateInlet {
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
     #[n(4)] pub(crate) authorized: Option<Identifier>,
-    /// A suffix route that will be applied after outlet_addr, and won't be used
-    /// to monitor the state of the connection
-    #[n(5)] pub(crate) suffix_route: Route,
     /// The maximum duration to wait for an outlet to be available
-    #[n(6)] pub(crate) wait_for_outlet_duration: Option<Duration>,
+    #[n(5)] pub(crate) wait_for_outlet_duration: Option<Duration>,
     /// The expression for the access control policy for this inlet.
     /// If not set, the policy set for the [TCP inlet resource type](ockam_abac::ResourceType::TcpInlet)
     /// will be used.
-    #[n(7)] pub(crate) policy_expression: Option<PolicyExpression>,
+    #[n(6)] pub(crate) policy_expression: Option<PolicyExpression>,
     /// Create the inlet and wait for the outlet to connect
-    #[n(8)] pub(crate) wait_connection: bool,
+    #[n(7)] pub(crate) wait_connection: bool,
     /// The identifier to be used to create the secure channel.
     /// If not set, the node's identifier will be used.
-    #[n(9)] pub(crate) secure_channel_identifier: Option<Identifier>,
+    #[n(8)] pub(crate) secure_channel_identifier: Option<Identifier>,
     /// Enable UDP NAT puncture.
-    #[n(10)] pub(crate) enable_udp_puncture: bool,
+    #[n(9)] pub(crate) enable_udp_puncture: bool,
     /// Disable fallback to TCP.
     /// TCP won't be used to transfer data between the Inlet and the Outlet.
-    #[n(11)] pub(crate) disable_tcp_fallback: bool,
+    #[n(10)] pub(crate) disable_tcp_fallback: bool,
     /// TLS certificate provider route.
-    #[n(12)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
+    #[n(11)] pub(crate) tls_certificate_provider: Option<MultiAddr>,
 }
 
 impl CreateInlet {
@@ -68,7 +65,6 @@ impl CreateInlet {
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
-        suffix_route: Route,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -82,7 +78,6 @@ impl CreateInlet {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider: None,
-            suffix_route,
         }
     }
 
@@ -95,7 +90,6 @@ impl CreateInlet {
         wait_connection: bool,
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
-        suffix_route: Route,
     ) -> Self {
         Self {
             listen_addr: listen,
@@ -109,7 +103,6 @@ impl CreateInlet {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider: None,
-            suffix_route,
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/background_node_client.rs
@@ -1,5 +1,4 @@
 use ockam::identity::Identifier;
-use ockam::Route;
 use ockam_abac::PolicyExpression;
 use ockam_core::api::{Reply, Request};
 use ockam_core::async_trait;
@@ -26,7 +25,6 @@ pub fn create_inlet_payload(
     enable_udp_puncture: bool,
     disable_tcp_fallback: bool,
     tls_certificate_provider: &Option<MultiAddr>,
-    outlet_suffix_address: Route,
 ) -> CreateInlet {
     let via_project = outlet_addr.matches(0, &[ProjectProto::CODE.into()]);
     let mut payload = if via_project {
@@ -37,7 +35,6 @@ pub fn create_inlet_payload(
             wait_connection,
             enable_udp_puncture,
             disable_tcp_fallback,
-            outlet_suffix_address,
         )
     } else {
         CreateInlet::to_node(
@@ -48,7 +45,6 @@ pub fn create_inlet_payload(
             wait_connection,
             enable_udp_puncture,
             disable_tcp_fallback,
-            outlet_suffix_address,
         )
     };
     if let Some(e) = policy_expression.as_ref() {
@@ -80,7 +76,6 @@ impl Inlets for BackgroundNodeClient {
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
         tls_certificate_provider: &Option<MultiAddr>,
-        outlet_suffix_addr: Route,
     ) -> miette::Result<Reply<InletStatus>> {
         let request = {
             let payload = create_inlet_payload(
@@ -95,7 +90,6 @@ impl Inlets for BackgroundNodeClient {
                 enable_udp_puncture,
                 disable_tcp_fallback,
                 tls_certificate_provider,
-                outlet_suffix_addr,
             );
             Request::post("/node/inlet").body(payload)
         };

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/inlets_trait.rs
@@ -1,5 +1,4 @@
 use ockam::identity::Identifier;
-use ockam::Route;
 use ockam_abac::PolicyExpression;
 use ockam_core::api::Reply;
 use ockam_core::async_trait;
@@ -27,7 +26,6 @@ pub trait Inlets {
         enable_udp_puncture: bool,
         disable_tcp_fallback: bool,
         tls_certificate_provider: &Option<MultiAddr>,
-        outlet_suffix_address: Route,
     ) -> miette::Result<Reply<InletStatus>>;
 
     async fn show_inlet(&self, ctx: &Context, alias: &str) -> miette::Result<Reply<InletStatus>>;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager_worker.rs
@@ -29,7 +29,6 @@ impl NodeManagerWorker {
             enable_udp_puncture,
             disable_tcp_fallback,
             tls_certificate_provider,
-            suffix_route,
         } = create_inlet;
         match self
             .node_manager
@@ -37,7 +36,7 @@ impl NodeManagerWorker {
                 ctx,
                 listen_addr,
                 route![],
-                suffix_route,
+                route![],
                 outlet_addr,
                 alias,
                 policy_expression,

--- a/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/incoming_services/commands.rs
@@ -6,7 +6,6 @@ use miette::IntoDiagnostic;
 use ockam::abac::expr::{eq, ident, str};
 use ockam::abac::PolicyExpression::FullExpression;
 use ockam::abac::SUBJECT_KEY;
-use ockam::route;
 use ockam::transport::HostnamePort;
 use ockam_api::address::get_free_address;
 use ockam_api::authenticator::direct::{
@@ -228,7 +227,6 @@ impl AppState {
                 false,
                 false,
                 &None,
-                route![],
             )
             .await
             .map_err(|err| {

--- a/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/mod.rs
@@ -1,2 +1,22 @@
+use std::str::FromStr;
+
 pub mod inlet;
 pub mod outlet;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeaseUsage {
+    Shared,
+    PerClient,
+}
+
+impl FromStr for LeaseUsage {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "shared" => Ok(LeaseUsage::Shared),
+            "per-client" | "per_client" => Ok(LeaseUsage::PerClient),
+            _ => Err(format!("Invalid lease usage: {}", s)),
+        }
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
@@ -5,7 +7,9 @@ use miette::IntoDiagnostic;
 use ockam::{Address, Context};
 use ockam_api::nodes::service::influxdb_portal_service::InfluxDBPortals;
 
+use crate::influxdb::LeaseUsage;
 use crate::node::util::initialize_default_node;
+use crate::util::parsers::duration_parser;
 use crate::{Command, CommandGlobalOpts};
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::BackgroundNodeClient;
@@ -20,9 +24,39 @@ pub struct InfluxDBCreateCommand {
     #[command(flatten)]
     pub outlet_create_command: OutletCreateCommand,
 
-    /// The route to the token leaser service
-    #[arg(long, value_name = "ROUTE")]
-    pub token_leaser: MultiAddr,
+    /// The organization ID of the InfluxDB server
+    #[arg(long, value_name = "ORG_ID", default_value_t = default_influxdb_org_id())]
+    pub influxdb_org_id: String,
+
+    /// The token to use to connect to the InfluxDB server
+    #[arg(long, value_name = "TOKEN", default_value_t = default_influxdb_token())]
+    pub influxdb_token: String,
+
+    /// The permissions to grant to new leases
+    #[arg(long, value_name = "JSON")]
+    pub lease_permissions: String,
+
+    /// Share the leases among the clients or use a separate lease for each client
+    #[arg(long, default_value = "shared")]
+    pub lease_usage: LeaseUsage,
+
+    /// The duration for which a lease is valid
+    #[arg(long = "expires-in", value_name = "DURATION", value_parser = duration_parser)]
+    pub expires_in: Duration,
+}
+
+fn default_influxdb_org_id() -> String {
+    "TODO".to_string()
+    /*std::env::var("INFLUXDB_ORG_ID").expect(
+        "Pass a value for `--influxdb-org-id` or export the INFLUXDB_ORG_ID environment variable",
+    ) */
+}
+
+fn default_influxdb_token() -> String {
+    "TODO".to_string()
+    /*std::env::var("INFLUXDB_TOKEN").expect(
+        "Pass a value for `--influxdb-token` or export the INFLUXDB_TOKEN environment variable",
+    ) */
 }
 
 #[async_trait]
@@ -41,6 +75,11 @@ impl Command for InfluxDBCreateCommand {
         }
         let node = BackgroundNodeClient::create(ctx, &opts.state, &outlet_cmd.at).await?;
         let node_name = node.node_name();
+        let usage = if self.lease_usage == LeaseUsage::Shared {
+            "shared".to_string()
+        } else {
+            "per-client".to_string()
+        };
         let outlet_status = node
             .create_influxdb_outlet(
                 ctx,
@@ -48,7 +87,11 @@ impl Command for InfluxDBCreateCommand {
                 outlet_cmd.tls,
                 outlet_cmd.from.clone().map(Address::from).as_ref(),
                 outlet_cmd.allow.clone(),
-                self.token_leaser.clone(),
+                self.influxdb_org_id,
+                self.influxdb_token,
+                self.lease_permissions,
+                usage, //self.lease_usage,
+                self.expires_in,
             )
             .await?;
         outlet_cmd

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -45,6 +45,8 @@ pub struct InfluxDBCreateCommand {
 }
 
 fn default_influxdb_org_id() -> String {
+    //TODO: FIXME:  as is, it doesn't work when using trom a node config yaml. 
+    //              the cmd fails to parse even when the parameter is given.
     "TODO".to_string()
     /*std::env::var("INFLUXDB_ORG_ID").expect(
         "Pass a value for `--influxdb-org-id` or export the INFLUXDB_ORG_ID environment variable",

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -14,7 +14,6 @@ use crate::{Command, CommandGlobalOpts};
 use ockam_api::colors::color_primary;
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_api::{fmt_log, fmt_ok};
-use ockam_multiaddr::MultiAddr;
 
 use crate::tcp::outlet::create::CreateCommand as OutletCreateCommand;
 

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -14,7 +14,7 @@ use crate::tcp::util::alias_parser;
 use crate::{docs, Command, CommandGlobalOpts, Error};
 use ockam::identity::Identifier;
 use ockam::transport::HostnamePort;
-use ockam::{route, Context};
+use ockam::Context;
 use ockam_abac::PolicyExpression;
 use ockam_api::address::extract_address_value;
 use ockam_api::cli_state::journeys::{
@@ -193,9 +193,6 @@ impl Command for CreateCommand {
                         cmd.udp,
                         cmd.no_tcp_fallback,
                         &cmd.tls_certificate_provider,
-                        cmd.outlet_suffix_address
-                            .as_ref()
-                            .map_or(route![], |s| route![s]),
                     )
                     .await?;
 


### PR DESCRIPTION
## lease-usage: per-client
### Outlet
```
name: n1
relays: n1
influxdb-outlets:
   influxdb:
     to: 8086
     influxdb-org-id: $ORG_ID
     influxdb-token: $TOKEN
     expires-in: 60
     lease-usage: per-client 
     lease-permissions: $PERMISSIONS_JSON

launch-config: |
  {
   "startup_services": {
      "secure_channel_listener": {
        "address" : "api"
      }
    }
  }
```
### Inlet
```
name: influxdb_proxy
influxdb-inlets:
  influxdb:
    from: 0.0.0.0:8087
    to: /project/default/service/forward_to_n1/secure/api/service/influxdb
    lease-usage: per-client
    tls: false | true
```

### Inlet (with custom route to lease_issuer)
```

name: influxdb_proxy
influxdb-inlets:
  influxdb:
    from: 0.0.0.0:8087
    to: /project/default/service/forward_to_n1/secure/api/service/influxdb
    lease-usage: per-client
    # This can be set to any route, not tied to the 'to' outlet.  Just to showcase that scenariom
    # here it actually points to the one derived from 'to'
    lease-issuer-route: /project/default/service/forward_to_n1/secure/api/service/influxdb_lease_issuer
    tls: false
```


## lease-usage: shared
### Outlet
```
name: n1
relays: n1

influxdb-outlets:
   influxdb:
     to: 8086
     influxdb-org-id: $ORG_ID
     influxdb-token: $TOKEN
     expires-in: 60
     lease-usage: shared 
     lease-permissions: $PERMISSIONS_JSON

launch-config: |
  {
   "startup_services": {
      "secure_channel_listener": {
        "address" : "api"
      }
    }
  }
```

### Inlet
```
name: influxdb_proxy

influxdb-inlets:
  influxd_in:
    from: 0.0.0.0:8087
    to: /project/default/service/forward_to_n1/secure/api/service/influxdb
    lease-usage: shared
    tls: false | true
```