### PR TITLE
feat(rust): added optional watchdog for tokio blocking tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,6 +4928,7 @@ dependencies = [
  "heapless 0.8.0",
  "hex",
  "minicbor",
+ "nix 0.29.0",
  "ockam_core",
  "ockam_executor",
  "ockam_macros",

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -68,6 +68,10 @@ metrics = []
 # message flows within Ockam apps.
 debugger = ["ockam_core/debugger"]
 
+# Feature: "watchdog" reports blocking task that compromise the runtime
+# neeeds to be compiled with RUSTFLAGS="--cfg tokio_unstable"
+watchdog = ["nix"]
+
 storage = [
   "std",
   "time",
@@ -87,6 +91,7 @@ fs2 = { version = "0.4.3", optional = true }
 futures = { version = "0.3.30", default-features = false }
 heapless = { version = "0.8", features = ["mpmc_large"], optional = true }
 minicbor = { version = "0.24.1", features = ["derive"] }
+nix = { version = "0.29", features = ["signal"], optional = true }
 ockam_core = { path = "../ockam_core", version = "^0.118.0", default-features = false }
 ockam_executor = { path = "../ockam_executor", version = "^0.87.0", default-features = false, optional = true }
 ockam_macros = { path = "../ockam_macros", version = "^0.35.0" }

--- a/implementations/rust/ockam/ockam_node/src/lib.rs
+++ b/implementations/rust/ockam/ockam_node/src/lib.rs
@@ -72,6 +72,9 @@ mod worker_builder;
 #[cfg(feature = "std")]
 pub mod runtime;
 
+#[cfg(feature = "watchdog")]
+mod watchdog;
+
 pub use context::*;
 pub use delayed::*;
 pub use error::*;

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -119,6 +119,12 @@ impl NodeBuilder {
         let mut exe = Executor::new(rt.clone(), &flow_controls);
         let addr: Address = "app".into();
 
+        #[cfg(feature = "watchdog")]
+        {
+            let watchdog = crate::watchdog::TokioRuntimeWatchdog::new();
+            watchdog.start_watchdog_loop(&rt);
+        }
+
         // The root application worker needs a mailbox and relay to accept
         // messages from workers, and to buffer incoming transcoded data.
         let (ctx, sender, _) = Context::new(

--- a/implementations/rust/ockam/ockam_node/src/watchdog.rs
+++ b/implementations/rust/ockam/ockam_node/src/watchdog.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::thread::ThreadId;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+struct ThreadInfo {
+    poll_count: u64,
+    parked_on_previous_iteration: bool,
+    thread_id: ThreadId,
+}
+
+/// Detects if there is any thread stuck on a task and write a warning log about it.
+/// Pauses the process with SIGSTOP to allow the debugger to attach to the process.
+pub(crate) struct TokioRuntimeWatchdog {
+    thread_map: HashMap<usize, ThreadInfo>,
+}
+
+impl TokioRuntimeWatchdog {
+    pub(crate) fn new() -> Self {
+        Self {
+            thread_map: HashMap::new(),
+        }
+    }
+
+    pub fn start_watchdog_loop(self, runtime: &Runtime) {
+        let metrics = runtime.metrics();
+        // to avoid spawning the watchdog within tokio runtime
+        std::thread::spawn(move || {
+            self.watchdog_loop(metrics);
+        });
+    }
+
+    fn watchdog_loop(mut self, tokio_metrics: tokio::runtime::RuntimeMetrics) {
+        info!("Starting tokio runtime watchdog");
+        const WATCHDOG_INTERVAL: Duration = Duration::from_millis(50);
+        let watchdog_interval = std::env::var("OCKAM_WATCHDOG_INTERVAL")
+            .map(|s| Duration::from_millis(s.parse().unwrap()))
+            .unwrap_or(WATCHDOG_INTERVAL);
+
+        loop {
+            // create any missing thread info, threads are always created and never destroyed
+            for tokio_worker in 0..tokio_metrics.num_workers() {
+                if !self.thread_map.contains_key(&tokio_worker) {
+                    if let Some(thread_id) = tokio_metrics.worker_thread_id(tokio_worker) {
+                        self.thread_map.insert(
+                            tokio_worker,
+                            ThreadInfo {
+                                poll_count: 0,
+                                parked_on_previous_iteration: true,
+                                thread_id,
+                            },
+                        );
+                    }
+                }
+            }
+
+            for (tokio_worker, thread_info) in self.thread_map.iter_mut() {
+                // poll_count is used as a proxy to count how many times .await was called
+                let poll_count = tokio_metrics.worker_poll_count(*tokio_worker);
+                // how many times the thread has been parked and unparked, since it starts as
+                // unparked, when odd, the worker is parked
+                let is_parked = tokio_metrics.worker_park_unpark_count(*tokio_worker) % 2 == 1;
+
+                // if the worker wasn't parked before, and it's not parked now, and it's still
+                // within the same poll count, then it's likely that the worker is stuck
+                if !thread_info.parked_on_previous_iteration
+                    && !is_parked
+                    && thread_info.poll_count == poll_count
+                {
+                    let ms = watchdog_interval.as_millis();
+                    let tid = thread_info.thread_id;
+                    let pid = std::process::id();
+                    let exe = std::env::current_exe().unwrap();
+                    let exe = exe.to_str().unwrap();
+
+                    warn!(
+                            "{tid:?} (tokio worker {tokio_worker}) is stuck, and it spent at least {ms} milliseconds without any await.
+                            In order to debug the issue the process was paused with SIGSTOP.
+                            False positives are unlikely but possible.
+                            You can attach the rust debugger with:
+                                rust-lldb {exe} --attach-pid {pid}
+                            and then select the thread with:
+                                thread select THREAD_ID
+                            and print the backtrace with:
+                                bt
+                            "
+                        );
+
+                    // Send SIGSTOP to self to pause the process in this precise moment in time
+                    // so the debugger can attach to the process, and inspect the threads.
+                    // SIGSTOP is sent twice to work around the debugger that sometimes
+                    // issues a SIGCONT when attaching to the process.
+                    for _n in 0..2 {
+                        let _ = nix::sys::signal::raise(nix::sys::signal::Signal::SIGSTOP);
+                    }
+                }
+                thread_info.parked_on_previous_iteration = is_parked;
+                thread_info.poll_count = poll_count;
+            }
+            std::thread::sleep(watchdog_interval);
+        }
+    }
+}


### PR DESCRIPTION
By building with the `watchdog` feature, every node runs a watchdog that monitors tokio tasks, if one thread remains more than 50ms (default) on the same task without calling `await` it's deemed as "stuck", this triggers a multiline warning log entry and pauses the process through a SIGSTOP.

The interval can be set using the `OCKAM_WATCHDOG_INTERVAL` environment variable.
Once the process is paused, it is possible to use the external debugger `rust-lldb` to understand why the thread was stuck.

To build the watchdog feature it's necessary to enable the `tokio_unstable` configuration:
`RUSTFLAGS='--cfg tokio_unstable' cargo build -p  ockam_command  -F ockam_node/watchdog`

<img width="1604" alt="Screenshot 2024-10-18 at 17 41 24" src="https://github.com/user-attachments/assets/67c46ad9-a0a0-46b6-b90d-3f7379612d5a">

^ in the screenshot a fictional example with a synchronous sleep()
