### PR TITLE
fix(rust): in test use a dedicated temporary directory

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -346,7 +346,8 @@ mod tests {
         assert!(cmd.has_name_arg());
 
         // False if it's a file path
-        let tmp_file = std::env::temp_dir().join("config.json");
+        let tmp_directory = tempfile::tempdir().unwrap();
+        let tmp_file = tmp_directory.path().join("config.json");
         std::fs::write(&tmp_file, "{}").unwrap();
         let cmd = CreateCommand {
             name: tmp_file.to_str().unwrap().to_string(),
@@ -364,7 +365,8 @@ mod tests {
 
     #[test]
     fn should_run_config() {
-        let tmp_file = std::env::temp_dir().join("config.json");
+        let tmp_directory = tempfile::tempdir().unwrap();
+        let tmp_file = tmp_directory.path().join("config.json");
         std::fs::write(&tmp_file, "{}").unwrap();
         let config_path = tmp_file.to_str().unwrap().to_string();
 

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -414,7 +414,8 @@ mod tests {
     #[tokio::test]
     async fn node_name_is_handled_correctly() {
         // The command doesn't define a node name, the config file does
-        let tmp_file = std::env::temp_dir().join("config.json");
+        let tmp_directory = tempfile::tempdir().unwrap();
+        let tmp_file = tmp_directory.path().join("config.json");
         std::fs::write(&tmp_file, "{name: n1}").unwrap();
         let cmd = CreateCommand {
             name: tmp_file.to_str().unwrap().to_string(),


### PR DESCRIPTION
On macos these test were failing