### PR TITLE
feat(rust): node's http server is enabled by default

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/nodes.rs
@@ -240,7 +240,10 @@ impl CliState {
         let mut attempts = 0;
         loop {
             match self.send_kill_signal(pid, signal) {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    self.notify_progress_finish_and_clear();
+                    return Ok(());
+                }
                 Err(err) => {
                     // Return if max attempts have been reached
                     if attempts > max_attempts {
@@ -318,7 +321,7 @@ impl CliState {
     ) -> Result<()> {
         Ok(self
             .nodes_repository()
-            .set_http_server_address(node_name, address)
+            .set_status_endpoint_address(node_name, address)
             .await?)
     }
 
@@ -440,7 +443,7 @@ impl CliState {
             || repository.get_nodes().await?.is_empty();
 
         let tcp_listener_address = repository.get_tcp_listener_address(node_name).await?;
-        let http_server_address = repository.get_http_server_address(node_name).await?;
+        let status_endpoint_address = repository.get_status_endpoint_address(node_name).await?;
 
         let node_info = NodeInfo::new(
             node_name.to_string(),
@@ -450,7 +453,7 @@ impl CliState {
             false,
             tcp_listener_address,
             Some(process::id()),
-            http_server_address,
+            status_endpoint_address,
         );
         repository.store_node(&node_info).await?;
         Ok(node_info)
@@ -554,7 +557,7 @@ pub struct NodeInfo {
     is_authority: bool,
     tcp_listener_address: Option<InternetAddress>,
     pid: Option<u32>,
-    http_server_address: Option<InternetAddress>,
+    status_endpoint_address: Option<InternetAddress>,
 }
 
 impl NodeInfo {
@@ -567,7 +570,7 @@ impl NodeInfo {
         is_authority: bool,
         tcp_listener_address: Option<InternetAddress>,
         pid: Option<u32>,
-        http_server_address: Option<InternetAddress>,
+        status_endpoint_address: Option<InternetAddress>,
     ) -> Self {
         Self {
             name,
@@ -577,7 +580,7 @@ impl NodeInfo {
             is_authority,
             tcp_listener_address,
             pid,
-            http_server_address,
+            status_endpoint_address,
         }
     }
     pub fn name(&self) -> String {
@@ -627,8 +630,8 @@ impl NodeInfo {
             .and_then(|t| t.multi_addr())?)
     }
 
-    pub fn http_server_address(&self) -> Option<InternetAddress> {
-        self.http_server_address.clone()
+    pub fn status_endpoint_address(&self) -> Option<InternetAddress> {
+        self.status_endpoint_address.clone()
     }
 
     pub fn pid(&self) -> Option<u32> {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/auto_retry.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/auto_retry.rs
@@ -231,12 +231,12 @@ impl<T: NodesRepository> NodesRepository for AutoRetry<T> {
         retry!(self.wrapped.set_tcp_listener_address(node_name, address))
     }
 
-    async fn set_http_server_address(
+    async fn set_status_endpoint_address(
         &self,
         node_name: &str,
         address: &InternetAddress,
     ) -> ockam_core::Result<()> {
-        retry!(self.wrapped.set_http_server_address(node_name, address))
+        retry!(self.wrapped.set_status_endpoint_address(node_name, address))
     }
 
     async fn set_as_authority_node(&self, node_name: &str) -> ockam_core::Result<()> {
@@ -250,11 +250,11 @@ impl<T: NodesRepository> NodesRepository for AutoRetry<T> {
         retry!(self.wrapped.get_tcp_listener_address(node_name))
     }
 
-    async fn get_http_server_address(
+    async fn get_status_endpoint_address(
         &self,
         node_name: &str,
     ) -> ockam_core::Result<Option<InternetAddress>> {
-        retry!(self.wrapped.get_http_server_address(node_name))
+        retry!(self.wrapped.get_status_endpoint_address(node_name))
     }
 
     async fn set_node_pid(&self, node_name: &str, pid: u32) -> ockam_core::Result<()> {

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
@@ -48,8 +48,8 @@ pub trait NodesRepository: Send + Sync + 'static {
         address: &InternetAddress,
     ) -> Result<()>;
 
-    /// Set the HTTP server address of a node
-    async fn set_http_server_address(
+    /// Set the status endpoint address of a node
+    async fn set_status_endpoint_address(
         &self,
         node_name: &str,
         address: &InternetAddress,
@@ -61,8 +61,9 @@ pub trait NodesRepository: Send + Sync + 'static {
     /// Get the TCP listener of a node
     async fn get_tcp_listener_address(&self, node_name: &str) -> Result<Option<InternetAddress>>;
 
-    /// Get the address of the HTTP server of a node
-    async fn get_http_server_address(&self, node_name: &str) -> Result<Option<InternetAddress>>;
+    /// Get the address of the status endpoint of a node
+    async fn get_status_endpoint_address(&self, node_name: &str)
+        -> Result<Option<InternetAddress>>;
 
     /// Set the process id of a node
     async fn set_node_pid(&self, node_name: &str, pid: u32) -> Result<()>;

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository_sql.rs
@@ -54,7 +54,7 @@ impl NodesRepository for NodesSqlxDatabase {
             .bind(node_info.pid().map(|p| p as i32))
             .bind(
                 node_info
-                    .http_server_address()
+                    .status_endpoint_address()
                     .as_ref()
                     .map(|a| a.to_string()),
             );
@@ -165,7 +165,7 @@ impl NodesRepository for NodesSqlxDatabase {
         query.execute(&*self.database.pool).await.void()
     }
 
-    async fn set_http_server_address(
+    async fn set_status_endpoint_address(
         &self,
         node_name: &str,
         address: &InternetAddress,
@@ -190,11 +190,14 @@ impl NodesRepository for NodesSqlxDatabase {
             .and_then(|n| n.tcp_listener_address()))
     }
 
-    async fn get_http_server_address(&self, node_name: &str) -> Result<Option<InternetAddress>> {
+    async fn get_status_endpoint_address(
+        &self,
+        node_name: &str,
+    ) -> Result<Option<InternetAddress>> {
         Ok(self
             .get_node(node_name)
             .await?
-            .and_then(|n| n.http_server_address()))
+            .and_then(|n| n.status_endpoint_address()))
     }
 
     async fn set_node_pid(&self, node_name: &str, pid: u32) -> Result<()> {
@@ -266,7 +269,7 @@ impl NodeRow {
             .tcp_listener_address
             .to_option()
             .and_then(|a| InternetAddress::new(&a));
-        let http_server_address = self
+        let status_endpoint_address = self
             .http_server_address
             .to_option()
             .and_then(|a| InternetAddress::new(&a));
@@ -279,7 +282,7 @@ impl NodeRow {
             self.is_authority.to_bool(),
             tcp_listener_address,
             self.pid.to_option().map(|p| p as u32),
-            http_server_address,
+            status_endpoint_address,
         ))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/node.rs
@@ -56,7 +56,7 @@ pub struct NodeResources {
     #[serde(flatten)]
     #[n(4)] pub status: NodeProcessStatus,
     #[n(5)] pub route: RouteToNode,
-    #[n(6)] pub http_server_address: Option<InternetAddress>,
+    #[n(6)] pub status_endpoint_address: Option<InternetAddress>,
     #[n(7)] pub transports: Vec<TransportStatus>,
     #[n(8)] pub secure_channel_listeners: Vec<SecureChannelListener>,
     #[n(9)] pub inlets: Vec<InletStatus>,
@@ -84,7 +84,7 @@ impl NodeResources {
                 short: node.route()?,
                 verbose: node.verbose_route()?,
             },
-            http_server_address: node.http_server_address(),
+            status_endpoint_address: node.status_endpoint_address(),
             transports,
             secure_channel_listeners: listeners,
             inlets,
@@ -103,7 +103,7 @@ impl NodeResources {
                 short: node.route()?,
                 verbose: node.verbose_route()?,
             },
-            http_server_address: None,
+            status_endpoint_address: None,
             transports: vec![],
             secure_channel_listeners: vec![],
             inlets: vec![],
@@ -123,10 +123,10 @@ impl Display for NodeResources {
 
         writeln!(f, "{}{}{}", fmt::PADDING, fmt::INDENTATION, self.status)?;
         writeln!(f, "{}{}{}", fmt::PADDING, fmt::INDENTATION, self.route)?;
-        if let Some(http_server) = self.http_server_address.as_ref() {
+        if let Some(http_server) = self.status_endpoint_address.as_ref() {
             writeln!(
                 f,
-                "{}{}HTTP server listening at {}",
+                "{}{}Status endpoint listening at {}",
                 fmt::PADDING,
                 fmt::INDENTATION,
                 color_primary(http_server.to_string())

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport/mod.rs
@@ -1,9 +1,11 @@
 mod common;
 mod json;
+mod port;
 mod request;
 mod response;
 
 pub use common::*;
 pub use json::*;
+pub use port::*;
 pub use request::*;
 pub use response::*;

--- a/implementations/rust/ockam/ockam_api/src/nodes/models/transport/port.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/models/transport/port.rs
@@ -1,0 +1,47 @@
+use crate::Result;
+use std::fmt::Display;
+use tokio::net::TcpListener;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Port {
+    TryExplicitOrRandom(u16),
+    Explicit(u16),
+}
+
+impl Port {
+    pub async fn bind_to_tcp_listener(&self) -> Result<TcpListener> {
+        match self {
+            Self::TryExplicitOrRandom(port) => {
+                // Try to bind to the explicit port
+                match TcpListener::bind(&format!("127.0.0.1:{port}")).await {
+                    Ok(listener) => Ok(listener),
+                    Err(err) => {
+                        // If the port is already in use, bind to a random port
+                        if err.kind() == std::io::ErrorKind::AddrInUse {
+                            Ok(TcpListener::bind("127.0.0.1:0").await?)
+                        } else {
+                            Err(err.into())
+                        }
+                    }
+                }
+            }
+            // If explicit, try to bind to that port or fail
+            Self::Explicit(port) => Ok(TcpListener::bind(&format!("127.0.0.1:{port}")).await?),
+        }
+    }
+}
+
+impl AsRef<u16> for Port {
+    fn as_ref(&self) -> &u16 {
+        match self {
+            Self::TryExplicitOrRandom(port) => port,
+            Self::Explicit(port) => port,
+        }
+    }
+}
+
+impl Display for Port {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/http.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/http.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Empty, Full};
@@ -10,11 +10,13 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response};
 use hyper_util::rt::TokioIo;
 
+use crate::nodes::models::transport::Port;
+use crate::nodes::NodeManager;
+use crate::{ApiError, HttpError, Result};
+use ockam_core::{async_trait, Address, Processor};
+use ockam_node::{Context, ProcessorBuilder};
 use serde::Serialize;
 use tokio::net::TcpListener;
-
-use crate::nodes::NodeManager;
-use crate::{HttpError, Result};
 
 /// An HTTP server that provides health check endpoints for the node.
 ///
@@ -22,50 +24,45 @@ use crate::{HttpError, Result};
 /// for health checks and monitoring of the node's status.
 ///
 /// It is not intended to be a full-fledged HTTP version of the node's API.
-pub struct HttpServer {
-    node_manager: Arc<NodeManager>,
-}
+pub struct HttpServer;
 
 impl HttpServer {
     /// Start a new HTTP server listening on the given port
     /// and return a handle to it that will be used to cancel the
     /// background async task when the NodeManager shuts down.
-    pub async fn start(node_manager: Arc<NodeManager>, port: u16) -> Result<SocketAddr> {
-        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], port))).await?;
+    pub async fn start(
+        context: &Context,
+        node_manager: Arc<NodeManager>,
+        port: Port,
+    ) -> Result<SocketAddr> {
+        debug!("Starting HTTP server on port: {port:?}");
+        let listener = port.bind_to_tcp_listener().await?;
         let addr = listener.local_addr()?;
-        let node_name = node_manager.node_name.clone();
-        let server = Self {
-            node_manager: node_manager.clone(),
-        };
-        tokio::spawn(server.run(listener));
         node_manager
             .cli_state
-            .set_node_http_server_addr(&node_name, &addr.into())
+            .set_node_http_server_addr(&node_manager.node_name, &addr.into())
             .await?;
-        info!("Http server listening on: {addr:?}");
+        let processor = HttpServerProcessor {
+            node_manager: Arc::downgrade(&node_manager),
+            tcp_listener: Arc::new(listener),
+        };
+        ProcessorBuilder::new(processor)
+            .with_address(Address::random_tagged("node_http_server"))
+            .start(context)
+            .await?;
+        info!("HTTP server listening on: {addr:?}");
         Ok(addr)
     }
+}
 
-    /// Loop to accept incoming connections and handle them
-    async fn run(self, listener: TcpListener) -> Result<()> {
-        loop {
-            let (stream, _) = listener.accept().await?;
-            let io = TokioIo::new(stream);
-            let node_manager = self.node_manager.clone();
-            let service = service_fn(move |req| {
-                let node_manager = node_manager.clone();
-                Self::handle_request(node_manager, req)
-            });
-            tokio::task::spawn(async move {
-                if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
-                    error!("Error serving connection: {err:?}");
-                }
-            });
-        }
-    }
+struct HttpServerProcessor {
+    node_manager: Weak<NodeManager>,
+    tcp_listener: Arc<TcpListener>,
+}
 
+impl HttpServerProcessor {
     async fn handle_request(
-        node_manager: Arc<NodeManager>,
+        node_manager: Weak<NodeManager>,
         req: Request<hyper::body::Incoming>,
     ) -> Result<Response<BoxBody<Bytes, Infallible>>> {
         debug!("Processing request: {req:?}");
@@ -78,7 +75,13 @@ impl HttpServer {
         match (req.method(), path.as_slice()) {
             (&Method::HEAD, []) => Ok(Response::new(Full::new(Bytes::new()).boxed())),
             (&Method::GET, ["show"]) => {
-                Self::json_response(node_manager.get_node_resources().await?)
+                let node_resources = {
+                    let node_manager = node_manager
+                        .upgrade()
+                        .ok_or_else(|| ApiError::core("node manager was shut down"))?;
+                    node_manager.get_node_resources().await?
+                };
+                Self::json_response(node_resources)
             }
             _ => {
                 warn!("Request received for a non supported endpoint: {req:?}");
@@ -102,5 +105,29 @@ impl HttpServer {
                 Ok(Response::new(Full::new(Bytes::from(json)).boxed()))
             }
         }
+    }
+}
+
+#[async_trait]
+impl Processor for HttpServerProcessor {
+    type Context = Context;
+
+    async fn shutdown(&mut self, _context: &mut Self::Context) -> ockam_core::Result<()> {
+        debug!("Shutting down HttpServerProcessor");
+        Ok(())
+    }
+
+    async fn process(&mut self, _context: &mut Self::Context) -> ockam_core::Result<bool> {
+        if let Ok((stream, _)) = self.tcp_listener.accept().await {
+            let io = TokioIo::new(stream);
+            let service = service_fn(|req| {
+                let node_manager = self.node_manager.clone();
+                Self::handle_request(node_manager, req)
+            });
+            if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
+                error!("Error serving connection: {err:?}");
+            }
+        }
+        Ok(true)
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -16,6 +16,7 @@ use crate::cli_state::random_name;
 use crate::cli_state::CliState;
 use crate::cloud::project::Project;
 use crate::cloud::{AuthorityNodeClient, ControllerClient, CredentialsEnabled, ProjectNodeClient};
+use crate::nodes::models::transport::Port;
 use crate::nodes::service::default_address::DefaultAddress;
 use crate::nodes::service::{
     NodeManagerGeneralOptions, NodeManagerTransportOptions, NodeManagerTrustOptions,
@@ -126,7 +127,7 @@ impl InMemoryNode {
         ctx: &Context,
         cli_state: &CliState,
         identity_name: &str,
-        http_server_port: Option<u16>,
+        status_endpoint_port: Option<Port>,
         project_name: Option<String>,
         authority_identity: Option<ChangeHistory>,
         authority_route: Option<MultiAddr>,
@@ -163,7 +164,7 @@ impl InMemoryNode {
                 cli_state.clone(),
                 node.name(),
                 false,
-                http_server_port,
+                status_endpoint_port,
                 false,
             ),
             NodeManagerTransportOptions::new(tcp_listener.flow_control_id().clone(), tcp, None),

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -5,7 +5,7 @@ use crate::nodes::connection::{
     SecureChannelInstantiator,
 };
 use crate::nodes::models::portal::OutletStatus;
-use crate::nodes::models::transport::{TransportMode, TransportType};
+use crate::nodes::models::transport::{Port, TransportMode, TransportType};
 use crate::nodes::registry::Registry;
 use crate::nodes::service::http::HttpServer;
 use crate::nodes::service::{
@@ -162,9 +162,8 @@ impl NodeManager {
 
         let s = Arc::new(s);
 
-        if let Some(http_server_port) = general_options.http_server_port {
-            debug!("start the http server");
-            HttpServer::start(s.clone(), http_server_port)
+        if let Some(status_endpoint_port) = general_options.status_endpoint_port {
+            HttpServer::start(ctx, s.clone(), status_endpoint_port)
                 .await
                 .map_err(|e| ApiError::core(e.to_string()))?;
         }
@@ -612,7 +611,7 @@ pub struct NodeManagerGeneralOptions {
     pub(super) cli_state: CliState,
     pub(super) node_name: String,
     pub(super) start_default_services: bool,
-    pub(super) http_server_port: Option<u16>,
+    pub(super) status_endpoint_port: Option<Port>,
     pub(super) persistent: bool,
 }
 
@@ -621,14 +620,14 @@ impl NodeManagerGeneralOptions {
         cli_state: CliState,
         node_name: String,
         start_default_services: bool,
-        http_server_port: Option<u16>,
+        status_endpoint_port: Option<Port>,
         persistent: bool,
     ) -> Self {
         Self {
             cli_state,
             node_name,
             start_default_services,
-            http_server_port,
+            status_endpoint_port,
             persistent,
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/create.rs
@@ -3,7 +3,7 @@ use ockam::transport::HostnamePort;
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{
     kafka::{kafka_default_consumer_server, kafka_default_project_route, kafka_inlet_default_addr},
     node::NodeOpts,
@@ -37,7 +37,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::create::CreateCommand {
             node_opts: self.node_opts,
             addr: self.addr,

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/delete.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{docs, node::NodeOpts, Command, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -19,7 +19,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::delete::DeleteCommand {
             node_opts: self.node_opts,
             address: Some(self.address),

--- a/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/consumer/list.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
 use crate::node::NodeOpts;
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{docs, Command, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -21,7 +21,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::list::ListCommand {
             node_opts: self.node_opts,
         }

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/create.rs
@@ -3,7 +3,7 @@ use ockam::transport::HostnamePort;
 use ockam_api::port_range::PortRange;
 use ockam_multiaddr::MultiAddr;
 
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{
     kafka::{kafka_default_producer_server, kafka_default_project_route, kafka_inlet_default_addr},
     node::NodeOpts,
@@ -36,7 +36,7 @@ pub struct CreateCommand {
 
 impl CreateCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::create::CreateCommand {
             node_opts: self.node_opts,
             addr: self.addr,

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/delete.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{docs, node::NodeOpts, Command, CommandGlobalOpts};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -19,7 +19,7 @@ pub struct DeleteCommand {
 
 impl DeleteCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::delete::DeleteCommand {
             node_opts: self.node_opts,
             address: Some(self.address),

--- a/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/producer/list.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
 use crate::node::NodeOpts;
-use crate::util::print_deprecated_warning;
+use crate::util::print_warning_for_deprecated_flag_replaced;
 use crate::{docs, Command, CommandGlobalOpts};
 
 const PREVIEW_TAG: &str = include_str!("../../static/preview_tag.txt");
@@ -21,7 +21,7 @@ pub struct ListCommand {
 
 impl ListCommand {
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        print_deprecated_warning(&opts, &self.name(), "kafka-inlet")?;
+        print_warning_for_deprecated_flag_replaced(&opts, &self.name(), "kafka-inlet")?;
         crate::kafka::inlet::list::ListCommand {
             node_opts: self.node_opts,
         }

--- a/implementations/rust/ockam/ockam_command/src/node/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create.rs
@@ -1,22 +1,3 @@
-use std::fmt::Write;
-use std::{path::PathBuf, str::FromStr};
-
-use async_trait::async_trait;
-use clap::Args;
-use colorful::Colorful;
-use miette::{miette, IntoDiagnostic, WrapErr};
-use opentelemetry::trace::TraceContextExt;
-use opentelemetry::KeyValue;
-use regex::Regex;
-use tracing::instrument;
-
-use ockam_api::cli_state::random_name;
-use ockam_api::colors::{color_error, color_primary};
-use ockam_api::terminal::notification::NotificationHandler;
-use ockam_api::{fmt_log, fmt_ok};
-use ockam_core::{opentelemetry_context_parser, OpenTelemetryContext};
-use ockam_node::Context;
-
 use crate::node::config::NodeConfig;
 use crate::node::create::config::ConfigArgs;
 use crate::node::util::NodeManagerDefaults;
@@ -24,9 +5,26 @@ use crate::service::config::Config;
 use crate::shared_args::TrustOpts;
 use crate::util::embedded_node_that_is_not_stopped;
 use crate::util::foreground_args::ForegroundArgs;
-use crate::util::{async_cmd, local_cmd};
+use crate::util::{async_cmd, local_cmd, print_warning_for_deprecated_flag_no_effect};
 use crate::value_parsers::is_url;
 use crate::{docs, Command, CommandGlobalOpts, Result};
+use async_trait::async_trait;
+use clap::Args;
+use colorful::Colorful;
+use miette::{miette, IntoDiagnostic, WrapErr};
+use ockam_api::cli_state::random_name;
+use ockam_api::colors::{color_error, color_primary};
+use ockam_api::nodes::models::transport::Port;
+use ockam_api::terminal::notification::NotificationHandler;
+use ockam_api::{fmt_log, fmt_ok};
+use ockam_core::{opentelemetry_context_parser, OpenTelemetryContext};
+use ockam_node::Context;
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::KeyValue;
+use regex::Regex;
+use std::fmt::Write;
+use std::{path::PathBuf, str::FromStr};
+use tracing::instrument;
 
 pub mod background;
 pub mod config;
@@ -35,6 +33,8 @@ pub mod foreground;
 const DEFAULT_NODE_NAME: &str = "_default_node_name";
 const LONG_ABOUT: &str = include_str!("./static/create/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
+
+const DEFAULT_NODE_STATUS_ENDPOINT_PORT: u16 = 23345;
 
 /// Create a new node
 #[derive(Clone, Debug, Args)]
@@ -71,8 +71,8 @@ pub struct CreateCommand {
     )]
     pub tcp_listener_address: String,
 
-    /// Enable the HTTP server for the node that will listen to in a random free port.
-    /// To specify a port, use `--http-server-port` instead.
+    /// [DEPRECATED] Enable the HTTP server for the node that will listen to in a random free port.
+    /// To specify a port, use `--status-endpoint-port` instead.
     #[arg(
         long,
         visible_alias = "enable-http-server",
@@ -81,9 +81,18 @@ pub struct CreateCommand {
     )]
     pub http_server: bool,
 
-    /// Enable the HTTP server at the given port.
-    #[arg(long, value_name = "PORT", conflicts_with = "http_server")]
-    pub http_server_port: Option<u16>,
+    /// Disable the node's status endpoint that serves the healthcheck endpoint.
+    #[arg(
+        long,
+        value_name = "BOOL",
+        default_value_t = false,
+        conflicts_with = "status_endpoint_port"
+    )]
+    pub no_status_endpoint: bool,
+
+    /// Specify the port that the status endpoint will listen to.
+    #[arg(long, value_name = "PORT")]
+    pub status_endpoint_port: Option<u16>,
 
     /// Enable UDP transport puncture.
     #[arg(
@@ -131,7 +140,8 @@ impl Default for CreateCommand {
             },
             tcp_listener_address: node_manager_defaults.tcp_listener_address,
             http_server: false,
-            http_server_port: None,
+            no_status_endpoint: false,
+            status_endpoint_port: None,
             udp: false,
             launch_configuration: None,
             identity: None,
@@ -152,7 +162,7 @@ impl Command for CreateCommand {
 
     #[instrument(skip_all)]
     fn run(mut self, opts: CommandGlobalOpts) -> miette::Result<()> {
-        self.parse_args()?;
+        self.parse_args(&opts)?;
         if self.should_run_config() {
             async_cmd(&self.name(), opts.clone(), |ctx| async move {
                 self.run_config(&ctx, opts).await
@@ -178,7 +188,7 @@ impl Command for CreateCommand {
     }
 
     async fn async_run(mut self, ctx: &Context, opts: CommandGlobalOpts) -> Result<()> {
-        self.parse_args()?;
+        self.parse_args(&opts)?;
         if self.should_run_config() {
             self.run_config(ctx, opts).await?
         } else {
@@ -236,7 +246,7 @@ impl CreateCommand {
         !self.name_arg_is_a_config()
     }
 
-    fn parse_args(&self) -> miette::Result<()> {
+    fn parse_args(&mut self, opts: &CommandGlobalOpts) -> miette::Result<()> {
         // return error if there are duplicated variables
         let mut variables = std::collections::HashMap::new();
         for (key, value) in self.config_args.variables.iter() {
@@ -260,7 +270,19 @@ impl CreateCommand {
             ));
         }
 
+        if self.http_server {
+            print_warning_for_deprecated_flag_no_effect(opts, "http-server")?;
+        }
+
         Ok(())
+    }
+
+    fn status_endpoint_port(&self) -> Option<Port> {
+        match (self.no_status_endpoint, self.status_endpoint_port) {
+            (true, _) => None,
+            (false, Some(port)) => Some(Port::Explicit(port)),
+            (false, None) => Some(Port::TryExplicitOrRandom(DEFAULT_NODE_STATUS_ENDPOINT_PORT)),
+        }
     }
 
     async fn plain_output(&self, opts: &CommandGlobalOpts, node_name: &str) -> Result<String> {
@@ -323,7 +345,7 @@ impl CreateCommand {
     }
 }
 
-pub fn parse_launch_config(config_or_path: &str) -> Result<Config> {
+fn parse_launch_config(config_or_path: &str) -> Result<Config> {
     match serde_json::from_str::<Config>(config_or_path) {
         Ok(c) => Ok(c),
         Err(_) => {

--- a/implementations/rust/ockam/ockam_command/src/node/create/config.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/config.rs
@@ -188,11 +188,11 @@ impl NodeConfig {
         if cmd.tcp_listener_address != default_cmd_args.tcp_listener_address {
             self.node.tcp_listener_address = Some(cmd.tcp_listener_address.clone().into());
         }
-        if cmd.http_server != default_cmd_args.http_server {
-            self.node.http_server = Some(cmd.http_server.into());
+        if cmd.no_status_endpoint != default_cmd_args.no_status_endpoint {
+            self.node.no_status_endpoint = Some(cmd.no_status_endpoint.into());
         }
-        if let Some(port) = cmd.http_server_port {
-            self.node.http_server_port = Some((port as isize).into());
+        if let Some(port) = cmd.status_endpoint_port {
+            self.node.status_endpoint_port = Some((port as isize).into());
         }
         if let Some(identity) = &cmd.identity {
             self.node.identity = Some(identity.clone().into());

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -82,18 +82,6 @@ impl CreateCommand {
             .await?;
         debug!("node info persisted {node_info:?}");
 
-        let http_server_port = if let Some(port) = self.http_server_port {
-            Some(port)
-        } else if self.http_server {
-            if let Some(addr) = node_info.http_server_address() {
-                Some(addr.port())
-            } else {
-                Some(0)
-            }
-        } else {
-            None
-        };
-
         let udp_transport = if self.udp {
             Some(UdpTransport::create(ctx).await.into_diagnostic()?)
         } else {
@@ -106,7 +94,7 @@ impl CreateCommand {
                 opts.state.clone(),
                 node_name.clone(),
                 self.launch_configuration.is_none(),
-                http_server_port,
+                self.status_endpoint_port(),
                 true,
             ),
             NodeManagerTransportOptions::new(

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,6 +1,6 @@
 use crate::terminal::tui::DeleteCommandTui;
 use crate::tui::PluralTerm;
-use crate::util::{async_cmd, print_deprecated_flag_warning};
+use crate::util::{async_cmd, print_warning_for_deprecated_flag_no_effect};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
@@ -51,7 +51,7 @@ impl DeleteCommand {
 
     async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
         if self.force {
-            print_deprecated_flag_warning(&opts, "--force")?;
+            print_warning_for_deprecated_flag_no_effect(&opts, "--force")?;
         }
         DeleteTui::run(opts, self.clone()).await
     }

--- a/implementations/rust/ockam/ockam_command/src/node/stop.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/stop.rs
@@ -4,7 +4,7 @@ use miette::miette;
 use ockam_api::colors::OckamColor;
 use ockam_api::{color, fmt_info, fmt_ok, fmt_warn};
 
-use crate::util::{async_cmd, print_deprecated_flag_warning};
+use crate::util::{async_cmd, print_warning_for_deprecated_flag_no_effect};
 use crate::{docs, CommandGlobalOpts};
 
 const LONG_ABOUT: &str = include_str!("./static/stop/long_about.txt");
@@ -40,7 +40,7 @@ impl StopCommand {
 
     async fn async_run(&self, opts: CommandGlobalOpts) -> miette::Result<()> {
         if self.force {
-            print_deprecated_flag_warning(&opts, "--force")?;
+            print_warning_for_deprecated_flag_no_effect(&opts, "--force")?;
         }
 
         let running_nodes = opts

--- a/implementations/rust/ockam/ockam_command/src/node/util.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/util.rs
@@ -57,8 +57,8 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         name,
         identity: identity_name,
         tcp_listener_address: address,
-        http_server,
-        http_server_port,
+        no_status_endpoint,
+        status_endpoint_port,
         udp,
         launch_configuration,
         trust_opts,
@@ -128,13 +128,13 @@ pub async fn spawn_node(opts: &CommandGlobalOpts, cmd: CreateCommand) -> miette:
         args.push(opentelemetry_context.to_string());
     }
 
-    if http_server {
-        args.push("--http-server".to_string());
+    if no_status_endpoint {
+        args.push("--no-status-endpoint".to_string());
     }
 
-    if let Some(http_server_port) = http_server_port {
-        args.push("--http-server-port".to_string());
-        args.push(http_server_port.to_string());
+    if let Some(status_endpoint_port) = status_endpoint_port {
+        args.push("--status-endpoint-port".to_string());
+        args.push(status_endpoint_port.to_string());
     }
 
     if udp {

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -20,7 +20,7 @@ use ockam_multiaddr::{MultiAddr, Protocol};
 
 use crate::node::util::initialize_default_node;
 use crate::shared_args::RetryOpts;
-use crate::util::{print_deprecated_flag_warning, process_nodes_multiaddr};
+use crate::util::{print_warning_for_deprecated_flag_no_effect, process_nodes_multiaddr};
 use crate::{docs, Command, CommandGlobalOpts, Error, Result};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
@@ -81,7 +81,7 @@ impl Command for CreateCommand {
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
         if self.project_relay {
-            print_deprecated_flag_warning(&opts, "--project-relay")?;
+            print_warning_for_deprecated_flag_no_effect(&opts, "--project-relay")?;
         }
 
         initialize_default_node(ctx, &opts).await?;

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/node.rs
@@ -25,8 +25,10 @@ pub struct Node {
     pub tcp_listener_address: Option<ArgValue>,
     #[serde(alias = "http-server", alias = "enable-http-server")]
     pub http_server: Option<ArgValue>,
-    #[serde(alias = "http-server-port")]
-    pub http_server_port: Option<ArgValue>,
+    #[serde(alias = "no-status-endpoint")]
+    pub no_status_endpoint: Option<ArgValue>,
+    #[serde(alias = "status-endpoint-port")]
+    pub status_endpoint_port: Option<ArgValue>,
     pub identity: Option<ArgValue>,
     pub project: Option<ArgValue>,
     #[serde(alias = "launch-config")]
@@ -60,11 +62,11 @@ impl Resource<CreateCommand> for Node {
         if let Some(tcp_listener_address) = self.tcp_listener_address {
             args.insert("tcp-listener-address".into(), tcp_listener_address);
         }
-        if let Some(enable_http_server) = self.http_server {
-            args.insert("http-server".into(), enable_http_server);
+        if let Some(no_status_endpoint) = self.no_status_endpoint {
+            args.insert("no-status-endpoint".into(), no_status_endpoint);
         }
-        if let Some(http_server_port) = self.http_server_port {
-            args.insert("http-server-port".into(), http_server_port);
+        if let Some(status_endpoint_port) = self.status_endpoint_port {
+            args.insert("status-endpoint-port".into(), status_endpoint_port);
         }
         if let Some(identity) = self.identity {
             args.insert("identity".into(), identity);

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -35,7 +35,7 @@ use ockam_node::compat::asynchronous::resolve_peer;
 
 use crate::util::parsers::duration_parser;
 use crate::util::parsers::hostname_parser;
-use crate::util::{find_available_port, port_is_free_guard, process_nodes_multiaddr};
+use crate::util::{port_is_free_guard, process_nodes_multiaddr};
 
 const AFTER_LONG_HELP: &str = include_str!("./static/create/after_long_help.txt");
 
@@ -151,8 +151,7 @@ pub struct CreateCommand {
 }
 
 pub(crate) fn default_from_addr() -> HostnamePort {
-    let port = find_available_port().expect("Failed to find available port");
-    HostnamePort::new("127.0.0.1", port)
+    HostnamePort::new("127.0.0.1", 0)
 }
 
 fn default_to_addr() -> String {

--- a/implementations/rust/ockam/ockam_command/src/util/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/mod.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use colorful::Colorful;
-use miette::Context as _;
 use miette::{miette, IntoDiagnostic};
 use opentelemetry::trace::FutureExt;
 use tokio::runtime::Runtime;
@@ -114,17 +113,6 @@ where
     res?.into_diagnostic()
 }
 
-pub fn find_available_port() -> Result<u16> {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .into_diagnostic()
-        .context("Unable to bind to an open port")?;
-    let address = listener
-        .local_addr()
-        .into_diagnostic()
-        .context("Unable to get local address")?;
-    Ok(address.port())
-}
-
 #[allow(unused)]
 pub fn print_path(p: &Path) -> String {
     p.to_str().unwrap_or("<unprintable>").to_string()
@@ -209,7 +197,11 @@ pub fn port_is_free_guard(address: &SocketAddr) -> Result<()> {
     Ok(())
 }
 
-pub fn print_deprecated_warning(opts: &CommandGlobalOpts, old: &str, new: &str) -> Result<()> {
+pub fn print_warning_for_deprecated_flag_replaced(
+    opts: &CommandGlobalOpts,
+    old: &str,
+    new: &str,
+) -> Result<()> {
     opts.terminal.write_line(fmt_warn!(
         "{} is deprecated. Please use {} instead",
         color_primary(old),
@@ -218,7 +210,10 @@ pub fn print_deprecated_warning(opts: &CommandGlobalOpts, old: &str, new: &str) 
     Ok(())
 }
 
-pub fn print_deprecated_flag_warning(opts: &CommandGlobalOpts, deprecated: &str) -> Result<()> {
+pub fn print_warning_for_deprecated_flag_no_effect(
+    opts: &CommandGlobalOpts,
+    deprecated: &str,
+) -> Result<()> {
     opts.terminal.write_line(fmt_warn!(
         "{} is deprecated. This flag has no effect",
         color_primary(deprecated),


### PR DESCRIPTION
- Node's HTTP server is now enabled by default
- The `--http-server` flag is deprecated in favor of `--no-healthcheck`
- If no port is provided, the port 23345 will be assigned. If that port is used, a random one will be assigned


I also found a flakyness source in the command wherever we use the `find_available_port` (and likely in [ockam_api](https://github.com/build-trust/ockam/blob/944a8fd2120a516a8ea8ffd185c67222adc69c51/implementations/rust/ockam/ockam_api/src/address.rs#L58)). In bats tests, where multiple nodes will run that function at the same time, there can be collisions. That can be fixed by delaying the port assignment until we create the TcpListener. I've created a struct to express the [port](https://github.com/build-trust/ockam/pull/8603/files#diff-953f71bae7a5f6e697345f4d5e5b9a45a150590c8e37ad2a15132339b0abc5e0) usage. Here's an [example](https://github.com/build-trust/ockam/pull/8603/files#diff-eb16923d98064a371a647e3cafb769767c25817f700d5773e8415a5c215030d4R39) of its usage relevant to this PR.