### PR TITLE
feat(rust): `project ticket` improvements

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -16,7 +16,10 @@ use crate::authenticator::{
     AuthorityEnrollmentTokenRepository, AuthorityMembersRepository, EnrollmentToken,
 };
 
-pub(super) const MAX_TOKEN_DURATION: Duration = Duration::from_secs(600);
+pub const DEFAULT_TOKEN_DURATION: Duration = Duration::from_secs(60 * 10);
+pub const MAX_RECOMMENDED_TOKEN_DURATION: Duration = Duration::from_secs(60 * 60 * 24 * 5);
+pub const DEFAULT_TOKEN_USAGE_COUNT: u64 = 1;
+pub const MAX_RECOMMENDED_TOKEN_USAGE_COUNT: u64 = 10;
 
 pub struct EnrollmentTokenIssuerError(pub String);
 
@@ -90,8 +93,8 @@ impl EnrollmentTokenIssuer {
             .take(10)
             .map(char::from)
             .collect();
-        let max_token_duration = token_duration.unwrap_or(MAX_TOKEN_DURATION);
-        let ttl_count = ttl_count.unwrap_or(1);
+        let max_token_duration = token_duration.unwrap_or(DEFAULT_TOKEN_DURATION);
+        let ttl_count = ttl_count.unwrap_or(DEFAULT_TOKEN_USAGE_COUNT);
         let now = now()?;
         let expires_at = now + max_token_duration.as_secs();
         let tkn = EnrollmentToken {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
@@ -269,13 +269,17 @@ impl LegacyEnrollmentTicket {
             .map_err(|_err| ApiError::core("Failed to authenticate with Okta"))?;
         Ok(hex::encode(serialized))
     }
+}
 
-    pub fn from_str(data: &str) -> Result<Self> {
-        if let Ok(data) = hex::decode(data) {
+impl FromStr for LegacyEnrollmentTicket {
+    type Err = ApiError;
+
+    fn from_str(contents: &str) -> std::result::Result<Self, Self::Err> {
+        if let Ok(data) = hex::decode(contents) {
             Ok(serde_json::from_slice(&data)
                 .map_err(|_err| ApiError::core("Failed to decode EnrollmentTicket json"))?)
         } else {
-            Ok(serde_json::from_str(data)
+            Ok(serde_json::from_str(contents)
                 .map_err(|_err| ApiError::core("Failed to decode EnrollmentTicket json"))?)
         }
     }

--- a/implementations/rust/ockam/ockam_app_lib/src/lib.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! It exposes C APIs that can be used by the frontend to interact with the application.
 //!
+#![recursion_limit = "256"]
 
 use thiserror::Error;
 mod api;

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -80,15 +80,16 @@ impl Command for CreateCommand {
     }
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
+        if self.project_relay {
+            print_deprecated_flag_warning(&opts, "--project-relay")?;
+        }
+
         initialize_default_node(ctx, &opts).await?;
+
         let cmd = self.parse_args(&opts).await?;
         let at = cmd.at();
         let alias = cmd.relay_name();
         let return_timing = cmd.return_timing();
-
-        if cmd.project_relay {
-            print_deprecated_flag_warning(&opts, "--project-relay")?;
-        }
 
         let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.to).await?;
         let relay_info = {

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -46,3 +46,25 @@ pub(crate) fn project_name_parser(s: &str) -> Result<String> {
 pub(crate) fn duration_parser(arg: &str) -> std::result::Result<Duration, clap::Error> {
     parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))
 }
+
+pub(crate) fn duration_to_human_format(duration: &Duration) -> String {
+    let mut parts = vec![];
+    let secs = duration.as_secs();
+    let days = secs / 86400;
+    if days > 0 {
+        parts.push(format!("{}d", days));
+    }
+    let hours = (secs % 86400) / 3600;
+    if hours > 0 {
+        parts.push(format!("{}h", hours));
+    }
+    let minutes = (secs % 3600) / 60;
+    if minutes > 0 {
+        parts.push(format!("{}m", minutes));
+    }
+    let seconds = secs % 60;
+    if seconds > 0 {
+        parts.push(format!("{}s", seconds));
+    }
+    parts.join(" ")
+}

--- a/implementations/rust/ockam/ockam_command/src/value_parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/value_parsers.rs
@@ -32,7 +32,7 @@ pub async fn parse_enrollment_ticket(
     let contents = parse_string_or_path_or_url(value).await?;
 
     // Try to parse it using the old format
-    if let Ok(ticket) = LegacyEnrollmentTicket::from_hex(&contents) {
+    if let Ok(ticket) = LegacyEnrollmentTicket::from_str(&contents) {
         // TODO: disabled until release 0.138.0
         // opts.terminal.write_line(fmt_warn!(
         //     "The enrollment ticket was generated from an old Ockam version"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -259,3 +259,19 @@ EOF
   # Check that the identity can reach the project
   run_success $OCKAM message send hi --to "/project/default/service/echo"
 }
+
+@test "nodes - create with config, using a json-encoded enrollment ticket" {
+  $OCKAM project ticket --output json >"$OCKAM_HOME/enrollment.ticket"
+  export ENROLLMENT_TICKET="$OCKAM_HOME/enrollment.ticket"
+
+  cat <<EOF >"$OCKAM_HOME/config.yaml"
+ticket: ${ENROLLMENT_TICKET}
+name: n1
+EOF
+
+  run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml"
+  run_success "$OCKAM" node show n1
+
+  # Check that the identity can reach the project
+  run_success $OCKAM message send hi --to "/project/default/service/echo"
+}


### PR DESCRIPTION
- add support to `project ticket` and `project enroll` to produce/consume json encoded enrollment tickets
- show a warning when a ticket is generated with high values for both usage/expiration arguments. This won't prevent the user from generating the ticket.
- add plain output to `project ticket` 

![image](https://github.com/user-attachments/assets/fbb014ad-edfa-4a30-b472-0cc4681c79c8)


