### PR TITLE
feat(rust): more options on token management for influxdb_outlet

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/influxdb/gateway/token_lease_refresher.rs
+++ b/implementations/rust/ockam/ockam_api/src/influxdb/gateway/token_lease_refresher.rs
@@ -15,6 +15,10 @@ pub struct TokenLeaseRefresher {
 }
 
 impl TokenLeaseRefresher {
+    pub fn new_with_fixed_token(token: String) -> TokenLeaseRefresher {
+        let token = Arc::new(RwLock::new(Some(token)));
+        Self { token }
+    }
     pub async fn new(
         ctx: &Context,
         node_manager: Weak<InMemoryNode>,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/default_address.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/default_address.rs
@@ -21,7 +21,7 @@ impl DefaultAddress {
     pub const OKTA_IDENTITY_PROVIDER: &'static str = "okta";
     pub const KAFKA_OUTLET: &'static str = "kafka_outlet";
     pub const KAFKA_INLET: &'static str = "kafka_inlet";
-    pub const LEASE_ISSUER: &'static str = "lease_issuer";
+    pub const LEASE_MANAGER: &'static str = "lease_manager";
 
     pub fn get_rendezvous_server_address() -> Address {
         let server_address = std::env::var("OCKAM_RENDEZVOUS_SERVER")
@@ -44,7 +44,7 @@ impl DefaultAddress {
             | Self::OKTA_IDENTITY_PROVIDER
             | Self::KAFKA_INLET
             | Self::KAFKA_OUTLET
-            | Self::LEASE_ISSUER)
+            | Self::LEASE_MANAGER)
     }
 
     pub fn iter() -> impl Iterator<Item = &'static str> {
@@ -64,7 +64,7 @@ impl DefaultAddress {
             Self::OKTA_IDENTITY_PROVIDER,
             Self::KAFKA_INLET,
             Self::KAFKA_OUTLET,
-            Self::LEASE_ISSUER,
+            Self::LEASE_MANAGER,
         ]
         .iter()
         .copied()

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/worker.rs
@@ -142,12 +142,12 @@ impl NodeManagerWorker {
                 self.delete_kafka_service(ctx, dec.decode()?, KafkaServiceKind::Inlet)
                     .await,
             )?,
-            (Post, ["node", "services", DefaultAddress::LEASE_ISSUER]) => encode_response(
+            (Post, ["node", "services", DefaultAddress::LEASE_MANAGER]) => encode_response(
                 req,
                 self.start_influxdb_lease_issuer_service(ctx, dec.decode()?)
                     .await,
             )?,
-            (Delete, ["node", "services", DefaultAddress::LEASE_ISSUER]) => encode_response(
+            (Delete, ["node", "services", DefaultAddress::LEASE_MANAGER]) => encode_response(
                 req,
                 self.delete_influxdb_lease_issuer_service(ctx, dec.decode()?)
                     .await,

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -22,7 +22,7 @@ pub struct InfluxDBCreateCommand {
     pub tcp_inlet: InletCreateCommand,
 
     /// Share the leases among the clients or use a separate lease for each client
-    #[arg(long, default_value = "shared")]
+    #[arg(long, default_value = "per-client")]
     pub leased_token_strategy: LeaseUsage,
 
     /// The route to the lease issuer service.

--- a/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/outlet/create.rs
@@ -7,9 +7,11 @@ use clap::Args;
 use colorful::Colorful;
 use ockam::{Address, Context};
 use ockam_api::colors::color_primary;
+use ockam_api::influxdb::portal::{LeaseManagerConfig, TokenConfig};
 use ockam_api::influxdb::{InfluxDBPortals, LeaseUsage};
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_api::{fmt_log, fmt_ok};
+use ockam_multiaddr::MultiAddr;
 use std::time::Duration;
 
 /// Create InfluxDB Outlets
@@ -18,6 +20,23 @@ pub struct InfluxDBCreateCommand {
     #[command(flatten)]
     pub tcp_outlet: OutletCreateCommand,
 
+    /// Share the leases among the clients or use a separate lease for each client
+    #[arg(long, default_value = "shared")]
+    pub leased_token_strategy: LeaseUsage,
+
+    #[arg(long, conflicts_with_all(["LeaseManagerConfigArgs", "lease_manager_route"]))]
+    fixed_token: Option<String>,
+
+    #[arg(long, conflicts_with_all(["LeaseManagerConfigArgs", "fixed_token"]))]
+    lease_manager_route: Option<MultiAddr>,
+
+    #[clap(flatten)]
+    lease_manager_config: Option<LeaseManagerConfigArgs>,
+}
+
+#[derive(Args, Clone, Debug)]
+#[group(multiple = true)]
+pub struct LeaseManagerConfigArgs {
     /// The organization ID of the InfluxDB server
     #[arg(long, value_name = "ORG_ID", default_value = "INFLUXDB_ORG_ID")]
     pub org_id: String,
@@ -30,10 +49,6 @@ pub struct InfluxDBCreateCommand {
     #[arg(long, value_name = "JSON")]
     pub leased_token_permissions: String,
 
-    /// Share the leases among the clients or use a separate lease for each client
-    #[arg(long, default_value = "shared")]
-    pub leased_token_strategy: LeaseUsage,
-
     /// The duration for which a lease is valid
     #[arg(long, value_name = "DURATION", value_parser = duration_parser)]
     pub leased_token_expires_in: Duration,
@@ -44,8 +59,8 @@ impl Command for InfluxDBCreateCommand {
     const NAME: &'static str = "influxdb-outlet create";
 
     async fn async_run(mut self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        println!("{:?}", self);
         initialize_default_node(ctx, &opts).await?;
-        self = self.parse_args().await?;
 
         if let Some(pb) = opts.terminal.progress_bar() {
             pb.set_message(format!(
@@ -53,6 +68,21 @@ impl Command for InfluxDBCreateCommand {
                 color_primary(self.tcp_outlet.to.to_string())
             ));
         }
+        let token_config = if let Some(t) = self.fixed_token {
+            TokenConfig::FixedToken(t)
+        } else if let Some(r) = self.lease_manager_route {
+            TokenConfig::FromLeaseManager(r)
+        } else if let Some(config) = self.lease_manager_config {
+            let config = config.parse_args().await?;
+            TokenConfig::StartLeaseManager(LeaseManagerConfig::new(
+                config.org_id,
+                config.all_access_token,
+                config.leased_token_permissions,
+                config.leased_token_expires_in,
+            ))
+        } else {
+            todo!()
+        };
 
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.tcp_outlet.at).await?;
         let outlet_status = node
@@ -62,11 +92,8 @@ impl Command for InfluxDBCreateCommand {
                 self.tcp_outlet.tls,
                 self.tcp_outlet.from.clone().map(Address::from).as_ref(),
                 self.tcp_outlet.allow.clone(),
-                self.org_id,
-                self.all_access_token,
-                self.leased_token_permissions,
                 self.leased_token_strategy,
-                self.leased_token_expires_in,
+                token_config,
             )
             .await?;
         self.tcp_outlet
@@ -91,12 +118,11 @@ impl Command for InfluxDBCreateCommand {
             .machine(&outlet_status.worker_addr)
             .json_obj(&outlet_status)?
             .write_line()?;
-
         Ok(())
     }
 }
 
-impl InfluxDBCreateCommand {
+impl LeaseManagerConfigArgs {
     async fn parse_args(mut self) -> miette::Result<Self> {
         if self.org_id == "INFLUXDB_ORG_ID" {
             self.org_id = std::env::var("INFLUXDB_ORG_ID").expect(

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_outlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_outlets.rs
@@ -62,7 +62,6 @@ mod tests {
                 to: 127.0.0.1:6060
                 from: my_outlet
                 leased-token-permissions: ""
-                leased-token-strategy: shared
                 leased-token-expires-in: 1h
         "#;
         let parsed: InfluxDBOutlets = serde_yaml::from_str(named).unwrap();


### PR DESCRIPTION
On the inlet side:  change the default leased-token-strategy to be `per-client` leases.

On outlet side, remove the leased-token-strategy argument:  it's implied now based on the other options:   
  - If the (newly introduced) `fixed-token` argument is given, it means token injection will be done at the outlet side,  with that fixed token.   inlet must be configured with  `leased-token-strategy: shared`
  - if a root token and other arguments needed to create leases are provided,  a lease manager is started using these arguments.  Token injection is to be used at the inlet side,  so inlet must be configured with `leased-token-strategy: per-client`
