### PR TITLE
ci: use id-token permission when using aws oidc

### DIFF
--- a/.github/workflows/release-ockam-package.yml
+++ b/.github/workflows/release-ockam-package.yml
@@ -38,6 +38,7 @@ jobs:
       actions: read
       contents: write
       packages: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Fixes this failure https://github.com/build-trust/ockam/actions/runs/12876678173/job/35900017928#step:3:28