### PR TITLE
fix(rust): usage of `ENROLLMENT_TICKET` in `node create` and `project enroll` used in a node config

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/run/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/config.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use ockam_node::Context;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use crate::run::parser::config::ConfigParser;
 use crate::run::parser::resource::*;
@@ -54,18 +54,35 @@ impl Config {
     /// For more details about the parsing, see the [parser](crate::run::parser) module.
     /// You can also check examples of valid configuration files in the demo folder of this module.
     pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
-        for cmd in self.parse_commands()? {
-            cmd.run(ctx, opts).await?
-        }
-        Ok(())
-    }
-
-    // Build commands and return validation errors
-    fn parse_commands(self) -> miette::Result<Vec<ParsedCommands>> {
-        Ok(vec![
+        // Pre-enroll commands
+        let cmds: Vec<ParsedCommands> = vec![
             self.vaults.into_parsed_commands()?.into(),
             self.identities.into_parsed_commands()?.into(),
-            self.project_enroll.into_parsed_commands(None)?.into(),
+        ];
+        for cmd in cmds {
+            cmd.run(ctx, opts).await?
+        }
+
+        // Project enroll
+        if let Some(cmd) = self
+            .project_enroll
+            .into_parsed_commands(None)?
+            .into_iter()
+            .next()
+        {
+            cmd.run(ctx, opts).await?;
+
+            // Newline before the next command
+            opts.terminal.write_line("")?;
+            debug!("project enroll command finished");
+
+            // Unset the `ENROLLMENT_TICKET` env var, so that the `node create` command
+            // doesn't try to use it again
+            std::env::remove_var("ENROLLMENT_TICKET");
+        }
+
+        // Post-enroll commands
+        let cmds: Vec<ParsedCommands> = vec![
             self.nodes.into_parsed_commands()?.into(),
             self.relays.into_parsed_commands(None)?.into(),
             self.policies.into_parsed_commands()?.into(),
@@ -73,7 +90,12 @@ impl Config {
             self.tcp_inlets.into_parsed_commands(None)?.into(),
             self.kafka_inlet.into_parsed_commands(None)?.into(),
             self.kafka_outlet.into_parsed_commands(None)?.into(),
-        ])
+        ];
+        for cmd in cmds {
+            cmd.run(ctx, opts).await?
+        }
+
+        Ok(())
     }
 
     pub async fn parse_and_run(


### PR DESCRIPTION
When using the `ENROLLMENT_TICKET` environment variable as part of a node configuration file, a collision was happening, producing a loop of `project enroll` calls within the `node create` command.

The configuration file is parsed correctly, the `project enroll` command was running as expected, but then, when jumping to the next command (i.e. `node create`), it was receiving the enrollment ticket as an argument set automatically from the env var. This triggered the `node create` command to be run in `config` mode, running the `project enroll` command again.

So, this was affecting config files where the enrollment ticket was set using the `ENROLLMENT_TICKET` env var:

```yaml
ticket: ${ENROLLMENT_TICKET}
...
```