### PR TITLE
feat(rust): make an env. variable for the auth0 client id

### DIFF
--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -90,7 +90,7 @@ impl AppState {
         self.publish_state().await;
 
         // get an OIDC token
-        let oidc_service = OidcService::default();
+        let oidc_service = OidcService::new()?;
         let token = oidc_service.get_token_with_pkce().await?;
 
         // retrieve the user information

--- a/implementations/rust/ockam/ockam_command/src/enroll/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/enroll/command.rs
@@ -268,7 +268,7 @@ impl EnrollCommand {
         ))?;
 
         // Run OIDC service
-        let oidc_service = OidcService::default();
+        let oidc_service = OidcService::new()?;
         let token = if self.authorization_code_flow {
             oidc_service.get_token_with_pkce().await.into_diagnostic()?
         } else {

--- a/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/addon/configure_okta.rs
@@ -123,7 +123,9 @@ impl AddonConfigureOktaSubcommand {
         );
 
         // Validate okta configuration
-        let auth0 = OidcService::new(Arc::new(OktaOidcProvider::new(okta_config.clone().into())));
+        let auth0 = OidcService::new_with_provider(Arc::new(OktaOidcProvider::new(
+            okta_config.clone().into(),
+        )));
         auth0.validate_provider_config().await?;
 
         // Do request

--- a/implementations/rust/ockam/ockam_command/src/project/enroll.rs
+++ b/implementations/rust/ockam/ockam_command/src/project/enroll.rs
@@ -236,7 +236,7 @@ impl EnrollCommand {
             pb.set_message("Authenticating with Okta...");
         }
 
-        let auth0 = OidcService::new(Arc::new(OktaOidcProvider::new(okta_config)));
+        let auth0 = OidcService::new_with_provider(Arc::new(OktaOidcProvider::new(okta_config)));
         let token = auth0.get_token_interactively(opts).await?;
         authority_node_client
             .enroll_with_oidc_token_okta(ctx, token)


### PR DESCRIPTION
This allows testing with another Auth0 application.
