### PR TITLE
feat(rust): update the postgres schema

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/spaces.rs
@@ -82,36 +82,40 @@ impl CliState {
 mod test {
     use super::*;
     use crate::cloud::subscription::SubscriptionName;
+    use ockam_node::database::skip_if_postgres;
 
     #[tokio::test]
     async fn test_cli_spaces() -> Result<()> {
-        let cli = CliState::test().await?;
+        skip_if_postgres(|| async {
+            let cli = CliState::test().await?;
 
-        // the first created space becomes the default
-        let space1 = cli
-            .store_space(
-                "1",
-                "name1",
-                vec!["me@ockam.io", "you@ockam.io"],
-                Some(&Subscription::new(
-                    SubscriptionName::Gold,
-                    false,
-                    None,
-                    None,
-                    None,
-                )),
-            )
-            .await?;
-        let result = cli.get_default_space().await?;
-        assert_eq!(result, space1);
+            // the first created space becomes the default
+            let space1 = cli
+                .store_space(
+                    "1",
+                    "name1",
+                    vec!["me@ockam.io", "you@ockam.io"],
+                    Some(&Subscription::new(
+                        SubscriptionName::Gold,
+                        false,
+                        None,
+                        None,
+                        None,
+                    )),
+                )
+                .await?;
+            let result = cli.get_default_space().await?;
+            assert_eq!(result, space1);
 
-        // the store method can be used to update a space
-        let updated_space1 = cli
-            .store_space("1", "name1", vec!["them@ockam.io"], None)
-            .await?;
-        let result = cli.get_default_space().await?;
-        assert_eq!(result, updated_space1);
+            // the store method can be used to update a space
+            let updated_space1 = cli
+                .store_space("1", "name1", vec!["them@ockam.io"], None)
+                .await?;
+            let result = cli.get_default_space().await?;
+            assert_eq!(result, updated_space1);
 
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/nodes_repository.rs
@@ -71,12 +71,6 @@ pub trait NodesRepository: Send + Sync + 'static {
 
     /// Unset the process id of a node
     async fn set_no_node_pid(&self, node_name: &str) -> Result<()>;
-
-    /// Associate a node to a project
-    async fn set_node_project_name(&self, node_name: &str, project_name: &str) -> Result<()>;
-
-    /// Return the name of the project associated to a node
-    async fn get_node_project_name(&self, node_name: &str) -> Result<Option<String>>;
 }
 
 #[async_trait]
@@ -150,13 +144,5 @@ impl<T: NodesRepository> NodesRepository for AutoRetry<T> {
 
     async fn set_no_node_pid(&self, node_name: &str) -> Result<()> {
         retry!(self.wrapped.set_no_node_pid(node_name))
-    }
-
-    async fn set_node_project_name(&self, node_name: &str, project_name: &str) -> Result<()> {
-        retry!(self.wrapped.set_node_project_name(node_name, project_name))
-    }
-
-    async fn get_node_project_name(&self, node_name: &str) -> Result<Option<String>> {
-        retry!(self.wrapped.get_node_project_name(node_name))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/projects_repository_sql.rs
@@ -635,12 +635,12 @@ mod test {
         SpacesRepository, SpacesSqlxDatabase, UsersRepository, UsersSqlxDatabase,
     };
     use crate::cloud::enroll::auth0::UserInfo;
-    use ockam_node::database::with_dbs;
+    use ockam_node::database::with_sqlite_dbs;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_repository() -> Result<()> {
-        with_dbs(|db| async move {
+        with_sqlite_dbs(|db| async move {
             let repository: Arc<dyn UsersRepository> = Arc::new(UsersSqlxDatabase::new(db.clone()));
             repository
                 .store_user(&UserInfo {
@@ -736,7 +736,7 @@ mod test {
 
     #[tokio::test]
     async fn test_store_project_space() -> Result<()> {
-        with_dbs(|db| async move {
+        with_sqlite_dbs(|db| async move {
             let projects_repository: Arc<dyn ProjectsRepository> =
                 Arc::new(ProjectsSqlxDatabase::new(db.clone()));
 

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/spaces_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/spaces_repository_sql.rs
@@ -333,13 +333,13 @@ impl SubscriptionRow {
 mod test {
     use super::*;
     use crate::cloud::subscription::SubscriptionName;
-    use ockam_node::database::with_dbs;
+    use ockam_node::database::with_sqlite_dbs;
     use std::ops::Add;
     use time::ext::NumericalDuration;
 
     #[tokio::test]
     async fn test_repository() -> Result<()> {
-        with_dbs(|db| async move {
+        with_sqlite_dbs(|db| async move {
             let repository = SpacesSqlxDatabase::new(db);
 
             // create and store 2 spaces

--- a/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_api/src/cli_state/storage/users_repository_sql.rs
@@ -218,12 +218,12 @@ impl UserRow {
 mod test {
     use super::*;
 
-    use ockam_node::database::with_dbs;
+    use ockam_node::database::with_sqlite_dbs;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_repository() -> Result<()> {
-        with_dbs(|db| async move {
+        with_sqlite_dbs(|db| async move {
             let repository: Arc<dyn UsersRepository> = Arc::new(UsersSqlxDatabase::new(db));
 
             let my_email_address: EmailAddress = "me@ockam.io".try_into().unwrap();

--- a/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
+++ b/implementations/rust/ockam/ockam_api/src/nodes/service/in_memory_node.rs
@@ -147,7 +147,6 @@ impl InMemoryNode {
             .start_node_with_optional_values(
                 &defaults.node_name,
                 &Some(identity_name.to_string()),
-                &project_name,
                 Some(&tcp_listener),
             )
             .await

--- a/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/test_utils/mod.rs
@@ -70,7 +70,7 @@ pub async fn start_manager_for_tests(
 
     let node_name = random_name();
     cli_state
-        .start_node_with_optional_values(&node_name, &None, &None, Some(&tcp_listener))
+        .start_node_with_optional_values(&node_name, &None, Some(&tcp_listener))
         .await
         .unwrap();
 

--- a/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/enroll/enroll_user.rs
@@ -208,10 +208,6 @@ impl AppState {
             .projects()
             .set_default_project(project.project_id())
             .await?;
-        self.state()
-            .await
-            .set_node_project(&node_manager.node_name(), &Some(project.name().to_string()))
-            .await?;
         Ok(project)
     }
 }

--- a/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/mod.rs
@@ -693,7 +693,7 @@ pub(crate) async fn make_node_manager(
         .into_diagnostic()?;
 
     let _ = cli_state
-        .start_node_with_optional_values(NODE_NAME, &None, &None, Some(&listener))
+        .start_node_with_optional_values(NODE_NAME, &None, Some(&listener))
         .await?;
 
     let trust_options = cli_state

--- a/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
+++ b/implementations/rust/ockam/ockam_app_lib/src/state/model_state_repository_sql.rs
@@ -157,13 +157,13 @@ impl PersistentIncomingServiceRow {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ockam::with_dbs;
     use ockam_api::nodes::models::portal::OutletStatus;
     use ockam_core::Address;
+    use ockam_node::database::with_sqlite_dbs;
 
     #[tokio::test]
     async fn store_and_load() -> ockam_core::Result<()> {
-        with_dbs(|db| async move {
+        with_sqlite_dbs(|db| async move {
             let repository: Arc<dyn ModelStateRepository> =
                 Arc::new(ModelStateSqlxDatabase::new(db.clone()));
 

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -146,7 +146,7 @@ impl CreateCommand {
         };
 
         opts.state
-            .create_node_with_optional_values(&self.node_name, &self.identity, &None)
+            .create_node_with_optional_identity(&self.node_name, &self.identity)
             .await?;
 
         // Construct the arguments list and re-execute the ockam
@@ -303,7 +303,7 @@ impl CreateCommand {
         };
 
         let node = state
-            .start_node_with_optional_values(&self.node_name, &Some(identity_name), &None, None)
+            .start_node_with_optional_values(&self.node_name, &Some(identity_name), None)
             .await?;
         state
             .set_tcp_listener_address(&node.name(), &self.tcp_listener_address)

--- a/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/create/foreground.rs
@@ -66,12 +66,7 @@ impl CreateCommand {
         };
         let node_info = opts
             .state
-            .start_node_with_optional_values(
-                &node_name,
-                &self.identity,
-                &self.trust_opts.project_name,
-                Some(&tcp_listener),
-            )
+            .start_node_with_optional_values(&node_name, &self.identity, Some(&tcp_listener))
             .await?;
         debug!("node info persisted {node_info:?}");
 

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240703100000_add_subscriptions.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240703100000_add_subscriptions.sql
@@ -1,9 +1,0 @@
--- This migration adds the subscriptions table based on the following rust struct
-CREATE TABLE subscription (
-    space_id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    is_free_trial BOOLEAN NOT NULL,
-    marketplace TEXT,
-    start_date INTEGER,
-    end_date INTEGER
-);

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20241112100000_add_privileged_portals.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20241112100000_add_privileged_portals.sql
@@ -1,7 +1,0 @@
--- Add privileged column to the tcp_outlet_status table
-ALTER TABLE tcp_outlet_status
-        ADD privileged BOOLEAN DEFAULT FALSE; -- boolean indicating if the outlet is operating in privileged mode
-
--- Add privileged column to the tcp_inlet table
-ALTER TABLE tcp_inlet
-        ADD privileged BOOLEAN DEFAULT FALSE; -- boolean indicating if the inlet is operating in privileged mode

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250110100000_remove_node_project.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250110100000_remove_node_project.sql
@@ -1,0 +1,2 @@
+-- This table is not used anymore
+DROP TABLE node_project;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/sqlx_database.rs
@@ -426,6 +426,21 @@ impl Clean {
     }
 }
 
+/// This function can be used to run some test code with the 2 SQLite databases implementations
+pub async fn with_sqlite_dbs<F, Fut>(f: F) -> Result<()>
+where
+    F: Fn(SqlxDatabase) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
+{
+    let db = SqlxDatabase::in_memory("test").await?;
+    rethrow("SQLite in memory", f(db)).await?;
+
+    let db_file = NamedTempFile::new().unwrap();
+    let db = SqlxDatabase::create_sqlite(db_file.path()).await?;
+    rethrow("SQLite on disk", f(db)).await?;
+    Ok(())
+}
+
 /// This function can be used to run some test code with the 3 different databases implementations
 pub async fn with_dbs<F, Fut>(f: F) -> Result<()>
 where
@@ -439,10 +454,23 @@ where
     let db = SqlxDatabase::create_sqlite(db_file.path()).await?;
     rethrow("SQLite on disk", f(db)).await?;
 
-    // only run the postgres tests if the OCKAM_POSTGRES_* environment variables are set
+    // only run the postgres tests if the OCKAM_DATABASE_CONNECTION_URL environment variables is set
     if let Ok(db) = SqlxDatabase::create_new_postgres().await {
         rethrow("Postgres local", f(db.clone())).await?;
         db.drop_all_postgres_tables().await?;
+    };
+    Ok(())
+}
+
+/// This function can be used to avoid running a test if the postgres database is used.
+pub async fn skip_if_postgres<F, Fut, R>(f: F) -> std::result::Result<(), R>
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = std::result::Result<(), R>> + Send + 'static,
+{
+    // only run the postgres tests if the OCKAM_DATABASE_CONNECTION_URL environment variables is not set
+    if SqlxDatabase::create_new_postgres().await.is_err() {
+        f().await?
     };
     Ok(())
 }

--- a/tools/stress-test/src/main.rs
+++ b/tools/stress-test/src/main.rs
@@ -172,7 +172,7 @@ impl State {
         let listener = tcp.listen(&"127.0.0.1:0", options).await?;
 
         let _ = cli_state
-            .start_node_with_optional_values(NODE_NAME, &None, &None, Some(&listener))
+            .start_node_with_optional_values(NODE_NAME, &None, Some(&listener))
             .await?;
 
         let trust_options = cli_state


### PR DESCRIPTION
This PR: 

 1. Consolidates the current Postgres database schema (that schema is not yet used in production). Some tables are removed from that schema since Postgres will be used for managed nodes where some notions don't apply, like `space`, `user` and `project`.
 2. Removes the unused `project_node` table.
 3. Deactivates the automatic database upgrades on startup when Postgres is used (because we can't allow one individual managed node to trigger a full database migration).
 4. Makes sure that the `ockam reset` command cannot be used with a Postgres database.
 5. Adds some test support to run only the relevant tests with Postgres.