### PR TITLE
fix(rust): add retry to the command's upgrade github request

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -84,8 +84,7 @@ impl OckamCommand {
             warn!("Failed to check for upgrade, error={err}");
             options
                 .terminal
-                .write_line(&fmt_warn!("Failed to check for upgrade"))
-                .unwrap();
+                .write_line(&fmt_warn!("Failed to check for upgrade"))?;
         }
 
         let tracer = global::tracer(OCKAM_TRACER_NAME);


### PR DESCRIPTION
Sometimes the github endpoint we use to retrieve the latest ockam version is flaky. 

This PR adds a retry loop and reduces the timeout from 30 to 3 seconds to reduce the time we block the command.