### PR TITLE
fix(rust): when an item is not found an error is returned

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
+++ b/implementations/rust/ockam/ockam_command/src/terminal/tui.rs
@@ -23,7 +23,7 @@ pub trait ShowCommandTui {
     async fn show(&self) -> miette::Result<()> {
         let terminal = self.terminal();
         let items_names = self.list_items_names().await?;
-        if items_names.is_empty() {
+        if items_names.is_empty() && self.cmd_arg_item_name().is_none() {
             terminal
                 .stdout()
                 .plain(fmt_info!(

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/nodes.bats
@@ -17,8 +17,8 @@ teardown() {
 force_kill_node() {
   max_retries=5
   i=0
+  pid="$($OCKAM node show $1 --output json | jq .pid)"
   while [[ $i -lt $max_retries ]]; do
-    pid="$($OCKAM node show $1 --output json | jq .pid)"
     run kill -9 $pid
     # Killing a node created without `-f` leaves the
     # process in a defunct state when running within Docker.
@@ -88,34 +88,34 @@ force_kill_node() {
 
 @test "node - fail to create two foreground nodes with the same name" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 3
   run_success "$OCKAM" node show n
   run_failure "$OCKAM" node create n -f
 }
 
 @test "node - can recreate a foreground node after it was killed" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 3
   run_success "$OCKAM" node show n
 
   force_kill_node n
 
   # Recreate node
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 3
   run_success "$OCKAM" node show n
 }
 
 @test "node - can recreate a foreground node after it was gracefully stopped" {
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 3
   run_success "$OCKAM" node show n
 
   run_success "$OCKAM" node stop n
 
   # Recreate node
   run_success "$OCKAM" node create n -f &
-  sleep 1
+  sleep 3
   run_success "$OCKAM" node show n
 }
 
@@ -143,8 +143,7 @@ force_kill_node() {
   # The config file has invalid port to trigger an error after the node is created.
   # The command should return an error and the node should be deleted.
   run_failure "$OCKAM" node create --configuration "{name: n, tcp-outlets: {db-outlet: {to: \"localhost:65536\"}}}"
-  run_success $OCKAM node show n --output json
-  assert_output --partial "[]"
+  run_failure $OCKAM node show n
 }
 
 @test "node - create two nodes with the same inline configuration" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/policies.bats
@@ -21,8 +21,7 @@ teardown() {
   assert_output --partial '(= subject.component \"global_value\")'
 
   run_success $OCKAM policy delete tcp-outlet -y
-  run_success $OCKAM policy show tcp-outlet
-  refute_output --partial "tcp-outlet"
+  run_failure $OCKAM policy show tcp-outlet
 }
 
 @test "policies - create resource type policy" {
@@ -35,8 +34,7 @@ teardown() {
   run_failure $OCKAM policy showype not-a-resource-type
 
   run_success $OCKAM policy delete tcp-outlet -y
-  run_success $OCKAM policy show tcp-outlet
-  refute_output --partial "tcp-outlet"
+  run_failure $OCKAM policy show tcp-outlet
 }
 
 @test "policies - create scoped policy" {
@@ -46,8 +44,7 @@ teardown() {
   assert_output --partial '(= subject.component \"scoped_value\")'
 
   run_success $OCKAM policy delete my_policy -y
-  run_success $OCKAM policy show my_policy
-  refute_output --partial "my_policy"
+  run_failure $OCKAM policy show my_policy
 }
 
 @test "policies - create policy with a boolean expression" {


### PR DESCRIPTION
When a show command is executed on any resource and that resource is missing, it'll simply print `There are no <type> to show`, return a SUCCESS (0) exit code.

```
$ ockam node show hello
  > There are no nodes to show
$ echo $?
0
```
This could be misleading, and an error should be printed.
Also, some tests rely on the fact that the shown command returning 0 means the resource exists.

With this patch the resource not found triggers an error instead.

```
$ target/debug/ockam node show hello


    Error:
    ────────────────────────────────────────────────────────────────────────────────

    There is no node with name hello (origin: Api, kind: NotFound, source location: implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs:311:17)
    Please report this issue, with a copy of your logs, to https://github.com/build-trust/ockam/issues
    
    Error code: OCK500
    version: 0.134.0
    compiled from: d071009f2ce6f9f7c7be1d04e89308abc8c4420a

    If you need help, please email us on support@ockam.io
    We will promptly help you get unstuck and quickly resolve any problems.

    ────────────────────────────────────────────────────────────────────────────────
$ echo $?
70
```

While it's nice to return a non-successful exit code, this error message could be too much.


