### PR TITLE
feat(rust): don't return an error when a tcp processor does not receive an ockam message

### DIFF
--- a/implementations/rust/ockam/ockam_node/src/context/worker_lifecycle.rs
+++ b/implementations/rust/ockam/ockam_node/src/context/worker_lifecycle.rs
@@ -176,4 +176,9 @@ impl Context {
     pub fn stop_address(&self, address: &Address) -> Result<()> {
         self.router()?.stop_address(address, false)
     }
+
+    /// Stop a Worker or a Processor running on the context primary address
+    pub fn stop_primary_address(&self) -> Result<()> {
+        self.stop_address(self.primary_address())
+    }
 }


### PR DESCRIPTION
This PR do no fail the initialization of a TCP receiver when it receives a message which does not support the Ockam protocol.
This reduces the number of errors logged in authority nodes when we used their TCP listener to check for liveness.