### PR TITLE
feat(rust): reduce the api versions to the supported range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.87",
 ]
 
@@ -2159,37 +2158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -3849,15 +3817,14 @@ dependencies = [
 
 [[package]]
 name = "kafka-protocol"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568bb6ab2e96399bbce79e33ddaf01f5db0827a182bb2cb5f95d6a9eae0ea68"
+checksum = "d1edaf2fc3ecebe689bbc4fd97a6921cacd4cd09df8ebeda348a8e23c9fd48d4"
 dependencies = [
  "anyhow",
  "bytes 1.8.0",
  "crc",
  "crc32c",
- "derive_builder",
  "flate2",
  "indexmap 2.6.0",
  "lz4",

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -159,9 +159,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | ctrlc | MIT, Apache-2.0 | https://crates.io/crates/ctrlc |
 | curve25519-dalek | BSD-3-Clause | https://crates.io/crates/curve25519-dalek |
 | curve25519-dalek-derive | MIT, Apache-2.0 | https://crates.io/crates/curve25519-dalek-derive |
-| darling | MIT | https://crates.io/crates/darling |
-| darling_core | MIT | https://crates.io/crates/darling_core |
-| darling_macro | MIT | https://crates.io/crates/darling_macro |
 | dashmap | MIT | https://crates.io/crates/dashmap |
 | data-encoding | MIT | https://crates.io/crates/data-encoding |
 | dbus | Apache-2.0, MIT | https://crates.io/crates/dbus |
@@ -169,9 +166,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | delegate | MIT, Apache-2.0 | https://crates.io/crates/delegate |
 | der | Apache-2.0, MIT | https://crates.io/crates/der |
 | deranged | MIT, Apache-2.0 | https://crates.io/crates/deranged |
-| derive_builder | MIT, Apache-2.0 | https://crates.io/crates/derive_builder |
-| derive_builder_core | MIT, Apache-2.0 | https://crates.io/crates/derive_builder_core |
-| derive_builder_macro | MIT, Apache-2.0 | https://crates.io/crates/derive_builder_macro |
 | dialoguer | MIT | https://crates.io/crates/dialoguer |
 | digest | MIT, Apache-2.0 | https://crates.io/crates/digest |
 | displaydoc | MIT, Apache-2.0 | https://crates.io/crates/displaydoc |
@@ -272,7 +266,6 @@ This file contains attributions for any 3rd-party open source code used in this 
 | icu_properties_data | Unicode-3.0 | https://crates.io/crates/icu_properties_data |
 | icu_provider | Unicode-3.0 | https://crates.io/crates/icu_provider |
 | icu_provider_macros | Unicode-3.0 | https://crates.io/crates/icu_provider_macros |
-| ident_case | MIT, Apache-2.0 | https://crates.io/crates/ident_case |
 | idna | MIT, Apache-2.0 | https://crates.io/crates/idna |
 | idna_adapter | Apache-2.0, MIT | https://crates.io/crates/idna_adapter |
 | image | MIT, Apache-2.0 | https://crates.io/crates/image |

--- a/implementations/rust/ockam/ockam_api/Cargo.toml
+++ b/implementations/rust/ockam/ockam_api/Cargo.toml
@@ -73,7 +73,7 @@ jaq-core = "1"
 jaq-interpret = "1"
 jaq-parse = "1"
 jaq-std = "1"
-kafka-protocol = "0.10"
+kafka-protocol = "0.13"
 log = "0.4"
 miette = { version = "7.2.0", features = ["fancy-no-backtrace"] }
 minicbor = { version = "0.25.1", default-features = false, features = ["alloc", "derive"] }

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/response.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/outlet/response.rs
@@ -58,11 +58,11 @@ impl KafkaMessageResponseInterceptor for OutletInterceptorImpl {
                 let response: MetadataResponse =
                     decode_body(&mut buffer, request_info.request_api_version)?;
 
-                for (broker_id, metadata) in response.brokers {
-                    let address = format!("{}:{}", metadata.host.as_str(), metadata.port);
+                for broker in response.brokers {
+                    let address = format!("{}:{}", broker.host.as_str(), broker.port);
                     let outlet_address = self
                         .outlet_controller
-                        .assert_outlet_for_broker(context, broker_id.0, address)
+                        .assert_outlet_for_broker(context, broker.node_id.0, address)
                         .await?;
 
                     // allow the interceptor to reach the outlet

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/tests.rs
@@ -14,7 +14,7 @@ mod test {
     use kafka_protocol::messages::BrokerId;
     use kafka_protocol::messages::{ApiVersionsRequest, MetadataRequest, MetadataResponse};
     use kafka_protocol::messages::{ApiVersionsResponse, RequestHeader, ResponseHeader};
-    use kafka_protocol::protocol::{Builder, StrBytes};
+    use kafka_protocol::protocol::StrBytes;
     use ockam_abac::{Action, Env, Resource, ResourceType};
     use ockam_core::route;
     use ockam_multiaddr::MultiAddr;
@@ -82,20 +82,13 @@ mod test {
                 .intercept_request(
                     context,
                     encode_request(
-                        &RequestHeader::builder()
-                            .request_api_version(api_version)
-                            .correlation_id(correlation_id)
-                            .request_api_key(ApiKey::ApiVersionsKey as i16)
-                            .unknown_tagged_fields(Default::default())
-                            .client_id(None)
-                            .build()
-                            .unwrap(),
-                        &ApiVersionsRequest::builder()
-                            .client_software_name(StrBytes::from_static_str("mr. software"))
-                            .client_software_version(StrBytes::from_static_str("1.0.0"))
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
+                        &RequestHeader::default()
+                            .with_request_api_version(api_version)
+                            .with_correlation_id(correlation_id)
+                            .with_request_api_key(ApiKey::ApiVersionsKey as i16),
+                        &ApiVersionsRequest::default()
+                            .with_client_software_name(StrBytes::from_static_str("mr. software"))
+                            .with_client_software_version(StrBytes::from_static_str("1.0.0")),
                         api_version,
                         ApiKey::ApiVersionsKey,
                     )
@@ -111,21 +104,8 @@ mod test {
                 .intercept_response(
                     context,
                     encode_response(
-                        &ResponseHeader::builder()
-                            .correlation_id(correlation_id)
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
-                        &ApiVersionsResponse::builder()
-                            .error_code(0)
-                            .api_keys(Default::default())
-                            .throttle_time_ms(0)
-                            .supported_features(Default::default())
-                            .finalized_features_epoch(0)
-                            .finalized_features(Default::default())
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
+                        &ResponseHeader::default().with_correlation_id(correlation_id),
+                        &ApiVersionsResponse::default(),
                         api_version,
                         ApiKey::ApiVersionsKey,
                     )
@@ -145,22 +125,11 @@ mod test {
                 .intercept_request(
                     context,
                     encode_request(
-                        &RequestHeader::builder()
-                            .request_api_version(api_version)
-                            .correlation_id(correlation_id)
-                            .request_api_key(ApiKey::MetadataKey as i16)
-                            .unknown_tagged_fields(Default::default())
-                            .client_id(None)
-                            .build()
-                            .unwrap(),
-                        &MetadataRequest::builder()
-                            .topics(None)
-                            .allow_auto_topic_creation(true)
-                            .include_cluster_authorized_operations(false)
-                            .include_topic_authorized_operations(false)
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
+                        &RequestHeader::default()
+                            .with_request_api_version(api_version)
+                            .with_correlation_id(correlation_id)
+                            .with_request_api_key(ApiKey::MetadataKey as i16),
+                        &MetadataRequest::default(),
                         api_version,
                         ApiKey::MetadataKey,
                     )
@@ -176,21 +145,8 @@ mod test {
                 .intercept_response(
                     context,
                     encode_response(
-                        &ResponseHeader::builder()
-                            .correlation_id(correlation_id)
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
-                        &MetadataResponse::builder()
-                            .throttle_time_ms(0)
-                            .brokers(Default::default())
-                            .cluster_id(None)
-                            .controller_id(BrokerId::from(0_i32))
-                            .cluster_authorized_operations(-2147483648)
-                            .topics(Default::default())
-                            .unknown_tagged_fields(Default::default())
-                            .build()
-                            .unwrap(),
+                        &ResponseHeader::default().with_correlation_id(correlation_id),
+                        &MetadataResponse::default().with_controller_id(BrokerId::from(0_i32)),
                         api_version,
                         ApiKey::MetadataKey,
                     )

--- a/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
+++ b/implementations/rust/ockam/ockam_api/src/kafka/protocol_aware/utils.rs
@@ -11,8 +11,9 @@ where
 {
     let response = match T::decode(buffer, api_version) {
         Ok(response) => response,
-        Err(_) => {
-            warn!("cannot decode kafka message");
+        Err(error) => {
+            warn!("cannot decode kafka message, closing connection");
+            debug!("error: {:?}", error);
             return Err(InterceptError::InvalidData);
         }
     };


### PR DESCRIPTION
The latest kafka client `3.9.0` uses the version 4 of `ApiVersions` request, which is not supported at this time and causes Kafka inlet to fail.
To avoid the above-mentioned failure, and future similar issues, we can reduce the supported API version range only to the supported versions.
The `kafka-protocol` was updated to the latest version, resulting in some breaking changes.

```
$ OCKAM=target/debug/ockam DOCS_TESTS=1 ORCHESTRATOR_TESTS=1 bats implementations/rust/ockam/ockam_command/tests/bats/kafka/
docker.bats
 ✓ kafka - docker - end-to-end-encrypted - explicit consumer - redpanda
 ✓ kafka - docker - end-to-end-encrypted - explicit consumer - apache
 ✓ kafka - docker - end-to-end-encrypted - project relay consumer - redpanda
 ✓ kafka - docker - end-to-end-encrypted - project relay consumer - apache
 ✓ kafka - docker - end-to-end-encrypted - rust relay consumer - redpanda
 ✓ kafka - docker - end-to-end-encrypted - rust relay consumer - apache
 ✓ kafka - docker - end-to-end-encrypted - direct connection - redpanda
 ✓ kafka - docker - end-to-end-encrypted - direct connection - apache
 ✓ kafka - docker - end-to-end-encrypted - single gateway - redpanda
 ✓ kafka - docker - end-to-end-encrypted - single gateway - apache
 ✓ kafka - docker - cleartext - redpanda
 ✓ kafka - docker - cleartext - apache
 ✓ kafka - docker - end-to-end-encrypted - offset decryption - redpanda
 ✓ kafka - docker - end-to-end-encrypted - offset decryption - apache
 ✓ kafka - docker - encrypt only two fields - redpanda
 ✓ kafka - docker - encrypt only two fields - apache
```