### PR TITLE
refactor(rust): add more granular scopes for command logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4707,6 +4707,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sqlx",
  "strip-ansi-escapes",
@@ -4751,7 +4752,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -4809,7 +4809,6 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
- "tracing-core",
  "url",
  "which 6.0.3",
 ]

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -171,6 +171,7 @@ pretty_assertions = "1.4.1"
 proptest = "1.5.0"
 quickcheck = "1.0.1"
 quickcheck_macros = "1.0.0"
+serial_test = "3.0.0"
 tempfile = "3.10.1"
 tokio = { version = "1.39.2", features = ["full"] }
 tracing-core = "0.1.32"

--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -2,9 +2,6 @@
 /// LOGGING CONFIGURATION
 ///
 
-/// DEPRECATED! Accepted values, see LogLevel. For example: trace, debug, info
-pub(crate) const OCKAM_LOG: &str = "OCKAM_LOG";
-
 /// Decides if logs should be created. Accepted values, see FromString<bool>. For example; true, false, 1, 0
 pub(crate) const OCKAM_LOGGING: &str = "OCKAM_LOGGING";
 

--- a/implementations/rust/ockam/ockam_app_lib/Cargo.toml
+++ b/implementations/rust/ockam/ockam_app_lib/Cargo.toml
@@ -47,7 +47,6 @@ sqlx = { version = "0.8.2", default-features = false }
 thiserror = "1.0"
 tokio = { version = "1.39.2", features = ["full"] }
 tracing = { version = "0.1", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
 
 [dev-dependencies]
 ockam_api = { path = "../ockam_api", version = "0.81.0", default-features = false, features = ["test-utils"] }

--- a/implementations/rust/ockam/ockam_app_lib/src/log.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/log.rs
@@ -1,8 +1,8 @@
 use crate::state::{AppState, NODE_NAME};
 use ockam_api::logs::{
-    logging_configuration, Colored, CratesFilter, ExportingConfiguration, LoggingTracing,
+    logging_configuration, Colored, ExportingConfiguration, LogLevelWithCratesFilter,
+    LoggingTracing,
 };
-use tracing_core::Level;
 
 impl AppState {
     /// Setup logging and tracing for the Portals application
@@ -19,26 +19,11 @@ impl AppState {
                 .block_on(async move { this.state().await });
             state.node_dir(NODE_NAME)
         };
-        let ockam_crates = CratesFilter::Selected(vec![
-            "ockam".to_string(),
-            "ockam_node".to_string(),
-            "ockam_core".to_string(),
-            "ockam_vault".to_string(),
-            "ockam_identity".to_string(),
-            "ockam_transport_tcp".to_string(),
-            "ockam_api".to_string(),
-            "ockam_command".to_string(),
-            "ockam_app_lib".to_string(),
-        ]);
-
+        let level_and_crates = LogLevelWithCratesFilter::from_verbose(2)
+            .unwrap()
+            .add_crates(vec!["ockam_app_lib"]);
         let tracing_guard = LoggingTracing::setup(
-            &logging_configuration(
-                Some(Level::DEBUG),
-                Colored::Off,
-                Some(node_dir),
-                ockam_crates,
-            )
-            .unwrap(),
+            &logging_configuration(level_and_crates, Some(node_dir), Colored::Off).unwrap(),
             &ExportingConfiguration::foreground().unwrap(),
             "portals",
             Some("portals".to_string()),

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -101,7 +101,6 @@ time = { version = "0.3", default-features = false, features = ["std", "local-of
 tokio = { version = "1.39.2", features = ["full"] }
 tokio-retry = "0.3"
 tracing = { version = "0.1", default-features = false }
-tracing-core = { version = "0.1.32", default-features = false }
 url = "2.5.2"
 which = "6.0.2"
 

--- a/implementations/rust/ockam/ockam_command/src/entry_point.rs
+++ b/implementations/rust/ockam/ockam_command/src/entry_point.rs
@@ -6,7 +6,8 @@ use miette::IntoDiagnostic;
 use ockam_api::cli_state::CliState;
 use ockam_api::fmt_log;
 use ockam_api::logs::{
-    crates_filter, logging_configuration, Colored, ExportingConfiguration, LoggingTracing,
+    logging_configuration, Colored, ExportingConfiguration, LogLevelWithCratesFilter,
+    LoggingTracing,
 };
 
 use crate::{
@@ -43,12 +44,9 @@ pub fn run() -> miette::Result<()> {
                     .collect::<Vec<String>>()
                     .join(" ");
 
-                let logging_configuration = logging_configuration(
-                    None,
-                    Colored::On,
-                    None,
-                    crates_filter().into_diagnostic()?,
-                );
+                let level_and_crates = LogLevelWithCratesFilter::new().into_diagnostic()?;
+                let logging_configuration =
+                    logging_configuration(level_and_crates, None, Colored::On);
                 let _guard = LoggingTracing::setup(
                     &logging_configuration.into_diagnostic()?,
                     &ExportingConfiguration::foreground().into_diagnostic()?,


### PR DESCRIPTION
Change the logic to define the log level and crates filter together so that:
- no verbose: no logs, will fallback to whatever is defined by env vars
- `-v`: level INFO and crates `ockam_command, ockam_api::ui::terminal`. The last crate is necessary to show the contents we write through the `Terminal` abstraction, which includes the command output
- `-vv`: level INFO and the [core crates](https://github.com/build-trust/ockam/pull/8560/files#diff-7bc1797d356e51984fef554b044acc1fbf368347d4eccb49fef297818015c306R396)
- `-vvv`: level DEBUG and the core crates
- `-vvvv`: level TRACE and the core crates
- `-vvvvv`: level TRACE and all crates, including deps

Other important considerations (no changes here, just a reminder):
- The verbose flag takes precedence over env vars
- To fully customize the behavior, we can use `OCKAM_LOG_LEVEL` and `OCKAM_LOG_CRATES_FILTER`