### PR TITLE
fix(rust): fix the migration of in-memory sqlite database the start-up of authority nodes

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -223,7 +223,6 @@ impl CreateCommand {
         if self.disable_trust_context_id {
             args.push("--disable_trust_context_id".to_string());
         }
-        args.push(self.node_name());
 
         run_ockam(args, opts.global_args.quiet).await
     }


### PR DESCRIPTION
This PR fixes:

 - The migration of nodes using a SQLite database in-memory
 - The start of background authority nodes where an unnecessary argument (the node name) was added to the command line

