### PR TITLE
ci: update release page homebrew command

### DIFF
--- a/.github/workflows/release-draft-binaries.yml
+++ b/.github/workflows/release-draft-binaries.yml
@@ -71,7 +71,7 @@ jobs:
           To install this release using Homebrew:
 
           \`\`\`bash
-          $ brew install build-trust/ockam/ockam
+          brew install build-trust/ockam/ockam
           \`\`\`"
 
           # Install Docker image


### PR DESCRIPTION
* Remove `$` so it's easy to copy paste brew command to install ockam from ockam release page