### PR TITLE
feat(rust): setting `no_delay` in every tcp connection

### DIFF
--- a/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/portal/inlet_listener.rs
@@ -178,6 +178,7 @@ impl Processor for TcpInletListenProcessor {
     #[instrument(skip_all, name = "TcpInletListenProcessor::process")]
     async fn process(&mut self, ctx: &mut Self::Context) -> Result<bool> {
         let (stream, socket_addr) = self.inner.accept().await.map_err(TransportError::from)?;
+        stream.set_nodelay(true).map_err(TransportError::from)?;
 
         let addresses = Addresses::generate(PortalType::Inlet);
 

--- a/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/transport/common.rs
@@ -47,6 +47,7 @@ pub(crate) async fn create_tcp_stream(to: &HostnamePort) -> Result<TcpStream> {
     socket
         .set_tcp_keepalive(&keepalive)
         .map_err(TransportError::from)?;
+    socket.set_nodelay(true).map_err(TransportError::from)?;
 
     Ok(connection)
 }

--- a/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
+++ b/implementations/rust/ockam/ockam_transport_tcp/src/workers/listener.rs
@@ -79,6 +79,8 @@ impl Processor for TcpListenProcessor {
 
         // Wait for an incoming connection
         let (stream, peer) = self.inner.accept().await.map_err(TransportError::from)?;
+
+        stream.set_nodelay(true).map_err(TransportError::from)?;
         debug!("TCP connection accepted");
 
         let mode = TcpConnectionMode::Incoming;


### PR DESCRIPTION
Slash the latency of ockam communication by sending packets as soon as a socket is written.