### PR TITLE
feat(rust): provide additional ways to pass the database password

### DIFF
--- a/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
+++ b/implementations/rust/ockam/ockam_command/src/environment/static/env_info.txt
@@ -27,6 +27,7 @@ Database
 - OCKAM_DATABASE_INSTANCE: Database host, port and name in the form `{host}:{port}/{database_name}`.
 - OCKAM_DATABASE_USER: The database user
 - OCKAM_DATABASE_PASSWORD: The database user password
+- OCKAM_DATABASE_USER_AND_PASSWORD: The database user password as `{"username":"pgadmin", "password":"12345"}` for environments that provide both at the same time.
 
 Tracing
 - OCKAM_TELEMETRY_EXPORT: set this variable to a false value to disable tracing: `0`, `false`, `no`. Default value: `true`


### PR DESCRIPTION
This PR provides an additional way to pass the user name and password for the database.
This is useful for an environment where the AWS Secrets Manager service is used since the secret is a JSON key/value string containing both the user name and the password.
