### PR TITLE
feat(rust): review cli node shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4865,6 +4865,7 @@ dependencies = [
  "miette",
  "minicbor",
  "mockito",
+ "nix 0.29.0",
  "ockam",
  "ockam_abac",
  "ockam_api",

--- a/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
@@ -49,10 +49,14 @@ pub(crate) const DEFAULT_SPAN_EXPORT_QUEUE_SIZE: u16 = 32768;
 // Size of the queue used to batch logs.
 pub(crate) const DEFAULT_LOG_EXPORT_QUEUE_SIZE: u16 = 32768;
 
-// Maximum time for sending log record batches when using a portal
-pub(crate) const DEFAULT_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Duration =
-    Duration::from_millis(3000);
+// Maximum time for sending log record batches when using a foreground node
+pub(crate) const DEFAULT_FOREGROUND_LOG_EXPORT_CUTOFF: Duration = Duration::from_millis(3000);
 
-// Maximum time for sending span batches when using a portal
-pub(crate) const DEFAULT_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: Duration =
-    Duration::from_millis(3000);
+// Maximum time for sending span batches when using a foreground node
+pub(crate) const DEFAULT_FOREGROUND_SPAN_EXPORT_CUTOFF: Duration = Duration::from_millis(3000);
+
+// Maximum time for sending log record batches when using a background node
+pub(crate) const DEFAULT_BACKGROUND_LOG_EXPORT_CUTOFF: Duration = Duration::from_millis(3000);
+
+// Maximum time for sending span batches when using a background node
+pub(crate) const DEFAULT_BACKGROUND_SPAN_EXPORT_CUTOFF: Duration = Duration::from_millis(3000);

--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -108,14 +108,20 @@ pub(crate) const OCKAM_SPAN_EXPORT_QUEUE_SIZE: &str = "OCKAM_SPAN_EXPORT_QUEUE_S
 pub(crate) const OCKAM_LOG_EXPORT_QUEUE_SIZE: &str = "OCKAM_LOG_EXPORT_QUEUE_SIZE";
 
 /// Maximum time for sending a log batch and not waiting for a response when running
-/// a foreground command and using a portal to export log records. For example: 200ms
-pub(crate) const OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: &str =
-    "OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF";
+/// a foreground command export log records. For example: 200ms
+pub(crate) const OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF: &str = "OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF";
 
 /// Maximum time for sending a span batch and not waiting for a response when running
-/// a foreground command and using a portal to export span batches. For example: 200ms
-pub(crate) const OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: &str =
-    "OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF";
+/// a foreground command to export span batches. For example: 200ms
+pub(crate) const OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF: &str = "OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF";
+
+/// Maximum time for sending a log batch and not waiting for a response when running
+/// a background command to export log records. For example: 200ms
+pub(crate) const OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF: &str = "OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF";
+
+/// Maximum time for sending a span batch and not waiting for a response when running
+/// a background command to export span batches. For example: 200ms
+pub(crate) const OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF: &str = "OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF";
 
 ///
 /// OPENTELEMETRY COLLECTOR ERRORS CONFIGURATION

--- a/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/exporting_configuration.rs
@@ -53,9 +53,9 @@ pub struct ExportingConfiguration {
     /// This boolean is set on spans to distinguish internal usage for external usage
     is_ockam_developer: bool,
     /// Maximum time for exporting a batch of spans (with no response)
-    span_export_portal_cutoff: Option<Duration>,
+    span_export_cutoff: Option<Duration>,
     /// Maximum time for exporting a batch of log records (with no response)
-    log_export_portal_cutoff: Option<Duration>,
+    log_export_cutoff: Option<Duration>,
 }
 
 impl ExportingConfiguration {
@@ -101,12 +101,12 @@ impl ExportingConfiguration {
 
     /// Return the maximum time to wait until sending the current batch of spans (without waiting for a response)
     pub fn span_export_cutoff(&self) -> Option<Duration> {
-        self.span_export_portal_cutoff
+        self.span_export_cutoff
     }
 
     /// Return the maximum time to wait until sending the current batch of log records (without waiting for a response)
     pub fn log_export_cutoff(&self) -> Option<Duration> {
-        self.log_export_portal_cutoff
+        self.log_export_cutoff
     }
 
     /// Return the URL where to export spans and log records
@@ -132,8 +132,8 @@ impl ExportingConfiguration {
                 log_export_queue_size: log_export_queue_size()?,
                 opentelemetry_endpoint: endpoint.url(),
                 is_ockam_developer: is_ockam_developer()?,
-                span_export_portal_cutoff: Some(foreground_span_export_portal_cutoff().unwrap()),
-                log_export_portal_cutoff: Some(foreground_log_export_portal_cutoff().unwrap()),
+                span_export_cutoff: Some(foreground_span_export_portal_cutoff()?),
+                log_export_cutoff: Some(foreground_log_export_cutoff()?),
             }),
         }
     }
@@ -155,8 +155,8 @@ impl ExportingConfiguration {
                 log_export_queue_size: log_export_queue_size()?,
                 opentelemetry_endpoint: endpoint.url(),
                 is_ockam_developer: is_ockam_developer()?,
-                span_export_portal_cutoff: None,
-                log_export_portal_cutoff: None,
+                span_export_cutoff: Some(background_span_export_portal_cutoff()?),
+                log_export_cutoff: Some(background_log_export_cutoff()?),
             }),
         }
     }
@@ -173,8 +173,8 @@ impl ExportingConfiguration {
             log_export_queue_size: DEFAULT_LOG_EXPORT_QUEUE_SIZE,
             opentelemetry_endpoint: Self::default_opentelemetry_endpoint()?,
             is_ockam_developer: is_ockam_developer()?,
-            span_export_portal_cutoff: None,
-            log_export_portal_cutoff: None,
+            span_export_cutoff: None,
+            log_export_cutoff: None,
         })
     }
 
@@ -489,19 +489,35 @@ pub fn background_log_export_scheduled_delay() -> ockam_core::Result<Duration> {
     )
 }
 
-/// Return the maximum time for sending log record batches when using a portal
-pub fn foreground_log_export_portal_cutoff() -> ockam_core::Result<Duration> {
+/// Return the maximum time for sending log record batches when using a foreground node
+pub fn foreground_log_export_cutoff() -> ockam_core::Result<Duration> {
     get_env_with_default(
-        OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF,
-        DEFAULT_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF,
+        OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF,
+        DEFAULT_FOREGROUND_LOG_EXPORT_CUTOFF,
     )
 }
 
-/// Return the maximum time for sending span batches when using a portal
+/// Return the maximum time for sending span batches when using a foreground node
 pub fn foreground_span_export_portal_cutoff() -> ockam_core::Result<Duration> {
     get_env_with_default(
-        OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF,
-        DEFAULT_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF,
+        OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF,
+        DEFAULT_FOREGROUND_SPAN_EXPORT_CUTOFF,
+    )
+}
+
+/// Return the maximum time for sending log record batches when using a background node
+pub fn background_log_export_cutoff() -> ockam_core::Result<Duration> {
+    get_env_with_default(
+        OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF,
+        DEFAULT_BACKGROUND_LOG_EXPORT_CUTOFF,
+    )
+}
+
+/// Return the maximum time for sending span batches when using a background node
+pub fn background_span_export_portal_cutoff() -> ockam_core::Result<Duration> {
+    get_env_with_default(
+        OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF,
+        DEFAULT_BACKGROUND_SPAN_EXPORT_CUTOFF,
     )
 }
 

--- a/implementations/rust/ockam/ockam_command/Cargo.toml
+++ b/implementations/rust/ockam/ockam_command/Cargo.toml
@@ -64,6 +64,7 @@ indicatif = "0.17.8"
 indoc = "2.0.5"
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.25.1", default-features = false, features = ["alloc", "derive"] }
+nix = { version = "0.29", features = ["signal"] }
 ockam = { path = "../ockam", version = "^0.141.0", features = ["software_vault"] }
 ockam_abac = { path = "../ockam_abac", version = "0.73.0", features = ["std"] }
 ockam_api = { path = "../ockam_api", version = "0.84.0", default-features = false, features = ["std"] }

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Formatter};
-use std::process::exit;
 use std::str::FromStr;
 
 use clap::Args;
@@ -21,7 +20,7 @@ use ockam_api::cloud::project::models::ProjectModel;
 use ockam_api::colors::color_primary;
 use ockam_api::config::lookup::InternetAddress;
 use ockam_api::nodes::service::default_address::DefaultAddress;
-use ockam_api::{authority_node, fmt_err, fmt_ok};
+use ockam_api::{authority_node, fmt_err};
 use ockam_core::compat::collections::BTreeMap;
 use ockam_core::compat::fmt;
 
@@ -449,16 +448,9 @@ impl CreateCommand {
         )
         .await?;
 
-        let _ = ctx.stop().await;
+        // Clean up and exit
         let _ = opts.state.stop_node(&self.node_name).await;
-        if foreground_args.child_process {
-            opts.shutdown();
-            exit(0);
-        } else {
-            opts.terminal
-                .write_line(fmt_ok!("Node stopped successfully"))?;
-            Ok(())
-        }
+        Ok(())
     }
 
     pub async fn guard_node_is_not_already_running(

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -28,13 +28,6 @@ Database
 - OCKAM_POSTGRES_USER: Postgres database user. If it is not set, no authorization will be used to access the database.
 - OCKAM_POSTGRES_PASSWORD: Postgres database password. If it is not set, no authorization will be used to access the database.
 
-- OCKAM_LOGGING: set this variable to any value in order to enable logging.
-- OCKAM_LOG_LEVEL: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`. Default value: `debug`.
-- OCKAM_LOG_FORMAT: a `string` that overrides the default format of the logs: `default`, `json`, or `pretty`. Default value: `default`.
-- OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB. Default value `100`.
-- OCKAM_LOG_MAX_FILES: an `integer` that defines the maximum number of log files to keep per node. Default value `60`.
-- OCKAM_LOG_CRATES_FILTER: a filter for log messages based on crate names: `all`, `default`, comma-separated list of crate names. Default value: `default`, i.e. the list of `ockam` crates.
-
 Tracing
 - OCKAM_OPENTELEMETRY_EXPORT: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`
 - OCKAM_OPENTELEMETRY_ENDPOINT: the URL of an OpenTelemetry collector accepting gRPC.
@@ -48,9 +41,10 @@ Tracing
 - OCKAM_SPAN_EXPORT_QUEUE_SIZE: Size of the queue used to store batched spans before export. When the queue is full, spans are dropped. Default value: `32768`
 - OCKAM_LOG_EXPORT_QUEUE_SIZE: Size of the queue used to store batched log records before export. When the queue is full, log records are dropped. Default value: `32768`
 - OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `logfile`.
-- OCKAM_FOREGROUND_LOG_EXPORT_PORTAL_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `3s`.
-- OCKAM_FOREGROUND_SPAN_EXPORT_PORTAL_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry portal inlet, without waiting for a response. Default value: `3s`.
-- OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `console`.
+- OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry foreground node, without waiting for a response. Default value: `3s`.
+- OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry foreground inlet, without waiting for a response. Default value: `3s`.
+- OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry baclground node, without waiting for a response. Default value: `3s`.
+- OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry background inlet, without waiting for a response. Default value: `3s`.
 
 UDP Puncture
 - OCKAM_RENDEZVOUS_SERVER: set this variable to the hostname and port of the Rendezvous service

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -1,7 +1,5 @@
-use std::process::exit;
 use std::sync::Arc;
 
-use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
 use tokio::time::{sleep, Duration};
 use tracing::{debug, info, instrument};
@@ -15,13 +13,13 @@ use ockam::tcp::{TcpListenerOptions, TcpTransport};
 use ockam::udp::UdpTransport;
 use ockam::{Address, Context};
 use ockam_api::colors::color_primary;
+use ockam_api::fmt_log;
 use ockam_api::nodes::{
     service::{NodeManagerGeneralOptions, NodeManagerTransportOptions},
     NodeManagerWorker, NODEMANAGER_ADDR,
 };
 use ockam_api::nodes::{BackgroundNodeClient, InMemoryNode};
 use ockam_api::terminal::notification::NotificationHandler;
-use ockam_api::{fmt_log, fmt_ok};
 use ockam_core::{route, LOCAL};
 
 impl CreateCommand {
@@ -138,7 +136,6 @@ impl CreateCommand {
                 .write_line()?;
         }
 
-        drop(_notification_handler);
         wait_for_exit_signal(
             &self.foreground_args,
             &opts,
@@ -147,16 +144,8 @@ impl CreateCommand {
         .await?;
 
         // Clean up and exit
-        let _ = ctx.stop().await;
         let _ = opts.state.stop_node(&node_name).await;
-        if self.foreground_args.child_process {
-            opts.shutdown();
-            exit(0);
-        } else {
-            opts.terminal
-                .write_line(fmt_ok!("Node stopped successfully"))?;
-            Ok(())
-        }
+        Ok(())
     }
 
     async fn start_services(&self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -7,7 +7,7 @@ use console::Term;
 use miette::IntoDiagnostic;
 
 use ockam_api::CliState;
-use tokio_retry::strategy::FibonacciBackoff;
+use tokio_retry::strategy::FixedInterval;
 use tracing::{info, trace, warn};
 
 use ockam_api::nodes::models::node::{NodeResources, NodeStatus};
@@ -26,10 +26,10 @@ const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
 const IS_NODE_ACCESSIBLE_TIME_BETWEEN_CHECKS_MS: u64 = 100;
-const IS_NODE_ACCESSIBLE_TIMEOUT: Duration = Duration::from_secs(180);
+const IS_NODE_ACCESSIBLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 const IS_NODE_READY_TIME_BETWEEN_CHECKS_MS: u64 = 100;
-const IS_NODE_READY_TIMEOUT: Duration = Duration::from_secs(180);
+const IS_NODE_READY_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Show the details of a node
 #[derive(Clone, Debug, Args)]
@@ -183,7 +183,7 @@ async fn is_node_accessible(
     wait_until_ready: bool,
 ) -> Result<bool> {
     let node_name = node.node_name();
-    let retries = FibonacciBackoff::from_millis(IS_NODE_ACCESSIBLE_TIME_BETWEEN_CHECKS_MS);
+    let retries = FixedInterval::from_millis(IS_NODE_ACCESSIBLE_TIME_BETWEEN_CHECKS_MS);
     let mut total_time = Duration::from_secs(0);
     for timeout_duration in retries {
         if total_time >= IS_NODE_ACCESSIBLE_TIMEOUT || !wait_until_ready && !total_time.is_zero() {
@@ -207,7 +207,7 @@ async fn is_node_ready(
     wait_until_ready: bool,
 ) -> Result<bool> {
     let node_name = node.node_name();
-    let retries = FibonacciBackoff::from_millis(IS_NODE_READY_TIME_BETWEEN_CHECKS_MS);
+    let retries = FixedInterval::from_millis(IS_NODE_READY_TIME_BETWEEN_CHECKS_MS);
     let now = std::time::Instant::now();
     let mut total_time = Duration::from_secs(0);
     for timeout_duration in retries {

--- a/implementations/rust/ockam/ockam_command/src/rendezvous/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/rendezvous/create/foreground.rs
@@ -1,15 +1,13 @@
 use miette::IntoDiagnostic;
-use std::process::exit;
 use tracing::{error, info, instrument};
 
 use crate::rendezvous::create::CreateCommand;
 use crate::util::foreground_args::wait_for_exit_signal;
 use crate::CommandGlobalOpts;
-use colorful::Colorful;
 use ockam::transport::parse_socket_addr;
 use ockam::udp::{RendezvousService, UdpBindArguments, UdpBindOptions, UdpTransport};
 use ockam::Context;
-use ockam_api::{fmt_ok, DefaultAddress, RendezvousHealthcheck};
+use ockam_api::{DefaultAddress, RendezvousHealthcheck};
 
 impl CreateCommand {
     #[instrument(skip_all)]
@@ -58,14 +56,6 @@ impl CreateCommand {
         if let Err(err) = healthcheck.stop().await {
             error!("Error while stopping healthcheck: {}", err);
         }
-        let _ = ctx.stop().await;
-        if self.foreground_args.child_process {
-            opts.shutdown();
-            exit(0);
-        } else {
-            opts.terminal
-                .write_line(fmt_ok!("Rendezvous Server stopped successfully"))?;
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/utils.rs
@@ -34,8 +34,8 @@ pub fn subprocess_stdio(quiet: bool) -> Stdio {
         // the stdout/stderr to the child process
         Stdio::null()
     } else {
-        // Otherwise, we need to inherit the stdout/stderr of the parent process
-        // to see the output written in the child process
+        // Otherwise, we need to inherit the stdout/stderr of the current process
+        // to see the output written in the spawned process
         Stdio::inherit()
     }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -79,7 +79,7 @@ force_kill_node() {
   pid="$($OCKAM node show $1 --output json | jq .pid)"
   while [[ $i -lt $max_retries ]]; do
     run kill -9 $pid
-    # Killing a node created without `-f` leaves the
+    # Killing a background node (created without `-f`) leaves the
     # process in a defunct state when running within Docker.
     if ! ps -p $pid || ps -p $pid | grep defunct; then
       return

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -29,8 +29,8 @@ teardown() {
 
   run_success "$OCKAM" node start n1
 
-  run "$OCKAM" node delete n1 --yes
-  run "$OCKAM" node delete --all --yes
+  run_success "$OCKAM" node delete n1 --yes
+  run_success "$OCKAM" node delete --all --yes
 }
 
 @test "workers and services" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -165,7 +165,7 @@ teardown() {
 
   file_name="$(random_str)".bin
   pushd "$OCKAM_HOME_BASE" && dd if=/dev/urandom of="./.tmp/$file_name" bs=1M count=50 && popd
-  run_success curl -sSf -m 20 -o "$OCKAM_HOME/$file_name" "http://127.0.0.1:$port/.tmp/$file_name"
+  run_success curl -sSf -m 20 -o /dev/null "http://127.0.0.1:$port/.tmp/$file_name"
 }
 
 @test "portals - create an inlet/outlet, upload file" {
@@ -258,7 +258,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$inlet_port" --to /node/blue/secure/api/service/outlet
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
-  force_kill_node blue
+  run_success "$OCKAM" node delete blue --yes
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
@@ -315,11 +315,10 @@ teardown() {
   # when the credential expires
   file_name="$(random_str)".bin
   pushd "$OCKAM_HOME_BASE" && dd if=/dev/urandom of="./.tmp/$file_name" bs=1M count=50 && popd
-  run_failure curl -sSf -m 20 --limit-rate 5M \
-    -o "$OCKAM_HOME/$file_name" "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
+  run_failure curl -sSf -m 20 --limit-rate 5M -o /dev/null "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
 
   # Consequent attempt fails
-  run_failure curl -sSf -m 20 -o "$OCKAM_HOME/$file_name" "http://127.0.0.1:$inlet_port/.tmp/$file_name"
+  run_failure curl -sSf -m 20 -o /dev/null "http://127.0.0.1:$inlet_port/.tmp/$file_name"
 }
 
 @test "portals - local portal, curl upload, inlet credential expires" {
@@ -400,11 +399,10 @@ teardown() {
   # when the credential expires
   file_name="$(random_str)".bin
   pushd "$OCKAM_HOME_BASE" && dd if=/dev/urandom of="./.tmp/$file_name" bs=1M count=50 && popd
-  run_failure curl -sSf -m 20 --limit-rate 5M \
-    -o "$OCKAM_HOME/$file_name" "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
+  run_failure curl -sSf -m 20 --limit-rate 5M -o /dev/null "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
 
   # Consequent attempt fails
-  run_failure curl -sSf -m 20 -o "$OCKAM_HOME/$file_name" "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
+  run_failure curl -sSf -m 20 -o /dev/null "http://127.0.0.1:$inlet_port/.tmp/$file_name" >/dev/null
 }
 
 @test "portals - local portal, curl upload, outlet credential expires" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -209,7 +209,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$inlet_port" --via "$relay_name"
   run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
-  force_kill_node blue
+  $OCKAM node delete blue --yes
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
 
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/back_compatibility.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/back_compatibility.bats
@@ -17,7 +17,7 @@ teardown() {
 
 # ===== TESTS
 
-@test "backcompat - generate ticket, enroll with old version" {
+@test "back compatibility - generate ticket, enroll with old version" {
   skip "docker call not supported in CI yet"
   latest_version=$($OCKAM --version | grep -o 'ockam [0-9]*\.[0-9]*\.[0-9]*' | sed 's/ockam //')
   latest_minor_version=$(echo $latest_version | cut -d. -f2)


### PR DESCRIPTION
- Background nodes were using tracing without a cutoff value. There are now env vars to control that with default values, just as we do with foreground nodes
- Foreground nodes were exiting differently than background nodes. See [here](https://github.com/build-trust/ockam/pull/8625/files#diff-11d072980aa61e0db956f9b7339d26c69ed4db11a2e0714c635ddd610485d283L152-L159). That logic is not relevant anymore, as the `opts.shutdown();` is called at the [end](https://github.com/build-trust/ockam/blob/0d88c208cc78ee0bf851d19a784ff911835b144f/implementations/rust/ockam/ockam_command/src/command.rs#L102) of every command
- Spawned processes are now forked from the main process. This aims to fix the problems of killing processes on docker 
- Fixes an important issue when recreating nodes. In current develop, when the first node is stopped (e.g. `node create --foreground`), is left as the default node, so no node could take the default role unless manually set with the `node default` command. This is now changed so that, when a node checks if it should be the default node, it also takes into account wether the current default node is stopped
- Related to the previous, now the default node name used in `node create` will reuse the stopped node name if possible. That means that running `ockam node create --foreground`, then exiting, and again `ockam node create --foreground` will result in using the same node name.