### PR TITLE
test(rust): update tests using the `ENROLLMENT_TICKET` env var

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -405,21 +405,4 @@ mod tests {
             .map(|f| f.unwrap().file_name().to_string_lossy().to_string())
             .collect()
     }
-
-    #[tokio::test]
-    async fn random_name_generator() {
-        // Same process
-        let mut names = Vec::new();
-        for _ in 0..100 {
-            names.push(random_name());
-        }
-        assert_eq!(names.len(), names.iter().unique().count());
-
-        // In an async context
-        let mut names = Vec::new();
-        for _ in 0..100 {
-            names.push(tokio::task::spawn_blocking(random_name).await.unwrap());
-        }
-        assert_eq!(names.len(), names.iter().unique().count());
-    }
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -240,12 +240,9 @@ EOF
   export ENROLLMENT_TICKET=$(cat "$OCKAM_HOME/enrollment.ticket")
 
   setup_home_dir
-  cat <<EOF >"$OCKAM_HOME/config.yaml"
-ticket: ${ENROLLMENT_TICKET}
-name: n1
-EOF
-
-  run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml"
+  # The ENROLLMENT_TICKET is parsed automatically, so the `node create` command will
+  # first use the ticket before creating the node
+  run_success "$OCKAM" node create n1
   run_success "$OCKAM" node show n1
 
   # Check that the identity can reach the project
@@ -257,12 +254,7 @@ EOF
   export ENROLLMENT_TICKET=$(cat "$OCKAM_HOME/enrollment.ticket")
 
   setup_home_dir
-  cat <<EOF >"$OCKAM_HOME/config.yaml"
-ticket: ${ENROLLMENT_TICKET}
-name: n1
-EOF
-
-  run_success "$OCKAM" node create "$OCKAM_HOME/config.yaml" -f &
+  run_success "$OCKAM" node create n1 -f &
   sleep 10
   run_success "$OCKAM" node show n1
 


### PR DESCRIPTION
The syntax to pass an enrollment ticket to the `node create` config changed and the command it's now able to read the env var directly without explicitly setting it as a config variable or as a command argument.