### PR TITLE
fix(rust): make sure that traces are exported when a command is executed

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
@@ -50,8 +50,9 @@ pub(crate) const DEFAULT_SPAN_EXPORT_QUEUE_SIZE: u16 = 32768;
 pub(crate) const DEFAULT_LOG_EXPORT_QUEUE_SIZE: u16 = 32768;
 
 // Maximum time for sending log record batches when using a portal
-pub(crate) const DEFAULT_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Duration = Duration::from_millis(300);
+pub(crate) const DEFAULT_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Duration =
+    Duration::from_millis(3000);
 
 // Maximum time for sending span batches when using a portal
 pub(crate) const DEFAULT_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: Duration =
-    Duration::from_millis(300);
+    Duration::from_millis(3000);

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -48,8 +48,8 @@ Tracing
 - OCKAM_SPAN_EXPORT_QUEUE_SIZE: Size of the queue used to store batched spans before export. When the queue is full, spans are dropped. Default value: `32768`
 - OCKAM_LOG_EXPORT_QUEUE_SIZE: Size of the queue used to store batched log records before export. When the queue is full, log records are dropped. Default value: `32768`
 - OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `logfile`.
-- OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `300ms`.
-- OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `300ms`.
+- OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `3s`.
+- OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `3s`.
 - OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `console`.
 
 UDP Puncture

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -58,7 +58,7 @@ where
 {
     let (ctx, mut executor) = NodeBuilder::new()
         .no_logging()
-        .with_runtime(opts.rt)
+        .with_runtime(opts.rt.clone())
         .build();
     let res = executor.execute(
         async move {
@@ -76,6 +76,7 @@ where
         }
         .with_context(OpenTelemetryContext::current_context()),
     );
+    opts.force_flush();
     match res {
         Ok(Err(e)) => Err(e),
         Ok(Ok(t)) => Ok(t),


### PR DESCRIPTION
This PR fixes the sending of spans for user commands:

 - We make sure to flush the logs and spans at the end of a command.
 - The cutoff timeout for exporting is set to a higher time to make sure that all spans have the time to be exported (note for the reviewers: I haven't changed the naming of the `CUTOFF` variables but they apply even if we don't use a portal to send traces).
  
