### PR TITLE
feat(rust): improve delete behavior on different commands

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -241,6 +241,7 @@ impl NodeManager {
     }
 }
 
+#[derive(Clone)]
 pub struct AuthorityNodeClient {
     secure_client: SecureClient,
 }

--- a/implementations/rust/ockam/ockam_command/src/identity/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/identity/delete.rs
@@ -1,14 +1,14 @@
+use crate::terminal::tui::DeleteCommandTui;
+use crate::tui::PluralTerm;
+use crate::util::async_cmd;
+use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
 use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_api::terminal::{Terminal, TerminalStream};
-
-use crate::terminal::tui::DeleteCommandTui;
-use crate::tui::PluralTerm;
-use crate::util::async_cmd;
-use crate::{docs, CommandGlobalOpts};
+use ockam_core::AsyncTryClone;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -47,6 +47,7 @@ impl DeleteCommand {
     }
 }
 
+#[derive(AsyncTryClone)]
 pub struct DeleteTui {
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,

--- a/implementations/rust/ockam/ockam_command/src/kafka/inlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/inlet/delete.rs
@@ -9,6 +9,7 @@ use ockam_api::nodes::models::services::{DeleteServiceRequest, ServiceStatus};
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::api::Request;
+use ockam_core::AsyncTryClone;
 use ockam_node::Context;
 
 use crate::tui::{DeleteCommandTui, PluralTerm};
@@ -40,26 +41,27 @@ impl Command for DeleteCommand {
     const NAME: &'static str = "kafka-inlet delete";
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(DeleteTui::run(ctx, opts, &self).await?)
+        Ok(DeleteTui::run(ctx, opts, self).await?)
     }
 }
 
-struct DeleteTui<'a> {
-    ctx: &'a Context,
+#[derive(AsyncTryClone)]
+struct DeleteTui {
+    ctx: Context,
     opts: CommandGlobalOpts,
     node: BackgroundNodeClient,
-    cmd: &'a DeleteCommand,
+    cmd: DeleteCommand,
 }
 
-impl<'a> DeleteTui<'a> {
+impl DeleteTui {
     pub async fn run(
-        ctx: &'a Context,
+        ctx: &Context,
         opts: CommandGlobalOpts,
-        cmd: &'a DeleteCommand,
+        cmd: DeleteCommand,
     ) -> miette::Result<()> {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.node_opts.at_node).await?;
         let tui = Self {
-            ctx,
+            ctx: ctx.async_try_clone().await?,
             opts,
             node,
             cmd,
@@ -69,7 +71,7 @@ impl<'a> DeleteTui<'a> {
 }
 
 #[async_trait]
-impl<'a> DeleteCommandTui for DeleteTui<'a> {
+impl DeleteCommandTui for DeleteTui {
     const ITEM_NAME: PluralTerm = PluralTerm::KafkaInlet;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
@@ -92,7 +94,7 @@ impl<'a> DeleteCommandTui for DeleteTui<'a> {
         let inlets: Vec<ServiceStatus> = self
             .node
             .ask(
-                self.ctx,
+                &self.ctx,
                 Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_INLET)),
             )
             .await?;
@@ -103,7 +105,7 @@ impl<'a> DeleteCommandTui for DeleteTui<'a> {
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
         self.node
             .tell(
-                self.ctx,
+                &self.ctx,
                 Request::delete(format!("/node/services/{}", DefaultAddress::KAFKA_INLET))
                     .body(DeleteServiceRequest::new(item_name)),
             )

--- a/implementations/rust/ockam/ockam_command/src/kafka/outlet/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/kafka/outlet/delete.rs
@@ -9,6 +9,7 @@ use ockam_api::nodes::models::services::{DeleteServiceRequest, ServiceStatus};
 use ockam_api::nodes::BackgroundNodeClient;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_core::api::Request;
+use ockam_core::AsyncTryClone;
 use ockam_node::Context;
 
 use crate::tui::{DeleteCommandTui, PluralTerm};
@@ -37,26 +38,27 @@ impl Command for DeleteCommand {
     const NAME: &'static str = "kafka-outlet delete";
 
     async fn async_run(self, ctx: &Context, opts: CommandGlobalOpts) -> crate::Result<()> {
-        Ok(DeleteTui::run(ctx, opts, &self).await?)
+        Ok(DeleteTui::run(ctx, opts, self).await?)
     }
 }
 
-struct DeleteTui<'a> {
-    ctx: &'a Context,
+#[derive(AsyncTryClone)]
+struct DeleteTui {
+    ctx: Context,
     opts: CommandGlobalOpts,
     node: BackgroundNodeClient,
-    cmd: &'a DeleteCommand,
+    cmd: DeleteCommand,
 }
 
-impl<'a> DeleteTui<'a> {
+impl DeleteTui {
     pub async fn run(
-        ctx: &'a Context,
+        ctx: &Context,
         opts: CommandGlobalOpts,
-        cmd: &'a DeleteCommand,
+        cmd: DeleteCommand,
     ) -> miette::Result<()> {
         let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.node_opts.at_node).await?;
         let tui = Self {
-            ctx,
+            ctx: ctx.async_try_clone().await?,
             opts,
             node,
             cmd,
@@ -66,7 +68,7 @@ impl<'a> DeleteTui<'a> {
 }
 
 #[async_trait]
-impl<'a> DeleteCommandTui for DeleteTui<'a> {
+impl DeleteCommandTui for DeleteTui {
     const ITEM_NAME: PluralTerm = PluralTerm::KafkaOutlet;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
@@ -89,7 +91,7 @@ impl<'a> DeleteCommandTui for DeleteTui<'a> {
         let outlets: Vec<ServiceStatus> = self
             .node
             .ask(
-                self.ctx,
+                &self.ctx,
                 Request::get(format!("/node/services/{}", DefaultAddress::KAFKA_OUTLET)),
             )
             .await?;
@@ -100,7 +102,7 @@ impl<'a> DeleteCommandTui for DeleteTui<'a> {
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
         self.node
             .tell(
-                self.ctx,
+                &self.ctx,
                 Request::delete(format!("/node/services/{}", DefaultAddress::KAFKA_OUTLET))
                     .body(DeleteServiceRequest::new(item_name)),
             )

--- a/implementations/rust/ockam/ockam_command/src/node/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/delete.rs
@@ -1,3 +1,6 @@
+use crate::terminal::tui::DeleteCommandTui;
+use crate::tui::PluralTerm;
+use crate::util::{async_cmd, print_deprecated_flag_warning};
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
@@ -6,10 +9,7 @@ use ockam_api::colors::color_primary;
 use ockam_api::fmt_ok;
 use ockam_api::terminal::notification::NotificationHandler;
 use ockam_api::terminal::{Terminal, TerminalStream};
-
-use crate::terminal::tui::DeleteCommandTui;
-use crate::tui::PluralTerm;
-use crate::util::{async_cmd, print_deprecated_flag_warning};
+use ockam_core::AsyncTryClone;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -57,6 +57,7 @@ impl DeleteCommand {
     }
 }
 
+#[derive(AsyncTryClone)]
 pub struct DeleteTui {
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,
@@ -113,5 +114,9 @@ impl DeleteCommandTui for DeleteTui {
             .json(serde_json::json!({ "name": &item_name }))
             .write_line()?;
         Ok(())
+    }
+
+    async fn delete_multiple(&self, items_names: Vec<String>) -> miette::Result<()> {
+        self.delete_multiple_async(items_names).await
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/policy/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/policy/delete.rs
@@ -47,6 +47,7 @@ impl DeleteCommand {
     }
 }
 
+#[derive(AsyncTryClone)]
 struct DeleteTui {
     ctx: Context,
     opts: CommandGlobalOpts,

--- a/implementations/rust/ockam/ockam_command/src/relay/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/delete.rs
@@ -58,6 +58,7 @@ impl DeleteCommand {
     }
 }
 
+#[derive(AsyncTryClone)]
 struct DeleteTui {
     ctx: Context,
     opts: CommandGlobalOpts,

--- a/implementations/rust/ockam/ockam_command/src/reset.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset.rs
@@ -7,6 +7,7 @@ use crate::CommandGlobalOpts;
 use ockam_api::cloud::space::Spaces;
 use ockam_api::colors::OckamColor;
 use ockam_api::nodes::InMemoryNode;
+use ockam_api::terminal::notification::NotificationHandler;
 use ockam_api::terminal::ConfirmResult;
 use ockam_api::{color, fmt_ok, CliState};
 use ockam_node::Context;
@@ -74,7 +75,11 @@ impl ResetCommand {
                 }
             }
         }
-        opts.state.reset().await?;
+        {
+            let _notification_handler =
+                NotificationHandler::start(&opts.state, opts.terminal.clone());
+            opts.state.reset().await?;
+        }
 
         #[cfg(ebpf_alias)]
         ockam::tcp::TcpTransport::detach_all_ockam_ebpfs_globally();

--- a/implementations/rust/ockam/ockam_command/src/space/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/space/delete.rs
@@ -2,7 +2,11 @@ use async_trait::async_trait;
 use clap::Args;
 use colorful::Colorful;
 use console::Term;
+use std::sync::Arc;
 
+use crate::shared_args::IdentityOpts;
+use crate::terminal::tui::DeleteCommandTui;
+use crate::tui::PluralTerm;
 use crate::{docs, Command, CommandGlobalOpts};
 use ockam::Context;
 use ockam_api::cloud::space::Spaces;
@@ -10,10 +14,7 @@ use ockam_api::colors::OckamColor;
 use ockam_api::nodes::InMemoryNode;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{color, fmt_ok};
-
-use crate::shared_args::IdentityOpts;
-use crate::terminal::tui::DeleteCommandTui;
-use crate::tui::PluralTerm;
+use ockam_core::AsyncTryClone;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -46,24 +47,25 @@ impl Command for DeleteCommand {
     }
 }
 
-pub struct DeleteTui<'a> {
-    ctx: &'a Context,
+#[derive(AsyncTryClone)]
+pub struct DeleteTui {
+    ctx: Context,
     opts: CommandGlobalOpts,
-    node: InMemoryNode,
+    node: Arc<InMemoryNode>,
     cmd: DeleteCommand,
 }
 
-impl<'a> DeleteTui<'a> {
+impl DeleteTui {
     pub async fn run(
-        ctx: &'a Context,
+        ctx: &Context,
         opts: CommandGlobalOpts,
         cmd: DeleteCommand,
     ) -> miette::Result<()> {
         let node = InMemoryNode::start(ctx, &opts.state).await?;
         let tui = Self {
-            ctx,
+            ctx: ctx.async_try_clone().await?,
             opts,
-            node,
+            node: Arc::new(node),
             cmd,
         };
         tui.delete().await
@@ -71,7 +73,7 @@ impl<'a> DeleteTui<'a> {
 }
 
 #[ockam_core::async_trait]
-impl<'a> DeleteCommandTui for DeleteTui<'a> {
+impl DeleteCommandTui for DeleteTui {
     const ITEM_NAME: PluralTerm = PluralTerm::Space;
 
     fn cmd_arg_item_name(&self) -> Option<String> {
@@ -102,7 +104,7 @@ impl<'a> DeleteCommandTui for DeleteTui<'a> {
     }
 
     async fn delete_single(&self, item_name: &str) -> miette::Result<()> {
-        self.node.delete_space_by_name(self.ctx, item_name).await?;
+        self.node.delete_space_by_name(&self.ctx, item_name).await?;
 
         self.terminal()
             .stdout()

--- a/implementations/rust/ockam/ockam_command/src/vault/delete.rs
+++ b/implementations/rust/ockam/ockam_command/src/vault/delete.rs
@@ -1,3 +1,6 @@
+use crate::terminal::tui::DeleteCommandTui;
+use crate::tui::PluralTerm;
+use crate::util::async_cmd;
 use crate::{docs, CommandGlobalOpts};
 use clap::Args;
 use colorful::Colorful;
@@ -5,10 +8,7 @@ use console::Term;
 use ockam_api::colors::OckamColor;
 use ockam_api::terminal::{Terminal, TerminalStream};
 use ockam_api::{color, fmt_ok};
-
-use crate::terminal::tui::DeleteCommandTui;
-use crate::tui::PluralTerm;
-use crate::util::async_cmd;
+use ockam_core::AsyncTryClone;
 
 const LONG_ABOUT: &str = include_str!("./static/delete/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/delete/after_long_help.txt");
@@ -47,6 +47,7 @@ impl DeleteCommand {
     }
 }
 
+#[derive(AsyncTryClone)]
 pub struct DeleteTui {
     opts: CommandGlobalOpts,
     cmd: DeleteCommand,


### PR DESCRIPTION
Main changes:
- I've refactored the logic of killing nodes processes. Now, when a node receives the SIGKILL signal correctly
- I've also made some changes in the `reset` command so it doesn't fail when it fails to remove one of the elements (any vault, identity or node)


Minor improvements:
- Commands using the `DeleteCommandTui` interface can now delete the elements in parallel (only enabled for the `node delete` for now)
- I also added this logic to the `project-member delete` command. Doesn't seem to have a big effect though
