### PR TITLE
feat(rust): custom branding config allows you to specify which commands are included

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1608,7 +1608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2468,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3899,7 +3899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5902,7 +5902,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6348,7 +6348,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7530,7 +7530,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8619,7 +8619,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/env_variables.rs
@@ -38,7 +38,7 @@ pub(crate) const OCKAM_OPENTELEMETRY_EXPORT: &str = "OCKAM_OPENTELEMETRY_EXPORT"
 pub(crate) const OCKAM_TELEMETRY_EXPORT_VIA_PORTAL: &str = "OCKAM_TELEMETRY_EXPORT_VIA_PORTAL";
 
 /// Boolean set to true if the current user is an Ockam developer
-pub(crate) const OCKAM_DEVELOPER: &str = "OCKAM_DEVELOPER";
+pub const OCKAM_DEVELOPER: &str = "OCKAM_DEVELOPER";
 
 /// If this variable is true, print statements will debug the setting of the OpenTelemetry export
 pub(crate) const OCKAM_OPENTELEMETRY_EXPORT_DEBUG: &str = "OCKAM_OPENTELEMETRY_EXPORT_DEBUG";

--- a/implementations/rust/ockam/ockam_api/src/logs/mod.rs
+++ b/implementations/rust/ockam/ockam_api/src/logs/mod.rs
@@ -11,7 +11,7 @@
 ///
 mod current_span;
 mod default_values;
-mod env_variables;
+pub mod env_variables;
 pub mod exporting_configuration;
 mod log_exporters;
 pub mod logging_configuration;

--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -29,6 +29,10 @@ fn binary_name() {
     println!("cargo:rustc-env=OCKAM_HOME={home_dir}");
     println!("cargo:rerun-if-env-changed=OCKAM_HOME");
 
+    let commands = env::var("OCKAM_COMMANDS").unwrap_or("".to_string());
+    println!("cargo:rustc-env=OCKAM_COMMANDS={commands}");
+    println!("cargo:rerun-if-env-changed=OCKAM_COMMANDS");
+
     let orchestrator_identifier =
         env::var("OCKAM_CONTROLLER_IDENTITY_ID").unwrap_or("".to_string());
     println!("cargo:rustc-env=OCKAM_CONTROLLER_IDENTITY_ID={orchestrator_identifier}");

--- a/implementations/rust/ockam/ockam_command/build.rs
+++ b/implementations/rust/ockam/ockam_command/build.rs
@@ -12,6 +12,10 @@ fn hash() {
 }
 
 fn binary_name() {
+    let is_developer = env::var("OCKAM_DEVELOPER").unwrap_or("false".to_string());
+    println!("cargo:rustc-env=OCKAM_DEVELOPER={is_developer}");
+    println!("cargo:rerun-if-env-changed=OCKAM_DEVELOPER");
+
     let bin_name = env::var("OCKAM_COMMAND_BIN_NAME").unwrap_or("ockam".to_string());
     println!("cargo:rustc-env=OCKAM_COMMAND_BIN_NAME={bin_name}");
     println!("cargo:rerun-if-env-changed=OCKAM_COMMAND_BIN_NAME");

--- a/implementations/rust/ockam/ockam_command/src/bin/brand.rs
+++ b/implementations/rust/ockam/ockam_command/src/bin/brand.rs
@@ -4,7 +4,7 @@ use ockam_api::colors::color_primary;
 use ockam_api::fmt_log;
 use ockam_api::orchestrator::{OCKAM_CONTROLLER_ADDRESS, OCKAM_CONTROLLER_IDENTIFIER};
 use ockam_api::terminal::PADDING;
-use ockam_command::{
+use ockam_command::environment::compile_time_vars::{
     OCKAM_COMMANDS, OCKAM_COMMAND_BIN_NAME, OCKAM_COMMAND_BRAND_NAME, OCKAM_COMMAND_SUPPORT_EMAIL,
 };
 use once_cell::sync::Lazy;

--- a/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
+++ b/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
@@ -5,6 +5,8 @@ bin:
   home_dir: /home/brand1 # if not set, will default to $HOME/.bin
   orchestrator_identifier: brand1 # if not set, will default to the OCKAM_CONTROLLER_IDENTITY_ID env var
   orchestrator_address: brand1.network # if not set, will default to the OCKAM_CONTROLLER_ADDR env var
+  build_args: # if not set, will default to empty string
+    - --release
   commands:
     - node: "host"
     - node_list

--- a/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
+++ b/implementations/rust/ockam/ockam_command/src/bin/brand.sample.yaml
@@ -5,3 +5,7 @@ bin:
   home_dir: /home/brand1 # if not set, will default to $HOME/.bin
   orchestrator_identifier: brand1 # if not set, will default to the OCKAM_CONTROLLER_IDENTITY_ID env var
   orchestrator_address: brand1.network # if not set, will default to the OCKAM_CONTROLLER_ADDR env var
+  commands:
+    - node: "host"
+    - node_list
+    - node_create: "init"

--- a/implementations/rust/ockam/ockam_command/src/branding.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding.rs
@@ -33,8 +33,8 @@ impl Debug for Command {
 }
 
 impl Commands {
-    pub fn from_env() -> Result<Self> {
-        let commands = COMMANDS
+    fn new(commands: &str) -> Result<Self> {
+        let commands = commands
             .split(',')
             .filter_map(|c| {
                 if c.is_empty() {
@@ -53,6 +53,10 @@ impl Commands {
             })
             .collect();
         Ok(Self { commands })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        Self::new(COMMANDS)
     }
 
     pub fn hide(&self, command_name: &str) -> bool {
@@ -77,33 +81,28 @@ impl Commands {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::OCKAM_COMMANDS;
 
     #[test]
     fn test_hide() {
-        std::env::set_var(OCKAM_COMMANDS, "node create=host create,project,enroll");
-        let commands = Commands::from_env().unwrap();
+        let commands = Commands::new("node create=host create,project,enroll").unwrap();
         assert!(!commands.hide("node create"));
         assert!(!commands.hide("project"));
         assert!(!commands.hide("enroll"));
         assert!(commands.hide("command4"));
 
-        std::env::set_var(OCKAM_COMMANDS, "");
-        let commands = Commands::from_env().unwrap();
+        let commands = Commands::new("").unwrap();
         assert!(!commands.hide("command1"));
     }
 
     #[test]
     fn test_commands() {
-        std::env::set_var(OCKAM_COMMANDS, "node create=host create,project,enroll");
-        let commands = Commands::from_env().unwrap();
+        let commands = Commands::new("node create=host create,project,enroll").unwrap();
         assert_eq!(commands.name("node create"), "host create");
         assert_eq!(commands.name("project"), "project");
         assert_eq!(commands.name("enroll"), "enroll");
         assert_eq!(commands.name("command4"), "command4");
 
-        std::env::set_var(OCKAM_COMMANDS, "");
-        let commands = Commands::from_env().unwrap();
+        let commands = Commands::new("").unwrap();
         assert_eq!(commands.name("command1"), "command1");
     }
 }

--- a/implementations/rust/ockam/ockam_command/src/branding.rs
+++ b/implementations/rust/ockam/ockam_command/src/branding.rs
@@ -1,0 +1,109 @@
+use crate::environment::compile_time_vars::COMMANDS;
+use crate::Result;
+use once_cell::sync::Lazy;
+use std::fmt::{Debug, Formatter};
+
+pub(crate) fn name(name: &str) -> &'static str {
+    CUSTOM_COMMANDS.name(name)
+}
+
+pub(crate) fn hide(name: &str) -> bool {
+    CUSTOM_COMMANDS.hide(name)
+}
+
+pub(crate) static CUSTOM_COMMANDS: Lazy<Commands> =
+    Lazy::new(|| Commands::from_env().expect("Failed to load custom commands"));
+
+pub(crate) struct Commands {
+    commands: Vec<Command>,
+}
+
+pub(crate) struct Command {
+    name: String,
+    custom_name: String,
+}
+
+impl Debug for Command {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Command")
+            .field("name", &self.name)
+            .field("custom_name", &self.custom_name)
+            .finish()
+    }
+}
+
+impl Commands {
+    pub fn from_env() -> Result<Self> {
+        let commands = COMMANDS
+            .split(',')
+            .filter_map(|c| {
+                if c.is_empty() {
+                    return None;
+                }
+                let mut parts = c.split('=');
+                let name = match parts.next() {
+                    Some(name) => name,
+                    None => return None,
+                };
+                let custom_name = parts.next().unwrap_or(name);
+                Some(Command {
+                    name: name.to_string(),
+                    custom_name: custom_name.to_string(),
+                })
+            })
+            .collect();
+        Ok(Self { commands })
+    }
+
+    pub fn hide(&self, command_name: &str) -> bool {
+        if self.commands.is_empty() {
+            return false;
+        }
+        !self.commands.iter().any(|c| c.name == command_name)
+    }
+
+    pub fn name(&self, command_name: &str) -> &'static str {
+        if self.commands.is_empty() {
+            return Box::leak(command_name.to_string().into_boxed_str());
+        }
+        self.commands
+            .iter()
+            .find(|c| c.name == command_name)
+            .map(|c| Box::leak(c.custom_name.clone().into_boxed_str()))
+            .unwrap_or(Box::leak(command_name.to_string().into_boxed_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OCKAM_COMMANDS;
+
+    #[test]
+    fn test_hide() {
+        std::env::set_var(OCKAM_COMMANDS, "node create=host create,project,enroll");
+        let commands = Commands::from_env().unwrap();
+        assert!(!commands.hide("node create"));
+        assert!(!commands.hide("project"));
+        assert!(!commands.hide("enroll"));
+        assert!(commands.hide("command4"));
+
+        std::env::set_var(OCKAM_COMMANDS, "");
+        let commands = Commands::from_env().unwrap();
+        assert!(!commands.hide("command1"));
+    }
+
+    #[test]
+    fn test_commands() {
+        std::env::set_var(OCKAM_COMMANDS, "node create=host create,project,enroll");
+        let commands = Commands::from_env().unwrap();
+        assert_eq!(commands.name("node create"), "host create");
+        assert_eq!(commands.name("project"), "project");
+        assert_eq!(commands.name("enroll"), "enroll");
+        assert_eq!(commands.name("command4"), "command4");
+
+        std::env::set_var(OCKAM_COMMANDS, "");
+        let commands = Commands::from_env().unwrap();
+        assert_eq!(commands.name("command1"), "command1");
+    }
+}

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -20,7 +20,7 @@ const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
 
 pub use crate::environment::compile_time_vars::{
     BIN_NAME, BRAND_NAME, OCKAM_COMMANDS, OCKAM_COMMAND_BIN_NAME, OCKAM_COMMAND_BRAND_NAME,
-    OCKAM_COMMAND_SUPPORT_EMAIL,
+    OCKAM_COMMAND_SUPPORT_EMAIL, SUPPORT_EMAIL,
 };
 
 /// Top-level command, with:

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -1,5 +1,6 @@
 use crate::command_events::{add_command_error_event, add_command_event};
 use crate::command_global_opts::CommandGlobalOpts;
+use crate::environment::compile_time_vars::BIN_NAME;
 use crate::global_args::GlobalArgs;
 use crate::subcommand::OckamSubcommand;
 use crate::upgrade::check_if_an_upgrade_is_available;
@@ -17,11 +18,6 @@ use tracing::{instrument, warn};
 const ABOUT: &str = include_str!("./static/about.txt");
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
-
-pub use crate::environment::compile_time_vars::{
-    BIN_NAME, BRAND_NAME, OCKAM_COMMANDS, OCKAM_COMMAND_BIN_NAME, OCKAM_COMMAND_BRAND_NAME,
-    OCKAM_COMMAND_SUPPORT_EMAIL, SUPPORT_EMAIL,
-};
 
 /// Top-level command, with:
 ///  - Global arguments

--- a/implementations/rust/ockam/ockam_command/src/command.rs
+++ b/implementations/rust/ockam/ockam_command/src/command.rs
@@ -19,7 +19,7 @@ const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
 const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
 
 pub use crate::environment::compile_time_vars::{
-    BIN_NAME, BRAND_NAME, OCKAM_COMMAND_BIN_NAME, OCKAM_COMMAND_BRAND_NAME,
+    BIN_NAME, BRAND_NAME, OCKAM_COMMANDS, OCKAM_COMMAND_BIN_NAME, OCKAM_COMMAND_BRAND_NAME,
     OCKAM_COMMAND_SUPPORT_EMAIL,
 };
 

--- a/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
+++ b/implementations/rust/ockam/ockam_command/src/command_global_opts.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, info};
 
-use crate::command::{BIN_NAME, BRAND_NAME};
-use crate::environment::compile_time_vars::load_compile_time_vars;
+use crate::environment::compile_time_vars::{load_compile_time_vars, BIN_NAME, BRAND_NAME};
 use crate::subcommand::OckamSubcommand;
 use crate::util::exitcode;
 use crate::version::Version;

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -1,4 +1,4 @@
-use crate::command::{BIN_NAME, BRAND_NAME, SUPPORT_EMAIL};
+use crate::environment::compile_time_vars::{BIN_NAME, BRAND_NAME, SUPPORT_EMAIL};
 use crate::Result;
 use colorful::Colorful;
 use ockam_api::terminal::TextHighlighter;

--- a/implementations/rust/ockam/ockam_command/src/docs.rs
+++ b/implementations/rust/ockam/ockam_command/src/docs.rs
@@ -1,4 +1,4 @@
-use crate::command::{BIN_NAME, BRAND_NAME};
+use crate::command::{BIN_NAME, BRAND_NAME, SUPPORT_EMAIL};
 use crate::Result;
 use colorful::Colorful;
 use ockam_api::terminal::TextHighlighter;
@@ -11,7 +11,9 @@ const PREVIEW_TAG: &str = include_str!("./static/preview_tag.txt");
 const UNSAFE_TOOLTIP_TEXT: &str = include_str!("./static/unsafe_tooltip.txt");
 const UNSAFE_TAG: &str = include_str!("./static/unsafe_tag.txt");
 
-const FOOTER: &str = "
+static FOOTER: Lazy<String> = Lazy::new(|| {
+    if BIN_NAME == "ockam" {
+        "
 Learn More:
 
 Use 'ockam <SUBCOMMAND> --help' for more information about a subcommand.
@@ -22,8 +24,22 @@ Learn more about Ockam: https://docs.ockam.io/reference/command
 Feedback:
 
 If you have questions, as you explore, join us on the contributors
-discord channel https://discord.ockam.io
-";
+discord channel https://discord.ockam.io"
+            .to_string()
+    } else {
+        format!(
+            "
+Learn More:
+
+Use 'ockam <SUBCOMMAND> --help' for more information about a subcommand.
+Where <SUBCOMMAND> might be: 'node', 'status', 'enroll', etc.
+
+Feedback:
+
+If you have questions, please email us on {SUPPORT_EMAIL}"
+        )
+    }
+});
 
 static HEADER_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new("^(Examples|Learn More|Feedback):$".into()));
@@ -63,7 +79,7 @@ pub(crate) fn after_help(text: &str) -> &'static str {
     } else {
         processed.push_str("Examples:\n\n");
         processed.push_str(text);
-        processed.push_str(FOOTER);
+        processed.push_str(&FOOTER);
     }
     render(processed.as_str())
 }

--- a/implementations/rust/ockam/ockam_command/src/environment/compile_time_vars.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/compile_time_vars.rs
@@ -5,15 +5,20 @@ use ockam_core::env::get_env_with_default;
 pub const OCKAM_COMMAND_BIN_NAME: &str = "OCKAM_COMMAND_BIN_NAME";
 pub const OCKAM_COMMAND_BRAND_NAME: &str = "OCKAM_COMMAND_BRAND_NAME";
 pub const OCKAM_COMMAND_SUPPORT_EMAIL: &str = "OCKAM_COMMAND_SUPPORT_EMAIL";
+pub const OCKAM_COMMANDS: &str = "OCKAM_COMMANDS";
 
 pub const BIN_NAME: &str = env!("OCKAM_COMMAND_BIN_NAME");
 pub const BRAND_NAME: &str = env!("OCKAM_COMMAND_BRAND_NAME");
 pub const SUPPORT_EMAIL: &str = env!("OCKAM_COMMAND_SUPPORT_EMAIL");
+/// A comma separated list of commands that can be run
+/// in the format `command1=customName,command2,command3`
+pub const COMMANDS: &str = env!("OCKAM_COMMANDS");
 
 pub fn load_compile_time_vars() {
     std::env::set_var(OCKAM_COMMAND_BIN_NAME, BIN_NAME);
     std::env::set_var(OCKAM_COMMAND_BRAND_NAME, BRAND_NAME);
     std::env::set_var(OCKAM_COMMAND_SUPPORT_EMAIL, SUPPORT_EMAIL);
+    std::env::set_var(OCKAM_COMMANDS, COMMANDS);
     if let Ok(home_dir) = get_env_with_default(OCKAM_HOME, env!("OCKAM_HOME").to_string()) {
         if !home_dir.is_empty() {
             std::env::set_var(OCKAM_HOME, home_dir);

--- a/implementations/rust/ockam/ockam_command/src/environment/compile_time_vars.rs
+++ b/implementations/rust/ockam/ockam_command/src/environment/compile_time_vars.rs
@@ -1,12 +1,15 @@
 use ockam_api::cli_state::OCKAM_HOME;
 use ockam_api::orchestrator::{OCKAM_CONTROLLER_ADDRESS, OCKAM_CONTROLLER_IDENTIFIER};
-use ockam_core::env::get_env_with_default;
+use ockam_core::env::{get_env_with_default, FromString};
 
+// Runtime environment variables names used in the brand.rs binary
 pub const OCKAM_COMMAND_BIN_NAME: &str = "OCKAM_COMMAND_BIN_NAME";
 pub const OCKAM_COMMAND_BRAND_NAME: &str = "OCKAM_COMMAND_BRAND_NAME";
 pub const OCKAM_COMMAND_SUPPORT_EMAIL: &str = "OCKAM_COMMAND_SUPPORT_EMAIL";
 pub const OCKAM_COMMANDS: &str = "OCKAM_COMMANDS";
 
+// Compile time environment variables names used in the command binary
+pub const OCKAM_DEVELOPER: &str = env!("OCKAM_DEVELOPER");
 pub const BIN_NAME: &str = env!("OCKAM_COMMAND_BIN_NAME");
 pub const BRAND_NAME: &str = env!("OCKAM_COMMAND_BRAND_NAME");
 pub const SUPPORT_EMAIL: &str = env!("OCKAM_COMMAND_SUPPORT_EMAIL");
@@ -15,10 +18,10 @@ pub const SUPPORT_EMAIL: &str = env!("OCKAM_COMMAND_SUPPORT_EMAIL");
 pub const COMMANDS: &str = env!("OCKAM_COMMANDS");
 
 pub fn load_compile_time_vars() {
-    std::env::set_var(OCKAM_COMMAND_BIN_NAME, BIN_NAME);
-    std::env::set_var(OCKAM_COMMAND_BRAND_NAME, BRAND_NAME);
-    std::env::set_var(OCKAM_COMMAND_SUPPORT_EMAIL, SUPPORT_EMAIL);
-    std::env::set_var(OCKAM_COMMANDS, COMMANDS);
+    std::env::set_var(
+        ockam_api::logs::env_variables::OCKAM_DEVELOPER,
+        OCKAM_DEVELOPER,
+    );
     if let Ok(home_dir) = get_env_with_default(OCKAM_HOME, env!("OCKAM_HOME").to_string()) {
         if !home_dir.is_empty() {
             std::env::set_var(OCKAM_HOME, home_dir);
@@ -40,4 +43,8 @@ pub fn load_compile_time_vars() {
             std::env::set_var(OCKAM_CONTROLLER_ADDRESS, orchestrator_address);
         }
     }
+}
+
+pub fn is_ockam_developer() -> bool {
+    bool::from_string(OCKAM_DEVELOPER).unwrap_or(false)
 }

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -39,7 +39,7 @@ mod credential;
 mod docs;
 pub mod enroll;
 pub mod entry_point;
-mod environment;
+pub mod environment;
 pub mod error;
 mod flow_control;
 mod global_args;

--- a/implementations/rust/ockam/ockam_command/src/lib.rs
+++ b/implementations/rust/ockam/ockam_command/src/lib.rs
@@ -30,6 +30,7 @@ pub use terminal::*;
 mod admin;
 mod arguments;
 mod authority;
+mod branding;
 mod command;
 mod command_events;
 mod command_global_opts;

--- a/implementations/rust/ockam/ockam_command/src/manpages.rs
+++ b/implementations/rust/ockam/ockam_command/src/manpages.rs
@@ -12,7 +12,8 @@ use tracing::error;
 
 use ockam_core::env::get_env_with_default;
 
-use crate::{docs, OckamCommand, BIN_NAME};
+use crate::environment::compile_time_vars::BIN_NAME;
+use crate::{docs, OckamCommand};
 
 #[derive(Clone, Debug, Args)]
 #[command(

--- a/implementations/rust/ockam/ockam_command/src/markdown/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/markdown/mod.rs
@@ -9,8 +9,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::error;
 
-use crate::OckamCommand;
-use crate::{docs, BIN_NAME};
+use crate::environment::compile_time_vars::BIN_NAME;
+use crate::{docs, OckamCommand};
 
 #[derive(Clone, Debug, Args)]
 #[command(

--- a/implementations/rust/ockam/ockam_command/src/node/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/node/mod.rs
@@ -29,10 +29,10 @@ const AFTER_LONG_HELP: &str = include_str!("./static/after_long_help.txt");
 /// Manage Nodes
 #[derive(Clone, Debug, Args)]
 #[command(
-arg_required_else_help = true,
-subcommand_required = true,
-long_about = docs::about(LONG_ABOUT),
-after_long_help = docs::after_help(AFTER_LONG_HELP)
+    arg_required_else_help = true,
+    subcommand_required = true,
+    long_about = docs::about(LONG_ABOUT),
+    after_long_help = docs::after_help(AFTER_LONG_HELP),
 )]
 pub struct NodeCommand {
     #[command(subcommand)]
@@ -48,20 +48,13 @@ impl NodeCommand {
 #[derive(Clone, Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum NodeSubcommand {
-    #[command(display_order = 800)]
     Create(CreateCommand),
-    #[command(display_order = 800)]
     Delete(DeleteCommand),
-    #[command(display_order = 800)]
     List(ListCommand),
-    #[command(display_order = 800)]
     Logs(LogCommand),
     Show(ShowCommand),
-    #[command(display_order = 800)]
     Start(StartCommand),
-    #[command(display_order = 800)]
     Stop(StopCommand),
-    #[command(display_order = 800)]
     Default(DefaultCommand),
 }
 

--- a/implementations/rust/ockam/ockam_command/src/reset/mod.rs
+++ b/implementations/rust/ockam/ockam_command/src/reset/mod.rs
@@ -13,6 +13,7 @@ use ockam_api::{color, fmt_ok, CliState};
 use ockam_node::Context;
 
 use crate::docs;
+use crate::environment::compile_time_vars::is_ockam_developer;
 use crate::util::async_cmd;
 
 const LONG_ABOUT: &str = include_str!("./static/long_about.txt");
@@ -56,7 +57,7 @@ impl ResetCommand {
 
     async fn async_run(&self, ctx: &Context, opts: CommandGlobalOpts) -> miette::Result<()> {
         let delete_orchestrator_resources =
-            self.all && opts.state.is_enrolled().await.unwrap_or_default();
+            is_ockam_developer() && self.all && opts.state.is_enrolled().await.unwrap_or_default();
         if !self.yes {
             let msg = if delete_orchestrator_resources {
                 "This will delete the local Ockam configuration and remove your spaces from the Orchestrator. Are you sure?"

--- a/implementations/rust/ockam/ockam_command/src/subcommand.rs
+++ b/implementations/rust/ockam/ockam_command/src/subcommand.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use clap::Subcommand;
 use colorful::Colorful;
-use miette::IntoDiagnostic;
+use miette::{miette, IntoDiagnostic};
 use tokio_retry::strategy::jitter;
 use tracing::warn;
 
@@ -17,6 +17,7 @@ use ockam_node::Context;
 
 use crate::admin::AdminCommand;
 use crate::authority::{AuthorityCommand, AuthoritySubcommand};
+use crate::branding;
 use crate::command_global_opts::CommandGlobalOpts;
 use crate::completion::CompletionCommand;
 use crate::credential::CredentialCommand;
@@ -68,52 +69,94 @@ use crate::Result;
 #[derive(Clone, Debug, Subcommand)]
 #[command(about = docs::about("List of commands which can be executed with `ockam`"))]
 pub enum OckamSubcommand {
+    #[command(name = branding::name("enroll"), hide = branding::hide("enroll"))]
+    Enroll(EnrollCommand),
+
+    #[command(name = branding::name("node"), hide = branding::hide("node"))]
     Node(NodeCommand),
+    #[command(name = branding::name("vault"), hide = branding::hide("vault"))]
     Vault(VaultCommand),
+    #[command(name = branding::name("identity"), hide = branding::hide("identity"))]
     Identity(IdentityCommand),
+    #[command(name = branding::name("project"), hide = branding::hide("project"))]
     Project(ProjectCommand),
+    #[command(name = branding::name("policy"), hide = branding::hide("policy"))]
     Policy(PolicyCommand),
+    #[command(name = branding::name("credential"), hide = branding::hide("credential"))]
     Credential(CredentialCommand),
+    #[command(name = branding::name("relay"), hide = branding::hide("relay"))]
     Relay(RelayCommand),
+    #[command(name = branding::name("tcp-outlet"), hide = branding::hide("tcp-outlet"))]
     TcpOutlet(TcpOutletCommand),
+    #[command(name = branding::name("tcp-inlet"), hide = branding::hide("tcp-inlet"))]
     TcpInlet(TcpInletCommand),
+    #[command(name = branding::name("kafka-inlet"), hide = branding::hide("kafka-inlet"))]
     KafkaInlet(KafkaInletCommand),
+    #[command(name = branding::name("kafka-outlet"), hide = branding::hide("kafka-outlet"))]
     KafkaOutlet(KafkaOutletCommand),
-    #[command(name = "influxdb-inlet")]
+    #[command(name = branding::name("influxdb-inlet"), hide = branding::hide("influxdb-inlet"))]
     InfluxDBInlet(InfluxDBInletCommand),
-    #[command(name = "influxdb-outlet")]
+    #[command(name = branding::name("influxdb-outlet"), hide = branding::hide("influxdb-outlet"))]
     InfluxDBOutlet(InfluxDBOutletCommand),
-    #[command(hide = docs::hide())]
+    #[command(name = branding::name("rendezvous"), hide = branding::hide("rendezvous") || docs::hide())]
     Rendezvous(RendezvousCommand),
+    #[command(name = branding::name("status"), hide = branding::hide("status"))]
     Status(StatusCommand),
+    #[command(name = branding::name("reset"), hide = branding::hide("reset"))]
     Reset(ResetCommand),
+    #[command(name = branding::name("run"), hide = branding::hide("run"))]
     Run(RunCommand),
+    #[command(name = branding::name("manpages"), hide = branding::hide("manpages"))]
     Manpages(ManpagesCommand),
+    #[command(name = branding::name("completion"), hide = branding::hide("completion"))]
     Completion(CompletionCommand),
+    #[command(name = branding::name("environment"), hide = branding::hide("environment"))]
     Environment(EnvironmentCommand),
 
-    Enroll(EnrollCommand),
+    #[command(name = branding::name("admin"), hide = branding::hide("admin"))]
     Admin(AdminCommand),
+    #[command(name = branding::name("space"), hide = branding::hide("space"))]
     Space(SpaceCommand),
+    #[command(name = branding::name("space-admin"), hide = branding::hide("space-admin"))]
     SpaceAdmin(SpaceAdminCommand),
+    #[command(name = branding::name("project-admin"), hide = branding::hide("project-admin"))]
     ProjectAdmin(ProjectAdminCommand),
+    #[command(name = branding::name("project-member"), hide = branding::hide("project-member"))]
     ProjectMember(ProjectMemberCommand),
+    #[command(name = branding::name("sidecar"), hide = branding::hide("sidecar"))]
     Sidecar(SidecarCommand),
+    #[command(name = branding::name("subscription"), hide = branding::hide("subscription"))]
     Subscription(SubscriptionCommand),
+    #[command(name = branding::name("lease"), hide = branding::hide("lease"))]
     Lease(LeaseCommand),
+    #[command(name = branding::name("authority"), hide = branding::hide("authority"))]
     Authority(AuthorityCommand),
-    Markdown(MarkdownCommand),
-    Worker(WorkerCommand),
+    #[command(name = branding::name("service"), hide = branding::hide("service"))]
     Service(ServiceCommand),
+    #[command(name = branding::name("message"), hide = branding::hide("message"))]
     Message(MessageCommand),
+    #[command(name = branding::name("markdown"), hide = branding::hide("markdown"))]
+    Markdown(MarkdownCommand),
+
+    #[command(name = branding::name("migrate-database"), hide = branding::hide("migrate-database"))]
     MigrateDatabase(MigrateDatabaseCommand),
+    #[command(name = branding::name("worker"), hide = branding::hide("worker"))]
+    Worker(WorkerCommand),
+    #[command(name = branding::name("secure-channel-listener"), hide = branding::hide("secure-channel-listener"))]
     SecureChannelListener(SecureChannelListenerCommand),
+    #[command(name = branding::name("secure-channel"), hide = branding::hide("secure-channel"))]
     SecureChannel(SecureChannelCommand),
+    #[command(name = branding::name("tcp-listener"), hide = branding::hide("tcp-listener"))]
     TcpListener(TcpListenerCommand),
+    #[command(name = branding::name("tcp-connection"), hide = branding::hide("tcp-connection"))]
     TcpConnection(TcpConnectionCommand),
+    #[command(name = branding::name("flow-control"), hide = branding::hide("flow-control"))]
     FlowControl(FlowControlCommand),
+    #[command(name = branding::name("kafka-consumer"), hide = branding::hide("kafka-consumer"))]
     KafkaConsumer(KafkaConsumerCommand),
+    #[command(name = branding::name("kafka-producer"), hide = branding::hide("kafka-producer"))]
     KafkaProducer(KafkaProducerCommand),
+    #[command(name = branding::name("share"), hide = branding::hide("share"))]
     Share(ShareCommand),
 }
 
@@ -121,6 +164,8 @@ impl OckamSubcommand {
     /// Run the subcommand
     pub fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
         match self {
+            OckamSubcommand::Enroll(c) => c.run(opts),
+
             OckamSubcommand::Node(c) => c.run(opts),
             OckamSubcommand::Vault(c) => c.run(opts),
             OckamSubcommand::Identity(c) => c.run(opts),
@@ -142,7 +187,6 @@ impl OckamSubcommand {
             OckamSubcommand::Completion(c) => c.run(),
             OckamSubcommand::Environment(c) => c.run(),
 
-            OckamSubcommand::Enroll(c) => c.run(opts),
             OckamSubcommand::Admin(c) => c.run(opts),
             OckamSubcommand::Space(c) => c.run(opts),
             OckamSubcommand::SpaceAdmin(c) => c.run(opts),
@@ -152,11 +196,12 @@ impl OckamSubcommand {
             OckamSubcommand::Subscription(c) => c.run(opts),
             OckamSubcommand::Lease(c) => c.run(opts),
             OckamSubcommand::Authority(c) => c.run(opts),
-            OckamSubcommand::Markdown(c) => c.run(),
-            OckamSubcommand::MigrateDatabase(c) => c.run(opts),
-            OckamSubcommand::Worker(c) => c.run(opts),
             OckamSubcommand::Service(c) => c.run(opts),
             OckamSubcommand::Message(c) => c.run(opts),
+            OckamSubcommand::Markdown(c) => c.run(),
+
+            OckamSubcommand::MigrateDatabase(c) => c.run(opts),
+            OckamSubcommand::Worker(c) => c.run(opts),
             OckamSubcommand::SecureChannelListener(c) => c.run(opts),
             OckamSubcommand::SecureChannel(c) => c.run(opts),
             OckamSubcommand::TcpListener(c) => c.run(opts),
@@ -267,6 +312,7 @@ impl OckamSubcommand {
     /// Return the subcommand name
     pub fn name(&self) -> String {
         match self {
+            OckamSubcommand::Enroll(c) => c.name(),
             OckamSubcommand::Node(c) => c.name(),
             OckamSubcommand::Vault(c) => c.name(),
             OckamSubcommand::Identity(c) => c.name(),
@@ -287,7 +333,6 @@ impl OckamSubcommand {
             OckamSubcommand::Manpages(c) => c.name(),
             OckamSubcommand::Completion(c) => c.name(),
             OckamSubcommand::Environment(c) => c.name(),
-            OckamSubcommand::Enroll(c) => c.name(),
             OckamSubcommand::Admin(c) => c.name(),
             OckamSubcommand::Space(c) => c.name(),
             OckamSubcommand::SpaceAdmin(c) => c.name(),
@@ -319,7 +364,11 @@ pub trait Command: Debug + Clone + Sized + Send + Sync + 'static {
     const NAME: &'static str;
 
     fn name(&self) -> String {
-        Self::NAME.into()
+        branding::CUSTOM_COMMANDS.name(Self::NAME).to_string()
+    }
+
+    fn hide() -> bool {
+        branding::CUSTOM_COMMANDS.hide(Self::NAME)
     }
 
     fn retry_opts(&self) -> Option<RetryOpts> {
@@ -327,6 +376,9 @@ pub trait Command: Debug + Clone + Sized + Send + Sync + 'static {
     }
 
     fn run(self, opts: CommandGlobalOpts) -> miette::Result<()> {
+        if Self::hide() {
+            return Err(miette!("This command is not available"));
+        }
         async_cmd(Self::NAME, opts.clone(), |ctx| async move {
             self.async_run_with_retry(&ctx, opts).await
         })

--- a/implementations/rust/ockam/ockam_command/src/version.rs
+++ b/implementations/rust/ockam/ockam_command/src/version.rs
@@ -6,7 +6,7 @@ use ockam_api::output::Output;
 use serde::Serialize;
 use std::fmt::Display;
 
-use crate::BIN_NAME;
+use crate::environment::compile_time_vars::BIN_NAME;
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct Version {


### PR DESCRIPTION
In the configuration passed to the brand binary, we can now pass the commands we want to include and optionally set a custom name. If none are passed, all the commands are available:

```yaml
bin_name:
  commands:
    - node: "host" # 'node' top-level command will be renamed to 'host'
    - node_list
    - node_create: "init" # 'node create' -> 'host init'
```

So far I’ve added the ability to add/rename top-level commands only (e.g. node, project, space, ...) but not subcommands.
