### PR TITLE
fix(rust): error chain is kept in ockam_command crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4798,7 +4798,6 @@ dependencies = [
  "rustls-pki-types",
  "semver 1.0.23",
  "serde",
- "serde_bare",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -4910,6 +4909,7 @@ name = "ockam_multiaddr"
 version = "0.63.0"
 dependencies = [
  "bincode",
+ "miette",
  "minicbor",
  "multiaddr",
  "ockam_core",

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -75,7 +75,7 @@ jaq-parse = "1"
 jaq-std = "1"
 kafka-protocol = "0.10"
 log = "0.4"
-miette = "7"
+miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.24.1", features = ["alloc", "derive"] }
 nix = { version = "0.29", features = ["signal"] }
 once_cell = { version = "1", default-features = false }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/enrollments.rs
@@ -104,7 +104,7 @@ impl CliState {
             let message =
                 "There should be a default space set for the current user. Please re-enroll";
             error!("{}", message);
-            return Err(CliStateError::from(message))?;
+            return Err(CliStateError::Other(message.into()))?;
         }
 
         let default_project_exists = self.projects().get_default_project().await.is_ok();
@@ -112,7 +112,7 @@ impl CliState {
             let message =
                 "There should be a default project set for the current user. Please re-enroll";
             error!("{}", message);
-            return Err(CliStateError::from(message))?;
+            return Err(CliStateError::Other(message.into()))?;
         }
 
         Ok(true)

--- a/implementations/rust/ockam/ockam_api/src/cli_state/error.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/error.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::unconditional_recursion)]
 use miette::Diagnostic;
-use ockam_core::Error;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, CliStateError>;
@@ -23,6 +22,10 @@ pub enum CliStateError {
     #[diagnostic(code("OCK500"))]
     Ockam(#[from] ockam_core::Error),
 
+    #[error(transparent)]
+    #[diagnostic(code("OCK500"))]
+    MultiAddr(#[from] ockam_multiaddr::Error),
+
     #[error("A {resource} named {name} already exists")]
     #[diagnostic(
         code("OCK409"),
@@ -30,7 +33,7 @@ pub enum CliStateError {
     )]
     AlreadyExists { resource: String, name: String },
 
-    #[error("Unable to find {resource} named {name}")]
+    #[error("There is no {resource} with name {name}")]
     #[diagnostic(code("OCK404"))]
     ResourceNotFound { resource: String, name: String },
 
@@ -62,12 +65,13 @@ pub enum CliStateError {
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+// TODO: remove this and use ApiError instead of ockam_core::Error within the crate
 impl From<CliStateError> for ockam_core::Error {
     #[track_caller]
     fn from(e: CliStateError) -> Self {
         match e {
             CliStateError::Ockam(e) => e,
-            _ => Error::new(
+            _ => ockam_core::Error::new(
                 ockam_core::errcode::Origin::Application,
                 ockam_core::errcode::Kind::Internal,
                 e,
@@ -75,25 +79,3 @@ impl From<CliStateError> for ockam_core::Error {
         }
     }
 }
-
-impl From<ockam_multiaddr::Error> for CliStateError {
-    #[track_caller]
-    fn from(e: ockam_multiaddr::Error) -> Self {
-        e.into()
-    }
-}
-
-macro_rules! gen_from_impl {
-    ($t:ty) => {
-        impl From<$t> for CliStateError {
-            #[track_caller]
-            fn from(e: $t) -> Self {
-                CliStateError::Other(e.into())
-            }
-        }
-    };
-}
-
-gen_from_impl!(miette::Error);
-gen_from_impl!(&str);
-gen_from_impl!(dialoguer::Error);

--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -333,11 +333,10 @@ impl CliState {
         if let Some(node) = self.nodes_repository().get_node(node_name).await? {
             Ok(node)
         } else {
-            Err(Error::new(
-                Origin::Api,
-                Kind::NotFound,
-                format!("There is no node with name {node_name}"),
-            ))?
+            Err(CliStateError::ResourceNotFound {
+                resource: "node".to_string(),
+                name: node_name.to_string(),
+            })?
         }
     }
 

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
@@ -2,6 +2,8 @@
 pub const PADDING: &str = "    ";
 /// Left padding for all terminal output that starts with an icon
 pub const ICON_PADDING: &str = "  ";
+/// Left padding for miette errors
+pub const MIETTE_PADDING: &str = "  ";
 /// A two-space indentation for nested terminal output
 pub const INDENTATION: &str = "  ";
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -91,13 +91,11 @@ rustls-native-certs = "0.8.0"
 rustls-pki-types = "1.7.0"
 semver = "1.0.23"
 serde = { version = "1", features = ["derive"] }
-serde_bare = { version = "0.5.0", default-features = false, features = ["alloc"] }
 serde_json = "1"
 serde_yaml = "0.9"
 shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 syntect = { version = "5.2.0", default-features = false, features = ["default-syntaxes", "regex-onig"] }
 thiserror = "1"
-time = { version = "0.3", default-features = false, features = ["std", "local-offset"] }
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-retry = "0.3"
 tracing = { version = "0.1", default-features = false }

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -177,7 +177,7 @@ impl CommandGlobalOpts {
         debug!("Arguments: {}", arguments.join(" "));
         debug!("Global arguments: {:#?}", &global_args);
         debug!("Command: {:#?}", &cmd);
-        debug!("Version: {}", Version::short());
+        debug!("Version: {}", Version::new());
 
         info!("Tracing initialized");
         debug!("{:#?}", logging_configuration);

--- a/implementations/rust/ockam/ockam_command/src/credential/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/credential/mod.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
-use colorful::core::StrMarker;
 use colorful::Colorful;
+use miette::miette;
 use serde::Serialize;
 use serde_json::json;
 
@@ -14,7 +14,6 @@ pub(crate) use store::StoreCommand;
 pub(crate) use verify::VerifyCommand;
 
 use crate::credential::list::ListCommand;
-use crate::error::Error;
 use crate::{CommandGlobalOpts, Result};
 
 pub(crate) mod issue;
@@ -81,10 +80,9 @@ impl CredentialOutput {
         let credential_data = credential.credential.get_credential_data()?;
         let purpose_key_data = credential.purpose_key_attestation.get_attestation_data()?;
 
-        let subject = credential_data.subject.ok_or(Error::InternalError {
-            error_message: "credential subject is missing".to_str(),
-            exit_code: 1,
-        })?;
+        let subject = credential_data
+            .subject
+            .ok_or(miette!("credential subject is missing"))?;
 
         let mut attributes = HashMap::<String, String>::default();
         for (k, v) in credential_data.subject_attributes.map {

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/create.rs
@@ -143,8 +143,7 @@ impl Command for CreateCommand {
                 "The bootstrap port {} can't overlap with the brokers port range {}",
                 self.from.port(),
                 brokers_port_range.to_string()
-            )
-            .into());
+            ));
         }
 
         let at_node = self.node_opts.at_node.clone();

--- a/implementations/rust/ockam/ockam_command/src/lease/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/lease/mod.rs
@@ -71,5 +71,5 @@ async fn resolve_at_arg(at: &MultiAddr, state: &CliState) -> miette::Result<Mult
 
     // Parse "to" as a multiaddr again with all the values in place
     let to = MultiAddr::from_str(&at).into_diagnostic()?;
-    Ok(process_nodes_multiaddr(&to, state).await?)
+    process_nodes_multiaddr(&to, state).await
 }

--- a/implementations/rust/ockam/ockam_command/src/manpages.rs
+++ b/implementations/rust/ockam/ockam_command/src/manpages.rs
@@ -66,14 +66,14 @@ fn get_man_page_directory(cmd_man_dir: &Option<String>) -> crate::Result<PathBuf
                 home_dir
             }
             None => {
-                let mut man_dir = env::current_dir()?;
+                let mut man_dir = env::current_dir().into_diagnostic()?;
                 man_dir.push("ockam_man_pages");
                 println!("Man pages stored at: {}", man_dir.display());
                 man_dir
             }
         },
     };
-    create_dir_all(&man_dir)?;
+    create_dir_all(&man_dir).into_diagnostic()?;
     Ok(man_dir)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -4,8 +4,7 @@ use std::{path::PathBuf, str::FromStr};
 use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
-use miette::Context as _;
-use miette::{miette, IntoDiagnostic};
+use miette::{miette, IntoDiagnostic, WrapErr};
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::KeyValue;
 use regex::Regex;
@@ -270,7 +269,8 @@ impl CreateCommand {
             buf,
             "{}",
             fmt_ok!("Created a new Node named {}", color_primary(node_name))
-        )?;
+        )
+        .into_diagnostic()?;
         if opts.state.get_node(node_name).await?.is_default() {
             writeln!(
                 buf,
@@ -279,7 +279,8 @@ impl CreateCommand {
                     "Marked {} as your default Node, on this machine",
                     color_primary(node_name)
                 )
-            )?;
+            )
+            .into_diagnostic()?;
         }
         writeln!(
             buf,
@@ -288,7 +289,8 @@ impl CreateCommand {
                 "To see more details on this Node, run: {}",
                 color_primary(format!("ockam node show {}", node_name))
             )
-        )?;
+        )
+        .into_diagnostic()?;
         Ok(buf)
     }
 
@@ -327,7 +329,7 @@ pub fn parse_launch_config(config_or_path: &str) -> Result<Config> {
         Err(_) => {
             let path = PathBuf::from_str(config_or_path)
                 .into_diagnostic()
-                .wrap_err(miette!("Not a valid path"))?;
+                .wrap_err(format!("Invalid path {config_or_path}"))?;
             Config::read(path)
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -183,7 +183,7 @@ fn query_certificate_chain(domain: &str) -> Result<String> {
     let mut client_connection = ClientConnection::new(client_configuration, server_name.to_owned())
         .into_diagnostic()
         .wrap_err("failed to create a client connection")?;
-    let mut tcp_stream = TcpStream::connect(domain_with_port)?;
+    let mut tcp_stream = TcpStream::connect(domain_with_port).into_diagnostic()?;
     let mut stream = Stream::new(&mut client_connection, &mut tcp_stream);
     stream
         .write_all(

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -200,11 +200,13 @@ impl EnrollCommand {
                 return Err(Error::Retry(miette!(
                     "Failed to enroll identity with project. {msg}"
                 )))
+                .into_diagnostic()
             }
             EnrollStatus::UnexpectedStatus(msg, status) => {
                 return Err(Error::Retry(miette!(
                     "Failed to enroll identity with project. {msg} {status}"
                 )))
+                .into_diagnostic()
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/delete.rs
@@ -50,7 +50,7 @@ impl Command for DeleteCommand {
         if self.member.is_none() && !self.all {
             return Err(miette!(
                 "You need to specify either an identifier to delete or use the --all flag to delete all the members from a project."
-            ).into());
+            ));
         }
 
         let (authority_node_client, project_name) =
@@ -82,7 +82,7 @@ impl Command for DeleteCommand {
             {
                 return Err(miette!(
                         "You need to use an enrolled identity to delete all the members from a Project."
-                    ).into());
+                    ));
             }
             let self_identifier = identity.identifier();
             let member_identifiers = authority_node_client.list_member_ids(ctx).await?;

--- a/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/project_member/mod.rs
@@ -114,9 +114,8 @@ pub(super) async fn create_authority_client(
         .get_identity_name_or_default(&identity_opts.identity_name)
         .await?;
 
-    Ok(node
-        .create_authority_client_with_project(ctx, project, Some(identity))
-        .await?)
+    node.create_authority_client_with_project(ctx, project, Some(identity))
+        .await
 }
 
 pub(crate) fn create_member_attributes(

--- a/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/secure_channel/create.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use colorful::Colorful;
-use miette::{miette, IntoDiagnostic, WrapErr};
+use miette::{miette, WrapErr};
 use serde_json::json;
 use tokio::{sync::Mutex, try_join};
 
@@ -96,9 +96,7 @@ impl CreateCommand {
             Some(get_default_timeout()),
         )
         .await?;
-        clean_projects_multiaddr(to, projects_sc)
-            .into_diagnostic()
-            .wrap_err("Could not parse projects from route")
+        clean_projects_multiaddr(to, projects_sc).wrap_err("Could not parse projects from route")
     }
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/service/start.rs
+++ b/implementations/rust/ockam/ockam_command/src/service/start.rs
@@ -1,6 +1,6 @@
 use clap::{Args, Subcommand};
 use colorful::Colorful;
-use miette::miette;
+use miette::WrapErr;
 use minicbor::Encode;
 
 use crate::{CommandGlobalOpts, Result};
@@ -77,10 +77,9 @@ pub(crate) async fn start_service_impl<T>(
 where
     T: Encode<()>,
 {
-    Ok(node
-        .tell(ctx, req)
+    node.tell(ctx, req)
         .await
-        .map_err(|e| miette!("Failed to start {service_name} service: {e}"))?)
+        .wrap_err(format!("Failed to start {service_name} service"))
 }
 
 /// Public so `ockam_command::node::create` can use it.

--- a/implementations/rust/ockam/ockam_command/src/space/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/create.rs
@@ -44,9 +44,9 @@ impl Command for CreateCommand {
             .is_identity_enrolled(&self.identity_opts.identity_name)
             .await?
         {
-            return Err(
-                miette!("Please enroll using 'ockam enroll' before using this command").into(),
-            );
+            return Err(miette!(
+                "Please enroll using 'ockam enroll' before using this command"
+            ));
         };
 
         let node = InMemoryNode::start(ctx, &opts.state).await?;

--- a/implementations/rust/ockam/ockam_command/src/status.rs
+++ b/implementations/rust/ockam/ockam_command/src/status.rs
@@ -108,7 +108,7 @@ impl StatusData {
         nodes: Vec<NodeResources>,
     ) -> Result<Self> {
         Ok(Self {
-            ockam_version: Version,
+            ockam_version: Version::new(),
             orchestrator_version,
             spaces,
             identities,

--- a/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/connection/create.rs
@@ -56,7 +56,7 @@ impl Command for CreateCommand {
             .stdout()
             .plain(output.item()?)
             .machine(output.address.to_string())
-            .json(serde_json::to_string(&output)?)
+            .json(serde_json::to_string(&output).into_diagnostic()?)
             .write_line()?;
         Ok(())
     }

--- a/implementations/rust/ockam/ockam_command/src/util/api.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/api.rs
@@ -1,3 +1,4 @@
+use miette::IntoDiagnostic;
 use ockam::identity::Identifier;
 use ockam_api::nodes::models::flow_controls::AddConsumer;
 use ockam_api::nodes::models::services::StartHopServiceRequest;
@@ -68,7 +69,8 @@ pub(crate) fn create_secure_channel_listener(
     let mut buf = vec![];
     Request::post("/node/secure_channel_listener")
         .body(payload)
-        .encode(&mut buf)?;
+        .encode(&mut buf)
+        .into_diagnostic()?;
     Ok(buf)
 }
 

--- a/implementations/rust/ockam/ockam_command/src/util/parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/parsers.rs
@@ -2,7 +2,7 @@ use clap::error::{Error, ErrorKind};
 use std::str::FromStr;
 use std::time::Duration;
 
-use miette::miette;
+use miette::{miette, WrapErr};
 
 use ockam::identity::Identifier;
 use ockam::transport::HostnamePort;
@@ -16,20 +16,21 @@ use crate::Result;
 /// It is possible to just input a `port`. In that case the address will be assumed to be
 /// 127.0.0.1:<port>
 pub(crate) fn hostname_parser(input: &str) -> Result<HostnamePort> {
-    Ok(HostnamePort::from_str(input)
-        .map_err(|e| miette!("cannot parse the address {input} as a socket address: {e}"))?)
+    HostnamePort::from_str(input).wrap_err(format!(
+        "cannot parse the address {input} as a socket address"
+    ))
 }
 
 /// Helper fn for parsing an identifier from user input by using
 /// [`ockam_identity::Identifier::from_str()`]
 pub(crate) fn identity_identifier_parser(input: &str) -> Result<Identifier> {
-    Ok(Identifier::from_str(input).map_err(|_| miette!("Invalid identity identifier: {input}"))?)
+    Identifier::from_str(input).wrap_err(format!("Invalid identity identifier: {input}"))
 }
 
 /// Helper fn for parsing an InternetAddress from user input by using
 /// [`InternetAddress::new()`]
 pub(crate) fn internet_address_parser(input: &str) -> Result<InternetAddress> {
-    Ok(InternetAddress::new(input).ok_or_else(|| miette!("Invalid address: {input}"))?)
+    InternetAddress::new(input).ok_or_else(|| miette!("Invalid address: {input}"))
 }
 
 pub(crate) fn project_name_parser(s: &str) -> Result<String> {
@@ -44,7 +45,7 @@ pub(crate) fn project_name_parser(s: &str) -> Result<String> {
 }
 
 pub(crate) fn duration_parser(arg: &str) -> std::result::Result<Duration, clap::Error> {
-    parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration."))
+    parse_duration(arg).map_err(|_| Error::raw(ErrorKind::InvalidValue, "Invalid duration"))
 }
 
 pub(crate) fn duration_to_human_format(duration: &Duration) -> String {

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -2,50 +2,113 @@
 
 use clap::crate_version;
 use ockam_api::colors::color_primary;
-use serde::ser::SerializeStruct;
+use ockam_api::output::Output;
 use serde::Serialize;
 use std::fmt::Display;
 
-pub(crate) struct Version;
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Version {
+    #[serde(skip)]
+    no_color: bool,
+    #[serde(skip)]
+    multiline: bool,
+    version: String,
+    hash: String,
+}
 
 impl Version {
-    pub(crate) fn long() -> &'static str {
-        Self::short()
+    pub(crate) fn new() -> Self {
+        Self {
+            no_color: false,
+            multiline: false,
+            version: crate_version!().to_string(),
+            hash: option_env!("GIT_HASH").unwrap_or("N/A").to_string(),
+        }
     }
 
-    pub(crate) fn short() -> &'static str {
-        let message = format!("{}\ncompiled from: {}", Self::version(), Self::hash());
-        Box::leak(message.into_boxed_str())
+    pub(crate) fn no_color(mut self) -> Self {
+        self.no_color = true;
+        self
     }
 
-    fn version() -> &'static str {
-        crate_version!()
+    pub(crate) fn multiline(mut self) -> Self {
+        self.multiline = true;
+        self
     }
 
-    fn hash() -> &'static str {
-        option_env!("GIT_HASH").unwrap_or("N/A")
+    pub(crate) fn clappy() -> &'static str {
+        Box::leak(
+            Self::new()
+                .item()
+                .expect("Failed to process version")
+                .into_boxed_str(),
+        )
+    }
+
+    fn prepare(&self) -> crate::Result<String> {
+        let (version, hash) = if self.no_color {
+            (self.version.clone(), self.hash.clone())
+        } else {
+            (
+                color_primary(&self.version).to_string(),
+                color_primary(&self.hash).to_string(),
+            )
+        };
+        let msg = format!("ockam {version}\ncompiled from {hash}");
+        if self.multiline {
+            Ok(msg)
+        } else {
+            Ok(msg.replace("\n", ", "))
+        }
     }
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}, compiled from: {}",
-            color_primary(Self::version()),
-            color_primary(Self::hash())
-        )
+        write!(f, "{}", self.prepare().expect("Failed to process version"))
     }
 }
 
-impl Serialize for Version {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("Version", 2)?;
-        state.serialize_field("version", Self::version())?;
-        state.serialize_field("hash", &Self::hash())?;
-        state.end()
+impl Output for Version {
+    fn item(&self) -> ockam_api::Result<String> {
+        Ok(self.padded_display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_mocked_version() -> Version {
+        Version {
+            no_color: false,
+            multiline: false,
+            version: "0.0.1".to_string(),
+            hash: "e895fd75".to_string(),
+        }
+    }
+
+    #[test]
+    fn version_default() {
+        let version = get_mocked_version().to_string();
+        assert!(version.contains("0.0.1"));
+        assert!(version.contains("e895fd75"));
+        assert!(version.contains("\u{1b}[38;2;79;218;184m"));
+    }
+
+    #[test]
+    fn version_no_color() {
+        let version = get_mocked_version().no_color().to_string();
+        assert!(version.contains("0.0.1"));
+        assert!(version.contains("e895fd75"));
+        assert!(!version.contains("\u{1b}[38;2;79;218;184m"));
+    }
+
+    #[test]
+    fn version_multiline() {
+        let version = get_mocked_version().multiline().to_string();
+        assert!(version.contains("0.0.1"));
+        assert!(version.contains("e895fd75"));
+        assert_eq!(version.lines().count(), 2);
     }
 }

--- a/implementations/rust/ockam/ockam_core/Cargo.toml
+++ b/implementations/rust/ockam/ockam_core/Cargo.toml
@@ -59,7 +59,7 @@ alloc = [
   "serde_bare/alloc",
 ]
 
-# Feature: "error-traces" cover whether not our errors capture
+# Feature: "error-traces" cover whether our errors capture
 # backtraces and/or spantraces by default.
 error-traces = [
   "tracing-error",
@@ -78,7 +78,7 @@ core2 = { version = "0.4.0", default-features = false, optional = true }
 futures-util = { version = "0.3.30", default-features = false, features = ["alloc", "async-await-macro", "sink"] }
 hashbrown = { version = "0.14", default-features = false, features = ["ahash", "serde"] }
 hex = { version = "0.4", default-features = false, optional = true }
-miette = { version = "7", optional = true }
+miette = { version = "7.2.0", features = ["fancy-no-backtrace"], optional = true }
 minicbor = { version = "0.24.1", features = ["derive"] }
 ockam_macros = { path = "../ockam_macros", version = "^0.35.0", default-features = false }
 once_cell = { version = "1", optional = true, default-features = false }

--- a/implementations/rust/ockam/ockam_core/src/error/mod.rs
+++ b/implementations/rust/ockam/ockam_core/src/error/mod.rs
@@ -38,6 +38,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 ///   lost over serialization).
 #[derive(Serialize, Deserialize)]
 pub struct Error(ErrorData);
+
 impl Error {
     /// Construct a new error given ErrorCodes and a cause.
     #[cold]
@@ -144,6 +145,9 @@ impl ErrorTrait for Error {
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl miette::Diagnostic for Error {}
 
 impl From<core::fmt::Error> for Error {
     #[cfg(feature = "std")]

--- a/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
+++ b/implementations/rust/ockam/ockam_multiaddr/Cargo.toml
@@ -25,10 +25,11 @@ description = "An implementation of multiformats.io/multiaddr"
 
 [features]
 default = ["std"]
-std = ["ockam_core/std", "unsigned-varint/std", "serde?/std", "minicbor/std"]
+std = ["ockam_core/std", "unsigned-varint/std", "serde?/std", "minicbor/std", "miette"]
 cbor = ["minicbor"]
 
 [dependencies]
+miette = { version = "7.2.0", features = ["fancy-no-backtrace"], optional = true }
 minicbor = { version = "0.24.1", default-features = false, features = ["alloc"], optional = true }
 once_cell = { version = "1.19.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.204", default-features = false, optional = true }

--- a/implementations/rust/ockam/ockam_multiaddr/src/error.rs
+++ b/implementations/rust/ockam/ockam_multiaddr/src/error.rs
@@ -37,6 +37,9 @@ impl Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl miette::Diagnostic for Error {}
+
 #[derive(Debug)]
 pub(crate) enum ErrorImpl {
     Unregistered(Code),


### PR DESCRIPTION
The error chain was broken every time we converted from a `miette::Error` to an `ockam_command::Error`. When showing the error details in the console, we were only able to show the top-level error.

The main change to fix this is in the [`Result` type](https://github.com/build-trust/ockam/pull/8602/files#diff-ecd0ca50cb651b85d68eff33f32042de209e6546af1ae9b2126b36ba8fd8a58dR10) used in `ockam_command`. Now, it's just the miette's result type, which allows us to build error diagnostics keeping the error chain from previous errors. 

There is still a [conversion](https://github.com/build-trust/ockam/pull/8602/files#diff-a96c424d2cf2cfdd01fc828842e009839f681eb5c5a574a32cb5368d112c636cR68) that breaks the miette's error chain in the `ockam_api` crate, but I'll tackle that in a separate PR.