### PR TITLE
feat(rust): compact enrollment ticket encoded format

### DIFF
--- a/examples/rust/get_started/src/token.rs
+++ b/examples/rust/get_started/src/token.rs
@@ -1,11 +1,11 @@
+use anyhow::anyhow;
 use std::process::Command;
 use std::str;
-
-use anyhow::anyhow;
+use std::str::FromStr;
 
 use ockam::Result;
 use ockam_api::authenticator::one_time_code::OneTimeCode;
-use ockam_api::cli_state::enrollments::EnrollmentTicket;
+use ockam_api::cli_state::ExportedEnrollmentTicket;
 use ockam_core::errcode::{Kind, Origin};
 use ockam_core::Error;
 
@@ -27,8 +27,9 @@ pub async fn create_token(attribute_name: &str, attribute_value: &str) -> Result
     // we unwrap the result of decoding the token as UTF-8 since it should be some valid UTF-8 string
     let token_string = str::from_utf8(token_output.stdout.as_slice()).unwrap().trim();
 
-    let decoded = hex::decode(token_string).map_err(|e| error(format!("{e}")))?;
-    let ticket: EnrollmentTicket = serde_json::from_slice(&decoded).map_err(|e| error(format!("{e}")))?;
+    let decoded =
+        ExportedEnrollmentTicket::from_str(token_string).map_err(|e| error(format!("could not decode token: {e}")))?;
+    let ticket = decoded.import().await?;
 
     Ok(ticket.one_time_code.clone())
 }

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -25,6 +25,7 @@ description = "Ockam's request-response API"
 
 [features]
 default = ["std", "rust-crypto", "ebpf"]
+test-utils = []
 std = [
   "either/use_std",
   "hex/std",

--- a/implementations/rust/ockam/ockam_api/src/authenticator/one_time_code.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/one_time_code.rs
@@ -12,7 +12,7 @@ use std::fmt::{Debug, Formatter};
 
 /// A one-time code can be used to enroll
 /// a node with some authenticated attributes
-/// It can be retrieve with a command like `ockam project ticket --attribute component=control`
+/// It can be retrieved with a command like `ockam project ticket --attribute component=control`
 #[derive(Clone, Encode, Decode, CborLen, PartialEq, Eq)]
 #[rustfmt::skip]
 #[cbor(map)]

--- a/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
@@ -1,10 +1,4 @@
-use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
-use time::OffsetDateTime;
-
 use crate::authenticator::one_time_code::OneTimeCode;
-use ockam::identity::{Identifier, TimestampInSeconds};
-
 use crate::cli_state::Result;
 use crate::cli_state::{CliState, CliStateError};
 use crate::cloud::email_address::EmailAddress;
@@ -13,6 +7,13 @@ use crate::colors::{color_ok, color_primary, color_warn};
 use crate::error::ApiError;
 use crate::output::human_readable_time;
 use crate::terminal::fmt;
+use ockam::identity::{Identifier, Identity, TimestampInSeconds, Vault};
+use ockam_multiaddr::proto::DnsAddr;
+use ockam_multiaddr::{MultiAddr, Protocol};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+use time::OffsetDateTime;
 
 /// The following CliState methods help keeping track of
 ///
@@ -250,12 +251,12 @@ impl Display for IdentityEnrollment {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct EnrollmentTicket {
+pub struct LegacyEnrollmentTicket {
     pub one_time_code: OneTimeCode,
     pub project: Option<ProjectModel>,
 }
 
-impl EnrollmentTicket {
+impl LegacyEnrollmentTicket {
     pub fn new(one_time_code: OneTimeCode, project: Option<ProjectModel>) -> Self {
         Self {
             one_time_code,
@@ -274,5 +275,483 @@ impl EnrollmentTicket {
             .map_err(|_err| ApiError::core("Failed to decode EnrollmentTicket hex"))?;
         Ok(serde_json::from_slice(&data)
             .map_err(|_err| ApiError::core("Failed to decode EnrollmentTicket json"))?)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExportedEnrollmentTicket {
+    pub one_time_code: OneTimeCode,
+    project_route: ProjectRoute,
+    project_identifier: String,
+    project_name: String,
+    project_change_history: String,
+    authority_change_history: String,
+    authority_route: Option<String>,
+}
+
+impl ExportedEnrollmentTicket {
+    const MANDATORY_FIELDS_NUM: usize = 6;
+
+    pub fn new(
+        one_time_code: OneTimeCode,
+        project_route: ProjectRoute,
+        project_identifier: impl Into<String>,
+        project_name: impl Into<String>,
+        project_change_history: impl Into<String>,
+        authority_change_history: impl Into<String>,
+        authority_route: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            one_time_code,
+            project_route,
+            project_identifier: project_identifier.into(),
+            project_name: project_name.into(),
+            project_change_history: project_change_history.into(),
+            authority_change_history: authority_change_history.into(),
+            authority_route: authority_route.map(Into::into),
+        }
+    }
+
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn new_test() -> Self {
+        Self::new(
+            OneTimeCode::new(),
+            ProjectRoute::new_with_id("project_id").unwrap(),
+            "I5cf1bc8d300018d9a0fa6a177c073347abe35f95e55837b23e22a5f6857a1e0c",
+            crate::cli_state::random_name(),
+            "81825837830101583285f68200815820245ba33c7729dce1c94d8c1a00fcf89a7af33689d4563176f9dffbdd147d4488f41a66e2ee7b1a79aef17b820081584070856bb8da621154a39c894a2fedded55257715b00940b9cffe54b51d87889aff2c077124ee6e0e1c2e711688470affbc65d909c87acf4e41d38bdfb03e2000d",
+            "81825837830101583285f6820081582045d9dac79f226762025fc82e7407aee4a4c8e7068dc04edd44f1c777b8f0cf6bf41a66e2ee7b1a79aef17b8200815840c65ce655fd57cf2ea0b0679066a24bc99e2b223341186b5eaec951101f291e96c5fc8343291a23cbd8dc063ad1f9a9554f036e8f34ab5388e444977e7e29ab0b",
+            None::<String>,
+        )
+    }
+
+    pub async fn import(self) -> Result<EnrollmentTicket> {
+        EnrollmentTicket::new(
+            self.one_time_code,
+            self.project_route.id,
+            self.project_name,
+            self.project_route.route.to_string(),
+            self.project_change_history,
+            self.authority_change_history,
+            self.authority_route,
+        )
+        .await
+    }
+}
+
+impl FromStr for ExportedEnrollmentTicket {
+    type Err = ApiError;
+
+    fn from_str(contents: &str) -> std::result::Result<Self, Self::Err> {
+        // Decode as comma-separated text
+        let values: Vec<&str> = contents.split(',').collect();
+        if values.len() < Self::MANDATORY_FIELDS_NUM {
+            return Err(ApiError::core("Missing fields in enrollment ticket").into());
+        }
+        let (
+            project_route,
+            project_identifier,
+            project_name,
+            one_time_code,
+            project_change_history,
+            authority_change_history,
+        ) = (
+            values[0], values[1], values[2], values[3], values[4], values[5],
+        );
+        let authority_route = values.get(6).map(|r| r.to_string());
+
+        let project_route = if project_route.starts_with('/') {
+            ProjectRoute::new_with_route(MultiAddr::from_str(project_route)?)?
+        } else {
+            ProjectRoute::new_with_id(project_route)?
+        };
+        Ok(Self::new(
+            OneTimeCode::from_str(one_time_code)?,
+            project_route,
+            project_identifier.to_string(),
+            project_name.to_string(),
+            project_change_history.to_string(),
+            authority_change_history.to_string(),
+            authority_route,
+        ))
+    }
+}
+
+impl Display for ExportedEnrollmentTicket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{},{},{},{},{},{}",
+            self.project_route.route,
+            self.project_identifier,
+            self.project_name,
+            String::from(&self.one_time_code),
+            self.project_change_history,
+            self.authority_change_history,
+        )?;
+        if let Some(authority_route) = &self.authority_route {
+            write!(f, ",{}", authority_route)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ProjectRoute {
+    id: String,
+    route: MultiAddr,
+}
+
+impl ProjectRoute {
+    pub fn new_with_id(id: impl Into<String>) -> Result<Self> {
+        let id = id.into();
+        Ok(Self {
+            id: id.clone(),
+            route: MultiAddr::from_str(&format!(
+                "/dnsaddr/{id}.projects.orchestrator.ockam.io/tcp/443/service/{id}/service/api"
+            ))?,
+        })
+    }
+
+    pub fn new_with_route(route: impl Into<MultiAddr>) -> Result<Self> {
+        let route = route.into();
+        match route.iter().next() {
+            Some(pv) => {
+                // from a project route like: "/dnsaddr/<id>.projects.orchestrator.ockam.io/tcp/.."
+                // extract the "<id>" segment
+                if pv.code() != DnsAddr::CODE {
+                    return Err(CliStateError::InvalidData(
+                        "Invalid project route".to_string(),
+                    ));
+                }
+                let dnsaddr = String::from_utf8(pv.data().to_vec())
+                    .map_err(|e| CliStateError::InvalidData(format!("{}", e)))?;
+                let project_id = dnsaddr
+                    .split('.')
+                    .next()
+                    .ok_or(CliStateError::InvalidData(
+                        "Invalid project route".to_string(),
+                    ))?
+                    .to_string();
+                Ok(Self {
+                    id: project_id,
+                    route,
+                })
+            }
+            None => Err(CliStateError::InvalidData(
+                "Invalid project route".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EnrollmentTicket {
+    pub one_time_code: OneTimeCode,
+    project_id: String,
+    project_name: String,
+    project_route: MultiAddr,
+    project_identity: Identity,
+    authority_identity: Identity,
+    authority_route: MultiAddr,
+}
+
+impl EnrollmentTicket {
+    pub async fn new(
+        one_time_code: OneTimeCode,
+        project_id: impl Into<String>,
+        project_name: impl Into<String>,
+        project_route: impl Into<String>,
+        project_change_history: impl Into<String>,
+        authority_change_history: impl Into<String>,
+        authority_route: Option<String>,
+    ) -> Result<Self> {
+        let project_id = project_id.into();
+        let project_route = project_route.into();
+        let project_change_history = project_change_history.into();
+        let project_identity = Identity::import_from_string(
+            None,
+            &project_change_history,
+            Vault::create_verifying_vault(),
+        )
+        .await?;
+        let authority_change_history = authority_change_history.into();
+        let authority_identity = Identity::import_from_string(
+            None,
+            &authority_change_history,
+            Vault::create_verifying_vault(),
+        )
+        .await?;
+        let authority_route = match authority_route {
+            Some(a) => MultiAddr::from_str(&a)?,
+            None => MultiAddr::from_str(&format!(
+                "/dnsaddr/{project_id}.projects.orchestrator.ockam.io/tcp/443/service/{project_id}/service/authority/service/api"
+            ))?
+        };
+        Ok(Self {
+            one_time_code,
+            project_id: project_id.clone(),
+            project_name: project_name.into(),
+            project_route: MultiAddr::from_str(&project_route)?,
+            project_identity,
+            authority_identity,
+            authority_route,
+        })
+    }
+
+    pub async fn new_from_project(
+        one_time_code: OneTimeCode,
+        project: &ProjectModel,
+    ) -> Result<Self> {
+        let project_change_history = project
+            .project_change_history
+            .as_ref()
+            .ok_or(ApiError::core("no project change history"))?;
+        let authority_change_history = project
+            .authority_identity
+            .as_ref()
+            .ok_or(ApiError::core("no authority change history"))?;
+        let authority_route = project
+            .authority_access_route
+            .as_ref()
+            .map(|r| r.to_string());
+        Self::new(
+            one_time_code,
+            &project.id,
+            &project.name,
+            &project.access_route,
+            project_change_history,
+            authority_change_history,
+            authority_route,
+        )
+        .await
+    }
+
+    pub async fn new_from_legacy(ticket: LegacyEnrollmentTicket) -> Result<Self> {
+        let project = ticket
+            .project
+            .as_ref()
+            .ok_or(ApiError::core("no project in legacy ticket"))?;
+        let project_id = project.id.clone();
+        let project_name = project.name.clone();
+        let project_change_history = project
+            .project_change_history
+            .as_ref()
+            .ok_or(ApiError::core("no project change history in legacy ticket"))?
+            .clone();
+        let authority_change_history = project
+            .authority_identity
+            .as_ref()
+            .ok_or(ApiError::core(
+                "no authority change history in legacy ticket",
+            ))?
+            .clone();
+        let authority_route = project
+            .authority_access_route
+            .as_ref()
+            .map(|r| r.to_string());
+        Self::new(
+            ticket.one_time_code,
+            project_id,
+            project_name,
+            &project.access_route,
+            project_change_history,
+            authority_change_history,
+            authority_route,
+        )
+        .await
+    }
+
+    pub fn project(&self) -> Result<ProjectModel> {
+        Ok(ProjectModel {
+            id: self.project_id.clone(),
+            name: self.project_name.clone(),
+            space_name: "".to_string(),
+            access_route: self.project_route.to_string(),
+            users: vec![],
+            space_id: "".to_string(),
+            identity: Some(self.project_identity.identifier().clone()),
+            authority_access_route: Some(self.authority_route.to_string()),
+            authority_identity: Some(self.authority_identity.export_as_string()?),
+            okta_config: None,
+            kafka_config: None,
+            version: None,
+            running: None,
+            operation_id: None,
+            user_roles: vec![],
+            project_change_history: Some(self.project_identity.export_as_string()?),
+        })
+    }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    pub fn set_project_name(&mut self, name: impl Into<String>) {
+        self.project_name = name.into();
+    }
+
+    pub fn export(self) -> Result<ExportedEnrollmentTicket> {
+        Ok(ExportedEnrollmentTicket::new(
+            self.one_time_code,
+            ProjectRoute::new_with_id(self.project_id)?,
+            self.project_identity.identifier().to_string(),
+            self.project_name,
+            self.project_identity.export_as_string()?,
+            self.authority_identity.export_as_string()?,
+            Some(self.authority_route.to_string()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exported_enrollment_ticket() {
+        let exported = ExportedEnrollmentTicket::new_test();
+        let encoded = exported.to_string();
+        assert!(encoded.contains(&String::from(&exported.one_time_code)));
+        assert!(encoded.contains(&exported.project_route.id));
+        assert!(encoded.contains(&exported.project_route.route.to_string()));
+        assert!(encoded.contains(&exported.project_name));
+        assert!(encoded.contains(&exported.project_change_history));
+        assert!(encoded.contains(&exported.authority_change_history));
+
+        let decoded = ExportedEnrollmentTicket::from_str(&encoded).unwrap();
+        assert_eq!(decoded, exported);
+    }
+
+    #[test]
+    fn test_project_id_or_route() {
+        let project_id = "c4a6a4b4-537b-4f2e-ace4-ef1992b922a6";
+
+        let route = MultiAddr::from_str(&format!("/dnsaddr/{project_id}.projects.orchestrator.ockam.io/tcp/443/service/{project_id}/service/api")).unwrap();
+        let from_route = ProjectRoute::new_with_route(route).unwrap();
+        assert_eq!(from_route.id, project_id);
+
+        let from_id = ProjectRoute::new_with_id(project_id).unwrap();
+        assert_eq!(from_id.id, project_id);
+
+        let from_invalid_route =
+            ProjectRoute::new_with_route(MultiAddr::from_str("/node/n1").unwrap());
+        assert!(from_invalid_route.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_enrollment_ticket_from_legacy() {
+        let otc = OneTimeCode::new();
+        let project_id = "c4a6a4b4-537b-4f2e-ace4-ef1992b922a6";
+        let project_name = "name";
+        let project_change_history = "81825837830101583285f68200815820245ba33c7729dce1c94d8c1a00fcf89a7af33689d4563176f9dffbdd147d4488f41a66e2ee7b1a79aef17b820081584070856bb8da621154a39c894a2fedded55257715b00940b9cffe54b51d87889aff2c077124ee6e0e1c2e711688470affbc65d909c87acf4e41d38bdfb03e2000d";
+        let authority_change_history = "81825837830101583285f6820081582045d9dac79f226762025fc82e7407aee4a4c8e7068dc04edd44f1c777b8f0cf6bf41a66e2ee7b1a79aef17b8200815840c65ce655fd57cf2ea0b0679066a24bc99e2b223341186b5eaec951101f291e96c5fc8343291a23cbd8dc063ad1f9a9554f036e8f34ab5388e444977e7e29ab0b";
+        let project = ProjectModel {
+            id: project_id.to_string(),
+            name: project_name.to_string(),
+            space_name: "".to_string(),
+            access_route: "/dnsaddr/project.ockam.io/tcp/443".to_string(),
+            users: vec![],
+            space_id: "".to_string(),
+            identity: None,
+            authority_access_route: Some("/dnsaddr/authority.ockam.io/tcp/443".to_string()),
+            authority_identity: Some(authority_change_history.to_string()),
+            okta_config: None,
+            kafka_config: None,
+            version: None,
+            running: None,
+            operation_id: None,
+            user_roles: vec![],
+            project_change_history: Some(project_change_history.to_string()),
+        };
+        let legacy = LegacyEnrollmentTicket::new(otc.clone(), Some(project.clone()));
+        let enrollment_ticket = EnrollmentTicket::new_from_legacy(legacy).await.unwrap();
+        assert_eq!(enrollment_ticket.one_time_code, otc);
+        assert_eq!(enrollment_ticket.project_id, project_id);
+        assert_eq!(enrollment_ticket.project_name, project_name);
+        assert_eq!(
+            &enrollment_ticket.project_identity,
+            &Identity::import_from_string(
+                None,
+                project_change_history,
+                Vault::create_verifying_vault()
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(
+            &enrollment_ticket.project_route,
+            &MultiAddr::from_str("/dnsaddr/project.ockam.io/tcp/443").unwrap()
+        );
+        assert_eq!(
+            &enrollment_ticket.authority_identity,
+            &Identity::import_from_string(
+                None,
+                authority_change_history,
+                Vault::create_verifying_vault()
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(
+            &enrollment_ticket.authority_route,
+            &MultiAddr::from_str("/dnsaddr/authority.ockam.io/tcp/443").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enrollment_ticket_from_exported() {
+        let otc = OneTimeCode::new();
+        let project_id = "c4a6a4b4-537b-4f2e-ace4-ef1992b922a6";
+        let project_name = "name";
+        let project_change_history = "81825837830101583285f68200815820245ba33c7729dce1c94d8c1a00fcf89a7af33689d4563176f9dffbdd147d4488f41a66e2ee7b1a79aef17b820081584070856bb8da621154a39c894a2fedded55257715b00940b9cffe54b51d87889aff2c077124ee6e0e1c2e711688470affbc65d909c87acf4e41d38bdfb03e2000d";
+        let project_identity = Identity::import_from_string(
+            None,
+            project_change_history,
+            Vault::create_verifying_vault(),
+        )
+        .await
+        .unwrap();
+        let authority_change_history = "81825837830101583285f6820081582045d9dac79f226762025fc82e7407aee4a4c8e7068dc04edd44f1c777b8f0cf6bf41a66e2ee7b1a79aef17b8200815840c65ce655fd57cf2ea0b0679066a24bc99e2b223341186b5eaec951101f291e96c5fc8343291a23cbd8dc063ad1f9a9554f036e8f34ab5388e444977e7e29ab0b";
+        let authority_identity = Identity::import_from_string(
+            None,
+            authority_change_history,
+            Vault::create_verifying_vault(),
+        )
+        .await
+        .unwrap();
+        let exported = ExportedEnrollmentTicket::new(
+            otc.clone(),
+            ProjectRoute::new_with_id(project_id).unwrap(),
+            project_identity.identifier().to_string(),
+            project_name,
+            project_change_history,
+            authority_change_history,
+            None::<String>,
+        );
+        let enrollment_ticket = exported.clone().import().await.unwrap();
+        assert_eq!(enrollment_ticket.project_id, project_id);
+        assert_eq!(enrollment_ticket.project_name, project_name);
+        assert_eq!(&enrollment_ticket.project_identity, &project_identity);
+        assert_eq!(&enrollment_ticket.authority_identity, &authority_identity);
+        assert_eq!(&enrollment_ticket.one_time_code, &otc);
+
+        let exported_back = enrollment_ticket.clone().export().unwrap();
+        assert_eq!(exported_back.project_route, exported.project_route);
+        assert_eq!(
+            exported_back.project_identifier,
+            exported.project_identifier
+        );
+        assert_eq!(exported_back.project_name, exported.project_name);
+        assert_eq!(exported_back.one_time_code, exported.one_time_code);
+        assert_eq!(
+            exported_back.project_change_history,
+            exported.project_change_history
+        );
+        assert_eq!(
+            exported_back.authority_change_history,
+            exported.authority_change_history
+        );
+        assert!(exported_back.authority_route.is_some());
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/share/create.rs
@@ -3,12 +3,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
+use super::{RoleInShare, ShareScope};
 use crate::cli_state::{CliState, EnrollmentTicket};
 use crate::cloud::email_address::EmailAddress;
 use crate::error::ApiError;
 use ockam::identity::Identifier;
-
-use super::{RoleInShare, ShareScope};
 
 #[derive(Clone, Debug, Encode, Decode, CborLen, Serialize)]
 #[cbor(map)]
@@ -56,13 +55,8 @@ impl CreateServiceInvitation {
             .get_project_by_name(project_name.as_ref())
             .await?;
         let project_authority_route = project.authority_multiaddr()?;
-        // see also: ockam_command::project::ticket
-        let enrollment_ticket = hex::encode(
-            serde_json::to_vec(&enrollment_ticket)
-                .map_err(|_| ApiError::core("Could not encode enrollment ticket"))?,
-        );
         Ok(CreateServiceInvitation {
-            enrollment_ticket,
+            enrollment_ticket: enrollment_ticket.export()?.to_string(),
             expires_at,
             project_id: project.project_id().to_string(),
             recipient_email: recipient_email.clone(),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -238,7 +238,7 @@ impl InMemoryNode {
         }
     }
 
-    pub async fn create_authority_client(
+    pub async fn create_authority_client_with_project(
         &self,
         ctx: &Context,
         project: &Project,
@@ -246,7 +246,32 @@ impl InMemoryNode {
     ) -> miette::Result<AuthorityNodeClient> {
         let client = self
             .node_manager
-            .create_authority_client(ctx, project, caller_identity_name)
+            .create_authority_client_with_project(ctx, project, caller_identity_name)
+            .await?;
+        if let Some(timeout) = self.timeout {
+            Ok(client
+                .with_request_timeout(&timeout)
+                .with_secure_channel_timeout(&timeout))
+        } else {
+            Ok(client)
+        }
+    }
+
+    pub async fn create_authority_client_with_authority(
+        &self,
+        ctx: &Context,
+        authority_identifier: &Identifier,
+        authority_route: &MultiAddr,
+        caller_identity_name: Option<String>,
+    ) -> miette::Result<AuthorityNodeClient> {
+        let client = self
+            .node_manager
+            .create_authority_client_with_authority(
+                ctx,
+                authority_identifier,
+                authority_route,
+                caller_identity_name,
+            )
             .await?;
         if let Some(timeout) = self.timeout {
             Ok(client

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -415,7 +415,7 @@ impl NodeManager {
         Ok(project)
     }
 
-    pub async fn create_authority_client(
+    pub async fn create_authority_client_with_project(
         &self,
         ctx: &Context,
         project: &Project,
@@ -449,6 +449,28 @@ impl NodeManager {
             project.authority_multiaddr().into_diagnostic()?,
             &caller_identifier,
             credential_retriever_creator,
+        )
+        .await
+        .into_diagnostic()
+    }
+
+    pub async fn create_authority_client_with_authority(
+        &self,
+        _ctx: &Context,
+        authority_identifier: &Identifier,
+        authority_route: &MultiAddr,
+        caller_identity_name: Option<String>,
+    ) -> miette::Result<AuthorityNodeClient> {
+        let caller_identifier = self
+            .get_identifier_by_name(caller_identity_name)
+            .await
+            .into_diagnostic()?;
+
+        self.make_authority_node_client(
+            authority_identifier,
+            authority_route,
+            &caller_identifier,
+            None,
         )
         .await
         .into_diagnostic()

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -50,6 +50,7 @@ tracing = { version = "0.1", default-features = false }
 tracing-core = { version = "0.1.32", default-features = false }
 
 [dev-dependencies]
+ockam_api = { path = "../ockam_api", version = "0.77.0", default-features = false, features = ["test-utils"] }
 tempfile = { version = "3.10.1" }
 
 [build-dependencies]

--- a/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
@@ -42,7 +42,10 @@ impl AppState {
                 None,
             )
             .await?;
-        Ok(EnrollmentTicket::new(otc, Some(project.model().clone())))
+        let ticket = EnrollmentTicket::new_from_project(otc, project.model())
+            .await
+            .into_diagnostic()?;
+        Ok(ticket)
     }
 
     pub(crate) async fn refresh_projects(&self) -> Result<()> {

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -129,10 +129,13 @@ impl AppState {
     /// Creates a new AppState for testing purposes
     #[cfg(test)]
     pub async fn test(context: &Context, cli_state: CliState) -> AppState {
-        let context = ockam_core::AsyncTryClone::async_try_clone(context)
-            .await
-            .unwrap();
-        Self::make(Arc::new(context), None, None, cli_state).await
+        Self::make(
+            Arc::new(context.async_try_clone().await.unwrap()),
+            None,
+            None,
+            cli_state,
+        )
+        .await
     }
 
     async fn make(
@@ -388,7 +391,7 @@ impl AppState {
     ) -> Result<AuthorityNodeClient> {
         let node_manager = self.node_manager.read().await;
         Ok(node_manager
-            .create_authority_client(ctx, project, caller_identity_name)
+            .create_authority_client_with_project(ctx, project, caller_identity_name)
             .await?)
     }
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -109,6 +109,7 @@ which = "6.0.2"
 [dev-dependencies]
 assert_cmd = "2"
 mockito = "1.5.0"
+ockam_api = { path = "../ockam_api", version = "0.77.0", default-features = false, features = ["test-utils"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.35.0" }
 proptest = "1.5.0"
 tempfile = "3.10.1"

--- a/implementations/rust/ockam/ockam_command/src/project/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/util.rs
@@ -216,7 +216,9 @@ async fn check_authority_node_accessible(
     retry_strategy: Take<FixedInterval>,
     spinner_option: Option<ProgressBar>,
 ) -> Result<Project> {
-    let authority_node = node.create_authority_client(ctx, &project, None).await?;
+    let authority_node = node
+        .create_authority_client_with_project(ctx, &project, None)
+        .await?;
 
     if let Some(spinner) = spinner_option.as_ref() {
         spinner.set_message("Establishing secure channel to project authority...");

--- a/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
@@ -146,7 +146,7 @@ pub(super) async fn create_authority_client(
         .await?;
 
     Ok(node
-        .create_authority_client(ctx, project, Some(identity))
+        .create_authority_client_with_project(ctx, project, Some(identity))
         .await?)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/project_enroll.rs
@@ -62,31 +62,31 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use ockam_api::authenticator::one_time_code::OneTimeCode;
-    use ockam_api::cli_state::EnrollmentTicket;
+    use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     use super::*;
 
     #[test]
     fn project_enroll_config() {
-        let enrollment_ticket = EnrollmentTicket::new(OneTimeCode::new(), None);
-        let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
+        let enrollment_ticket = ExportedEnrollmentTicket::new_test();
+        let enrollment_ticket_encoded = enrollment_ticket.to_string();
 
         // As contents
-        let config = format!("ticket: {enrollment_ticket_hex}");
+        let config = format!("ticket: {enrollment_ticket_encoded}");
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
         let cmds = parsed.into_parsed_commands(None).unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(
             cmds[0].enrollment_ticket.as_ref().unwrap(),
-            &enrollment_ticket_hex
+            &enrollment_ticket_encoded
         );
 
         // As path
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("my.ticket");
         let mut file = File::create(&file_path).unwrap();
-        file.write_all(enrollment_ticket_hex.as_bytes()).unwrap();
+        file.write_all(enrollment_ticket_encoded.as_bytes())
+            .unwrap();
         let config = format!("ticket: {}", file_path.to_str().unwrap());
         let parsed: ProjectEnroll = serde_yaml::from_str(&config).unwrap();
         let cmds = parsed

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -124,20 +124,19 @@ impl SecureRelayInlet {
 mod tests {
     use super::*;
     use crate::run::parser::config::ConfigParser;
-    use ockam_api::authenticator::one_time_code::OneTimeCode;
-    use ockam_api::cli_state::EnrollmentTicket;
+    use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     #[test]
     fn test_that_recipe_is_valid() {
-        let enrollment_ticket = EnrollmentTicket::new(OneTimeCode::new(), None);
-        let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
+        let enrollment_ticket = ExportedEnrollmentTicket::new_test();
+        let enrollment_ticket_encoded = enrollment_ticket.to_string();
 
         let cmd = SecureRelayInlet {
             service_name: "service_name".to_string(),
             from: HostnamePort::new("127.0.0.1", 8080),
             dry_run: false,
             enroll: Enroll {
-                enroll_ticket: Some(enrollment_ticket_hex),
+                enroll_ticket: Some(enrollment_ticket_encoded),
                 okta: false,
             },
         };

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -124,8 +124,7 @@ impl SecureRelayOutlet {
 
 #[cfg(test)]
 mod tests {
-    use ockam_api::authenticator::one_time_code::OneTimeCode;
-    use ockam_api::cli_state::EnrollmentTicket;
+    use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     use crate::run::parser::config::ConfigParser;
 
@@ -133,15 +132,15 @@ mod tests {
 
     #[test]
     fn test_that_recipe_is_valid() {
-        let enrollment_ticket = EnrollmentTicket::new(OneTimeCode::new(), None);
-        let enrollment_ticket_hex = enrollment_ticket.hex_encoded().unwrap();
+        let enrollment_ticket = ExportedEnrollmentTicket::new_test();
+        let enrollment_ticket_encoded = enrollment_ticket.to_string();
 
         let cmd = SecureRelayOutlet {
             service_name: "service_name".to_string(),
             to: HostnamePort::new("127.0.0.1", 8080),
             dry_run: false,
             enroll: Enroll {
-                enroll_ticket: Some(enrollment_ticket_hex),
+                enroll_ticket: Some(enrollment_ticket_encoded),
                 okta: false,
             },
         };

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -45,8 +45,8 @@ teardown() {
   run "$OCKAM" identity create account_authority
 
   run "$OCKAM" identity create admin
-  # m1 will be pre-enrolled on authority.  m2 will be added directly, m3 will be added through enrollment token
-  # m4 and m5 will be added by a shared enrollment token, m6 won't be added
+  # m1 will be pre-enrolled on authority.  m2 will be added directly, m3 will be added through enrollment ticket
+  # m4 and m5 will be added by a shared enrollment ticket, m6 won't be added
   run "$OCKAM" identity create m1
   run "$OCKAM" identity create m2
   run "$OCKAM" identity create m3
@@ -138,7 +138,7 @@ EOF
 @test "authority - enrollment ticket ttl" {
   run "$OCKAM" identity create authority
   run "$OCKAM" identity create enroller
-  #m3 will be added through enrollment token
+  #m3 will be added through enrollment ticket
   run "$OCKAM" identity create m3
 
   enroller_identifier=$($OCKAM identity show enroller)
@@ -172,14 +172,14 @@ EOF
   run_success bash -c "$OCKAM project import --project-file $OCKAM_HOME/project.json"
 
   # Enrollment ticket expired by the time it's used
-  token=$($OCKAM project ticket --identity enroller --attribute sample_attr=m3_member --expires-in 1s)
+  ticket=$($OCKAM project ticket --identity enroller --attribute sample_attr=m3_member --expires-in 1s)
   sleep 2
-  run "$OCKAM" project enroll $token --identity m3
+  run "$OCKAM" project enroll $ticket --identity m3
   assert_failure
 
   # Enrollment ticket with enough ttl
-  token=$($OCKAM project ticket --identity enroller --attribute sample_attr=m3_member --expires-in 30s)
-  run_success "$OCKAM" project enroll $token --identity m3
+  ticket=$($OCKAM project ticket --identity enroller --attribute sample_attr=m3_member --expires-in 30s)
+  run_success "$OCKAM" project enroll $ticket --identity m3
   assert_output --partial "m3_member"
 }
 
@@ -253,7 +253,7 @@ EOF
   m_identifier=$($OCKAM identity show m)
 
   # Start the authority node.  We pass a set of pre trusted-identities containing m1' identity identifier
-  # For the first test we start the node with no direct authentication service nor token enrollment
+  # For the first test we start the node with no direct authentication service nor ticket enrollment
   trusted="{\"$enroller_identifier\": {\"ockam-role\": \"enroller\"}}"
   port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"


### PR DESCRIPTION
The enrollment tickets are now a comma-separated text line, with all the necessary information. The fields are ordered as follows: 

`<project route>,<project identifier>,<project name>,<token>,<project change history>,<authority change history>,<authority route>`

The project route will follow a similar structure to this: 

`/dnsaddr/<id>.projects.orchestrator.ockam.io/tcp/443/service/<id>/service/api`

The authority route is optional. It will derive it from the project id/route if not present. The project identifier and project name will eventually disappear from this format, but we need it there for now.

## Using the previous format

A message will be shown asking the user to use an up-to-date ockam version. It will still convert the old ticket into the new format, and use it normally to enroll.

![image](https://github.com/user-attachments/assets/63cd9a1b-498a-48c4-be22-2fc484b9006c)
