### PR TITLE
feat(rust): improvements to portals commands outputs

### DIFF
--- a/implementations/rust/ockam/ockam/src/remote/worker.rs
+++ b/implementations/rust/ockam/ockam/src/remote/worker.rs
@@ -13,7 +13,7 @@ impl Worker for RemoteRelay {
     type Message = Any;
 
     async fn initialize(&mut self, ctx: &mut Self::Context) -> Result<()> {
-        debug!("RemoteRelay registration...");
+        debug!(registration_route = %self.registration_route, "RemoteRelay initializing...");
 
         ctx.send_from_address(
             self.registration_route.clone(),
@@ -21,6 +21,8 @@ impl Worker for RemoteRelay {
             self.addresses.main_remote.clone(),
         )
         .await?;
+
+        debug!(registration_route = %self.registration_route, "RemoteRelay initialized");
 
         Ok(())
     }
@@ -39,7 +41,7 @@ impl Worker for RemoteRelay {
 
             match local_message.onward_route().next() {
                 Err(_) => {
-                    debug!("RemoteRelay received service message");
+                    debug!(registration_route = %self.registration_route, "RemoteRelay received service message");
 
                     let payload = String::decode(local_message.payload_ref())
                         .map_err(|_| OckamError::InvalidResponseFromRelayService)?;
@@ -51,7 +53,7 @@ impl Worker for RemoteRelay {
                     }
 
                     if !self.completion_msg_sent {
-                        info!("RemoteRelay registered with route: {}", return_route);
+                        info!(registration_route = %self.registration_route, "RemoteRelay registered with route: {}", return_route);
                         let address = match return_route.recipient()?.to_string().strip_prefix("0#")
                         {
                             Some(addr) => addr.to_string(),
@@ -83,7 +85,7 @@ impl Worker for RemoteRelay {
                 }
                 Ok(_) => {
                     // Forwarding the message
-                    debug!("RemoteRelay received payload message");
+                    debug!(registration_route = %self.registration_route, "RemoteRelay received payload message");
 
                     // Send the message on its onward_route
                     ctx.forward_from_address(local_message, self.addresses.main_internal.clone())

--- a/implementations/rust/ockam/ockam_api/src/cloud/project/models.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/project/models.rs
@@ -173,7 +173,7 @@ impl Display for AdminInfo {
 
 impl Output for AdminInfo {
     fn item(&self) -> crate::Result<String> {
-        Ok(format!("{}", self))
+        Ok(self.padded_display())
     }
 }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
@@ -170,7 +170,7 @@ impl Display for NodeResources {
         } else {
             writeln!(f, "{}{}Portals:", fmt::PADDING, fmt::INDENTATION)?;
             for i in &self.inlets {
-                writeln!(f, "{}{}{}", fmt::PADDING, fmt::INDENTATION.repeat(2), i)?;
+                writeln!(f, "{}", i.iter_output().pad().indent().indent())?;
             }
 
             for o in &self.outlets {

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/relay.rs
@@ -1,5 +1,5 @@
-use colorful::Colorful;
 use minicbor::{CborLen, Decode, Encode};
+use std::fmt::Display;
 
 use ockam::identity::Identifier;
 use ockam::remote::RemoteRelayInfo;
@@ -7,9 +7,9 @@ use ockam::route;
 use ockam_core::flow_control::FlowControlId;
 use ockam_multiaddr::MultiAddr;
 
-use crate::colors::OckamColor;
+use crate::colors::color_primary;
 use crate::error::ApiError;
-use crate::output::{colorize_connection_status, Output};
+use crate::output::Output;
 use crate::session::replacer::ReplacerOutputKind;
 use crate::session::session::Session;
 use crate::{route_to_multiaddr, ConnectionStatus};
@@ -21,8 +21,8 @@ use crate::{route_to_multiaddr, ConnectionStatus};
 pub struct CreateRelay {
     /// Address to create relay at.
     #[n(1)] pub(crate) address: MultiAddr,
-    /// Relay alias.
-    #[n(2)] pub(crate) alias: String,
+    /// Relay name.
+    #[n(2)] pub(crate) name: String,
     /// An authorised identity for secure channels.
     /// Only set for non-project addresses as for projects the project's
     /// authorised identity will be used.
@@ -34,13 +34,13 @@ pub struct CreateRelay {
 impl CreateRelay {
     pub fn new(
         address: MultiAddr,
-        alias: String,
+        name: String,
         auth: Option<Identifier>,
         relay_address: Option<String>,
     ) -> Self {
         Self {
             address,
-            alias,
+            name,
             authorized: auth,
             relay_address,
         }
@@ -50,8 +50,8 @@ impl CreateRelay {
         &self.address
     }
 
-    pub fn alias(&self) -> &str {
-        &self.alias
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn authorized(&self) -> Option<Identifier> {
@@ -74,19 +74,19 @@ pub struct RelayInfo {
     #[n(4)] flow_control_id: Option<FlowControlId>,
     #[n(5)] connection_status: ConnectionStatus,
     #[n(6)] destination_address: MultiAddr,
-    #[n(7)] alias: String,
+    #[n(7)] name: String,
     #[n(8)] last_failure: Option<String>,
 }
 
 impl RelayInfo {
     pub fn new(
         destination_address: MultiAddr,
-        alias: String,
+        name: String,
         connection_status: ConnectionStatus,
     ) -> Self {
         Self {
             destination_address,
-            alias,
+            name,
             forwarding_route: None,
             remote_address: None,
             worker_address: None,
@@ -96,8 +96,8 @@ impl RelayInfo {
         }
     }
 
-    pub fn from_session(session: &Session, destination_address: MultiAddr, alias: String) -> Self {
-        let relay_info = Self::new(destination_address, alias, session.connection_status());
+    pub fn from_session(session: &Session, destination_address: MultiAddr, name: String) -> Self {
+        let relay_info = Self::new(destination_address, name, session.connection_status());
         if let Some(outcome) = session.last_outcome() {
             match outcome {
                 ReplacerOutputKind::Relay(info) => relay_info.with(info),
@@ -118,7 +118,7 @@ impl RelayInfo {
             flow_control_id: remote_relay_info.flow_control_id().clone(),
             connection_status: self.connection_status,
             destination_address: self.destination_address,
-            alias: self.alias,
+            name: self.name,
             last_failure: self.last_failure,
         }
     }
@@ -131,7 +131,7 @@ impl RelayInfo {
             flow_control_id: self.flow_control_id,
             connection_status: self.connection_status,
             destination_address: self.destination_address,
-            alias: self.alias,
+            name: self.name,
             last_failure: Some(last_failure),
         }
     }
@@ -144,8 +144,8 @@ impl RelayInfo {
         &self.destination_address
     }
 
-    pub fn alias(&self) -> &str {
-        &self.alias
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     pub fn forwarding_route(&self) -> &Option<String> {
@@ -181,29 +181,31 @@ impl RelayInfo {
     }
 }
 
+impl Display for RelayInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Relay {} is {} at {}",
+            color_primary(&self.name),
+            self.connection_status(),
+            color_primary(self.destination_address.to_string())
+        )?;
+        writeln!(
+            f,
+            "With address {}",
+            color_primary(
+                self.remote_address_ma()
+                    .unwrap_or(None)
+                    .map(|x| x.to_string())
+                    .unwrap_or("N/A".into())
+            ),
+        )?;
+        Ok(())
+    }
+}
+
 impl Output for RelayInfo {
     fn item(&self) -> crate::Result<String> {
-        Ok(r#"
-Relay:
-    "#
-        .to_owned()
-            + self.as_list_item()?.as_str())
-    }
-
-    fn as_list_item(&self) -> crate::Result<String> {
-        let output = format!(
-            r#"Alias: {alias}
-Status: {connection_status}
-Remote Address: {remote_address}"#,
-            alias = self.alias().color(OckamColor::PrimaryResource.color()),
-            connection_status = colorize_connection_status(self.connection_status()),
-            remote_address = self
-                .remote_address_ma()?
-                .map(|x| x.to_string())
-                .unwrap_or("N/A".into())
-                .color(OckamColor::PrimaryResource.color()),
-        );
-
-        Ok(output)
+        Ok(self.padded_display())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/services.rs
@@ -1,7 +1,6 @@
 use crate::colors::{color_primary, color_warn};
 use crate::kafka::{ConsumerPublishing, ConsumerResolution};
 use crate::output::Output;
-use crate::terminal::fmt;
 use minicbor::{CborLen, Decode, Encode};
 use ockam_abac::PolicyExpression;
 use ockam_core::Address;
@@ -9,7 +8,6 @@ use ockam_multiaddr::MultiAddr;
 use ockam_transport_core::HostnamePort;
 use serde::Serialize;
 use std::fmt::Display;
-use std::fmt::Write;
 
 #[derive(Debug, Clone, Encode, Decode, CborLen)]
 #[rustfmt::skip]
@@ -244,8 +242,6 @@ impl Display for ServiceStatus {
 
 impl Output for ServiceStatus {
     fn item(&self) -> crate::Result<String> {
-        let mut f = String::new();
-        writeln!(f, "{}{}", fmt::PADDING, self)?;
-        Ok(f)
+        Ok(self.padded_display())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport/response.rs
@@ -136,6 +136,6 @@ impl Display for TransportStatus {
 
 impl Output for TransportStatus {
     fn item(&self) -> crate::Result<String> {
-        Ok(format!("{}", self))
+        Ok(self.padded_display())
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -37,19 +37,20 @@ impl NodeManagerWorker {
     ) -> Result<Response<RelayInfo>, Response<Error>> {
         let CreateRelay {
             address,
-            alias,
+            name,
             authorized,
             relay_address,
         } = create_relay;
+
         match self
             .node_manager
-            .create_relay(ctx, &address, alias, authorized, relay_address)
+            .create_relay(ctx, &address, name.clone(), authorized, relay_address)
             .await
         {
             Ok(body) => Ok(Response::ok().with_headers(req).body(body)),
             Err(err) => Err(Response::internal_error(
                 req,
-                &format!("Failed to create relay: {}", err),
+                &format!("Failed to create relay at {address} with name {name}. {err}"),
             )),
         }
     }

--- a/implementations/rust/ockam/ockam_api/src/ui/output/utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/output/utils.rs
@@ -1,7 +1,3 @@
-use crate::colors::OckamColor;
-use crate::ConnectionStatus;
-use colorful::core::color_string::CString;
-use colorful::Colorful;
 use ockam::identity::TimestampInSeconds;
 
 pub fn comma_separated<T: AsRef<str>>(data: &[T]) -> String {
@@ -39,14 +35,6 @@ pub fn human_readable_time(time: TimestampInSeconds) -> String {
             "unix time is invalid",
         ))
         .to_string(),
-    }
-}
-
-pub fn colorize_connection_status(status: ConnectionStatus) -> CString {
-    let text = status.to_string();
-    match status {
-        ConnectionStatus::Up => text.color(OckamColor::PrimaryResource.color()),
-        ConnectionStatus::Down => text.color(OckamColor::Failure.color()),
     }
 }
 

--- a/implementations/rust/ockam/ockam_app_lib/src/invitations/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/invitations/mod.rs
@@ -27,7 +27,7 @@ impl AppState {
                 m.tcp_outlets
                     .iter()
                     .find(|o| &o.to == to)
-                    .map(|o| o.worker_address())
+                    .map(|o| o.worker_route())
             })
             .await
             .ok_or::<Error>(format!("The outlet {to} wasn't found in the App state").into())??;

--- a/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/projects/commands.rs
@@ -22,7 +22,7 @@ impl AppState {
         project_id: &str,
         invitation_email: &EmailAddress,
     ) -> Result<EnrollmentTicket> {
-        debug!(?project_id, "Creating enrollment ticket");
+        debug!(?project_id, "Creating an enrollment ticket");
         let projects = self.projects();
         let projects_guard = projects.read().await;
         let project = projects_guard

--- a/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/shared_service/relay/create.rs
@@ -121,7 +121,7 @@ async fn get_relay(
         .get_relays()
         .await
         .into_iter()
-        .find(|r| r.alias() == relay_alias))
+        .find(|r| r.name() == relay_alias))
 }
 
 async fn relay_remote_address(cli_state: &CliState) -> ockam::Result<String> {

--- a/implementations/rust/ockam/ockam_command/src/identity/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/show.rs
@@ -209,7 +209,7 @@ impl Display for ShowIdentity {
 
 impl Output for ShowIdentity {
     fn item(&self) -> ockam_api::Result<String> {
-        Ok(self.to_string())
+        Ok(self.padded_display())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -140,7 +140,7 @@ impl Command for InfluxDBCreateCommand {
             .stdout()
             .plain(plain)
             .machine(inlet_status.bind_addr.to_string())
-            .json(serde_json::json!(&inlet_status))
+            .json_obj(&inlet_status)?
             .write_line()?;
 
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -98,8 +98,8 @@ pub struct CreateCommand {
     /// A configuration in JSON format to set up the node services.
     /// Node configuration is run asynchronously and may take several
     /// seconds to complete.
-    #[arg(hide = true, long, value_parser = parse_launch_config)]
-    pub launch_config: Option<Config>,
+    #[arg(hide = true, long, visible_alias = "launch-config", value_parser = parse_launch_config)]
+    pub launch_configuration: Option<Config>,
 
     /// The name of an existing Ockam Identity that this node will use.
     /// You can use `ockam identity list` to get a list of existing Identities.
@@ -132,7 +132,7 @@ impl Default for CreateCommand {
             http_server: false,
             http_server_port: None,
             udp: false,
-            launch_config: None,
+            launch_configuration: None,
             identity: None,
             trust_opts: node_manager_defaults.trust_opts,
             opentelemetry_context: None,

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -105,7 +105,7 @@ impl CreateCommand {
             NodeManagerGeneralOptions::new(
                 opts.state.clone(),
                 node_name.clone(),
-                self.launch_config.is_none(),
+                self.launch_configuration.is_none(),
                 http_server_port,
                 true,
             ),
@@ -181,7 +181,7 @@ impl CreateCommand {
             ));
         }
 
-        if let Some(config) = &self.launch_config {
+        if let Some(config) = &self.launch_configuration {
             if let Some(startup_services) = &config.startup_services {
                 if let Some(cfg) = startup_services.secure_channel_listener.clone() {
                     if !cfg.disabled {

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -77,7 +77,7 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         http_server,
         http_server_port,
         udp,
-        launch_config,
+        launch_configuration,
         trust_opts,
         opentelemetry_context,
         ..
@@ -120,7 +120,7 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         args.push(identity_name);
     }
 
-    if let Some(config) = launch_config {
+    if let Some(config) = launch_configuration {
         args.push("--launch-config".to_string());
         args.push(serde_json::to_string(&config).unwrap());
     }

--- a/implementations/rust/ockam/ockam_command/src/output/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/output/mod.rs
@@ -201,7 +201,7 @@ pub struct CredentialAndPurposeKeyDisplay(#[n(0)] pub CredentialAndPurposeKey);
 
 impl Output for CredentialAndPurposeKeyDisplay {
     fn item(&self) -> ockam_api::Result<String> {
-        Ok(format!("{}", self))
+        Ok(self.padded_display())
     }
 }
 
@@ -234,7 +234,7 @@ impl fmt::Display for IdentifierDisplay {
 
 impl Output for IdentifierDisplay {
     fn item(&self) -> ockam_api::Result<String> {
-        Ok(self.to_string())
+        Ok(self.padded_display())
     }
 }
 
@@ -278,7 +278,7 @@ impl fmt::Display for IdentityDisplay {
 
 impl Output for IdentityDisplay {
     fn item(&self) -> ockam_api::Result<String> {
-        Ok(format!("{}", self))
+        Ok(self.padded_display())
     }
 }
 

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -116,10 +116,16 @@ impl Command for TicketCommand {
 
         // Request an enrollment token that a future member can use to get a
         // credential.
-        let token = authority_node_client
-            .create_token(ctx, attributes, self.expires_in, self.usage_count)
-            .await
-            .map_err(Error::Retry)?;
+        let token = {
+            let pb = opts.terminal.progress_bar();
+            if let Some(pb) = pb.as_ref() {
+                pb.set_message("Creating an enrollment ticket...");
+            }
+            authority_node_client
+                .create_token(ctx, attributes, self.expires_in, self.usage_count)
+                .await
+                .map_err(Error::Retry)?
+        };
         let project = project.model();
         let ticket = ExportedEnrollmentTicket::new(
             token,

--- a/implementations/rust/ockam/ockam_command/src/project_admin/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_admin/mod.rs
@@ -7,11 +7,11 @@ use clap::{Args, Subcommand};
 use crate::project_admin::add::AddCommand;
 use crate::project_admin::delete::DeleteCommand;
 use crate::project_admin::list::ListCommand;
-use crate::{Command, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 
 /// Manage Project Admins in Ockam Orchestrator
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, subcommand_required = true)]
+#[command(hide = docs::hide(), arg_required_else_help = true, subcommand_required = true)]
 pub struct ProjectAdminCommand {
     #[command(subcommand)]
     subcommand: ProjectAdminSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -107,7 +107,7 @@ impl DeleteCommandTui for DeleteTui {
             .node
             .ask(&self.ctx, Request::get("/node/relay"))
             .await?;
-        Ok(relays.into_iter().map(|i| i.alias().to_string()).collect())
+        Ok(relays.into_iter().map(|i| i.name().to_string()).collect())
     }
 
     async fn delete_single(&self, relay_name: &str) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/relay/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/list.rs
@@ -1,13 +1,8 @@
 use clap::Args;
-use colorful::Colorful;
-use miette::IntoDiagnostic;
-use tokio::sync::Mutex;
-use tokio::try_join;
-use tracing::trace;
 
 use ockam::Context;
 use ockam_api::address::extract_address_value;
-use ockam_api::colors::OckamColor;
+use ockam_api::colors::color_primary;
 use ockam_api::nodes::models::relay::RelayInfo;
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::api::Request;
@@ -46,34 +41,24 @@ impl ListCommand {
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &self.to).await?;
-        let is_finished: Mutex<bool> = Mutex::new(false);
-
-        let get_relays = async {
-            let relay_infos: Vec<RelayInfo> = node.ask(ctx, Request::get("/node/relay")).await?;
-            *is_finished.lock().await = true;
-            Ok(relay_infos)
+        let relays: Vec<RelayInfo> = {
+            let pb = opts.terminal.progress_bar();
+            if let Some(pb) = pb {
+                pb.set_message(format!(
+                    "Listing Relays on {}...\n",
+                    color_primary(node.node_name())
+                ));
+            }
+            node.ask(ctx, Request::get("/node/relay")).await?
         };
-
-        let output_messages = vec![format!(
-            "Listing Relays on {}...\n",
-            node.node_name().color(OckamColor::PrimaryResource.color())
-        )];
-
-        let progress_output = opts.terminal.loop_messages(&output_messages, &is_finished);
-
-        let (relays, _) = try_join!(get_relays, progress_output)?;
-        trace!(?relays, "Relays retrieved");
-
         let plain = opts.terminal.build_list(
             &relays,
-            &format!("No Relays found on node {}.", node.node_name()),
+            &format!("No Relays found on node {}", node.node_name()),
         )?;
-        let json = serde_json::to_string(&relays).into_diagnostic()?;
-
         opts.terminal
             .stdout()
             .plain(plain)
-            .json(json)
+            .json_obj(relays)?
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/relay/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/show.rs
@@ -11,8 +11,8 @@ use ockam_api::nodes::BackgroundNodeClient;
 use ockam_core::api::Request;
 use ockam_multiaddr::MultiAddr;
 
-use crate::{docs, CommandGlobalOpts};
 use ockam_api::colors::OckamColor;
+use ockam_api::output::Output;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::ConnectionStatus;
 use ockam_core::AsyncTryClone;
@@ -21,8 +21,7 @@ use serde::Serialize;
 use crate::terminal::tui::ShowCommandTui;
 use crate::tui::PluralTerm;
 use crate::util::async_cmd;
-use crate::util::colorize_connection_status;
-use ockam_api::output::Output;
+use crate::{docs, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
@@ -110,7 +109,7 @@ impl ShowCommandTui for ShowTui {
             .node
             .ask(&self.ctx, Request::get("/node/relay"))
             .await?;
-        Ok(relays.into_iter().map(|i| i.alias().to_string()).collect())
+        Ok(relays.into_iter().map(|i| i.name().to_string()).collect())
     }
 
     async fn show_single(&self, item_name: &str) -> miette::Result<()> {
@@ -131,7 +130,7 @@ impl ShowCommandTui for ShowTui {
 
 #[derive(Serialize)]
 struct RelayShowOutput {
-    pub alias: String,
+    pub name: String,
     pub destination: MultiAddr,
     pub connection_status: ConnectionStatus,
     pub relay_route: Option<String>,
@@ -142,7 +141,7 @@ struct RelayShowOutput {
 impl From<RelayInfo> for RelayShowOutput {
     fn from(r: RelayInfo) -> Self {
         Self {
-            alias: r.alias().to_string(),
+            name: r.name().to_string(),
             destination: r.destination_address().clone(),
             connection_status: r.connection_status(),
             relay_route: r.forwarding_route().clone(),
@@ -157,15 +156,15 @@ impl Output for RelayShowOutput {
         Ok(formatdoc!(
             r#"
         Relay:
-            Alias: {alias}
+            Name: {alias}
             Destination: {destination_address}
             Status: {connection_status}
             Relay Route: {route}
             Remote Address: {remote_addr}
             Worker Address: {worker_addr}
         "#,
-            alias = self.alias,
-            connection_status = colorize_connection_status(self.connection_status),
+            alias = self.name,
+            connection_status = self.connection_status.to_string(),
             destination_address = self.destination.to_string(),
             route = self.relay_route.as_deref().unwrap_or("N/A"),
             remote_addr = self
@@ -184,14 +183,14 @@ impl Output for RelayShowOutput {
     fn as_list_item(&self) -> ockam_api::Result<String> {
         Ok(formatdoc!(
             r#"
-            Alias: {alias}
+            Name: {alias}
             Status: {connection_status}
             Remote Address: {remote_address}"#,
             alias = self
-                .alias
+                .name
                 .as_str()
                 .color(OckamColor::PrimaryResource.color()),
-            connection_status = colorize_connection_status(self.connection_status),
+            connection_status = self.connection_status.to_string(),
             remote_address = self
                 .remote_address
                 .as_ref()

--- a/implementations/rust/ockam/ockam_command/src/rendezvous/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/rendezvous/mod.rs
@@ -6,11 +6,11 @@ use clap::{Args, Subcommand};
 use create::CreateCommand;
 
 use crate::rendezvous::get_my_address::GetMyAddressCommand;
-use crate::{Command, CommandGlobalOpts};
+use crate::{docs, Command, CommandGlobalOpts};
 
 /// Manage Rendezvous server
 #[derive(Clone, Debug, Args)]
-#[command(arg_required_else_help = true, subcommand_required = true)]
+#[command(hide = docs::hide(), arg_required_else_help = true, subcommand_required = true)]
 pub struct RendezvousCommand {
     #[command(subcommand)]
     pub subcommand: RendezvousSubcommand,

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/list.rs
@@ -76,7 +76,7 @@ impl ListCommand {
             .iter()
             .map(|outlet| {
                 Ok(serde_json::json!({
-                    "from": outlet.worker_address()?,
+                    "from": outlet.worker_route()?,
                     "to": outlet.to,
                 }))
             })

--- a/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/outlet/show.rs
@@ -58,7 +58,7 @@ impl Command for ShowCommand {
 #[derive(Debug, Serialize)]
 struct OutletInformation {
     node_name: String,
-    worker_addr: MultiAddr,
+    worker_address: MultiAddr,
     to: String,
 }
 
@@ -67,7 +67,7 @@ impl Output for OutletInformation {
         let mut w = String::new();
         write!(w, "Outlet")?;
         write!(w, "\n  On Node: {}", self.node_name)?;
-        write!(w, "\n  From address: {}", self.worker_addr)?;
+        write!(w, "\n  From address: {}", self.worker_address)?;
         write!(w, "\n  To TCP server: {}", self.to)?;
         Ok(w)
     }
@@ -142,13 +142,13 @@ impl ShowCommandTui for ShowTui {
             .await?;
         let info = OutletInformation {
             node_name: self.node.node_name(),
-            worker_addr: outlet_status.worker_address().into_diagnostic()?,
+            worker_address: outlet_status.worker_route().into_diagnostic()?,
             to: outlet_status.to.to_string(),
         };
         self.terminal()
             .stdout()
             .plain(info.item()?)
-            .json(serde_json::json!(info))
+            .json_obj(info)?
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -4,7 +4,6 @@ use std::{
     path::Path,
 };
 
-use colorful::core::color_string::CString;
 use colorful::Colorful;
 use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
@@ -15,9 +14,9 @@ use tracing::{debug, error};
 use ockam::{Address, Context, NodeBuilder};
 use ockam_api::cli_state::CliState;
 use ockam_api::cli_state::CliStateError;
-use ockam_api::colors::{color_primary, OckamColor};
+use ockam_api::colors::color_primary;
 use ockam_api::config::lookup::{InternetAddress, LookupMeta};
-use ockam_api::{fmt_warn, ConnectionStatus};
+use ockam_api::fmt_warn;
 use ockam_core::{DenyAll, OpenTelemetryContext};
 use ockam_multiaddr::proto::{DnsAddr, Ip4, Ip6, Project, Space, Tcp};
 use ockam_multiaddr::{proto::Node, MultiAddr, Protocol};
@@ -208,14 +207,6 @@ pub fn port_is_free_guard(address: &SocketAddr) -> Result<()> {
         ))?;
     }
     Ok(())
-}
-
-pub fn colorize_connection_status(status: ConnectionStatus) -> CString {
-    let text = status.to_string();
-    match status {
-        ConnectionStatus::Up => text.color(OckamColor::PrimaryResource.color()),
-        ConnectionStatus::Down => text.color(OckamColor::Failure.color()),
-    }
 }
 
 pub fn print_deprecated_warning(opts: &CommandGlobalOpts, old: &str, new: &str) -> Result<()> {

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -80,7 +80,7 @@ teardown() {
   run_success $OCKAM tcp-outlet create --at /node/n2 --to $port_2
 
   run_success $OCKAM tcp-outlet show outlet --at /node/n1
-  assert_output --partial "\"worker_addr\":\"/service/outlet\""
+  assert_output --partial "\"worker_address\":\"/service/outlet\""
   assert_output --partial "\"to\":\"127.0.0.1:$port_1\""
 
   run_success $OCKAM tcp-outlet delete "outlet" --yes
@@ -126,7 +126,7 @@ teardown() {
   run_success $OCKAM tcp-inlet show "test-inlet" --at /node/n2
 
   # Test if non-existing TCP inlet returns NotFound
-  run_failure $OCKAM tcp-inlet show "non-existing-inlet"
+  run_failure $OCKAM tcp-inlet show "non-existing-inlet" --at /node/n2
   assert_output --partial "not found"
 }
 

--- a/implementations/rust/ockam/ockam_command/tests/bats/run.sh
+++ b/implementations/rust/ockam/ockam_command/tests/bats/run.sh
@@ -65,6 +65,7 @@ if [ "$orchestrator_enroll_suite" = true ]; then
 fi
 
 if [ "$orchestrator_suite" = true ]; then
+  echo "Running orchestrator suite..."
   bats "$current_directory/orchestrator" --timing
 fi
 

--- a/tools/stress-test/src/execution.rs
+++ b/tools/stress-test/src/execution.rs
@@ -39,7 +39,7 @@ impl State {
                 match result {
                     Ok(info) => {
                         self.relays.lock().unwrap().insert(
-                            info.alias().to_string(),
+                            info.name().to_string(),
                             Relay {
                                 failures_detected: 0,
                                 usages: 0,
@@ -100,7 +100,7 @@ impl State {
 
                 let relay_flow_control_id = relays
                     .iter()
-                    .find(|relay| relay.alias() == relay_address_id)
+                    .find(|relay| relay.name() == relay_address_id)
                     .unwrap()
                     .flow_control_id()
                     .clone()


### PR DESCRIPTION
New behaviour:
- The plain output of commands will always be logged, regardless of the passed output format. This fixes the issue where only the machine or json output was logged, lacking the necessary context to understand the command output.

Review output of the commands:
- `project enroll`
- `relay create`
- `tcp-inlet/outlet create`
- `influxdb-inlet/outlet create`
