### PR TITLE
fix(rust): influxdb and tcp inlets delay the alias random value initialization to prevent collisions

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -405,4 +405,21 @@ mod tests {
             .map(|f| f.unwrap().file_name().to_string_lossy().to_string())
             .collect()
     }
+
+    #[tokio::test]
+    async fn random_name_generator() {
+        // Same process
+        let mut names = Vec::new();
+        for _ in 0..100 {
+            names.push(random_name());
+        }
+        assert_eq!(names.len(), names.iter().unique().count());
+
+        // In an async context
+        let mut names = Vec::new();
+        for _ in 0..100 {
+            names.push(tokio::task::spawn_blocking(random_name).await.unwrap());
+        }
+        assert_eq!(names.len(), names.iter().unique().count());
+    }
 }

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -61,7 +61,7 @@ impl Command for InfluxDBCreateCommand {
                         ctx,
                         &self.tcp_inlet.from,
                         &self.tcp_inlet.to(),
-                        &self.tcp_inlet.alias,
+                        self.tcp_inlet.alias.as_ref().expect("The `alias` argument should be set to its default value if not provided"),
                         &self.tcp_inlet.authorized,
                         &self.tcp_inlet.allow,
                         self.tcp_inlet.connection_wait,

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/influxdb_inlets.rs
@@ -74,10 +74,10 @@ mod tests {
             .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
-        assert_eq!(cmds[0].tcp_inlet.alias, "ti1");
+        assert_eq!(cmds[0].tcp_inlet.alias.as_ref().unwrap(), "ti1");
         assert_eq!(cmds[0].tcp_inlet.from, HostnamePort::new("127.0.0.1", 6060));
         assert_eq!(cmds[0].tcp_inlet.at.as_ref().unwrap(), "n");
-        assert_eq!(cmds[1].tcp_inlet.alias, "my_inlet");
+        assert_eq!(cmds[1].tcp_inlet.alias.as_ref().unwrap(), "my_inlet");
         assert_eq!(cmds[1].tcp_inlet.from, HostnamePort::new("127.0.0.1", 6061));
         assert_eq!(cmds[1].tcp_inlet.at.as_ref(), Some(&default_node_name));
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/tcp_inlets.rs
@@ -71,10 +71,10 @@ mod tests {
             .into_parsed_commands(Some(&default_node_name))
             .unwrap();
         assert_eq!(cmds.len(), 2);
-        assert_eq!(cmds[0].alias, "ti1");
+        assert_eq!(cmds[0].alias.as_ref().unwrap(), "ti1");
         assert_eq!(cmds[0].from, HostnamePort::new("127.0.0.1", 6060));
         assert_eq!(cmds[0].at.as_ref().unwrap(), "n");
-        assert_eq!(cmds[1].alias, "my_inlet");
+        assert_eq!(cmds[1].alias.as_ref().unwrap(), "my_inlet");
         assert_eq!(cmds[1].from, HostnamePort::new("127.0.0.1", 6061));
         assert_eq!(cmds[1].at.as_ref(), Some(&default_node_name));
 

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -1,16 +1,16 @@
 use std::collections::BTreeMap;
 use std::process::Stdio;
 
+use crate::run::parser::building_blocks::{as_command_args, ArgKey, ArgValue};
+use crate::run::parser::resource::utils::{binary_path, subprocess_stdio};
+use crate::{Command, CommandGlobalOpts, GlobalArgs};
 use async_trait::async_trait;
 use miette::{IntoDiagnostic, Result};
+use ockam_api::colors::color_primary;
 use ockam_core::AsyncTryClone;
 use ockam_node::Context;
 use tokio::process::{Child, Command as ProcessCommand};
 use tracing::debug;
-
-use crate::run::parser::building_blocks::{as_command_args, ArgKey, ArgValue};
-use crate::run::parser::resource::utils::{binary_path, subprocess_stdio};
-use crate::{Command, CommandGlobalOpts, GlobalArgs};
 
 /// This trait defines the methods that a resource must implement before it's parsed into a Command.
 ///
@@ -84,7 +84,7 @@ where
     }
 
     async fn run(&self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
-        debug!("Running command: {}", self.name());
+        debug!("Running command {}\n{:?}", color_primary(self.name()), self);
         Ok(self.clone().async_run_with_retry(ctx, opts.clone()).await?)
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -1,4 +1,5 @@
 use std::cmp::min;
+use std::fmt::Debug;
 use std::ops::Add;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -330,7 +331,7 @@ impl OckamSubcommand {
 }
 
 #[async_trait]
-pub trait Command: Clone + Sized + Send + Sync + 'static {
+pub trait Command: Debug + Clone + Sized + Send + Sync + 'static {
     const NAME: &'static str;
 
     fn name(&self) -> String {

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -80,8 +80,8 @@ pub struct CreateCommand {
     pub authorized: Option<Identifier>,
 
     /// Assign a name to this TCP Inlet.
-    #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser, default_value_t = random_name(), hide_default_value = true)]
-    pub alias: String,
+    #[arg(long, display_order = 900, id = "ALIAS", value_parser = alias_parser)]
+    pub alias: Option<String>,
 
     /// Policy expression that will be used for access control to the TCP Inlet.
     /// If you don't provide it, the policy set for the "tcp-inlet" resource type will be used.
@@ -186,7 +186,7 @@ impl Command for CreateCommand {
                         ctx,
                         &cmd.from,
                         &cmd.to(),
-                        &cmd.alias,
+                        cmd.alias.as_ref().expect("The `alias` argument should be set to its default value if not provided"),
                         &cmd.authorized,
                         &cmd.allow,
                         cmd.connection_wait,
@@ -303,6 +303,7 @@ impl CreateCommand {
     }
 
     pub async fn parse_args(mut self, opts: &CommandGlobalOpts) -> miette::Result<Self> {
+        self.alias = self.alias.or_else(|| Some(random_name()));
         let from = resolve_peer(self.from.to_string())
             .await
             .into_diagnostic()?;

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -275,3 +275,23 @@ EOF
   # Check that the identity can reach the project
   run_success $OCKAM message send hi --to "/project/default/service/echo"
 }
+
+@test "nodes - create node with both tcp and influx inlets" {
+  tcp_inlet_port="$(random_port)"
+  influxdb_inlet_port="$(random_port)"
+  cat <<EOF >"$OCKAM_HOME/node.yaml"
+name: n1
+
+tcp-inlet:
+  from: 0.0.0.0:${tcp_inlet_port}
+  no-connection-wait: true
+
+influxdb-inlet:
+  from: 0.0.0.0:${influxdb_inlet_port}
+  leased-token-strategy: shared
+  no-connection-wait: true
+EOF
+
+  # We just want to check that the command doesn't fail
+  run_success "$OCKAM" node create "$OCKAM_HOME/node.yaml"
+}


### PR DESCRIPTION
The `alias` argument in `influxdb-inlet create` and `tcp-inlet create` are shared (i.e. both point to the `tcp-inlet create` command's argument). Clappy initializes the default values for all the defined commands at startup, so both commands were getting the same default value for the `alias` argument. This caused issues when trying to use a node configuration with both types of inlets:

```yaml
name: n1

tcp-inlet:
  from: 0.0.0.0:15432
  allow: postgres

influxdb-inlet:
  from: 0.0.0.0:25432
  allow: postgres
  leased-token-strategy: shared
```


Now, the argument is an Option and is set to the random default value when the command is executed.