### PR TITLE
fix(rust): use legacy netlink ebpf attachment on kernel version 6.6.0+

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/ebpf_support.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/privileged_portal/ebpf_support.rs
@@ -4,7 +4,7 @@ use crate::privileged_portal::{
     Iface, InletRegistry, OutletRegistry, Port, Proto, RawSocketProcessor, TcpPacketWriter,
 };
 use aya::maps::{MapData, MapError};
-use aya::programs::tc::SchedClassifierLink;
+use aya::programs::tc::{NlOptions, SchedClassifierLink, TcAttachOptions};
 use aya::programs::{tc, Link, ProgramError, SchedClassifier, TcAttachType};
 use aya::{Ebpf, EbpfError};
 use aya_log::EbpfLogger;
@@ -277,11 +277,17 @@ impl TcpTransportEbpfSupport {
             .unwrap()
             .try_into()
             .map_err(map_program_error)?;
+
         if !skip_load {
             program_ingress.load().map_err(map_program_error)?;
         }
+
         let link_id = program_ingress
-            .attach(&iface, TcAttachType::Ingress)
+            .attach_with_options(
+                &iface,
+                TcAttachType::Ingress,
+                TcAttachOptions::Netlink(NlOptions::default()),
+            )
             .map_err(map_program_error)?;
         let link_id = program_ingress
             .take_link(link_id)
@@ -306,11 +312,17 @@ impl TcpTransportEbpfSupport {
             .unwrap()
             .try_into()
             .map_err(map_program_error)?;
+
         if !skip_load {
             program_egress.load().map_err(map_program_error)?;
         }
+
         let link_id = program_egress
-            .attach(&iface, TcAttachType::Egress)
+            .attach_with_options(
+                &iface,
+                TcAttachType::Egress,
+                TcAttachOptions::Netlink(NlOptions::default()),
+            )
             .map_err(map_program_error)?;
         let link_id = program_egress
             .take_link(link_id)


### PR DESCRIPTION
aya uses newer approach for attaching eBPFs on kernel version 6.6.0+. That attachment approach should be preferable, but currently I notice an unwanted behaviour with it: `TC_ACT_PIPE` returned from the eBPF doesn't pass the packet to the next eBPF, instead it's treated as `TC_ACT_OK` and moves the packet further the kernel network stack. This makes impossible attaching more that 1 Ockam eBPF at a time, which means only one Ockam node with Privileged Portals can function at a time on a machine.

This PR is a hotfix and uses older netlink interface to attach the eBPF even if the kernel supports the newer approach.