### PR TITLE
test(rust): in bats tests, use `--retry-all-errors` flag to curl usages

### DIFF
--- a/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/command_reference.bats
@@ -93,7 +93,7 @@ teardown() {
   run_success "$OCKAM" tcp-outlet create --at n3 --to "$PYTHON_SERVER_PORT"
   run_success "$OCKAM" tcp-inlet create --at n1 --from "$inlet_port" --to "/worker/${n1_id}/service/forward_to_n3/service/hop/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # ===== TESTS https://docs.ockam.io/reference/command/routing

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/portals.bats
@@ -152,7 +152,7 @@ teardown() {
   port="$(random_port)"
   run_success "$OCKAM" tcp-inlet create --at /node/n2 --from "$port" --to /node/n1/service/outlet
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - create an inlet/outlet, download file" {
@@ -165,7 +165,7 @@ teardown() {
 
   file_name="$(random_str)".bin
   pushd "$OCKAM_HOME_BASE" && dd if=/dev/urandom of="./.tmp/$file_name" bs=1M count=50 && popd
-  run_success curl -sSf -m 20 -o /dev/null "http://127.0.0.1:$port/.tmp/$file_name"
+  run_success curl -sSf --retry-all-errors --retry-delay 5 --retry 10 -m 20 -o /dev/null "http://127.0.0.1:$port/.tmp/$file_name"
 }
 
 @test "portals - create an inlet/outlet, upload file" {
@@ -182,7 +182,7 @@ teardown() {
   mkdir "$tmp_dir_name"
   dd if=/dev/urandom of="./$tmp_dir_name/$file_name" bs=1M count=50
   popd
-  run_success curl -sS -m 20 -X POST "http://127.0.0.1:$port/upload" -F "files=@$OCKAM_HOME_BASE/.tmp/$tmp_dir_name/$file_name"
+  run_success curl -sS --retry-all-errors --retry-delay 5 --retry 10 -m 20 -X POST "http://127.0.0.1:$port/upload" -F "files=@$OCKAM_HOME_BASE/.tmp/$tmp_dir_name/$file_name"
 }
 
 @test "portals - create an inlet/outlet pair and move tcp traffic through it, where the outlet points to an HTTPs endpoint" {
@@ -209,7 +209,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /node/relay/service/forward_to_blue/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 
   run_success "$OCKAM" secure-channel list --at green
   assert_output --partial "/service"
@@ -256,7 +256,7 @@ teardown() {
   run_success "$OCKAM" node create green
   inlet_port="$(random_port)"
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$inlet_port" --to /node/blue/secure/api/service/outlet
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   run_success "$OCKAM" node delete blue --yes
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
@@ -278,7 +278,7 @@ teardown() {
   run_success "$OCKAM" tcp-outlet create --at /node/n2 --to "$PYTHON_SERVER_PORT"
 
   sleep 15
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"
 }
 
 @test "portals - local portal, curl download, inlet credential expires" {
@@ -467,5 +467,5 @@ teardown() {
   # Create an inlet with the alt's identifier. Now it should be allowed to connect
   port="$(random_port)"
   run_success "$OCKAM" tcp-inlet create --from "127.0.0.1:$port" --to /node/n/secure/api/service/outlet --identity alt
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 2 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 2 -m 5 "127.0.0.1:$port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/rendezvous_server.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/rendezvous_server.bats
@@ -22,7 +22,7 @@ teardown() {
 
   sleep 1
 
-  run_success curl -m 5 "127.0.0.1:$port"
+  run_success curl --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
   assert_output --partial "Alive"
 }
 
@@ -42,5 +42,5 @@ teardown() {
   run_success "$OCKAM" node create alice --udp
   run_success "$OCKAM" tcp-inlet create --at alice --udp --no-tcp-fallback --from "$inlet_port" --to /node/bob/secure/api/service/outlet
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/local/use_cases.bats
@@ -32,5 +32,5 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/client_sidecar --to /node/relay/service/forward_to_server_sidecar/service/api \
               | $OCKAM tcp-inlet create --at /node/client_sidecar --from $port --to -/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/portals.bats
@@ -30,7 +30,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - create an inlet using only default arguments, an outlet, a relay in an orchestrator project and move tcp traffic through it" {
@@ -41,7 +41,7 @@ teardown() {
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
 
   addr=$($OCKAM tcp-inlet create --via $relay_name)
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 $addr
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 $addr
 }
 
 @test "portals - create an inlet (with implicit secure channel creation), an outlet, a relay in an orchestrator project and move tcp traffic through it" {
@@ -56,7 +56,7 @@ teardown() {
   run_success "$OCKAM" node create green
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$port" --via "$relay_name"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - inlet/outlet example with credential, not provided" {
@@ -160,7 +160,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
               | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - inlet (with implicit secure channel creation) / outlet example with enrollment token" {
@@ -193,7 +193,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green \
     --from "$port" --via "$relay_name" --allow '(= subject.app "app1")'
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "portals - local inlet and outlet passing through a relay, removing and re-creating the outlet" {
@@ -207,7 +207,7 @@ teardown() {
 
   run_success "$OCKAM" node create green
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "$inlet_port" --via "$relay_name"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   $OCKAM node delete blue --yes
   run_failure curl -sfI -m 3 "127.0.0.1:$inlet_port"
@@ -215,7 +215,7 @@ teardown() {
   run_success "$OCKAM" node create blue --tcp-listener-address "127.0.0.1:$node_port"
   run_success "$OCKAM" tcp-outlet create --at /node/blue --to 127.0.0.1:$PYTHON_SERVER_PORT
   run_success "$OCKAM" relay create "$relay_name" --to /node/blue
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 @test "portals - create an inlet/outlet pair, copy heavy payload" {
@@ -235,7 +235,7 @@ teardown() {
   run_success openssl rand -out "${OCKAM_HOME_BASE}/.tmp/payload" $((1024 * 1024 * 10))
 
   # write payload to file `payload.copy`
-  run_success curl -sf -m 60 "127.0.0.1:${port}/.tmp/payload" -o "${OCKAM_HOME}/payload.copy"
+  run_success curl -sf --retry-all-errors --retry-delay 5 --retry 10 -m 60 "127.0.0.1:${port}/.tmp/payload" -o "${OCKAM_HOME}/payload.copy"
 
   # compare `payload` and `payload.copy`
   run_success cmp "${OCKAM_HOME_BASE}/.tmp/payload" "${OCKAM_HOME}/payload.copy"
@@ -264,7 +264,7 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --at /node/green --from "${inlet_port}" \
     --via "${relay_name}"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:${inlet_port}"
   status=$("$OCKAM" relay show "${relay_name}" --output json | jq .connection_status -r)
   assert_equal "$status" "Up"
 
@@ -300,13 +300,13 @@ teardown() {
   run_success "$OCKAM" tcp-inlet create --tls --from $port --to /secure/api/service/outlet
 
   # first wait for the connection without validation
-  run_success curl -sfI --insecure --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+  run_success curl -sfI --insecure --retry-all-errors --retry-delay 5 --retry 10 -m 5 \
     "https://127.0.0.1:${port}"
 
   # extract certificate subject
   subject=$(openssl s_client -showcerts -connect "127.0.0.1:${port}" </dev/null 2>&1 |
     grep -o 'subject=CN=.*' | sed -E 's/.*CN=[*][.](.*)/\1/')
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 \
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 \
     "https://arbitrary-name.${subject}:${port}"
 }

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/relay.bats
@@ -30,7 +30,7 @@ teardown() {
   run_success bash -c "$OCKAM secure-channel create --from /node/green --to /project/default/service/forward_to_$relay_name/service/api \
     | $OCKAM tcp-inlet create --at /node/green --from $port --to -/service/outlet"
 
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port"
 }
 
 @test "relay - control who can create/claim a relay" {

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator/use_cases.bats
@@ -34,7 +34,7 @@ teardown() {
 
   # Client
   run_success $OCKAM tcp-inlet create --from "$inlet_port" --via "$relay_name"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # https://docs.ockam.io/use-cases/apply-fine-grained-permissions-with-attribute-based-access-control-abac
@@ -70,7 +70,7 @@ teardown() {
   $OCKAM node create edge_plane1 --identity edge_identity
   $OCKAM tcp-inlet create --at /node/edge_plane1 --from "$port_1" \
     --via "$relay_name" --allow '(= subject.component "control")'
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port_1"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$port_1"
 
   ## The following is denied
   $OCKAM identity create x_identity
@@ -91,6 +91,7 @@ teardown() {
 
   # Ensure that telegraf works without using Ockam route
   run_success curl -s \
+    --retry-all-errors --retry-delay 5 --retry 10 \
     --header "Authorization: Token $INFLUX_TOKEN" \
     --header "Accept: application/csv" \
     --header 'Content-type: application/vnd.flux' \
@@ -124,6 +125,7 @@ teardown() {
 
   # Ensure that telegraf works with using Ockam route
   run_success curl -s \
+    --retry-all-errors --retry-delay 5 --retry 10 \
     --header "Authorization: Token $INFLUX_TOKEN" \
     --header "Accept: application/csv" \
     --header 'Content-type: application/vnd.flux' \

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/nodes.bats
@@ -44,14 +44,14 @@ EOF
   run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.basic.config.yaml" \
     --enrollment-ticket "$ticket_path" \
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 
   ## Second time it will skip the enrollment step and the node will be set up as expected
   run_success "$OCKAM" node delete --all -y
   run_success "$OCKAM" node create "$BATS_TEST_DIRNAME/fixtures/node-create.basic.config.yaml" \
     --enrollment-ticket "$ticket_path" \
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 }
 
 @test "nodes - create with config in foreground" {
@@ -72,7 +72,7 @@ EOF
     --variable SERVICE_PORT="$PYTHON_SERVER_PORT" &
   sleep 10
   run_success "$OCKAM" message send hello --timeout 2 --to "/node/n1/secure/api/service/echo"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 }
 
 @test "nodes - create with config, single machine, unnamed portal" {
@@ -88,7 +88,7 @@ EOF
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$NODE_PORT/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 }
 
 @test "nodes - in-memory, create with config, single machine, unnamed portal" {
@@ -106,7 +106,7 @@ EOF
   sleep 5
 
   # portal is working: inlet -> relay -> outlet -> python server
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 
   kill -9 $pid
 }
@@ -124,7 +124,7 @@ EOF
   # tcp-listener-address set to expected port
   run_success "$OCKAM" message send --timeout 5 hello --to "/dnsaddr/127.0.0.1/tcp/$NODE_PORT/secure/api/service/echo"
   # portal is working: inlet -> relay -> outlet -> python server
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CLIENT_PORT"
 }
 
 @test "nodes - create with config, multiple machines" {
@@ -171,7 +171,7 @@ EOF
 
   # Test: SaaS service can be reached from Customer's inlet
   $OCKAM message send hi --to "/project/default/service/forward_to_to-$SAAS_RELAY_NAME/secure/api/service/echo"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CUSTOMER_INLET_PORT"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$CUSTOMER_INLET_PORT"
 
   # Test: Customer node can be reached from SaaS's side
   export OCKAM_HOME="$SAAS_HOME_DIR"

--- a/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/policies.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/orchestrator_enroll/policies.bats
@@ -36,7 +36,7 @@ teardown() {
   run_success $OCKAM project enroll $web_ticket
   inlet_port="$(random_port)"
   run_success $OCKAM tcp-inlet create --from $inlet_port --via $relay_name
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Dashboard - Doesn't have the right attribute, so it should not be able to connect
   setup_home_dir
@@ -73,7 +73,7 @@ teardown() {
   # Update resource type policy and try again. Now the policy is satisfied
   export OCKAM_HOME=$DB_OCKAM_HOME
   run_success $OCKAM policy create --resource-type tcp-outlet --allow 'component.web'
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 
   # Update the policy for the outlet and try again. It will fail because the local policy is not satisfied
   run_success $OCKAM policy create --resource-type tcp-outlet --allow 'component.NOT_web'

--- a/implementations/rust/ockam/ockam_command/tests/bats/serial/use_cases.bats
+++ b/implementations/rust/ockam/ockam_command/tests/bats/serial/use_cases.bats
@@ -36,7 +36,7 @@ teardown() {
 
   # Client
   run_success $OCKAM tcp-inlet create --from "$inlet_port"
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 "127.0.0.1:$inlet_port"
 }
 
 # https://docs.ockam.io/guides/examples/create-secure-communication-with-a-private-database-from-anywhere
@@ -98,7 +98,7 @@ teardown() {
 
   # Alice request to access Machine 1 in San Francisco is allowed
   run_success "$OCKAM" tcp-inlet create --at /node/alice --from 127.0.0.1:8000 --via m1 --allow '(= subject.application "Smart Factory")'
-  run_success curl -sfI --retry-connrefused --retry-delay 5 --retry 10 -m 5 127.0.0.1:8000
+  run_success curl -sfI --retry-all-errors --retry-delay 5 --retry 10 -m 5 127.0.0.1:8000
 
   # Alice request to access Machine 2 in New York is denied
   run_success "$OCKAM" tcp-inlet create --at /node/alice --from 127.0.0.1:9000 --via m2 --allow '(= subject.application "Smart Factory")'
@@ -213,11 +213,11 @@ EOF
   run_success start_python_server
 
   # Visit website
-  run_success curl -f -m 5 "http://127.0.0.1:$FLASK_PORT"
+  run_success curl -f --retry-all-errors --retry-delay 5 --retry 10 -m 5 "http://127.0.0.1:$FLASK_PORT"
   assert_output --partial "I've been visited 1 times"
 
   # Visit website second time
-  run_success curl -f -m 5 "http://127.0.0.1:$FLASK_PORT"
+  run_success curl -f --retry-all-errors --retry-delay 5 --retry 10 -m 5 "http://127.0.0.1:$FLASK_PORT"
   assert_output --partial "I've been visited 2 times"
 
   run_success kill_flask_server
@@ -252,9 +252,9 @@ EOF
   run_success start_python_server
 
   # Visit website
-  run_success curl -f -m 5 "http://127.0.0.1:$FLASK_PORT"
+  run_success curl -f --retry-all-errors --retry-delay 5 --retry 10 -m 5 "http://127.0.0.1:$FLASK_PORT"
   assert_output --partial "I've been visited 3 times"
   # Visit website second time
-  run_success curl -f -m 5 "http://127.0.0.1:$FLASK_PORT"
+  run_success curl -f --retry-all-errors --retry-delay 5 --retry 10 -m 5 "http://127.0.0.1:$FLASK_PORT"
   assert_output --partial "I've been visited 4 times"
 }


### PR DESCRIPTION
Fixes https://github.com/build-trust/codebase/issues/963