### PR TITLE
feat(rust): add a tcp listener for liveness checks on an authority node

### DIFF
--- a/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/authority.rs
@@ -18,8 +18,9 @@ use ockam::identity::{
 use ockam::tcp::{TcpListenerOptions, TcpTransport};
 use ockam_core::compat::sync::Arc;
 use ockam_core::env::get_env;
+use ockam_core::errcode::{Kind, Origin};
 use ockam_core::flow_control::FlowControlId;
-use ockam_core::Result;
+use ockam_core::{Error, Result};
 use ockam_node::database::SqlxDatabase;
 use ockam_node::Context;
 
@@ -156,6 +157,18 @@ impl Authority {
             .await?;
 
         info!("started a TCP listener at {listener:?}");
+
+        let liveness_tcp_listener = tokio::net::TcpListener::bind(
+            configuration.liveness_tcp_listener_address().to_string(),
+        )
+        .await
+        .map_err(|e| Error::new(Origin::Api, Kind::Invalid, format!("{e:?}")))?;
+
+        info!("started a liveness TCP listener at {liveness_tcp_listener:?}");
+
+        self.start_liveness_tcp_listener(liveness_tcp_listener)
+            .await?;
+
         Ok(secure_channel_listener_flow_control_id)
     }
 
@@ -306,6 +319,20 @@ impl Authority {
             .add_consumer(&address.into(), secure_channel_flow_control_id);
 
         ctx.start_worker(address, Echoer)
+    }
+
+    /// Start the liveness tcp listener
+    pub async fn start_liveness_tcp_listener(
+        &self,
+        liveness_tcp_listener: tokio::net::TcpListener,
+    ) -> Result<()> {
+        let _handle = tokio::spawn(async move {
+            loop {
+                // Accept any incoming connection
+                let _result = liveness_tcp_listener.accept().await;
+            }
+        });
+        Ok(())
     }
 
     /// Add a member directly to storage, without additional validation
@@ -506,6 +533,7 @@ mod tests {
             database_configuration: DatabaseConfiguration::postgres()?.unwrap(),
             project_identifier: "123456".to_string(),
             tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", port)).unwrap(),
+            liveness_tcp_listener_address: InternetAddress::new(&format!("127.0.0.1:{}", 4300)).unwrap(),
             secure_channel_listener_name: None,
             authenticator_name: None,
             trusted_identities: PreTrustedIdentities::new(trusted_identities),

--- a/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
+++ b/implementations/rust/ockam/ockam_api/src/authority_node/configuration.rs
@@ -26,6 +26,9 @@ pub struct Configuration {
     /// listener address for the TCP listener, for example "127.0.0.1:4000"
     pub tcp_listener_address: InternetAddress,
 
+    /// listener address for the TCP listener as a liveness check, for example "127.0.0.1:4300"
+    pub liveness_tcp_listener_address: InternetAddress,
+
     /// service name for the secure channel listener, for example "api"
     /// The default is DefaultAddress::SECURE_CHANNEL_LISTENER
     pub secure_channel_listener_name: Option<String>,
@@ -72,6 +75,11 @@ impl Configuration {
     /// Return the address for the TCP listener
     pub(crate) fn tcp_listener_address(&self) -> InternetAddress {
         self.tcp_listener_address.clone()
+    }
+
+    /// Return the address for the TCP liveness listener
+    pub(crate) fn liveness_tcp_listener_address(&self) -> InternetAddress {
+        self.liveness_tcp_listener_address.clone()
     }
 
     /// Return the service name for the secure_channel_listener

--- a/implementations/rust/ockam/ockam_command/src/authority/create.rs
+++ b/implementations/rust/ockam/ockam_command/src/authority/create.rs
@@ -61,6 +61,17 @@ pub struct CreateCommand {
     )]
     tcp_listener_address: InternetAddress,
 
+    /// TCP listener address which can be used as a liveliness check
+    #[arg(
+        display_order = 900,
+        long,
+        short,
+        id = "LIVENESS_ADDRESS",
+        default_value = "127.0.0.1:4300",
+        value_parser = internet_address_parser
+    )]
+    liveness_tcp_listener_address: InternetAddress,
+
     /// Name of the Identity that the authority will use
     #[arg(long = "identity", value_name = "IDENTITY_NAME")]
     identity: Option<String>,
@@ -147,6 +158,8 @@ impl CreateCommand {
             "--child-process".to_string(),
             "--tcp-listener-address".to_string(),
             self.tcp_listener_address.to_string(),
+            "--liveness-tcp-listener-address".to_string(),
+            self.liveness_tcp_listener_address.to_string(),
             "--project-identifier".to_string(),
             self.project_identifier.clone(),
             "--trusted-identities".to_string(),
@@ -342,6 +355,7 @@ impl CreateCommand {
             database_configuration: opts.state.database_configuration()?,
             project_identifier: self.project_identifier.clone(),
             tcp_listener_address: self.tcp_listener_address.clone(),
+            liveness_tcp_listener_address: self.liveness_tcp_listener_address.clone(),
             secure_channel_listener_name: None,
             authenticator_name: None,
             trusted_identities,


### PR DESCRIPTION
The current TCP listener used on an authority node for secure channels is used for liveness checks. 
This leads to errors being created in the logs since a liveness check does not send any Ockam message.

This PR adds an additional TCP listener that drops any incoming connection, in order to be used as a liveness check endpoint.