### PR TITLE
feat(rust): portals commands feedback improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,7 @@ dependencies = [
  "mockall",
  "multimap",
  "nix 0.29.0",
+ "nu-ansi-term 0.50.1",
  "ockam",
  "ockam_abac",
  "ockam_core",

--- a/examples/rust/mitm_node/src/tcp_interceptor/workers/processor.rs
+++ b/examples/rust/mitm_node/src/tcp_interceptor/workers/processor.rs
@@ -7,7 +7,7 @@ use ockam_node::Context;
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::{io::AsyncReadExt, net::tcp::OwnedReadHalf};
-use tracing::{debug, info};
+use tracing::debug;
 
 pub(crate) struct TcpMitmProcessor {
     address_of_other_processor: Address,
@@ -83,7 +83,7 @@ impl Processor for TcpMitmProcessor {
         let len = match self.read_half.read(&mut buf).await {
             Ok(l) if l != 0 => l,
             _ => {
-                info!("Connection was closed; dropping stream {}", ctx.address());
+                debug!("Connection was closed; dropping stream {}", ctx.address());
 
                 let _ = ctx.stop_processor(self.address_of_other_processor.clone()).await;
 

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -78,6 +78,7 @@ log = "0.4"
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.25.1", default-features = false, features = ["alloc", "derive"] }
 nix = { version = "0.29", features = ["signal"] }
+nu-ansi-term = "0.50"
 once_cell = { version = "1", default-features = false }
 open = "5.3.0"
 opentelemetry = { version = "0.26.0", features = ["logs", "metrics", "trace"] }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -44,8 +44,7 @@ pub struct CliState {
     database: SqlxDatabase,
     application_database: SqlxDatabase,
     exporting_enabled: ExportingEnabled,
-    /// Broadcast channel to be notified of major events during a process supported by the
-    /// CliState API
+    /// Broadcast channel to be notified of major events during a process supported by the CliState API
     notifications: Sender<Notification>,
 }
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/cli_state.rs
@@ -118,7 +118,6 @@ impl CliState {
     }
 
     fn notify(&self, notification: Notification) {
-        debug!("{:?}", notification.contents());
         let _ = self.notifications.send(notification);
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_options.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_options.rs
@@ -109,7 +109,7 @@ impl OckamLogFormat {
     }
 
     fn format_timestamp(&self, writer: &mut Writer<'_>) -> std::fmt::Result {
-        let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.6fZ");
         if writer.has_ansi_escapes() {
             let style = Style::new().dimmed();
             write!(writer, "{}", style.prefix())?;

--- a/implementations/rust/ockam/ockam_api/src/logs/logging_options.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/logging_options.rs
@@ -1,6 +1,11 @@
+use nu_ansi_term::{Color, Style};
 use ockam_core::env::FromString;
 use ockam_core::errcode::{Kind, Origin};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
+use tracing_core::{Event, Level, Subscriber};
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, FormattedFields};
+use tracing_subscriber::registry::LookupSpan;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum LoggingEnabled {
@@ -85,12 +90,158 @@ impl FromString for LogFormat {
     }
 }
 
-impl std::fmt::Display for LogFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Display for LogFormat {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
             LogFormat::Default => write!(f, "default"),
             LogFormat::Pretty => write!(f, "pretty"),
             LogFormat::Json => write!(f, "json"),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct OckamLogFormat {}
+
+impl OckamLogFormat {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn format_timestamp(&self, writer: &mut Writer<'_>) -> std::fmt::Result {
+        let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        if writer.has_ansi_escapes() {
+            let style = Style::new().dimmed();
+            write!(writer, "{}", style.prefix())?;
+            write!(writer, "{}", now)?;
+            write!(writer, "{} ", style.suffix())?;
+        } else {
+            write!(writer, "{}", now)?;
+            writer.write_char(' ')?;
+        }
+        Ok(())
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for OckamLogFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let meta = event.metadata();
+        let dimmed = if writer.has_ansi_escapes() {
+            Style::new().dimmed()
+        } else {
+            Style::new()
+        };
+        let bold = if writer.has_ansi_escapes() {
+            Style::new().bold()
+        } else {
+            Style::new()
+        };
+
+        // Timestamp
+        self.format_timestamp(&mut writer)?;
+
+        // Level
+        let fmt_level = FmtLevel::new(meta.level(), writer.has_ansi_escapes());
+        write!(writer, "{} ", fmt_level)?;
+
+        // Event
+        ctx.format_fields(writer.by_ref(), event)?;
+        writer.write_char(' ')?;
+
+        // Scope
+        if let Some(scope) = ctx.event_scope() {
+            let mut seen = false;
+
+            for span in scope.from_root() {
+                write!(writer, "{}", bold.paint(span.metadata().name()))?;
+                seen = true;
+
+                let ext = span.extensions();
+                if let Some(fields) = &ext.get::<FormattedFields<N>>() {
+                    if !fields.is_empty() {
+                        write!(writer, "{}{}{}", bold.paint("{"), fields, bold.paint("}"))?;
+                    }
+                }
+                write!(writer, "{}", dimmed.paint(":"))?;
+            }
+
+            if seen {
+                writer.write_char(' ')?;
+            }
+        };
+
+        // Target
+        write!(writer, "{} ", dimmed.paint(meta.target()))?;
+
+        // File and line
+        let line_number = meta.line();
+        if let Some(filename) = meta.file() {
+            write!(
+                writer,
+                "{}{}{}",
+                dimmed.paint(filename),
+                dimmed.paint(":"),
+                if line_number.is_some() { "" } else { " " }
+            )?;
+        }
+        if let Some(line_number) = line_number {
+            write!(
+                writer,
+                "{}{}{}",
+                dimmed.prefix(),
+                line_number,
+                dimmed.suffix()
+            )?;
+        }
+
+        writeln!(writer)
+    }
+}
+
+struct FmtLevel<'a> {
+    level: &'a Level,
+    ansi: bool,
+}
+
+impl<'a> FmtLevel<'a> {
+    pub(crate) fn new(level: &'a Level, ansi: bool) -> Self {
+        Self { level, ansi }
+    }
+}
+
+const TRACE_STR: &str = "TRACE";
+const DEBUG_STR: &str = "DEBUG";
+const INFO_STR: &str = " INFO";
+const WARN_STR: &str = " WARN";
+const ERROR_STR: &str = "ERROR";
+
+impl Display for FmtLevel<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.ansi {
+            match *self.level {
+                Level::TRACE => write!(f, "{}", Color::Purple.paint(TRACE_STR)),
+                Level::DEBUG => write!(f, "{}", Color::Blue.paint(DEBUG_STR)),
+                Level::INFO => write!(f, "{}", Color::Green.paint(INFO_STR)),
+                Level::WARN => write!(f, "{}", Color::Yellow.paint(WARN_STR)),
+                Level::ERROR => write!(f, "{}", Color::Red.paint(ERROR_STR)),
+            }
+        } else {
+            match *self.level {
+                Level::TRACE => f.pad(TRACE_STR),
+                Level::DEBUG => f.pad(DEBUG_STR),
+                Level::INFO => f.pad(INFO_STR),
+                Level::WARN => f.pad(WARN_STR),
+                Level::ERROR => f.pad(ERROR_STR),
+            }
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/logs/setup.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/setup.rs
@@ -3,7 +3,6 @@ use opentelemetry::trace::TracerProvider;
 use opentelemetry::{global, KeyValue};
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk as sdk;
 use opentelemetry_sdk::export::logs::LogExporter;
 use opentelemetry_sdk::export::trace::SpanExporter;
 use opentelemetry_sdk::logs::{BatchLogProcessor, LoggerProvider};

--- a/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/connection/project.rs
@@ -53,7 +53,7 @@ impl Instantiator for ProjectInstantiator {
         let (project_multiaddr, project_identifier) =
             node_manager.resolve_project(&project).await?;
 
-        debug!(addr = %project_multiaddr, "creating secure channel");
+        debug!(to = %project_multiaddr, identifier = %project_identifier, "creating secure channel");
         let transport_res = RemoteMultiaddrResolver::new(
             Some(node_manager.tcp_transport.clone()),
             None, // We can't connect to the project node via UDP atm
@@ -67,7 +67,6 @@ impl Instantiator for ProjectInstantiator {
             ))
         })?;
 
-        debug!("create a secure channel to the project {project_identifier}");
         let sc = node_manager
             .create_secure_channel_internal(
                 ctx,

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/manager.rs
@@ -298,13 +298,13 @@ impl NodeManager {
     pub async fn make_connection(
         &self,
         ctx: &Context,
-        addr: &MultiAddr,
+        address: &MultiAddr,
         identifier: Identifier,
         authorized: Option<Identifier>,
         timeout: Option<Duration>,
     ) -> ockam_core::Result<Connection> {
         let authorized = authorized.map(|authorized| vec![authorized]);
-        self.connect(ctx, addr, identifier, authorized, timeout)
+        self.connect(ctx, address, identifier, authorized, timeout)
             .await
     }
 
@@ -313,13 +313,13 @@ impl NodeManager {
     async fn connect(
         &self,
         ctx: &Context,
-        addr: &MultiAddr,
+        address: &MultiAddr,
         identifier: Identifier,
         authorized: Option<Vec<Identifier>>,
         timeout: Option<Duration>,
     ) -> ockam_core::Result<Connection> {
-        debug!(?timeout, "connecting to {}", &addr);
-        let connection = ConnectionBuilder::new(addr.clone())
+        debug!(%address, ?timeout, "connecting");
+        let connection = ConnectionBuilder::new(address.clone())
             .instantiate(
                 ctx,
                 self,
@@ -333,13 +333,12 @@ impl NodeManager {
             .instantiate(
                 ctx,
                 self,
-                SecureChannelInstantiator::new(&identifier, timeout, authorized),
+                SecureChannelInstantiator::new(&identifier, timeout, authorized.clone()),
             )
             .await?
             .build();
         connection.add_default_consumers(ctx);
-
-        debug!("connected to {connection:?}");
+        info!(%address, %identifier, ?authorized, "connection established");
         Ok(connection)
     }
 

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/relay.rs
@@ -204,7 +204,6 @@ impl NodeManager {
 
         info!(
             %alias, %address, ?authorized, ?relay_address,
-            forwarding_route = ?relay_info.forwarding_route(),
             remote_address = ?relay_info.remote_address(),
             "relay created"
         );

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/secure_channel.rs
@@ -210,7 +210,7 @@ impl NodeManager {
         timeout: Option<Duration>,
         secure_channel_type: SecureChannelType,
     ) -> Result<SecureChannel> {
-        debug!(%sc_route, "Creating secure channel");
+        debug!(route = %sc_route, %identifier, "initiating secure channel");
         let options = SecureChannelOptions::new();
 
         let options = if let Some(timeout) = timeout {
@@ -224,8 +224,8 @@ impl NodeManager {
             None => options,
         };
 
-        let options = if let Some(credential) = credential {
-            options.with_credential(credential)?
+        let options = if let Some(credential) = credential.as_ref() {
+            options.with_credential(credential.clone())?
         } else {
             match self.credential_retriever_creators.project_member.as_ref() {
                 None => options,
@@ -251,7 +251,7 @@ impl NodeManager {
             .create_secure_channel(ctx, identifier, sc_route.clone(), options)
             .await?;
 
-        debug!(%sc_route, %sc, "Created secure channel");
+        info!(route = %sc_route, %identifier, "secure channel initiated");
 
         self.registry
             .secure_channels

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/node_manager.rs
@@ -26,10 +26,10 @@ impl NodeManager {
     pub async fn create_inlet(
         self: &Arc<Self>,
         ctx: &Context,
-        listen_addr: HostnamePort,
+        listen_address: HostnamePort,
         prefix_route: Route,
         suffix_route: Route,
-        outlet_addr: MultiAddr,
+        outlet_address: MultiAddr,
         alias: String,
         policy_expression: Option<PolicyExpression>,
         wait_for_outlet_duration: Option<Duration>,
@@ -42,16 +42,15 @@ impl NodeManager {
         privileged: bool,
         tls_certificate_provider: Option<MultiAddr>,
     ) -> Result<InletStatus> {
-        info!("Handling request to create inlet portal");
         debug! {
-            listen_addr = %listen_addr,
+            %listen_address,
             prefix = %prefix_route,
             suffix = %suffix_route,
-            outlet_addr = %outlet_addr,
+            %outlet_address,
             %alias,
             %enable_udp_puncture,
             %disable_tcp_fallback,
-            "Creating inlet portal"
+            "creating inlet"
         }
 
         let udp_transport = if enable_udp_puncture {
@@ -69,8 +68,8 @@ impl NodeManager {
         // the port could be zero, to simplify the following code we
         // resolve the address to a full socket address
         let socket_addr =
-            ockam_node::compat::asynchronous::resolve_peer(listen_addr.to_string()).await?;
-        let listen_addr = if listen_addr.port() == 0 {
+            ockam_node::compat::asynchronous::resolve_peer(listen_address.to_string()).await?;
+        let listen_addr = if listen_address.port() == 0 {
             get_free_address_for(&socket_addr.ip().to_string())
                 .map_err(|err| ockam_core::Error::new(Origin::Transport, Kind::Invalid, err))?
         } else {
@@ -113,7 +112,7 @@ impl NodeManager {
             udp_transport,
             context: ctx.async_try_clone().await?,
             listen_addr: listen_addr.to_string(),
-            outlet_addr: outlet_addr.clone(),
+            outlet_addr: outlet_address.clone(),
             prefix_route,
             suffix_route,
             authorized,
@@ -141,7 +140,7 @@ impl NodeManager {
             .create_tcp_inlet(
                 &self.node_name,
                 &listen_addr,
-                &outlet_addr,
+                &outlet_address,
                 &alias,
                 privileged,
             )
@@ -190,7 +189,7 @@ impl NodeManager {
                 alias.clone(),
                 InletInfo::new(
                     &listen_addr.to_string(),
-                    outlet_addr.clone(),
+                    outlet_address.clone(),
                     session,
                     privileged,
                 ),
@@ -206,9 +205,16 @@ impl NodeManager {
             None,
             outcome.clone().map(|s| s.route.to_string()),
             connection_status,
-            outlet_addr.to_string(),
+            outlet_address.to_string(),
             privileged,
         );
+
+        info! {
+            %listen_address,
+            %outlet_address,
+            %alias,
+            "inlet created"
+        }
 
         Ok(tcp_inlet_status)
     }

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/tcp_inlets/session_replacer.rs
@@ -203,6 +203,9 @@ impl InletSessionReplacer {
         };
 
         self.main_route = Some(normalized_stripped_route);
+        info!(address = ?inlet_address,
+            route = %self.main_route.as_ref().map(|r| r.to_string()).unwrap_or("None".to_string()),
+            "tcp inlet restored");
 
         Ok(ReplacerOutcome {
             ping_route: transport_route,
@@ -273,7 +276,7 @@ impl SessionReplacer for InletSessionReplacer {
                 Err(ApiError::core("timeout"))
             }
             Ok(Err(e)) => {
-                warn!(%self.outlet_addr, err = %e, "error creating new tcp inlet");
+                warn!(%self.outlet_addr, err = %e, "failed to create tcp inlet");
                 Err(e)
             }
             Ok(Ok(route)) => Ok(route),

--- a/implementations/rust/ockam/ockam_api/src/session/replacer.rs
+++ b/implementations/rust/ockam/ockam_api/src/session/replacer.rs
@@ -14,6 +14,10 @@ pub trait SessionReplacer: Send + Sync + 'static {
     async fn create(&mut self) -> Result<ReplacerOutcome>;
 
     async fn close(&mut self);
+
+    async fn on_session_down(&self);
+
+    async fn on_session_replaced(&self);
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
+++ b/implementations/rust/ockam/ockam_api/src/ui/terminal/fmt.rs
@@ -38,7 +38,7 @@ macro_rules! fmt_log {
     ($input:expr $(, $args:expr)* $(,)?) => {
         format!("{}{}",
         $crate::terminal::PADDING,
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -58,7 +58,7 @@ macro_rules! fmt_ok {
         "✔"
             .color($crate::colors::OckamColor::FmtOKBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -78,7 +78,7 @@ macro_rules! fmt_para {
         "│"
             .color($crate::colors::OckamColor::FmtINFOBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -98,7 +98,7 @@ macro_rules! fmt_list {
         "│"
             .color($crate::colors::OckamColor::FmtLISTBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -114,7 +114,7 @@ macro_rules! fmt_heading {
     ($input:expr $(, $args:expr)* $(,)?) => {
         format!("\n{}{}\n{}{}",
         $crate::terminal::PADDING,
-        format!($input, $($args),+),
+        format!($input, $($args),*),
         $crate::terminal::PADDING,
         "─".repeat($crate::terminal::get_separator_width()).dim().light_gray())
     };
@@ -150,7 +150,7 @@ macro_rules! fmt_info {
         ">"
             .color($crate::colors::OckamColor::FmtINFOBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -170,7 +170,7 @@ macro_rules! fmt_warn {
         "!"
             .color($crate::colors::OckamColor::FmtWARNBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }
 
@@ -190,6 +190,6 @@ macro_rules! fmt_err {
         "✗"
             .color($crate::colors::OckamColor::FmtERRORBackground.color())
             .bold(),
-        format!($input, $($args),+))
+        format!($input, $($args),*))
     };
 }

--- a/implementations/rust/ockam/ockam_api/tests/common/session.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/session.rs
@@ -171,6 +171,14 @@ impl SessionReplacer for MockReplacer {
     async fn close(&mut self) {
         self.close_impl()
     }
+
+    async fn on_session_down(&self) {
+        info!("MockReplacer {} on_session_down called", self.name);
+    }
+
+    async fn on_session_replaced(&self) {
+        info!("MockReplacer {} on_session_replaced called", self.name);
+    }
 }
 
 #[async_trait]

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -5,11 +5,6 @@ use ockam_api::logs::{
 
 use opentelemetry::global;
 use opentelemetry::trace::Tracer;
-
-use opentelemetry_sdk as sdk;
-use sdk::testing::logs::*;
-use sdk::testing::trace::*;
-
 use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
 use opentelemetry_sdk::testing::trace::InMemorySpanExporter;
 use std::fs;

--- a/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
+++ b/implementations/rust/ockam/ockam_api/tests/logging_tracing.rs
@@ -10,8 +10,9 @@ use opentelemetry_sdk as sdk;
 use sdk::testing::logs::*;
 use sdk::testing::trace::*;
 
+use opentelemetry_sdk::testing::logs::InMemoryLogsExporter;
+use opentelemetry_sdk::testing::trace::InMemorySpanExporter;
 use std::fs;
-
 use tempfile::NamedTempFile;
 
 use ockam_api::cli_state::{random_name, CliStateMode};
@@ -81,12 +82,12 @@ fn test_log_and_traces() {
         if file_path.to_string_lossy().contains("stdout") {
             let contents = fs::read_to_string(file_path).unwrap();
             assert!(
-                contents.contains("INFO logging_tracing: inside span"),
+                contents.contains("INFO inside span logging_tracing"),
                 "{:?}",
                 contents
             );
             assert!(
-                contents.contains("ERROR logging_tracing: something went wrong!"),
+                contents.contains("ERROR something went wrong! logging_tracing"),
                 "{:?}",
                 contents
             );

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -185,7 +185,7 @@ impl CommandGlobalOpts {
         debug!("Arguments: {}", arguments.join(" "));
         debug!("Global arguments: {:#?}", &global_args);
         debug!("Command: {:#?}", &cmd);
-        debug!("Version: {}", Version::new());
+        debug!("Version: {}", Version::new().no_color());
 
         info!("Tracing initialized");
         debug!("{:#?}", logging_configuration);

--- a/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/influxdb/inlet/create.rs
@@ -111,29 +111,29 @@ impl Command for InfluxDBCreateCommand {
             .add_inlet_created_event(&opts, &node_name, &inlet_status)
             .await?;
 
-        let created_message = fmt_ok!(
-            "Created a new InfluxDB Inlet in the Node {} bound to {}\n",
+        let created_message = format!(
+            "Created a new InfluxDB Inlet in the Node {} bound to {}",
             color_primary(&node_name),
-            color_primary(&self.tcp_inlet.from)
+            color_primary(self.tcp_inlet.from.to_string()),
         );
 
         let plain = if self.tcp_inlet.no_connection_wait {
-            created_message + &fmt_log!("It will automatically connect to the TCP Outlet at {} as soon as it is available",
+            fmt_ok!("{created_message}\n")
+                + &fmt_log!("It will automatically connect to the InfluxDB Outlet at {} as soon as it is available\n",
                 color_primary(&self.tcp_inlet.to)
             )
         } else if inlet_status.status == ConnectionStatus::Up {
-            created_message
+            fmt_ok!("{created_message}\n")
                 + &fmt_log!(
-                    "sending traffic to the TCP Outlet at {}",
+                    "sending traffic to the TCP Outlet at {}\n",
                     color_primary(&self.tcp_inlet.to)
                 )
         } else {
-            fmt_warn!(
-                "A InfluxDB Inlet was created in the Node {} bound to {} but failed to connect to the TCP Outlet at {}\n",
-                color_primary(&node_name),
-                 color_primary(self.tcp_inlet.from.to_string()),
+            fmt_warn!("{created_message}\n")
+                + &fmt_log!(
+                "but failed to connect to the TCP Outlet at {}\n",
                 color_primary(&self.tcp_inlet.to)
-            ) + &fmt_info!("It will retry to connect automatically")
+            ) + &fmt_info!("It will automatically connect to the InfluxDB Outlet as soon as it is available\n")
         };
 
         opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -53,7 +53,17 @@ impl CreateCommand {
 
         // Set node_name so that node can isolate its data in the storage from other nodes
         self.get_or_create_identity(&opts, &self.identity).await?;
-        let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
+        let _notification_handler = if self.foreground_args.child_process {
+            // If enabled, the user's terminal will receive notifications
+            // from the node after the command exited.
+            None
+        } else {
+            // Enable the notifications only on explicit foreground nodes.
+            Some(NotificationHandler::start(
+                &opts.state,
+                opts.terminal.clone(),
+            ))
+        };
         let node_info = opts
             .state
             .start_node_with_optional_values(

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -54,7 +54,7 @@ impl CreateCommand {
         // Set node_name so that node can isolate its data in the storage from other nodes
         self.get_or_create_identity(&opts, &self.identity).await?;
         let _notification_handler = if self.foreground_args.child_process {
-            // If enabled, the user's terminal will receive notifications
+            // If enabled, the user's terminal would receive notifications
             // from the node after the command exited.
             None
         } else {

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -144,17 +144,18 @@ impl CreateCommand {
     }
 
     async fn start_services(&self, ctx: &Context, opts: &CommandGlobalOpts) -> miette::Result<()> {
-        // Wait until the node is fully started
-        let mut node =
-            BackgroundNodeClient::create(ctx, &opts.state, &Some(self.name.clone())).await?;
-        if !is_node_up(ctx, &mut node, true).await? {
-            return Err(miette!(
-                "Couldn't start services because the node is not up"
-            ));
-        }
-
         if let Some(config) = &self.launch_configuration {
             if let Some(startup_services) = &config.startup_services {
+                // Wait until the node is fully started
+                let mut node =
+                    BackgroundNodeClient::create(ctx, &opts.state, &Some(self.name.clone()))
+                        .await?;
+                if !is_node_up(ctx, &mut node, true).await? {
+                    return Err(miette!(
+                        "Couldn't start services because the node is not up"
+                    ));
+                }
+
                 if let Some(cfg) = startup_services.secure_channel_listener.clone() {
                     if !cfg.disabled {
                         opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -171,7 +171,7 @@ pub async fn is_node_up(
         .ask_with_timeout::<(), NodeStatus>(ctx, api::query_status(), Duration::from_secs(1))
         .await
     {
-        if status.status.is_running() {
+        if status.process_status.is_running() {
             return Ok(true);
         }
     }

--- a/implementations/rust/ockam/ockam_command/src/node/show.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/show.rs
@@ -166,6 +166,15 @@ pub async fn is_node_up(
 ) -> Result<bool> {
     debug!("waiting for node to be up");
     let node_name = node.node_name();
+    // Check if node is already up and running to skip the accessible/ready checks
+    if let Ok(status) = node
+        .ask_with_timeout::<(), NodeStatus>(ctx, api::query_status(), Duration::from_secs(1))
+        .await
+    {
+        if status.status.is_running() {
+            return Ok(true);
+        }
+    }
     if !is_node_accessible(ctx, node, wait_until_ready).await? {
         warn!(%node_name, "the node was not accessible in time");
         return Ok(false);
@@ -233,7 +242,7 @@ async fn is_node_ready(
         if let Ok(node_status) = result {
             if node_status.process_status.is_running() {
                 let elapsed = now.elapsed();
-                info!(%node_name, ?elapsed, "node is ready {:?}", node_status);
+                info!(%node_name, ?elapsed, "node is ready");
                 return Ok(true);
             } else {
                 trace!(%node_name, "node is initializing");

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -91,8 +91,6 @@ impl Command for CreateCommand {
         let alias = cmd.relay_name();
         let return_timing = cmd.return_timing();
 
-        // let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
-
         let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.to).await?;
         let relay_info = {
             if at.starts_with(Project::CODE) && cmd.authorized.is_some() {

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use clap::Args;
 use colorful::Colorful;
 use miette::{miette, IntoDiagnostic};
-use tracing::info;
+use tracing::debug;
 
 use ockam::identity::Identifier;
 use ockam::Context;
@@ -91,6 +91,8 @@ impl Command for CreateCommand {
         let alias = cmd.relay_name();
         let return_timing = cmd.return_timing();
 
+        // let _notification_handler = NotificationHandler::start(&opts.state, opts.terminal.clone());
+
         let node = BackgroundNodeClient::create(ctx, &opts.state, &cmd.to).await?;
         let relay_info = {
             if at.starts_with(Project::CODE) && cmd.authorized.is_some() {
@@ -98,7 +100,11 @@ impl Command for CreateCommand {
                     "--authorized can not be used with project addresses"
                 ))?;
             };
-            info!("creating a relay at {} to {}", at, node.node_name());
+            debug!(
+                "sending request to {} to create a relay at {}",
+                node.node_name(),
+                at
+            );
             let pb = opts.terminal.spinner();
             if let Some(pb) = pb.as_ref() {
                 pb.set_message(format!(
@@ -123,10 +129,8 @@ impl Command for CreateCommand {
                 let plain = {
                     let from = color_primary(&at);
                     let to = color_primary(format!("/node/{}", &node.node_name()));
-
                     fmt_ok!("Relay will be created automatically from {from} → {to} as soon as a connection can be established.")
                 };
-
                 opts.terminal
                     .stdout()
                     .plain(plain)
@@ -166,11 +170,9 @@ impl Command for CreateCommand {
                     let plain = {
                         let from = color_primary(&at);
                         let to = color_primary(format!("/node/{}", &node.node_name()));
-
                         fmt_warn!("A relay was created at {to} but failed to connect to {from}\n")
                             + &fmt_info!("It will retry to connect automatically")
                     };
-
                     opts.terminal
                         .stdout()
                         .plain(plain)

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -169,7 +169,7 @@ impl Command for CreateCommand {
                         let at = color_primary(&at);
                         let node = color_primary(format!("/node/{}", &node.node_name()));
                         fmt_warn!("A relay was created at {node} but failed to connect to {at}\n")
-                            + &fmt_info!("It will retry to connect automatically")
+                            + &fmt_info!("It will automatically connect to the Relay as soon as it is available")
                     };
                     opts.terminal
                         .stdout()

--- a/implementations/rust/ockam/ockam_command/src/relay/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/relay/create.rs
@@ -166,9 +166,9 @@ impl Command for CreateCommand {
                         .write_line()?;
                 } else {
                     let plain = {
-                        let from = color_primary(&at);
-                        let to = color_primary(format!("/node/{}", &node.node_name()));
-                        fmt_warn!("A relay was created at {to} but failed to connect to {from}\n")
+                        let at = color_primary(&at);
+                        let node = color_primary(format!("/node/{}", &node.node_name()));
+                        fmt_warn!("A relay was created at {node} but failed to connect to {at}\n")
                             + &fmt_info!("It will retry to connect automatically")
                     };
                     opts.terminal

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -71,13 +71,11 @@ impl ParsedCommands {
         if len > 0 {
             opts.terminal.write_line("")?;
         }
-        for (idx, cmd) in self.commands.into_iter().enumerate() {
+        for cmd in self.commands.into_iter() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
-                if idx < len - 1 {
-                    // Newline between commands
-                    opts.terminal.write_line("")?;
-                }
+                // Newline after each command
+                opts.terminal.write_line("")?;
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
+++ b/implementations/rust/ockam/ockam_command/src/run/parser/resource/traits.rs
@@ -68,14 +68,12 @@ impl ParsedCommands {
     /// Validate and run each command
     pub async fn run(self, ctx: &Context, opts: &CommandGlobalOpts) -> Result<()> {
         let len = self.commands.len();
-        if len > 0 {
-            opts.terminal.write_line("")?;
-        }
-        for cmd in self.commands.into_iter() {
+        for (idx, cmd) in self.commands.into_iter().enumerate() {
             if cmd.is_valid(ctx, opts).await? {
                 cmd.run(ctx, opts).await?;
-                // Newline after each command
-                opts.terminal.write_line("")?;
+                if idx < len - 1 {
+                    opts.terminal.write_line("")?;
+                }
             }
         }
         Ok(())

--- a/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/tcp/inlet/create.rs
@@ -233,39 +233,37 @@ impl Command for CreateCommand {
             .await?;
 
         let created_message = format!(
-            "Created a new TCP Inlet in the Node {} bound to {}\n",
+            "Created a new TCP Inlet in the Node {} bound to {}",
             color_primary(&node_name),
             color_primary(cmd.from.to_string()),
         );
 
-        let created_message = fmt_ok!("{}", created_message);
-
         let mut plain = if cmd.no_connection_wait {
-            created_message
-                + &fmt_log!(
+            fmt_ok!("{created_message}\n")
+                + &fmt_info!(
                     "It will automatically connect to the TCP Outlet at {} as soon as it is available\n",
                     color_primary(&cmd.to)
                 )
         } else if inlet_status.status == ConnectionStatus::Up {
-            created_message
+            fmt_ok!("{created_message}\n")
                 + &fmt_log!(
                     "sending traffic to the TCP Outlet at {}\n",
                     color_primary(&cmd.to)
                 )
         } else {
-            let mut msg = fmt_warn!("A TCP Inlet was created in the Node {} bound to {} but failed to connect to the TCP Outlet at {}\n",
-                color_primary(&node_name),
-                color_primary(cmd.from.to_string()),
-                color_primary(&cmd.to));
-
-            msg += &fmt_info!("It will retry to connect automatically\n");
-
-            msg
+            fmt_warn!("{created_message}\n")
+                + &fmt_log!(
+                    "but it failed to connect to the TCP Outlet at {}\n",
+                    color_primary(&cmd.to)
+                )
+                + &fmt_info!(
+                    "It will automatically connect to the TCP Outlet as soon as it is available\n",
+                )
         };
 
         if privileged {
             plain += &fmt_info!(
-                "This Inlet is operating in {} mode\n",
+                "This TCP Inlet is operating in {} mode\n",
                 color_primary_alt("privileged".to_string())
             );
         }

--- a/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
@@ -1,7 +1,6 @@
 use crate::CommandGlobalOpts;
 use clap::Args;
 use colorful::Colorful;
-use ockam_abac::expr::and;
 use ockam_api::{fmt_log, fmt_warn};
 use std::io;
 use std::io::Read;

--- a/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
+++ b/implementations/rust/ockam/ockam_command/src/util/foreground_args.rs
@@ -1,6 +1,7 @@
 use crate::CommandGlobalOpts;
 use clap::Args;
 use colorful::Colorful;
+use ockam_abac::expr::and;
 use ockam_api::{fmt_log, fmt_warn};
 use std::io;
 use std::io::Read;
@@ -43,7 +44,8 @@ pub async fn wait_for_exit_signal(
                 let _ = tx.blocking_send(());
                 info!("Exit signal received");
                 if !is_child_process {
-                    let _ = terminal.write_line(fmt_warn!("Exit signal received"));
+                    let _ =
+                        terminal.write_line("\n".to_string() + &fmt_warn!("Exit signal received"));
                 }
                 processed = true
             }
@@ -70,9 +72,9 @@ pub async fn wait_for_exit_signal(
 
     debug!("waiting for exit signal");
 
-    if !args.child_process {
+    if !args.child_process && opts.terminal.is_tty() {
         opts.terminal.write_line("")?;
-        opts.terminal.write_line(fmt_log!("{}", msg))?;
+        opts.terminal.write(fmt_log!("{}", msg))?;
     }
 
     // Wait for signal SIGINT, SIGTERM, SIGHUP or EOF; or for the tx to be closed.

--- a/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
+++ b/implementations/rust/ockam/ockam_identity/src/credentials/retriever/remote_retriever/remote_retriever.rs
@@ -256,20 +256,17 @@ impl RemoteCredentialRetriever {
     /// into EncryptorWorker's own internal mailbox which it will use as a trigger to get a new
     /// credential and present it to the other side.
     fn schedule_credentials_refresh_impl(&self, refresh_in: Duration, is_retry: bool) {
-        let is_retry_str = if is_retry { " retry " } else { " " };
-        info!(
-            "Scheduling background credentials refresh{}from {} in {} seconds",
-            is_retry_str,
-            self.issuer_info.issuer,
-            refresh_in.as_secs()
-        );
-
+        debug!(issuer=%self.issuer_info.issuer, is_retry,
+            "Scheduling background credentials refresh in {} seconds",
+            refresh_in.as_secs());
         self.request_new_credential_in_background(refresh_in, is_retry);
     }
 }
 
 impl RemoteCredentialRetriever {
     async fn get_new_credential(&self) -> Result<()> {
+        debug!(subject=%self.subject, issuer=%self.issuer_info.issuer,
+            "retrieving a new credential");
         let cache = self
             .secure_channels
             .identities
@@ -286,7 +283,7 @@ impl RemoteCredentialRetriever {
             self.timing_options.request_timeout,
         );
 
-        let credential = client
+        let credential: CredentialAndPurposeKey = client
             .ask(
                 &self.ctx,
                 &self.issuer_info.service_address,
@@ -298,10 +295,23 @@ impl RemoteCredentialRetriever {
             .await?
             .success()?;
 
-        info!(
-            "Retrieved a new credential for {} from {}",
-            self.subject, &self.issuer_info.route
-        );
+        let credential_data = credential.get_credential_data()?;
+        let attributes = credential_data.get_attributes_display();
+        let purpose_key_data = credential.purpose_key_attestation.get_attestation_data()?;
+        info! {
+            subject = %self.subject,
+            %attributes,
+            schema = %credential_data.subject_attributes.schema.0,
+            created_at = %credential_data.created_at,
+            expires_at = %credential_data.expires_at,
+            "retrieved credential"
+        }
+        debug! {
+            subject = %purpose_key_data.subject,
+            created_at = %purpose_key_data.created_at,
+            expires_at = %purpose_key_data.expires_at,
+            "retrieved credential - purpose key attestation"
+        }
 
         let credential_and_purpose_key_data = self
             .secure_channels
@@ -316,7 +326,7 @@ impl RemoteCredentialRetriever {
             .await?;
         let expires_at = credential_and_purpose_key_data.credential_data.expires_at;
 
-        trace!("The retrieved credential is valid");
+        trace!("the retrieved credential is valid");
 
         *self.last_presented_credential.write().unwrap() = Some(LastPresentedCredential {
             credential: credential.clone(),
@@ -334,10 +344,8 @@ impl RemoteCredentialRetriever {
             .await;
 
         if let Some(err) = caching_res.err() {
-            error!(
-                "Error caching credential for {} from {}. Err={}",
-                self.subject, &self.issuer_info.issuer, err
-            );
+            error!(subject=%self.subject, issuer=%self.issuer_info.issuer, %err,
+                "error caching credential");
         }
 
         self.notify_subscribers().await?;
@@ -351,29 +359,20 @@ impl RemoteCredentialRetriever {
     fn request_new_credential_in_background(&self, wait: Duration, is_retry: bool) {
         let s = self.clone();
         ockam_node::spawn(async move {
-            let is_retry_str = if is_retry { " retry " } else { " " };
-            info!(
-                "Scheduled background credentials refresh{}from {} in {} seconds",
-                is_retry_str,
-                s.issuer_info.issuer,
-                wait.as_secs()
-            );
+            info!(issuer=%s.issuer_info.issuer, is_retry,
+                "scheduled background credentials refresh in {} seconds",
+                wait.as_secs());
             s.ctx
                 .sleep_long_until(*now().unwrap() + wait.as_secs())
                 .await;
-            info!(
-                "Executing background credentials refresh{}from {}",
-                is_retry_str, s.issuer_info.issuer,
-            );
-            let res = s.get_new_credential().await;
-
-            if let Some(err) = res.err() {
-                error!(
-                    "Error refreshing credential for {} in the background: {}",
-                    s.subject, err
-                );
-
+            debug!(issuer=%s.issuer_info.issuer, is_retry,
+                "executing background credentials refresh");
+            if let Some(err) = s.get_new_credential().await.err() {
+                error!(subject=%s.subject, is_retry, %err,
+                    "error refreshing credential in the background");
                 s.schedule_credentials_refresh(now().unwrap(), true);
+            } else {
+                debug!(issuer=%s.issuer_info.issuer, is_retry, "credentials refreshed");
             }
         });
     }

--- a/implementations/rust/ockam/ockam_identity/src/models/credential_and_purpose_key.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/credential_and_purpose_key.rs
@@ -1,5 +1,4 @@
 use minicbor::{CborLen, Decode, Encode};
-
 use ockam_core::compat::string::String;
 use ockam_core::compat::vec::Vec;
 use ockam_core::errcode::{Kind, Origin};

--- a/implementations/rust/ockam/ockam_identity/src/models/timestamp.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/timestamp.rs
@@ -1,3 +1,4 @@
+use core::fmt::Display;
 use minicbor::{CborLen, Decode, Encode};
 use serde::{Deserialize, Serialize};
 
@@ -7,3 +8,11 @@ use serde::{Deserialize, Serialize};
 #[cbor(transparent)]
 #[serde(transparent)]
 pub struct TimestampInSeconds(#[n(0)] pub u64);
+
+impl Display for TimestampInSeconds {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Convert to human-readable time
+        let date = chrono::DateTime::from_timestamp(self.0 as i64, 0).ok_or(core::fmt::Error)?;
+        write!(f, "{}", date)
+    }
+}

--- a/implementations/rust/ockam/ockam_identity/src/models/utils/credentials.rs
+++ b/implementations/rust/ockam/ockam_identity/src/models/utils/credentials.rs
@@ -1,6 +1,8 @@
 use crate::models::{CredentialData, CredentialSignature, VersionedData, CREDENTIAL_DATA_TYPE};
 use crate::{Credential, IdentityError};
 
+use ockam_core::compat::str;
+use ockam_core::compat::string::String;
 use ockam_core::compat::vec::Vec;
 use ockam_core::Result;
 use ockam_vault::Signature;
@@ -33,6 +35,22 @@ impl CredentialData {
         }
 
         Ok(minicbor::decode(&versioned_data.data)?)
+    }
+
+    /// Return the credential's attributes as a displayable string
+    pub fn get_attributes_display(&self) -> String {
+        self.subject_attributes
+            .map
+            .iter()
+            .map(|(k, v)| {
+                format!(
+                    "{}={}",
+                    str::from_utf8(k).unwrap_or("**binary**"),
+                    str::from_utf8(v).unwrap_or("**binary**")
+                )
+            })
+            .collect::<Vec<String>>()
+            .join(";")
     }
 }
 

--- a/implementations/rust/ockam/ockam_identity/src/purpose_keys/purpose_key_verification.rs
+++ b/implementations/rust/ockam/ockam_identity/src/purpose_keys/purpose_key_verification.rs
@@ -1,13 +1,14 @@
 use ockam_core::compat::sync::Arc;
 use ockam_core::Result;
 use ockam_vault::VaultForVerifyingSignatures;
+use tracing::trace;
 
 use crate::models::{Identifier, PurposeKeyAttestation, PurposeKeyAttestationData, VersionedData};
 use crate::utils::now;
 use crate::{ChangeHistoryRepository, IdentitiesVerification, IdentityError, TimestampInSeconds};
 
 /// We allow purpose keys to be created in the future related to this machine's time due to
-/// possible time dyssynchronization
+/// possible time desynchronization
 const MAX_ALLOWED_TIME_DRIFT: TimestampInSeconds = TimestampInSeconds(60);
 
 /// This struct supports all the services related to identities
@@ -45,6 +46,8 @@ impl PurposeKeyVerification {
         expected_subject: Option<&Identifier>,
         attestation: &PurposeKeyAttestation,
     ) -> Result<PurposeKeyAttestationData> {
+        trace!(?expected_subject, "verifying purpose key attestation");
+
         let versioned_data_hash = self.verifying_vault.sha256(&attestation.data).await?;
 
         let versioned_data: VersionedData = minicbor::decode(&attestation.data)?;
@@ -117,6 +120,8 @@ impl PurposeKeyVerification {
         {
             return Err(IdentityError::PurposeKeyAttestationVerificationFailed)?;
         }
+
+        trace!(?expected_subject, "verified purpose key attestation");
 
         Ok(purpose_key_data)
     }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channel/handshake/handshake.rs
@@ -13,6 +13,8 @@ use ockam_vault::{
     X25519PublicKey, X25519SecretKeyHandle, X25519_PUBLIC_KEY_LENGTH,
 };
 use sha2::{Digest, Sha256};
+#[cfg(feature = "debugger")]
+use tracing::debug;
 use Status::*;
 
 /// The number of bytes in a SHA256 digest
@@ -50,6 +52,9 @@ impl Handshake {
 
     /// Encode the first message, sent from the initiator to the responder
     pub(super) async fn encode_message1(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Encoding message 1");
+
         let mut state = self.state.clone();
         // output e.pubKey
         let e_pub_key = self.get_public_key(state.e()?).await?;
@@ -70,6 +75,9 @@ impl Handshake {
 
     /// Decode the first message to get the ephemeral public key sent by the initiator
     pub(super) async fn decode_message1(&mut self, message1: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Decoding message 2");
+
         if message1.len() > NOISE_MAX_MESSAGE_SIZE {
             return Err(XXError::ExceededMaxMessageLen)?;
         }
@@ -93,6 +101,9 @@ impl Handshake {
     /// That message contains: the responder ephemeral public key + a Diffie-Hellman key +
     ///   an encrypted payload containing the responder identity / signature / credentials
     pub(super) async fn encode_message2(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Encoding message 2");
+
         let mut state = self.state.clone();
         // output e.pubKey
         let e_pub_key = self.get_public_key(state.e()?).await?;
@@ -126,6 +137,9 @@ impl Handshake {
 
     /// Decode the second message sent by the responder
     pub(super) async fn decode_message2(&mut self, message2: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Decoding message 2");
+
         if message2.len() > NOISE_MAX_MESSAGE_SIZE {
             return Err(XXError::ExceededMaxMessageLen)?;
         }
@@ -166,6 +180,9 @@ impl Handshake {
     /// That message contains: the initiator static public key (encrypted) + a Diffie-Hellman key +
     ///   an encrypted payload containing the initiator identity / signature / credentials
     pub(super) async fn encode_message3(&mut self, payload: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Encoding message 3");
+
         let mut state = self.state.clone();
         // encrypt s.pubKey
         let s_pub_key = self.get_public_key(state.s()?).await?;
@@ -190,6 +207,9 @@ impl Handshake {
 
     /// Decode the third message sent by the initiator
     pub(super) async fn decode_message3(&mut self, message3: &[u8]) -> Result<Vec<u8>> {
+        #[cfg(feature = "debugger")]
+        debug!("Decoding message 3");
+
         if message3.len() > NOISE_MAX_MESSAGE_SIZE {
             return Err(XXError::ExceededMaxMessageLen)?;
         }
@@ -219,6 +239,9 @@ impl Handshake {
     /// Set the final state of the state machine by creating the encryption / decryption keys
     /// and return the other party identity
     pub(super) async fn set_final_state(&mut self, role: Role) -> Result<()> {
+        #[cfg(feature = "debugger")]
+        debug!("Setting final state");
+
         // k1, k2 = HKDF(ck, zerolen, 2)
         let mut state = self.state.clone();
         let (k1, k2) = self.compute_final_keys(&mut state).await?;
@@ -239,6 +262,9 @@ impl Handshake {
 
     /// Return the final results of the handshake if we reached the final state
     pub(super) fn get_handshake_keys(&self) -> Option<HandshakeKeys> {
+        #[cfg(feature = "debugger")]
+        debug!("Getting handshake keys");
+
         match &self.state.status {
             Ready(keys) => Some(keys.clone()),
             _ => None,

--- a/implementations/rust/ockam/ockam_node/src/api.rs
+++ b/implementations/rust/ockam/ockam_node/src/api.rs
@@ -132,7 +132,8 @@ impl Client {
             method = ?req.header().method(),
             path   = %req.header().path(),
             body   = %req.header().has_body(),
-        };
+            "sending request"
+        }
         let options = if let Some(t) = timeout {
             MessageSendReceiveOptions::new().with_timeout(t)
         } else {
@@ -146,6 +147,15 @@ impl Client {
             .await?;
         let local_info = resp.local_message().local_info().to_vec();
         let body = resp.into_body()?;
+
+        trace! {
+            target:  "ockam_api",
+            id     = %req.header().id(),
+            method = ?req.header().method(),
+            path   = %req.header().path(),
+            body   = %req.header().has_body(),
+            "received response"
+        }
 
         Ok((body, local_info))
     }

--- a/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/context_lifecycle.rs
@@ -32,9 +32,10 @@ pub type AsyncDropSender = tokio::sync::oneshot::Sender<Address>;
 impl Drop for Context {
     fn drop(&mut self) {
         if let Some(sender) = self.async_drop_sender.take() {
-            trace!("De-allocated detached context {}", self.address());
-            if let Err(e) = sender.send(self.address()) {
-                warn!("Encountered error while dropping detached context: {}", e);
+            trace!(address=%self.address(), "de-allocated detached context");
+            if let Err(err) = sender.send(self.address()) {
+                warn!(address=%self.address(), %err,
+                    "couldn't drop detached context");
             }
         }
     }

--- a/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/receive_message.rs
@@ -61,7 +61,7 @@ impl Context {
     pub(crate) async fn receiver_next(&mut self) -> Result<Option<RelayMessage>> {
         loop {
             let relay_msg = if let Some(msg) = self.receiver.recv().await.map(|msg| {
-                trace!("{}: received new message!", self.address());
+                trace!(address=%self.address(), "received new message!");
 
                 // First we update the mailbox fill metrics
                 self.mailbox_count.fetch_sub(1, Ordering::Acquire);

--- a/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
+++ b/implementations/rust/ockam/ockam_node/src/router/shutdown.rs
@@ -107,7 +107,7 @@ pub(super) async fn graceful(
             warn!(%timeout, "shutdown timeout reached; aborting node!");
             // This works only because the state of the router is `Stopping`
             if sender.send(NodeMessage::AbortNode).await.is_err() {
-                warn!("failed to send node abort signal to router");
+                warn!("couldn't send node abort signal to router");
             }
         });
     }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/lib.rs
@@ -11,11 +11,10 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate core;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate core;
 
 mod options;
 mod portal;

--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/addresses.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/addresses.rs
@@ -1,3 +1,4 @@
+use core::fmt::Display;
 use ockam_core::Address;
 
 /// Enumerate all portal types
@@ -24,6 +25,12 @@ impl PortalType {
             PortalType::Inlet | PortalType::Outlet => false,
             PortalType::PrivilegedInlet | PortalType::PrivilegedOutlet => true,
         }
+    }
+}
+
+impl Display for PortalType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.str())
     }
 }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/portals.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/portals.rs
@@ -9,7 +9,7 @@ use ockam_core::{route, Address, Result, Route};
 use ockam_node::compat::asynchronous::RwLock;
 use ockam_node::Context;
 use ockam_transport_core::{parse_socket_addr, HostnamePort};
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 impl TcpTransport {
     /// Create Tcp Inlet that listens on bind_addr, transforms Tcp stream into Ockam Routable
@@ -237,8 +237,8 @@ impl TcpInlet {
 
     /// Pause TCP Inlet, all incoming TCP streams will be dropped.
     pub async fn pause(&self) {
+        debug!(address = %self.socket_address, "pausing inlet");
         let mut inlet_shared_state = self.inlet_shared_state.write().await;
-
         inlet_shared_state.set_is_paused(true);
     }
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/receiver.rs
@@ -16,7 +16,7 @@ use ockam_core::{Processor, Result};
 use ockam_node::{Context, ProcessorBuilder};
 use ockam_transport_core::TransportError;
 use tokio::{io::AsyncReadExt, net::tcp::OwnedReadHalf};
-use tracing::{info, instrument, trace};
+use tracing::{debug, instrument, trace};
 
 /// A TCP receiving message processor
 ///
@@ -99,7 +99,7 @@ impl TcpRecvProcessor {
     }
 
     async fn notify_sender_stream_dropped(&self, ctx: &Context, msg: impl Display) -> Result<()> {
-        info!(
+        debug!(
             "Connection to peer '{}' was closed; dropping stream. {}",
             self.socket_address, msg
         );

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/sender.rs
@@ -14,7 +14,7 @@ use ockam_transport_core::TransportError;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::net::tcp::OwnedWriteHalf;
-use tracing::{info, instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 
 #[derive(Serialize, Deserialize, Message, Clone)]
 pub(crate) enum TcpSendWorkerMsg {
@@ -223,7 +223,7 @@ impl Worker for TcpSendWorker {
 
             match msg {
                 TcpSendWorkerMsg::ConnectionClosed => {
-                    info!(
+                    debug!(
                         "Stopping sender due to closed connection {}",
                         self.socket_address
                     );

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/receiver.rs
@@ -6,7 +6,7 @@ use ockam_core::{
 use ockam_node::Context;
 use ockam_transport_core::TransportError;
 use tokio::{io::AsyncReadExt, net::unix::OwnedReadHalf};
-use tracing::{error, info, trace};
+use tracing::{debug, error, trace};
 
 /// A UDS receiving message processor
 ///
@@ -48,7 +48,7 @@ impl Processor for UdsRecvProcessor {
         let len = match self.rx.read_u16().await {
             Ok(len) => len,
             Err(_e) => {
-                info!(
+                debug!(
                     "Connection to peer '{}' was closed; dropping stream",
                     self.peer_addr
                 );

--- a/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
+++ b/implementations/rust/ockam/ockam_transport_uds/src/workers/sender.rs
@@ -258,7 +258,7 @@ impl Worker for UdsSendWorker {
 
             match msg {
                 UdsSendWorkerMsg::ConnectionClosed => {
-                    warn!("Stopping sender due to closed connection");
+                    debug!("Stopping sender due to closed connection");
                     // No need to stop Receiver as it notified us about connection drop and will
                     // stop itself
                     self.rx_should_be_stopped = false;

--- a/implementations/rust/ockam/ockam_transport_websocket/src/workers/receiver.rs
+++ b/implementations/rust/ockam/ockam_transport_websocket/src/workers/receiver.rs
@@ -58,7 +58,7 @@ where
             Some(res) => match res {
                 Ok(ws_msg) => ws_msg,
                 Err(_e) => {
-                    info!(
+                    debug!(
                         "Connection to peer '{}' was closed; dropping stream",
                         self.peer_addr
                     );


### PR DESCRIPTION
Improves the logs at the `-vv` level for node/relay/inlet/outlet commands.

The goal of these changes is to show the most relevant information, and move the rest to the next verbosity level.


### Log format
This PR also adds a custom log format, to show the event contents before the scope, and not the other way around:


```
# before
2024-12-10T15:22:03.822769Z DEBUG foreground_mode{node_name="n1"}:new in-memory node{node_name="n1"}:create_node_manager{node_name="n1"}: ockam_abac::policy::storage::resource_type_policy_repository_sql: create a repository for resource type policies

# now
2024-12-10T15:22:03.822769Z DEBUG create a repository for resource type [policies foreground_mode{node_name="n1"}:new in-memory node{node_name="n1"}:create_node_manager{node_name="n1"}: ockam_abac::policy::storage::resource_type_policy_repository_sql] 
```

### TCP Inlet and Relay status updates

The command now shows messages when an inlet/relay loses/restores the connection:

![image](https://github.com/user-attachments/assets/5125844d-8025-49e2-8f29-69fc91ef4afb)
