### PR TITLE
feat(rust): return new ticket format in `project ticket`

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/value_parsers.rs
+++ b/implementations/rust/ockam/ockam_command/src/value_parsers.rs
@@ -34,12 +34,6 @@ pub async fn parse_enrollment_ticket(
 
     // Try to parse it using the old format
     if let Ok(ticket) = LegacyEnrollmentTicket::from_str(&contents) {
-        // TODO: disabled until release 0.138.0
-        // opts.terminal.write_line(fmt_warn!(
-        //     "The enrollment ticket was generated from an old Ockam version"
-        // ))?;
-        // opts.terminal
-        //     .write_line(fmt_warn!("Please make sure the machine that generated the ticket is using the latest Ockam version"))?;
         return Ok(EnrollmentTicket::new_from_legacy(ticket).await?);
     }
 


### PR DESCRIPTION
It also adds two hidden arguments so we have a way to generate other formats, in case we need them:
- `--hex-encoded`: to hex encode the new format
- `--legacy`: to return the old format

The `project enroll` command is able to decode new and legacy tickets in plain, json and hex formats.