### PR TITLE
feat(rust): add more environment variables to build the postgres connection url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5036,6 +5036,7 @@ dependencies = [
  "ockam_transport_core",
  "once_cell",
  "opentelemetry",
+ "percent-encoding",
  "regex",
  "serde",
  "serde_json",

--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -23,7 +23,10 @@ Logging
 
 Database
 - OCKAM_SQLITE_IN_MEMORY: a `boolean` to set the SQLite mode to `memory`. This can only be used in the `node create` command with the `--foreground` flag. Default value: `false`.
-- OCKAM_DATABASE_CONNECTION_URL: Database url in the form `postgres://[{user}:{password}@]{host}:{port}/{database_name}` (for now only `postgres` is supported). Example: 'postgres://admin:secr3t@localhost:5432/ockam'.
+- OCKAM_DATABASE_CONNECTION_URL: Database url in the form `postgres://[{user}:{password}@]{host}:{port}/{database_name}`. Alternatively provide INSTANCE + USER + PASSWORD below. Example: 'postgres://admin:secr3t@localhost:5432/ockam'.
+- OCKAM_DATABASE_INSTANCE: Database host, port and name in the form `{host}:{port}/{database_name}`.
+- OCKAM_DATABASE_USER: The database user
+- OCKAM_DATABASE_PASSWORD: The database user password
 
 Tracing
 - OCKAM_TELEMETRY_EXPORT: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`

--- a/implementations/rust/ockam/ockam_node/Cargo.toml
+++ b/implementations/rust/ockam/ockam_node/Cargo.toml
@@ -95,6 +95,7 @@ ockam_macros = { path = "../ockam_macros", version = "^0.37.0" }
 ockam_transport_core = { path = "../ockam_transport_core", version = "^0.101.0", default-features = false, optional = true }
 once_cell = { version = "1.19.0", optional = true, default-features = false }
 opentelemetry = { version = "0.26.0", features = ["logs", "metrics", "trace"], optional = true }
+percent-encoding = { version = "2.3", default-features = false }
 regex = { version = "1.10.6", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1", optional = true }


### PR DESCRIPTION
This PR introduces additional environment variables to build the Postgres connection url. This is useful when:

 - The database password is regularly rotated.
 - The password needs to be URL-encoded.