### PR TITLE
feat(rust): improve parsing of node config files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "serde_bare",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "shellexpand",
  "syntect",
  "tempfile",

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -110,6 +110,7 @@ mockito = "1.5.0"
 ockam_api = { path = "../ockam_api", version = "0.82.0", default-features = false, features = ["test-utils"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.35.0" }
 proptest = "1.5.0"
+serial_test = "3.0.0"
 tempfile = "3.10.1"
 time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -195,6 +195,11 @@ impl Command for CreateCommand {
 impl CreateCommand {
     /// Return true if the command should be run in config mode
     fn should_run_config(&self) -> bool {
+        // Ignore the config args if it's a child process (i.e. only the top level process can run the config)
+        if self.foreground_args.child_process {
+            return false;
+        }
+
         let name_arg_is_a_config = !self.has_name_arg();
 
         let no_config_args = !name_arg_is_a_config

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -72,7 +72,7 @@ impl CreateCommand {
     /// or read the inline configuration
     #[instrument(skip_all, fields(app.event.command.configuration_file))]
     pub async fn get_node_config(&self) -> miette::Result<NodeConfig> {
-        let mut contents = match self.config_args.configuration.clone() {
+        let contents = match self.config_args.configuration.clone() {
             Some(contents) => contents,
             None => match parse_path_or_url(&self.name).await {
                 Ok(contents) => contents,
@@ -95,7 +95,7 @@ impl CreateCommand {
             std::env::set_var(key, value);
         }
         // Parse the configuration
-        let node_config = NodeConfig::parse(&mut contents)?;
+        let node_config = NodeConfig::parse(contents.clone())?;
         // Record the configuration contents if the node configuration was successfully parsed
         Span::current().record(
             APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE.as_str(),
@@ -132,8 +132,8 @@ pub struct NodeConfig {
 }
 
 impl NodeConfig {
-    fn parse(contents: &mut String) -> miette::Result<Self> {
-        ConfigParser::parse(contents)
+    fn parse(mut contents: String) -> miette::Result<Self> {
+        ConfigParser::parse(&mut contents)
     }
 
     /// Merge the arguments of the node defined in the config with the arguments from the
@@ -403,8 +403,8 @@ mod tests {
         for file in files {
             let file = file.unwrap();
             let path = file.path();
-            let mut contents = std::fs::read_to_string(&path).unwrap();
-            let res = NodeConfig::parse(&mut contents);
+            let contents = std::fs::read_to_string(&path).unwrap();
+            let res = NodeConfig::parse(contents);
             res.unwrap();
         }
     }
@@ -463,8 +463,8 @@ mod tests {
         };
 
         // No node config, cli args should be used
-        let mut contents = String::new();
-        let mut config = NodeConfig::parse(&mut contents).unwrap();
+        let contents = String::new();
+        let mut config = NodeConfig::parse(contents).unwrap();
         config.merge(&cli_args).unwrap();
         let node = config.node.into_parsed_commands().unwrap().pop().unwrap();
         assert_eq!(node.tcp_listener_address, "127.0.0.1:1234");
@@ -476,15 +476,15 @@ mod tests {
         // Config used, cli args should override the overlapping args
         let config_enrollment_ticket = ExportedEnrollmentTicket::new_test();
         let config_enrollment_ticket_encoded = config_enrollment_ticket.to_string();
-        std::env::set_var("ENROLLMENT_TICKET", config_enrollment_ticket_encoded);
+        std::env::set_var(ENROLLMENT_TICKET, config_enrollment_ticket_encoded);
 
-        let mut contents = r#"
+        let contents = r#"
             ticket: $ENROLLMENT_TICKET
             name: n1
             tcp-listener-address: 127.0.0.1:5555
         "#
         .to_string();
-        let mut config = NodeConfig::parse(&mut contents).unwrap();
+        let mut config = NodeConfig::parse(contents).unwrap();
         config.merge(&cli_args).unwrap();
         let node = config.node.into_parsed_commands().unwrap().pop().unwrap();
         assert_eq!(node.name, "n1");

--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -77,29 +77,29 @@ impl Config {
     pub async fn parse_and_run(
         ctx: &Context,
         opts: CommandGlobalOpts,
-        contents: &mut String,
+        contents: String,
     ) -> miette::Result<()> {
         Self::parse(contents)?.run(ctx, &opts).await
     }
 
-    pub(crate) fn parse(contents: &mut String) -> miette::Result<Self> {
-        ConfigParser::parse(contents)
+    pub(crate) fn parse(mut contents: String) -> miette::Result<Self> {
+        ConfigParser::parse(&mut contents)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::node::config::ENROLLMENT_TICKET;
+    use crate::run::parser::building_blocks::*;
+    use crate::run::parser::VersionValue;
+    use serial_test::serial;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
-    use crate::run::parser::building_blocks::*;
-    use crate::run::parser::VersionValue;
-
-    use super::*;
-
     #[test]
     fn parse_complete_config() {
-        let mut config = r#"
+        let config = r#"
             vaults:
               - v1
               - v2
@@ -152,7 +152,7 @@ mod tests {
               - r2
         "#
         .to_string();
-        let parsed = Config::parse(&mut config).unwrap();
+        let parsed = Config::parse(config).unwrap();
 
         let expected = Config {
             version: Version {
@@ -294,21 +294,22 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn resolve_variables() {
         std::env::set_var("SUFFIX", "node");
-        let mut config = r#"
+        let config = r#"
             variables:
               prefix: ockam
-              ticket_path: ./path/to/ticket
+              ENROLLMENT_TICKET: ./path/to/ticket
 
-            ticket: ${ticket_path}
+            ticket: ${ENROLLMENT_TICKET}
 
             nodes:
               - ${prefix}_n1_${SUFFIX}
               - ${prefix}_n2_${SUFFIX}
         "#
         .to_string();
-        let parsed = Config::parse(&mut config).unwrap();
+        let parsed = Config::parse(config).unwrap();
         let expected = Config {
             version: Version {
                 version: VersionValue::latest(),
@@ -335,14 +336,18 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn parse_demo_config_files() {
-        std::env::set_var("ENROLLMENT_TICKET", "ticket");
-        let files = std::fs::read_dir(demo_config_files_dir()).unwrap();
+        let files = std::fs::read_dir(demo_config_files_dir())
+            .unwrap()
+            .collect::<Vec<_>>();
+        assert_eq!(files.len(), 7);
         for file in files {
+            std::env::set_var(ENROLLMENT_TICKET, "ticket");
             let file = file.unwrap();
             let path = file.path();
-            let mut contents = std::fs::read_to_string(&path).unwrap();
-            match Config::parse(&mut contents) {
+            let contents = std::fs::read_to_string(&path).unwrap();
+            match Config::parse(contents) {
                 Ok(_) => {}
                 Err(e) => {
                     eprintln!("Error parsing file {path:?}: {e}");
@@ -353,10 +358,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn parse_demo_config_file_1() {
         let path = demo_config_files_dir().join("1.portal.single-machine.yaml");
-        let mut config = std::fs::read_to_string(path).unwrap();
-        let parsed = Config::parse(&mut config).unwrap();
+        let config = std::fs::read_to_string(path).unwrap();
+        let parsed = Config::parse(config).unwrap();
         assert_eq!(parsed.version.version, VersionValue::latest());
         assert_eq!(parsed.vaults.vaults, None);
         assert_eq!(parsed.identities.identities, None);
@@ -398,10 +404,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn parse_demo_config_file_2_inlet() {
         let path = demo_config_files_dir().join("2.portal.inlet.yaml");
-        let mut config = std::fs::read_to_string(path).unwrap();
-        let parsed = Config::parse(&mut config).unwrap();
+        let config = std::fs::read_to_string(path).unwrap();
+        let parsed = Config::parse(config).unwrap();
         assert_eq!(parsed.version.version, VersionValue::latest());
         assert_eq!(parsed.vaults.vaults, None);
         assert_eq!(parsed.identities.identities, None);
@@ -440,10 +447,11 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn parse_demo_config_file_2_outlet() {
         let path = demo_config_files_dir().join("2.portal.outlet.yaml");
-        let mut config = std::fs::read_to_string(path).unwrap();
-        let parsed = Config::parse(&mut config).unwrap();
+        let config = std::fs::read_to_string(path).unwrap();
+        let parsed = Config::parse(config).unwrap();
         assert_eq!(parsed.version.version, VersionValue::latest());
         assert_eq!(parsed.vaults.vaults, None);
         assert_eq!(parsed.identities.identities, None);

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -46,7 +46,7 @@ impl RunCommand {
 
     #[instrument(skip_all, fields(app.event.command.configuration_file))]
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let mut contents = match &self.inline {
+        let contents = match &self.inline {
             Some(contents) => contents.to_string(),
             None => {
                 let path = match &self.recipe {
@@ -82,6 +82,6 @@ impl RunCommand {
             APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE.as_str(),
             &contents,
         );
-        Config::parse_and_run(ctx, opts, &mut contents).await
+        Config::parse_and_run(ctx, opts, contents).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/mod.rs
@@ -46,7 +46,7 @@ impl RunCommand {
 
     #[instrument(skip_all, fields(app.event.command.configuration_file))]
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
-        let contents = match &self.inline {
+        let mut contents = match &self.inline {
             Some(contents) => contents.to_string(),
             None => {
                 let path = match &self.recipe {
@@ -82,6 +82,6 @@ impl RunCommand {
             APPLICATION_EVENT_COMMAND_CONFIGURATION_FILE.as_str(),
             &contents,
         );
-        Config::parse_and_run(ctx, opts, &contents).await
+        Config::parse_and_run(ctx, opts, &mut contents).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/building_blocks.rs
@@ -330,8 +330,8 @@ pub fn as_command_args(args: BTreeMap<ArgKey, ArgValue>) -> Vec<String> {
 }
 
 /// Return the command representation of the argument name and its value.
-fn as_command_arg(key: ArgKey, values: ArgValue) -> Vec<String> {
-    match values {
+fn as_command_arg(key: ArgKey, value: ArgValue) -> Vec<String> {
+    match value {
         ArgValue::List(values) => values
             .into_iter()
             .flat_map(|value| as_command_arg(key.clone(), value))

--- a/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/config.rs
@@ -4,24 +4,93 @@ use serde::Deserialize;
 
 use crate::run::parser::Variables;
 
-pub trait ConfigParser<'de>: Deserialize<'de> {
-    /// Parse variables section and resolve them
-    fn resolve(contents: &str) -> miette::Result<String> {
-        Variables::resolve(contents)
-    }
-    /// Parses a given yaml configuration
-    fn parse(contents: &'de str) -> miette::Result<Self> {
+pub struct ConfigParser;
+
+impl ConfigParser {
+    pub fn parse<'de, T: Deserialize<'de>>(contents: &'de mut String) -> miette::Result<T> {
+        // Resolve the environment variables section
+        Variables::resolve(contents)?;
+
+        // Parse the configuration file as the given T type
         serde_yaml::from_str(contents)
             .map_err(|e| {
                 ockam_core::Error::new(
                     Origin::Api,
                     Kind::Serialization,
                     format!(
-                        "could not parse the node configuration file: {e:?}\n\n{}",
+                        "could not parse the configuration file: {e:?}\n\n{}",
                         contents
                     ),
                 )
             })
             .into_diagnostic()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::parser::building_blocks::ArgsToCommands;
+    use crate::run::parser::resource::{Nodes, Relays};
+    use serde::Serialize;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    pub struct TestConfig {
+        #[serde(flatten)]
+        pub nodes: Nodes,
+        #[serde(flatten)]
+        pub relays: Relays,
+    }
+
+    #[test]
+    fn parse_yaml_config() {
+        let mut contents = r#"
+            variables:
+              var_b: true
+              var_i: 1 # comment
+            nodes:
+              # comment
+              - node1
+              - node2
+            relays:
+              r1:
+                at: /project/default
+                to: outlet-node
+        "#
+        .to_string();
+
+        let result = ConfigParser::parse::<TestConfig>(&mut contents).unwrap();
+        assert_eq!(std::env::var("var_b").unwrap(), "true");
+        assert_eq!(std::env::var("var_i").unwrap(), "1");
+        assert_eq!(result.nodes.nodes.unwrap().len(), 2);
+    }
+
+    #[test]
+    fn parse_json_config() {
+        let mut contents = r#"
+            {
+                # comment
+                "variables": {
+                    "var_b": true,
+                    "var_i": 1, # trailing commas are supported
+                },
+                "nodes": [
+                    "node1",
+                    "node2",
+                ],
+                "relays": {
+                    "r1": {
+                        # comment
+                        "at": "/project/default",
+                        "to": "outlet-node",
+                    }
+                }
+            }
+        "#
+        .to_string();
+        let result = ConfigParser::parse::<TestConfig>(&mut contents).unwrap();
+        assert_eq!(std::env::var("var_b").unwrap(), "true");
+        assert_eq!(std::env::var("var_i").unwrap(), "1");
+        assert_eq!(result.nodes.nodes.unwrap().len(), 2);
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 use crate::node::CreateCommand;
 use crate::run::parser::building_blocks::{as_command_args, ArgKey, ArgValue};
 
-use crate::node::config::ENROLLMENT_TICKET;
 use crate::run::parser::resource::utils::parse_cmd_from_args;
 use crate::run::parser::resource::Resource;
 use crate::{node, Command, OckamSubcommand};
@@ -118,15 +117,15 @@ impl Node {
     }
 
     pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
-        // Unset the `ENROLLMENT_TICKET` env var, so that the `node create` command
-        // doesn't try to run in config mode again.
-        std::env::remove_var(ENROLLMENT_TICKET);
         Ok(vec![Self::get_subcommand(&self.args())?])
     }
 
     fn get_subcommand(args: &[String]) -> Result<CreateCommand> {
         if let OckamSubcommand::Node(cmd) = parse_cmd_from_args(CreateCommand::NAME, args)? {
-            if let node::NodeSubcommand::Create(c) = cmd.subcommand {
+            if let node::NodeSubcommand::Create(mut c) = cmd.subcommand {
+                c.config_args.configuration = None;
+                c.config_args.variables = vec![];
+                c.config_args.enrollment_ticket = None;
                 return Ok(c);
             }
         }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/nodes.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use crate::node::CreateCommand;
 use crate::run::parser::building_blocks::{ArgsToCommands, ResourcesContainer};
 
-use crate::node::config::ENROLLMENT_TICKET;
 use crate::run::parser::resource::utils::parse_cmd_from_args;
 use crate::{node, Command, OckamSubcommand};
 
@@ -29,9 +28,6 @@ impl Nodes {
     }
 
     pub fn into_parsed_commands(self) -> Result<Vec<CreateCommand>> {
-        // Unset the `ENROLLMENT_TICKET` env var, so that the `node create` command
-        // doesn't try to run in config mode again.
-        std::env::remove_var(ENROLLMENT_TICKET);
         match self.nodes {
             Some(c) => c.into_commands(Self::get_subcommand),
             None => Ok(vec![]),

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -74,7 +74,7 @@ impl SecureRelayInlet {
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
-        let mut recipe = self.create_config_recipe();
+        let recipe = self.create_config_recipe();
 
         if self.dry_run {
             opts.terminal.write_line(recipe.as_str())?;
@@ -90,7 +90,7 @@ impl SecureRelayInlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, &mut recipe).await
+        Config::parse_and_run(ctx, opts, recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -139,8 +139,8 @@ mod tests {
                 okta: false,
             },
         };
-        let mut config_recipe = cmd.create_config_recipe();
-        let config = Config::parse(&mut config_recipe).unwrap();
+        let config_recipe = cmd.create_config_recipe();
+        let config = Config::parse(config_recipe).unwrap();
         config.project_enroll.into_parsed_commands(None).unwrap();
         config.tcp_inlets.into_parsed_commands(None).unwrap();
     }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_inlet.rs
@@ -74,7 +74,7 @@ impl SecureRelayInlet {
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
-        let recipe = self.create_config_recipe();
+        let mut recipe = self.create_config_recipe();
 
         if self.dry_run {
             opts.terminal.write_line(recipe.as_str())?;
@@ -90,7 +90,7 @@ impl SecureRelayInlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, &recipe).await
+        Config::parse_and_run(ctx, opts, &mut recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -123,7 +123,6 @@ impl SecureRelayInlet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::run::parser::config::ConfigParser;
     use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     #[test]
@@ -140,8 +139,8 @@ mod tests {
                 okta: false,
             },
         };
-        let config_recipe = cmd.create_config_recipe();
-        let config = Config::parse(config_recipe.as_str()).unwrap();
+        let mut config_recipe = cmd.create_config_recipe();
+        let config = Config::parse(&mut config_recipe).unwrap();
         config.project_enroll.into_parsed_commands(None).unwrap();
         config.tcp_inlets.into_parsed_commands(None).unwrap();
     }

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -73,7 +73,7 @@ impl SecureRelayOutlet {
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
-        let mut recipe: String = self.create_config_recipe();
+        let recipe: String = self.create_config_recipe();
 
         if self.dry_run {
             opts.terminal.write_line(recipe.as_str())?;
@@ -89,7 +89,7 @@ impl SecureRelayOutlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, &mut recipe).await
+        Config::parse_and_run(ctx, opts, recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -141,8 +141,8 @@ mod tests {
                 okta: false,
             },
         };
-        let mut config_recipe = cmd.create_config_recipe();
-        let config = Config::parse(&mut config_recipe).unwrap();
+        let config_recipe = cmd.create_config_recipe();
+        let config = Config::parse(config_recipe).unwrap();
         config.project_enroll.into_parsed_commands(None).unwrap();
         config.policies.into_parsed_commands().unwrap();
         config.tcp_outlets.into_parsed_commands(None).unwrap();

--- a/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
+++ b/implementations/rust/ockam/ockam_command/src/sidecar/secure_relay_outlet.rs
@@ -73,7 +73,7 @@ impl SecureRelayOutlet {
         ctx: &Context,
         opts: CommandGlobalOpts,
     ) -> miette::Result<()> {
-        let recipe: String = self.create_config_recipe();
+        let mut recipe: String = self.create_config_recipe();
 
         if self.dry_run {
             opts.terminal.write_line(recipe.as_str())?;
@@ -89,7 +89,7 @@ impl SecureRelayOutlet {
             recipe.as_str().dark_gray()
         ))?;
 
-        Config::parse_and_run(ctx, opts, &recipe).await
+        Config::parse_and_run(ctx, opts, &mut recipe).await
     }
 
     fn create_config_recipe(&self) -> String {
@@ -124,11 +124,8 @@ impl SecureRelayOutlet {
 
 #[cfg(test)]
 mod tests {
-    use ockam_api::cli_state::ExportedEnrollmentTicket;
-
-    use crate::run::parser::config::ConfigParser;
-
     use super::*;
+    use ockam_api::cli_state::ExportedEnrollmentTicket;
 
     #[test]
     fn test_that_recipe_is_valid() {
@@ -144,8 +141,8 @@ mod tests {
                 okta: false,
             },
         };
-        let config_recipe = cmd.create_config_recipe();
-        let config = Config::parse(config_recipe.as_str()).unwrap();
+        let mut config_recipe = cmd.create_config_recipe();
+        let config = Config::parse(&mut config_recipe).unwrap();
         config.project_enroll.into_parsed_commands(None).unwrap();
         config.policies.into_parsed_commands().unwrap();
         config.tcp_outlets.into_parsed_commands(None).unwrap();

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -236,8 +236,24 @@ ticket: ${ENROLLMENT_TICKET}
 name: n1
 EOF
 
-  # The values from the config file will be overridden by the command line arguments
   run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml"
+  run_success "$OCKAM" node show n1
+
+  # Check that the identity can reach the project
+  run_success $OCKAM message send hi --to "/project/default/service/echo"
+}
+
+@test "nodes - create with config, using the specified enrollment ticket as an env var, in foreground" {
+  $OCKAM project ticket >"$OCKAM_HOME/enrollment.ticket"
+  export ENROLLMENT_TICKET=$(cat "$OCKAM_HOME/enrollment.ticket")
+
+  cat <<EOF >"$OCKAM_HOME/config.yaml"
+ticket: ${ENROLLMENT_TICKET}
+name: n1
+EOF
+
+  run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml" -f &
+  sleep 10
   run_success "$OCKAM" node show n1
 
   # Check that the identity can reach the project


### PR DESCRIPTION
Improves the parsing logic of config files:
- Env vars defined in the `variables` section are only used in the expand step. After that, they are unset
- Improve tests in the different parsing steps
- Improve handling of the `ENROLLMENT_TICKET` env var


The following json config syntax was already supported out of the box. I added tests to make sure we don't modify this behavior. Here's an example of a valid json configuration file:

```yaml
{
    # comment
    "variables": {
        "var_b": true,
        "var_i": 1, # trailing commas are supported
    },
    "nodes": [
        "node1",
        "node2",
    ],
    "relays": {
        "r1": {
            # comment
            "at": "/project/default",
            "to": "outlet-node",
        }
    }
}
```

- Comments are supported with `#` (c-style comments are not supported)
- Trailing commas are supported