### PR TITLE
fix: adjust timeout used when waiting for a node to be ready

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -25,10 +25,10 @@ const LONG_ABOUT: &str = include_str!("./static/show/long_about.txt");
 const PREVIEW_TAG: &str = include_str!("../static/preview_tag.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/show/after_long_help.txt");
 
-const IS_NODE_ACCESSIBLE_TIME_BETWEEN_CHECKS_MS: u64 = 100;
+const IS_NODE_ACCESSIBLE_TIME_BETWEEN_CHECKS_MS: u64 = 25;
 const IS_NODE_ACCESSIBLE_TIMEOUT: Duration = Duration::from_secs(10);
 
-const IS_NODE_READY_TIME_BETWEEN_CHECKS_MS: u64 = 100;
+const IS_NODE_READY_TIME_BETWEEN_CHECKS_MS: u64 = 25;
 const IS_NODE_READY_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Show the details of a node
@@ -190,7 +190,7 @@ async fn is_node_accessible(
             return Ok(false);
         };
         if node.is_accessible(ctx).await.is_ok() {
-            trace!(%node_name, "node is accessible");
+            info!(%node_name, "node is accessible");
             return Ok(true);
         }
         trace!(%node_name, "node is not accessible");
@@ -217,7 +217,7 @@ async fn is_node_ready(
         // Test if node is ready
         // If the node is down, we expect it won't reply and the timeout will trigger the next loop
         let result = node
-            .ask_with_timeout::<(), NodeStatus>(ctx, api::query_status(), timeout_duration)
+            .ask_with_timeout::<(), NodeStatus>(ctx, api::query_status(), Duration::from_secs(1))
             .await;
         if let Ok(node_status) = result {
             if node_status.status.is_running() {


### PR DESCRIPTION
In `node create`, once the NodeManager is created, we wait until it's ready (it responds to a `GET /node` request).

This fixes an issue where the NodeManager was unable to respond in time (100ms) and it was retrying for longer than needed. Now we use a longer timeout and a shorter time between retries.