### PR TITLE
refactor(rust): rename telemetry env vars

### DIFF
--- a/examples/command/portals/snowflake/example-1/README.md
+++ b/examples/command/portals/snowflake/example-1/README.md
@@ -115,7 +115,7 @@ spec:
           allow: snowflake-api-service-inlet
     env:
         OCKAM_DISABLE_UPGRADE_CHECK: true
-        OCKAM_OPENTELEMETRY_EXPORT: false
+        OCKAM_TELEMETRY_EXPORT: false
 $$
 EXTERNAL_ACCESS_INTEGRATIONS = (OCKAM);
 

--- a/examples/command/portals/snowflake/example-2/README.md
+++ b/examples/command/portals/snowflake/example-2/README.md
@@ -137,7 +137,7 @@ spec:
     image: /acmecorp_db/acmecorp_schema/acmecorp_repository/ockam
     env:
         OCKAM_DISABLE_UPGRADE_CHECK: true
-        OCKAM_OPENTELEMETRY_EXPORT: false
+        OCKAM_TELEMETRY_EXPORT: false
     args:
       - node
       - create

--- a/examples/command/portals/snowflake/example-2/acme_api_service/docker-compose.yml
+++ b/examples/command/portals/snowflake/example-2/acme_api_service/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       ENROLLMENT_TICKET: ${ENROLLMENT_TICKET}
       OCKAM_DEVELOPER: ${OCKAM_DEVELOPER:-false}
-      OCKAM_OPENTELEMETRY_EXPORT: "false"
+      OCKAM_TELEMETRY_EXPORT: "false"
     command:
       - node
       - create

--- a/examples/command/portals/snowflake/example-5/README.md
+++ b/examples/command/portals/snowflake/example-5/README.md
@@ -186,7 +186,7 @@ $$
         image: /cdc_test_db/cdc_test_schema/cdc_test_repo/ockam
         env:
           OCKAM_DISABLE_UPGRADE_CHECK: true
-          OCKAM_OPENTELEMETRY_EXPORT: false
+          OCKAM_TELEMETRY_EXPORT: false
           ENROLLMENT_TICKET: "<OCKAM_ENROLLMENT_TICKET>"
       - name: publisher
         image: /cdc_test_db/cdc_test_schema/cdc_test_repo/snowflake_cdc_kafka_bridge

--- a/examples/command/portals/vercel/example-1/api/index.py
+++ b/examples/command/portals/vercel/example-1/api/index.py
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import time
 from http.server import BaseHTTPRequestHandler
+
 import requests
 
 # Constants
@@ -21,9 +22,11 @@ REQUEST_TIMEOUT = 3  # seconds
 # Only one Ockam node should run per serverless function runtime - this flag prevents multiple node creation attempts.
 NODE_INITIALIZED = False
 
+
 def is_production() -> bool:
     """Check if the environment is production."""
     return os.environ.get('VERCEL_ENV') == 'production'
+
 
 def get_ockam_version() -> str:
     """
@@ -40,6 +43,7 @@ def get_ockam_version() -> str:
         return result.stdout.strip() if result.returncode == 0 else f"Error running ockam: {result.stderr}"
     except Exception as e:
         return f"Error: {str(e)} (CWD: {os.getcwd()})"
+
 
 class handler(BaseHTTPRequestHandler):
     """Handler for Snowflake API requests via Ockam secure channel."""
@@ -83,7 +87,7 @@ class handler(BaseHTTPRequestHandler):
                     ], env={
                         **os.environ,
                         'OCKAM_HOME': '/tmp',
-                        'OCKAM_OPENTELEMETRY_EXPORT': 'false',
+                        'OCKAM_TELEMETRY_EXPORT': 'false',
                         'OCKAM_DISABLE_UPGRADE_CHECK': 'true'
                     })
 

--- a/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/default_values.rs
@@ -22,15 +22,15 @@ pub(crate) const DEFAULT_OPENTELEMETRY_ENDPOINT: &str =
 /// TRACING
 ///
 
-/// Timeout for trying to access the OpenTelemetry collector endpoint when running a command
+/// Timeout for trying to access the Telemetry collector endpoint when running a command
 /// It is quite high but experimentation shows that sometimes there's quite some lag even if the endpoint is available
-pub(crate) const DEFAULT_OPENTELEMETRY_ENDPOINT_FOREGROUND_CONNECTION_TIMEOUT: Duration =
+pub(crate) const DEFAULT_TELEMETRY_ENDPOINT_FOREGROUND_CONNECTION_TIMEOUT: Duration =
     Duration::from_millis(500);
 
-/// Timeout for trying to access the OpenTelemetry collector endpoint for a background
+/// Timeout for trying to access the Telemetry collector endpoint for a background
 /// Since the node is going to run uninterrupted, we leave a longer amount of time than for a command
 /// to try to reach the endpoint
-pub(crate) const DEFAULT_OPENTELEMETRY_ENDPOINT_BACKGROUND_CONNECTION_TIMEOUT: Duration =
+pub(crate) const DEFAULT_TELEMETRY_ENDPOINT_BACKGROUND_CONNECTION_TIMEOUT: Duration =
     Duration::from_secs(2);
 
 /// Timeout for exporting spans or log records

--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -29,11 +29,13 @@ pub(crate) const OCKAM_LOG_CRATES_FILTER: &str = "OCKAM_LOG_CRATES_FILTER";
 ///
 
 /// Decides if spans and log records should be created and exported. Accepted values, see BooleanVar. For example; true, false, 1, 0
+pub(crate) const OCKAM_TELEMETRY_EXPORT: &str = "OCKAM_TELEMETRY_EXPORT";
+
+/// Deprecated, use OCKAM_TELEMETRY_EXPORT instead
 pub(crate) const OCKAM_OPENTELEMETRY_EXPORT: &str = "OCKAM_OPENTELEMETRY_EXPORT";
 
 /// Decides if spans and log records should be exported via the project exporter portal. Accepted values, see BooleanVar. For example; true, false, 1, 0
-pub(crate) const OCKAM_OPENTELEMETRY_EXPORT_VIA_PORTAL: &str =
-    "OCKAM_OPENTELEMETRY_EXPORT_VIA_PORTAL";
+pub(crate) const OCKAM_TELEMETRY_EXPORT_VIA_PORTAL: &str = "OCKAM_TELEMETRY_EXPORT_VIA_PORTAL";
 
 /// Boolean set to true if the current user is an Ockam developer
 pub(crate) const OCKAM_DEVELOPER: &str = "OCKAM_DEVELOPER";
@@ -42,7 +44,7 @@ pub(crate) const OCKAM_DEVELOPER: &str = "OCKAM_DEVELOPER";
 pub(crate) const OCKAM_OPENTELEMETRY_EXPORT_DEBUG: &str = "OCKAM_OPENTELEMETRY_EXPORT_DEBUG";
 
 ///
-/// OPENTELEMETRY COLLECTOR ENDPOINT CONFIGURATION
+/// TELEMETRY COLLECTOR ENDPOINT CONFIGURATION
 ///
 
 /// URL for the OpenTelemetry collector. Accepted values, see UrlVar. For example: http://127.0.0.1:4317
@@ -50,26 +52,26 @@ pub(crate) const OCKAM_OPENTELEMETRY_ENDPOINT: &str = "OCKAM_OPENTELEMETRY_ENDPO
 
 /// Timeout for trying to connect to the endpoint before deciding that exporting traces
 /// from a foreground command will not be possible. For example: 500ms
-pub(crate) const OCKAM_FOREGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: &str =
-    "OCKAM_FOREGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT";
+pub(crate) const OCKAM_FOREGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: &str =
+    "OCKAM_FOREGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT";
 
 /// Timeout for trying to connect to the endpoint before deciding that exporting traces
 /// from a background node will not be possible. Accepted values, see DurationVar. For example: 500ms
-pub(crate) const OCKAM_BACKGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: &str =
-    "OCKAM_BACKGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT";
+pub(crate) const OCKAM_BACKGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: &str =
+    "OCKAM_BACKGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT";
 
 ///
-/// OPENTELEMETRY COLLECTOR EXPORT CONFIGURATION
+/// TELEMETRY COLLECTOR EXPORT CONFIGURATION
 ///
 
-/// Name of the background node used to export OpenTelemetry traces
-pub(crate) const OCKAM_OPENTELEMETRY_NODE_NAME: &str = "ockam-opentelemetry-inlet";
+/// Name of the background node used to export Telemetry traces
+pub(crate) const OCKAM_TELEMETRY_NODE_NAME: &str = "ockam-telemetry-inlet";
 
-/// Name of the inlet used to export OpenTelemetry traces
-pub(crate) const OCKAM_OPENTELEMETRY_INLET_ALIAS: &str = "ockam-opentelemetry";
+/// Name of the inlet used to export Telemetry traces
+pub(crate) const OCKAM_TELEMETRY_INLET_ALIAS: &str = "ockam-telemetry";
 
-/// Name of the relay used to export OpenTelemetry traces
-pub(crate) const OCKAM_OPENTELEMETRY_RELAY_NAME: &str = "ockam-opentelemetry";
+/// Name of the relay used to export Telemetry traces
+pub(crate) const OCKAM_TELEMETRY_RELAY_NAME: &str = "ockam-telemetry";
 
 /// Timeout for trying to export spans to the endpoint.
 /// Accepted values, see DurationVar. For example: 500ms
@@ -124,7 +126,7 @@ pub(crate) const OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF: &str = "OCKAM_BACKGROUND_LO
 pub(crate) const OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF: &str = "OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF";
 
 ///
-/// OPENTELEMETRY COLLECTOR ERRORS CONFIGURATION
+/// TELEMETRY COLLECTOR ERRORS CONFIGURATION
 ///
 
 /// Global error handler for the tracing crate

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -14,7 +14,7 @@ CLI Behavior
 
 Logging
 - OCKAM_LOG (deprecated, use OCKAM_LOGGING and OCKAM_LOG_LEVEL instead): a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`.
-- OCKAM_LOGGING: set this variable to any value in order to enable logging.
+- OCKAM_LOGGING: set this variable to a true value to enable logging: `1`, `true`, `yes`. Default value: `false`
 - OCKAM_LOG_LEVEL: a `string` that defines the verbosity of the logs when the `--verbose` argument is not passed: `info`, `warn`, `error`, `debug` or `trace`. Default value: `debug`.
 - OCKAM_LOG_FORMAT: a `string` that overrides the default format of the logs: `default`, `json`, or `pretty`. Default value: `default`.
 - OCKAM_LOG_MAX_SIZE_MB: an `integer` that defines the maximum size of a log file in MB. Default value `100`.
@@ -30,11 +30,11 @@ Database
 - OCKAM_POSTGRES_PASSWORD: Postgres database password. If it is not set, no authorization will be used to access the database.
 
 Tracing
-- OCKAM_OPENTELEMETRY_EXPORT: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`
+- OCKAM_TELEMETRY_EXPORT: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`
 - OCKAM_OPENTELEMETRY_ENDPOINT: the URL of an OpenTelemetry collector accepting gRPC.
 - OCKAM_OPENTELEMETRY_HEADERS: additional headers for the OTLP collector. This is where the Honeycomb API key can be specified if sending traces to Honeycomb directly.
-- OCKAM_FOREGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: Timeout for checking the availability of the OpenTelemetry collector endpoint for commands. Default value: `500ms`.
-- OCKAM_BACKGROUND_OPENTELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: Timeout for checking the availability of the OpenTelemetry collector endpoint for a background node. Default value: `5s`.
+- OCKAM_FOREGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: Timeout for checking the availability of the OpenTelemetry collector endpoint for commands. Default value: `500ms`.
+- OCKAM_BACKGROUND_TELEMETRY_ENDPOINT_CONNECTION_TIMEOUT: Timeout for checking the availability of the OpenTelemetry collector endpoint for a background node. Default value: `5s`.
 - OCKAM_SPAN_EXPORT_TIMEOUT: Timeout for trying to export spans. Default value: `5s`.
 - OCKAM_LOG_EXPORT_TIMEOUT: Timeout for trying to export log records. Default value: `5s`.
 - OCKAM_FOREGROUND_SPAN_EXPORT_SCHEDULED_DELAY: Timeout for exporting the current batch of spans. Default value: `1000s` (this value is high to avoid a deadlock in the tracing library).
@@ -42,10 +42,10 @@ Tracing
 - OCKAM_SPAN_EXPORT_QUEUE_SIZE: Size of the queue used to store batched spans before export. When the queue is full, spans are dropped. Default value: `32768`
 - OCKAM_LOG_EXPORT_QUEUE_SIZE: Size of the queue used to store batched log records before export. When the queue is full, log records are dropped. Default value: `32768`
 - OCKAM_TRACING_GLOBAL_ERROR_HANDLER: Configuration for printing tracing/logging errors: `console`, `logfile`, `off`. Default value: `logfile`.
-- OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry foreground node, without waiting for a response. Default value: `3s`.
-- OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry foreground inlet, without waiting for a response. Default value: `3s`.
-- OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an OpenTelemetry baclground node, without waiting for a response. Default value: `3s`.
-- OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an OpenTelemetry background inlet, without waiting for a response. Default value: `3s`.
+- OCKAM_FOREGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an Telemetry foreground node, without waiting for a response. Default value: `3s`.
+- OCKAM_FOREGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an Telemetry foreground inlet, without waiting for a response. Default value: `3s`.
+- OCKAM_BACKGROUND_LOG_EXPORT_CUTOFF: Cutoff time for sending log records batches to an Telemetry background node, without waiting for a response. Default value: `3s`.
+- OCKAM_BACKGROUND_SPAN_EXPORT_CUTOFF: Cutoff time for sending span batches to an Telemetry background inlet, without waiting for a response. Default value: `3s`.
 
 UDP
 - OCKAM_RENDEZVOUS_SERVER: set this variable to the hostname and port of the Rendezvous service
@@ -64,7 +64,7 @@ Devs Usage
 - OCKAM_AUTHENTICATOR_ENDPOINT: a `string` that overrides the default endpoint of the authenticator. Defaults to `https://account.ockam.io`.
 - OCKAM_DEVELOPER: a `boolean` specifying if the current user is an Ockam developer (for more accurate metrics).
 - OCKAM_OPENTELEMETRY_EXPORT_DEBUG: a `boolean` specifying if debug messages must be printed to the console when the OpenTelemetry export is configured.
-- OCKAM_OPENTELEMETRY_EXPORT_VIA_PORTAL: a `boolean` specifying if traces must be exported via a portal when a project exists (this feature flag is set to `false` for now)
+- OCKAM_TELEMETRY_EXPORT_VIA_PORTAL: a `boolean` specifying if traces must be exported via a portal when a project exists (this feature flag is set to `false` for now)
 - OCKAM_DEFAULT_TIMEOUT: a `Duration` used to timeout secure channels creation and API requests. Default value: `120s`.
 
 Internal (to enable some special behavior in the logic)

--- a/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
+++ b/implementations/rust/ockam/ockam_command/tests/bats/load/base.bash
@@ -136,8 +136,8 @@ run_failure() {
 
 bats_require_minimum_version 1.5.0
 
-# Disable the opentelemetry export to improve performances
-export OCKAM_OPENTELEMETRY_EXPORT=false
+# Disable the telemetry export to improve performances
+export OCKAM_TELEMETRY_EXPORT=false
 
 # Set a high timeout for CI tests
 export OCKAM_DEFAULT_TIMEOUT=5m

--- a/tools/profile/portal.allocations
+++ b/tools/profile/portal.allocations
@@ -27,7 +27,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 if [ "$(uname)" == "Darwin" ]; then
   rm -rf /tmp/ockam.trace/

--- a/tools/profile/portal.baseline
+++ b/tools/profile/portal.baseline
@@ -14,7 +14,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 "${OCKAM}" node create portal -f &
 

--- a/tools/profile/portal.cpu
+++ b/tools/profile/portal.cpu
@@ -26,7 +26,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 if [ "$(uname)" == "Darwin" ]; then
   rm -rf /tmp/ockam.trace/

--- a/tools/profile/portal_relay.baseline
+++ b/tools/profile/portal_relay.baseline
@@ -14,7 +14,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 "${OCKAM}" node create portal -f &
 

--- a/tools/profile/portal_relay.cpu
+++ b/tools/profile/portal_relay.cpu
@@ -19,7 +19,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 perf record --call-graph dwarf -F 99 --output /tmp/ockam.perf -- "${OCKAM}" node create portal -f &
 perf_pid=$!

--- a/tools/profile/portal_two_nodes.baseline
+++ b/tools/profile/portal_two_nodes.baseline
@@ -14,7 +14,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 "${OCKAM}" node create inlet -f &
 "${OCKAM}" node create outlet -f &

--- a/tools/profile/portal_two_nodes.cpu
+++ b/tools/profile/portal_two_nodes.cpu
@@ -19,7 +19,7 @@ fi
 
 "${OCKAM}" node delete portal -y >/dev/null 2>&1 || true
 export OCKAM_LOG_LEVEL=info
-export OCKAM_OPENTELEMETRY_EXPORT=0
+export OCKAM_TELEMETRY_EXPORT=0
 
 perf record --call-graph dwarf -F 99 --output /tmp/ockam.inlet.perf -- "${OCKAM}" node create inlet -f &
 perf record --call-graph dwarf -F 99 --output /tmp/ockam.outlet.perf -- "${OCKAM}" node create outlet -f &


### PR DESCRIPTION
Rename `OpenTelemetry` to `Telemetry` from environment variables that are generic to telemetry.
- The `OCKAM_OPENTELEMETRY_EXPORT` var is kept as a fallback, to ensure backwards compatibility
- The `OCKAM_OPENTELEMETRY_ENDPOINT` and `OCKAM_OPENTELEMETRY_HEADERS` vars are kept because they are an implementation detail of opentelemetry