### PR TITLE
fix(rust): force flush the traces later

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/journeys/journey_event.rs
@@ -59,7 +59,7 @@ impl Display for JourneyEvent {
             JourneyEvent::TcpOutletCreated => f.write_str("✅ tcp outlet created"),
             JourneyEvent::RelayCreated => f.write_str("✅ relay created"),
             JourneyEvent::PortalCreated => f.write_str("✅ portal created"),
-            JourneyEvent::Ok { command_name } => f.write_str(command_name),
+            JourneyEvent::Ok { command_name } => f.write_fmt(format_args!("🔨 {command_name}")),
             JourneyEvent::Error { command_name, .. } => {
                 f.write_fmt(format_args!("❌ {} error", command_name))
             }

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -201,6 +201,7 @@ impl CommandGlobalOpts {
     /// Shutdown resources
     pub fn shutdown(&self) {
         if let Some(tracing_guard) = self.tracing_guard.clone() {
+            tracing_guard.force_flush();
             tracing_guard.shutdown();
         };
     }

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -76,7 +76,6 @@ where
         }
         .with_context(OpenTelemetryContext::current_context()),
     );
-    opts.force_flush();
     match res {
         Ok(Err(e)) => Err(e),
         Ok(Ok(t)) => Ok(t),


### PR DESCRIPTION
This fix makes sure that we flush traces after user errors are reported.
