### PR TITLE
feat(rust): output processor errors as trace instead of error

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
+++ b/implementations/rust/ockam/ockam_node/src/relay/processor_relay.rs
@@ -54,7 +54,7 @@ where
                             e
                         );
                         #[cfg(not(feature = "debugger"))]
-                        error!(
+                        trace!(
                             "Error encountered during '{}' processing: {}",
                             ctx.primary_address(),
                             e


### PR DESCRIPTION
This prevents the logs to be flooded with errors with it is pinged for liveness.

