### PR TITLE
fix(rust): `project enroll` should not try to fetch project data from orchestrator

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/projects.rs
@@ -41,7 +41,7 @@ impl ProjectsOrchestratorApi for InMemoryNode {
                 .import_and_store_project(project.clone())
                 .await?),
             Err(e) => {
-                warn!("could no get the project {project_id} from the controller: {e:?}");
+                warn!("could no get the project {project_id} from the controller: {e}");
                 Ok(self.cli_state.projects().get_project(project_id).await?)
             }
         }

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -18,7 +18,6 @@ use crate::{docs, Command, CommandGlobalOpts, Error, Result};
 use ockam::Context;
 use ockam_api::cli_state::{EnrollmentTicket, NamedIdentity};
 use ockam_api::cloud::project::models::OktaAuth0;
-use ockam_api::cloud::project::ProjectsOrchestratorApi;
 use ockam_api::cloud::AuthorityNodeClient;
 use ockam_api::colors::color_primary;
 use ockam_api::enroll::enrollment::{EnrollStatus, Enrollment};
@@ -130,9 +129,6 @@ impl Command for EnrollCommand {
             self.use_enrollment_ticket(ctx, &opts, &authority_node_client, enrollment_ticket)
                 .await?;
         }
-
-        // Refresh project data
-        node.get_project(ctx, project.project_id()).await?;
 
         // Issue credential
         let credential = authority_node_client


### PR DESCRIPTION
- Remove `get_project()` call from `project enroll` command. A machine enrolling using an enrollment ticket won't have access to the controller, so that call will fail. In that case, a warning message is logged (the command doesn't fail).
- In that warning log, print the miette report using the display impl instead of its debug trait. The debug implementation is meant to be shown in stdout only, not in logs. 