### PR TITLE
Fix flaky test by improving SQLite concurrency model

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -59,12 +59,20 @@ impl Authority {
     /// Create an identity for an authority from the configured public identity and configured vault
     /// The list of trusted identities in the configuration is used to pre-populate an attributes storage
     /// In practice it contains the list of identities with the ockam-role attribute set as 'enroller'
-    pub async fn create(configuration: &Configuration) -> Result<Self> {
+    pub async fn create(
+        configuration: &Configuration,
+        database: Option<SqlxDatabase>,
+    ) -> Result<Self> {
         debug!(?configuration, "creating the authority");
 
         // create the database
         let node_name = "authority";
-        let database = SqlxDatabase::create(&configuration.database_configuration).await?;
+        let database = if let Some(database) = database {
+            database
+        } else {
+            SqlxDatabase::create(&configuration.database_configuration).await?
+        };
+
         let members = Arc::new(AuthorityMembersSqlxDatabase::new(database.clone()));
         let tokens = Arc::new(AuthorityEnrollmentTokenSqlxDatabase::new(database.clone()));
         let secure_channel_repository = Arc::new(SecureChannelSqlxDatabase::new(database.clone()));

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -289,16 +289,7 @@ impl CliState {
         let _ = std::fs::remove_dir_all(Self::make_commands_log_dir_path(root_path));
         // Delete the nodes database, keep the application database
         if let Some(path) = Self::make_database_configuration(root_path)?.path() {
-            std::fs::remove_file(path.clone())?;
-            // wal and shm files may not exist, depending on the database state
-            let wal_path = path.with_extension("sqlite3-wal");
-            if wal_path.exists() {
-                std::fs::remove_file(wal_path)?;
-            }
-            let shm_path = path.with_extension("sqlite3-shm");
-            if shm_path.exists() {
-                std::fs::remove_file(shm_path)?;
-            }
+            std::fs::remove_file(path)?;
         };
         Ok(())
     }
@@ -409,16 +400,9 @@ mod tests {
 
     /// HELPERS
     fn list_file_names(dir: &Path) -> Vec<String> {
-        let file_names: Vec<_> = fs::read_dir(dir)
+        fs::read_dir(dir)
             .unwrap()
             .map(|f| f.unwrap().file_name().to_string_lossy().to_string())
-            .collect();
-
-        // remove -wal and -shm files from the list
-        // they may or may not exist depending on the database state
-        file_names
-            .into_iter()
-            .filter(|file| !file.ends_with("-wal") && !file.ends_with("-shm"))
-            .collect::<Vec<String>>()
+            .collect()
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -289,7 +289,16 @@ impl CliState {
         let _ = std::fs::remove_dir_all(Self::make_commands_log_dir_path(root_path));
         // Delete the nodes database, keep the application database
         if let Some(path) = Self::make_database_configuration(root_path)?.path() {
-            std::fs::remove_file(path)?
+            std::fs::remove_file(path.clone())?;
+            // wal and shm files may not exist, depending on the database state
+            let wal_path = path.with_extension("sqlite3-wal");
+            if wal_path.exists() {
+                std::fs::remove_file(wal_path)?;
+            }
+            let shm_path = path.with_extension("sqlite3-shm");
+            if shm_path.exists() {
+                std::fs::remove_file(shm_path)?;
+            }
         };
         Ok(())
     }
@@ -400,9 +409,16 @@ mod tests {
 
     /// HELPERS
     fn list_file_names(dir: &Path) -> Vec<String> {
-        fs::read_dir(dir)
+        let file_names: Vec<_> = fs::read_dir(dir)
             .unwrap()
             .map(|f| f.unwrap().file_name().to_string_lossy().to_string())
-            .collect()
+            .collect();
+
+        // remove -wal and -shm files from the list
+        // they may or may not exist depending on the database state
+        file_names
+            .into_iter()
+            .filter(|file| !file.ends_with("-wal") && !file.ends_with("-shm"))
+            .collect::<Vec<String>>()
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/repositories.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/repositories.rs
@@ -4,6 +4,7 @@ use ockam::identity::{
     CredentialSqlxDatabase,
 };
 use ockam_core::compat::sync::Arc;
+use ockam_node::database::DatabaseConfiguration;
 use ockam_vault::storage::{SecretsRepository, SecretsSqlxDatabase};
 
 use crate::cli_state::storage::*;
@@ -17,54 +18,171 @@ use crate::cli_state::{UsersRepository, UsersSqlxDatabase};
 /// stored in the database
 impl CliState {
     pub fn change_history_repository(&self) -> Arc<dyn ChangeHistoryRepository> {
-        Arc::new(ChangeHistorySqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(ChangeHistorySqlxDatabase::new(database)))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(ChangeHistorySqlxDatabase::new(database))
+            }
+        }
     }
 
     pub(super) fn identities_repository(&self) -> Arc<dyn IdentitiesRepository> {
-        Arc::new(IdentitiesSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(IdentitiesSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(IdentitiesSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn purpose_keys_repository(&self) -> Arc<dyn PurposeKeysRepository> {
-        Arc::new(PurposeKeysSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => Arc::new(AutoRetry::new(
+                PurposeKeysSqlxDatabase::new(self.database()),
+            )),
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(PurposeKeysSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn secrets_repository(&self) -> Arc<dyn SecretsRepository> {
-        Arc::new(SecretsSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(SecretsSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(SecretsSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn vaults_repository(&self) -> Arc<dyn VaultsRepository> {
-        Arc::new(VaultsSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(VaultsSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(VaultsSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn enrollment_repository(&self) -> Arc<dyn EnrollmentsRepository> {
-        Arc::new(EnrollmentsSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => Arc::new(AutoRetry::new(
+                EnrollmentsSqlxDatabase::new(self.database()),
+            )),
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(EnrollmentsSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn nodes_repository(&self) -> Arc<dyn NodesRepository> {
-        Arc::new(NodesSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(NodesSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(NodesSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn tcp_portals_repository(&self) -> Arc<dyn TcpPortalsRepository> {
-        Arc::new(TcpPortalsSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(TcpPortalsSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(TcpPortalsSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn projects_repository(&self) -> Arc<dyn ProjectsRepository> {
-        Arc::new(ProjectsSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(ProjectsSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(ProjectsSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn spaces_repository(&self) -> Arc<dyn SpacesRepository> {
-        Arc::new(SpacesSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(SpacesSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(SpacesSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn users_repository(&self) -> Arc<dyn UsersRepository> {
-        Arc::new(UsersSqlxDatabase::new(self.database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => {
+                Arc::new(AutoRetry::new(UsersSqlxDatabase::new(self.database())))
+            }
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(UsersSqlxDatabase::new(self.database()))
+            }
+        }
     }
 
     pub(super) fn user_journey_repository(&self) -> Arc<dyn JourneysRepository> {
-        Arc::new(JourneysSqlxDatabase::new(self.application_database()))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => Arc::new(AutoRetry::new(
+                JourneysSqlxDatabase::new(self.application_database()),
+            )),
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(JourneysSqlxDatabase::new(self.application_database()))
+            }
+        }
     }
 
     pub fn cached_credentials_repository(&self, node_name: &str) -> Arc<dyn CredentialRepository> {
-        Arc::new(CredentialSqlxDatabase::new(self.database(), node_name))
+        let database = self.database();
+        match database.configuration {
+            DatabaseConfiguration::SqlitePersistent { .. }
+            | DatabaseConfiguration::SqliteInMemory { .. } => Arc::new(AutoRetry::new(
+                CredentialSqlxDatabase::new(self.database(), node_name),
+            )),
+            DatabaseConfiguration::Postgres { .. } => {
+                Arc::new(CredentialSqlxDatabase::new(self.database(), node_name))
+            }
+        }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/auto_retry.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/auto_retry.rs
@@ -1,0 +1,628 @@
+use crate::cli_state::journeys::{Journey, ProjectJourney};
+use crate::cli_state::{
+    EnrollmentsRepository, IdentitiesRepository, IdentityEnrollment, JourneysRepository,
+    NamedIdentity, NamedVault, NodeInfo, NodesRepository, ProjectsRepository, SpacesRepository,
+    TcpInlet, TcpPortalsRepository, UsersRepository, VaultType, VaultsRepository,
+};
+use crate::cloud::email_address::EmailAddress;
+use crate::cloud::enroll::auth0::UserInfo;
+use crate::cloud::project::models::ProjectModel;
+use crate::cloud::space::Space;
+use crate::config::lookup::InternetAddress;
+use crate::nodes::models::portal::OutletStatus;
+use chrono::{DateTime, Utc};
+use ockam::identity::models::{ChangeHistory, CredentialAndPurposeKey, PurposeKeyAttestation};
+use ockam::identity::storage::PurposeKeysRepository;
+use ockam::identity::{
+    ChangeHistoryRepository, CredentialRepository, Identifier, Identity, Purpose,
+    TimestampInSeconds,
+};
+use ockam_core::{async_trait, Address};
+use ockam_vault::storage::SecretsRepository;
+use ockam_vault::{
+    AeadSecret, AeadSecretKeyHandle, SigningSecret, SigningSecretKeyHandle, X25519SecretKey,
+    X25519SecretKeyHandle,
+};
+
+macro_rules! retry {
+    ($async_function:expr) => {{
+        let mut retries = 0;
+        loop {
+            match $async_function.await {
+                Ok(result) => break Ok(result),
+                Err(err) => {
+                    if err.to_string().contains("database is locked") && retries < 100 {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                    } else {
+                        break Err(err);
+                    }
+                    retries += 1;
+                }
+            }
+        }
+    }};
+}
+
+#[derive(Clone)]
+pub(crate) struct AutoRetry<T: Sized + Send + Sync + 'static> {
+    wrapped: T,
+}
+
+impl<T: Send + Sync + 'static> AutoRetry<T> {
+    pub(crate) fn new(wrapped_trait: T) -> AutoRetry<T> {
+        Self {
+            wrapped: wrapped_trait,
+        }
+    }
+}
+
+#[async_trait]
+impl<T: EnrollmentsRepository> EnrollmentsRepository for AutoRetry<T> {
+    async fn set_as_enrolled(
+        &self,
+        identifier: &Identifier,
+        email: &EmailAddress,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_as_enrolled(identifier, email))
+    }
+
+    async fn get_enrolled_identities(&self) -> ockam_core::Result<Vec<IdentityEnrollment>> {
+        retry!(self.wrapped.get_enrolled_identities())
+    }
+
+    async fn get_all_identities_enrollments(&self) -> ockam_core::Result<Vec<IdentityEnrollment>> {
+        retry!(self.wrapped.get_all_identities_enrollments())
+    }
+
+    async fn is_default_identity_enrolled(&self) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.is_default_identity_enrolled())
+    }
+
+    async fn is_identity_enrolled(&self, name: &str) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.is_identity_enrolled(name))
+    }
+}
+
+#[async_trait]
+impl<T: IdentitiesRepository + Send + Sync + 'static> IdentitiesRepository for AutoRetry<T> {
+    async fn store_named_identity(
+        &self,
+        identifier: &Identifier,
+        name: &str,
+        vault_name: &str,
+    ) -> ockam_core::Result<NamedIdentity> {
+        retry!(self
+            .wrapped
+            .store_named_identity(identifier, name, vault_name))
+    }
+
+    async fn delete_identity(&self, name: &str) -> ockam_core::Result<Option<Identifier>> {
+        retry!(self.wrapped.delete_identity(name))
+    }
+
+    async fn delete_identity_by_identifier(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<Option<String>> {
+        retry!(self.wrapped.delete_identity_by_identifier(identifier))
+    }
+
+    async fn get_identifier(&self, name: &str) -> ockam_core::Result<Option<Identifier>> {
+        retry!(self.wrapped.get_identifier(name))
+    }
+
+    async fn get_identity_name_by_identifier(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<Option<String>> {
+        retry!(self.wrapped.get_identity_name_by_identifier(identifier))
+    }
+
+    async fn get_named_identity(&self, name: &str) -> ockam_core::Result<Option<NamedIdentity>> {
+        retry!(self.wrapped.get_named_identity(name))
+    }
+
+    async fn get_named_identity_by_identifier(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<Option<NamedIdentity>> {
+        retry!(self.wrapped.get_named_identity_by_identifier(identifier))
+    }
+
+    async fn get_named_identities(&self) -> ockam_core::Result<Vec<NamedIdentity>> {
+        retry!(self.wrapped.get_named_identities())
+    }
+
+    async fn get_named_identities_by_vault_name(
+        &self,
+        vault_name: &str,
+    ) -> ockam_core::Result<Vec<NamedIdentity>> {
+        retry!(self.wrapped.get_named_identities_by_vault_name(vault_name))
+    }
+
+    async fn set_as_default(&self, name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_as_default(name))
+    }
+
+    async fn set_as_default_by_identifier(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_as_default_by_identifier(identifier))
+    }
+
+    async fn get_default_named_identity(&self) -> ockam_core::Result<Option<NamedIdentity>> {
+        retry!(self.wrapped.get_default_named_identity())
+    }
+}
+
+#[async_trait]
+impl<T: JourneysRepository> JourneysRepository for AutoRetry<T> {
+    async fn store_project_journey(
+        &self,
+        project_journey: ProjectJourney,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_project_journey(project_journey.clone()))
+    }
+
+    async fn get_project_journey(
+        &self,
+        project_id: &str,
+        now: DateTime<Utc>,
+    ) -> ockam_core::Result<Option<ProjectJourney>> {
+        retry!(self.wrapped.get_project_journey(project_id, now))
+    }
+
+    async fn delete_project_journeys(&self, project_id: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_project_journeys(project_id))
+    }
+
+    async fn store_host_journey(&self, host_journey: Journey) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_host_journey(host_journey.clone()))
+    }
+
+    async fn get_host_journey(&self, now: DateTime<Utc>) -> ockam_core::Result<Option<Journey>> {
+        retry!(self.wrapped.get_host_journey(now))
+    }
+}
+
+#[async_trait]
+impl<T: NodesRepository> NodesRepository for AutoRetry<T> {
+    async fn store_node(&self, node_info: &NodeInfo) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_node(node_info))
+    }
+
+    async fn get_nodes(&self) -> ockam_core::Result<Vec<NodeInfo>> {
+        retry!(self.wrapped.get_nodes())
+    }
+
+    async fn get_node(&self, node_name: &str) -> ockam_core::Result<Option<NodeInfo>> {
+        retry!(self.wrapped.get_node(node_name))
+    }
+
+    async fn get_nodes_by_identifier(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<Vec<NodeInfo>> {
+        retry!(self.wrapped.get_nodes_by_identifier(identifier))
+    }
+
+    async fn get_default_node(&self) -> ockam_core::Result<Option<NodeInfo>> {
+        retry!(self.wrapped.get_default_node())
+    }
+
+    async fn set_default_node(&self, node_name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_default_node(node_name))
+    }
+
+    async fn is_default_node(&self, node_name: &str) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.is_default_node(node_name))
+    }
+
+    async fn delete_node(&self, node_name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_node(node_name))
+    }
+
+    async fn set_tcp_listener_address(
+        &self,
+        node_name: &str,
+        address: &InternetAddress,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_tcp_listener_address(node_name, address))
+    }
+
+    async fn set_http_server_address(
+        &self,
+        node_name: &str,
+        address: &InternetAddress,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_http_server_address(node_name, address))
+    }
+
+    async fn set_as_authority_node(&self, node_name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_as_authority_node(node_name))
+    }
+
+    async fn get_tcp_listener_address(
+        &self,
+        node_name: &str,
+    ) -> ockam_core::Result<Option<InternetAddress>> {
+        retry!(self.wrapped.get_tcp_listener_address(node_name))
+    }
+
+    async fn get_http_server_address(
+        &self,
+        node_name: &str,
+    ) -> ockam_core::Result<Option<InternetAddress>> {
+        retry!(self.wrapped.get_http_server_address(node_name))
+    }
+
+    async fn set_node_pid(&self, node_name: &str, pid: u32) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_node_pid(node_name, pid))
+    }
+
+    async fn set_no_node_pid(&self, node_name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_no_node_pid(node_name))
+    }
+
+    async fn set_node_project_name(
+        &self,
+        node_name: &str,
+        project_name: &str,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_node_project_name(node_name, project_name))
+    }
+
+    async fn get_node_project_name(&self, node_name: &str) -> ockam_core::Result<Option<String>> {
+        retry!(self.wrapped.get_node_project_name(node_name))
+    }
+}
+
+#[async_trait]
+impl<T: ProjectsRepository> ProjectsRepository for AutoRetry<T> {
+    async fn store_project(&self, project: &ProjectModel) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_project(project))
+    }
+
+    async fn get_project(&self, project_id: &str) -> ockam_core::Result<Option<ProjectModel>> {
+        retry!(self.wrapped.get_project(project_id))
+    }
+
+    async fn get_project_by_name(&self, name: &str) -> ockam_core::Result<Option<ProjectModel>> {
+        retry!(self.wrapped.get_project_by_name(name))
+    }
+
+    async fn get_projects(&self) -> ockam_core::Result<Vec<ProjectModel>> {
+        retry!(self.wrapped.get_projects())
+    }
+
+    async fn get_default_project(&self) -> ockam_core::Result<Option<ProjectModel>> {
+        retry!(self.wrapped.get_default_project())
+    }
+
+    async fn set_default_project(&self, project_id: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_default_project(project_id))
+    }
+
+    async fn delete_project(&self, project_id: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_project(project_id))
+    }
+}
+
+#[async_trait]
+impl<T: SpacesRepository> SpacesRepository for AutoRetry<T> {
+    async fn store_space(&self, space: &Space) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_space(space))
+    }
+
+    async fn get_space(&self, space_id: &str) -> ockam_core::Result<Option<Space>> {
+        retry!(self.wrapped.get_space(space_id))
+    }
+
+    async fn get_space_by_name(&self, name: &str) -> ockam_core::Result<Option<Space>> {
+        retry!(self.wrapped.get_space_by_name(name))
+    }
+
+    async fn get_spaces(&self) -> ockam_core::Result<Vec<Space>> {
+        retry!(self.wrapped.get_spaces())
+    }
+
+    async fn get_default_space(&self) -> ockam_core::Result<Option<Space>> {
+        retry!(self.wrapped.get_default_space())
+    }
+
+    async fn set_default_space(&self, space_id: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_default_space(space_id))
+    }
+
+    async fn delete_space(&self, space_id: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_space(space_id))
+    }
+}
+
+#[async_trait]
+impl<T: TcpPortalsRepository> TcpPortalsRepository for AutoRetry<T> {
+    async fn store_tcp_inlet(
+        &self,
+        node_name: &str,
+        tcp_inlet: &TcpInlet,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_tcp_inlet(node_name, tcp_inlet))
+    }
+
+    async fn get_tcp_inlet(
+        &self,
+        node_name: &str,
+        alias: &str,
+    ) -> ockam_core::Result<Option<TcpInlet>> {
+        retry!(self.wrapped.get_tcp_inlet(node_name, alias))
+    }
+
+    async fn delete_tcp_inlet(&self, node_name: &str, alias: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_tcp_inlet(node_name, alias))
+    }
+
+    async fn store_tcp_outlet(
+        &self,
+        node_name: &str,
+        tcp_outlet_status: &OutletStatus,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_tcp_outlet(node_name, tcp_outlet_status))
+    }
+
+    async fn get_tcp_outlet(
+        &self,
+        node_name: &str,
+        worker_addr: &Address,
+    ) -> ockam_core::Result<Option<OutletStatus>> {
+        retry!(self.wrapped.get_tcp_outlet(node_name, worker_addr))
+    }
+
+    async fn delete_tcp_outlet(
+        &self,
+        node_name: &str,
+        worker_addr: &Address,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_tcp_outlet(node_name, worker_addr))
+    }
+}
+
+#[async_trait]
+impl<T: UsersRepository> UsersRepository for AutoRetry<T> {
+    async fn store_user(&self, user: &UserInfo) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_user(user))
+    }
+
+    async fn get_default_user(&self) -> ockam_core::Result<Option<UserInfo>> {
+        retry!(self.wrapped.get_default_user())
+    }
+
+    async fn set_default_user(&self, email: &EmailAddress) -> ockam_core::Result<()> {
+        retry!(self.wrapped.set_default_user(email))
+    }
+
+    async fn get_user(&self, email: &EmailAddress) -> ockam_core::Result<Option<UserInfo>> {
+        retry!(self.wrapped.get_user(email))
+    }
+
+    async fn get_users(&self) -> ockam_core::Result<Vec<UserInfo>> {
+        retry!(self.wrapped.get_users())
+    }
+
+    async fn delete_user(&self, email: &EmailAddress) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_user(email))
+    }
+}
+
+#[async_trait]
+impl<T: VaultsRepository> VaultsRepository for AutoRetry<T> {
+    async fn store_vault(
+        &self,
+        name: &str,
+        vault_type: VaultType,
+    ) -> ockam_core::Result<NamedVault> {
+        retry!(self.wrapped.store_vault(name, vault_type.clone()))
+    }
+
+    async fn update_vault(&self, name: &str, vault_type: VaultType) -> ockam_core::Result<()> {
+        retry!(self.wrapped.update_vault(name, vault_type.clone()))
+    }
+
+    async fn delete_named_vault(&self, name: &str) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_named_vault(name))
+    }
+
+    async fn get_database_vault(&self) -> ockam_core::Result<Option<NamedVault>> {
+        retry!(self.wrapped.get_database_vault())
+    }
+
+    async fn get_named_vault(&self, name: &str) -> ockam_core::Result<Option<NamedVault>> {
+        retry!(self.wrapped.get_named_vault(name))
+    }
+
+    async fn get_named_vaults(&self) -> ockam_core::Result<Vec<NamedVault>> {
+        retry!(self.wrapped.get_named_vaults())
+    }
+}
+
+#[async_trait]
+impl<T: ChangeHistoryRepository> ChangeHistoryRepository for AutoRetry<T> {
+    async fn update_identity(
+        &self,
+        identity: &Identity,
+        ignore_older: bool,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.update_identity(identity, ignore_older))
+    }
+
+    async fn store_change_history(
+        &self,
+        identifier: &Identifier,
+        change_history: ChangeHistory,
+    ) -> ockam_core::Result<()> {
+        retry!(self
+            .wrapped
+            .store_change_history(identifier, change_history.clone()))
+    }
+
+    async fn delete_change_history(&self, identifier: &Identifier) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_change_history(identifier))
+    }
+
+    async fn get_change_history(
+        &self,
+        identifier: &Identifier,
+    ) -> ockam_core::Result<Option<ChangeHistory>> {
+        retry!(self.wrapped.get_change_history(identifier))
+    }
+
+    async fn get_change_histories(&self) -> ockam_core::Result<Vec<ChangeHistory>> {
+        retry!(self.wrapped.get_change_histories())
+    }
+}
+
+#[async_trait]
+impl<T: PurposeKeysRepository> PurposeKeysRepository for AutoRetry<T> {
+    async fn set_purpose_key(
+        &self,
+        subject: &Identifier,
+        purpose: Purpose,
+        purpose_key_attestation: &PurposeKeyAttestation,
+    ) -> ockam_core::Result<()> {
+        retry!(self
+            .wrapped
+            .set_purpose_key(subject, purpose, purpose_key_attestation))
+    }
+
+    async fn delete_purpose_key(
+        &self,
+        subject: &Identifier,
+        purpose: Purpose,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_purpose_key(subject, purpose))
+    }
+
+    async fn get_purpose_key(
+        &self,
+        identifier: &Identifier,
+        purpose: Purpose,
+    ) -> ockam_core::Result<Option<PurposeKeyAttestation>> {
+        retry!(self.wrapped.get_purpose_key(identifier, purpose))
+    }
+
+    async fn delete_all(&self) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_all())
+    }
+}
+
+#[async_trait]
+impl<T: CredentialRepository> CredentialRepository for AutoRetry<T> {
+    async fn get(
+        &self,
+        subject: &Identifier,
+        issuer: &Identifier,
+        scope: &str,
+    ) -> ockam_core::Result<Option<CredentialAndPurposeKey>> {
+        retry!(self.wrapped.get(subject, issuer, scope))
+    }
+
+    async fn put(
+        &self,
+        subject: &Identifier,
+        issuer: &Identifier,
+        scope: &str,
+        expires_at: TimestampInSeconds,
+        credential: CredentialAndPurposeKey,
+    ) -> ockam_core::Result<()> {
+        retry!(self
+            .wrapped
+            .put(subject, issuer, scope, expires_at, credential.clone()))
+    }
+
+    async fn delete(
+        &self,
+        subject: &Identifier,
+        issuer: &Identifier,
+        scope: &str,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete(subject, issuer, scope))
+    }
+}
+
+#[async_trait]
+impl<T: SecretsRepository> SecretsRepository for AutoRetry<T> {
+    async fn store_signing_secret(
+        &self,
+        handle: &SigningSecretKeyHandle,
+        secret: SigningSecret,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_signing_secret(handle, secret.clone()))
+    }
+
+    async fn delete_signing_secret(
+        &self,
+        handle: &SigningSecretKeyHandle,
+    ) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.delete_signing_secret(handle))
+    }
+
+    async fn get_signing_secret(
+        &self,
+        handle: &SigningSecretKeyHandle,
+    ) -> ockam_core::Result<Option<SigningSecret>> {
+        retry!(self.wrapped.get_signing_secret(handle))
+    }
+
+    async fn get_signing_secret_handles(&self) -> ockam_core::Result<Vec<SigningSecretKeyHandle>> {
+        retry!(self.wrapped.get_signing_secret_handles())
+    }
+
+    async fn store_x25519_secret(
+        &self,
+        handle: &X25519SecretKeyHandle,
+        secret: X25519SecretKey,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_x25519_secret(handle, secret.clone()))
+    }
+
+    async fn delete_x25519_secret(
+        &self,
+        handle: &X25519SecretKeyHandle,
+    ) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.delete_x25519_secret(handle))
+    }
+
+    async fn get_x25519_secret(
+        &self,
+        handle: &X25519SecretKeyHandle,
+    ) -> ockam_core::Result<Option<X25519SecretKey>> {
+        retry!(self.wrapped.get_x25519_secret(handle))
+    }
+
+    async fn get_x25519_secret_handles(&self) -> ockam_core::Result<Vec<X25519SecretKeyHandle>> {
+        retry!(self.wrapped.get_x25519_secret_handles())
+    }
+
+    async fn store_aead_secret(
+        &self,
+        handle: &AeadSecretKeyHandle,
+        secret: AeadSecret,
+    ) -> ockam_core::Result<()> {
+        retry!(self.wrapped.store_aead_secret(handle, secret.clone()))
+    }
+
+    async fn delete_aead_secret(&self, handle: &AeadSecretKeyHandle) -> ockam_core::Result<bool> {
+        retry!(self.wrapped.delete_aead_secret(handle))
+    }
+
+    async fn get_aead_secret(
+        &self,
+        handle: &AeadSecretKeyHandle,
+    ) -> ockam_core::Result<Option<AeadSecret>> {
+        retry!(self.wrapped.get_aead_secret(handle))
+    }
+
+    async fn delete_all(&self) -> ockam_core::Result<()> {
+        retry!(self.wrapped.delete_all())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) use auto_retry::*;
 pub use enrollments_repository::*;
 pub use enrollments_repository_sql::*;
 pub use identities_repository::*;
@@ -17,6 +18,7 @@ pub use users_repository_sql::*;
 pub use vaults_repository::*;
 pub use vaults_repository_sql::*;
 
+mod auto_retry;
 mod enrollments_repository;
 mod enrollments_repository_sql;
 mod identities_repository;

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -58,10 +58,7 @@ impl Drop for InMemoryNode {
         // because in that case they can be restarted
         if !self.persistent {
             executor::block_on(async {
-                // We need to recreate the CliState here to make sure that
-                // we get a fresh connection to the database (otherwise this code blocks)
-                let cli_state = CliState::create(self.cli_state.dir()).await.unwrap();
-                cli_state
+                self.cli_state
                     .remove_node(&self.node_name)
                     .await
                     .unwrap_or_else(|e| panic!("cannot delete the node {}: {e:?}", self.node_name));

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -63,7 +63,7 @@ impl Drop for InMemoryNode {
                     // code: 1032 maps to SQLITE_READONLY_DBMOVED - meaning the database has been
                     // moved to another directory, most likely already deleted
                     if !err.to_string().contains("code: 1032") {
-                        panic!("cannot delete the node {}: {err:?}", self.node_name);
+                        error!("Cannot delete the node {}: {err:?}", self.node_name);
                     }
                 }
             });

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -46,7 +46,9 @@ pub async fn default_configuration() -> Result<Configuration> {
     };
 
     // Hack to create Authority Identity using the same vault and storage
-    let authority_sc_temp = Authority::create(&configuration).await?.secure_channels();
+    let authority_sc_temp = Authority::create(&configuration, None)
+        .await?
+        .secure_channels();
 
     let authority_identifier = authority_sc_temp
         .identities()
@@ -163,6 +165,6 @@ pub fn change_client_identifier(
 }
 
 pub async fn start_authority_node(ctx: &Context, configuration: &Configuration) -> Result<()> {
-    let authority = Authority::create(configuration).await?;
+    let authority = Authority::create(configuration, None).await?;
     authority_node::start_node(ctx, configuration, authority).await
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -67,10 +67,10 @@ teardown_home_dir() {
       echo "Failed test dir: $OCKAM_HOME" >&3
       cp -r "$OCKAM_HOME" "$HOME/.bats-tests"
     fi
-    run $OCKAM node delete --all --force --yes
+    run $OCKAM node delete --all --yes
   done
   export OCKAM_HOME=$OCKAM_HOME_BASE
-  run $OCKAM node delete --all --force --yes
+  run $OCKAM node delete --all --yes
 }
 
 to_uppercase() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -11,7 +11,7 @@ function orchestrator_setup_suite() {
   OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM project-member delete --all || true
 
   # Remove all nodes from the root OCKAM_HOME directory
-  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force --yes || true
+  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --yes || true
 }
 
 function orchestrator_teardown_suite() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -43,7 +43,14 @@ function get_project_data() {
 
 function copy_enrolled_home_dir() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
-    cp -r $OCKAM_HOME_BASE/application_database.sqlite3 $OCKAM_HOME/
-    cp -r $OCKAM_HOME_BASE/database.sqlite3 $OCKAM_HOME/
+    cp -a $OCKAM_HOME_BASE/application_database.sqlite3 $OCKAM_HOME/
+    if [ -f $OCKAM_HOME_BASE/application_database.sqlite3-wal ]; then
+      cp -a $OCKAM_HOME_BASE/application_database.sqlite3-wal $OCKAM_HOME
+    fi
+
+    cp -a $OCKAM_HOME_BASE/database.sqlite3 $OCKAM_HOME/
+    if [ -f $OCKAM_HOME_BASE/database.sqlite3-wal ]; then
+      cp -a $OCKAM_HOME_BASE/database.sqlite3-wal $OCKAM_HOME
+    fi
   fi
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/orchestrator.bash
@@ -44,13 +44,6 @@ function get_project_data() {
 function copy_enrolled_home_dir() {
   if [ ! -z "${ORCHESTRATOR_TESTS}" ]; then
     cp -a $OCKAM_HOME_BASE/application_database.sqlite3 $OCKAM_HOME/
-    if [ -f $OCKAM_HOME_BASE/application_database.sqlite3-wal ]; then
-      cp -a $OCKAM_HOME_BASE/application_database.sqlite3-wal $OCKAM_HOME
-    fi
-
     cp -a $OCKAM_HOME_BASE/database.sqlite3 $OCKAM_HOME/
-    if [ -f $OCKAM_HOME_BASE/database.sqlite3-wal ]; then
-      cp -a $OCKAM_HOME_BASE/database.sqlite3-wal $OCKAM_HOME
-    fi
   fi
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/authority.bats
@@ -20,6 +20,7 @@ teardown() {
   trusted="{}"
   port="$(random_port)"
   run_success "$OCKAM" authority create --tcp-listener-address="127.0.0.1:$port" --project-identifier 1 --trusted-identities "$trusted"
+  sleep 1
   run_success "$OCKAM" node show authority
   assert_output --partial "\"status\":\"running\""
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -17,8 +17,8 @@ teardown() {
 force_kill_node() {
   max_retries=5
   i=0
+  pid="$($OCKAM node show $1 --output json | jq .pid)"
   while [[ $i -lt $max_retries ]]; do
-    pid="$($OCKAM node show $1 --output json | jq .pid)"
     run kill -9 $pid
     # Killing a node created without `-f` leaves the
     # process in a defunct state when running within Docker.
@@ -88,34 +88,34 @@ force_kill_node() {
 
 @test "node - fail to create two foreground nodes with the same name" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 2
   run_success "$OCKAM" node show n
   run_failure "$OCKAM" node create n -f
 }
 
 @test "node - can recreate a foreground node after it was killed" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 2
   run_success "$OCKAM" node show n
 
   force_kill_node n
 
   # Recreate node
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 2
   run_success "$OCKAM" node show n
 }
 
 @test "node - can recreate a foreground node after it was gracefully stopped" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 2
   run_success "$OCKAM" node show n
 
   run_success "$OCKAM" node stop n
 
   # Recreate node
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 2
   run_success "$OCKAM" node show n
 }
 
@@ -127,7 +127,7 @@ force_kill_node() {
 
 @test "node - foreground node logs to stdout only" {
   run_success "$OCKAM" node create n -vv -f &
-  sleep 1
+  sleep 2
   # It should even create the node directory
   run_failure ls -l "$OCKAM_HOME/nodes/n"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
@@ -34,6 +34,9 @@ teardown() {
   # reset the OCKAM_HOME directory
   run_success "$OCKAM" reset --yes
 
+  # it may, or may not exist, so we remove it to have a consistent state
+  run_success rm -f "$OCKAM_HOME"/application_database.sqlite3-wal
+
   # list all remaining files and directories
   run_success ls "$OCKAM_HOME"
   assert_output 'application_database.sqlite3
@@ -42,6 +45,9 @@ env'
 
   # reset the OCKAM_HOME directory twice, this should not fail
   run_success "$OCKAM" reset --yes
+
+  run_success rm -f "$OCKAM_HOME"/application_database.sqlite3-wal
+
   run_success ls "$OCKAM_HOME"
   assert_output 'application_database.sqlite3
 bin

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/reset.bats
@@ -34,9 +34,6 @@ teardown() {
   # reset the OCKAM_HOME directory
   run_success "$OCKAM" reset --yes
 
-  # it may, or may not exist, so we remove it to have a consistent state
-  run_success rm -f "$OCKAM_HOME"/application_database.sqlite3-wal
-
   # list all remaining files and directories
   run_success ls "$OCKAM_HOME"
   assert_output 'application_database.sqlite3
@@ -45,8 +42,6 @@ env'
 
   # reset the OCKAM_HOME directory twice, this should not fail
   run_success "$OCKAM" reset --yes
-
-  run_success rm -f "$OCKAM_HOME"/application_database.sqlite3-wal
 
   run_success ls "$OCKAM_HOME"
   assert_output 'application_database.sqlite3

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/setup_suite.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/setup_suite.bash
@@ -5,7 +5,7 @@ setup_suite() {
   setup_python_server
 
   # Remove all nodes from the root OCKAM_HOME directory
-  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --force --yes
+  OCKAM_HOME=$OCKAM_HOME_BASE $OCKAM node delete --all --yes
 }
 
 teardown_suite() {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -197,7 +197,6 @@ teardown() {
 }
 
 @test "portals - local inlet and outlet passing through a relay, removing and re-creating the outlet" {
-  skip
   port="$(random_port)"
   node_port="$(random_port)"
   relay_name="$(random_str)"

--- a/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
@@ -289,14 +289,12 @@ impl SqlxDatabase {
                     // synchronous = EXTRA - trade performance for durability and reliability
                     // locking_mode = NORMAL - it's important because WAL mode changes behavior
                     //                         if locking_mode is set to EXCLUSIVE *before* WAL is set
-                    // journal_mode = WAL - write-ahead logging, mainly for better concurrency
                     // busy_timeout = 10000 - wait for 10 seconds before failing a query due to exclusive lock
                     let _ = connection
                         .execute(
                             r#"
 PRAGMA synchronous = EXTRA;
 PRAGMA locking_mode = NORMAL;
-PRAGMA journal_mode = WAL;
 PRAGMA busy_timeout = 10000;
                 "#,
                         )


### PR DESCRIPTION
~~Changed mode to operate SQLite to `WAL` mode, see https://sqlite.org/wal.html~~
To address migration locking, an exclusive lock is used, which is skipped whenever migration isn't necessary.
To address concurrent database access WAL mode plus an operation-level retry mechanism when database deadlocks.