### PR TITLE
feat: allow authority nodes to share a Postgres instance

### DIFF
--- a/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
+++ b/examples/rust/get_started/examples/06-credentials-exchange-issuer.rs
@@ -76,7 +76,7 @@ async fn main(ctx: Context) -> Result<()> {
         pre_trusted_identities.insert(identifier.clone(), attributes.clone());
     }
     members
-        .bootstrap_pre_trusted_members(&pre_trusted_identities.into())
+        .bootstrap_pre_trusted_members(&issuer, &pre_trusted_identities.into())
         .await?;
 
     let tcp_listener_options = TcpListenerOptions::new();

--- a/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/common.rs
@@ -40,10 +40,11 @@ impl EnrollerAccessControlChecks {
     }
 
     pub(crate) async fn check_is_member(
+        authority: &Identifier,
         members: Arc<dyn AuthorityMembersRepository>,
         identifier: &Identifier,
     ) -> Result<EnrollerCheckResult> {
-        let r = match members.get_member(identifier).await? {
+        let r = match members.get_member(authority, identifier).await? {
             Some(member) => {
                 let is_enroller = Self::check_bin_attributes_is_enroller(member.attributes());
                 EnrollerCheckResult {
@@ -65,12 +66,13 @@ impl EnrollerAccessControlChecks {
     }
 
     pub(crate) async fn check_identifier(
+        authority: &Identifier,
         members: Arc<dyn AuthorityMembersRepository>,
         identities_attributes: Arc<IdentitiesAttributes>,
         identifier: &Identifier,
         account_authority: &Option<AccountAuthorityInfo>,
     ) -> Result<EnrollerCheckResult> {
-        let mut r = Self::check_is_member(members, identifier).await?;
+        let mut r = Self::check_is_member(authority, members, identifier).await?;
 
         if let Some(info) = account_authority {
             if let Some(attrs) = identities_attributes

--- a/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/credential_issuer/credential_issuer.rs
@@ -108,7 +108,7 @@ impl CredentialIssuer {
 
         // Otherwise, check if it's a member managed by this authority
 
-        let member = match self.members.get_member(subject).await? {
+        let member = match self.members.get_member(&self.issuer, subject).await? {
             Some(member) => member,
             None => return Ok(None),
         };

--- a/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/direct/direct_authenticator_worker.rs
@@ -20,12 +20,14 @@ pub struct DirectAuthenticatorWorker {
 
 impl DirectAuthenticatorWorker {
     pub fn new(
+        authority: &Identifier,
         members: Arc<dyn AuthorityMembersRepository>,
         identities_attributes: Arc<IdentitiesAttributes>,
         account_authority: Option<AccountAuthorityInfo>,
     ) -> Self {
         Self {
             authenticator: DirectAuthenticator::new(
+                authority,
                 members,
                 identities_attributes,
                 account_authority,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor.rs
@@ -15,16 +15,22 @@ pub struct EnrollmentTokenAcceptorError(pub String);
 pub type EnrollmentTokenAcceptorResult<T> = Either<T, EnrollmentTokenAcceptorError>;
 
 pub struct EnrollmentTokenAcceptor {
+    authority: Identifier,
     pub(super) tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
     pub(super) members: Arc<dyn AuthorityMembersRepository>,
 }
 
 impl EnrollmentTokenAcceptor {
     pub fn new(
+        authority: &Identifier,
         tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
         members: Arc<dyn AuthorityMembersRepository>,
     ) -> Self {
-        Self { tokens, members }
+        Self {
+            authority: authority.clone(),
+            tokens,
+            members,
+        }
     }
 
     #[instrument(skip_all, fields(from = %from))]
@@ -33,8 +39,12 @@ impl EnrollmentTokenAcceptor {
         otc: OneTimeCode,
         from: &Identifier,
     ) -> Result<EnrollmentTokenAcceptorResult<()>> {
-        let check =
-            EnrollerAccessControlChecks::check_is_member(self.members.clone(), from).await?;
+        let check = EnrollerAccessControlChecks::check_is_member(
+            &self.authority,
+            self.members.clone(),
+            from,
+        )
+        .await?;
 
         // Not allow updating existing members
         if check.is_member {
@@ -72,7 +82,7 @@ impl EnrollmentTokenAcceptor {
 
         let member = AuthorityMember::new(from.clone(), attrs, token.issued_by, now()?, false);
 
-        if let Err(err) = self.members.add_member(member).await {
+        if let Err(err) = self.members.add_member(&self.authority, member).await {
             warn!(
                 "Error adding member {} using enrollment token: {}",
                 from, err

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/acceptor_worker.rs
@@ -16,11 +16,12 @@ pub struct EnrollmentTokenAcceptorWorker {
 
 impl EnrollmentTokenAcceptorWorker {
     pub fn new(
+        authority: &Identifier,
         tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
         members: Arc<dyn AuthorityMembersRepository>,
     ) -> Self {
         Self {
-            acceptor: EnrollmentTokenAcceptor::new(tokens, members),
+            acceptor: EnrollmentTokenAcceptor::new(authority, tokens, members),
         }
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer.rs
@@ -26,6 +26,7 @@ pub struct EnrollmentTokenIssuerError(pub String);
 pub type EnrollmentTokenIssuerResult<T> = Either<T, EnrollmentTokenIssuerError>;
 
 pub struct EnrollmentTokenIssuer {
+    authority: Identifier,
     pub(super) tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
     pub(super) members: Arc<dyn AuthorityMembersRepository>,
     pub(super) identities_attributes: Arc<IdentitiesAttributes>,
@@ -34,12 +35,14 @@ pub struct EnrollmentTokenIssuer {
 
 impl EnrollmentTokenIssuer {
     pub fn new(
+        authority: &Identifier,
         tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
         members: Arc<dyn AuthorityMembersRepository>,
         identities_attributes: Arc<IdentitiesAttributes>,
         account_authority: Option<AccountAuthorityInfo>,
     ) -> Self {
         Self {
+            authority: authority.clone(),
             tokens,
             members,
             identities_attributes,
@@ -56,6 +59,7 @@ impl EnrollmentTokenIssuer {
         ttl_count: Option<u64>,
     ) -> Result<EnrollmentTokenIssuerResult<OneTimeCode>> {
         let check = EnrollerAccessControlChecks::check_identifier(
+            &self.authority,
             self.members.clone(),
             self.identities_attributes.clone(),
             enroller,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer_worker.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/enrollment_tokens/issuer_worker.rs
@@ -20,6 +20,7 @@ pub struct EnrollmentTokenIssuerWorker {
 
 impl EnrollmentTokenIssuerWorker {
     pub fn new(
+        authority: &Identifier,
         tokens: Arc<dyn AuthorityEnrollmentTokenRepository>,
         members: Arc<dyn AuthorityMembersRepository>,
         identities_attributes: Arc<IdentitiesAttributes>,
@@ -27,6 +28,7 @@ impl EnrollmentTokenIssuerWorker {
     ) -> Self {
         Self {
             issuer: EnrollmentTokenIssuer::new(
+                authority,
                 tokens,
                 members,
                 identities_attributes,

--- a/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_members_repository.rs
+++ b/implementations/rust/ockam/ockam_api/src/authenticator/storage/authority_members_repository.rs
@@ -11,48 +11,58 @@ use ockam_node::retry;
 #[async_trait]
 pub trait AuthorityMembersRepository: Send + Sync + 'static {
     /// Return an existing member of the Project
-    async fn get_member(&self, identifier: &Identifier) -> Result<Option<AuthorityMember>>;
+    async fn get_member(
+        &self,
+        authority: &Identifier,
+        identifier: &Identifier,
+    ) -> Result<Option<AuthorityMember>>;
 
     /// Return all members of the Project
-    async fn get_members(&self) -> Result<Vec<AuthorityMember>>;
+    async fn get_members(&self, authority: &Identifier) -> Result<Vec<AuthorityMember>>;
 
     /// Delete a member from the Project (unless it's pre-trusted)
-    async fn delete_member(&self, identifier: &Identifier) -> Result<()>;
+    async fn delete_member(&self, authority: &Identifier, identifier: &Identifier) -> Result<()>;
 
     /// Add a member to the Project
-    async fn add_member(&self, member: AuthorityMember) -> Result<()>;
+    async fn add_member(&self, authority: &Identifier, member: AuthorityMember) -> Result<()>;
 
     /// Remove the old pre-trusted members and store new pre-trusted members
     async fn bootstrap_pre_trusted_members(
         &self,
+        authority: &Identifier,
         pre_trusted_identities: &PreTrustedIdentities,
     ) -> Result<()>;
 }
 
 #[async_trait]
 impl<T: AuthorityMembersRepository> AuthorityMembersRepository for AutoRetry<T> {
-    async fn get_member(&self, identifier: &Identifier) -> Result<Option<AuthorityMember>> {
-        retry!(self.wrapped.get_member(identifier))
+    async fn get_member(
+        &self,
+        authority: &Identifier,
+        identifier: &Identifier,
+    ) -> Result<Option<AuthorityMember>> {
+        retry!(self.wrapped.get_member(authority, identifier))
     }
 
-    async fn get_members(&self) -> Result<Vec<AuthorityMember>> {
-        retry!(self.wrapped.get_members())
+    async fn get_members(&self, authority: &Identifier) -> Result<Vec<AuthorityMember>> {
+        retry!(self.wrapped.get_members(authority))
     }
 
-    async fn delete_member(&self, identifier: &Identifier) -> Result<()> {
-        retry!(self.wrapped.delete_member(identifier))
+    async fn delete_member(&self, authority: &Identifier, identifier: &Identifier) -> Result<()> {
+        retry!(self.wrapped.delete_member(authority, identifier))
     }
 
-    async fn add_member(&self, member: AuthorityMember) -> Result<()> {
-        retry!(self.wrapped.add_member(member.clone()))
+    async fn add_member(&self, authority: &Identifier, member: AuthorityMember) -> Result<()> {
+        retry!(self.wrapped.add_member(authority, member.clone()))
     }
 
     async fn bootstrap_pre_trusted_members(
         &self,
+        authority: &Identifier,
         pre_trusted_identities: &PreTrustedIdentities,
     ) -> Result<()> {
         retry!(self
             .wrapped
-            .bootstrap_pre_trusted_members(pre_trusted_identities))
+            .bootstrap_pre_trusted_members(authority, pre_trusted_identities))
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -29,11 +29,13 @@ use crate::nodes::service::default_address::DefaultAddress;
 
 /// This struct represents an Authority, which is an
 /// Identity which other identities trust to authenticate attributes
-/// An Authority is able to start a few services
-//   - a direct authenticator
-//   - a credential issuer
-//   - an enrollment token issuer
-//   - an enrollment token acceptor
+///
+/// An Authority is able to start a few services:
+//   - a direct authenticator: can add and retrieve members.
+//   - a credential issuer: return the attributes of a member as a time-limited credential.
+//   - an enrollment token issuer: create a token attributed allowing an identity to acquire some specific attributes.
+//   - an enrollment token acceptor: create or update a member, given a token.
+#[derive(Clone)]
 pub struct Authority {
     identifier: Identifier,
     secure_channels: Arc<SecureChannels>,
@@ -169,6 +171,7 @@ impl Authority {
         }
 
         let direct = DirectAuthenticatorWorker::new(
+            &self.identifier,
             self.members.clone(),
             self.secure_channels.identities().identities_attributes(),
             self.account_authority.clone(),
@@ -196,13 +199,17 @@ impl Authority {
         }
 
         let issuer = EnrollmentTokenIssuerWorker::new(
+            &self.identifier,
             self.tokens.clone(),
             self.members.clone(),
             self.secure_channels.identities().identities_attributes(),
             self.account_authority.clone(),
         );
-        let acceptor =
-            EnrollmentTokenAcceptorWorker::new(self.tokens.clone(), self.members.clone());
+        let acceptor = EnrollmentTokenAcceptorWorker::new(
+            &self.identifier,
+            self.tokens.clone(),
+            self.members.clone(),
+        );
 
         // start an enrollment token issuer with an abac policy checking that
         // the caller is an enroller for the authority project
@@ -272,6 +279,7 @@ impl Authority {
     ) -> Result<()> {
         if let Some(okta) = &configuration.okta {
             let okta_worker = crate::okta::Server::new(
+                &self.identifier,
                 self.members.clone(),
                 okta.tenant_base_url(),
                 okta.certificate(),
@@ -313,13 +321,16 @@ impl Authority {
             .collect();
 
         self.members
-            .add_member(AuthorityMember::new(
-                identifier.clone(),
-                attrs,
-                self.identifier.clone(),
-                now()?,
-                false,
-            ))
+            .add_member(
+                &self.identifier,
+                AuthorityMember::new(
+                    identifier.clone(),
+                    attrs,
+                    self.identifier.clone(),
+                    now()?,
+                    false,
+                ),
+            )
             .await
     }
 }
@@ -334,7 +345,354 @@ impl Authority {
         configuration: &Configuration,
     ) -> Result<()> {
         members
-            .bootstrap_pre_trusted_members(&configuration.trusted_identities)
+            .bootstrap_pre_trusted_members(
+                &configuration.identifier,
+                &configuration.trusted_identities,
+            )
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authenticator::direct::{
+        Members, OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE, OCKAM_ROLE_ATTRIBUTE_KEY,
+    };
+    use crate::authenticator::enrollment_tokens::TokenIssuer;
+    use crate::authenticator::one_time_code::OneTimeCode;
+    use crate::authenticator::{PreTrustedIdentities, PreTrustedIdentity};
+    use crate::authority_node;
+    use crate::cloud::AuthorityNodeClient;
+    use crate::config::lookup::InternetAddress;
+    use crate::enroll::enrollment::{EnrollStatus, Enrollment};
+    use crate::nodes::NodeManager;
+    use ockam::identity::{identities, secure_channels, TimestampInSeconds};
+    use ockam_core::TryClone;
+    use ockam_multiaddr::MultiAddr;
+    use ockam_node::database::{with_postgres, DatabaseConfiguration};
+    use ockam_node::NodeBuilder;
+    use std::future::Future;
+    use std::net::TcpListener;
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    /// This test gets a reference to the postgres database and starts 2 authority nodes
+    /// to make sure that they can work even when using the same database.
+    ///
+    /// We test:
+    ///
+    ///  - That adding a member works with trusted identities
+    ///  - Issuing a credential works
+    ///  - Issuing and accepting a token works
+    #[test]
+    fn test_create_two_authority_managed_nodes_using_the_same_postgres_database() {
+        let result = execute_test(|db_base, ctx1_base, ctx2_base, ctx_client_base| {
+            let db = db_base.clone();
+            let ctx1 = ctx1_base.try_clone().unwrap();
+            let ctx2 = ctx2_base.try_clone().unwrap();
+            let ctx_client = ctx_client_base.try_clone().unwrap();
+            async move {
+                let port1 = random_port();
+                let port2 = random_port();
+                let secure_channels: Arc<SecureChannels> = secure_channels().await?;
+                let identities_creation = secure_channels.identities().identities_creation();
+
+                let enroller1 = identities_creation.create_identity().await?;
+                let enroller2 = identities_creation.create_identity().await?;
+
+                let authority1 = start_authority_node(
+                    db.clone(),
+                    &ctx1,
+                    port1,
+                    "authority-node-1",
+                    &[enroller1.clone()],
+                )
+                .await?;
+                let authority2 = start_authority_node(
+                    db,
+                    &ctx2,
+                    port2,
+                    "authority-node-2",
+                    &[enroller2.clone()],
+                )
+                .await?;
+
+                let client1 = make_authority_node_client(
+                    &ctx_client,
+                    secure_channels.clone(),
+                    &authority1.identifier,
+                    &MultiAddr::from_str(&format!("/dnsaddr/127.0.0.1/tcp/{}/secure/api", port1))?,
+                    &enroller1,
+                )
+                .await?;
+                let client2 = make_authority_node_client(
+                    &ctx_client,
+                    secure_channels.clone(),
+                    &authority2.identifier,
+                    &MultiAddr::from_str(&format!("/dnsaddr/127.0.0.1/tcp/{}/secure/api", port2))?,
+                    &enroller2,
+                )
+                .await?;
+
+                // adding members must work for both authorities
+                let identities_creation = secure_channels.identities().identities_creation();
+                let member1 = identities_creation.create_identity().await?;
+                let member2 = identities_creation.create_identity().await?;
+
+                add_member(&ctx_client, &client1, &member1, ("key1", "value1")).await?;
+                add_member(&ctx_client, &client1, &member1, ("key1", "updated_value1")).await?;
+                assert_eq!(
+                    get_attribute_value(&ctx_client, &client1, &member1, "key1").await?,
+                    Some("updated_value1".to_string())
+                );
+
+                add_member(&ctx_client, &client2, &member2, ("key1", "value1")).await?;
+                add_member(&ctx_client, &client2, &member2, ("key2", "updated_value2")).await?;
+                assert_eq!(
+                    get_attribute_value(&ctx_client, &client2, &member2, "key2").await?,
+                    Some("updated_value2".to_string())
+                );
+
+                // issuing credentials must work for both authorities
+                issue_credential(&ctx_client, &client1, &member1).await?;
+                issue_credential(&ctx_client, &client2, &member2).await?;
+
+                // issuing a token must work for both authorities
+                let token1 = create_token(&ctx_client, &client1, &enroller1).await?;
+                let token2 = create_token(&ctx_client, &client2, &enroller2).await?;
+
+                // accepting a token must work for both authorities
+                let member3 = identities_creation.create_identity().await?;
+                let member4 = identities_creation.create_identity().await?;
+                let enroll_status1 = accept_token(&ctx_client, &client1, &member3, token1).await?;
+                let enroll_status2 = accept_token(&ctx_client, &client2, &member4, token2).await?;
+
+                assert_eq!(enroll_status1, EnrollStatus::EnrolledSuccessfully);
+                assert_eq!(enroll_status2, EnrollStatus::EnrolledSuccessfully);
+                Ok(())
+            }
+        });
+        result.unwrap()
+    }
+
+    /// HELPERS
+
+    /// Create an Authority configuration with:
+    ///
+    /// - The authority identifier
+    /// - A port for the TCP listener (must not clash with another authority port)
+    /// - An identity that should be trusted as an enroller
+    fn create_configuration(
+        authority: &Identifier,
+        port: u16,
+        trusted: &[Identifier],
+    ) -> Result<Configuration> {
+        let mut trusted_identities = BTreeMap::new();
+        for t in trusted {
+            let mut attributes = BTreeMap::new();
+            attributes.insert(
+                OCKAM_ROLE_ATTRIBUTE_KEY.as_bytes().to_vec(),
+                OCKAM_ROLE_ATTRIBUTE_ENROLLER_VALUE.as_bytes().to_vec(),
+            );
+
+            trusted_identities.insert(
+                t.clone(),
+                PreTrustedIdentity::new(attributes, TimestampInSeconds(0), None, authority.clone()),
+            );
+        }
+        Ok(Configuration {
+            identifier: authority.clone(),
+            database_configuration: DatabaseConfiguration::postgres()?.unwrap(),
+            project_identifier: "123456".to_string(),
+            tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
+            secure_channel_listener_name: None,
+            authenticator_name: None,
+            trusted_identities: PreTrustedIdentities::new(trusted_identities),
+            no_direct_authentication: false,
+            no_token_enrollment: false,
+            okta: None,
+            account_authority: None,
+            enforce_admin_checks: false,
+            disable_trust_context_id: false,
+        })
+    }
+
+    /// Make a client to access the services of an Authority
+    async fn make_authority_node_client(
+        ctx: &Context,
+        secure_channels: Arc<SecureChannels>,
+        authority_identifier: &Identifier,
+        authority_route: &MultiAddr,
+        caller: &Identifier,
+    ) -> Result<AuthorityNodeClient> {
+        let client = NodeManager::authority_node_client(
+            &TcpTransport::create(ctx)?,
+            secure_channels,
+            authority_identifier,
+            authority_route,
+            caller,
+            None,
+        )
+        .await?;
+        Ok(client
+            .with_secure_channel_timeout(&Duration::from_secs(1))
+            .with_request_timeout(&Duration::from_secs(1)))
+    }
+
+    /// Create and start an authority node, with:
+    ///  - A specific TCP listener port
+    ///  - A specific node name
+    ///  - An identifier for an enroller
+    async fn start_authority_node(
+        db: SqlxDatabase,
+        ctx: &Context,
+        port: u16,
+        node_name: &str,
+        trusted: &[Identifier],
+    ) -> Result<Authority> {
+        let identities = identities::create(db.clone(), node_name);
+        let authority = identities.identities_creation().create_identity().await?;
+
+        let configuration = create_configuration(&authority, port, trusted)?;
+        let authority = Authority::create(&configuration, Some(db.clone())).await?;
+        authority_node::start_node(ctx, &configuration, authority.clone()).await?;
+        Ok(authority)
+    }
+
+    /// Add a member
+    /// Add a member
+    async fn add_member(
+        ctx: &Context,
+        client: &AuthorityNodeClient,
+        member: &Identifier,
+        attribute: (&str, &str),
+    ) -> Result<()> {
+        let mut attributes = BTreeMap::new();
+        attributes.insert(attribute.0.to_string(), attribute.1.to_string());
+        client
+            .add_member(ctx, member.clone(), attributes)
+            .await
+            .unwrap();
+        Ok(())
+    }
+
+    /// Get the value of a member attribute if present.
+    async fn get_attribute_value(
+        ctx: &Context,
+        client: &AuthorityNodeClient,
+        member: &Identifier,
+        attribute_key: &str,
+    ) -> Result<Option<String>> {
+        let attributes_entry = client.show_member(ctx, member.clone()).await.unwrap();
+        Ok(attributes_entry
+            .attrs()
+            .get(&attribute_key.as_bytes().to_vec())
+            .to_owned()
+            .map(|v| String::from_utf8(v.clone()).unwrap()))
+    }
+
+    /// Issue a credential for a given member
+    async fn issue_credential(
+        ctx: &Context,
+        client: &AuthorityNodeClient,
+        member: &Identifier,
+    ) -> Result<()> {
+        client
+            .clone()
+            .with_client_identifier(member)
+            .issue_credential(ctx)
+            .await
+            .unwrap();
+        Ok(())
+    }
+
+    /// Issue a token
+    async fn create_token(
+        ctx: &Context,
+        client: &AuthorityNodeClient,
+        enroller: &Identifier,
+    ) -> Result<OneTimeCode> {
+        let mut attributes = BTreeMap::new();
+        attributes.insert("name".to_string(), "value".to_string());
+        Ok(client
+            .clone()
+            .with_client_identifier(enroller)
+            .create_token(ctx, attributes, None, None)
+            .await
+            .unwrap())
+    }
+
+    /// Accept a token
+    async fn accept_token(
+        ctx: &Context,
+        client: &AuthorityNodeClient,
+        member: &Identifier,
+        token: OneTimeCode,
+    ) -> Result<EnrollStatus> {
+        let mut attributes = BTreeMap::new();
+        attributes.insert("name".to_string(), "value".to_string());
+        Ok(client
+            .clone()
+            .with_client_identifier(member)
+            .present_token(ctx, &token)
+            .await
+            .unwrap())
+    }
+
+    /// Create 3 contexts representing 3 nodes: 2 authority nodes and a client node.
+    /// Then execute some test code using the postgres database and the 3 contexts.
+    fn execute_test<F, Fut>(f: F) -> Result<()>
+    where
+        F: Fn(&SqlxDatabase, &Context, &Context, &Context) -> Fut + Send + Sync + 'static + Clone,
+        Fut: Future<Output = Result<()>> + Send + 'static,
+    {
+        // skip everything if postgres is not available
+        if DatabaseConfiguration::postgres()?.is_some() {
+            return Ok(());
+        };
+
+        // set logging to true if debugging is needed
+        let logging = false;
+
+        // prepare the nodes
+        let node_builder1 = NodeBuilder::new().with_logging(logging);
+        let (ctx1, mut executor1) = node_builder1.build();
+        let node_builder2 = NodeBuilder::new()
+            .with_runtime(executor1.get_runtime())
+            .with_logging(logging);
+        let (ctx2, _executor2) = node_builder2.build();
+        let client_node_builder = NodeBuilder::new()
+            .with_runtime(executor1.get_runtime())
+            .with_logging(logging);
+        let (ctx_client, _executor_client) = client_node_builder.build();
+
+        // run the code with the necessary contexts
+        executor1.execute(async move {
+            // we need to make separate clones to be able to close the contexts after the test.
+            let ctx1_handle = ctx1.try_clone().unwrap();
+            let ctx2_handle = ctx2.try_clone().unwrap();
+            let ctx_client_handle = ctx_client.try_clone().unwrap();
+
+            let result = with_postgres(move |db| {
+                let f_clone = f.clone();
+                let db_clone = db.clone();
+                let ctx1_clone = ctx1.try_clone().unwrap();
+                let ctx2_clone = ctx2.try_clone().unwrap();
+                let ctx_client_clone = ctx_client.try_clone().unwrap();
+                async move { f_clone(&db_clone, &ctx1_clone, &ctx2_clone, &ctx_client_clone).await }
+            })
+            .await;
+            ctx1_handle.shutdown_node().await?;
+            ctx2_handle.shutdown_node().await?;
+            ctx_client_handle.shutdown_node().await?;
+            result
+        })?
+    }
+
+    fn random_port() -> u16 {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to address");
+        let address = listener.local_addr().expect("Failed to get local address");
+        address.port()
     }
 }

--- a/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
+++ b/implementations/rust/ockam/ockam_api/src/cloud/secure_clients.rs
@@ -321,6 +321,13 @@ impl AuthorityNodeClient {
             secure_client: self.secure_client.with_request_timeout(timeout),
         }
     }
+
+    /// Change the client Identifier
+    pub fn with_client_identifier(self, client_identifier: &Identifier) -> Self {
+        Self {
+            secure_client: self.secure_client.with_client_identifier(client_identifier),
+        }
+    }
 }
 
 impl ProjectNodeClient {

--- a/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
+++ b/implementations/rust/ockam/ockam_api/src/enroll/enrollment.rs
@@ -11,6 +11,7 @@ use ockam_node::Context;
 
 const TARGET: &str = "ockam_api::cloud::enroll";
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EnrollStatus {
     EnrolledSuccessfully,
     AlreadyEnrolled,

--- a/implementations/rust/ockam/ockam_api/tests/common/common.rs
+++ b/implementations/rust/ockam/ockam_api/tests/common/common.rs
@@ -25,25 +25,14 @@ use tempfile::NamedTempFile;
 // with freshly created Authority Identifier and temporary files for storage and vault
 pub async fn default_configuration() -> Result<Configuration> {
     let database_path = NamedTempFile::new().unwrap().keep().unwrap().1;
-
+    let database_configuration = DatabaseConfiguration::sqlite(database_path.as_path());
     let port = thread_rng().gen_range(10000..65535);
 
-    let mut configuration = authority_node::Configuration {
-        identifier: "I4dba4b2e53b2ed95967b3bab350b6c9ad9c624e5a1b2c3d4e5f6a6b5c4d3e2f1"
-            .try_into()?,
-        database_configuration: DatabaseConfiguration::sqlite(database_path.as_path()),
-        project_identifier: "123456".to_string(),
-        tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
-        secure_channel_listener_name: None,
-        authenticator_name: None,
-        trusted_identities: Default::default(),
-        no_direct_authentication: true,
-        no_token_enrollment: true,
-        okta: None,
-        account_authority: None,
-        enforce_admin_checks: false,
-        disable_trust_context_id: false,
-    };
+    let mut configuration = create_configuration(
+        "I4dba4b2e53b2ed95967b3bab350b6c9ad9c624e5a1b2c3d4e5f6a6b5c4d3e2f1",
+        port,
+        &database_configuration,
+    )?;
 
     // Hack to create Authority Identity using the same vault and storage
     let authority_sc_temp = Authority::create(&configuration, None)
@@ -59,6 +48,28 @@ pub async fn default_configuration() -> Result<Configuration> {
     configuration.identifier = authority_identifier;
 
     Ok(configuration)
+}
+
+pub fn create_configuration(
+    identifier: &str,
+    port: u16,
+    database_configuration: &DatabaseConfiguration,
+) -> Result<Configuration> {
+    Ok(Configuration {
+        identifier: identifier.try_into()?,
+        database_configuration: database_configuration.clone(),
+        project_identifier: "123456".to_string(),
+        tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
+        secure_channel_listener_name: None,
+        authenticator_name: None,
+        trusted_identities: Default::default(),
+        no_direct_authentication: true,
+        no_token_enrollment: true,
+        okta: None,
+        account_authority: None,
+        enforce_admin_checks: false,
+        disable_trust_context_id: false,
+    })
 }
 
 pub struct AuthorityClient {

--- a/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
+++ b/implementations/rust/ockam/ockam_api/tests/credential_issuer.rs
@@ -42,7 +42,7 @@ async fn credential(ctx: &mut Context) -> Result<()> {
 
     let members = Arc::new(AuthorityMembersSqlxDatabase::create().await?);
     members
-        .bootstrap_pre_trusted_members(&pre_trusted.into())
+        .bootstrap_pre_trusted_members(&auth_identifier, &pre_trusted.into())
         .await?;
 
     // Now recreate the identities services with the previous vault

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -245,7 +245,7 @@ impl OckamSubcommand {
             OckamSubcommand::Authority(cmd) => match &cmd.subcommand {
                 AuthoritySubcommand::Create(cmd) => {
                     if cmd.child_process {
-                        Some(cmd.node_name.clone())
+                        Some(cmd.node_name())
                     } else {
                         None
                     }
@@ -271,7 +271,7 @@ impl OckamSubcommand {
             OckamSubcommand::Authority(cmd) => match &cmd.subcommand {
                 AuthoritySubcommand::Create(cmd) => {
                     if cmd.child_process || !cmd.foreground {
-                        CliState::default_node_dir(&cmd.node_name).ok()
+                        CliState::default_node_dir(&cmd.node_name()).ok()
                     } else {
                         None
                     }

--- a/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
+++ b/implementations/rust/ockam/ockam_identity/src/secure_channels/secure_client.rs
@@ -126,6 +126,14 @@ impl SecureClient {
             ..self
         }
     }
+
+    /// Change the client Identifier
+    pub fn with_client_identifier(self, client_identifier: &Identifier) -> Self {
+        Self {
+            client_identifier: client_identifier.clone(),
+            ..self
+        }
+    }
 }
 
 impl SecureClient {

--- a/implementations/rust/ockam/ockam_node/src/executor.rs
+++ b/implementations/rust/ockam/ockam_node/src/executor.rs
@@ -64,6 +64,11 @@ impl Executor {
         Arc::downgrade(&self.router)
     }
 
+    /// Return the runtime
+    pub fn get_runtime(&self) -> Arc<Runtime> {
+        self.runtime.clone()
+    }
+
     /// Initialise and run the Ockam node executor context
     ///
     /// Any errors encountered by the router or provided application

--- a/implementations/rust/ockam/ockam_node/src/node.rs
+++ b/implementations/rust/ockam/ockam_node/src/node.rs
@@ -49,6 +49,15 @@ impl NodeBuilder {
         }
     }
 
+    /// Enable logging on this node
+    pub fn with_logging(self, logging: bool) -> Self {
+        Self {
+            logging,
+            exit_on_panic: self.exit_on_panic,
+            rt: self.rt,
+        }
+    }
+
     /// Disable exit on panic on this node
     pub fn no_exit_on_panic(self) -> Self {
         Self {

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/node_migration_set.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/node_migration_set.rs
@@ -9,6 +9,7 @@ use ockam_core::Result;
 
 use crate::database::migrations::migration_set::MigrationSet;
 use crate::database::migrations::{Migrator, RustMigration};
+use crate::database::sqlite::migration_20250114100000_members_authority_id::SetAuthorityId;
 use crate::migrate;
 
 /// This struct defines the migration to apply to the nodes database
@@ -33,6 +34,7 @@ impl MigrationSet for NodeMigrationSet {
                 Box::new(SplitPolicies),
                 Box::new(RemoveOrphanResources),
                 Box::new(UpdatePolicyExpressions),
+                Box::new(SetAuthorityId),
             ],
             DatabaseType::Postgres => vec![],
         };

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/sqlite/migration_20250114100000_members_authority_id.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/sqlite/migration_20250114100000_members_authority_id.rs
@@ -1,0 +1,150 @@
+use crate::database::migrations::RustMigration;
+use crate::database::{FromSqlxError, ToVoid};
+use ockam_core::{async_trait, Result};
+use sqlx::*;
+
+/// This migration sets the authority id for existing members
+#[derive(Debug)]
+pub struct SetAuthorityId;
+
+#[async_trait]
+impl RustMigration for SetAuthorityId {
+    fn name(&self) -> &str {
+        Self::name()
+    }
+
+    fn version(&self) -> i64 {
+        Self::version()
+    }
+
+    async fn migrate(&self, connection: &mut AnyConnection) -> Result<bool> {
+        Self::set_authority_id(connection).await
+    }
+}
+
+impl SetAuthorityId {
+    /// Migration version
+    pub fn version() -> i64 {
+        20250114100000
+    }
+
+    /// Migration name
+    pub fn name() -> &'static str {
+        "migration_20250114100000_members_authority_id"
+    }
+
+    pub(crate) async fn set_authority_id(connection: &mut AnyConnection) -> Result<bool> {
+        let mut transaction = Connection::begin(&mut *connection).await.into_core()?;
+        let authority_id: Option<String> =
+            query("SELECT identifier FROM node WHERE name = 'authority'")
+                .fetch_optional(&mut *transaction)
+                .await
+                .into_core()?
+                .map(|r| r.get(0));
+
+        if let Some(authority_id) = authority_id {
+            query("UPDATE authority_member SET authority_id = $1")
+                .bind(authority_id)
+                .execute(&mut *transaction)
+                .await
+                .void()?;
+        }
+
+        // Commit
+        transaction.commit().await.void()?;
+
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::database::migrations::node_migration_set::NodeMigrationSet;
+    use crate::database::{DatabaseType, MigrationSet, SqlxDatabase};
+    use sqlx::any::{AnyArguments, AnyRow};
+    use sqlx::query::Query;
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_migration() -> Result<()> {
+        // create the database pool and migrate the tables
+        let db_file = NamedTempFile::new().unwrap();
+        let db_file = db_file.path();
+
+        let pool = SqlxDatabase::create_sqlite_single_connection_pool(db_file).await?;
+
+        NodeMigrationSet::new(DatabaseType::Sqlite)
+            .create_migrator()?
+            .migrate_up_to_skip_last_rust_migration(&pool, SetAuthorityId::version())
+            .await?;
+
+        let mut connection = pool.acquire().await.into_core()?;
+
+        // set an identifier for the authority node
+        let authority_id = "authority_id_123";
+        insert_node(authority_id)
+            .execute(&mut *connection)
+            .await
+            .void()?;
+
+        // insert some members
+        let member1 = insert_member("1");
+        let member2 = insert_member("2");
+        member1.execute(&mut *connection).await.void()?;
+        member2.execute(&mut *connection).await.void()?;
+
+        // SQLite EXCLUSIVE lock needs exactly one connection during the migration
+        drop(connection);
+
+        // apply migrations
+        NodeMigrationSet::new(DatabaseType::Sqlite)
+            .create_migrator()?
+            .migrate_up_to(&pool, SetAuthorityId::version())
+            .await?;
+
+        let mut connection = pool.acquire().await.into_core()?;
+
+        // check that the update was successful for members
+        let rows: Vec<AnyRow> = query("SELECT authority_id FROM authority_member")
+            .fetch_all(&mut *connection)
+            .await
+            .into_core()?;
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|e| {
+            let s: String = e.get(0);
+            assert_eq!(s, authority_id);
+            true
+        }));
+        Ok(())
+    }
+
+    #[derive(FromRow)]
+    #[allow(dead_code)]
+    struct ResourceTypePolicyRow {
+        resource_type: String,
+        action: String,
+        expression: String,
+        node_name: String,
+    }
+
+    /// HELPERS
+    fn insert_member(identifier: &str) -> Query<'_, Any, AnyArguments<'_>> {
+        query("INSERT INTO authority_member (identifier, added_by, added_at, is_pre_trusted, attributes) VALUES ($1, $2, $3, $4, $5)")
+            .bind(identifier)
+            .bind("someone")
+            .bind(0)
+            .bind(0)
+            .bind("")
+    }
+
+    fn insert_node(identifier: &str) -> Query<'_, Any, AnyArguments<'_>> {
+        query("INSERT INTO node (name, identifier, verbosity, is_default, is_authority) VALUES ($1, $2, $3, $4, $5)")
+            .bind("authority")
+            .bind(identifier)
+            .bind(1)
+            .bind(0)
+            .bind(0)
+    }
+}

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/sqlite/mod.rs
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/rust/sqlite/mod.rs
@@ -12,3 +12,5 @@ pub mod migration_20240212100000_split_policies;
 pub mod migration_20240313100000_remove_orphan_resources;
 /// This migration updates the policy expressions so that they start with an operator
 pub mod migration_20240503100000_update_policy_expressions;
+/// This migration adds an authority_id to the authority_members table to track the authority having members.
+pub mod migration_20250114100000_members_authority_id;

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240613100000_create_database.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/postgres/20240613100000_create_database.sql
@@ -38,11 +38,11 @@ CREATE TABLE named_identity
 CREATE TABLE identity_attributes
 (
     identifier  TEXT PRIMARY KEY, -- identity possessing those attributes
-    attributes  BYTEA NOT NULL,   -- serialized list of attribute names and values for the identity
+    attributes  BYTEA   NOT NULL, -- serialized list of attribute names and values for the identity
     added       INTEGER NOT NULL, -- UNIX timestamp in seconds: when those attributes were inserted in the database
     expires     INTEGER,          -- optional UNIX timestamp in seconds: when those attributes expire
     attested_by TEXT,             -- optional identifier which attested of these attributes
-    node_name   TEXT NOT NULL     -- node name to isolate attributes that each node knows
+    node_name   TEXT    NOT NULL  -- node name to isolate attributes that each node knows
 );
 
 CREATE UNIQUE INDEX identity_attributes_index ON identity_attributes (identifier, node_name);
@@ -58,22 +58,22 @@ CREATE INDEX identity_node_name_index ON identity_attributes (node_name);
 -- This table stores credentials as received by the application
 CREATE TABLE credential
 (
-    subject_identifier TEXT NOT NULL,
-    issuer_identifier  TEXT NOT NULL,
-    scope              TEXT NOT NULL,
+    subject_identifier TEXT  NOT NULL,
+    issuer_identifier  TEXT  NOT NULL,
+    scope              TEXT  NOT NULL,
     credential         BYTEA NOT NULL,
     expires_at         INTEGER,
-    node_name          TEXT NOT NULL -- node name to isolate credential that each node has
+    node_name          TEXT  NOT NULL -- node name to isolate credential that each node has
 );
 
 CREATE UNIQUE INDEX credential_issuer_subject_scope_index ON credential (issuer_identifier, subject_identifier, scope);
-CREATE UNIQUE INDEX credential_issuer_subject_index ON credential(issuer_identifier, subject_identifier);
+CREATE UNIQUE INDEX credential_issuer_subject_index ON credential (issuer_identifier, subject_identifier);
 
 -- This table stores purpose keys that have been created by a given identity
 CREATE TABLE purpose_key
 (
-    identifier              TEXT NOT NULL,  -- Identity identifier
-    purpose                 TEXT NOT NULL,  -- Purpose of the key: SecureChannels, or Credentials
+    identifier              TEXT  NOT NULL, -- Identity identifier
+    purpose                 TEXT  NOT NULL, -- Purpose of the key: SecureChannels, or Credentials
     purpose_key_attestation BYTEA NOT NULL  -- Encoded attestation: attestation data and attestation signature
 );
 
@@ -96,7 +96,7 @@ CREATE TABLE vault
 CREATE TABLE signing_secret
 (
     handle      BYTEA PRIMARY KEY, -- Secret handle
-    secret_type TEXT NOT NULL,     -- Secret type (EdDSACurve25519 or ECDSASHA256CurveP256)
+    secret_type TEXT  NOT NULL,    -- Secret type (EdDSACurve25519 or ECDSASHA256CurveP256)
     secret      BYTEA NOT NULL     -- Secret binary
 );
 
@@ -113,22 +113,23 @@ CREATE TABLE x25519_secret
 
 CREATE TABLE authority_member
 (
-    identifier     TEXT NOT NULL UNIQUE,
-    added_by       TEXT NOT NULL,
+    identifier     TEXT    NOT NULL UNIQUE,
+    added_by       TEXT    NOT NULL,
     added_at       INTEGER NOT NULL,
     is_pre_trusted BOOLEAN NOT NULL,
-    attributes     BYTEA
+    attributes     BYTEA,
+    authority_id   TEXT    NOT NULL
 );
 
-CREATE UNIQUE INDEX authority_member_identifier_index ON authority_member(identifier);
-CREATE INDEX authority_member_is_pre_trusted_index ON authority_member(is_pre_trusted);
+CREATE UNIQUE INDEX authority_member_identifier_index ON authority_member (identifier);
+CREATE INDEX authority_member_is_pre_trusted_index ON authority_member (is_pre_trusted);
 
 -- Reference is a random string that uniquely identifies an enrollment token. However, unlike the one_time_code,
 -- it's not sensitive so can be logged and used to track a lifecycle of a specific enrollment token.
 CREATE TABLE authority_enrollment_token
 (
-    one_time_code TEXT NOT NULL UNIQUE,
-    issued_by     TEXT NOT NULL,
+    one_time_code TEXT    NOT NULL UNIQUE,
+    issued_by     TEXT    NOT NULL,
     created_at    INTEGER NOT NULL,
     expires_at    INTEGER NOT NULL,
     ttl_count     INTEGER NOT NULL,
@@ -136,8 +137,8 @@ CREATE TABLE authority_enrollment_token
     reference     TEXT
 );
 
-CREATE UNIQUE INDEX authority_enrollment_token_one_time_code_index ON authority_enrollment_token(one_time_code);
-CREATE INDEX authority_enrollment_token_expires_at_index ON authority_enrollment_token(expires_at);
+CREATE UNIQUE INDEX authority_enrollment_token_one_time_code_index ON authority_enrollment_token (one_time_code);
+CREATE INDEX authority_enrollment_token_expires_at_index ON authority_enrollment_token (expires_at);
 
 ------------
 -- SERVICES
@@ -159,40 +160,40 @@ CREATE UNIQUE INDEX resource_policy_index ON resource_policy (node_name, resourc
 -- Create a new table for resource type policies
 CREATE TABLE resource_type_policy
 (
-    resource_type   TEXT NOT NULL, -- resource type
-    action          TEXT NOT NULL, -- action name
-    expression      TEXT NOT NULL, -- encoded expression to evaluate
-    node_name       TEXT NOT NULL  -- node name
+    resource_type TEXT NOT NULL, -- resource type
+    action        TEXT NOT NULL, -- action name
+    expression    TEXT NOT NULL, -- encoded expression to evaluate
+    node_name     TEXT NOT NULL  -- node name
 );
 CREATE UNIQUE INDEX resource_type_policy_index ON resource_type_policy (node_name, resource_type, action);
 
 -- Create a new table for resource to resource type mapping
 CREATE TABLE resource
 (
-    resource_name   TEXT NOT NULL, -- resource name
-    resource_type   TEXT NOT NULL, -- resource type
-    node_name       TEXT NOT NULL  -- node name
+    resource_name TEXT NOT NULL, -- resource name
+    resource_type TEXT NOT NULL, -- resource type
+    node_name     TEXT NOT NULL  -- node name
 );
 CREATE UNIQUE INDEX resource_index ON resource (node_name, resource_name, resource_type);
 
 -- This table stores the current state of a TCP outlet
 CREATE TABLE tcp_outlet_status
 (
-    node_name   TEXT NOT NULL,       -- Node where that tcp outlet has been created
-    socket_addr TEXT NOT NULL,       -- Socket address that the outlet connects to
-    worker_addr TEXT NOT NULL,       -- Worker address for the outlet itself
-    payload     TEXT,                -- Optional status payload
-    privileged BOOLEAN DEFAULT FALSE -- boolean indicating if the outlet is operating in privileged mode
+    node_name   TEXT NOT NULL,        -- Node where that tcp outlet has been created
+    socket_addr TEXT NOT NULL,        -- Socket address that the outlet connects to
+    worker_addr TEXT NOT NULL,        -- Worker address for the outlet itself
+    payload     TEXT,                 -- Optional status payload
+    privileged  BOOLEAN DEFAULT FALSE -- boolean indicating if the outlet is operating in privileged mode
 );
 
 -- This table stores the current state of a TCP inlet
 CREATE TABLE tcp_inlet
 (
-    node_name    TEXT NOT NULL,      -- Node where that tcp inlet has been created
-    bind_addr    TEXT NOT NULL,      -- Input address to connect to
-    outlet_addr  TEXT NOT NULL,      -- MultiAddress to the outlet
-    alias        TEXT NOT NULL,      -- Alias for that inlet
-    privileged BOOLEAN DEFAULT FALSE -- boolean indicating if the inlet is operating in privileged mode
+    node_name   TEXT NOT NULL,        -- Node where that tcp inlet has been created
+    bind_addr   TEXT NOT NULL,        -- Input address to connect to
+    outlet_addr TEXT NOT NULL,        -- MultiAddress to the outlet
+    alias       TEXT NOT NULL,        -- Alias for that inlet
+    privileged  BOOLEAN DEFAULT FALSE -- boolean indicating if the inlet is operating in privileged mode
 );
 
 ---------
@@ -219,21 +220,21 @@ CREATE TABLE node
 -- This table stores secure channels in order to restore them on a restart
 CREATE TABLE secure_channel
 (
-    role                        TEXT NOT NULL,
-    my_identifier               TEXT NOT NULL,
-    their_identifier            TEXT NOT NULL,
-    decryptor_remote_address    TEXT PRIMARY KEY,
-    decryptor_api_address       TEXT NOT NULL,
-    decryption_key_handle       BYTEA NOT NULL
+    role                     TEXT  NOT NULL,
+    my_identifier            TEXT  NOT NULL,
+    their_identifier         TEXT  NOT NULL,
+    decryptor_remote_address TEXT PRIMARY KEY,
+    decryptor_api_address    TEXT  NOT NULL,
+    decryption_key_handle    BYTEA NOT NULL
     -- TODO: Add date?
 );
 
-CREATE UNIQUE INDEX secure_channel_decryptor_api_address_index ON secure_channel(decryptor_remote_address);
+CREATE UNIQUE INDEX secure_channel_decryptor_api_address_index ON secure_channel (decryptor_remote_address);
 
 -- This table stores aead secrets
 CREATE TABLE aead_secret
 (
-    handle      BYTEA PRIMARY KEY, -- Secret handle
-    type        TEXT NOT NULL,    -- Secret type
-    secret      BYTEA NOT NULL     -- Secret binary
+    handle BYTEA PRIMARY KEY, -- Secret handle
+    type   TEXT  NOT NULL,    -- Secret type
+    secret BYTEA NOT NULL     -- Secret binary
 );

--- a/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250114100000_members_authority_id.sql
+++ b/implementations/rust/ockam/ockam_node/src/storage/database/migrations/node_migrations/sql/sqlite/20250114100000_members_authority_id.sql
@@ -1,0 +1,3 @@
+-- Add a column to track the authority id
+ALTER TABLE authority_member
+    ADD authority_id TEXT NOT NULL DEFAULT 'fixme';


### PR DESCRIPTION
This PR makes sure that we can start several authority nodes using a shared Postgres database:

 - It adds an `authority_id` column to the `authority_member` table in order to isolate members from authority to authority
 - It adds some tests to show that 2 authority nodes can be started with the same Postgres database with all their services running:
   - direct authentication.
   - issue credentials.
   - issue tokens.
   - accept tokens.