### PR TITLE
feat(rust): add a payment role

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
@@ -801,6 +801,7 @@ mod test {
                 RoleInShare::Admin => "me@ockam.io",
                 RoleInShare::Service => "service@ockam.com",
                 RoleInShare::Guest => "guest@ockam.com",
+                RoleInShare::Payment => "payment@ockam.com",
             },
         }
         .try_into()

--- a/implementations/rust/ockam/ockam_api/src/orchestrator/share/invitation.rs
+++ b/implementations/rust/ockam/ockam_api/src/orchestrator/share/invitation.rs
@@ -16,6 +16,7 @@ pub enum RoleInShare {
     #[n(0)] Admin,
     #[n(1)] Guest,
     #[n(2)] Service,
+    #[n(3)] Payment,
 }
 
 impl Display for RoleInShare {
@@ -24,6 +25,7 @@ impl Display for RoleInShare {
             Self::Admin => write!(f, "admin"),
             Self::Guest => write!(f, "guest"),
             Self::Service => write!(f, "service_user"),
+            Self::Payment => write!(f, "payment"),
         }
     }
 }
@@ -36,6 +38,7 @@ impl FromStr for RoleInShare {
             "admin" => Ok(Self::Admin),
             "guest" => Ok(Self::Guest),
             "service_user" => Ok(Self::Service),
+            "payment" => Ok(Self::Payment),
             other => Err(format!("unknown role: {other}")),
         }
     }


### PR DESCRIPTION
This role corresponds to [the `billing` role (soon to be renamed to `payment`) role on the Orchestrator side](https://github.com/build-trust/ockam-orchestrator/blob/892d701eefdb392f451deebe81fc01ec12b1b9b3/controller/controller/lib/ockam_cloud_console_api/projects/protocol/user_role.ex#L10).