### PR TITLE
feat(rust): change behavior of how nodes' processes are stopped

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -123,7 +123,7 @@ impl CliState {
     /// Stop nodes and remove all the directories storing state
     pub async fn reset(&self) -> Result<()> {
         self.delete_all_named_identities().await?;
-        self.delete_all_nodes(true).await?;
+        self.delete_all_nodes().await?;
         self.delete_all_named_vaults().await?;
         self.delete().await
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/background_node_client.rs
@@ -80,7 +80,7 @@ impl BackgroundNodeClient {
     }
 
     pub async fn delete(&self) -> miette::Result<()> {
-        Ok(self.cli_state.delete_node(&self.node_name(), false).await?)
+        Ok(self.cli_state.delete_node(&self.node_name()).await?)
     }
 
     // Set a different node name
@@ -140,7 +140,7 @@ impl BackgroundNodeClient {
             .success()
             .into_diagnostic();
 
-        _ = tcp_connection.stop(ctx).await;
+        let _ = tcp_connection.stop(ctx).await;
         res
     }
 
@@ -158,7 +158,7 @@ impl BackgroundNodeClient {
         let (tcp_connection, client) = self.make_client().await?;
         let res = client.ask(ctx, req).await.into_diagnostic();
 
-        _ = tcp_connection.stop(ctx).await;
+        let _ = tcp_connection.stop(ctx).await;
         res
     }
 
@@ -175,7 +175,7 @@ impl BackgroundNodeClient {
             .success()
             .into_diagnostic();
 
-        _ = tcp_connection.stop(ctx).await;
+        let _ = tcp_connection.stop(ctx).await;
         res
     }
 
@@ -191,7 +191,7 @@ impl BackgroundNodeClient {
         let (tcp_connection, client) = self.make_client().await?;
         let res = client.tell(ctx, req).await.into_diagnostic();
 
-        _ = tcp_connection.stop(ctx).await;
+        let _ = tcp_connection.stop(ctx).await;
         res
     }
 

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/notification.rs
@@ -91,6 +91,10 @@ impl<T: TerminalWriter + Debug + Send + 'static> NotificationHandler<T> {
                 select! {
                     _ = sleep(REPORTING_CHANNEL_POLL_DELAY) => {
                         if *self.stop.lock().unwrap() {
+                            // Drain the channel
+                            while let Ok(notification) = self.rx.try_recv() {
+                                self.handle_notification(notification).await;
+                            }
                             break;
                         }
                     }

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -414,7 +414,7 @@ impl AppState {
     }
 
     pub async fn delete_background_node(&self, node_name: &str) -> Result<()> {
-        Ok(self.state().await.delete_node(node_name, true).await?)
+        Ok(self.state().await.delete_node(node_name).await?)
     }
 
     pub async fn is_enrolled(&self) -> Result<bool> {

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -440,7 +440,7 @@ impl CreateCommand {
         .await?;
 
         let _ = ctx.stop().await;
-        let _ = opts.state.stop_node(&self.node_name, true).await;
+        let _ = opts.state.stop_node(&self.node_name).await;
         if foreground_args.child_process {
             opts.shutdown();
             exit(0);

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -59,7 +59,7 @@ impl CreateCommand {
                 .await
         };
         if res.is_err() {
-            let _ = opts.state.delete_node(&node_name, false).await;
+            let _ = opts.state.delete_node(&node_name).await;
         }
         res
     }

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -160,7 +160,7 @@ impl CreateCommand {
 
         // Clean up and exit
         let _ = ctx.stop().await;
-        let _ = opts.state.stop_node(&node_name, true).await;
+        let _ = opts.state.stop_node(&node_name).await;
         if self.foreground_args.child_process {
             opts.shutdown();
             exit(0);

--- a/implementations/rust/ockam/ockam_command/src/node/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/start.rs
@@ -167,7 +167,7 @@ async fn run_node(
     opts: &CommandGlobalOpts,
 ) -> miette::Result<BackgroundNodeClient> {
     let node_info = opts.state.get_node(node_name).await?;
-    opts.state.stop_node(node_name, false).await?;
+    opts.state.stop_node(node_name).await?;
     let node_address = node_info
         .tcp_listener_address()
         .map(|a| a.to_string())

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -1,5 +1,5 @@
+use miette::Context as _;
 use miette::IntoDiagnostic;
-use miette::{miette, Context as _};
 use ockam_core::env::get_env_with_default;
 use ockam_node::Context;
 use rand::random;
@@ -27,23 +27,6 @@ impl Default for NodeManagerDefaults {
             trust_opts: TrustOpts::default(),
         }
     }
-}
-
-pub async fn delete_all_nodes(opts: &CommandGlobalOpts, force: bool) -> miette::Result<()> {
-    let nodes = opts.state.get_nodes().await?;
-    let mut deletion_errors = Vec::new();
-    for n in nodes {
-        if let Err(e) = opts.state.delete_node(&n.name(), force).await {
-            deletion_errors.push((n.name(), e));
-        }
-    }
-    if !deletion_errors.is_empty() {
-        return Err(miette!(
-            "errors while deleting nodes: {:?}",
-            deletion_errors
-        ));
-    }
-    Ok(())
 }
 
 pub async fn initialize_default_node(

--- a/implementations/rust/ockam/ockam_command/src/project/ticket.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/ticket.rs
@@ -124,9 +124,10 @@ impl Command for TicketCommand {
         let ticket = ExportedEnrollmentTicket::new(
             token,
             ProjectRoute::new(MultiAddr::from_str(&project.access_route)?)?,
-            project.identity.as_ref().ok_or(miette!(
-                "missing project's identity, this should not happen"
-            ))?,
+            project
+                .identity
+                .as_ref()
+                .ok_or(miette!("missing project's identity"))?,
             &project.name,
             project
                 .project_change_history


### PR DESCRIPTION
- Remove `force` option in `CliState::stop_node` function
- Now, a node will be stopped with `SIGTERM` first, and if it fails, it will try again with `SIGKILL`
- Deprecate `--force` flag in commands 

[![asciicast](https://asciinema.org/a/5DQ3M8rUBuOTGqRIsOjldZouk.svg)](https://asciinema.org/a/5DQ3M8rUBuOTGqRIsOjldZouk)