### PR TITLE
feat: deleting project members

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/client.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/client.rs
@@ -26,6 +26,7 @@ pub trait Members {
         identifier: Identifier,
     ) -> miette::Result<AttributesEntry>;
 
+    async fn delete_all_members(&self, ctx: &Context) -> miette::Result<()>;
     async fn delete_member(&self, ctx: &Context, identifier: Identifier) -> miette::Result<()>;
 
     async fn list_member_ids(&self, ctx: &Context) -> miette::Result<Vec<Identifier>>;
@@ -61,6 +62,16 @@ impl Members for AuthorityNodeClient {
         let req = Request::get(format!("/{identifier}"));
         self.get_secure_client()
             .ask(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
+            .await
+            .into_diagnostic()?
+            .success()
+            .into_diagnostic()
+    }
+
+    async fn delete_all_members(&self, ctx: &Context) -> miette::Result<()> {
+        let req = Request::delete("/members");
+        self.get_secure_client()
+            .tell(ctx, DefaultAddress::DIRECT_AUTHENTICATOR, req)
             .await
             .into_diagnostic()?
             .success()

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator.rs
@@ -214,6 +214,24 @@ impl DirectAuthenticator {
         Ok(Either::Left(res))
     }
 
+    #[instrument(skip_all, fields(enroller = %enroller))]
+    pub async fn delete_all_members(
+        &self,
+        enroller: &Identifier,
+    ) -> Result<DirectAuthenticatorResult<()>> {
+        match self.list_members(enroller).await? {
+            Either::Left(members) => {
+                for member in members.keys() {
+                    if member != enroller {
+                        _ = self.delete_member(enroller, member).await?
+                    }
+                }
+                Ok(Either::Left(()))
+            }
+            Either::Right(e) => Ok(Either::Right(e)),
+        }
+    }
+
     #[instrument(skip_all, fields(enroller = %enroller, identifier = %identifier))]
     pub async fn delete_member(
         &self,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
@@ -106,6 +106,13 @@ impl Worker for DirectAuthenticatorWorker {
                     Either::Right(error) => Response::forbidden(&req, &error.0).to_vec()?,
                 }
             }
+            (Some(Method::Delete), ["members"]) => {
+                let res = self.authenticator.delete_all_members(&from).await?;
+                match res {
+                    Either::Left(_) => Response::ok().with_headers(&req).to_vec()?,
+                    Either::Right(error) => Response::forbidden(&req, &error.0).to_vec()?,
+                }
+            }
             (Some(Method::Delete), [id]) | (Some(Method::Delete), ["members", id]) => {
                 let identifier = Identifier::try_from(id.to_string())?;
                 let res = self.authenticator.delete_member(&from, &identifier).await?;
@@ -115,7 +122,6 @@ impl Worker for DirectAuthenticatorWorker {
                     Either::Right(error) => Response::forbidden(&req, &error.0).to_vec()?,
                 }
             }
-
             _ => Response::unknown_path(&req).to_vec()?,
         };
 

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::InMemoryNode;
 
 use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
-use crate::{docs, CommandGlobalOpts};
+use crate::{docs, project_member, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -53,6 +53,28 @@ impl DeleteCommand {
             "Are you sure you want to delete this project?",
         )? {
             let node = InMemoryNode::start(ctx, &opts.state).await?;
+
+            // Remove project members first
+            let project = opts
+                .state
+                .projects()
+                .get_project_by_name_or_default(&Some(self.project_name.clone()))
+                .await?;
+
+            let authority_client = node
+                .create_authority_client_with_project(ctx, &project, None)
+                .await?;
+
+            project_member::delete::delete_all_members(
+                opts.terminal.clone(),
+                ctx,
+                authority_client,
+                self.project_name.clone(),
+                node.identifier(),
+            )
+            .await?;
+
+            // Now, delete the project
             node.delete_project_by_name(ctx, &self.space_name, &self.project_name)
                 .await?;
             opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/project/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/delete.rs
@@ -8,7 +8,7 @@ use ockam_api::nodes::InMemoryNode;
 
 use crate::shared_args::IdentityOpts;
 use crate::util::async_cmd;
-use crate::{docs, project_member, CommandGlobalOpts};
+use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -54,27 +54,6 @@ impl DeleteCommand {
         )? {
             let node = InMemoryNode::start(ctx, &opts.state).await?;
 
-            // Remove project members first
-            let project = opts
-                .state
-                .projects()
-                .get_project_by_name_or_default(&Some(self.project_name.clone()))
-                .await?;
-
-            let authority_client = node
-                .create_authority_client_with_project(ctx, &project, None)
-                .await?;
-
-            project_member::delete::delete_all_members(
-                opts.terminal.clone(),
-                ctx,
-                authority_client,
-                self.project_name.clone(),
-                node.identifier(),
-            )
-            .await?;
-
-            // Now, delete the project
             node.delete_project_by_name(ctx, &self.space_name, &self.project_name)
                 .await?;
             opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/project_member/add.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/add.rs
@@ -10,7 +10,6 @@ use ockam::Context;
 use ockam_api::authenticator::direct::Members;
 use ockam_api::colors::color_primary;
 use ockam_api::{fmt_log, fmt_ok};
-use ockam_multiaddr::MultiAddr;
 
 use crate::project_member::{authority_client, create_member_attributes};
 use crate::shared_args::{IdentityOpts, RetryOpts};
@@ -34,9 +33,9 @@ pub struct AddCommand {
     #[command(flatten)]
     identity_opts: IdentityOpts,
 
-    /// The route to the Project to which a member should be added
-    #[arg(long, short, value_name = "ROUTE_TO_PROJECT")]
-    to: Option<MultiAddr>,
+    /// The Project to which a member should be added
+    #[arg(long, short, value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
 
     /// The Identifier of the member to add
     #[arg(value_name = "IDENTIFIER")]
@@ -74,7 +73,7 @@ impl Command for AddCommand {
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
         let (authority_node_client, project_name) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.to).await?;
+            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
 
         let attributes =
             create_member_attributes(&self.attributes, &self.allowed_relay_name, self.enroller)?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -1,22 +1,20 @@
 use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
-use console::Term;
 use miette::miette;
 use serde::Serialize;
 use std::fmt::Display;
 use tracing::warn;
 
-use super::authority_client;
-use crate::shared_args::IdentityOpts;
-use crate::{docs, Command, CommandGlobalOpts};
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
-use ockam_api::cloud::AuthorityNodeClient;
 use ockam_api::colors::color_primary;
-use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{fmt_info, fmt_ok};
+
+use super::authority_client;
+use crate::shared_args::IdentityOpts;
+use crate::{docs, Command, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -63,22 +61,17 @@ impl Command for DeleteCommand {
             .get_named_identity_or_default(&self.identity_opts.identity_name)
             .await?;
 
+        let mut output = DeleteMemberOutput {
+            project: project_name.clone(),
+            identifiers: vec![],
+        };
+
         // Delete the passed member
         if let Some(member) = &self.member {
             authority_node_client
                 .delete_member(ctx, member.clone())
                 .await?;
-
-            let output = DeleteMemberOutput {
-                project: project_name.clone(),
-                identifiers: vec![member.clone()],
-            };
-
-            opts.terminal
-                .stdout()
-                .plain(output.to_string())
-                .json_obj(&output)?
-                .write_line()?;
+            output.identifiers.push(member.clone());
         }
         // Try to delete all members except the current default identity
         else if self.all {
@@ -91,71 +84,47 @@ impl Command for DeleteCommand {
                         "You need to use an enrolled identity to delete all the members from a Project."
                     ).into());
             }
-            delete_all_members(
-                opts.terminal,
-                ctx,
-                authority_node_client,
-                project_name,
-                identity.identifier(),
-            )
-            .await?;
+            let self_identifier = identity.identifier();
+            let member_identifiers = authority_node_client.list_member_ids(ctx).await?;
+            if !member_identifiers.is_empty() {
+                opts.terminal.write_line(fmt_info!(
+                    "Found {} members in the Project {}",
+                    member_identifiers.len(),
+                    project_name
+                ))?;
+            }
+
+            let members_to_delete = member_identifiers
+                .into_iter()
+                .filter(|id| id != &self_identifier)
+                .collect::<Vec<_>>();
+
+            let pb = opts.terminal.progress_bar();
+            for identifier in members_to_delete.into_iter() {
+                if let Some(pb) = &pb {
+                    pb.set_message(format!("Trying to delete member {identifier}..."));
+                }
+                if let Err(e) = authority_node_client
+                    .delete_member(ctx, identifier.clone())
+                    .await
+                {
+                    warn!("Failed to delete member {}: {}", identifier, e);
+                } else {
+                    output.identifiers.push(identifier.clone());
+                }
+            }
         } else {
             unreachable!("Either a member or the --all flag should be set");
         }
 
+        opts.terminal
+            .stdout()
+            .plain(output.to_string())
+            .json_obj(&output)?
+            .write_line()?;
+
         Ok(())
     }
-}
-
-pub async fn delete_all_members(
-    terminal: Terminal<TerminalStream<Term>>,
-    ctx: &Context,
-    authority_node_client: AuthorityNodeClient,
-    project_name: String,
-    identifier: Identifier,
-) -> crate::Result<()> {
-    let member_identifiers = authority_node_client.list_member_ids(ctx).await?;
-    if !member_identifiers.is_empty() {
-        terminal.write_line(fmt_info!(
-            "Found {} members in the Project {}",
-            member_identifiers.len(),
-            project_name
-        ))?;
-    }
-
-    let members_to_delete = member_identifiers
-        .into_iter()
-        .filter(|id| id != &identifier)
-        .collect::<Vec<_>>();
-
-    let mut output = DeleteMemberOutput {
-        project: project_name.clone(),
-        identifiers: vec![],
-    };
-
-    let pb = terminal.progress_bar();
-    let mut i = 1;
-    for identifier in members_to_delete.into_iter() {
-        if let Some(pb) = &pb {
-            pb.set_message(format!("{i}. Trying to delete member {identifier}..."));
-        }
-        i += 1;
-        if let Err(e) = authority_node_client
-            .delete_member(ctx, identifier.clone())
-            .await
-        {
-            warn!("Failed to delete member {}: {}", identifier, e);
-        } else {
-            output.identifiers.push(identifier.clone());
-        }
-    }
-
-    terminal
-        .stdout()
-        .plain(output.to_string())
-        .json_obj(&output)?
-        .write_line()?;
-    Ok(())
 }
 
 #[derive(Serialize)]

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -134,10 +134,12 @@ pub async fn delete_all_members(
     };
 
     let pb = terminal.progress_bar();
+    let mut i = 1;
     for identifier in members_to_delete.into_iter() {
         if let Some(pb) = &pb {
-            pb.set_message(format!("Trying to delete member {identifier}..."));
+            pb.set_message(format!("{i}. Trying to delete member {identifier}..."));
         }
+        i += 1;
         if let Err(e) = authority_node_client
             .delete_member(ctx, identifier.clone())
             .await

--- a/implementations/rust/ockam/ockam_command/src/project_member/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list.rs
@@ -5,7 +5,6 @@ use ockam::Context;
 use ockam_api::authenticator::direct::{
     Members, OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
 };
-use ockam_multiaddr::MultiAddr;
 
 use crate::shared_args::IdentityOpts;
 use crate::{docs, Command, CommandGlobalOpts, Result};
@@ -23,9 +22,9 @@ pub struct ListCommand {
     #[command(flatten)]
     identity_opts: IdentityOpts,
 
-    /// The route to the Project to list members from
-    #[arg(long, short, value_name = "ROUTE_TO_PROJECT")]
-    to: Option<MultiAddr>,
+    /// The Project to list members from
+    #[arg(long, short, value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
 
     /// Return only the enroller members
     #[arg(long, visible_alias = "enroller")]
@@ -38,7 +37,7 @@ impl Command for ListCommand {
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
         let (authority_node_client, _) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.to).await?;
+            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
 
         let members = authority_node_client
             .list_members(ctx)

--- a/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/list_ids.rs
@@ -5,7 +5,6 @@ use serde::Serialize;
 use ockam::identity::Identifier;
 use ockam::Context;
 use ockam_api::authenticator::direct::Members;
-use ockam_multiaddr::MultiAddr;
 
 use super::authority_client;
 use crate::shared_args::IdentityOpts;
@@ -23,9 +22,9 @@ pub struct ListIdsCommand {
     #[command(flatten)]
     identity_opts: IdentityOpts,
 
-    /// The route to the Project to list members from
-    #[arg(long, short, value_name = "ROUTE_TO_PROJECT")]
-    to: Option<MultiAddr>,
+    /// The Project to list members from
+    #[arg(long, short, value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
 }
 
 #[async_trait]
@@ -34,7 +33,7 @@ impl Command for ListIdsCommand {
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
         let (authority_node_client, _) =
-            authority_client(ctx, &opts, &self.identity_opts, &self.to).await?;
+            authority_client(ctx, &opts, &self.identity_opts, &self.project_name).await?;
 
         let member_ids = authority_node_client
             .list_member_ids(ctx)

--- a/implementations/rust/ockam/ockam_command/src/project_member/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/show.rs
@@ -11,7 +11,6 @@ use ockam_api::cloud::AuthorityNodeClient;
 use ockam_api::output::Output;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::AsyncTryClone;
-use ockam_multiaddr::MultiAddr;
 
 use crate::project_member::{authority_client, MemberOutput};
 use crate::shared_args::IdentityOpts;
@@ -32,9 +31,9 @@ pub struct ShowCommand {
     #[command(flatten)]
     identity_opts: IdentityOpts,
 
-    /// The route of the Project that the member belongs to
-    #[arg(long, short, value_name = "ROUTE_TO_PROJECT")]
-    to: Option<MultiAddr>,
+    /// The Project that the member belongs to
+    #[arg(long, short, value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
 
     /// The Identifier of the member to show
     #[arg(value_name = "IDENTIFIER")]
@@ -64,7 +63,7 @@ impl ShowTui {
         cmd: ShowCommand,
     ) -> miette::Result<()> {
         let (authority_node_client, _) =
-            authority_client(&ctx, &opts, &cmd.identity_opts, &cmd.to).await?;
+            authority_client(&ctx, &opts, &cmd.identity_opts, &cmd.project_name).await?;
         let tui = Self {
             ctx,
             opts,


### PR DESCRIPTION
This PR:

- Deletes all the members of a project before deleting the project itself. 
- Adds an endpoint to delete all the members of a project at once, instead of one by one, in order to speed up the deletion. This endpoint is not yet used, we need first to deploy it on Authority nodes.
- Simplifies the passing of a project name for member commands. Instead of having to pass `--to /project/<project name>`, where the only type of route that can be passed to `--to` is only `/project/<project name>`, we now pass directly `--project-name <project name>`.